### PR TITLE
Conditionally set --nodes on master

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -6,8 +6,9 @@
   lineinfile:
     dest: /etc/sysconfig/openshift-master
     regexp: '^OPTIONS='
-    line: "OPTIONS=\"--public-master={{ openshift_hostname }} --nodes={{ openshift_node_ips
-              | join(',') }}  --loglevel={{ openshift_master_debug_level }}\""
+    line: "OPTIONS=\"--public-master={{ openshift_hostname }} {% if
+    openshift_node_ips %} --nodes={{ openshift_node_ips
+              | join(',') }} {% endif %} --loglevel={{ openshift_master_debug_level }}\""
   notify:
   - restart openshift-master
 


### PR DESCRIPTION
- only add --nodes option to /etc/sysconfig/openshift-master when  openshift_node_ips is not an empty list.