### PR TITLE
namespace the byo inventory so the group names aren't so generic

### DIFF
--- a/README_OSE.md
+++ b/README_OSE.md
@@ -65,8 +65,8 @@ option to ansible-playbook.
 
 # Create an OSEv3 group that contains the masters and nodes groups
 [OSEv3:children]
-masters
-nodes
+openshift_masters
+openshift_nodes
 
 # Set variables common for all OSEv3 hosts
 [OSEv3:vars]
@@ -96,11 +96,11 @@ openshift_additional_repos=[{'id': 'ose-devel', 'name': 'ose-devel',
 'https://copr-be.cloud.fedoraproject.org/results/maxamillion/origin-next/pubkey.gpg'}]
 
 # host group for masters
-[masters]
+[openshift_masters]
 ose3-master.example.com
 
 # host group for nodes
-[nodes]
+[openshift_nodes]
 ose3-node[1:2].example.com
 ```
 
@@ -234,7 +234,7 @@ what we expect them to be (if not, we can override them).
 To override the the defaults, you can set the variables in your inventory:
 ```
 ...snip...
-[masters]
+[openshift_masters]
 ose3-master.example.com openshift_ip=1.1.1.1 openshift_hostname=ose3-master.example.com openshift_public_ip=2.2.2.2 openshift_public_hostname=ose3-master.public.example.com
 ...snip...
 ```

--- a/README_origin.md
+++ b/README_origin.md
@@ -54,8 +54,8 @@ option to ansible-playbook.
 
 # Create an OSEv3 group that contains the masters and nodes groups
 [OSv3:children]
-masters
-nodes
+openshift_masters
+openshift_nodes
 
 # Set variables common for all OSEv3 hosts
 [OSv3:vars]
@@ -68,11 +68,11 @@ ansible_ssh_user=root
 deployment_type=origin
 
 # host group for masters
-[masters]
+[openshift_masters]
 osv3-master.example.com
 
 # host group for nodes
-[nodes]
+[openshift_nodes]
 osv3-node[1:2].example.com
 ```
 
@@ -207,7 +207,7 @@ what we expect them to be (if not, we can override them).
 To override the the defaults, you can set the variables in your inventory:
 ```
 ...snip...
-[masters]
+[openshift_masters]
 osv3-master.example.com openshift_ip=1.1.1.1 openshift_hostname=osv3-master.example.com openshift_public_ip=2.2.2.2 openshift_public_hostname=osv3-master.public.example.com
 ...snip...
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,8 +52,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.limit = 'all'
       ansible.sudo = true
       ansible.groups = {
-        "masters" => ["master"],
-        "nodes"   => ["node1", "node2"],
+        "openshift_masters" => ["master"],
+        "openshift_nodes"   => ["node1", "node2"],
       }
       ansible.extra_vars = {
         openshift_deployment_type: "origin",

--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -2,8 +2,8 @@
 
 # Create an OSEv3 group that contains the masters and nodes groups
 [OSEv3:children]
-masters
-nodes
+openshift_masters
+openshift_nodes
 etcd
 
 # Set variables common for all OSEv3 hosts
@@ -58,13 +58,13 @@ deployment_type=enterprise
 #osm_default_subdomain=apps.test.example.com
 
 # host group for masters
-[masters]
+[openshift_masters]
 ose3-master[1:3]-ansible.test.example.com
 
 [etcd]
 ose3-etcd[1:3]-ansible.test.example.com
 
 # host group for nodes
-[nodes]
+[openshift_nodes]
 ose3-master[1:3]-ansible.test.example.com openshift_scheduleable=False
 ose3-node[1:2]-ansible.test.example.com openshift_node_labels="{'region': 'primary', 'zone': 'default'}"

--- a/playbooks/byo/openshift-cluster/config.yml
+++ b/playbooks/byo/openshift-cluster/config.yml
@@ -2,8 +2,8 @@
 - include: ../../common/openshift-cluster/config.yml
   vars:
     g_etcd_group: "{{ 'etcd' }}"
-    g_masters_group: "{{ 'masters' }}"
-    g_nodes_group: "{{ 'nodes' }}"
+    g_masters_group: "{{ 'openshift_masters' }}"
+    g_nodes_group: "{{ 'openshift_nodes' }}"
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
     openshift_debug_level: 4
     openshift_deployment_type: "{{ deployment_type }}"


### PR DESCRIPTION
When importing the openshift-ansible roles and playbooks into a pre-existing git repository hosting infrastructure configuration for an entire environment (datacenter/$whatever) and not just an ansible repo dedicated to OpenShift, the names 'nodes' and 'masters' are a bit vague.

I've tested this in a byo deployment and it worked. Also, from what I understand this won't have an effect on the IaaS deployment playbooks because of the abstraction to `g_nodes_group` and `g_masters_group` respectively.

@twiest @detiber @wshearn - please review 