### PR TITLE
'setfacl ...' works on Fedora 22 and solves a permissions issue

### DIFF
--- a/README_libvirt.md
+++ b/README_libvirt.md
@@ -75,7 +75,7 @@ In order to fix that issue, you have several possibilities:
    * accessible by the qemu user.
  * Grant the qemu user access to the storage pool.
 
-On Arch:
+On Arch or Fedora 22+:
 
 ```
 setfacl -m g:kvm:--x ~


### PR DESCRIPTION
Issue with the lenaic master qcow image (docs mention Arch currently).