### PR TITLE
Fix openshift_examples

### DIFF
--- a/roles/openshift_examples/tasks/main.yml
+++ b/roles/openshift_examples/tasks/main.yml
@@ -9,7 +9,7 @@
   command: >
     {{ openshift.common.client_binary }} {{ openshift_examples_import_command }} -n openshift -f {{ rhel_image_streams }}
   when: openshift_examples_load_rhel
-  register: oex_import_rhel_streams | bool
+  register: oex_import_rhel_streams
   failed_when: "'already exists' not in oex_import_rhel_streams.stderr and oex_import_rhel_streams.rc != 0"
   changed_when: false
 


### PR DESCRIPTION
Fixes the following error

```
TASK: [openshift_examples | Import RHEL streams] ****************************** 
fatal: [ose3-master.example.com] => error while evaluating conditional: 'already exists' not in oex_import_rhel_streams.stderr and oex_import_rhel_streams.rc != 0
```

@abutcher PTAL