### PR TITLE
Add LDAPPasswordIdentityProvider bits to identity_provider_config macro.

### DIFF
--- a/roles/openshift_master/templates/v1_partials/oauthConfig.j2
+++ b/roles/openshift_master/templates/v1_partials/oauthConfig.j2
@@ -10,6 +10,20 @@
       {{ key }}: {{ identity_provider[key] }}"
 {% endif %}
 {% endfor %}
+{% elif identity_provider.kind == 'LDAPPasswordIdentityProvider' %}
+      attributes:
+{% for attribute_key in identity_provider.attributes %}
+        {{ attribute_key }}:
+{% for attribute_value in identity_provider.attributes[attribute_key] %}
+        - {{ attribute_value }}
+{% endfor %}
+{% endfor %}
+{% for key in ('bindDN', 'bindPassword', 'ca') %}
+      {{ key }}: "{{ identity_provider[key] }}"
+{% endfor %}
+{% for key in ('insecure', 'url') %}
+      {{ key }}: {{ identity_provider[key] }}
+{% endfor %}
 {% elif identity_provider.kind == 'RequestHeaderIdentityProvider' %}
       headers: {{ identity_provider.headers }}
 {% if 'clientCA' in identity_provider %}


### PR DESCRIPTION
Adds LDAPPasswordIdentityProvider section to the identity_provider_config macro for #345.

Changes allow for `bindDN`, `bindPassword` and `ca` keys to be empty.

Example config section:
```
  identityProviders:
  - name: "my_ldap_provider"
    challenge: true
    login: true
    provider:
      apiVersion: v1
      kind: LDAPPasswordIdentityProvider
      attributes:
        id:
        - dn
        email:
        - mail
        name:
        - cn
        preferredUsername:
        - uid
      bindDN: ""
      bindPassword: ""
      ca: my-ldap-ca-bundle.crt
      insecure: false
      url: "ldap://ldap.example.com/ou=users,dc=acme,dc=com?uid"
```

Tested with /etc/ansible/hosts variable line:
```
openshift_master_identity_providers=[{'name': 'my_ldap_provider', 'challenge': 'true', 'login': 'true', 'kind': 'LDAPPasswordIdentityProvider', 'attributes': {'id': ['dn'], 'email': ['mail'], 'name': ['cn'], 'preferredUsername': ['uid']}, 'bindDN': '', 'bindPassword': '', 'ca': 'my-ldap-ca-bundle.crt', 'insecure': 'false', 'url': 'ldap://ldap.example.com/ou=users,dc=acme,dc=com?uid'}]
```