### PR TITLE
Fix yaml tabbing

### DIFF
--- a/playbooks/adhoc/upgrades/upgrade.yml
+++ b/playbooks/adhoc/upgrades/upgrade.yml
@@ -61,7 +61,7 @@
         --exclude-groups=system:unauthenticated
         --exclude-users=system:anonymous
         --additive-only=true --confirm
-  when: ( _new_version.stdout | version_compare('1.0.6', '>') and _new_version.stdout | version_compare('3.0','<') ) or _new_version.stdout | version_compare('3.0.2','>')
+      when: ( _new_version.stdout | version_compare('1.0.6', '>') and _new_version.stdout | version_compare('3.0','<') ) or _new_version.stdout | version_compare('3.0.2','>')
 
 - name: Upgrade default router
   hosts: oo_first_master


### PR DESCRIPTION
without this

```
$ ansible-playbook -i ~/ansible-ose adhoc/upgrades/upgrade.yml 
ERROR: when is not a legal parameter of an Ansible Play
```

CC: @abutcher 