### PR TITLE
Fine tune RHEL repos

### DIFF
--- a/roles/rhel_subscribe/tasks/enterprise.yml
+++ b/roles/rhel_subscribe/tasks/enterprise.yml
@@ -6,5 +6,4 @@
   command: subscription-manager repos \
                --enable="rhel-7-server-rpms" \
                --enable="rhel-7-server-extras-rpms" \
-               --enable="rhel-7-server-optional-rpms" \
                --enable="rhel-7-server-ose-3.0-rpms"

--- a/roles/rhel_subscribe/tasks/enterprise.yml
+++ b/roles/rhel_subscribe/tasks/enterprise.yml
@@ -1,5 +1,10 @@
 ---
+- name: Disable all repositories
+  command: subscription-manager repos --disable="*"
+
 - name: Enable RHEL repositories
   command: subscription-manager repos \
                --enable="rhel-7-server-rpms" \
+               --enable="rhel-7-server-extras-rpms" \
+               --enable="rhel-7-server-optional-rpms" \
                --enable="rhel-7-server-ose-3.0-rpms"


### PR DESCRIPTION
Sometimes repos might be polluted (e.g. depending on the result of rhsm auto-attach). Disalbe all repos before explicitly enable the needed ones.

Also enable Extras and Optional repos.