### PR TITLE
RH subscription: optional satellite and pkg update

### DIFF
--- a/roles/rhel_subscribe/tasks/main.yml
+++ b/roles/rhel_subscribe/tasks/main.yml
@@ -6,18 +6,25 @@
 - set_fact:
     rhel_subscription_user: "{{ lookup('oo_option', 'rhel_subscription_user') | default(rhsub_user, True) | default(omit, True) }}"
     rhel_subscription_pass: "{{ lookup('oo_option', 'rhel_subscription_pass') | default(rhsub_pass, True) | default(omit, True) }}"
+    rhel_subscription_server: "{{ lookup('oo_option', 'rhel_subscription_server') | default(rhsub_server) }}"
 
 - fail:
     msg: "This role is only supported for Red Hat hosts"
   when: ansible_distribution != 'RedHat'
 
 - fail:
-    msg: Either rsub_user or the rhel_subscription_user env variable are required for this role.
+    msg: Either rhsub_user or the rhel_subscription_user env variable are required for this role.
   when: rhel_subscription_user is not defined
 
 - fail:
-    msg: Either rsub_pass or the rhel_subscription_pass env variable are required for this role.
+    msg: Either rhsub_pass or the rhel_subscription_pass env variable are required for this role.
   when: rhel_subscription_pass is not defined
+
+- name: Satellite preparation
+  command: "rpm -Uvh http://{{ rhel_subscription_server }}/pub/katello-ca-consumer-latest.noarch.rpm"
+  args:
+    creates: /etc/rhsm/ca/katello-server-ca.pem
+  when: rhel_subscription_server is defined and rhel_subscription_server
 
 - name: RedHat subscriptions
   redhat_subscription:


### PR DESCRIPTION
Add an optional rhel_subscription_server fact to configure RHSM registration to a Red Hat Satellite server.

If rhel_subscription_server is set to satellite.example.com, this will install the katello-ca-consumer-latest RPM hosted by satellite.example.com before calling redhat_subscription. This RPM gets the certs from the satellite and configures rhsm.conf to point to it.
