### PR TITLE
Make package updates optional

### DIFF
--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -24,6 +24,14 @@ debug_level=2
 # deployment type valid values are origin, online, atomic-enterprise, and openshift-enterprise
 deployment_type=atomic-enterprise
 
+# Skip subscription via rhel_subscription / subscription-manager
+# This can be set globally and/or overriden per host
+#openshift_rhel_skip_subscription=false
+
+# By default the installer attempts to update the system before installing
+# and configuring. Set openshift_skip_pkg_update=true to prevent that update
+#openshift_skip_pkg_update=false
+
 # Install the openshift examples
 #openshift_install_examples=true
 

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -24,6 +24,14 @@ debug_level=2
 # deployment type valid values are origin, online, atomic-enterprise, and openshift-enterprise
 deployment_type=openshift-enterprise
 
+# Skip subscription via rhel_subscription / subscription-manager
+# This can be set globally and/or overriden per host
+#openshift_rhel_skip_subscription=false
+
+# By default the installer attempts to update the system before installing
+# and configuring. Set openshift_skip_pkg_update=true to prevent that update
+#openshift_skip_pkg_update=false
+
 # Install the openshift examples
 #openshift_install_examples=true
 

--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -1,12 +1,19 @@
 ---
-- hosts: all
-  vars:
-    openshift_deployment_type: "{{ deployment_type }}"
-  roles:
-  - role: rhel_subscribe
-    when: deployment_type in ['atomic-enterprise', 'enterprise', 'openshift-enterprise'] and
-          ansible_distribution == "RedHat" and
-          lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
-          default('no', True) | lower in ['no', 'false']
-  - openshift_repos
-  - os_update_latest
+- name: Populate oo_hosts_to_update group
+  hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  vars_files:
+  - openshift-cluster/cluster_hosts.yml
+  tasks:
+  - name: Evaluate oo_hosts_to_update
+    add_host:
+      name: "{{ item }}"
+      groups: oo_hosts_to_update
+      openshift_cluster_id: "{{ cluster_id | default('default') }}"
+      openshift_debug_level: 2
+      openshift_deployment_type: "{{ deployment_type }}"
+    with_items: "{{ g_all_hosts | default([]) }}"
+
+- include: ../common/openshift-cluster/update_repos_and_packages.yml

--- a/playbooks/common/openshift-cluster/update_repos_and_packages.yml
+++ b/playbooks/common/openshift-cluster/update_repos_and_packages.yml
@@ -5,8 +5,10 @@
   roles:
   - role: rhel_subscribe
     when: deployment_type in ["enterprise", "atomic-enterprise", "openshift-enterprise"] and
-          ansible_distribution == "RedHat" and
-          lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
-            default('no', True) | lower in ['no', 'false']
+          ansible_distribution == "RedHat" and not ( openshift_rhel_skip_subscription |
+          default(lookup('oo_option', 'rhel_skip_subscription')) | default(rhsub_skip) |
+          default(False) | bool )
   - openshift_repos
-  - os_update_latest
+  - role: os_update_latest
+    when: not (openshift_skip_pkg_update | default(lookup('oo_option', 'skip_pkg_update')) |
+          default(False) | bool or openshift.common.is_containerized)


### PR DESCRIPTION
Add an oo_option "skip_pkg_update" that allows to skip package updates (i.e. do not "yum update *" if this is set to something different than false)

This is useful when provisioning reproducer environments that should keep certain package versions
