### PR TITLE
Ae ansible merge services configs

### DIFF
--- a/bin/cluster
+++ b/bin/cluster
@@ -269,6 +269,9 @@ if __name__ == '__main__':
     meta_parser.add_argument('-t', '--deployment-type',
                              choices=['origin', 'online', 'enterprise'],
                              help='Deployment type. (default: origin)')
+    meta_parser.add_argument('-T', '--product-type',
+                             choices=['openshift' 'atomic-enterprise'],
+                             help='Product type. (default: openshift)')
     meta_parser.add_argument('-o', '--option', action='append',
                              help='options')
 

--- a/bin/cluster
+++ b/bin/cluster
@@ -38,6 +38,21 @@ class Cluster(object):
             deployment_type = os.environ['OS_DEPLOYMENT_TYPE']
         return deployment_type
 
+
+    def get_product_type(self, args):
+        """
+        Get the product_type based on the environment variables and the
+        command line arguments
+        :param args: command line arguments provided by the user
+        :return: string representing the product type
+        """
+        product_type = 'openshift'
+        if args.product_type:
+            product_type = args.product_type
+        elif 'OS_DEPLOYMENT_TYPE' in os.environ:
+            product_type = os.environ['OS_DEPLOYMENT_TYPE']
+        return product_type
+
     def create(self, args):
         """
         Create an OpenShift cluster for given provider
@@ -45,7 +60,8 @@ class Cluster(object):
         :return: exit status from run command
         """
         env = {'cluster_id': args.cluster_id,
-               'deployment_type': self.get_deployment_type(args)}
+               'deployment_type': self.get_deployment_type(args),
+               'product_type': self.get_product_type(args)}
         playbook = "playbooks/{}/openshift-cluster/launch.yml".format(args.provider)
         inventory = self.setup_provider(args.provider)
 
@@ -63,7 +79,8 @@ class Cluster(object):
         :return: exit status from run command
         """
         env = {'cluster_id': args.cluster_id,
-               'deployment_type': self.get_deployment_type(args)}
+               'deployment_type': self.get_deployment_type(args),
+               'product_type': self.get_product_type(args)}
         playbook = "playbooks/{}/openshift-cluster/terminate.yml".format(args.provider)
         inventory = self.setup_provider(args.provider)
 
@@ -76,7 +93,8 @@ class Cluster(object):
         :return: exit status from run command
         """
         env = {'cluster_id': args.cluster_id,
-               'deployment_type': self.get_deployment_type(args)}
+               'deployment_type': self.get_deployment_type(args),
+               'product_type': self.get_product_type(args)}
         playbook = "playbooks/{}/openshift-cluster/list.yml".format(args.provider)
         inventory = self.setup_provider(args.provider)
 
@@ -89,7 +107,8 @@ class Cluster(object):
         :return: exit status from run command
         """
         env = {'cluster_id': args.cluster_id,
-               'deployment_type': self.get_deployment_type(args)}
+               'deployment_type': self.get_deployment_type(args),
+               'product_type': self.get_product_type(args)}
         playbook = "playbooks/{}/openshift-cluster/config.yml".format(args.provider)
         inventory = self.setup_provider(args.provider)
 
@@ -102,7 +121,8 @@ class Cluster(object):
         :return: exit status from run command
         """
         env = {'cluster_id': args.cluster_id,
-               'deployment_type': self.get_deployment_type(args)}
+               'deployment_type': self.get_deployment_type(args),
+               'product_type': self.get_product_type(args)}
         playbook = "playbooks/{}/openshift-cluster/update.yml".format(args.provider)
         inventory = self.setup_provider(args.provider)
 
@@ -116,6 +136,7 @@ class Cluster(object):
         """
         env = {'cluster_id': args.cluster_id,
                'deployment_type': self.get_deployment_type(args),
+               'product_type': self.get_product_type(args),
                'new_cluster_state': args.state}
 
         playbook = "playbooks/{}/openshift-cluster/service.yml".format(args.provider)

--- a/bin/cluster
+++ b/bin/cluster
@@ -49,8 +49,8 @@ class Cluster(object):
         product_type = 'openshift'
         if args.product_type:
             product_type = args.product_type
-        elif 'OS_DEPLOYMENT_TYPE' in os.environ:
-            product_type = os.environ['OS_DEPLOYMENT_TYPE']
+        elif 'OS_PRODUCT_TYPE' in os.environ:
+            product_type = os.environ['OS_PRODUCT_TYPE']
         return product_type
 
     def create(self, args):

--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -20,8 +20,8 @@ ansible_ssh_user=root
 # deployment type valid values are origin, online and enterprise
 deployment_type=enterprise
 
-# product type valud values are openshift and atomic-enterprise
-product_type=openshift
+# product type valid values are openshift and atomic-enterprise
+#product_type=atomic-enterprise
 
 
 # Pre-release registry URL

--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -20,6 +20,10 @@ ansible_ssh_user=root
 # deployment type valid values are origin, online and enterprise
 deployment_type=enterprise
 
+# product type valud values are openshift and atomic-enterprise
+product_type=openshift
+
+
 # Pre-release registry URL
 #oreg_url=docker-buildvm-rhose.usersys.redhat.com:5000/openshift3/ose-${component}:${version}
 

--- a/playbooks/aws/openshift-cluster/config.yml
+++ b/playbooks/aws/openshift-cluster/config.yml
@@ -19,5 +19,6 @@
     openshift_cluster_id: "{{ cluster_id }}"
     openshift_debug_level: 4
     openshift_deployment_type: "{{ deployment_type }}"
+    openshift_product_type: "{{ product_type }}"
     openshift_hostname: "{{ ec2_private_ip_address }}"
     openshift_public_hostname: "{{ ec2_ip_address }}"

--- a/playbooks/byo/openshift-cluster/config.yml
+++ b/playbooks/byo/openshift-cluster/config.yml
@@ -7,3 +7,4 @@
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
     openshift_debug_level: 4
     openshift_deployment_type: "{{ deployment_type }}"
+    openshift_product_type: "{{ product_type }}"

--- a/playbooks/byo/openshift_facts.yml
+++ b/playbooks/byo/openshift_facts.yml
@@ -1,5 +1,5 @@
 ---
-- name: Gather OpenShift facts
+- name: Gather Atomic Enterprise facts
   hosts: all
   gather_facts: no
   roles:

--- a/playbooks/byo/openshift_facts.yml
+++ b/playbooks/byo/openshift_facts.yml
@@ -1,5 +1,5 @@
 ---
-- name: Gather Atomic Enterprise facts
+- name: Gather Cluster facts
   hosts: all
   gather_facts: no
   roles:

--- a/playbooks/common/openshift-cluster/update_repos_and_packages.yml
+++ b/playbooks/common/openshift-cluster/update_repos_and_packages.yml
@@ -2,6 +2,7 @@
 - hosts: oo_hosts_to_update
   vars:
     openshift_deployment_type: "{{ deployment_type }}"
+    openshift_product_type: "{{ product_type }}"
   roles:
   - role: rhel_subscribe
     when: deployment_type == "enterprise" and

--- a/playbooks/common/openshift-etcd/config.yml
+++ b/playbooks/common/openshift-etcd/config.yml
@@ -13,6 +13,7 @@
           hostname: "{{ openshift_hostname | default(None) }}"
           public_hostname: "{{ openshift_public_hostname | default(None) }}"
           deployment_type: "{{ openshift_deployment_type }}"
+          product_type: "{{ openshift_product_type }}"
   - name: Check status of etcd certificates
     stat:
       path: "{{ item }}"

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -22,6 +22,7 @@
           public_hostname: "{{ openshift_public_hostname | default(None) }}"
           deployment_type: "{{ openshift_deployment_type }}"
           product_type: "{{ openshift_product_type }}"
+          service_type: "{{ 'origin' if deployment_type == 'origin' else 'atomic-enterprise' }}"
       - role: master
         local_facts:
           api_port: "{{ openshift_master_api_port | default(None) }}"
@@ -36,6 +37,7 @@
           console_url: "{{ openshift_master_console_url | default(None) }}"
           console_use_ssl: "{{ openshift_master_console_use_ssl | default(None) }}"
           public_console_url: "{{ openshift_master_public_console_url | default(None) }}"
+          service_type: "{{ 'origin' if deployment_type == 'origin' else 'atomic-enterprise' }}"
   - name: Check status of external etcd certificatees
     stat:
       path: "/etc/openshift/master/{{ item }}"

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -21,6 +21,7 @@
           hostname: "{{ openshift_hostname | default(None) }}"
           public_hostname: "{{ openshift_public_hostname | default(None) }}"
           deployment_type: "{{ openshift_deployment_type }}"
+          product_type: "{{ openshift_product_type }}"
       - role: master
         local_facts:
           api_port: "{{ openshift_master_api_port | default(None) }}"

--- a/playbooks/common/openshift-master/service.yml
+++ b/playbooks/common/openshift-master/service.yml
@@ -10,9 +10,9 @@
     add_host: name={{ item }} groups=g_service_masters
     with_items: oo_host_group_exp | default([])
 
-- name: Change openshift-master state on master instance(s)
+- name: Change atomic-enterprise-master state on master instance(s)
   hosts: g_service_masters
   connection: ssh
   gather_facts: no
   tasks:
-    - service: name=openshift-master state="{{ new_cluster_state }}"
+    - service: name=atomic-enterprise-master state="{{ new_cluster_state }}"

--- a/playbooks/common/openshift-master/service.yml
+++ b/playbooks/common/openshift-master/service.yml
@@ -15,4 +15,4 @@
   connection: ssh
   gather_facts: no
   tasks:
-    - service: name={{ product_type }}-master state="{{ new_cluster_state }}"
+    - service: name={{ service_type }}-master state="{{ new_cluster_state }}"

--- a/playbooks/common/openshift-master/service.yml
+++ b/playbooks/common/openshift-master/service.yml
@@ -10,9 +10,9 @@
     add_host: name={{ item }} groups=g_service_masters
     with_items: oo_host_group_exp | default([])
 
-- name: Change atomic-enterprise-master state on master instance(s)
+- name: Change state on master instance(s)
   hosts: g_service_masters
   connection: ssh
   gather_facts: no
   tasks:
-    - service: name=atomic-enterprise-master state="{{ new_cluster_state }}"
+    - service: name={{ product_type }}-master state="{{ new_cluster_state }}"

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -89,9 +89,9 @@
       path: "{{ node_cert_dir }}"
       state: directory
 
-  # TODO: notify restart openshift-node
+  # TODO: notify restart atomic-enterprise-node
   # possibly test service started time against certificate/config file
-  # timestamps in openshift-node to trigger notify
+  # timestamps in atomic-enterprise-node to trigger notify
   - name: Unarchive the tarball on the node
     unarchive:
       src: "{{ sync_tmpdir }}/{{ node_subdir }}.tgz"

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -16,6 +16,7 @@
           hostname: "{{ openshift_hostname | default(None) }}"
           public_hostname: "{{ openshift_public_hostname | default(None) }}"
           deployment_type: "{{ openshift_deployment_type }}"
+          product_type: "{{ openshift_product_type }}"
       - role: node
         local_facts:
           labels: "{{ openshift_node_labels | default(None) }}"
@@ -89,9 +90,9 @@
       path: "{{ node_cert_dir }}"
       state: directory
 
-  # TODO: notify restart atomic-enterprise-node
+  # TODO: notify restart node
   # possibly test service started time against certificate/config file
-  # timestamps in atomic-enterprise-node to trigger notify
+  # timestamps in node to trigger notify
   - name: Unarchive the tarball on the node
     unarchive:
       src: "{{ sync_tmpdir }}/{{ node_subdir }}.tgz"

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -17,10 +17,12 @@
           public_hostname: "{{ openshift_public_hostname | default(None) }}"
           deployment_type: "{{ openshift_deployment_type }}"
           product_type: "{{ openshift_product_type }}"
+          service_type: "{{ 'origin' if deployment_type == 'origin' else 'atomic-enterprise' }}"
       - role: node
         local_facts:
           labels: "{{ openshift_node_labels | default(None) }}"
           annotations: "{{ openshift_node_annotations | default(None) }}"
+          service_type: "{{ 'origin' if deployment_type == 'origin' else 'atomic-enterprise' }}"
   - name: Check status of node certificates
     stat:
       path: "/etc/openshift/node/{{ item }}"

--- a/playbooks/common/openshift-node/service.yml
+++ b/playbooks/common/openshift-node/service.yml
@@ -10,9 +10,9 @@
     add_host: name={{ item }} groups=g_service_nodes
     with_items: oo_host_group_exp | default([])
 
-- name: Change openshift-node state on node instance(s)
+- name: Change atomic-enterprise-node state on node instance(s)
   hosts: g_service_nodes
   connection: ssh
   gather_facts: no
   tasks:
-    - service: name=openshift-node state="{{ new_cluster_state }}"
+    - service: name=atomic-enterprise-node state="{{ new_cluster_state }}"

--- a/playbooks/common/openshift-node/service.yml
+++ b/playbooks/common/openshift-node/service.yml
@@ -15,4 +15,4 @@
   connection: ssh
   gather_facts: no
   tasks:
-    - service: name={{ product_type }}-node state="{{ new_cluster_state }}"
+    - service: name={{ service_type }}-node state="{{ new_cluster_state }}"

--- a/playbooks/common/openshift-node/service.yml
+++ b/playbooks/common/openshift-node/service.yml
@@ -10,9 +10,9 @@
     add_host: name={{ item }} groups=g_service_nodes
     with_items: oo_host_group_exp | default([])
 
-- name: Change atomic-enterprise-node state on node instance(s)
+- name: Change state on node instance(s)
   hosts: g_service_nodes
   connection: ssh
   gather_facts: no
   tasks:
-    - service: name=atomic-enterprise-node state="{{ new_cluster_state }}"
+    - service: name={{ product_type }}-node state="{{ new_cluster_state }}"

--- a/playbooks/gce/openshift-cluster/config.yml
+++ b/playbooks/gce/openshift-cluster/config.yml
@@ -21,4 +21,5 @@
     openshift_cluster_id: "{{ cluster_id }}"
     openshift_debug_level: 4
     openshift_deployment_type: "{{ deployment_type }}"
+    openshift_product_type: "{{ product_type }}"
     openshift_hostname: "{{ gce_private_ip }}"

--- a/playbooks/libvirt/openshift-cluster/config.yml
+++ b/playbooks/libvirt/openshift-cluster/config.yml
@@ -22,3 +22,4 @@
     openshift_cluster_id: "{{ cluster_id }}"
     openshift_debug_level: 4
     openshift_deployment_type: "{{ deployment_type }}"
+    openshift_product_type: "{{ product_type }}"

--- a/playbooks/openstack/openshift-cluster/config.yml
+++ b/playbooks/openstack/openshift-cluster/config.yml
@@ -17,4 +17,5 @@
     openshift_cluster_id: "{{ cluster_id }}"
     openshift_debug_level: 4
     openshift_deployment_type: "{{ deployment_type }}"
+    openshift_product_type: "{{ product_type }}"
     openshift_hostname: "{{ ansible_default_ipv4.address }}"

--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Set common OpenShift facts
+- name: Set common Atomic Enterprise facts
   openshift_facts:
     role: common
     local_facts:

--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -12,7 +12,7 @@
       use_openshift_sdn: "{{ openshift_use_openshift_sdn | default(None) }}"
       sdn_network_plugin_name: "{{ os_sdn_network_plugin_name | default(None) }}"
       deployment_type: "{{ openshift_deployment_type }}"
-      product_type: ""{{ openshift_product_type }}"
+      product_type: "{{ openshift_product_type }}"
 
 - name: Set hostname
   hostname: name={{ openshift.common.hostname }}

--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Set common Atomic Enterprise facts
+- name: Set common Cluster facts
   openshift_facts:
     role: common
     local_facts:
@@ -12,6 +12,7 @@
       use_openshift_sdn: "{{ openshift_use_openshift_sdn | default(None) }}"
       sdn_network_plugin_name: "{{ os_sdn_network_plugin_name | default(None) }}"
       deployment_type: "{{ openshift_deployment_type }}"
+      product_type: ""{{ openshift_product_type }}"
 
 - name: Set hostname
   hostname: name={{ openshift.common.hostname }}

--- a/roles/openshift_common/vars/main.yml
+++ b/roles/openshift_common/vars/main.yml
@@ -6,4 +6,4 @@
 # interfaces)
 os_firewall_use_firewalld: False
 
-openshift_data_dir: /var/lib/openshift
+openshift_data_dir: /var/lib/atomic-enterprise

--- a/roles/openshift_common/vars/main.yml
+++ b/roles/openshift_common/vars/main.yml
@@ -6,4 +6,4 @@
 # interfaces)
 os_firewall_use_firewalld: False
 
-openshift_data_dir: /var/lib/{{ product_type }}
+openshift_data_dir: /var/lib/origin

--- a/roles/openshift_common/vars/main.yml
+++ b/roles/openshift_common/vars/main.yml
@@ -6,4 +6,4 @@
 # interfaces)
 os_firewall_use_firewalld: False
 
-openshift_data_dir: /var/lib/atomic-enterprise
+openshift_data_dir: /var/lib/{{ product_type }}

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -493,7 +493,7 @@ def get_current_config(facts):
         # anything from working properly as far as I can tell, perhaps because
         # we override the kubeconfig path everywhere we use it?
         # Query kubeconfig settings
-        kubeconfig_dir = '/var/lib/openshift/openshift.local.certificates'
+        kubeconfig_dir = '/var/lib/atomic-enterprise/openshift.local.certificates'
         if role == 'node':
             kubeconfig_dir = os.path.join(
                 kubeconfig_dir, "node-%s" % facts['common']['hostname']

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -498,7 +498,7 @@ def get_current_config(facts):
         # anything from working properly as far as I can tell, perhaps because
         # we override the kubeconfig path everywhere we use it?
         # Query kubeconfig settings
-        kubeconfig_dir = '/var/lib/{{ product_type }}/openshift.local.certificates'
+        kubeconfig_dir = '/var/lib/origin/openshift.local.certificates'
         if role == 'node':
             kubeconfig_dir = os.path.join(
                 kubeconfig_dir, "node-%s" % facts['common']['hostname']

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -6,7 +6,7 @@
 DOCUMENTATION = '''
 ---
 module: openshift_facts
-short_description: OpenShift Facts
+short_description: Cluster Facts
 author: Jason DeTiberus
 requirements: [ ]
 '''
@@ -299,6 +299,10 @@ def set_registry_url_if_unset(facts):
                 registry_url = "openshift/origin-${component}:${version}"
                 if deployment_type == 'enterprise':
                     registry_url = "openshift3/ose-${component}:${version}"
+                    if product_type == 'openshift':
+                       registry_url = "openshift3/ose-${component}:${version}"
+                    elif product_type == 'atomic-enterprise':
+                       registry_url = "openshift3/ose-${component}:latest"
                 elif deployment_type == 'online':
                     registry_url = ("docker-registry.ops.rhcloud.com/"
                                     "openshift3/ose-${component}:${version}")
@@ -493,7 +497,7 @@ def get_current_config(facts):
         # anything from working properly as far as I can tell, perhaps because
         # we override the kubeconfig path everywhere we use it?
         # Query kubeconfig settings
-        kubeconfig_dir = '/var/lib/atomic-enterprise/openshift.local.certificates'
+        kubeconfig_dir = '/var/lib/{{ product_type }}/openshift.local.certificates'
         if role == 'node':
             kubeconfig_dir = os.path.join(
                 kubeconfig_dir, "node-%s" % facts['common']['hostname']
@@ -640,25 +644,25 @@ def get_local_facts_from_file(filename):
 
 
 class OpenShiftFactsUnsupportedRoleError(Exception):
-    """OpenShift Facts Unsupported Role Error"""
+    """Facts Unsupported Role Error"""
     pass
 
 
 class OpenShiftFactsFileWriteError(Exception):
-    """OpenShift Facts File Write Error"""
+    """Facts File Write Error"""
     pass
 
 
 class OpenShiftFactsMetadataUnavailableError(Exception):
-    """OpenShift Facts Metadata Unavailable Error"""
+    """Facts Metadata Unavailable Error"""
     pass
 
 
 class OpenShiftFacts(object):
-    """ OpenShift Facts
+    """ Facts
 
         Attributes:
-            facts (dict): OpenShift facts for the host
+            facts (dict): facts for the host
 
         Args:
             role (str): role for setting local facts

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -645,22 +645,22 @@ def get_local_facts_from_file(filename):
 
 
 class OpenShiftFactsUnsupportedRoleError(Exception):
-    """Facts Unsupported Role Error"""
+    """Origin Facts Unsupported Role Error"""
     pass
 
 
 class OpenShiftFactsFileWriteError(Exception):
-    """Facts File Write Error"""
+    """Origin Facts File Write Error"""
     pass
 
 
 class OpenShiftFactsMetadataUnavailableError(Exception):
-    """Facts Metadata Unavailable Error"""
+    """Origin Facts Metadata Unavailable Error"""
     pass
 
 
 class OpenShiftFacts(object):
-    """ Facts
+    """ Origin Facts
 
         Attributes:
             facts (dict): facts for the host

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -299,6 +299,7 @@ def set_registry_url_if_unset(facts):
                 registry_url = "openshift/origin-${component}:${version}"
                 if deployment_type == 'enterprise':
                     registry_url = "openshift3/ose-${component}:${version}"
+                    product_type = facts['common']['product_type']
                     if product_type == 'openshift':
                        registry_url = "openshift3/ose-${component}:${version}"
                     elif product_type == 'atomic-enterprise':

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -6,5 +6,5 @@
     - ansible_version | version_compare('1.9.0', 'ne')
     - ansible_version | version_compare('1.9.0.1', 'ne')
 
-- name: Gather OpenShift facts
+- name: Gather Atomic Enterprise facts
   openshift_facts:

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -6,5 +6,5 @@
     - ansible_version | version_compare('1.9.0', 'ne')
     - ansible_version | version_compare('1.9.0.1', 'ne')
 
-- name: Gather Atomic Enterprise facts
+- name: Gather Cluster facts
   openshift_facts:

--- a/roles/openshift_master/README.md
+++ b/roles/openshift_master/README.md
@@ -1,7 +1,7 @@
-OpenShift Master
+Atomic Enterprise Master
 ================
 
-OpenShift Master service installation
+Atomic Enterprise Master service installation
 
 Requirements
 ------------

--- a/roles/openshift_master/README.md
+++ b/roles/openshift_master/README.md
@@ -15,8 +15,8 @@ Role Variables
 From this role:
 | Name                                | Default value         |                                                  |
 |-------------------------------------|-----------------------|--------------------------------------------------|
-| openshift_master_debug_level        | openshift_debug_level | Verbosity of the debug logs for openshift-master |
-| openshift_node_ips                  | []                    | List of the openshift node ip addresses to pre-register when openshift-master starts up |
+| openshift_master_debug_level        | openshift_debug_level | Verbosity of the debug logs for atomic-enterprise-master |
+| openshift_node_ips                  | []                    | List of the openshift node ip addresses to pre-register when atomic-enterprise-master starts up |
 | oreg_url                            | UNDEF                 | Default docker registry to use |
 | openshift_master_api_port           | UNDEF                 | |
 | openshift_master_console_port       | UNDEF                 | |

--- a/roles/openshift_master/README.md
+++ b/roles/openshift_master/README.md
@@ -1,5 +1,5 @@
-Cluster Master
-================
+OpenShift/Atomic Enterprise Master
+==================================
 
 Master service installation
 

--- a/roles/openshift_master/README.md
+++ b/roles/openshift_master/README.md
@@ -1,7 +1,7 @@
-Atomic Enterprise Master
+Cluster Master
 ================
 
-Atomic Enterprise Master service installation
+Master service installation
 
 Requirements
 ------------
@@ -15,8 +15,8 @@ Role Variables
 From this role:
 | Name                                | Default value         |                                                  |
 |-------------------------------------|-----------------------|--------------------------------------------------|
-| openshift_master_debug_level        | openshift_debug_level | Verbosity of the debug logs for atomic-enterprise-master |
-| openshift_node_ips                  | []                    | List of the openshift node ip addresses to pre-register when atomic-enterprise-master starts up |
+| openshift_master_debug_level        | openshift_debug_level | Verbosity of the debug logs for master |
+| openshift_node_ips                  | []                    | List of the openshift node ip addresses to pre-register when master starts up |
 | oreg_url                            | UNDEF                 | Default docker registry to use |
 | openshift_master_api_port           | UNDEF                 | |
 | openshift_master_console_port       | UNDEF                 | |

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -5,11 +5,11 @@ openshift_node_ips: []
 os_firewall_allow:
 - service: etcd embedded
   port: 4001/tcp
-- service: OpenShift api https
+- service: Atomic Enterprise api https
   port: 8443/tcp
-- service: OpenShift dns tcp
+- service: Atomic Enterprise dns tcp
   port: 53/tcp
-- service: OpenShift dns udp
+- service: Atomic Enterprise dns udp
   port: 53/udp
 - service: Fluentd td-agent tcp
   port: 24224/tcp
@@ -22,9 +22,9 @@ os_firewall_allow:
 - service: Corosync UDP
   port: 5405/udp
 os_firewall_deny:
-- service: OpenShift api http
+- service: Atomic Enterprise api http
   port: 8080/tcp
-- service: former OpenShift web console port
+- service: former Atomic Enterprise web console port
   port: 8444/tcp
 - service: former etcd peer port
   port: 7001/tcp

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -5,11 +5,11 @@ openshift_node_ips: []
 os_firewall_allow:
 - service: etcd embedded
   port: 4001/tcp
-- service: Atomic Enterprise api https
+- service: api server https
   port: 8443/tcp
-- service: Atomic Enterprise dns tcp
+- service: dns tcp
   port: 53/tcp
-- service: Atomic Enterprise dns udp
+- service: dns udp
   port: 53/udp
 - service: Fluentd td-agent tcp
   port: 24224/tcp
@@ -22,9 +22,9 @@ os_firewall_allow:
 - service: Corosync UDP
   port: 5405/udp
 os_firewall_deny:
-- service: Atomic Enterprise api http
+- service: api server http
   port: 8080/tcp
-- service: former Atomic Enterprise web console port
+- service: former web console port
   port: 8444/tcp
 - service: former etcd peer port
   port: 7001/tcp

--- a/roles/openshift_master/handlers/main.yml
+++ b/roles/openshift_master/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
-- name: restart openshift-master
-  service: name=openshift-master state=restarted
+- name: restart atomic-enterprise-master
+  service: name=atomic-enterprise-master state=restarted
   when: not openshift_master_ha | bool

--- a/roles/openshift_master/handlers/main.yml
+++ b/roles/openshift_master/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
-- name: restart atomic-enterprise-master
-  service: name=atomic-enterprise-master state=restarted
+- name: restart master
+  service: name={{ product_type }}-master state=restarted
   when: not openshift_master_ha | bool

--- a/roles/openshift_master/handlers/main.yml
+++ b/roles/openshift_master/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: restart master
-  service: name={{ product_type }}-master state=restarted
+  service: name={{ service_type }}-master state=restarted
   when: not openshift_master_ha | bool

--- a/roles/openshift_master/meta/main.yml
+++ b/roles/openshift_master/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Jhon Honce
-  description: OpenShift Master
+  description: Atomic Enterprise Master
   company: Red Hat, Inc.
   license: Apache License, Version 2.0
   min_ansible_version: 1.7

--- a/roles/openshift_master/meta/main.yml
+++ b/roles/openshift_master/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Jhon Honce
-  description: Atomic Enterprise Master
+  description: Master
   company: Red Hat, Inc.
   license: Apache License, Version 2.0
   min_ansible_version: 1.7

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -12,10 +12,6 @@
     msg: "openshift_master_cluster_password must be set for multi-master installations"
   when: openshift_master_ha | bool and not openshift.master.cluster_defer_ha | bool and openshift_master_cluster_password is not defined
 
-- name: Install Master package
-  yum: pkg={{ product_type }}-master state=present
-  register: install_result
-
 - name: Set master facts
   openshift_facts:
     role: master
@@ -54,6 +50,11 @@
       sdn_cluster_network_cidr: "{{ osm_cluster_network_cidr | default(None) }}"
       sdn_host_subnet_length: "{{ osm_host_subnet_length | default(None) }}"
       default_subdomain: "{{ osm_default_subdomain | default(None) }}"
+      product_type: "{{ openshift_product_type }}"
+
+- name: Install Master package
+  yum: pkg={{ product_type }}-master state=present
+  register: install_result
 
 # TODO: These values need to be configurable
 - name: Set dns facts

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -77,14 +77,14 @@
   args:
     creates: "{{ openshift_master_policy }}"
   notify:
-  - restart {{ product_type }}-master
+  - restart master
 
 - name: Create the scheduler config
   template:
     dest: "{{ openshift_master_scheduler_conf }}"
     src: scheduler.json.j2
   notify:
-  - restart {{ product_type }}-master
+  - restart master
 
 - name: Install httpd-tools if needed
   yum: pkg=httpd-tools state=present
@@ -106,7 +106,7 @@
     dest: "{{ openshift_master_config_file }}"
     src: master.yaml.v1.j2
   notify:
-  - restart {{ product_type }}-master
+  - restart master
 
 - name: Configure master settings
   lineinfile:
@@ -119,7 +119,7 @@
     - regex: '^CONFIG_FILE='
       line: "CONFIG_FILE={{ openshift_master_config_file }}"
   notify:
-  - restart {{ product_type }}-master
+  - restart master
 
 - name: Start and enable master
   service: name={{ product_type }}-master enabled=yes state=started

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -12,11 +12,11 @@
     msg: "openshift_master_cluster_password must be set for multi-master installations"
   when: openshift_master_ha | bool and not openshift.master.cluster_defer_ha | bool and openshift_master_cluster_password is not defined
 
-- name: Install OpenShift Master package
-  yum: pkg=openshift-master state=present
+- name: Install Atomic Enterprise Master package
+  yum: pkg=atomic-enterprise-master state=present
   register: install_result
 
-- name: Set master OpenShift facts
+- name: Set master Atomic Enterprise facts
   openshift_facts:
     role: master
     local_facts:
@@ -56,7 +56,7 @@
       default_subdomain: "{{ osm_default_subdomain | default(None) }}"
 
 # TODO: These values need to be configurable
-- name: Set dns OpenShift facts
+- name: Set dns Atomic Enterprise facts
   openshift_facts:
     role: dns
     local_facts:
@@ -107,7 +107,7 @@
   notify:
   - restart openshift-master
 
-- name: Configure OpenShift settings
+- name: Configure Atomic Enterprise settings
   lineinfile:
     dest: /etc/sysconfig/openshift-master
     regexp: "{{ item.regex }}"
@@ -142,7 +142,7 @@
   shell: echo {{ openshift_master_cluster_password | quote }} | passwd --stdin hacluster
   when: install_result | changed
 
-- name: Create the OpenShift client config dir(s)
+- name: Create the Atomic Enterprise client config dir(s)
   file:
     path: "~{{ item }}/.kube"
     state: directory
@@ -155,7 +155,7 @@
 
 # TODO: Update this file if the contents of the source file are not present in
 # the dest file, will need to make sure to ignore things that could be added
-- name: Copy the OpenShift admin client config(s)
+- name: Copy the Atomic Enterprise admin client config(s)
   command: cp {{ openshift_master_config_dir }}/admin.kubeconfig ~{{ item }}/.kube/config
   args:
     creates: ~{{ item }}/.kube/config
@@ -163,7 +163,7 @@
   - root
   - "{{ ansible_ssh_user }}"
 
-- name: Update the permissions on the OpenShift admin client config(s)
+- name: Update the permissions on the Atomic Enterprise admin client config(s)
   file:
     path: "~{{ item }}/.kube/config"
     state: file

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -76,14 +76,14 @@
   args:
     creates: "{{ openshift_master_policy }}"
   notify:
-  - restart openshift-master
+  - restart atomic-enterprise-master
 
 - name: Create the scheduler config
   template:
     dest: "{{ openshift_master_scheduler_conf }}"
     src: scheduler.json.j2
   notify:
-  - restart openshift-master
+  - restart atomic-enterprise-master
 
 - name: Install httpd-tools if needed
   yum: pkg=httpd-tools state=present
@@ -105,11 +105,11 @@
     dest: "{{ openshift_master_config_file }}"
     src: master.yaml.v1.j2
   notify:
-  - restart openshift-master
+  - restart atomic-enterprise-master
 
 - name: Configure Atomic Enterprise settings
   lineinfile:
-    dest: /etc/sysconfig/openshift-master
+    dest: /etc/sysconfig/atomic-enterprise-master
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
   with_items:
@@ -118,10 +118,10 @@
     - regex: '^CONFIG_FILE='
       line: "CONFIG_FILE={{ openshift_master_config_file }}"
   notify:
-  - restart openshift-master
+  - restart atomic-enterprise-master
 
-- name: Start and enable openshift-master
-  service: name=openshift-master enabled=yes state=started
+- name: Start and enable atomic-enterprise-master
+  service: name=atomic-enterprise-master enabled=yes state=started
   when: not openshift_master_ha | bool
   register: start_result
 

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -51,6 +51,7 @@
       sdn_host_subnet_length: "{{ osm_host_subnet_length | default(None) }}"
       default_subdomain: "{{ osm_default_subdomain | default(None) }}"
       product_type: "{{ openshift_product_type }}"
+      service_type: "{{ 'origin' if deployment_type == 'origin' else 'atomic-enterprise' }}"
 
 - name: Install Master package
   yum: pkg={{ product_type }}-master state=present
@@ -122,7 +123,7 @@
   - restart master
 
 - name: Start and enable master
-  service: name={{ product_type }}-master enabled=yes state=started
+  service: name={{ service_type }}-master enabled=yes state=started
   when: not openshift_master_ha | bool
   register: start_result
 

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -12,11 +12,11 @@
     msg: "openshift_master_cluster_password must be set for multi-master installations"
   when: openshift_master_ha | bool and not openshift.master.cluster_defer_ha | bool and openshift_master_cluster_password is not defined
 
-- name: Install Atomic Enterprise Master package
-  yum: pkg=atomic-enterprise-master state=present
+- name: Install Master package
+  yum: pkg={{ product_type }}-master state=present
   register: install_result
 
-- name: Set master Atomic Enterprise facts
+- name: Set master facts
   openshift_facts:
     role: master
     local_facts:
@@ -56,7 +56,7 @@
       default_subdomain: "{{ osm_default_subdomain | default(None) }}"
 
 # TODO: These values need to be configurable
-- name: Set dns Atomic Enterprise facts
+- name: Set dns facts
   openshift_facts:
     role: dns
     local_facts:
@@ -76,14 +76,14 @@
   args:
     creates: "{{ openshift_master_policy }}"
   notify:
-  - restart atomic-enterprise-master
+  - restart {{ product_type }}-master
 
 - name: Create the scheduler config
   template:
     dest: "{{ openshift_master_scheduler_conf }}"
     src: scheduler.json.j2
   notify:
-  - restart atomic-enterprise-master
+  - restart {{ product_type }}-master
 
 - name: Install httpd-tools if needed
   yum: pkg=httpd-tools state=present
@@ -105,11 +105,11 @@
     dest: "{{ openshift_master_config_file }}"
     src: master.yaml.v1.j2
   notify:
-  - restart atomic-enterprise-master
+  - restart {{ product_type }}-master
 
-- name: Configure Atomic Enterprise settings
+- name: Configure master settings
   lineinfile:
-    dest: /etc/sysconfig/atomic-enterprise-master
+    dest: /etc/sysconfig/{{ product_type }}-master
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
   with_items:
@@ -118,10 +118,10 @@
     - regex: '^CONFIG_FILE='
       line: "CONFIG_FILE={{ openshift_master_config_file }}"
   notify:
-  - restart atomic-enterprise-master
+  - restart {{ product_type }}-master
 
-- name: Start and enable atomic-enterprise-master
-  service: name=atomic-enterprise-master enabled=yes state=started
+- name: Start and enable master
+  service: name={{ product_type }}-master enabled=yes state=started
   when: not openshift_master_ha | bool
   register: start_result
 
@@ -142,7 +142,7 @@
   shell: echo {{ openshift_master_cluster_password | quote }} | passwd --stdin hacluster
   when: install_result | changed
 
-- name: Create the Atomic Enterprise client config dir(s)
+- name: Create the client config dir(s)
   file:
     path: "~{{ item }}/.kube"
     state: directory
@@ -155,7 +155,7 @@
 
 # TODO: Update this file if the contents of the source file are not present in
 # the dest file, will need to make sure to ignore things that could be added
-- name: Copy the Atomic Enterprise admin client config(s)
+- name: Copy the admin client config(s)
   command: cp {{ openshift_master_config_dir }}/admin.kubeconfig ~{{ item }}/.kube/config
   args:
     creates: ~{{ item }}/.kube/config
@@ -163,7 +163,7 @@
   - root
   - "{{ ansible_ssh_user }}"
 
-- name: Update the permissions on the Atomic Enterprise admin client config(s)
+- name: Update the permissions on the admin client config(s)
   file:
     path: "~{{ item }}/.kube/config"
     state: file

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -53,7 +53,7 @@ etcdStorageConfig:
   openShiftStorageVersion: v1
 imageConfig:
   format: {{ openshift.master.registry_url }}
-  latest: false
+  latest: true
 kind: MasterConfig
 kubeletClientInfo:
 {# TODO: allow user specified kubelet port #}

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -53,7 +53,7 @@ etcdStorageConfig:
   openShiftStorageVersion: v1
 imageConfig:
   format: {{ openshift.master.registry_url }}
-  latest: true
+  latest: false
 kind: MasterConfig
 kubeletClientInfo:
 {# TODO: allow user specified kubelet port #}

--- a/roles/openshift_master_ca/tasks/main.yml
+++ b/roles/openshift_master_ca/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install the OpenShift package for admin tooling
-  yum: pkg=openshift state=present
+  yum: pkg={{ product_type }} state=present
   register: install_result
 
 - name: Reload generated facts

--- a/roles/openshift_node/README.md
+++ b/roles/openshift_node/README.md
@@ -1,12 +1,12 @@
-OpenShift Node
+Atomic Enterprise Node
 ==============
 
-OpenShift Node service installation
+Atomic Enterprise Node service installation
 
 Requirements
 ------------
 
-One or more OpenShift Master servers.
+One or more Atomic Enterprise Master servers.
 
 A RHEL 7.1 host pre-configured with access to the rhel-7-server-rpms,
 rhel-7-server-extras-rpms, and rhel-7-server-ose-3.0-rpms repos.

--- a/roles/openshift_node/README.md
+++ b/roles/openshift_node/README.md
@@ -14,10 +14,10 @@ rhel-7-server-extras-rpms, and rhel-7-server-ose-3.0-rpms repos.
 Role Variables
 --------------
 From this role:
-| Name                                     | Default value         |                                        |
-|------------------------------------------|-----------------------|----------------------------------------|
-| openshift_node_debug_level               | openshift_debug_level | Verbosity of the debug logs for openshift-node |
-| oreg_url                                 | UNDEF (Optional)      | Default docker registry to use |
+| Name                                     | Default value         |                                                        |
+|------------------------------------------|-----------------------|--------------------------------------------------------|
+| openshift_node_debug_level               | openshift_debug_level | Verbosity of the debug logs for atomic-enterprise-node |
+| oreg_url                                 | UNDEF (Optional)      | Default docker registry to use                         |
 
 From openshift_common:
 | Name                          |  Default Value      |                     | 

--- a/roles/openshift_node/README.md
+++ b/roles/openshift_node/README.md
@@ -1,5 +1,5 @@
-Cluster Node
-==============
+OpenShift/Atomic Enterprise Node
+================================
 
 Node service installation
 

--- a/roles/openshift_node/README.md
+++ b/roles/openshift_node/README.md
@@ -1,12 +1,12 @@
-Atomic Enterprise Node
+Cluster Node
 ==============
 
-Atomic Enterprise Node service installation
+Node service installation
 
 Requirements
 ------------
 
-One or more Atomic Enterprise Master servers.
+One or more Master servers.
 
 A RHEL 7.1 host pre-configured with access to the rhel-7-server-rpms,
 rhel-7-server-extras-rpms, and rhel-7-server-ose-3.0-rpms repos.
@@ -16,7 +16,7 @@ Role Variables
 From this role:
 | Name                                     | Default value         |                                                        |
 |------------------------------------------|-----------------------|--------------------------------------------------------|
-| openshift_node_debug_level               | openshift_debug_level | Verbosity of the debug logs for atomic-enterprise-node |
+| openshift_node_debug_level               | openshift_debug_level | Verbosity of the debug logs for node |
 | oreg_url                                 | UNDEF (Optional)      | Default docker registry to use                         |
 
 From openshift_common:

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 os_firewall_allow:
-- service: OpenShift kubelet
+- service: Atomic Enterprise kubelet
   port: 10250/tcp
 - service: http
   port: 80/tcp

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 os_firewall_allow:
-- service: Atomic Enterprise kubelet
+- service: Kubernetes kubelet
   port: 10250/tcp
 - service: http
   port: 80/tcp

--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
-- name: restart openshift-node
-  service: name=openshift-node state=restarted
+- name: restart atomic-enterprise-node
+  service: name=atomic-enterprise-node state=restarted

--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
-- name: restart atomic-enterprise-node
-  service: name=atomic-enterprise-node state=restarted
+- name: restart node
+  service: name={{ product_type }}-node state=restarted

--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: restart node
-  service: name={{ product_type }}-node state=restarted
+  service: name={{ service_type }}-node state=restarted

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -11,7 +11,7 @@
   yum: pkg=atomic-enterprise-node state=present
   register: node_install_result
 
-- name: Install openshift-sdn-ovs
+- name: Install atomic-enterprise-sdn-ovs
   yum: pkg=atomic-enterprise-sdn-ovs state=present
   register: sdn_install_result
   when: openshift.common.use_openshift_sdn
@@ -40,11 +40,11 @@
     dest: "{{ openshift_node_config_file }}"
     src: node.yaml.v1.j2
   notify:
-  - restart openshift-node
+  - restart atomic-enterprise-node
 
 - name: Configure Atomic Enterprise Node settings
   lineinfile:
-    dest: /etc/sysconfig/openshift-node
+    dest: /etc/sysconfig/atomic-enterprise-node
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
   with_items:
@@ -53,7 +53,7 @@
     - regex: '^CONFIG_FILE='
       line: "CONFIG_FILE={{ openshift_node_config_file }}"
   notify:
-  - restart openshift-node
+  - restart atomic-enterprise-node
 
 - stat: path=/etc/sysconfig/docker
   register: docker_check
@@ -69,8 +69,8 @@
 - name: Allow NFS access for VMs
   seboolean: name=virt_use_nfs state=yes persistent=yes
 
-- name: Start and enable openshift-node
-  service: name=openshift-node enabled=yes state=started
+- name: Start and enable atomic-enterprise-node
+  service: name=atomic-enterprise-node enabled=yes state=started
   register: start_result
 
 - name: pause to prevent service restart from interfering with bootstrapping

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -7,16 +7,16 @@
     msg: This role requres that osn_cluster_dns_ip is set
   when: osn_cluster_dns_ip is not defined or not osn_cluster_dns_ip
 
-- name: Install OpenShift Node package
-  yum: pkg=openshift-node state=present
+- name: Install Atomic Enterprise Node package
+  yum: pkg=atomic-enterprise-node state=present
   register: node_install_result
 
 - name: Install openshift-sdn-ovs
-  yum: pkg=openshift-sdn-ovs state=present
+  yum: pkg=atomic-enterprise-sdn-ovs state=present
   register: sdn_install_result
   when: openshift.common.use_openshift_sdn
 
-- name: Set node OpenShift facts
+- name: Set node Atomic Enterprise facts
   openshift_facts:
     role: "{{ item.role }}"
     local_facts: "{{ item.local_facts }}"
@@ -42,7 +42,7 @@
   notify:
   - restart openshift-node
 
-- name: Configure OpenShift Node settings
+- name: Configure Atomic Enterprise Node settings
   lineinfile:
     dest: /etc/sysconfig/openshift-node
     regexp: "{{ item.regex }}"
@@ -59,7 +59,7 @@
   register: docker_check
 
   # TODO: Enable secure registry when code available in origin
-- name: Secure OpenShift Registry
+- name: Secure Atomic Enterprise Registry
   lineinfile:
     dest: /etc/sysconfig/docker
     regexp: '^OPTIONS=.*'

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -25,6 +25,7 @@
       registry_url: "{{ oreg_url | default(none) }}"
       debug_level: "{{ openshift_node_debug_level | default(openshift.common.debug_level) }}"
       portal_net: "{{ openshift_master_portal_net | default(None) }}"
+      product_type: "{{ openshift_product_type }}"
 
 - name: Install Node package
   yum: pkg={{ product_type }}-node state=present

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -7,16 +7,7 @@
     msg: This role requres that osn_cluster_dns_ip is set
   when: osn_cluster_dns_ip is not defined or not osn_cluster_dns_ip
 
-- name: Install Atomic Enterprise Node package
-  yum: pkg=atomic-enterprise-node state=present
-  register: node_install_result
-
-- name: Install atomic-enterprise-sdn-ovs
-  yum: pkg=atomic-enterprise-sdn-ovs state=present
-  register: sdn_install_result
-  when: openshift.common.use_openshift_sdn
-
-- name: Set node Atomic Enterprise facts
+- name: Set node facts
   openshift_facts:
     role: "{{ item.role }}"
     local_facts: "{{ item.local_facts }}"
@@ -26,6 +17,7 @@
       hostname: "{{ openshift_hostname | default(none) }}"
       public_hostname: "{{ openshift_public_hostname | default(none) }}"
       deployment_type: "{{ openshift_deployment_type }}"
+      product_type: "{{ openshift_product_type }}"
   - role: node
     local_facts:
       labels: "{{ openshift_node_labels | default(none) }}"
@@ -34,17 +26,26 @@
       debug_level: "{{ openshift_node_debug_level | default(openshift.common.debug_level) }}"
       portal_net: "{{ openshift_master_portal_net | default(None) }}"
 
+- name: Install Node package
+  yum: pkg={{ product_type }}-node state=present
+  register: node_install_result
+
+- name: Install sdn-ovs package
+  yum: pkg={{ product_type }}-sdn-ovs state=present
+  register: sdn_install_result
+  when: openshift.common.use_openshift_sdn
+
 # TODO: add the validate parameter when there is a validation command to run
 - name: Create the Node config
   template:
     dest: "{{ openshift_node_config_file }}"
     src: node.yaml.v1.j2
   notify:
-  - restart atomic-enterprise-node
+  - restart {{ product_type }}-node
 
-- name: Configure Atomic Enterprise Node settings
+- name: Configure Node settings
   lineinfile:
-    dest: /etc/sysconfig/atomic-enterprise-node
+    dest: /etc/sysconfig/{{ product_type }}-node
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
   with_items:
@@ -53,13 +54,13 @@
     - regex: '^CONFIG_FILE='
       line: "CONFIG_FILE={{ openshift_node_config_file }}"
   notify:
-  - restart atomic-enterprise-node
+  - restart {{ product_type }}-node
 
 - stat: path=/etc/sysconfig/docker
   register: docker_check
 
   # TODO: Enable secure registry when code available in origin
-- name: Secure Atomic Enterprise Registry
+- name: Secure Registry
   lineinfile:
     dest: /etc/sysconfig/docker
     regexp: '^OPTIONS=.*'
@@ -69,8 +70,8 @@
 - name: Allow NFS access for VMs
   seboolean: name=virt_use_nfs state=yes persistent=yes
 
-- name: Start and enable atomic-enterprise-node
-  service: name=atomic-enterprise-node enabled=yes state=started
+- name: Start and enable node
+  service: name={{ product_type }}-node enabled=yes state=started
   register: start_result
 
 - name: pause to prevent service restart from interfering with bootstrapping

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -42,7 +42,7 @@
     dest: "{{ openshift_node_config_file }}"
     src: node.yaml.v1.j2
   notify:
-  - restart {{ product_type }}-node
+  - restart node
 
 - name: Configure Node settings
   lineinfile:
@@ -55,7 +55,7 @@
     - regex: '^CONFIG_FILE='
       line: "CONFIG_FILE={{ openshift_node_config_file }}"
   notify:
-  - restart {{ product_type }}-node
+  - restart node
 
 - stat: path=/etc/sysconfig/docker
   register: docker_check

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -18,6 +18,7 @@
       public_hostname: "{{ openshift_public_hostname | default(none) }}"
       deployment_type: "{{ openshift_deployment_type }}"
       product_type: "{{ openshift_product_type }}"
+      service_type: "{{ 'origin' if deployment_type == 'origin' else 'atomic-enterprise' }}"
   - role: node
     local_facts:
       labels: "{{ openshift_node_labels | default(none) }}"
@@ -26,6 +27,7 @@
       debug_level: "{{ openshift_node_debug_level | default(openshift.common.debug_level) }}"
       portal_net: "{{ openshift_master_portal_net | default(None) }}"
       product_type: "{{ openshift_product_type }}"
+      service_type: "{{ 'origin' if deployment_type == 'origin' else 'atomic-enterprise' }}"
 
 - name: Install Node package
   yum: pkg={{ product_type }}-node state=present
@@ -72,7 +74,7 @@
   seboolean: name=virt_use_nfs state=yes persistent=yes
 
 - name: Start and enable node
-  service: name={{ product_type }}-node enabled=yes state=started
+  service: name={{ service_type }}-node enabled=yes state=started
   register: start_result
 
 - name: pause to prevent service restart from interfering with bootstrapping

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -8,7 +8,7 @@ imageConfig:
   format: {{ openshift.node.registry_url }}
   latest: false
 kind: NodeConfig
-masterKubeConfig: node.kubeconfig
+masterKubeConfig: system:node:{{ openshift.common.hostname }}.kubeconfig
 networkPluginName: {{ openshift.common.sdn_network_plugin_name }}
 nodeName: {{ openshift.common.hostname }}
 podManifestConfig:

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -6,7 +6,7 @@ dockerConfig:
   execHandlerName: ""
 imageConfig:
   format: {{ openshift.node.registry_url }}
-  latest: false
+  latest: true
 kind: NodeConfig
 masterKubeConfig: system:node:{{ openshift.common.hostname }}.kubeconfig
 networkPluginName: {{ openshift.common.sdn_network_plugin_name }}

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -8,7 +8,7 @@ imageConfig:
   format: {{ openshift.node.registry_url }}
   latest: false
 kind: NodeConfig
-masterKubeConfig: system:node:{{ openshift.common.hostname }}.kubeconfig
+masterKubeConfig: node.kubeconfig
 networkPluginName: {{ openshift.common.sdn_network_plugin_name }}
 nodeName: {{ openshift.common.hostname }}
 podManifestConfig:

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -6,7 +6,7 @@ dockerConfig:
   execHandlerName: ""
 imageConfig:
   format: {{ openshift.node.registry_url }}
-  latest: true
+  latest: false
 kind: NodeConfig
 masterKubeConfig: system:node:{{ openshift.common.hostname }}.kubeconfig
 networkPluginName: {{ openshift.common.sdn_network_plugin_name }}

--- a/roles/openshift_node_certificates/README.md
+++ b/roles/openshift_node_certificates/README.md
@@ -1,5 +1,5 @@
-OpenShift Node Certificates
-========================
+Atomic Enterprise Node Certificates
+====================================
 
 TODO
 

--- a/roles/openshift_node_certificates/README.md
+++ b/roles/openshift_node_certificates/README.md
@@ -1,5 +1,5 @@
-Node Certificates
-====================================
+OpenShift/Atomic Enterprise Node Certificates
+=============================================
 
 TODO
 

--- a/roles/openshift_node_certificates/README.md
+++ b/roles/openshift_node_certificates/README.md
@@ -1,4 +1,4 @@
-Atomic Enterprise Node Certificates
+Node Certificates
 ====================================
 
 TODO

--- a/roles/openshift_repos/tasks/main.yaml
+++ b/roles/openshift_repos/tasks/main.yaml
@@ -10,6 +10,9 @@
 - assert:
     that: openshift_deployment_type in known_openshift_deployment_types
 
+- assert:
+    that: openshift_product_type in known_openshift_product_types
+
 - name: Ensure libselinux-python is installed
   yum:
     pkg: libselinux-python

--- a/roles/openshift_repos/vars/main.yml
+++ b/roles/openshift_repos/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 known_openshift_deployment_types: ['origin', 'online', 'enterprise']
-known_openshift_product_types: ['origin', 'openshift', 'atomic-enterprise']
+known_openshift_product_types: ['openshift', 'atomic-enterprise']

--- a/roles/openshift_repos/vars/main.yml
+++ b/roles/openshift_repos/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 known_openshift_deployment_types: ['origin', 'online', 'enterprise']
+known_openshift_product_types: ['origin', 'openshift', 'atomic-enterprise']


### PR DESCRIPTION
Replaces #419 

This PR includes:

* Implementation of product_type feature to make the ansible installer work with openshift and atomic-enterprise.
* Merges changes related to services and config files in atomic-enterprise-ansible to openshift-ansible repo.
* Generalizes strings to make it not specific to openshift or atomic-enterprise.
* Reset of latest back to false
* Fixed mismatched environment variable