### PR TITLE
Allow disabling the network plugin configuration

### DIFF
--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -87,7 +87,9 @@ masterPublicURL: {{ openshift.master.public_api_url }}
 networkConfig:
   clusterNetworkCIDR: {{ openshift.master.sdn_cluster_network_cidr }}
   hostSubnetLength: {{ openshift.master.sdn_host_subnet_length }}
+  {% if openshift.common.use_openshift_sdn %}
   networkPluginName: {{ openshift.common.sdn_network_plugin_name }}
+  {% endif %}
 # serviceNetworkCIDR must match kubernetesMasterConfig.servicesSubnet
   serviceNetworkCIDR: {{ openshift.master.portal_net }}
 {% include 'v1_partials/oauthConfig.j2' %}

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -12,12 +12,16 @@ kind: NodeConfig
 kubeletArguments: {{ openshift.node.kubelet_args | to_json }}
 {% endif %}
 masterKubeConfig: system:node:{{ openshift.common.hostname }}.kubeconfig
+{% if openshift.common.use_openshift_sdn %}
 networkPluginName: {{ openshift.common.sdn_network_plugin_name }}
+{% endif %}
 # networkConfig struct introduced in origin 1.0.6 and OSE 3.0.2 which
 # deprecates networkPluginName above. The two should match.
 networkConfig:
    mtu: {{ openshift.node.sdn_mtu }}
+{% if openshift.common.use_openshift_sdn %}
    networkPluginName: {{ openshift.common.sdn_network_plugin_name }}
+{% endif %}
 nodeName: {{ openshift.common.hostname | lower }}
 podManifestConfig:
 servingInfo:


### PR DESCRIPTION
This is useful when we want to use a different networking solution
without having any networking plugin code run when the services start
up.