### PR TITLE
Fix etcd default interface

### DIFF
--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-etcd_interface: eth0
+etcd_interface: "{{ ansible_default_ipv4.interface }}"
 etcd_client_port: 2379
 etcd_peer_port: 2380
 etcd_peers_group: etcd


### PR DESCRIPTION
- instead of hardcoding to eth0, use the interface associated with the ipv4
  default route as the default instead.