### PR TITLE
Remove pylint comment from Sha-Bang. SSH process get hung when calling python

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python # pylint: disable=too-many-lines
+#!/usr/bin/python
+# pylint: disable=too-many-lines
 # -*- coding: utf-8 -*-
 # vim: expandtab:tabstop=4:shiftwidth=4
 # Reason: Disable pylint too-many-lines because we don't want to split up this file.


### PR DESCRIPTION
Remove pylint comment from Sha-Bang. SSH process get hung when calling python # pylint: disable=too-many-lines due to the "#" character.

i.e.
```ssh -C -tt -vvv -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/root/.ansible/cp/ansible-ssh-%h-%p-%r" -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 kc-oo-master.cloudapp.net /bin/sh -c 'LANG=C LC_CTYPE=C /usr/bin/python **# pylint: disable=too-many-lines** /root/.ansible/tmp/ansible-tmp-1445469086.97-187725002385036/openshift_facts```
doesn't work.

```ssh -C -tt -vvv -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/root/.ansible/cp/ansible-ssh-%h-%p-%r" -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 kc-oo-master.cloudapp.net /bin/sh -c 'LANG=C LC_CTYPE=C /usr/bin/python /root/.ansible/tmp/ansible-tmp-1445469086.97-187725002385036/openshift_facts```
works