### PR TITLE
Add a generic mechanism for passing options

### DIFF
--- a/README_libvirt.md
+++ b/README_libvirt.md
@@ -102,6 +102,16 @@ Test The Setup
   bin/cluster list libvirt ''
 ```
 
+Configuration
+-------------
+
+The following options can be passed via the `-o` flag of the `create` command or as environment variables:
+
+* `image_url` (default to `http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2`): URL of the QCOW2 image to download
+* `image_name` (default to `CentOS-7-x86_64-GenericCloud.qcow2`): Name of the QCOW2 image to boot the VMs on
+* `image_sha256` (default to `e324e3ab1d24a1bbf035ddb365e7f9058c0b454acf48d7aa15c5519fae5998ab`): Expected SHA256 checksum of the downloaded image
+* `skip_image_download` (default to `no`): Skip QCOW2 image download. This requires the `image_name` QCOW2 image to be already present in `$HOME/libvirt-storage-pool-openshift-ansible`
+
 Creating a cluster
 ------------------
 

--- a/bin/cluster
+++ b/bin/cluster
@@ -174,7 +174,7 @@ class Cluster(object):
         if args.option:
             for opt in args.option:
                 k, v = opt.split('=', 1)
-                env['opt_' + k] = v
+                env['cli_' + k] = v
 
         ansible_env = '-e \'{}\''.format(
             ' '.join(['%s=%s' % (key, value) for (key, value) in env.items()])

--- a/lookup_plugins/oo_option.py
+++ b/lookup_plugins/oo_option.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+# vim: expandtab:tabstop=4:shiftwidth=4
+
+'''
+oo_option lookup plugin for openshift-ansible
+
+Usage:
+
+    - debug:
+      msg: "{{ lookup('oo_option', '<key>') | default('<default_value>', True) }}"
+
+This returns, by order of priority:
+
+* if it exists, the `cli_<key>` ansible variable. This variable is set by `bin/cluster --option <key>=<value> …`
+* if it exists, the envirnoment variable named `<key>`
+* if none of the above conditions are met, empty string is returned
+'''
+
+from ansible.utils import template
+import os
+
+# Reason: disable too-few-public-methods because the `run` method is the only
+#     one required by the Ansible API
+# Status: permanently disabled
+# pylint: disable=too-few-public-methods
+class LookupModule(object):
+    ''' oo_option lookup plugin main class '''
+
+    # Reason: disable unused-argument because Ansible is calling us with many
+    #     parameters we are not interested in.
+    #     The lookup plugins of Ansible have this kwargs “catch-all” parameter
+    #     which is not used
+    # Status: permanently disabled unless Ansible API evolves
+    # pylint: disable=unused-argument
+    def __init__(self, basedir=None, **kwargs):
+        ''' Constructor '''
+        self.basedir = basedir
+
+    # Reason: disable unused-argument because Ansible is calling us with many
+    #     parameters we are not interested in.
+    #     The lookup plugins of Ansible have this kwargs “catch-all” parameter
+    #     which is not used
+    # Status: permanently disabled unless Ansible API evolves
+    # pylint: disable=unused-argument
+    def run(self, terms, inject=None, **kwargs):
+        ''' Main execution path '''
+
+        try:
+            terms = template.template(self.basedir, terms, inject)
+        # Reason: disable broad-except to really ignore any potential exception
+        #         This is inspired by the upstream "env" lookup plugin:
+        #         https://github.com/ansible/ansible/blob/devel/v1/ansible/runner/lookup_plugins/env.py#L29
+        # pylint: disable=broad-except
+        except Exception:
+            pass
+
+        if isinstance(terms, basestring):
+            terms = [terms]
+
+        ret = []
+
+        for term in terms:
+            option_name = term.split()[0]
+            cli_key = 'cli_' + option_name
+            if inject and cli_key in inject:
+                ret.append(inject[cli_key])
+            elif option_name in os.environ:
+                ret.append(os.environ[option_name])
+            else:
+                ret.append('')
+
+        return ret

--- a/playbooks/libvirt/openshift-cluster/lookup_plugins
+++ b/playbooks/libvirt/openshift-cluster/lookup_plugins
@@ -1,0 +1,1 @@
+../../../lookup_plugins

--- a/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
@@ -14,6 +14,7 @@
     url: '{{ image_url }}'
     sha256sum: '{{ image_sha256 }}'
     dest: '{{ os_libvirt_storage_pool_path }}/{{ image_name }}'
+  when: '{{ ( lookup("oo_option", "skip_image_download") | default("no", True) | lower ) in ["false", "no"] }}'
 
 - name: Create the cloud-init config drive path
   file:

--- a/playbooks/libvirt/openshift-cluster/vars.yml
+++ b/playbooks/libvirt/openshift-cluster/vars.yml
@@ -7,9 +7,12 @@ libvirt_uri: 'qemu:///system'
 deployment_vars:
   origin:
     image:
-      url: "http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2"
-      name: CentOS-7-x86_64-GenericCloud.qcow2
-      sha256: e324e3ab1d24a1bbf035ddb365e7f9058c0b454acf48d7aa15c5519fae5998ab
+      url:    "{{ lookup('oo_option', 'image_url') |
+                  default('http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2', True) }}"
+      name:   "{{ lookup('oo_option', 'image_name') |
+                  default('CentOS-7-x86_64-GenericCloud.qcow2', True) }}"
+      sha256: "{{ lookup('oo_option', 'image_sha256') |
+                  default('e324e3ab1d24a1bbf035ddb365e7f9058c0b454acf48d7aa15c5519fae5998ab', True) }}"
     ssh_user: openshift
     sudo: yes
   online:

--- a/playbooks/openstack/openshift-cluster/lookup_plugins
+++ b/playbooks/openstack/openshift-cluster/lookup_plugins
@@ -1,0 +1,1 @@
+../../../lookup_plugins

--- a/playbooks/openstack/openshift-cluster/vars.yml
+++ b/playbooks/openstack/openshift-cluster/vars.yml
@@ -1,27 +1,36 @@
 ---
-openstack_infra_heat_stack:     "{{ opt_infra_heat_stack  | default('files/heat_stack.yml') }}"
-openstack_network_prefix:       "{{ opt_network_prefix    | default('openshift-ansible-'+cluster_id) }}"
-openstack_network_cidr:         "{{ opt_net_cidr          | default('192.168.' + ( ( 1048576 | random % 256 ) | string() ) + '.0/24') }}"
-openstack_network_external_net: "{{ opt_external_net      | default('external') }}"
-openstack_floating_ip_pools:    "{{ opt_floating_ip_pools | default('external')        | oo_split() }}"
-openstack_network_dns:          "{{ opt_dns               | default('8.8.8.8,8.8.4.4') | oo_split() }}"
-openstack_ssh_keypair:          "{{ opt_keypair           | default(lookup('env', 'LOGNAME')+'_key') }}"
-openstack_ssh_public_key:       "{{ lookup('file', opt_public_key | default('~/.ssh/id_rsa.pub')) }}"
-openstack_ssh_access_from:      "{{ opt_ssh_from          | default('0.0.0.0/0') }}"
+openstack_infra_heat_stack:     "{{ lookup('oo_option', 'infra_heat_stack' ) |
+                                    default('files/heat_stack.yml',          True) }}"
+openstack_network_prefix:       "{{ lookup('oo_option', 'network_prefix'   ) |
+                                    default('openshift-ansible-'+cluster_id, True) }}"
+openstack_network_cidr:         "{{ lookup('oo_option', 'net_cidr'         ) |
+                                    default('192.168.' + ( ( 1048576 | random % 256 ) | string() ) + '.0/24', True) }}"
+openstack_network_external_net: "{{ lookup('oo_option', 'external_net'     ) |
+                                    default('external',                      True) }}"
+openstack_floating_ip_pools:    "{{ lookup('oo_option', 'floating_ip_pools') |
+                                    default('external',                      True) | oo_split() }}"
+openstack_network_dns:          "{{ lookup('oo_option', 'dns'              ) |
+                                    default('8.8.8.8,8.8.4.4',               True) | oo_split() }}"
+openstack_ssh_keypair:          "{{ lookup('oo_option', 'keypair'          ) |
+                                    default(lookup('env', 'LOGNAME')+'_key', True) }}"
+openstack_ssh_public_key:       "{{ lookup('file', lookup('oo_option', 'public_key') |
+                                    default('~/.ssh/id_rsa.pub',             True)) }}"
+openstack_ssh_access_from:      "{{ lookup('oo_option', 'ssh_from')          |
+                                    default('0.0.0.0/0',                     True) }}"
 openstack_flavor:
   master:
-    ram:     "{{ opt_master_flavor_ram     | default(2048) }}"
-    id:      "{{ opt_master_flavor_id      | default() }}"
-    include: "{{ opt_master_flavor_include | default() }}"
+    ram:     "{{ lookup('oo_option', 'master_flavor_ram'    ) | default(2048, True) }}"
+    id:      "{{ lookup('oo_option', 'master_flavor_id'     ) | default(True) }}"
+    include: "{{ lookup('oo_option', 'master_flavor_include') | default(True) }}"
   node:
-    ram:     "{{ opt_node_flavor_ram     | default(4096) }}"
-    id:      "{{ opt_node_flavor_id      | default() }}"
-    include: "{{ opt_node_flavor_include | default() }}"
+    ram:     "{{ lookup('oo_option', 'node_flavor_ram'      ) | default(4096, True) }}"
+    id:      "{{ lookup('oo_option', 'node_flavor_id'       ) | default(True) }}"
+    include: "{{ lookup('oo_option', 'node_flavor_include'  ) | default(True) }}"
 
 deployment_vars:
   origin:
     image:
-      name: "{{ opt_image_name | default('centos-70-raw') }}"
+      name: "{{ lookup('oo_option', 'image_name') | default('centos-70-raw', True) }}"
       id:
     ssh_user: openshift
     sudo: yes
@@ -33,7 +42,7 @@ deployment_vars:
     sudo: no
   enterprise:
     image:
-      name: "{{ opt_image_name | default('centos-70-raw') }}"
+      name: "{{ lookup('oo_option', 'image_name') | default('rhel-guest-image-7.1-20150224.0.x86_64', True) }}"
       id:
     ssh_user: openshift
     sudo: yes


### PR DESCRIPTION
And use it in the libvirt playbook

The idea is to provide a generic way to customize the behavior of openshift-ansible playbooks.

1. `bin/cluster` learnt the `--option <key>=<value>` command line parameter. This parameter can be specified several times
2. For each `--option <key>=<value>` parameter, `bin/cluster` creates a `opt_<key>` ansible variable. The variable is prefixed with `opt_` to avoid potential name conflicts and to prevent the end user from overriding ansible variables which were not intended to be set by him.
3. Inside the playbooks, the options can be read by the `oo_option` lookup plugin. For ex. `lookup('oo_option', '<key> default=<default_value>')` returns, by order of priority:
  1. if it exists, the `opt_<key>` ansible variable. This variable is set by `bin/cluster --option <key>=<value> …`
  2. if it exists, the envirnoment variable named `<key>` (for backward compatibility with how current AWS and GCE playbooks can be customized)
  3. if present, the `<default_value>` passed in the lookup statement
  4. if none of the above conditions are met, empty string is returned