### PR TITLE
Fix libvirt playbook

### DIFF
--- a/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
@@ -59,14 +59,14 @@
   with_items: instances
 
 - name: Wait for the VMs to get an IP
-  shell: 'virsh net-dhcp-leases openshift-ansible | egrep -c ''{{ instances | join("|") }}'''
+  shell: 'virsh -c {{ libvirt_uri }} net-dhcp-leases openshift-ansible | egrep -c ''{{ instances | join("|") }}'''
   register: nb_allocated_ips
   until: nb_allocated_ips.stdout == '{{ instances | length }}'
   retries: 30
   delay: 1
 
 - name: Collect IP addresses of the VMs
-  shell: 'virsh net-dhcp-leases openshift-ansible | awk ''$6 == "{{ item }}" {gsub(/\/.*/, "", $5); print $5}'''
+  shell: 'virsh -c {{ libvirt_uri }} net-dhcp-leases openshift-ansible | awk ''$6 == "{{ item }}" {gsub(/\/.*/, "", $5); print $5}'''
   register: scratch_ip
   with_items: instances
 


### PR DESCRIPTION
If we don’t explicitly specify the libvirt URI to use for virsh,
it will use the LIBVIRT_DEFAULT_URI environment variable.
For a consistent behavior, all `virsh` invocation must be done with
the `-c <libvirt_uri>` parameter.