### PR TITLE
openshift_facts.py: Correct error case for uninstalled systems

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -605,6 +605,8 @@ def get_openshift_version():
         Returns:
             version: the current openshift version
     """
+    version = ''
+
     if os.path.isfile('/usr/bin/openshift'):
         _, output, _ = module.run_command(['/usr/bin/openshift', 'version'])
         versions = dict(e.split(' v') for e in output.splitlines())


### PR DESCRIPTION
This adds a default value to the version to cover the case where
the user doesn't have /usr/bin/openshift on the system, correcting
the bug found in PR #646.