### PR TITLE
Provide default value for openshift_node_ips.

### DIFF
--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 openshift_master_manage_service_externally: false
 openshift_master_debug_level: "{{ openshift_debug_level | default(0) }}"
+openshift_node_ips: []


### PR DESCRIPTION
- openshift_node_ips now defaults to []

- Previously an empty --nodes in /etc/sysconfig/master would result in the
  master creating a node for the localhost. The latest Origin and OSE builds
  now only create the implicit localhost node if run as openshift, not
  openshift-master. We can now safely default to setting no nodes in
  /etc/sysconfig/master and having nodes register themselves with the master
  when they come up via the 'Register node (if not already registered)' task
  in roles/openshift_node/tasks/main.yml)

- This had an associated change for the byo scripts that had not been merged
  into master yet, but this PR changes the behavior of the openshift_master
  role to not fail if openshift_node_ips is not set. This also prevents having
  the openshift_master service restarted when a node is added.