### PR TITLE
Prevent Ansible from serializing tasks

### DIFF
--- a/bin/cluster
+++ b/bin/cluster
@@ -23,6 +23,16 @@ class Cluster(object):
                 '-o ControlMaster=auto '
                 '-o ControlPersist=600s '
             )
+            # Because of `UserKnownHostsFile=/dev/null`
+            # our `.ssh/known_hosts` file most probably misses the ssh host public keys
+            # of our servers.
+            # In that case, ansible serializes the execution of ansible modules
+            # because we might be interactively prompted to accept the ssh host public keys.
+            # Because of `StrictHostKeyChecking=no` we know that we won't be prompted
+            # So, we don't want our modules execution to be serialized.
+            os.environ['ANSIBLE_HOST_KEY_CHECKING'] = 'False'
+            # TODO: A more secure way to proceed would consist in dynamically
+            # retrieving the ssh host public keys from the IaaS interface
 
     def get_deployment_type(self, args):
         """


### PR DESCRIPTION
Hi @twiest 

Thanks again for having brought to my knowledge the fact that ansible serializes tasks when the ssh `know_hosts` file misses the ssh public host keys of the machines because we might be interactively prompted to accept those keys.
https://stackoverflow.com/questions/17958949/how-do-i-drive-ansible-programmatically-and-concurrently/17979559#17979559

The workaround consisting in disabling the host key checking is a security issue.
But on the other hand, `bin/cluster` already sets ssh options to explicitly disable ssh public host keys checks (namely `StrictHostKeyChecking=no` and `UserKnownHostsFile=/dev/null`)

So, adding `ANSIBLE_HOST_KEY_CHECKING=False` only in the case where we put the above mentioned ssh options doesn’t degrade the security further, does it?