### PR TITLE
Changed default ssl port on the master from 8443 to 443

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -815,9 +815,9 @@ class OpenShiftFacts(object):
         defaults['common'] = common
 
         if 'master' in roles:
-            master = dict(api_use_ssl=True, api_port='8443',
+            master = dict(api_use_ssl=True, api_port='443',
                           console_use_ssl=True, console_path='/console',
-                          console_port='8443', etcd_use_ssl=True, etcd_hosts='',
+                          console_port='443', etcd_use_ssl=True, etcd_hosts='',
                           etcd_port='4001', portal_net='172.30.0.0/16',
                           embedded_etcd=True, embedded_kube=True,
                           embedded_dns=True, dns_port='53',

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -6,7 +6,7 @@ os_firewall_allow:
 - service: etcd embedded
   port: 4001/tcp
 - service: api server https
-  port: 8443/tcp
+  port: 443/tcp
 - service: dns tcp
   port: 53/tcp
 - service: dns udp

--- a/roles/openshift_master_cluster/tasks/configure.yml
+++ b/roles/openshift_master_cluster/tasks/configure.yml
@@ -38,7 +38,7 @@
 - name: Wait for the clustered master service to be available
   wait_for:
     host: "{{ openshift_master_cluster_vip }}"
-    port: 8443
+    port: 443
     state: started
     timeout: 180
     delay: 90


### PR DESCRIPTION
This is the patch that @wshearn wrote to make it so that the master defaults to 443 instead of 8443. We use it in all of our cluster builds, so I think it should get moved into master.