### PR TITLE
Make the AWS region, AMI, keypair, instance type and OpenShift binary customisable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 .DS_Store
 gce.ini
 multi_ec2.yaml
+/config

--- a/cluster.sh
+++ b/cluster.sh
@@ -3,6 +3,18 @@
 NODES=2
 MASTERS=1
 
+# Read the config file
+if [ -f "$(dirname $0)/config" ]; then
+    source "$(dirname $0)/config"
+else
+    cat <<EOF
+  ^    You have no "config" file. Default settings will be used.
+ /!\\   In order to override default settings, you can copy "config.sample"
+/___\\  as "config" and customize it.
+
+EOF
+fi
+
 # If the environment variable OO_PROVDER is defined, it used for the provider
 PROVIDER=${OO_PROVIDER:-''}
 # Otherwise, default is gce (Google Compute Engine)

--- a/config.sample
+++ b/config.sample
@@ -1,0 +1,80 @@
+####################
+# General settings #
+####################
+
+# OO_PROVIDER
+#
+# Selects the cloud provider to use
+# Choices: gce, aws
+# Default: gce
+
+#export OO_PROVIDER=aws
+
+# MASTERS
+#
+# Number of master nodes
+# Default: 1
+
+#export MASTERS=1
+
+# MINIONS
+#
+# Number of minion nodes
+# Default: 2
+
+#export MINIONS=2
+
+################
+# GCE settings #
+################
+
+################
+# AWS settings #
+################
+
+# Credentials
+#
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+
+#source ~/.awscred
+#export AWS_ACCESS_KEY_ID
+#export AWS_SECRET_ACCESS_KEY
+
+# OO_OPENSHIFT_BINARY
+#
+# Path of a locally built openshift binary
+#
+# If this variable is set, then, the locally built openshift will be installed
+# in /usr/local/bin on the AWS machines.
+# If this variable is not set, then, openshift will be installed from the yum repository
+
+#export OO_OPENSHIFT_BINARY=$HOME/doc/prog/RedHat/origin/_output/local/go/bin/openshift
+
+# OO_AWS_REGION
+#
+# Selects an AWS region
+# Default: us-east-1
+
+#export OO_AWS_REGION=us-east-1
+
+# OO_AWS_AMI
+#
+# AWS image to use to create the VMs
+# Default: ami-86781fee
+
+#export OO_AWS_AMI=ami-d2ee9fba
+
+# OO_AWS_KEYPAIR
+#
+# keypair to use for new VMs
+# Default: libra
+
+#export OO_AWS_KEYPAIR=lenaic@ncelhuard-Xperiment
+
+# OO_AWS_INSTANCE_TYPE
+#
+# Instance type of new VMs
+# Default: m3.large
+
+#export OO_AWS_INSTANCE_TYPE=t2.micro

--- a/lib/aws_command.rb
+++ b/lib/aws_command.rb
@@ -40,6 +40,15 @@ module OpenShift
         ah.extra_vars['oo_new_inst_tags'].merge!(AwsHelper.generate_host_type_tag(options[:type]))
         ah.extra_vars['oo_new_inst_tags'].merge!(AwsHelper.generate_env_host_type_tag(options[:env], options[:type]))
 
+        # Check if we install a custom openshift
+        ah.extra_vars['oo_openshift_binary'] = ENV['OO_OPENSHIFT_BINARY'] if !ENV['OO_OPENSHIFT_BINARY'].nil?
+
+        # Check AWS settings override
+        ah.extra_vars['oo_aws_region']  = ENV['OO_AWS_REGION']  if !ENV['OO_AWS_REGION'].nil?
+        ah.extra_vars['oo_aws_ami']     = ENV['OO_AWS_AMI']     if !ENV['OO_AWS_AMI'].nil?
+        ah.extra_vars['oo_aws_keypair'] = ENV['OO_AWS_KEYPAIR'] if !ENV['OO_AWS_KEYPAIR'].nil?
+        ah.extra_vars['oo_aws_instance_type'] = ENV['OO_AWS_INSTANCE_TYPE'] if !ENV['OO_AWS_INSTANCE_TYPE'].nil?
+
         puts
         puts "Creating #{options[:count]} #{options[:type]} instance(s) in AWS..."
 
@@ -87,6 +96,9 @@ module OpenShift
         else
           abort 'Error: you need to specify either --name or (--type and --env)'
         end
+
+        # Check if we install a custom openshift
+        ah.extra_vars['oo_openshift_binary'] = ENV['OO_OPENSHIFT_BINARY'] if !ENV['OO_OPENSHIFT_BINARY'].nil?
 
         puts
         puts "Configuring #{options[:type]} instance(s) in AWS..."

--- a/playbooks/aws/openshift-master/launch.yml
+++ b/playbooks/aws/openshift-master/launch.yml
@@ -5,8 +5,7 @@
   gather_facts: no
 
   vars:
-    inst_region: us-east-1
-    atomic_ami: ami-86781fee
+    inst_region: "{{ oo_aws_region | default('us-east-1') }}"
     user_data_file: user_data.txt
 
   vars_files:
@@ -17,10 +16,10 @@
       ec2:
         state: present
         region: "{{ inst_region }}"
-        keypair: libra
+        keypair: "{{ oo_aws_keypair | default('libra') }}"
         group: ['public']
-        instance_type: m3.large
-        image: "{{ atomic_ami }}"
+        instance_type: "{{ oo_aws_instance_type | default('m3.large') }}"
+        image: "{{ oo_aws_ami | default('ami-86781fee') }}"
         count: "{{ oo_new_inst_names | oo_len }}"
         user_data: "{{ lookup('file', user_data_file) }}"
         wait: yes

--- a/playbooks/aws/openshift-master/user_data.txt
+++ b/playbooks/aws/openshift-master/user_data.txt
@@ -1,0 +1,6 @@
+#cloud-config
+disable_root: 0
+
+system_info:
+  default_user:
+    name: root

--- a/playbooks/aws/openshift-node/launch.yml
+++ b/playbooks/aws/openshift-node/launch.yml
@@ -5,8 +5,7 @@
   gather_facts: no
 
   vars:
-    inst_region: us-east-1
-    atomic_ami: ami-86781fee
+    inst_region: "{{ oo_aws_region | default('us-east-1') }}"
     user_data_file: user_data.txt
 
   vars_files:
@@ -17,10 +16,10 @@
       ec2:
         state: present
         region: "{{ inst_region }}"
-        keypair: libra
+        keypair: "{{ oo_aws_keypair | default('libra') }}"
         group: ['public']
-        instance_type: m3.large
-        image: "{{ atomic_ami }}"
+        instance_type: "{{ oo_aws_instance_type | default('m3.large') }}"
+        image: "{{ oo_aws_ami | default('ami-86781fee') }}"
         count: "{{ oo_new_inst_names | oo_len }}"
         user_data: "{{ lookup('file', user_data_file) }}"
         wait: yes

--- a/playbooks/aws/openshift-node/user_data.txt
+++ b/playbooks/aws/openshift-node/user_data.txt
@@ -1,0 +1,6 @@
+#cloud-config
+disable_root: 0
+
+system_info:
+  default_user:
+    name: root

--- a/roles/openshift_master/files/openshift-master.service
+++ b/roles/openshift_master/files/openshift-master.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=OpenShift Master
+Documentation=https://github.com/openshift/origin
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/sysconfig/openshift-master
+ExecStart=/usr/local/bin/openshift start $ROLE $OPTIONS
+WorkingDirectory=/var/lib/openshift/
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -1,7 +1,14 @@
 ---
 # tasks file for openshift_master
-- name: Install Origin
-  yum: pkg=openshift-master state=installed
+
+- name: Install docker
+  yum: pkg=docker state=installed
+
+- include: openshift_from_yum.yml
+  when: oo_openshift_binary is not defined
+
+- include: openshift_from_local.yml
+  when: oo_openshift_binary is defined
 
   # fixme: Once openshift stops resolving hostnames for node queries remove this...
 - name: Set hostname to IP Addr (WORKAROUND)
@@ -12,7 +19,9 @@
     dest: /etc/sysconfig/openshift-master
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
+    create: yes
   with_items:
+    - { regex: '^ROLE=', line: 'ROLE=\"master\"' }
     - { regex: '^OPTIONS=', line: 'OPTIONS=\"--public-master={{ oo_public_ip }} --nodes={{ oo_node_ips | join(",") }}  --loglevel=5\"' }
   notify:
     - restart openshift-master

--- a/roles/openshift_master/tasks/openshift_from_local.yml
+++ b/roles/openshift_master/tasks/openshift_from_local.yml
@@ -1,0 +1,15 @@
+- name: Copy OpenShift binary
+  copy:
+    src: "{{ oo_openshift_binary }}"
+    dest: /usr/local/bin/openshift
+    mode: 0755
+
+- name: Configure OpenShift systemd unit
+  copy:
+    src: openshift-master.service
+    dest: /etc/systemd/system/openshift-master.service
+
+- name: Create /var/lib/openshift
+  file:
+    path: /var/lib/openshift
+    state: directory

--- a/roles/openshift_master/tasks/openshift_from_yum.yml
+++ b/roles/openshift_master/tasks/openshift_from_yum.yml
@@ -1,0 +1,2 @@
+- name: Install Origin
+  yum: pkg=openshift-master state=installed

--- a/roles/openshift_node/files/openshift-node.service
+++ b/roles/openshift_node/files/openshift-node.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=OpenShift Node
+After=docker.service
+Requires=docker.service
+Documentation=https://github.com/openshift/origin
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/sysconfig/openshift-node
+ExecStart=/usr/local/bin/openshift start $ROLE $OPTIONS
+WorkingDirectory=/var/lib/openshift/
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -1,8 +1,13 @@
 ---
 
-# tasks file for openshift_node
-- name: Install OpenShift
-  yum: pkg=openshift-node state=installed
+- name: Install docker
+  yum: pkg=docker state=installed
+
+- include: openshift_from_yum.yml
+  when: oo_openshift_binary is not defined
+
+- include: openshift_from_local.yml
+  when: oo_openshift_binary is defined
 
   # fixme: Once openshift stops resolving hostnames for node queries remove this...
 - name: Set hostname to IP Addr (WORKAROUND)
@@ -26,7 +31,9 @@
     dest: /etc/sysconfig/openshift-node
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
+    create: yes
   with_items:
+    - { regex: '^ROLE=', line: 'ROLE=\"node\"' }
     - { regex: '^OPTIONS=', line: 'OPTIONS=\"--master=http://{{ oo_master_ips[0] }}:8080  --loglevel=5\"' }
   notify:
     - restart openshift-node

--- a/roles/openshift_node/tasks/openshift_from_local.yml
+++ b/roles/openshift_node/tasks/openshift_from_local.yml
@@ -1,0 +1,15 @@
+- name: Copy OpenShift binary
+  copy:
+    src: "{{ oo_openshift_binary }}"
+    dest: /usr/local/bin/openshift
+    mode: 0755
+
+- name: Configure OpenShift systemd unit
+  copy:
+    src: openshift-node.service
+    dest: /etc/systemd/system/openshift-node.service
+
+- name: Create /var/lib/openshift
+  file:
+    path: /var/lib/openshift
+    state: directory

--- a/roles/openshift_node/tasks/openshift_from_yum.yml
+++ b/roles/openshift_node/tasks/openshift_from_yum.yml
@@ -1,0 +1,2 @@
+- name: Install OpenShift
+  yum: pkg=openshift-node state=installed


### PR DESCRIPTION
The AWS region, AMI, keypair and instance type are not hardcoded anymore.
They can be customized in the config file.
If the config file is empty, the default values are the previous hardcoded ones.
It is also possible to specify a local OpenShift binary to deploy.
If not specified, it will install one from the yum repository.