### PR TITLE
Add proxy client certs to master config

### DIFF
--- a/playbooks/adhoc/upgrades/upgrade.yml
+++ b/playbooks/adhoc/upgrades/upgrade.yml
@@ -1,4 +1,14 @@
 ---
+- name: Upgrade base package on masters
+  hosts: masters
+  roles:
+  - openshift_facts
+  vars:
+    openshift_version: "{{ openshift_pkg_version | default('') }}"
+  tasks:
+    - name: Upgrade base package
+      yum: pkg={{ openshift.common.service_type }}{{ openshift_version  }} state=latest
+
 - name: Re-Run cluster configuration to apply latest configuration changes
   include: ../../common/openshift-cluster/config.yml
   vars:

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -137,6 +137,7 @@
       openshift_master_certs_no_etcd:
       - admin.crt
       - master.kubelet-client.crt
+      - master.proxy-client.crt
       - master.server.crt
       - openshift-master.crt
       - openshift-registry.crt
@@ -144,6 +145,7 @@
       - etcd.server.crt
       openshift_master_certs_etcd:
       - master.etcd-client.crt
+
   - set_fact:
       openshift_master_certs: "{{ (openshift_master_certs_no_etcd | union(openshift_master_certs_etcd)) if (groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config) else openshift_master_certs_no_etcd }}"
 

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -134,13 +134,10 @@
   hosts: oo_masters_to_config
   tasks:
   - set_fact:
-      include_proxy_client_cert: "{{ (openshift.common.version | version_compare('1.0.6', '>')) if openshift.common.deployment_type == 'origin' else (openshift.common.version | version_compare('3.0.2', '>')) }}"
-
-  - set_fact:
       openshift_master_certs_no_etcd:
       - admin.crt
       - master.kubelet-client.crt
-      - "{{ 'master.proxy-client.crt' if include_proxy_client_cert else omit }}"
+      - "{{ 'master.proxy-client.crt' if openshift.common.version_greater_than_3_1_or_1_1 else omit }}"
       - master.server.crt
       - openshift-master.crt
       - openshift-registry.crt

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -134,10 +134,13 @@
   hosts: oo_masters_to_config
   tasks:
   - set_fact:
+      include_proxy_client_cert: "{{ (openshift.common.version | version_compare('1.0.6', '>')) if openshift.common.deployment_type == 'origin' else (openshift.common.version | version_compare('3.0.2', '>')) }}"
+
+  - set_fact:
       openshift_master_certs_no_etcd:
       - admin.crt
       - master.kubelet-client.crt
-      - master.proxy-client.crt
+      - "{{ 'master.proxy-client.crt' if include_proxy_client_cert else omit }}"
       - master.server.crt
       - openshift-master.crt
       - openshift-registry.crt
@@ -155,9 +158,9 @@
     with_items: openshift_master_certs
     register: g_master_cert_stat_result
   - set_fact:
-      master_certs_missing: "{{ g_master_cert_stat_result.results
+      master_certs_missing: "{{ False in (g_master_cert_stat_result.results
                                 | map(attribute='stat.exists')
-                                | list | intersect([false])}}"
+                                | list ) }}"
       master_cert_subdir: master-{{ openshift.common.hostname }}
       master_cert_config_dir: "{{ openshift.common.config_base }}/master"
 
@@ -189,6 +192,7 @@
     args:
       creates: "{{ master_generated_certs_dir }}/{{ item.master_cert_subdir }}.tgz"
     with_items: masters_needing_certs
+
   - name: Retrieve the master cert tarball from the master
     fetch:
       src: "{{ master_generated_certs_dir }}/{{ item.master_cert_subdir }}.tgz"

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -20,8 +20,8 @@ EXAMPLES = '''
 import ConfigParser
 import copy
 import os
-from ansible.runner.filter_plugins.core import version_compare
 from distutils.util import strtobool
+from distutils.version import LooseVersion
 
 
 def hostname_valid(hostname):
@@ -503,10 +503,13 @@ def set_deployment_facts_if_unset(facts):
                 data_dir = '/var/lib/openshift'
             facts['common']['data_dir'] = data_dir
         facts['common']['version'] = version = get_openshift_version()
-        if deployment_type == 'origin':
-            version_gt_3_1_or_1_1 = version_compare(version, '1.0.6', '>')
+        if version is not None:
+            if deployment_type == 'origin':
+                version_gt_3_1_or_1_1 = LooseVersion(version) > LooseVersion('1.0.6')
+            else:
+                version_gt_3_1_or_1_1 = LooseVersion(version) > LooseVersion('3.0.2')
         else:
-            version_gt_3_1_or_1_1 = version_compare(version, '3.0.2', '>')
+            version_gt_3_1_or_1_1 = True
         facts['common']['version_greater_than_3_1_or_1_1'] = version_gt_3_1_or_1_1
 
     for role in ('master', 'node'):

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -74,6 +74,9 @@ kubernetesMasterConfig:
   masterCount: 1
   masterIP: ""
   podEvictionTimeout: ""
+  proxyClientInfo:
+    certFile: master.proxy-client.crt
+    keyFile: master.proxy-client.key
   schedulerConfigFile: {{ openshift_master_scheduler_conf }}
   servicesNodePortRange: ""
   servicesSubnet: {{ openshift.master.portal_net }}

--- a/roles/openshift_master_ca/tasks/main.yml
+++ b/roles/openshift_master_ca/tasks/main.yml
@@ -18,5 +18,4 @@
       --master={{ openshift.master.api_url }}
       --public-master={{ openshift.master.public_api_url }}
       --cert-dir={{ openshift_master_config_dir }} --overwrite=false
-  args:
-    creates: "{{ openshift_master_config_dir }}/master.server.key"
+  when: master_certs_missing

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -20,8 +20,8 @@
     - admin.kubeconfig
     - master.kubelet-client.crt
     - master.kubelet-client.key
-    - "{{ 'master.proxy-client.crt' if openshift.master.include_proxy_client_cert else omit }}"
-    - "{{ 'master.proxy-client.key' if openshift.master.include_proxy_client_cert else omit }}"
+    - "{{ 'master.proxy-client.crt' if openshift.common.version_greater_than_3_1_or_1_1 else omit }}"
+    - "{{ 'master.proxy-client.key' if openshift.common.version_greater_than_3_1_or_1_1 else omit }}"
     - openshift-master.crt
     - openshift-master.key
     - openshift-master.kubeconfig

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -20,6 +20,8 @@
     - admin.kubeconfig
     - master.kubelet-client.crt
     - master.kubelet-client.key
+    - "{{ 'master.proxy-client.crt' if openshift.master.include_proxy_client_cert else omit }}"
+    - "{{ 'master.proxy-client.key' if openshift.master.include_proxy_client_cert else omit }}"
     - openshift-master.crt
     - openshift-master.key
     - openshift-master.kubeconfig
@@ -41,6 +43,5 @@
       --public-master={{ item.openshift.master.public_api_url }}
       --cert-dir={{ openshift_generated_configs_dir }}/{{ item.master_cert_subdir }}
       --overwrite=false
-  args:
-    creates: "{{ openshift_generated_configs_dir }}/{{ item.master_cert_subdir }}/master.server.crt"
+  when: master_certs_missing
   with_items: masters_needing_certs


### PR DESCRIPTION
Add proxy client certs to the master config. The upgrade playbook upgrades the base package first so that we can run `create-master-certs` while generating the rest of the configs. 

~~<3.1 installs will be running `create-master-certs` every run since they'll be missing `master.proxy-client.crt` - it's safe to do with `--overwrite=false` but we could combine version based lists of certs when we have the version fact to get around it...~~

For #685.

@sdodson @detiber @wshearn @brenton @liggitt 