### PR TITLE
Set local_facts for openshift_{node,master} later in the task list

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -2,13 +2,6 @@
 - name: Install OpenShift Master package
   yum: pkg=openshift-master state=installed
 
-- name: Set master OpenShift facts
-  include: "{{ role_path | dirname }}/openshift_common/tasks/set_facts.yml"
-  facts:
-  - { section: master, option: debug_level, value: "{{ openshift_master_debug_level }}" }
-  - { section: master, option: public_ip, value: "{{ openshift_public_ip }}" }
-  - { section: master, option: externally_managed, value: "{{ openshift_master_manage_service_externally }}" }
-
 - name: Configure firewall for OpenShift Master
   include: "{{ role_path | dirname }}/openshift_common/tasks/firewall.yml"
   allow:
@@ -27,6 +20,13 @@
           | join(',') }}  --loglevel={{ openshift_master_debug_level }}\""
   notify:
   - restart openshift-master
+
+- name: Set master OpenShift facts
+  include: "{{ role_path | dirname }}/openshift_common/tasks/set_facts.yml"
+  facts:
+  - { section: master, option: debug_level, value: "{{ openshift_master_debug_level }}" }
+  - { section: master, option: public_ip, value: "{{ openshift_public_ip }}" }
+  - { section: master, option: externally_managed, value: "{{ openshift_master_manage_service_externally }}" }
 
 - name: Start and enable openshift-master
   service: name=openshift-master enabled=yes state=started

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -2,11 +2,6 @@
 - name: Install OpenShift Node package
   yum: pkg=openshift-node state=installed
 
-- name: Set OpenShift node facts
-  include: "{{ role_path | dirname }}/openshift_common/tasks/set_facts.yml"
-  facts:
-  - { section: node, option: debug_level, value: "{{ openshift_node_debug_level }}" }
-
 - local_action: command /usr/bin/mktemp -d /tmp/openshift-ansible-XXXXXXX
   register: mktemp
 
@@ -34,6 +29,13 @@
     line: "OPTIONS=\"--master=https://{{ openshift_master_ips[0] }}:8443 --loglevel={{ openshift_node_debug_level }}\""
   notify:
   - restart openshift-node
+
+- name: Set OpenShift node facts
+  include: "{{ role_path | dirname }}/openshift_common/tasks/set_facts.yml"
+  facts:
+  - { section: node, option: debug_level, value: "{{ openshift_node_debug_level }}" }
+  - { section: node, option: public_ip, value: "{{ openshift_public_ip }}" }
+  - { section: node, option: externally_managed, value: "{{ openshift_node_manage_service_externally }}" }
 
 # fixme: Once the openshift_cluster playbook is published state should be started
 # Always bounce service to pick up new credentials


### PR DESCRIPTION
Avoid setting/updating the local_facts for openshift_master and openshift_node until all config tasks have been run.