### PR TITLE
Fix AWS playbooks

### DIFF
--- a/playbooks/aws/openshift-master/config.yml
+++ b/playbooks/aws/openshift-master/config.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   gather_facts: no
   tasks:
-  - name: Evaluate oo_host_group_exp if it's set
+  - name: "Evaluate oo_host_group_exp if it's set"
     add_host: "name={{ item }} groups=oo_hosts_to_config"
     with_items: "{{ oo_host_group_exp | default('') }}"
     when: oo_host_group_exp is defined
@@ -36,7 +36,7 @@
         role: openshift_master,
         openshift_node_ips: "{{ hostvars['localhost'].openshift_node_ips | default(['']) }}",
         openshift_env: "{{ oo_env }}"
-        # TODO: openshift_public_ip: set to aws instance public ip
+        openshift_public_ip: "{{ ec2_ip_address }}"
       }
     - pods
     - os_env_extras

--- a/playbooks/aws/openshift-node/config.yml
+++ b/playbooks/aws/openshift-node/config.yml
@@ -23,6 +23,12 @@
             | oo_select_keys(groups['tag_env-host-type_' + oo_env + '-openshift-master'])
             | oo_collect(attribute='ansible_default_ipv4.address') }}"
       when: groups['tag_env-host-type_' + oo_env + '-openshift-master'] is defined
+    - name: Setting openshift_master_public_ips fact on localhost
+      set_fact:
+        openshift_master_public_ips: "{{ hostvars
+            | oo_select_keys(groups['tag_env-host-type-' + oo_env + '-openshift-master'])
+            | oo_collect(attribute='ec2_ip_address') }}"
+      when: groups['tag_env-host-type-' + oo_env + '-openshift-master'] is defined
 
 - name: "Configure instances"
   hosts: oo_hosts_to_config
@@ -36,8 +42,8 @@
     - {
         role: openshift_node,
         openshift_master_ips: "{{ hostvars['localhost'].openshift_master_ips | default(['']) }}",
-        # TODO: add openshift_Master_public_ips
+        openshift_master_public_ips: "{{ hostvars['localhost'].openshift_master_public_ips | default(['']) }}",
         openshift_env: "{{ oo_env }}"
-        # TODO: openshift_public_ip: set to aws instance public ip
+        openshift_public_ip: "{{ ec2_ip_address }}"
       }
     - os_env_extras

--- a/playbooks/gce/openshift-master/config.yml
+++ b/playbooks/gce/openshift-master/config.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   gather_facts: no
   tasks:
-  - name: Evaluate oo_host_group_exp if it's set
+  - name: "Evaluate oo_host_group_exp if it's set"
     add_host: "name={{ item }} groups=oo_hosts_to_config"
     with_items: "{{ oo_host_group_exp | default('') }}"
     when: oo_host_group_exp is defined


### PR DESCRIPTION
The ansible variable `oo_master_public_ips` is used in `roles/openshift_node/tasks/main.yml` but defined only in the playbook `playbooks/gce/openshift-node/config.yml`.
As this role is also used from the AWS playbook, this one needs to define `oo_master_public_ips` also.

The ansible variable `oo_public_ip` is used in `roles/openshift_master/tasks/main.yml` and `roles/openshift_node/tasks/main.yml`, but is defined only in the playbooks `playbooks/gce/openshift-{master,node}/config.yml`
As this role is also used from the AWS playbooks, those ones need to define `oo_public_ip` also.