### PR TITLE
Add comments explaining changing the master/minion hostnames

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -3,7 +3,8 @@
 - name: Install Origin
   yum: pkg=origin state=installed
 
-- name: Set hostname to IP Addr
+  # fixme: Once openshift stops resolving hostnames for minion queries remove this...
+- name: Set hostname to IP Addr (WORKAROUND)
   command: /usr/bin/hostname {{ oo_bind_ip }}
 
 - name: Configure OpenShift Master settings

--- a/roles/openshift_minion/tasks/main.yml
+++ b/roles/openshift_minion/tasks/main.yml
@@ -3,7 +3,8 @@
 - name: Install OpenShift
   yum: pkg=origin state=installed
 
-- name: Set hostname to IP Addr
+  # fixme: Once openshift stops resolving hostnames for minion queries remove this...
+- name: Set hostname to IP Addr (WORKAROUND)
   command: /usr/bin/hostname {{ oo_bind_ip }}
 
 - name: Configure OpenShift Minion settings


### PR DESCRIPTION
- openshift forces resolving all minions to hostnames to query etcd keys
  rather than using the IP address
