### PR TITLE
openshift_facts.py: Ansible fact for openshift version

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -474,6 +474,7 @@ def set_deployment_facts_if_unset(facts):
             if deployment_type in ['enterprise', 'online']:
                 data_dir = '/var/lib/openshift'
             facts['common']['data_dir'] = data_dir
+        facts['common']['version'] = get_openshift_version()
 
     for role in ('master', 'node'):
         if role in facts:
@@ -598,6 +599,19 @@ def get_current_config(facts):
 
     return current_config
 
+def get_openshift_version():
+    """ Get current version of openshift on the host
+
+        Returns:
+            version: the current openshift version
+    """
+    if os.path.isfile('/usr/bin/openshift'):
+        _, output, _ = module.run_command(['/usr/bin/openshift', 'version'])
+        versions = dict(e.split(' v') for e in output.splitlines())
+        version = versions.get('openshift', '')
+
+        #TODO: acknowledge the possility of a containerized install
+    return version
 
 def apply_provider_facts(facts, provider_facts):
     """ Apply provider facts to supplied facts dict


### PR DESCRIPTION
This added some logic to add a new the version of openshift rpm-based
installations. This fact is intentionally not cached to account for
users potenially updating versions outside of ansible playbooks.