### PR TITLE
Latest docker ships docker-storage-setup

### DIFF
--- a/playbooks/aws/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/aws/openshift-cluster/tasks/launch_instances.yml
@@ -51,7 +51,7 @@
 
 - set_fact:
     latest_ami: "{{ ami_result.results | oo_ami_selector(ec2_image_name) }}"
-    user_data: "{{ lookup('template', '../templates/user_data.j2') if type == 'node' else None | default('omit') }}"
+    user_data: "{{ lookup('template', '../templates/user_data.j2') }}"
     volume_defs:
       master:
         root:

--- a/playbooks/aws/openshift-cluster/templates/user_data.j2
+++ b/playbooks/aws/openshift-cluster/templates/user_data.j2
@@ -1,4 +1,6 @@
 #cloud-config
+devices: ['/var'] # Workaround for https://bugs.launchpad.net/bugs/1455436
+
 mounts:
 - [ xvdb ]
 - [ ephemeral0 ]
@@ -13,4 +15,9 @@ write_files:
 
 {% if deployment_type == 'online' %}
 disable_root: 0
+growpart:
+  mode: auto
+  devices: ['/var']
+runcmd:
+- xfs_growfs /var
 {% endif %}

--- a/playbooks/aws/openshift-cluster/templates/user_data.j2
+++ b/playbooks/aws/openshift-cluster/templates/user_data.j2
@@ -1,17 +1,4 @@
 #cloud-config
-yum_repos:
-  jdetiber-copr:
-    name: Copr repo for origin owned by jdetiber
-    baseurl: https://copr-be.cloud.fedoraproject.org/results/jdetiber/origin/epel-7-$basearch/
-    skip_if_unavailable: true
-    gpgcheck: true
-    gpgkey: https://copr-be.cloud.fedoraproject.org/results/jdetiber/origin/pubkey.gpg
-    enabled: true
-
-packages:
-- xfsprogs # can be dropped after docker-storage-setup properly requires it: https://github.com/projectatomic/docker-storage-setup/pull/8
-- docker-storage-setup
-
 mounts:
 - [ xvdb ]
 - [ ephemeral0 ]
@@ -24,6 +11,6 @@ write_files:
   owner: root:root
   permissions: '0644'
 
-runcmd:
-- systemctl daemon-reload
-- systemctl enable lvm2-lvmetad.service docker-storage-setup.service
+{% if deployment_type == 'online' %}
+disable_root: 0
+{% endif %}

--- a/playbooks/aws/openshift-cluster/templates/user_data.j2
+++ b/playbooks/aws/openshift-cluster/templates/user_data.j2
@@ -1,6 +1,5 @@
 #cloud-config
-devices: ['/var'] # Workaround for https://bugs.launchpad.net/bugs/1455436
-
+{% if type == 'node' %}
 mounts:
 - [ xvdb ]
 - [ ephemeral0 ]
@@ -12,8 +11,11 @@ write_files:
   path: /etc/sysconfig/docker-storage-setup
   owner: root:root
   permissions: '0644'
+{% endif %}
 
 {% if deployment_type == 'online' %}
+devices: ['/var'] # Workaround for https://bugs.launchpad.net/bugs/1455436
+
 disable_root: 0
 growpart:
   mode: auto


### PR DESCRIPTION
@tdawson I haven't tested this change independently, but it should do the right thing IRT keeping root enabled (for the online deployment_type) and fixing the docker-storage-setup stuff since it now ships with the latest docker package.