### PR TITLE
Add cockpit role

### DIFF
--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -44,6 +44,12 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Configure Fluentd
 #use_fluentd=true
 
+# Enable cockpit
+#osm_use_cockpit=true
+#
+# Set cockpit plugins
+#osm_cockpit_plugins=['cockpit-kubernetes']
+
 # master cluster ha variables using pacemaker or RHEL HA
 #openshift_master_cluster_password=openshift_cluster
 #openshift_master_cluster_vip=192.168.133.25

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -219,6 +219,15 @@
   - role: openshift_cluster_metrics
     when: openshift.common.use_cluster_metrics | bool
 
+- name: Enable cockpit
+  hosts: oo_first_master
+  vars:
+    cockpit_plugins: "{{ osm_cockpit_plugins | default(['cockpit-kubernetes']) }}"
+  roles:
+  - role: cockpit
+    when: ( deployment_type in ['atomic-enterprise','openshift-enterprise'] ) and
+      (osm_use_cockpit | bool or osm_use_cockpit is undefined )
+
 # Additional instance config for online deployments
 - name: Additional instance config
   hosts: oo_masters_deployment_type_online

--- a/roles/cockpit/defaults/main.yml
+++ b/roles/cockpit/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+os_firewall_use_firewalld: false
+os_firewall_allow:
+- service: cockpit-ws
+  port: 9090/tcp

--- a/roles/cockpit/meta/main.yml
+++ b/roles/cockpit/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: Scott Dodson
+  description: Deploy and Enable cockpit-ws plus optional plugins
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 1.7
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+dependencies:
+  - { role: os_firewall }

--- a/roles/cockpit/tasks/main.yml
+++ b/roles/cockpit/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Install cockpit-ws
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - cockpit-ws
+    - cockpit-shell
+    - cockpit-bridge
+    - "{{ cockpit_plugins }}"
+
+- name: Enable cockpit-ws
+  service:
+    name: cockpit.socket
+    enabled: true
+    state: started


### PR DESCRIPTION
Install cockpit-ws and cockpit-kubernetes by default for `atomic-enterprise` and `openshift-enterprise` installs.

Regrettably somewhat openshift specific due to dependency on os_firewall.

CC: @stefwalter