### PR TITLE
Fix inconcistency in naming for rpm generated config test

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -2,6 +2,21 @@
 - name: Set master facts and determine if external etcd certs need to be generated
   hosts: oo_masters_to_config
   pre_tasks:
+  - name: Check for RPM generated config marker file .config_managed
+    stat:
+      path: /etc/origin/.config_managed
+    register: rpmgenerated_config
+
+  - name: Remove RPM generated config files if present
+    file:
+      path: "/etc/origin/{{ item }}"
+      state: absent
+    when: rpmgenerated_config.stat.exists == true and deployment_type in ['openshift-enterprise', 'atomic-enterprise']
+    with_items:
+    - master
+    - node
+    - .config_managed
+
   - set_fact:
       openshift_master_etcd_port: "{{ (etcd_client_port | default('2379')) if (groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config) else none }}"
       openshift_master_etcd_hosts: "{{ hostvars

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -636,7 +636,7 @@ def get_openshift_version():
 
     if os.path.isfile('/usr/bin/openshift'):
         _, output, _ = module.run_command(['/usr/bin/openshift', 'version'])
-        versions = dict(e.split(' v') for e in output.splitlines())
+        versions = dict(e.split(' v') for e in output.splitlines() if ' v' in e)
         version = versions.get('openshift', '')
 
         #TODO: acknowledge the possility of a containerized install

--- a/roles/openshift_master/handlers/main.yml
+++ b/roles/openshift_master/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: restart master
   service: name={{ openshift.common.service_type }}-master state=restarted
-  when: not openshift_master_ha | bool
+  when: not (openshift_master_ha | bool or skip_master_restart | default(false))

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -62,20 +62,6 @@
   yum: pkg={{ openshift.common.service_type }}-master{{ openshift_version  }} state=present
   register: install_result
 
-- name: Check for RPM generated config marker file /etc/origin/.config_managed
-  stat: path=/etc/origin/.rpmgenerated
-  register: rpmgenerated_config
-
-- name: Remove RPM generated config files
-  file:
-    path: "{{ item }}"
-    state: absent
-  when: openshift.common.service_type in ['atomic-enterprise','openshift-enterprise'] and rpmgenerated_config.stat.exists == true
-  with_items:
-    - "{{ openshift.common.config_base }}/master"
-    - "{{ openshift.common.config_base }}/node"
-    - "{{ openshift.common.config_base }}/.rpmgenerated"
-
 # TODO: These values need to be configurable
 - name: Set dns facts
   openshift_facts:

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -141,9 +141,8 @@
   when: not openshift_master_ha | bool
   register: start_result
 
-- name: pause to prevent service restart from interfering with bootstrapping
-  pause: seconds=30
-  when: start_result | changed
+- set_fact:
+    skip_master_restart = start_result | changed
 
 - name: Install cluster packages
   yum: pkg=pcs state=present

--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: restart node
   service: name={{ openshift.common.service_type }}-node state=restarted
+  when: not skip_node_restart | default(false)
 
 - name: restart docker
   service: name=docker state=restarted

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -128,6 +128,5 @@
   service: name={{ openshift.common.service_type }}-node enabled=yes state=started
   register: start_result
 
-- name: pause to prevent service restart from interfering with bootstrapping
-  pause: seconds=30
-  when: start_result | changed
+- set_fact:
+    skip_node_restart = start_result | changed


### PR DESCRIPTION
@sdodson - We create a .config_managed file from the rpm and we reference the same file from the task name below, but the actual task was checking for .rpmgenerated instead.