### PR TITLE
Conditionally include openshift_router role

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -257,7 +257,7 @@
 
 - name: Create services
   hosts: oo_first_master
-
   roles:
-    - openshift_router
-#    - openshift_registry
+  - role: openshift_router
+    when: openshift.master.infra_nodes is defined
+  #- role: openshift_registry

--- a/roles/openshift_router/tasks/main.yml
+++ b/roles/openshift_router/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Deploy OpenShift Router
   command: >
     {{ openshift.common.admin_binary }} router
-    --create --replicas={{ num_infra }}
+    --create --replicas={{ openshift.master.infra_nodes }}
     --service-account=router {{ _ortr_selector }}
     --credentials={{ openshift_master_config_dir }}/openshift-router.kubeconfig {{ _ortr_images }}
   register: _ortr_results


### PR DESCRIPTION
Install was failing for me without `openshift_router_selector` and `num_infra` set. I've tested this w/ and without infra nodes and it seems to do the trick.

PTAL @dak1n1 @sdodson @wshearn 