### PR TITLE
Improvements to uninstallation playbook

### DIFF
--- a/playbooks/adhoc/atomic_openshift_tutorial_reset.yml
+++ b/playbooks/adhoc/atomic_openshift_tutorial_reset.yml
@@ -1,6 +1,9 @@
 # This deletes *ALL* Docker images, and uninstalls OpenShift and
 # Atomic Enterprise RPMs.  It is primarily intended for use
 # with the tutorial as well as for developers to reset state.
+#
+---
+- include: uninstall.yml
 
 - hosts:
     - OSEv3:children
@@ -8,59 +11,6 @@
   sudo: yes
 
   tasks:
-    - service: name={{ item }} state=stopped
-      with_items:
-        - openvswitch
-        - origin-master
-        - origin-node
-        - atomic-openshift-master
-        - atomic-openshift-node
-        - openshift-master
-        - openshift-node
-        - atomic-enterprise-master
-        - atomic-enterprise-node
-        - etcd
-
-    - yum: name={{ item }} state=absent
-      with_items:
-        - openvswitch
-        - etcd
-        - origin
-        - origin-master
-        - origin-node
-        - origin-sdn-ovs
-        - tuned-profiles-origin-node
-        - atomic-openshift
-        - atomic-openshift-master
-        - atomic-openshift-node
-        - atomic-openshift-sdn-ovs
-        - tuned-profiles-atomic-openshift-node
-        - atomic-enterprise
-        - atomic-enterprise-master
-        - atomic-enterprise-node
-        - atomic-enterprise-sdn-ovs
-        - tuned-profiles-atomic-enterprise-node
-        - openshift
-        - openshift-master
-        - openshift-node
-        - openshift-sdn-ovs
-        - tuned-profiles-openshift-node
-
-    - shell: systemctl reset-failed
-      changed_when: False
-
-    - shell: systemctl daemon-reload
-      changed_when: False
-
-    - shell: find /var/lib/origin/openshift.local.volumes -type d -exec umount {} \; 2>/dev/null || true
-      changed_when: False
-
-    - shell: find /var/lib/atomic-enterprise/openshift.local.volumes -type d -exec umount {} \; 2>/dev/null || true
-      changed_when: False
-
-    - shell: find /var/lib/openshift/openshift.local.volumes -type d -exec umount {} \; 2>/dev/null || true
-      changed_when: False
-
     - shell: docker ps -a -q | xargs docker stop
       changed_when: False
       failed_when: False
@@ -72,27 +22,6 @@
     - shell:  docker images -q |xargs docker rmi
       changed_when: False
       failed_when: False
-
-    - file: path={{ item }} state=absent
-      with_items:
-        - /etc/openshift-sdn
-        - /root/.kube
-        - /etc/origin
-        - /etc/atomic-enterprise
-        - /etc/openshift
-        - /var/lib/origin
-        - /var/lib/openshift
-        - /var/lib/atomic-enterprise
-        - /etc/sysconfig/origin-master
-        - /etc/sysconfig/origin-node
-        - /etc/sysconfig/atomic-openshift-master
-        - /etc/sysconfig/atomic-openshift-node
-        - /etc/sysconfig/openshift-master
-        - /etc/sysconfig/openshift-node
-        - /etc/sysconfig/atomic-enterprise-master
-        - /etc/sysconfig/atomic-enterprise-node
-        - /etc/etcd
-        - /var/lib/etcd
 
     - user: name={{ item }} state=absent remove=yes
       with_items:

--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -1,0 +1,111 @@
+# This deletes *ALL* Origin, Atomic Enterprise Platform and OpenShift
+# Enterprise content installed by ansible.  This includes:
+# 
+#    configuration
+#    containers
+#    example templates and imagestreams
+#    images
+#    RPMs
+---
+- hosts:
+    - OSEv3:children
+
+  sudo: yes
+
+  tasks:
+    - service: name={{ item }} state=stopped
+      with_items:
+        - openvswitch
+        - origin-master
+        - origin-node
+        - atomic-openshift-master
+        - atomic-openshift-node
+        - openshift-master
+        - openshift-node
+        - atomic-enterprise-master
+        - atomic-enterprise-node
+        - etcd
+
+    - yum: name={{ item }} state=absent
+      with_items:
+        - openvswitch
+        - etcd
+        - origin
+        - origin-master
+        - origin-node
+        - origin-sdn-ovs
+        - tuned-profiles-origin-node
+        - atomic-openshift
+        - atomic-openshift-master
+        - atomic-openshift-node
+        - atomic-openshift-sdn-ovs
+        - tuned-profiles-atomic-openshift-node
+        - atomic-enterprise
+        - atomic-enterprise-master
+        - atomic-enterprise-node
+        - atomic-enterprise-sdn-ovs
+        - tuned-profiles-atomic-enterprise-node
+        - openshift
+        - openshift-master
+        - openshift-node
+        - openshift-sdn-ovs
+        - tuned-profiles-openshift-node
+
+    - shell: systemctl reset-failed
+      changed_when: False
+
+    - shell: systemctl daemon-reload
+      changed_when: False
+
+    - shell: find /var/lib/origin/openshift.local.volumes -type d -exec umount {} \; 2>/dev/null || true
+      changed_when: False
+
+    - shell: find /var/lib/atomic-enterprise/openshift.local.volumes -type d -exec umount {} \; 2>/dev/null || true
+      changed_when: False
+
+    - shell: find /var/lib/openshift/openshift.local.volumes -type d -exec umount {} \; 2>/dev/null || true
+      changed_when: False
+
+    - shell: docker rm -f "{{ item }}"-master "{{ item }}"-node 
+      changed_when: False
+      failed_when: False
+      with_items:
+        - openshift-enterprise
+        - atomic-enterprise
+        - origin
+
+    - shell: docker images | grep {{ item }} | awk '{ print $3 }'
+      changed_when: False
+      failed_when: False
+      register: images_to_delete
+      with_items:
+        - registry.access.redhat.com/openshift3
+        - registry.access.redhat.com/aep3
+        - docker.io/openshift
+
+    - shell:  "docker rmi {{ item.stdout_lines | join(' ') }}"
+      changed_when: False
+      failed_when: False
+      with_items: "{{ images_to_delete.results }}"
+
+    - file: path={{ item }} state=absent
+      with_items:
+        - /etc/atomic-enterprise
+        - /etc/etcd
+        - /etc/openshift
+        - /etc/openshift-sdn
+        - /etc/origin
+        - /etc/sysconfig/atomic-enterprise-master
+        - /etc/sysconfig/atomic-enterprise-node
+        - /etc/sysconfig/atomic-openshift-master
+        - /etc/sysconfig/atomic-openshift-node
+        - /etc/sysconfig/openshift-master
+        - /etc/sysconfig/openshift-node
+        - /etc/sysconfig/origin-master
+        - /etc/sysconfig/origin-node
+        - /root/.kube
+        - /usr/share/openshift/examples
+        - /var/lib/atomic-enterprise
+        - /var/lib/etcd
+        - /var/lib/openshift
+        - /var/lib/origin

--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -96,6 +96,7 @@
 
     - file: path={{ item }} state=absent
       with_items:
+        - /etc/ansible/facts.d/openshift.fact
         - /etc/atomic-enterprise
         - /etc/etcd
         - /etc/openshift

--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -15,41 +15,47 @@
   tasks:
     - service: name={{ item }} state=stopped
       with_items:
-        - openvswitch
-        - origin-master
-        - origin-node
-        - atomic-openshift-master
-        - atomic-openshift-node
-        - openshift-master
-        - openshift-node
         - atomic-enterprise-master
         - atomic-enterprise-node
+        - atomic-openshift-master
+        - atomic-openshift-master-api
+        - atomic-openshift-master-controllers
+        - atomic-openshift-node
         - etcd
+        - openshift-master
+        - openshift-master-api
+        - openshift-master-controllers
+        - openshift-node
+        - openvswitch
+        - origin-master
+        - origin-master-api
+        - origin-master-controllers
+        - origin-node
 
     - yum: name={{ item }} state=absent
       with_items:
-        - openvswitch
-        - etcd
-        - origin
-        - origin-master
-        - origin-node
-        - origin-sdn-ovs
-        - tuned-profiles-origin-node
-        - atomic-openshift
-        - atomic-openshift-master
-        - atomic-openshift-node
-        - atomic-openshift-sdn-ovs
-        - tuned-profiles-atomic-openshift-node
         - atomic-enterprise
         - atomic-enterprise-master
         - atomic-enterprise-node
         - atomic-enterprise-sdn-ovs
-        - tuned-profiles-atomic-enterprise-node
+        - atomic-openshift
+        - atomic-openshift-master
+        - atomic-openshift-node
+        - atomic-openshift-sdn-ovs
+        - etcd
         - openshift
         - openshift-master
         - openshift-node
         - openshift-sdn-ovs
+        - openvswitch
+        - origin
+        - origin-master
+        - origin-node
+        - origin-sdn-ovs
+        - tuned-profiles-atomic-enterprise-node
+        - tuned-profiles-atomic-openshift-node
         - tuned-profiles-openshift-node
+        - tuned-profiles-origin-node
 
     - shell: systemctl reset-failed
       changed_when: False

--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -39,6 +39,7 @@
         - atomic-enterprise-node
         - atomic-enterprise-sdn-ovs
         - atomic-openshift
+        - atomic-openshift-clients
         - atomic-openshift-master
         - atomic-openshift-node
         - atomic-openshift-sdn-ovs
@@ -46,6 +47,7 @@
         - openshift
         - openshift-master
         - openshift-node
+        - openshift-sdn
         - openshift-sdn-ovs
         - openvswitch
         - origin
@@ -80,6 +82,20 @@
         - atomic-enterprise
         - origin
 
+    - shell: docker ps -a | grep Exited | grep "{{ item }}" | awk '{print $1}'
+      changed_when: False
+      failed_when: False
+      register: exited_containers_to_delete
+      with_items:
+        - aep3/aep
+        - openshift3/ose
+        - openshift/origin
+
+    - shell: "docker rm {{ item.stdout_lines | join(' ') }}"
+      changed_when: False
+      failed_when: False
+      with_items: "{{ exited_containers_to_delete.results }}"
+
     - shell: docker images | grep {{ item }} | awk '{ print $3 }'
       changed_when: False
       failed_when: False
@@ -89,7 +105,7 @@
         - registry.access.redhat.com/aep3
         - docker.io/openshift
 
-    - shell:  "docker rmi {{ item.stdout_lines | join(' ') }}"
+    - shell:  "docker rmi -f {{ item.stdout_lines | join(' ') }}"
       changed_when: False
       failed_when: False
       with_items: "{{ images_to_delete.results }}"


### PR DESCRIPTION
This is related to https://trello.com/c/314nwSvt/58-3-uninstall-playbook

The original atomic_openshift_tutorial_reset.yml now calls the uninstall
playbook for most parts.  All the originally functionally is still intact.  The
main differences between the two playbooks is that the uninstall playbook is
careful only to delete content that ansible originally installed.