### PR TITLE
Better structure the output of the list playbook

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -433,13 +433,16 @@ class FilterModule(object):
         def _add_host(clusters,
                       env,
                       host_type,
+                      sub_host_type,
                       host):
             ''' Add a new host in the clusters data structure '''
             if env not in clusters:
                 clusters[env] = {}
             if host_type not in clusters[env]:
-                clusters[env][host_type] = []
-            clusters[env][host_type].append(host)
+                clusters[env][host_type] = {}
+            if sub_host_type not in clusters[env][host_type]:
+                clusters[env][host_type][sub_host_type] = []
+            clusters[env][host_type][sub_host_type].append(host)
 
         clusters = {}
         for host in data:
@@ -447,10 +450,10 @@ class FilterModule(object):
                 _add_host(clusters=clusters,
                           env=_get_tag_value(host['group_names'], 'env'),
                           host_type=_get_tag_value(host['group_names'], 'host-type'),
+                          sub_host_type=_get_tag_value(host['group_names'], 'sub-host-type'),
                           host={'name': host['inventory_hostname'],
                                 'public IP': host['ansible_ssh_host'],
-                                'private IP': host['ansible_default_ipv4']['address'],
-                                'subtype': _get_tag_value(host['group_names'], 'sub-host-type')})
+                                'private IP': host['ansible_default_ipv4']['address']})
             except KeyError:
                 pass
         return clusters

--- a/playbooks/libvirt/openshift-cluster/list.yml
+++ b/playbooks/libvirt/openshift-cluster/list.yml
@@ -18,6 +18,12 @@
 
 - name: List Hosts
   hosts: oo_list_hosts
+
+- name: List Hosts
+  hosts: localhost
+  gather_facts: no
+  vars_files:
+  - vars.yml
   tasks:
   - debug:
-      msg: 'public:{{ansible_default_ipv4.address}} private:{{ansible_default_ipv4.address}}'
+      msg: "{{ hostvars | oo_select_keys(groups[scratch_group] | default([])) | oo_pretty_print_cluster }}"

--- a/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
@@ -81,7 +81,7 @@
     ansible_ssh_host: '{{ item.1 }}'
     ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
     ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
-    groups: 'tag_env-{{ cluster }}, tag_host-type-{{ type }}, tag_env-host-type-{{ cluster }}-openshift-{{ type }}'
+    groups: 'tag_env-{{ cluster }}, tag_host-type-{{ type }}, tag_env-host-type-{{ cluster }}-openshift-{{ type }}, tag_sub-host-type-{{ g_sub_host_type }}'
   with_together:
     - instances
     - ips

--- a/playbooks/libvirt/openshift-cluster/templates/domain.xml
+++ b/playbooks/libvirt/openshift-cluster/templates/domain.xml
@@ -6,6 +6,7 @@
       <ansible:tag>env-{{ cluster }}</ansible:tag>
       <ansible:tag>env-host-type-{{ cluster }}-openshift-{{ type }}</ansible:tag>
       <ansible:tag>host-type-{{ type }}</ansible:tag>
+      <ansible:tag>sub-host-type-{{ g_sub_host_type }}</ansible:tag>
     </ansible:tags>
   </metadata>
   <currentMemory unit='GiB'>1</currentMemory>

--- a/playbooks/openstack/openshift-cluster/list.yml
+++ b/playbooks/openstack/openshift-cluster/list.yml
@@ -19,6 +19,12 @@
 
 - name: List Hosts
   hosts: oo_list_hosts
+
+- name: List Hosts
+  hosts: localhost
+  gather_facts: no
+  vars_files:
+  - vars.yml
   tasks:
   - debug:
-      msg: 'public:{{ansible_ssh_host}} private:{{ansible_default_ipv4.address}}'
+      msg: "{{ hostvars | oo_select_keys(groups[scratch_group] | default([])) | oo_pretty_print_cluster }}"


### PR DESCRIPTION
The list playbook listed the IPs of the VMs without logging their role like:

    TASK: [debug ] ************************************************************
    ok: [10.64.109.37] => {
        "msg": "public:10.64.109.37 private:192.168.165.5"
    }
    ok: [10.64.109.47] => {
        "msg": "public:10.64.109.47 private:192.168.165.6"
    }
    ok: [10.64.109.36] => {
        "msg": "public:10.64.109.36 private:192.168.165.4"
    }
    ok: [10.64.109.215] => {
        "msg": "public:10.64.109.215 private:192.168.165.2"
    }

The list playbook now prints the information in a more structured way with
a list of masters, a list of nodes and the subtype of the nodes like:

    TASK: [debug ] ************************************************************
    ok: [localhost] => {
        "msg": {
            "lenaicnewlist": {
                "master": [
                    {
                        "name": "10.64.109.215",
                        "private IP": "192.168.165.2",
                        "public IP": "10.64.109.215",
                        "subtype": "default"
                    }
                ],
                "node": [
                    {
                        "name": "10.64.109.47",
                        "private IP": "192.168.165.6",
                        "public IP": "10.64.109.47",
                        "subtype": "compute"
                    },
                    {
                        "name": "10.64.109.37",
                        "private IP": "192.168.165.5",
                        "public IP": "10.64.109.37",
                        "subtype": "compute"
                    },
                    {
                        "name": "10.64.109.36",
                        "private IP": "192.168.165.4",
                        "public IP": "10.64.109.36",
                        "subtype": "infra"
                    }
                ]
            }
        }
    }