### PR TITLE
Fix './cluster.sh list' on AWS when some VMs have no name

### DIFF
--- a/lib/aws_helper.rb
+++ b/lib/aws_helper.rb
@@ -19,7 +19,7 @@ module OpenShift
         retval = []
         hosts['_meta']['hostvars'].each do |host, info|
           retval << OpenStruct.new({
-            :name        => info['ec2_tag_Name'],
+            :name        => info['ec2_tag_Name']        || 'UNSET',
             :env         => info['ec2_tag_environment'] || 'UNSET',
             :public_ip   => info['ec2_ip_address'],
             :public_dns  => info['ec2_public_dns_name'],


### PR DESCRIPTION
In case some AWS VMs have no name (VMs not managed by openshift-online-ansible),
`./cluster.sh list` fails with the following error:

    ./cluster.sh list
    /home/lenaic/doc/prog/RedHat/openshift-online-ansible/lib/aws_helper.rb:31:in `sort_by': comparison of Array with Array failed (ArgumentError)
            from /home/lenaic/doc/prog/RedHat/openshift-online-ansible/lib/aws_helper.rb:31:in `sort_by!'
            from /home/lenaic/doc/prog/RedHat/openshift-online-ansible/lib/aws_helper.rb:31:in `get_hosts'
            from /home/lenaic/doc/prog/RedHat/openshift-online-ansible/lib/aws_command.rb:118:in `list'
            from /home/lenaic/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
            from /home/lenaic/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
            from /home/lenaic/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
            from /home/lenaic/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:115:in `invoke'
            from /home/lenaic/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor.rb:235:in `block in subcommand'
            from /home/lenaic/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
            from /home/lenaic/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
            from /home/lenaic/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
            from /home/lenaic/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
            from ./cloud.rb:27:in `block in <main>'
            from ./cloud.rb:25:in `chdir'
            from ./cloud.rb:25:in `<main>'

With that fix, we get the expected result:

    ./cluster.sh list

                                Name   Env    State        IP Address Created By
                                ----   ---    -----        ---------- ----------
                               UNSET UNSET  running     54.152.46.170
    test-openshift-master-92675686da  test  running     54.152.33.235  lenaic
      test-openshift-node-2a43dcb0b4  test  running        52.1.69.75  lenaic
      test-openshift-node-94af201376  test  running       54.86.4.149  lenaic