### PR TITLE
Fix infra node support on libvirt

### DIFF
--- a/playbooks/libvirt/openshift-cluster/launch.yml
+++ b/playbooks/libvirt/openshift-cluster/launch.yml
@@ -42,7 +42,7 @@
       count: "{{ num_infra }}"
   - include: tasks/launch_instances.yml
     vars:
-      instances: "{{ infra_names }}"
+      instances: "{{ node_names }}"
       cluster: "{{ cluster_id }}"
       type: "{{ k8s_type }}"
       g_sub_host_type: "{{ sub_host_type }}"


### PR DESCRIPTION
There was a typo in the infra node support on libvirt provider.
In fact, `set_node_launch_facts_tasks.yml` is always setting the `node_names` ansible variable for both the compute and the infra subtypes.

cc: @wshearn