### PR TITLE
added pause before td-agent restart

### DIFF
--- a/roles/fluentd_master/tasks/main.yml
+++ b/roles/fluentd_master/tasks/main.yml
@@ -39,6 +39,9 @@
     owner: 'td-agent'
     mode: 0444
 
+- name: "Pause before restarting td-agent, since openshift-master needs more time to start"
+  pause: seconds=20
+
 - name: ensure td-agent is running
   service:
     name: 'td-agent'


### PR DESCRIPTION
The td-agent restart notifies the openshift-master service, which restarts before all the components are ready. This pause gives the openshift-master service enough time to start up properly.