### PR TITLE
Adding Docker Log Options capabilities

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -30,6 +30,8 @@
       kubelet_args: "{{ openshift_node_kubelet_args | default(None) }}"
       sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
       schedulable: "{{ openshift_schedulable | default(openshift_scheduleable) | default(None) }}"
+      docker_log_driver:  "{{ lookup( 'oo_option' , 'docker_log_driver'  )  | default('',True) }}"
+      docker_log_options: "{{ lookup( 'oo_option' , 'docker_log_options' )  | default('',True) }}"
 
 # We have to add tuned-profiles in the same transaction otherwise we run into depsolving
 # problems because the rpms don't pin the version properly.
@@ -68,12 +70,14 @@
   register: docker_check
 
   # TODO: Enable secure registry when code available in origin
-- name: Secure Registry
+- name: Secure Registry and Logs Options
   lineinfile:
     dest: /etc/sysconfig/docker
     regexp: '^OPTIONS=.*$'
     line: "OPTIONS='--insecure-registry={{ openshift.node.portal_net }} \
-{% if ansible_selinux and ansible_selinux.status == '''enabled''' %}--selinux-enabled{% endif %}'"
+{% if ansible_selinux and ansible_selinux.status == '''enabled''' %}--selinux-enabled{% endif %} \
+{% if openshift.node.docker_log_driver is defined  %} --log-driver {{ openshift.node.docker_log_driver }}  {% endif %} \
+{% if openshift.node.docker_log_options is defined %}   {{ openshift.node.docker_log_options |  oo_split() | oo_prepend_strings_in_list('--log-opt ') | join(' ')}}  {% endif %} '"
   when: docker_check.stat.isreg
   notify:
     - restart docker


### PR DESCRIPTION
In regard of issue
https://github.com/openshift/openshift-ansible/issues/696

added option to : bin/cluster 
   -o log_driver=json-file -o log_options="max-size=5m,max-files=5"

will be added to OPTIONS in /etc/sysconfig/docker in all nodes of the cluster.