### PR TITLE
Fix test and workaround for rpm generated configs

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -2,6 +2,21 @@
 - name: Set master facts and determine if external etcd certs need to be generated
   hosts: oo_masters_to_config
   pre_tasks:
+  - name: Check for RPM generated config marker file .config_managed
+    stat:
+      path: /etc/origin/.config_managed
+    register: rpmgenerated_config
+
+  - name: Remove RPM generated config files if present
+    file:
+      path: "/etc/origin/{{ item }}"
+      state: absent
+    when: rpmgenerated_config.stat.exists == true and deployment_type in ['openshift-enterprise', 'atomic-enterprise']
+    with_items:
+    - master
+    - node
+    - .config_managed
+
   - set_fact:
       openshift_master_etcd_port: "{{ (etcd_client_port | default('2379')) if (groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config) else none }}"
       openshift_master_etcd_hosts: "{{ hostvars

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -62,20 +62,6 @@
   yum: pkg={{ openshift.common.service_type }}-master{{ openshift_version  }} state=present
   register: install_result
 
-- name: Check for RPM generated config marker file /etc/origin/.config_managed
-  stat: path=/etc/origin/.rpmgenerated
-  register: rpmgenerated_config
-
-- name: Remove RPM generated config files
-  file:
-    path: "{{ item }}"
-    state: absent
-  when: openshift.common.service_type in ['atomic-enterprise','openshift-enterprise'] and rpmgenerated_config.stat.exists == true
-  with_items:
-    - "{{ openshift.common.config_base }}/master"
-    - "{{ openshift.common.config_base }}/node"
-    - "{{ openshift.common.config_base }}/.rpmgenerated"
-
 # TODO: These values need to be configurable
 - name: Set dns facts
   openshift_facts:


### PR DESCRIPTION
- fixed inconcistency in naming for rpm generated config test
- refactoring to fix logic after the ha master refactoring had broken the
  previous steps