### PR TITLE
Bugfixes for openshift-common related changes

### DIFF
--- a/playbooks/aws/openshift-master/vars.yml
+++ b/playbooks/aws/openshift-master/vars.yml
@@ -1,0 +1,2 @@
+---
+openshift_debug_level: 4

--- a/playbooks/aws/openshift-node/vars.yml
+++ b/playbooks/aws/openshift-node/vars.yml
@@ -1,0 +1,2 @@
+---
+openshift_debug_level: 4

--- a/playbooks/gce/openshift-master/vars.yml
+++ b/playbooks/gce/openshift-master/vars.yml
@@ -1,0 +1,2 @@
+---
+openshift_debug_level: 4

--- a/playbooks/gce/openshift-node/vars.yml
+++ b/playbooks/gce/openshift-node/vars.yml
@@ -1,0 +1,2 @@
+---
+openshift_debug_level: 4

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -19,9 +19,6 @@
 - name: Store OpenShift Master credentials
   local_action: command /usr/bin/rsync --compress --archive --rsh 'ssh -S none -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' {{ mktemp.stdout }}/ root@{{ openshift_public_ip }}:/var/lib/openshift/openshift.local.certificates/admin
   ignore_errors: yes
-  # fixme: Once the openshift_cluster playbook is published state should be started
-  # Always bounce service to pick up new credentials
-  notify: restart openshift-node
 
 - local_action: file name={{ mktemp.stdout }} state=absent
 
@@ -34,10 +31,12 @@
   lineinfile:
     dest: /etc/sysconfig/openshift-node
     regexp: '^OPTIONS='
-    line: "OPTIONS=\"--master=http://{{ openshift_master_ips[0] }}:8080 --loglevel={{ openshift_node_debug_level }}\""
+    line: "OPTIONS=\"--master=https://{{ openshift_master_ips[0] }}:8443 --loglevel={{ openshift_node_debug_level }}\""
   notify:
   - restart openshift-node
 
+# fixme: Once the openshift_cluster playbook is published state should be started
+# Always bounce service to pick up new credentials
 - name: Start and enable openshift-node
-  service: name=openshift-node enabled=yes state=started
+  service: name=openshift-node enabled=yes state=restarted
   when: not openshift_node_manage_service_externally


### PR DESCRIPTION
- Fix failed attempt to cleanup service notify on creds changes
- Fix master URL for node to use https
- Set openshift_debug_level in vars.yml for playbooks
  - This puts us closer to the original debug settings, where after the
    openshift-common changes the debug settings were defaulting back to 0