### PR TITLE
Adding support for labeling nodes as unscheduleable

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -73,3 +73,24 @@
 
 - name: Start and enable openshift-node
   service: name=openshift-node enabled=yes state=started
+
+- name: Check scheduleable state
+  delegate_to: "{{ openshift_first_master }}"
+  command: >
+    {{ openshift.common.client_binary }} get node {{ inventory_hostname }}
+  register: ond_get_node
+  until: ond_get_node.rc == 0
+  retries: 10
+  delay: 5
+
+- name: Handle unscheduleable node
+  delegate_to: "{{ openshift_first_master }}"
+  command: >
+    {{ openshift.common.admin_binary }} manage-node {{ inventory_hostname }} --schedulable=false
+  when: openshift_scheduleable is defined and openshift_scheduleable == False and "SchedulingDisabled" not in ond_get_node.stdout
+
+- name: Handle scheduleable node
+  delegate_to: "{{ openshift_first_master }}"
+  command: >
+    {{ openshift.common.admin_binary }} manage-node {{ inventory_hostname }} --schedulable=true
+  when: (openshift_scheduleable is not defined or openshift_scheduleable == True) and "SchedulingDisabled" in ond_get_node.stdout


### PR DESCRIPTION
For idempotency it first checks the output of 'oc get node <hostname>' to see
if any action needs to be taken.  The trick was waiting to make sure that the
node autoregistration had actually happened.

If you set openshift_scheduleable=False in the inventory then the node will be
marked as unscheduleable.  Likewise setting it to True undoes the change.
Having openshift_scheduleable undefined is the same as True since that is the
default state of a Node.