### PR TITLE
Explicitely use python2

### DIFF
--- a/bin/oscp
+++ b/bin/oscp
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: expandtab:tabstop=4:shiftwidth=4
 
 import argparse

--- a/bin/ossh
+++ b/bin/ossh
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: expandtab:tabstop=4:shiftwidth=4
 
 import argparse

--- a/inventory/aws/ec2.py
+++ b/inventory/aws/ec2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 '''
 EC2 external inventory script

--- a/inventory/gce/gce.py
+++ b/inventory/gce/gce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/inventory/multi_ec2.py
+++ b/inventory/multi_ec2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: expandtab:tabstop=4:shiftwidth=4
 
 from time import time

--- a/test/units/mutli_ec2_test.py
+++ b/test/units/mutli_ec2_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import unittest
 import sys


### PR DESCRIPTION
Some distributions are using python3 as the default python.
On those ones, we need to explicitely use python2.