### PR TITLE
Require etcd-2.*

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install etcd
-  yum: pkg=etcd state=present
+  yum: pkg=etcd-2.* state=present
 
 - name: Validate permissions on the config dir
   file:


### PR DESCRIPTION
Fixes #422

When etcd-2.1 is available in RHEL7 / Centos 7 we'll bumpt to that as it's
considerably more stable with regard to WAL corruption and recovery.