### PR TITLE
Use AWS m4 instances types

### DIFF
--- a/README_AWS.md
+++ b/README_AWS.md
@@ -40,7 +40,7 @@ Alternatively, you can configure your ssh-agent to hold the credentials to conne
 
 By default, a cluster is launched with the following configuration:
 
-- Instance type: m3.large
+- Instance type: m4.large
 - AMI: ami-307b3658 (for online deployments, ami-acd999c4 for origin deployments and ami-10663b78 for enterprise deployments)
 - Region: us-east-1
 - Keypair name: libra
@@ -62,7 +62,7 @@ Node specific defaults:
 
 If needed, these values can be changed by setting environment variables on your system.
 
-- export ec2_instance_type='m3.large'
+- export ec2_instance_type='m4.large'
 - export ec2_image='ami-307b3658'
 - export ec2_region='us-east-1'
 - export ec2_keypair='libra'

--- a/playbooks/aws/openshift-cluster/library/ec2_ami_find.py
+++ b/playbooks/aws/openshift-cluster/library/ec2_ami_find.py
@@ -158,7 +158,7 @@ EXAMPLES = '''
 # Launch an EC2 instance
 - ec2:
     image: "{{ ami_search.results[0].ami_id }}"
-    instance_type: m3.medium
+    instance_type: m4.medium
     key_name: mykey
     wait: yes
 '''

--- a/playbooks/aws/openshift-cluster/vars.online.int.yml
+++ b/playbooks/aws/openshift-cluster/vars.online.int.yml
@@ -3,13 +3,13 @@ ec2_image: ami-9101c8fa
 ec2_image_name: libra-ops-rhel7*
 ec2_region: us-east-1
 ec2_keypair: mmcgrath_libra
-ec2_master_instance_type: m3.large
+ec2_master_instance_type: m4.large
 ec2_master_security_groups: [ 'integration', 'integration-master' ]
-ec2_infra_instance_type: m3.large
+ec2_infra_instance_type: m4.large
 ec2_infra_security_groups: [ 'integration', 'integration-infra' ]
-ec2_node_instance_type: m3.large
+ec2_node_instance_type: m4.large
 ec2_node_security_groups: [ 'integration', 'integration-node' ]
-ec2_etcd_instance_type: m3.large
+ec2_etcd_instance_type: m4.large
 ec2_etcd_security_groups: [ 'integration', 'integration-etcd' ]
 ec2_vpc_subnet: subnet-987c0def
 ec2_assign_public_ip: yes

--- a/playbooks/aws/openshift-cluster/vars.online.prod.yml
+++ b/playbooks/aws/openshift-cluster/vars.online.prod.yml
@@ -3,13 +3,13 @@ ec2_image: ami-9101c8fa
 ec2_image_name: libra-ops-rhel7*
 ec2_region: us-east-1
 ec2_keypair: mmcgrath_libra
-ec2_master_instance_type: m3.large
+ec2_master_instance_type: m4.large
 ec2_master_security_groups: [ 'production', 'production-master' ]
-ec2_infra_instance_type: m3.large
+ec2_infra_instance_type: m4.large
 ec2_infra_security_groups: [ 'production', 'production-infra' ]
-ec2_node_instance_type: m3.large
+ec2_node_instance_type: m4.large
 ec2_node_security_groups: [ 'production', 'production-node' ]
-ec2_etcd_instance_type: m3.large
+ec2_etcd_instance_type: m4.large
 ec2_etcd_security_groups: [ 'production', 'production-etcd' ]
 ec2_vpc_subnet: subnet-987c0def
 ec2_assign_public_ip: yes

--- a/playbooks/aws/openshift-cluster/vars.online.stage.yml
+++ b/playbooks/aws/openshift-cluster/vars.online.stage.yml
@@ -3,13 +3,13 @@ ec2_image: ami-9101c8fa
 ec2_image_name: libra-ops-rhel7*
 ec2_region: us-east-1
 ec2_keypair: mmcgrath_libra
-ec2_master_instance_type: m3.large
+ec2_master_instance_type: m4.large
 ec2_master_security_groups: [ 'stage', 'stage-master' ]
-ec2_infra_instance_type: m3.large
+ec2_infra_instance_type: m4.large
 ec2_infra_security_groups: [ 'stage', 'stage-infra' ]
-ec2_node_instance_type: m3.large
+ec2_node_instance_type: m4.large
 ec2_node_security_groups: [ 'stage', 'stage-node' ]
-ec2_etcd_instance_type: m3.large
+ec2_etcd_instance_type: m4.large
 ec2_etcd_security_groups: [ 'stage', 'stage-etcd' ]
 ec2_vpc_subnet: subnet-987c0def
 ec2_assign_public_ip: yes

--- a/playbooks/aws/openshift-cluster/vars.yml
+++ b/playbooks/aws/openshift-cluster/vars.yml
@@ -8,7 +8,7 @@ deployment_vars:
     ssh_user: fedora
     sudo: yes
     keypair: libra
-    type: m3.large
+    type: m4.large
     security_groups: [ 'public' ]
     vpc_subnet:
     assign_public_ip:
@@ -20,7 +20,7 @@ deployment_vars:
     ssh_user: root
     sudo: no
     keypair: libra
-    type: m3.large
+    type: m4.large
     security_groups: [ 'public' ]
     vpc_subnet:
     assign_public_ip:
@@ -32,7 +32,7 @@ deployment_vars:
     ssh_user: ec2-user
     sudo: yes
     keypair: libra
-    type: m3.large
+    type: m4.large
     security_groups: [ 'public' ]
     vpc_subnet:
     assign_public_ip:


### PR DESCRIPTION
AWS m4 replaces m3 and is a bit cheaper.