### PR TITLE
Add all the possible servicenames to openshift_all_hostnames

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -22,6 +22,7 @@ import copy
 import os
 from distutils.util import strtobool
 from distutils.version import LooseVersion
+from netaddr import IPNetwork
 
 
 def hostname_valid(hostname):
@@ -486,12 +487,21 @@ def set_aggregate_facts(facts):
     if 'common' in facts:
         all_hostnames.add(facts['common']['hostname'])
         all_hostnames.add(facts['common']['public_hostname'])
+        all_hostnames.add(facts['common']['ip'])
+        all_hostnames.add(facts['common']['public_ip'])
 
         if 'master' in facts:
+            # FIXME: not sure why but facts['dns']['domain'] fails
+            cluster_domain = 'cluster.local'
             if 'cluster_hostname' in facts['master']:
                 all_hostnames.add(facts['master']['cluster_hostname'])
             if 'cluster_public_hostname' in facts['master']:
                 all_hostnames.add(facts['master']['cluster_public_hostname'])
+            all_hostnames.update(['openshift', 'openshift.default', 'openshift.default.svc',
+                                  'openshift.default.svc.' + cluster_domain, 'kubernetes', 'kubernetes.default',
+                                  'kubernetes.default.svc', 'kubernetes.default.svc.' + cluster_domain])
+            first_svc_ip = str(IPNetwork(facts['master']['portal_net'])[1])
+            all_hostnames.add(first_svc_ip)
 
         facts['common']['all_hostnames'] = list(all_hostnames)
 

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -6,5 +6,8 @@
     - ansible_version | version_compare('1.9.0', 'ne')
     - ansible_version | version_compare('1.9.0.1', 'ne')
 
+- name: Ensure python-netaddr is installed
+  yum: pkg=python-netaddr state=installed
+
 - name: Gather Cluster facts
   openshift_facts:

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -34,6 +34,8 @@
     - serviceaccounts.private.key
     - serviceaccounts.public.key
 
+- debug: msg="{{ item.openshift.master.all_hostnames | join (',') }}"
+  with_items: masters_needing_certs
 
 - name: Create the master certificates if they do not already exist
   command: >


### PR DESCRIPTION
Fixes #411 
Related #586 

Adds the following hostnames to the master's cert by way of openshift_all_hostnames fact.
 - openshift
 - openshift.default
 - openshift.default.svc
 - openshift.default.svc.cluster.local
 - kubernetes
 - kubernetes.default
 - kubernetes.default.svc
 - kubernetes.default.svc.cluster.local
 - The first service ip based on service CIDR config
 - ip as determined by facts['common']['ip'] and facts['common']['public_ip']

Adds the following to all node certs
 - node's ip as determined by facts['common']['ip']

Does not handle updating certs.