### PR TITLE
Fix generation of node certificates

### DIFF
--- a/roles/openshift_node_certificates/tasks/main.yml
+++ b/roles/openshift_node_certificates/tasks/main.yml
@@ -25,7 +25,7 @@
   command: >
     {{ openshift.common.admin_binary }} create-server-cert
       --cert=server.crt --key=server.key --overwrite=true
-      --hostnames={{ openshift.common.all_hostnames |join(",") }}
+      --hostnames={{ item.openshift.common.all_hostnames |join(",") }}
       --signer-cert={{ openshift_master_ca_cert }}
       --signer-key={{ openshift_master_ca_key }}
       --signer-serial={{ openshift_master_ca_serial }}


### PR DESCRIPTION
@sdodson found it!  Instead of using the all_hostnames variable from the node, I was using the one from the first master.