### PR TITLE
Launch openshift on AWS issues 

### DIFF
--- a/README_AWS.md
+++ b/README_AWS.md
@@ -14,7 +14,7 @@ Create a credentials file
    export AWS_ACCESS_KEY_ID='AKIASTUFF'
    export AWS_SECRET_ACCESS_KEY='STUFF'
 ```
-1. source this file
+2. source this file
 ```
   source ~/.aws_creds
 ```
@@ -23,7 +23,7 @@ Note: You must source this file in each shell that you want to run cloud.rb
 
 (Optional) Setup your $HOME/.ssh/config file
 -------------------------------------------
-In case of a cluster creation, or any other case where you don't know the machine hostname in advance, you can use '.ssh/config' 
+In case of a cluster creation, or any other case where you don't know the machine hostname in advance, you can use '.ssh/config'
 to setup a private key file to allow ansible to connect to the created hosts.
 
 To do so, add the the following entry to your $HOME/.ssh/config file and make it point to the private key file which allows you to login on AWS.
@@ -34,6 +34,24 @@ Host *.compute-1.amazonaws.com
 
 Alternatively, you can configure your ssh-agent to hold the credentials to connect to your AWS instances.
 
+(Optional) Choose where the cluster will be launched
+----------------------------------------------------
+
+By default, a cluster is launched with the following configuration:
+
+- Instance type: m3.large
+- AMI: ami-307b3658
+- Region: us-east-1
+- Keypair name: libra
+- Security group: public
+
+If needed, these values can be changed by setting environment variables on your system.
+
+- export ec2_instance_type='m3.large'
+- export ec2_ami='ami-307b3658'
+- export ec2_region='us-east-1'
+- export ec2_keypair='libra'
+- export ec2_security_group='public'
 
 Install Dependencies
 --------------------

--- a/playbooks/aws/openshift-cluster/launch_instances.yml
+++ b/playbooks/aws/openshift-cluster/launch_instances.yml
@@ -5,6 +5,7 @@
     machine_region: "{{ lookup('env', 'ec2_region')|default('us-east-1', true) }}"
     machine_keypair: "{{ lookup('env', 'ec2_keypair')|default('libra', true) }}"
     created_by: "{{ lookup('env', 'LOGNAME')|default(cluster, true) }}"
+    security_group: "{{ lookup('env', 'ec2_security_group')|default('public', true) }}"
     env: "{{ cluster }}"
     host_type: "{{ type }}"
     env_host_type: "{{ cluster }}-openshift-{{ type }}"
@@ -14,7 +15,7 @@
     state: present
     region: "{{ machine_region }}"
     keypair: "{{ machine_keypair }}"
-    group: ['public']
+    group: "{{ security_group }}"
     instance_type: "{{ machine_type }}"
     image: "{{ machine_image }}"
     count: "{{ instances | oo_len }}"


### PR DESCRIPTION
Hello,

I've been wanting to launch openshift with the playbook provided by this repo.

I started from the scratch, creating a new AWS account. As I'm located in Australia, it's ideal to use Sydney.

#### First issue

Listing from an empty account raises an error. Same happens with create action.

```
$ bin/cluster list aws ''
ERROR: provided hosts list is empty
ACTION [list] failed with exit status 256
```

```
$ bin/cluster create aws staging
ERROR: provided hosts list is empty
ACTION [create] failed with exit status 256
```

I'm unsure whether this is expected, I can get around when I have an instance running though. 

#### Second issue

On fresh AWS accounts, security group is named `default`. Playbook assumed `public`, which in my opinion is a fair name. However, it's important to include ability to set your security group name.

I've updated accordingly, and set the default name to `public`.

#### Third issue

After finding a workaround for all above, it raises an error with invalid AMI.  I looked it up and `ami-307b3658` isn't publicly available.

I wonder if the image has anything in special, and if so, how can it be made public? I would be great if someone can help me with that.

Thanks for the great work.

Rick.