### PR TITLE
Fix git/pylint.sh

### DIFF
--- a/git/pylint.sh
+++ b/git/pylint.sh
@@ -15,7 +15,9 @@ NEWREV=$2
 
 PYTHON=/var/lib/jenkins/python27/bin/python
 
+set +e
 PY_DIFF=$(/usr/bin/git diff --name-only $OLDREV $NEWREV --diff-filter=ACM | grep ".py$")
+set -e
 
 FILES_TO_TEST=""
 
@@ -40,5 +42,7 @@ done
 
 if [ "${FILES_TO_TEST}" != "" ]; then
   echo "Testing files: ${FILES_TO_TEST}"
-  ${PYTHON} -m pylint --rcfile ${WORKSPACE}/git/.pylintrc ${FILES_TO_TEST}
+  exec ${PYTHON} -m pylint --rcfile ${WORKSPACE}/git/.pylintrc ${FILES_TO_TEST}
+else
+  exit 0
 fi


### PR DESCRIPTION
When a PR contains no python file, the very last command executed by `git/pylint.sh`
is `git diff --name-only … | grep ".py$"`.
This command exits with a non-zero exit code because grep has no match.
Because of the `set -e` option, the script aborts there immediately.

When a PR contains python files, `git/pylint.sh` exit code must be the one of `pylint`
When a PR doesn’t contain any python file, `git/pylint.sh` exit code must be 0.