### PR TITLE
Add masterCA to oauth template

### DIFF
--- a/roles/openshift_master/templates/v1_partials/oauthConfig.j2
+++ b/roles/openshift_master/templates/v1_partials/oauthConfig.j2
@@ -80,6 +80,7 @@ oauthConfig:
     provider:
 {{ identity_provider_config(identity_provider) }}
 {%- endfor %}
+  masterCA: ca.crt
   masterPublicURL: {{ openshift.master.public_api_url }}
   masterURL: {{ openshift.master.api_url }}
   sessionConfig:


### PR DESCRIPTION
Adds default value from https://github.com/openshift/origin/pull/4896

This is a reference to the same CA used in the service account config. I didn't see that templatized or variablized, so I used the same value