### PR TITLE
storage/nfs_lvm: Also export as ReadWriteOnce

### DIFF
--- a/roles/openshift_storage_nfs_lvm/templates/nfs.json.j2
+++ b/roles/openshift_storage_nfs_lvm/templates/nfs.json.j2
@@ -11,7 +11,7 @@
     "capacity": {
       "storage": "{{ osnl_volume_size }}Gi"
     },
-    "accessModes": [ "ReadWriteMany" ],
+    "accessModes": [ "ReadWriteOnce", "ReadWriteMany" ],
     "persistentVolumeReclaimPolicy": "Recycle",
     "nfs": {
       "Server": "{{ inventory_hostname }}",


### PR DESCRIPTION
While NFS supports `ReadWriteMany`, it's very common for pod authors
to only need `ReadWriteOnce`.  At the moment, kube will not auto-bind
a `RWO` claim to a `RWM` volume.
