### PR TITLE
Update syslog logrotate to compress and rotate daily

### DIFF
--- a/playbooks/aws/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/aws/openshift-cluster/tasks/launch_instances.yml
@@ -159,6 +159,22 @@
       type: "{{host_type}}"
   when: host_type != "node"
 
+- set_fact:
+    logrotate:
+        - name: syslog
+          path: "/var/log/cron
+                 \n/var/log/maillog
+                 \n/var/log/messages
+                 \n/var/log/secure
+                 \n/var/log/spooler \n"
+          options:
+            - daily
+            - rotate 7
+            - compress
+            - sharedscripts
+          scripts:
+            postrotate: "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"
+
 - name: Add new instances groups and variables
   add_host:
     hostname: "{{ item.0 }}"
@@ -169,6 +185,7 @@
     ec2_private_ip_address: "{{ item.1.private_ip }}"
     ec2_ip_address: "{{ item.1.public_ip }}"
     openshift_node_labels: "{{ node_label }}"
+    logrotate_scripts: "{{ logrotate }}"
   with_together:
   - instances
   - ec2.instances

--- a/playbooks/common/openshift-etcd/config.yml
+++ b/playbooks/common/openshift-etcd/config.yml
@@ -85,6 +85,7 @@
     when: etcd_server_certs_missing
   roles:
   - etcd
+  - role: nickhammond.logrotate
 
 - name: Delete temporary directory on localhost
   hosts: localhost

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -199,6 +199,7 @@
     when: master_certs_missing and 'oo_first_master' not in group_names
   roles:
   - openshift_master
+  - role: nickhammond.logrotate
   - role: fluentd_master
     when: openshift.common.use_fluentd | bool
   post_tasks:

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -99,6 +99,7 @@
     when: certs_missing
   roles:
   - openshift_node
+  - role: nickhammond.logrotate
   - role: fluentd_node
     when: openshift.common.use_fluentd | bool
   tasks:

--- a/roles/nickhammond.logrotate/.travis.yml
+++ b/roles/nickhammond.logrotate/.travis.yml
@@ -1,0 +1,14 @@
+---
+language: python
+python: "2.7"
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq python-apt python-pycurl
+install:
+  - pip install ansible
+script:
+  - "printf '[defaults]\nroles_path = ../' > ansible.cfg"
+  - ansible-playbook -i tests/inventory --syntax-check tests/test.yml
+  - ansible-playbook -i tests/inventory --connection=local --sudo -vvvv tests/test.yml
+notifications:
+  email: false

--- a/roles/nickhammond.logrotate/README.md
+++ b/roles/nickhammond.logrotate/README.md
@@ -1,0 +1,71 @@
+[![Build Status](https://travis-ci.org/nickhammond/ansible-logrotate.svg?branch=master)](https://travis-ci.org/nickhammond/ansible-logrotate)
+
+Role Name
+========
+
+Installs logrotate and provides an easy way to setup additional logrotate scripts by specifying a list of directives.
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+**logrotate_scripts**: A list of logrotate scripts and the directives to use for the rotation.
+
+* name - The name of the script that goes into /etc/logrotate.d/
+* path - Path to point logrotate to for the log rotation
+* options - List of directives for logrotate, view the logrotate man page for specifics
+* scripts - Dict of scripts for logrotate (see Example below)
+
+```
+logrotate_scripts:
+  - name: rails
+    path: "/srv/current/log/*.log"
+    options:
+      - weekly
+      - size 25M
+      - missingok
+      - compress
+      - delaycompress
+      - copytruncate
+```
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+-------------------------
+
+Setting up logrotate for additional Nginx logs, with postrotate script.
+
+```
+logrotate_scripts:
+  - name: nginx
+    path: /var/log/nginx/*.log
+    options:
+      - weekly
+      - size 25M
+      - rotate 7
+      - missingok
+      - compress
+      - delaycompress
+      - copytruncate
+    scripts:
+      postrotate: "[ -s /run/nginx.pid ] && kill USR1 `cat /run/nginx.pid`"
+
+```
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+Find [Nick Hammond]( http://www.nickhammond.com ) on [Twitter](http://twitter.com/nickhammond).

--- a/roles/nickhammond.logrotate/meta/.galaxy_install_info
+++ b/roles/nickhammond.logrotate/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Thu Aug 27 15:26:31 2015', version: master}

--- a/roles/nickhammond.logrotate/meta/main.yml
+++ b/roles/nickhammond.logrotate/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: Nick Hammond
+  description: Role to configure logrotate scripts
+  license: BSD
+  min_ansible_version: 1.5
+  platforms:
+  - name: Ubuntu
+    versions:
+    - lucid
+    - precise
+    - trusty
+  categories:
+  - system
+dependencies: []

--- a/roles/nickhammond.logrotate/tasks/main.yml
+++ b/roles/nickhammond.logrotate/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: nickhammond.logrotate | Install logrotate
+  action: "{{ansible_pkg_mgr}} pkg=logrotate state=present"
+
+- name: nickhammond.logrotate | Setup logrotate.d scripts
+  template:
+    src: logrotate.d.j2
+    dest: /etc/logrotate.d/{{ item.name }}
+  with_items: logrotate_scripts
+  when: logrotate_scripts is defined

--- a/roles/nickhammond.logrotate/templates/logrotate.d.j2
+++ b/roles/nickhammond.logrotate/templates/logrotate.d.j2
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+
+{{ item.path }} {
+  {% if item.options is defined -%}
+  {% for option in item.options -%}
+  {{ option }}
+  {% endfor -%}
+  {% endif %}
+  {%- if item.scripts is defined -%}
+  {%- for name, script in item.scripts.iteritems() -%}
+  {{ name }}
+    {{ script }}
+  endscript
+  {% endfor -%}
+  {% endif -%}
+}

--- a/roles/nickhammond.logrotate/tests/inventory
+++ b/roles/nickhammond.logrotate/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/roles/nickhammond.logrotate/tests/test.yml
+++ b/roles/nickhammond.logrotate/tests/test.yml
@@ -1,0 +1,18 @@
+---
+- hosts: all
+  sudo: True
+  roles:
+    - ansible-logrotate
+    - role: ansible-logrotate
+      logrotate_scripts:
+        - name: nginx-options
+          path: /var/log/nginx/options.log
+          options:
+            - daily
+
+    - role: ansible-logrotate
+      logrotate_scripts:
+        - name: nginx-scripts
+          path: /var/log/nginx/scripts.log
+          scripts:
+            postrotate: "echo test"


### PR DESCRIPTION
OpenShift V3 generates alot of logs.  To keep disk space from filling up we need to rotate the logs daily and compress them.  We will keep a weeks worth of these compressed logs.
