### PR TITLE
Reference deployment_type instead of hardcoding origin

### DIFF
--- a/README_vagrant.md
+++ b/README_vagrant.md
@@ -2,8 +2,27 @@ Requirements
 ------------
 - vagrant (tested against version 1.7.2)
 - vagrant-hostmanager plugin (tested against version 1.5.0)
+- vagrant-registration plugin (only required for enterprise deployment type)
 - vagrant-libvirt (tested against version 0.0.26)
   - Only required if using libvirt instead of virtualbox
+
+For ``enterprise`` deployment types the base RHEL box has to be added to Vagrant:
+
+1. Download the RHEL7 vagrant image (libvirt or virtualbox) available from the [Red Hat Container Development Kit downloads in the customer portal](https://access.redhat.com/downloads/content/293/ver=1/rhel---7/1.0.1/x86_64/product-downloads)
+
+2. Install it into vagrant
+
+   ``$ vagrant box add --name rhel-7 /path/to/rhel-server-libvirt-7.1-3.x86_64.box``
+
+3. (optional, recommended) Increase the disk size of the image to 20GB - This is a two step process. (these instructions are specific to libvirt)
+
+    Resize the actual qcow2 image:
+
+	``$ qemu-img resize ~/.vagrant.d/boxes/rhel-7/0/libvirt/box.img 20GB``
+
+    Edit `~/.vagrant.d/boxes/rhel-7/0/libvirt/metadata.json` to reflect the new size.  A corrected metadata.json looks like this:
+
+	``{"provider": "libvirt", "format": "qcow2", "virtual_size": 20}``
 
 Usage
 -----
@@ -21,5 +40,10 @@ vagrant provision
 Environment Variables
 ---------------------
 The following environment variables can be overriden:
-- OPENSHIFT_DEPLOYMENT_TYPE (defaults to origin, choices: origin, enterprise, online)
-- OPENSHIFT_NUM_NODES (the number of nodes to create, defaults to 2)
+- ``OPENSHIFT_DEPLOYMENT_TYPE`` (defaults to origin, choices: origin, enterprise, online)
+- ``OPENSHIFT_NUM_NODES`` (the number of nodes to create, defaults to 2)
+
+For ``enterprise`` deployment types these env variables should also be specified:
+- ``rhel_subscription_user``: rhsm user
+- ``rhel_subscription_pass``: rhsm password
+- (optional) ``rhel_subscription_pool``: poolID to attach a specific subscription besides what auto-attach detects

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         "nodes"   => ["node1", "node2"],
       }
       ansible.extra_vars = {
-        openshift_deployment_type: "origin",
+        openshift_deployment_type: deployment_type,
       }
       ansible.playbook = "playbooks/byo/config.yml"
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,7 +83,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         "nodes"   => ["master", "node1", "node2"],
       }
       ansible.extra_vars = {
-        openshift_deployment_type: deployment_type,
+        deployment_type: deployment_type,
       }
       ansible.playbook = "playbooks/byo/vagrant.yml"
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,28 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.hostmanager.manage_host = true
   config.hostmanager.include_offline = true
   config.ssh.insert_key = false
+
+  if deployment_type === 'enterprise'
+    unless Vagrant.has_plugin?('vagrant-registration')
+      raise 'vagrant-registration-plugin is required for enterprise deployment'
+    end
+    username = ENV['rhel_subscription_user']
+    password = ENV['rhel_subscription_pass']
+    unless username and password
+      raise 'rhel_subscription_user and rhel_subscription_pass are required'
+    end
+    config.registration.username = username
+    config.registration.password = password
+    # FIXME this is temporary until vagrant/ansible registration modules
+    # are capable of handling specific subscription pools
+    if not ENV['rhel_subscription_pool'].nil?
+      config.vm.provision "shell" do |s|
+        s.inline = "subscription-manager attach --pool=$1 || true"
+        s.args = "#{ENV['rhel_subscription_pool']}"
+      end
+    end
+  end
+
   config.vm.provider "virtualbox" do |vbox, override|
     override.vm.box = "chef/centos-7.1"
     vbox.memory = 1024
@@ -28,10 +50,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     libvirt.cpus = 2
     libvirt.memory = 1024
     libvirt.driver = 'kvm'
-    override.vm.box = "centos-7.1"
-    override.vm.box_url = "https://download.gluster.org/pub/gluster/purpleidea/vagrant/centos-7.1/centos-7.1.box"
-    override.vm.box_download_checksum = "b2a9f7421e04e73a5acad6fbaf4e9aba78b5aeabf4230eebacc9942e577c1e05"
-    override.vm.box_download_checksum_type = "sha256"
+    case deployment_type
+    when "enterprise"
+      override.vm.box = "rhel-7"
+    when "origin"
+      override.vm.box = "centos-7.1"
+      override.vm.box_url = "https://download.gluster.org/pub/gluster/purpleidea/vagrant/centos-7.1/centos-7.1.box"
+      override.vm.box_download_checksum = "b2a9f7421e04e73a5acad6fbaf4e9aba78b5aeabf4230eebacc9942e577c1e05"
+      override.vm.box_download_checksum_type = "sha256"
+    end
   end
 
   num_nodes.times do |n|
@@ -53,12 +80,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.sudo = true
       ansible.groups = {
         "masters" => ["master"],
-        "nodes"   => ["node1", "node2"],
+        "nodes"   => ["master", "node1", "node2"],
       }
       ansible.extra_vars = {
         openshift_deployment_type: deployment_type,
       }
-      ansible.playbook = "playbooks/byo/config.yml"
+      ansible.playbook = "playbooks/byo/vagrant.yml"
     end
   end
 end

--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -1,10 +1,10 @@
 ---
 - hosts: all
   vars:
-    deployment_type: "{{ openshift_deployment_type }}"
+    openshift_deployment_type: "{{ deployment_type }}"
   roles:
   - role: rhel_subscribe
-    when: openshift_deployment_type == "enterprise" and
+    when: deployment_type == "enterprise" and
           ansible_distribution == "RedHat" and
           lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
           default('no', True) | lower in ['no', 'false']

--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+  vars:
+    deployment_type: "{{ openshift_deployment_type }}"
+  roles:
+  - role: rhel_subscribe
+    when: openshift_deployment_type == "enterprise" and
+          ansible_distribution == "RedHat" and
+          lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
+          default('no', True) | lower in ['no', 'false']
+  - openshift_repos
+  - os_update_latest

--- a/playbooks/byo/vagrant.yml
+++ b/playbooks/byo/vagrant.yml
@@ -1,14 +1,4 @@
 ---
-- hosts: all
-  vars:
-    deployment_type: "{{ openshift_deployment_type }}"
-  roles:
-  - role: rhel_subscribe
-    when: openshift_deployment_type == "enterprise" and
-          ansible_distribution == "RedHat" and
-          lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
-          default('no', True) | lower in ['no', 'false']
-  - openshift_repos
-  - os_update_latest
+- include: rhel_subscribe.yml
 
 - include: config.yml

--- a/playbooks/byo/vagrant.yml
+++ b/playbooks/byo/vagrant.yml
@@ -1,0 +1,14 @@
+---
+- hosts: all
+  vars:
+    deployment_type: "{{ openshift_deployment_type }}"
+  roles:
+  - role: rhel_subscribe
+    when: openshift_deployment_type == "enterprise" and
+          ansible_distribution == "RedHat" and
+          lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
+          default('no', True) | lower in ['no', 'false']
+  - openshift_repos
+  - os_update_latest
+
+- include: config.yml


### PR DESCRIPTION
The Vagrantfile hardcodes "origin" as the deployment type, should use the env variable value instead.
