### PR TITLE
Conditionally include config.yml from launch.yml

### DIFF
--- a/cluster.sh
+++ b/cluster.sh
@@ -38,9 +38,9 @@ EOT
 # @formatter:on
 
 function create_cluster {
-    ./cloud.rb "${PROVIDER}" launch -e "${ENV}" --type=$MASTER_PLAYBOOK -c $MASTERS
+    ./cloud.rb "${PROVIDER}" launch --skip_config -e "${ENV}" --type=$MASTER_PLAYBOOK -c $MASTERS
 
-    ./cloud.rb "${PROVIDER}" launch -e "${ENV}" --type=$NODE_PLAYBOOK -c $NODES
+    ./cloud.rb "${PROVIDER}" launch --skip_config -e "${ENV}" --type=$NODE_PLAYBOOK -c $NODES
 
     update_cluster
 

--- a/lib/aws_command.rb
+++ b/lib/aws_command.rb
@@ -17,6 +17,7 @@ module OpenShift
              :desc => 'The number of instances to create'
       option :tag, :type => :array,
              :desc => 'The tag(s) to add to the new instances. Allowed characters are letters, numbers, and hyphens.'
+      option :skip_config, :type => :boolean
       desc "launch", "Launches instances."
       def launch()
         AwsHelper.check_creds()
@@ -42,6 +43,11 @@ module OpenShift
 
         puts
         puts "Creating #{options[:count]} #{options[:type]} instance(s) in AWS..."
+
+        # Should we skip the config at the end of the launch?
+        if options[:skip_config]
+          ah.skip_tags << 'config'
+        end
 
         # Make sure we're completely up to date before launching
         clear_cache()

--- a/playbooks/aws/openshift-master/config.yml
+++ b/playbooks/aws/openshift-master/config.yml
@@ -29,6 +29,7 @@
   user: root
   vars_files:
     - vars.yml
+  tags: config
   roles:
     - ../../../roles/base_os
     - ../../../roles/repos

--- a/playbooks/aws/openshift-node/config.yml
+++ b/playbooks/aws/openshift-node/config.yml
@@ -29,6 +29,7 @@
   user: root
   vars_files:
     - vars.yml
+  tags: config
   roles:
     - ../../../roles/base_os
     - ../../../roles/repos


### PR DESCRIPTION
It is not possible to first launch and configure the master and then to launch
and configure the minions because the master needs to know the IPs of the
minions (in the `--nodes` parameter found in `/etc/sysconfig/openshift-master`)

If we proceed in this order:
* launch the master machine
* configure the master
* launch the minion machines
* configure the minions
what happens is that the “`--nodes`” parameter of openshift-master is empty.
This prevents openshift master from starting.
Then the minions are starting, but they fail because they were enable to
connect to the master.
At the end, neither openshift master nor openshift minions are running.

In order to have things properly configured, i.e. to have the master know
the minions IPs and the minions knows the master IP, we need to proceed in
this order:
* launch the master machine
* launch the minion machines
* configure the master
* configure the minion

The “`config`” tag is used to skip the configuration step when launching
the machines. `cluster.sh` already takes care of doing the “`config`” step
after the “`launch`” one.