### PR TITLE
Start openshift-master with master address option

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -10,7 +10,7 @@
   lineinfile:
     dest: /etc/sysconfig/openshift-master
     regexp: '^OPTIONS='
-    line: "OPTIONS=\"--public-master={{ openshift_hostname }} {% if openshift_node_ips %} --nodes={{ openshift_node_ips | join(',') }} {% endif %} --loglevel={{ openshift_master_debug_level }}\""
+    line: "OPTIONS=\"--master={{ openshift_hostname }} --public-master={{ openshift_hostname }} {% if openshift_node_ips %} --nodes={{ openshift_node_ips | join(',') }} {% endif %} --loglevel={{ openshift_master_debug_level }}\""
   notify:
   - restart openshift-master
 


### PR DESCRIPTION
In case we start openshift-master WITHOUT master address option, openshift-master attempts to use the first public IPv4 non-loopback address registered on this host. (Please refer [1])

You should explicitly set master address too.

[1] https://github.com/openshift/origin/blob/master/pkg/cmd/server/start/master_args.go#L430-L432
