### PR TITLE
WIP: RC1 work

### DIFF
--- a/README_OSE.md
+++ b/README_OSE.md
@@ -19,7 +19,7 @@
 * Either ssh key based auth for the root user or ssh key based auth for a user
   with sudo access (no password)
 * A checkout of openshift-ansible from https://github.com/openshift/openshift-ansible/
-  
+
   ```sh
   git clone https://github.com/openshift/openshift-ansible.git
   cd openshift-ansible

--- a/README_OSE.md
+++ b/README_OSE.md
@@ -80,7 +80,7 @@ ansible_ssh_user=root
 deployment_type=enterprise
 
 # Pre-release registry URL
-oreg_url=docker-buildvm-rhose.usersys.redhat.com:5000/openshift3_beta/ose-${component}:${version}
+oreg_url=docker-buildvm-rhose.usersys.redhat.com:5000/openshift3/ose-${component}:${version}
 
 # Pre-release additional repo
 openshift_additional_repos=[{'id': 'ose-devel', 'name': 'ose-devel',
@@ -121,7 +121,7 @@ On the master host:
 ```sh
 openshift ex router --create=true \
   --credentials=/var/lib/openshift/openshift.local.certificates/openshift-router/.kubeconfig \
-  --images='docker-buildvm-rhose.usersys.redhat.com:5000/openshift3_beta/ose-${component}:${version}'
+  --images='docker-buildvm-rhose.usersys.redhat.com:5000/openshift3/ose-${component}:${version}'
 ```
 
 #### Create the default docker-registry
@@ -129,7 +129,7 @@ On the master host:
 ```sh
 openshift ex registry --create=true \
   --credentials=/var/lib/openshift/openshift.local.certificates/openshift-registry/.kubeconfig \
-  --images='docker-buildvm-rhose.usersys.redhat.com:5000/openshift3_beta/ose-${component}:${version}' \
+  --images='docker-buildvm-rhose.usersys.redhat.com:5000/openshift3/ose-${component}:${version}' \
   --mount-host=/var/lib/openshift/docker-registry
 ```
 

--- a/inventory/byo/hosts
+++ b/inventory/byo/hosts
@@ -17,7 +17,7 @@ ansible_ssh_user=root
 deployment_type=enterprise
 
 # Pre-release registry URL
-oreg_url=docker-buildvm-rhose.usersys.redhat.com:5000/openshift3_beta/ose-${component}:${version}
+oreg_url=docker-buildvm-rhose.usersys.redhat.com:5000/openshift3/ose-${component}:${version}
 
 # Pre-release additional repo
 openshift_additional_repos=[{'id': 'ose-devel', 'name': 'ose-devel', 'baseurl': 'http://buildvm-devops.usersys.redhat.com/puddle/build/OpenShiftEnterprise/3.0/latest/RH7-RHOSE-3.0/$basearch/os', 'enabled': 1, 'gpgcheck': 0}]

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -50,7 +50,7 @@
     register: mktemp
     changed_when: False
 
-- name: Register nodes
+- name: Create node certificates
   hosts: oo_first_master
   vars:
     nodes_needing_certs: "{{ hostvars
@@ -60,7 +60,7 @@
                          | oo_select_keys(groups['oo_nodes_to_config']) }}"
     sync_tmpdir: "{{ hostvars.localhost.mktemp.stdout }}"
   roles:
-  - openshift_register_nodes
+  - openshift_node_certificates
   post_tasks:
   - name: Create a tarball of the node config directories
     command: >

--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -15,4 +15,3 @@
 
 - name: Set hostname
   hostname: name={{ openshift.common.hostname }}
-

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -1,3 +1,6 @@
+apiLevels:
+- v1beta3
+- v1
 apiVersion: v1
 assetConfig:
   logoutURL: ""
@@ -8,6 +11,8 @@ assetConfig:
     certFile: master.server.crt
     clientCA: ""
     keyFile: master.server.key
+    maxRequestsInFlight: 0
+    requestTimeoutSeconds: 0
 corsAllowedOrigins:
 {# TODO: add support for user specified corsAllowedOrigins #}
 {% for origin in ['127.0.0.1', 'localhost', openshift.common.hostname, openshift.common.ip, openshift.common.public_hostname, openshift.common.public_ip] %}
@@ -43,9 +48,9 @@ etcdConfig:
 {% endif %}
 etcdStorageConfig:
   kubernetesStoragePrefix: kubernetes.io
-  kubernetesStorageVersion: v1beta3
-  kubernetesStoragePrefix: kubernetes.io
-  openShiftStorageVersion: v1beta3
+  kubernetesStorageVersion: v1
+  openShiftStoragePrefix: openshift.io
+  openShiftStorageVersion: v1
 imageConfig:
   format: {{ openshift.master.registry_url }}
   latest: false
@@ -58,10 +63,17 @@ kubeletClientInfo:
   port: 10250
 {% if openshift.master.embedded_kube %}
 kubernetesMasterConfig:
+  apiLevels:
+  - v1beta3
+  - v1
+  apiServerArguments: null
+  controllerArguments: null
 {# TODO: support overriding masterCount #}
   masterCount: 1
   masterIP: ""
+  podEvictionTimeout: ""
   schedulerConfigFile: {{ openshift_master_scheduler_conf }}
+  servicesNodePortRange: ""
   servicesSubnet: {{ openshift.master.portal_net }}
   staticNodeNames: {{ openshift_node_ips | default([], true) }}
 {% endif %}
@@ -77,12 +89,17 @@ networkConfig:
 {% include 'v1_partials/oauthConfig.j2' %}
 policyConfig:
   bootstrapPolicyFile: {{ openshift_master_policy }}
+  openshiftInfrastructureNamespace: openshift-infra
   openshiftSharedResourcesNamespace: openshift
 {# TODO: Allow users to override projectConfig items #}
 projectConfig:
   defaultNodeSelector: ""
   projectRequestMessage: ""
   projectRequestTemplate: ""
+  securityAllocator:
+    mcsAllocatorRange: s0:/2
+    mcsLabelsPerProject: 5
+    uidAllocatorRange: 1000000000-1999999999/10000
 serviceAccountConfig:
   managedNames:
   - default
@@ -95,3 +112,5 @@ servingInfo:
   certFile: master.server.crt
   clientCA: ca.crt
   keyFile: master.server.key
+  maxRequestsInFlight: 0
+  requestTimeoutSeconds: 0

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -67,7 +67,6 @@ kubernetesMasterConfig:
 {% endif %}
 masterClients:
 {# TODO: allow user to set externalKubernetesKubeConfig #}
-  deployerKubeConfig: openshift-deployer.kubeconfig
   externalKubernetesKubeConfig: ""
   openshiftLoopbackKubeConfig: openshift-client.kubeconfig
 masterPublicURL: {{ openshift.master.public_api_url }}

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -2,6 +2,8 @@ allowDisabledDocker: false
 apiVersion: v1
 dnsDomain: {{ hostvars[openshift_first_master].openshift.dns.domain }}
 dnsIP: {{ hostvars[openshift_first_master].openshift.dns.ip }}
+dockerConfig:
+  execHandlerName: ""
 imageConfig:
   format: {{ openshift.node.registry_url }}
   latest: false
@@ -9,7 +11,7 @@ kind: NodeConfig
 masterKubeConfig: node.kubeconfig
 networkPluginName: {{ openshift.common.sdn_network_plugin_name }}
 nodeName: {{ openshift.common.hostname }}
-podManifestConfig: null
+podManifestConfig:
 servingInfo:
   bindAddress: 0.0.0.0:10250
   certFile: server.crt

--- a/roles/openshift_node_certificates/README.md
+++ b/roles/openshift_node_certificates/README.md
@@ -1,0 +1,34 @@
+OpenShift Node Certificates
+========================
+
+TODO
+
+Requirements
+------------
+
+TODO
+
+Role Variables
+--------------
+
+TODO
+
+Dependencies
+------------
+
+TODO
+
+Example Playbook
+----------------
+
+TODO
+
+License
+-------
+
+Apache License Version 2.0
+
+Author Information
+------------------
+
+Jason DeTiberus (jdetiber@redhat.com)

--- a/roles/openshift_node_certificates/meta/main.yml
+++ b/roles/openshift_node_certificates/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: Jason DeTiberus
+  description:
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 1.8
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+  - system
+dependencies:
+- { role: openshift_facts }

--- a/roles/openshift_node_certificates/tasks/main.yml
+++ b/roles/openshift_node_certificates/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: Create openshift_generated_configs_dir if it doesn't exist
+  file:
+    path: "{{ openshift_generated_configs_dir }}"
+    state: directory
+
+- name: Generate the node client config
+  command: >
+    {{ openshift.common.admin_binary }} create-api-client-config
+      --certificate-authority={{ openshift_master_ca_cert }}
+      --client-dir={{ openshift_generated_configs_dir }}/node-{{ item.openshift.common.hostname }}
+      --groups=system:nodes
+      --master={{ openshift.master.api_url }}
+      --signer-cert={{ openshift_master_ca_cert }}
+      --signer-key={{ openshift_master_ca_key }}
+      --signer-serial={{ openshift_master_ca_serial }}
+      --user=system:node-{{ item.openshift.common.hostname }}
+  args:
+    chdir: "{{ openshift_generated_configs_dir }}"
+    creates: "{{ openshift_generated_configs_dir }}/node-{{ item.openshift.common.hostname }}"
+  with_items: nodes_needing_certs
+
+- name: Generate the node server certificate
+  delegate_to: "{{ openshift_first_master }}"
+  command: >
+    {{ openshift.common.admin_binary }} create-server-cert
+      --cert=server.crt --key=server.key --overwrite=true
+      --hostnames={{ [item.openshift.common.hostname, item.openshift.common.public_hostname]|unique|join(",") }}
+      --signer-cert={{ openshift_master_ca_cert }}
+      --signer-key={{ openshift_master_ca_key }}
+      --signer-serial={{ openshift_master_ca_serial }}
+  args:
+    chdir: "{{ openshift_generated_configs_dir }}/node-{{ item.openshift.common.hostname }}"
+    creates: "{{ openshift_generated_configs_dir }}/node-{{ item.openshift.common.hostname }}/server.crt"
+  with_items: nodes_needing_certs

--- a/roles/openshift_node_certificates/vars/main.yml
+++ b/roles/openshift_node_certificates/vars/main.yml
@@ -1,0 +1,8 @@
+---
+openshift_node_config_dir: /etc/openshift/node
+openshift_master_config_dir: /etc/openshift/master
+openshift_generated_configs_dir: /etc/openshift/generated-configs
+openshift_master_ca_cert: "{{ openshift_master_config_dir }}/ca.crt"
+openshift_master_ca_key: "{{ openshift_master_config_dir }}/ca.key"
+openshift_master_ca_serial: "{{ openshift_master_config_dir }}/ca.serial.txt"
+openshift_kube_api_version: v1beta3

--- a/roles/openshift_register_nodes/README.md
+++ b/roles/openshift_register_nodes/README.md
@@ -1,27 +1,8 @@
 OpenShift Register Nodes
 ========================
 
-TODO
-
-Requirements
-------------
-
-TODO
-
-Role Variables
---------------
-
-TODO
-
-Dependencies
-------------
-
-TODO
-
-Example Playbook
-----------------
-
-TODO
+DEPRECATED!!!
+Nodes should now auto register themselves. Use openshift_node_certificates role instead.
 
 License
 -------

--- a/roles/openshift_register_nodes/tasks/main.yml
+++ b/roles/openshift_register_nodes/tasks/main.yml
@@ -46,5 +46,8 @@
     host_ip: "{{ item.openshift.common.ip }}"
     labels: "{{ item.openshift.node.labels | default({}) }}"
     annotations: "{{ item.openshift.node.annotations | default({}) }}"
+    client_context: default/ose3-master-example-com:8443/system:openshift-client
+    client_user: system:openshift-client/ose3-master-example-com:8443
+    client_cluster: ose3-master-example-com:8443
   with_items: openshift_nodes
   register: register_result


### PR DESCRIPTION
[x] Switches back to node auto registration, but leaves openshift_register_nodes role in place encase we want to switch to it for some reason
[x] Template sync w/ latest Rc1, though I didn't see anything new that I knew we'd want to change