### PR TITLE
Make the OpenShift API server certificate valid when targeted through…

### DIFF
--- a/roles/openshift_master_ca/tasks/main.yml
+++ b/roles/openshift_master_ca/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: Create the master certificates if they do not already exist
   command: >
     {{ openshift.common.admin_binary }} create-master-certs
-      --hostnames={{ openshift.common.all_hostnames | join(',') }}
+      --hostnames={{ openshift.common.all_hostnames | join(',') }},kubernetes.default.svc.cluster.local
       --master={{ openshift.master.api_url }}
       --public-master={{ openshift.master.public_api_url }}
       --cert-dir={{ openshift_master_config_dir }} --overwrite=false

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -36,7 +36,7 @@
 - name: Create the master certificates if they do not already exist
   command: >
     {{ openshift.common.admin_binary }} create-master-certs
-      --hostnames={{ item.openshift.common.all_hostnames | join(',') }}
+      --hostnames={{ item.openshift.common.all_hostnames | join(',') }},kubernetes.default.svc.cluster.local
       --master={{ item.openshift.master.api_url }}
       --public-master={{ item.openshift.master.public_api_url }}
       --cert-dir={{ openshift_generated_configs_dir }}/{{ item.master_cert_subdir }}


### PR DESCRIPTION
… the kubernetes service

We’re trying to communicate with OpenShift API server from a POD.
We set up a service account and we use the root CA used by OpenShift master which is made available to the POD in `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.

From the POD, the certificate is considered as invalid because the certificate is valid for:
* the name of the machine hosting the master
* the private IP of the machine hosting the master
* the public IP of the machine hosting the master

But from a POD, we access the API server through the `kubernetes` kubernetes service.
This PR makes the certificate also valid for the `kubernetes.default.svc.cluster.local` hostname.

Ideally, we should make that certificate also valid for the `$KUBERNETES_SERVICE_HOST` IP for the processes that prefer using the environment variables rather than the DNS API to locate the services. But, as the `servicesSubnet` and `serviceNetworkCIDR` are configurable, I’m not sure we can assume that it will always be `172.30.0.1`.