### PR TITLE
Update README_origin.md

### DIFF
--- a/README_origin.md
+++ b/README_origin.md
@@ -91,14 +91,14 @@ inventory file use the -i option for ansible-playbook.
 #### Create the default router
 On the master host:
 ```sh
-openshift ex router --create=true \
+openshift admin router --create=true \
   --credentials=/etc/openshift/master/openshift-router.kubeconfig
 ```
 
 #### Create the default docker-registry
 On the master host:
 ```sh
-openshift ex registry --create=true \
+openshift admin registry --create=true \
   --credentials=/etc/openshift/master/openshift-registry.kubeconfig \
   --mount-host=/var/lib/openshift/docker-registry
 ```


### PR DESCRIPTION
Old version specified openshift ex (experimental command) in the instructions rather than the correct openshift admin.