### PR TITLE
Bug 1246458 - dnsIP does not point to cluster IP

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -59,7 +59,7 @@
   openshift_facts:
     role: dns
     local_facts:
-      ip: "{{ openshift.common.ip }}"
+      ip: "{{ openshift_master_cluster_vip | default(openshift.common.ip, true) | default(None) }}"
       domain: cluster.local
   when: openshift.master.embedded_dns
 


### PR DESCRIPTION
- Previously when configuring an HA cluster for multi-master the dns ip in the
  node config was pointing only to the first master instead of the cluster ip.