### PR TITLE
add openshift_hostname workaround var

### DIFF
--- a/roles/openshift_common/defaults/main.yml
+++ b/roles/openshift_common/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 openshift_bind_ip: "{{ ansible_default_ipv4.address }}"
 openshift_debug_level: 0
+
+# TODO: Once openshift stops resolving hostnames for node queries remove
+# this...
+openshift_hostname_workaround: true

--- a/roles/openshift_common/defaults/main.yml
+++ b/roles/openshift_common/defaults/main.yml
@@ -5,3 +5,4 @@ openshift_debug_level: 0
 # TODO: Once openshift stops resolving hostnames for node queries remove
 # this...
 openshift_hostname_workaround: true
+openshift_hostname: "{{ openshift_public_ip if openshift_hostname_workaround else ansible_fqdn }}"

--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -2,6 +2,7 @@
 # fixme: Once openshift stops resolving hostnames for node queries remove this...
 - name: Set hostname to IP Addr (WORKAROUND)
   hostname: name={{ openshift_bind_ip }}
+  when: openshift_hostname_workaround
 
 - name: Configure local facts file
   file: path=/etc/ansible/facts.d/ state=directory mode=0750

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -16,8 +16,9 @@
   lineinfile:
     dest: /etc/sysconfig/openshift-master
     regexp: '^OPTIONS='
-    line: "OPTIONS=\"--public-master={{ openshift_public_ip }} --nodes={{ openshift_node_ips
-          | join(',') }}  --loglevel={{ openshift_master_debug_level }}\""
+    line: "OPTIONS=\"--public-master={{ openshift_public_ip if
+          openshift_hostname_workaround else ansible_fqdn  }} --nodes={{ openshift_node_ips
+              | join(',') }}  --loglevel={{ openshift_master_debug_level }}\""
   notify:
   - restart openshift-master
 

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -16,8 +16,7 @@
   lineinfile:
     dest: /etc/sysconfig/openshift-master
     regexp: '^OPTIONS='
-    line: "OPTIONS=\"--public-master={{ openshift_public_ip if
-          openshift_hostname_workaround else ansible_fqdn  }} --nodes={{ openshift_node_ips
+    line: "OPTIONS=\"--public-master={{ openshift_hostname }} --nodes={{ openshift_node_ips
               | join(',') }}  --loglevel={{ openshift_master_debug_level }}\""
   notify:
   - restart openshift-master


### PR DESCRIPTION
- use openshift_bind_ip for hostname when openshift_hostname_workaround is true
- defaults to true to maintain current behavior.