### PR TITLE
create storage_nfs_lvm role

### DIFF
--- a/roles/openshift_storage_nfs_lvm/README.md
+++ b/roles/openshift_storage_nfs_lvm/README.md
@@ -1,0 +1,108 @@
+# openshift_storage_nfs_lvm
+
+This role is useful to create and export nfs disks for openshift persistent volumes.
+It does so by creating lvm partitions on an already setup pv/vg, creating xfs 
+filesystem on each partition, mounting the partitions, exporting the mounts via NFS
+and creating a json file for each mount that an openshift master can use to
+create persistent volumes.
+
+## Requirements
+
+* NFS server with NFS, iptables, and everything setup.
+
+* A lvm volume group created on the nfs server (default: openshiftvg)
+
+* The lvm volume needs to have as much free space as you are allocating
+
+## Role Variables
+
+```
+# Options of NFS exports.
+osnl_nfs_export_options: "*(rw,sync,all_squash)"
+
+# Directory, where the created partitions should be mounted. They will be
+# mounted as <osnl_mount_dir>/<lvm volume name> 
+osnl_mount_dir: /exports/openshift
+
+# Volume Group to use.
+# This role always assumes that there is enough free space on the volume
+#   group for all the partitions you will be making
+osnl_volume_group: openshiftvg
+
+# volume names
+# volume names are {{osnl_volume_prefix}}{{osnl_volume_size}}g{{volume number}}
+#   example: stg5g0004
+
+# osnl_volume_prefix
+# Useful if you are using the nfs server for more than one cluster
+osnl_volume_prefix: "stg"
+
+# osnl_volume_size
+# Size of the volumes/partitions in Gigabytes.
+osnl_volume_size: 5
+
+# osnl_volume_num_start
+# Where to start the volume number numbering.
+osnl_volume_num_start: 3
+
+# osnl_number_of_volumes
+# How many volumes/partitions to build, with the size we stated.
+osnl_number_of_volumes: 2
+
+```
+
+## Dependencies
+
+None
+
+## Example Playbook
+
+With this playbook, 2 5Gig lvm partitions are created, named stg5g0003 and stg5g0004
+Both of them are mounted into `/exports/openshift` directory.  Both directories are 
+exported via NFS.  json files are created in /root.
+
+    - hosts: nfsservers
+      sudo: no
+      remote_user: root
+      gather_facts: no
+      roles:
+        - role: openshift_storage_nfs_lvm
+          osnl_mount_dir: /exports/openshift
+          osnl_volume_prefix: "stg"
+          osnl_volume_size: 5
+          osnl_volume_num_start: 3
+          osnl_number_of_volumes: 2
+
+
+## Full example
+
+
+* Create an `inventory` file:
+    ```
+    [nfsservers]
+    10.0.0.1
+    10.0.0.2
+    ```
+
+* Create an ansible playbook, say `setupnfs.yaml`:
+    ```
+    - hosts: nfsservers
+      sudo: no
+      remote_user: root
+      gather_facts: no
+      roles:
+        - role: openshift_storage_nfs_lvm
+          osnl_mount_dir: /exports/stg
+          osnl_volume_prefix: "stg"
+          osnl_volume_size: 5
+          osnl_volume_num_start: 3
+          osnl_number_of_volumes: 2
+
+* Run the playbook:
+    ```
+    ansible-playbook -i inventory setupnfs.yml
+    ```
+
+## License
+
+Apache 2.0

--- a/roles/openshift_storage_nfs_lvm/defaults/main.yml
+++ b/roles/openshift_storage_nfs_lvm/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# Options of NFS exports.
+osnl_nfs_export_options: "*(rw,sync,all_squash)"
+
+# Directory, where the created partitions should be mounted. They will be
+# mounted as <osnl_mount_dir>/test1g0001 etc.
+osnl_mount_dir: /exports/openshift
+
+# Volume Group to use.
+osnl_volume_group: openshiftvg

--- a/roles/openshift_storage_nfs_lvm/handlers/main.yml
+++ b/roles/openshift_storage_nfs_lvm/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart nfs
+  service: name=nfs-server state=restarted

--- a/roles/openshift_storage_nfs_lvm/meta/main.yml
+++ b/roles/openshift_storage_nfs_lvm/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: Jan Safranek, Troy Dawson
+  description: Create LVM volumes and use them as openshift persistent volumes.
+  company: Red Hat, Inc.
+  license: license (Apache)
+  min_ansible_version: 1.4
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  - name: Fedora
+    versions:
+    - all
+  categories:
+    - openshift

--- a/roles/openshift_storage_nfs_lvm/tasks/main.yml
+++ b/roles/openshift_storage_nfs_lvm/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Create lvm volumes
+  lvol: vg={{osnl_volume_group}} lv={{ item }} size={{osnl_volume_size}}G
+  with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
+
+- name: create filesystem
+  filesystem: fstype=xfs dev=/dev/{{osnl_volume_group}}/{{ item }}
+  with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
+
+- name: mount volumes
+  mount: name={{osnl_mount_dir}}/{{ item }} src=/dev/{{osnl_volume_group}}/{{ item }} state=mounted fstype=xfs passno=0
+  with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
+
+- name: Make mounts owned by nfsnobody
+  file: path={{osnl_mount_dir}}/{{ item }} owner=nfsnobody group=nfsnobody mode=0700
+  with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
+
+- include: nfs.yml
+
+- name: Create volume json file
+  template: src=../templates/nfs.json.j2 dest=/root/persistent-volume.{{ item }}.json
+  with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
+
+# TODO - Get the json files to an openshift-master, and load them.

--- a/roles/openshift_storage_nfs_lvm/tasks/nfs.yml
+++ b/roles/openshift_storage_nfs_lvm/tasks/nfs.yml
@@ -1,0 +1,16 @@
+---
+- name: Install NFS server
+  yum: name=nfs-utils state=present
+
+- name: Start rpcbind
+  service: name=rpcbind state=started enabled=yes
+
+- name: Start nfs
+  service: name=nfs-server state=started enabled=yes
+
+- name: Export the directories
+  lineinfile: dest=/etc/exports
+              regexp="^{{ osnl_mount_dir }}/{{ item }} "
+              line="{{ osnl_mount_dir }}/{{ item }} {{osnl_nfs_export_options}}"
+  with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
+  notify: restart nfs

--- a/roles/openshift_storage_nfs_lvm/templates/nfs.json.j2
+++ b/roles/openshift_storage_nfs_lvm/templates/nfs.json.j2
@@ -1,0 +1,21 @@
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolume",
+  "metadata": {
+    "name": "pv-{{ inventory_hostname | regex_replace("\.", "-")  }}-{{ item }}",
+    "labels": {
+      "type": "nfs"
+    }
+  },
+  "spec": {
+    "capacity": {
+      "storage": "{{ osnl_volume_size }}Gi"
+    },
+    "accessModes": [ "ReadWriteMany" ],
+    "persistentVolumeReclaimPolicy": "Recycle",
+    "nfs": {
+      "Server": "{{ inventory_hostname }}",
+      "Path": "{{ osnl_mount_dir }}/{{ item }}"
+    }
+  }
+}


### PR DESCRIPTION
This role is useful to create and export nfs disks for openshift persistent volumes.
It does so by creating lvm partitions on an already setup pv/vg, creating xfs 
filesystem on each partition, mounting the partitions, exporting the mounts via NFS
and creating a json file for each mount that an openshift master can use to
create persistent volumes.