### PR TITLE
Adjust the logic as to when examples are deployed

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -216,8 +216,7 @@
   roles:
   - role: openshift_master_cluster
     when: openshift_master_ha | bool
-  - role: openshift_examples
-    when: deployment_type in ['enterprise','openshift-enterprise','origin']
+  - openshift_examples
   - role: openshift_cluster_metrics
     when: openshift.common.use_cluster_metrics | bool
 

--- a/roles/openshift_examples/defaults/main.yml
+++ b/roles/openshift_examples/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 # By default install rhel and xpaas streams on enterprise installs
-openshift_examples_load_centos: "{{ openshift_deployment_type not in ['enterprise','openshift-enterprise','atomic-enterprise'] }}"
-openshift_examples_load_rhel: "{{ openshift_deployment_type in ['enterprise','openshift-enterprise','atomic-enterprise'] }}"
+openshift_examples_load_centos: "{{ openshift_deployment_type not in ['enterprise','openshift-enterprise','atomic-enterprise','online'] }}"
+openshift_examples_load_rhel: "{{ openshift_deployment_type in ['enterprise','openshift-enterprise','atomic-enterprise','online'] }}"
 openshift_examples_load_db_templates: true
-openshift_examples_load_xpaas: "{{ openshift_deployment_type in ['enterprise','openshift-enterprise','atomic-enterprise']  }}"
+openshift_examples_load_xpaas: "{{ openshift_deployment_type in ['enterprise','openshift-enterprise','atomic-enterprise','online']  }}"
 openshift_examples_load_quickstarts: true
 
 examples_base: /usr/share/openshift/examples

--- a/roles/openshift_examples/defaults/main.yml
+++ b/roles/openshift_examples/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 # By default install rhel and xpaas streams on enterprise installs
-openshift_examples_load_centos: "{{ openshift_deployment_type != 'enterprise' }}"
-openshift_examples_load_rhel: "{{ openshift_deployment_type == 'enterprise' }}"
+openshift_examples_load_centos: "{{ openshift_deployment_type not in ['enterprise','openshift-enterprise','atomic-enterprise'] }}"
+openshift_examples_load_rhel: "{{ openshift_deployment_type in ['enterprise','openshift-enterprise','atomic-enterprise'] }}"
 openshift_examples_load_db_templates: true
-openshift_examples_load_xpaas: "{{ openshift_deployment_type == 'enterprise' }}"
+openshift_examples_load_xpaas: "{{ openshift_deployment_type in ['enterprise','openshift-enterprise','atomic-enterprise']  }}"
 openshift_examples_load_quickstarts: true
 
 examples_base: /usr/share/openshift/examples

--- a/roles/openshift_examples/tasks/main.yml
+++ b/roles/openshift_examples/tasks/main.yml
@@ -9,7 +9,7 @@
   command: >
     {{ openshift.common.client_binary }} {{ openshift_examples_import_command }} -n openshift -f {{ rhel_image_streams }}
   when: openshift_examples_load_rhel
-  register: oex_import_rhel_streams
+  register: oex_import_rhel_streams | bool
   failed_when: "'already exists' not in oex_import_rhel_streams.stderr and oex_import_rhel_streams.rc != 0"
   changed_when: false
 
@@ -32,7 +32,7 @@
 - name: Import quickstart-templates
   command: >
     {{ openshift.common.client_binary }} {{ openshift_examples_import_command }} -n openshift -f {{ quickstarts_base }}
-  when: openshift_examples_load_quickstarts
+  when: openshift_examples_load_quickstarts | bool
   register: oex_import_quickstarts
   failed_when: "'already exists' not in oex_import_quickstarts.stderr and oex_import_quickstarts.rc != 0"
   changed_when: false


### PR DESCRIPTION
* Move all example enablement into the openshift_examples role
* Add openshift-enterprise and atomic-openshift to the mix