### PR TITLE
Force “public hostname” to be the public IP

### DIFF
--- a/playbooks/libvirt/openshift-cluster/config.yml
+++ b/playbooks/libvirt/openshift-cluster/config.yml
@@ -22,3 +22,4 @@
     openshift_cluster_id: "{{ cluster_id }}"
     openshift_debug_level: 4
     openshift_deployment_type: "{{ deployment_type }}"
+    openshift_public_hostname: "{{ ansible_default_ipv4.address }}"

--- a/playbooks/openstack/openshift-cluster/config.yml
+++ b/playbooks/openstack/openshift-cluster/config.yml
@@ -18,3 +18,4 @@
     openshift_debug_level: 4
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_hostname: "{{ ansible_default_ipv4.address }}"
+    openshift_public_hostname: "{{ ansible_ssh_host }}"


### PR DESCRIPTION
on OpenStack and libvirt because the machine name is not something that
is DNS solvable from the outside of the cluster.
As a consequence, the OpenShift GUI renerated redirections to “unknown hosts”.

Fixes #469