### PR TITLE
take number of nodes into account when pausing

### DIFF
--- a/roles/fluentd_master/tasks/main.yml
+++ b/roles/fluentd_master/tasks/main.yml
@@ -39,8 +39,8 @@
     owner: 'td-agent'
     mode: 0444
 
-- name: "Pause before restarting td-agent, since openshift-master needs more time to start"
-  pause: seconds=20
+- name: "Pause before restarting td-agent and openshift-master, depending on the number of nodes."
+  pause: seconds={{ num_nodes|int * 5 }}
 
 - name: ensure td-agent is running
   service:


### PR DESCRIPTION
The more nodes we have, the longer the pause needed.