### PR TITLE
Correct syntax error of missing quotes

### DIFF
--- a/playbooks/aws/openshift-node/config.yml
+++ b/playbooks/aws/openshift-node/config.yml
@@ -38,6 +38,6 @@
         role: openshift_node,
         openshift_master_ips: "{{ hostvars['localhost'].openshift_master_ips | default(['']) }}",
         # TODO: add openshift_Master_public_ips
-        openshift_env: {{ "oo_env" }}
+        openshift_env: "{{ oo_env }}"
         # TODO: openshift_public_ip: set to aws instance public ip
       }


### PR DESCRIPTION
Always quote template expression brackets when they start a value.