### PR TITLE
wait for ports instead of waiting for an arbitrary period of time

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -186,6 +186,7 @@
   vars:
     sync_tmpdir: "{{ hostvars.localhost.g_master_mktemp.stdout }}"
     openshift_master_ha: "{{ groups.oo_masters_to_config | length > 1 }}"
+    embedded_etcd: "{{ openshift.master.embedded_etcd }}"
   pre_tasks:
   - name: Ensure certificate directory exists
     file:

--- a/roles/fluentd_master/tasks/main.yml
+++ b/roles/fluentd_master/tasks/main.yml
@@ -39,8 +39,13 @@
     owner: 'td-agent'
     mode: 0444
 
-- name: "Pause before restarting td-agent and openshift-master, depending on the number of nodes."
-  pause: seconds={{ ( num_nodes|int < 3 ) | ternary(15, (num_nodes|int * 5)) }}
+- name: wait for etcd to start up
+  wait_for: port=4001 delay=10
+  when: embedded_etcd | bool
+
+- name: wait for etcd peer to start up
+  wait_for: port=7001 delay=10
+  when: embedded_etcd | bool
 
 - name: ensure td-agent is running
   service:


### PR DESCRIPTION
This fixes the issue of intermittent failed builds for 2-node clusters.