### PR TITLE
Fix for name conflict

### DIFF
--- a/roles/openshift_examples/files/examples/xpaas-templates/eap6-https-sti.json
+++ b/roles/openshift_examples/files/examples/xpaas-templates/eap6-https-sti.json
@@ -6,10 +6,10 @@
             "iconClass" : "icon-jboss",
             "description": "Application template for EAP 6 applications built using STI."
         },
-        "name": "eap6-basic-sti"
+        "name": "eap6-https-sti"
     },
     "labels": {
-        "template": "eap6-basic-sti"
+        "template": "eap6-https-sti"
     },
     "parameters": [
         {


### PR DESCRIPTION
Template name is conflicting with the template name from 'eap6-basic-sti.json' .