### PR TITLE
Replace outdated beta repo ids with 3.0 release

### DIFF
--- a/README_OSE.md
+++ b/README_OSE.md
@@ -46,7 +46,7 @@ subscription-manager repos --disable="*"
 subscription-manager repos \
 --enable="rhel-7-server-rpms" \
 --enable="rhel-7-server-extras-rpms" \
---enable="rhel-server-7-ose-beta-rpms"
+--enable="rhel-7-server-ose-3.0-rpms"
 ```
 * Configuration of router is not automated yet
 * Configuration of docker-registry is not automated yet

--- a/README_origin.md
+++ b/README_origin.md
@@ -35,7 +35,7 @@ subscription-manager repos --disable="*"
 subscription-manager repos \
 --enable="rhel-7-server-rpms" \
 --enable="rhel-7-server-extras-rpms" \
---enable="rhel-server-7-ose-beta-rpms"
+--enable="rhel-7-server-ose-3.0-rpms"
 ```
 * Configuration of router is not automated yet
 * Configuration of docker-registry is not automated yet

--- a/roles/openshift_common/README.md
+++ b/roles/openshift_common/README.md
@@ -7,7 +7,7 @@ Requirements
 ------------
 
 A RHEL 7.1 host pre-configured with access to the rhel-7-server-rpms,
-rhel-7-server-extra-rpms, and rhel-7-server-ose-beta-rpms repos.
+rhel-7-server-extra-rpms, and rhel-7-server-ose-3.0-rpms repos.
 
 Role Variables
 --------------

--- a/roles/openshift_master/README.md
+++ b/roles/openshift_master/README.md
@@ -7,7 +7,7 @@ Requirements
 ------------
 
 A RHEL 7.1 host pre-configured with access to the rhel-7-server-rpms,
-rhel-7-server-extras-rpms, and rhel-server-7-ose-beta-rpms repos.
+rhel-7-server-extras-rpms, and rhel-7-server-ose-3.0-rpms repos.
 
 Role Variables
 --------------

--- a/roles/openshift_node/README.md
+++ b/roles/openshift_node/README.md
@@ -9,7 +9,7 @@ Requirements
 One or more OpenShift Master servers.
 
 A RHEL 7.1 host pre-configured with access to the rhel-7-server-rpms,
-rhel-7-server-extras-rpms, and rhel-server-7-ose-beta-rpms repos.
+rhel-7-server-extras-rpms, and rhel-7-server-ose-3.0-rpms repos.
 
 Role Variables
 --------------

--- a/roles/openshift_repos/README.md
+++ b/roles/openshift_repos/README.md
@@ -7,7 +7,7 @@ Requirements
 ------------
 
 A RHEL 7.1 host pre-configured with access to the rhel-7-server-rpms,
-rhel-7-server-extra-rpms, and rhel-7-server-ose-beta-rpms repos.
+rhel-7-server-extra-rpms, and rhel-7-server-ose-3.0-rpms repos.
 
 Role Variables
 --------------


### PR DESCRIPTION
Remove beta repo and use rhel-7-server-ose-3.0-rpms instead.