### PR TITLE
short-term fix up for cluster.sh supported environment tags

### DIFF
--- a/cluster.sh
+++ b/cluster.sh
@@ -15,7 +15,7 @@ function usage {
         ${0} : [create|terminate|update|list] {GCE environment tag}
 
         Supported environment tags:
-        $(grep 'SUPPORTED_ENVS.*=' ./cloud.rb)
+        $(grep 'SUPPORTED_ENVS.*=' ./lib/gce_command.rb)
 EOT
 }
 # @formatter:on


### PR DESCRIPTION
I'm not sure what the end goal is here but I noticed that this no longer works. The output isn't exactly pretty but I didn't want to put too much thought/effort into output formatting for something that I assume is in a state of flux.
