### PR TITLE
Fix a minor bug involving AWS ENV Keys

### DIFF
--- a/bin/cluster
+++ b/bin/cluster
@@ -164,7 +164,7 @@ class Cluster(object):
             boto_configs = [conf for conf in boto_conf_files if conf_exists(conf)]
 
             if len(key_missing) > 0 and len(boto_configs) == 0:
-                raise ValueError("PROVIDER aws requires {} environment variable(s). See README_AWS.md".format(missing))
+                raise ValueError("PROVIDER aws requires {} environment variable(s). See README_AWS.md".format(key_missing))
 
         elif 'libvirt' == provider:
             inventory = '-i inventory/libvirt/hosts'


### PR DESCRIPTION
* If a user forgot to set their AWS keys, we'd get a non descriptive error about a variable not being set
* This patch uses the correct variable so the error message is more informative
* actually resolves #417 