### PR TITLE
Allow for overriding node resources

### DIFF
--- a/roles/openshift_node/README.md
+++ b/roles/openshift_node/README.md
@@ -21,6 +21,7 @@ From this role:
 | openshift_master_public_ips              | UNDEF (Required)      | List of the public IPs for the openhift-master hosts |
 | openshift_master_ips                     | UNDEF (Required)      | List of IP addresses for the openshift-master hosts to be used for node -> master communication |
 | openshift_registry_url                   | UNDEF (Optional)      | Default docker registry to use |
+| openshift_node_resources                 | { capacity: { cpu: , memory: } } | Resource specification for this node, cpu is the number of CPUs to advertise and memory is the amount of memory in bytes to advertise. Default values chosen when not set are the number of logical CPUs for the host and 75% of total system memory |
 
 From openshift_common:
 | Name                          |  Default Value      |                     | 

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -4,3 +4,7 @@ openshift_node_debug_level: "{{ openshift_debug_level | default(0) }}"
 os_firewall_allow:
 - service: OpenShift kubelet
   port: 10250/tcp
+openshift_node_resources:
+  capacity:
+    cpu:
+    memory:

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -72,8 +72,7 @@
   args:
     creates: /root/.kube/.kubeconfig
 
-# TODO: expose openshift_register_node options to allow for overriding the
-# defaults.
 - name: Register node (if not already registered)
   openshift_register_node:
     name: "{{ openshift_hostname }}"
+    resources: "{{ openshift_node_resources }}"


### PR DESCRIPTION
- add variable openshift_node_resources to openshift_node role
- set default value for openshift_node_resources to
  { capacity: { cpu: ,memory: }}
- If cpu is not set, then the default value will be chosen by the
  openshift_register_node module (num logical cpus)
- If memory is not set, then the default value will be chosen by the
  openshift_register_node module (75% MemTotal according to /proc/meminfo)