### PR TITLE
Avoid attribute error in merge facts

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -644,7 +644,7 @@ def merge_facts(orig, new):
     facts = dict()
     for key, value in orig.iteritems():
         if key in new:
-            if isinstance(value, dict):
+            if isinstance(value, dict) and isinstance(new[key], dict):
                 facts[key] = merge_facts(value, new[key])
             else:
                 facts[key] = copy.copy(new[key])


### PR DESCRIPTION
In order to continue recursively merging old and new facts both values need to be dictionaries.

This issue can be seen with #599 where `identity_providers` was originally configured as a dictionary and then changed to a list in a subsequent run.