### PR TITLE
Support HA or single router. Deploy after service accounts are created

### DIFF
--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -75,6 +75,10 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # default project node selector
 #osm_default_node_selector='region=primary'
 
+# default selectors for router and registry services
+# openshift_router_selector='region=infra'
+# openshift_registry_selector='region=infra'
+
 # set RPM version for debugging purposes
 #openshift_pkg_version=-3.0.0.0
 

--- a/playbooks/adhoc/s3_registry/s3_registry.yml
+++ b/playbooks/adhoc/s3_registry/s3_registry.yml
@@ -6,13 +6,14 @@
 # The AWS access/secret keys should be the keys of a separate user (not your main user), containing only the necessary S3 access role.
 # The 'clusterid' is the short name of your cluster.
 
-- hosts: security_group_{{ clusterid }}_master
+- hosts: tag_env-host-type_{{ clusterid }}-openshift-master
   remote_user: root
   gather_facts: False
 
   vars:
-    aws_access_key: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
-    aws_secret_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"
+    aws_access_key: "{{ lookup('env', 'S3_ACCESS_KEY_ID') }}"
+    aws_secret_key: "{{ lookup('env', 'S3_SECRET_ACCESS_KEY') }}"
+
   tasks:
 
   - name: Check for AWS creds
@@ -23,9 +24,15 @@
     - aws_access_key
     - aws_secret_key
 
+  - name: Scale down registry
+    command: oc scale --replicas=0 dc/docker-registry
+
   - name: Create S3 bucket
     local_action:
       module: s3 bucket="{{ clusterid }}-docker" mode=create
+
+  - name: Set up registry environment variable
+    command: oc env dc/docker-registry REGISTRY_CONFIGURATION_PATH=/etc/registryconfig/config.yml
 
   - name: Generate docker registry config
     template: src="s3_registry.j2" dest="/root/config.yml" owner=root mode=0600
@@ -53,6 +60,9 @@
   - name: Add secrets to registry deployment config
     command: oc volume dc/docker-registry --add --name=dockersecrets -m /etc/registryconfig --type=secret --secret-name=dockerregistry
     when: "'dockersecrets' not in dc.stdout"
+
+  - name: Wait for deployment config to take effect before scaling up
+    pause: seconds=30
 
   - name: Scale up registry
     command: oc scale --replicas=1 dc/docker-registry

--- a/playbooks/aws/openshift-cluster/launch.yml
+++ b/playbooks/aws/openshift-cluster/launch.yml
@@ -55,9 +55,4 @@
     when: master_names is defined and master_names.0 is defined
 
 - include: update.yml
-
-- include: ../../common/openshift-cluster/create_services.yml
-  vars:
-     g_svc_master: "{{ service_master }}"
-
 - include: list.yml

--- a/playbooks/common/openshift-cluster/create_services.yml
+++ b/playbooks/common/openshift-cluster/create_services.yml
@@ -1,8 +1,0 @@
----
-- name: Deploy OpenShift Services
-  hosts: "{{ g_svc_master }}"
-  connection: ssh
-  gather_facts: yes
-  roles:
-  - openshift_registry
-  - openshift_router

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -254,3 +254,10 @@
 
   roles:
   - openshift_serviceaccounts
+
+- name: Create services
+  hosts: oo_first_master
+
+  roles:
+    - openshift_router
+#    - openshift_registry

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1,6 +1,9 @@
-#!/usr/bin/python
+#!/usr/bin/python # pylint: disable=too-many-lines
 # -*- coding: utf-8 -*-
 # vim: expandtab:tabstop=4:shiftwidth=4
+# Reason: Disable pylint too-many-lines because we don't want to split up this file.
+# Status: Permanently disabled to keep this module as self-contained as possible.
+
 """Ansible module for retrieving and setting openshift related facts"""
 
 DOCUMENTATION = '''
@@ -316,6 +319,29 @@ def set_node_schedulability(facts):
                 facts['node']['schedulable'] = False
             else:
                 facts['node']['schedulable'] = True
+    return facts
+
+def set_master_selectors(facts):
+    """ Set selectors facts if not already present in facts dict
+        Args:
+            facts (dict): existing facts
+        Returns:
+            dict: the facts dict updated with the generated selectors
+            facts if they were not already present
+
+    """
+    if 'master' in facts:
+        if 'infra_nodes' in facts['master']:
+            deployment_type = facts['common']['deployment_type']
+            if deployment_type == 'online':
+                selector = "type=infra"
+            else:
+                selector = "region=infra"
+
+            if 'router_selector' not in facts['master']:
+                facts['master']['router_selector'] = selector
+            if 'registry_selector' not in facts['master']:
+                facts['master']['registry_selector'] = selector
     return facts
 
 def set_metrics_facts_if_unset(facts):
@@ -782,6 +808,7 @@ class OpenShiftFacts(object):
         facts = set_url_facts_if_unset(facts)
         facts = set_fluentd_facts_if_unset(facts)
         facts = set_node_schedulability(facts)
+        facts = set_master_selectors(facts)
         facts = set_metrics_facts_if_unset(facts)
         facts = set_identity_providers_if_unset(facts)
         facts = set_sdn_facts_if_unset(facts)

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -52,8 +52,11 @@
       default_subdomain: "{{ osm_default_subdomain | default(None) }}"
       custom_cors_origins: "{{ osm_custom_cors_origins | default(None) }}"
       default_node_selector: "{{ osm_default_node_selector | default(None) }}"
+      router_selector: "{{ openshift_router_selector | default(None) }}"
+      registry_selector: "{{ openshift_registry_selector | default(None) }}"
       api_server_args: "{{ osm_api_server_args | default(None) }}"
       controller_args: "{{ osm_controller_args | default(None) }}"
+      infra_nodes: "{{ num_infra | default(None) }}"
 
 - name: Install Master package
   yum: pkg={{ openshift.common.service_type }}-master{{ openshift_version  }} state=present

--- a/roles/openshift_registry/tasks/main.yml
+++ b/roles/openshift_registry/tasks/main.yml
@@ -1,11 +1,14 @@
 ---
-- set_fact: _oreg_images="--images={{ oreg_url|quote }}"
-  when: oreg_url is defined
+# This role is unused until we add options for configuring the backend storage
+
+- set_fact: _oreg_images="--images='{{ openshift.master.registry_url }}'"
+
+- set_fact: _oreg_selector="--selector='{{ openshift.master.registry_selector }}'"
 
 - name: Deploy OpenShift Registry
   command: >
     {{ openshift.common.admin_binary }} registry
-    --create
-    --credentials={{ openshift_master_config_dir }}/openshift-registry.kubeconfig {{ _oreg_images|default() }}
+    --create --service-account=registry {{ _oreg_selector }}
+    --credentials={{ openshift_master_config_dir }}/openshift-registry.kubeconfig {{ _oreg_images }}
   register: _oreg_results
   changed_when: "'service exists' not in _oreg_results.stdout"

--- a/roles/openshift_router/tasks/main.yml
+++ b/roles/openshift_router/tasks/main.yml
@@ -1,11 +1,14 @@
 ---
-- set_fact: _ortr_images="--images={{ oreg_url|quote }}"
-  when: oreg_url is defined
+
+- set_fact: _ortr_images="--images='{{ openshift.master.registry_url }}'"
+
+- set_fact: _ortr_selector="--selector='{{ openshift.master.router_selector }}'"
 
 - name: Deploy OpenShift Router
   command: >
     {{ openshift.common.admin_binary }} router
-    --create
-    --credentials={{ openshift_master_config_dir }}/openshift-router.kubeconfig {{ _ortr_images|default() }}
+    --create --replicas={{ num_infra }}
+    --service-account=router {{ _ortr_selector }}
+    --credentials={{ openshift_master_config_dir }}/openshift-router.kubeconfig {{ _ortr_images }}
   register: _ortr_results
   changed_when: "'service exists' not in _ortr_results.stdout"


### PR DESCRIPTION
Moved router deployment to common playbook. Deploy router after router service account exists.