### PR TITLE
Add ansible_connection=local to localhost in inventory

### DIFF
--- a/inventory/aws/hosts/hosts
+++ b/inventory/aws/hosts/hosts
@@ -1,1 +1,1 @@
-localhost ansible_sudo=no ansible_python_interpreter=/usr/bin/python2
+localhost ansible_connection=local ansible_sudo=no ansible_python_interpreter=/usr/bin/python2

--- a/inventory/gce/hosts/hosts
+++ b/inventory/gce/hosts/hosts
@@ -1,1 +1,1 @@
-localhost ansible_sudo=no ansible_python_interpreter=/usr/bin/python2
+localhost ansible_connection=local ansible_sudo=no ansible_python_interpreter=/usr/bin/python2

--- a/inventory/libvirt/hosts/hosts
+++ b/inventory/libvirt/hosts/hosts
@@ -1,1 +1,1 @@
-localhost ansible_sudo=no ansible_python_interpreter=/usr/bin/python2 connection=local
+localhost ansible_connection=local ansible_sudo=no ansible_python_interpreter=/usr/bin/python2


### PR DESCRIPTION
@tdawson @wshearn This should address the tempdir issue.

Still not sure why making the temp dir was successful, but trying to remove it was not, other than maybe ansible handles the file module differently than the command module for deciding the connection type to use by default for localhost.