### PR TITLE
Prevent dns resolution recursion (loop).

### DIFF
--- a/playbooks/libvirt/openshift-cluster/templates/network.xml
+++ b/playbooks/libvirt/openshift-cluster/templates/network.xml
@@ -8,7 +8,7 @@
   <!-- TODO: query for first available virbr interface available -->
   <bridge name='virbr3' stp='on' delay='0'/>
   <!-- TODO: make overridable -->
-  <domain name='example.com'/>
+  <domain name='example.com' localOnly='yes' />
   <dns>
     <!-- TODO: automatically add host entries -->
   </dns>


### PR DESCRIPTION
The dnsmasq should not be resolving the example.com recursively, because
in case that we have /etc/NetworkManager/dnsmasq.d/libvirt_dnsmasq.conf:

    server=/example.com/192.168.55.1

the dnsmasq will be asking itself, therefore a dns resolution loop is
created, which causes

    Maximum number of concurrent DNS queries reached (max: 150)

and performance degradation of dns resolution on the whole hypervizor and
guests.

This patch will fix that in the domain.xml, which will cause adding

    local=/example.com/

to the /var/lib/libvirt/dnsmasq/openshift-ansible.conf, effectively
fixing the problem.