### PR TITLE
Move openshift_data_dir to openshift.common.data_dir fact based on deployment_type

### DIFF
--- a/roles/openshift_common/vars/main.yml
+++ b/roles/openshift_common/vars/main.yml
@@ -5,5 +5,3 @@
 # chains with the public zone (or the zone associated with the correct
 # interfaces)
 os_firewall_use_firewalld: False
-
-openshift_data_dir: /var/lib/origin

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -454,6 +454,8 @@ def set_deployment_facts_if_unset(facts):
             dict: the facts dict updated with the generated deployment_type
             facts
     """
+    # Perhaps re-factor this as a map?
+    # pylint: disable=too-many-branches
     if 'common' in facts:
         deployment_type = facts['common']['deployment_type']
         if 'service_type' not in facts['common']:
@@ -470,6 +472,13 @@ def set_deployment_facts_if_unset(facts):
             elif deployment_type == 'origin':
                 config_base = '/etc/openshift'
             facts['common']['config_base'] = config_base
+        if 'data_dir' not in facts['common']:
+            data_dir = '/var/lib/origin'
+            if deployment_type in ['enterprise', 'online']:
+                data_dir = '/var/lib/openshift'
+            elif deployment_type == 'origin':
+                data_dir = '/var/lib/openshift'
+            facts['common']['data_dir'] = data_dir
 
     for role in ('master', 'node'):
         if role in facts:

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -46,7 +46,7 @@ etcdConfig:
     certFile: etcd.server.crt
     clientCA: ca.crt
     keyFile: etcd.server.key
-  storageDirectory: {{ openshift_data_dir }}/openshift.local.etcd
+  storageDirectory: {{ openshift.common.data_dir }}/openshift.local.etcd
 {% endif %}
 etcdStorageConfig:
   kubernetesStoragePrefix: kubernetes.io

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -25,5 +25,5 @@ servingInfo:
   certFile: server.crt
   clientCA: ca.crt
   keyFile: server.key
-volumeDirectory: {{ openshift_data_dir }}/openshift.local.volumes
+volumeDirectory: {{ openshift.common.data_dir }}/openshift.local.volumes
 {% include 'partials/kubeletArguments.j2' %}


### PR DESCRIPTION
Previously this was being set to /var/lib/origin regardless of deployment_type
which isn't correct given that existing 'enterprise' and 'online' deployments
would have been deployed with /var/lib/openshift