### PR TITLE
Vagrantfile cleanup: remove unnecessary RHEL registration and network workaround

### DIFF
--- a/README_vagrant.md
+++ b/README_vagrant.md
@@ -2,7 +2,6 @@ Requirements
 ------------
 - vagrant (tested against version 1.7.2)
 - vagrant-hostmanager plugin (tested against version 1.5.0)
-- vagrant-registration plugin (only required for enterprise deployment type)
 - vagrant-libvirt (tested against version 0.0.26)
   - Only required if using libvirt instead of virtualbox
 
@@ -43,7 +42,8 @@ The following environment variables can be overriden:
 - ``OPENSHIFT_DEPLOYMENT_TYPE`` (defaults to origin, choices: origin, enterprise, online)
 - ``OPENSHIFT_NUM_NODES`` (the number of nodes to create, defaults to 2)
 
-For ``enterprise`` deployment types these env variables should also be specified:
+Note that if ``OPENSHIFT_DEPLOYMENT_TYPE`` is ``enterprise`` you should also specify environment variables related to ``subscription-manager`` which are used by the ``rhel_subscribe`` role:
+
 - ``rhel_subscription_user``: rhsm user
 - ``rhel_subscription_pass``: rhsm password
 - (optional) ``rhel_subscription_pool``: poolID to attach a specific subscription besides what auto-attach detects

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,27 +16,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.hostmanager.include_offline = true
   config.ssh.insert_key = false
 
-  if deployment_type === 'enterprise'
-    unless Vagrant.has_plugin?('vagrant-registration')
-      raise 'vagrant-registration-plugin is required for enterprise deployment'
-    end
-    username = ENV['rhel_subscription_user']
-    password = ENV['rhel_subscription_pass']
-    unless username and password
-      raise 'rhel_subscription_user and rhel_subscription_pass are required'
-    end
-    config.registration.username = username
-    config.registration.password = password
-    # FIXME this is temporary until vagrant/ansible registration modules
-    # are capable of handling specific subscription pools
-    if not ENV['rhel_subscription_pool'].nil?
-      config.vm.provision "shell" do |s|
-        s.inline = "subscription-manager attach --pool=$1 || true"
-        s.args = "#{ENV['rhel_subscription_pool']}"
-      end
-    end
-  end
-
   config.vm.provider "virtualbox" do |vbox, override|
     override.vm.box = "centos/7"
     vbox.memory = 1024


### PR DESCRIPTION
Since the inclusion of #264 (commit fb4083b) RHEL registration is already managed by the playbooks. #331 did not take this into account and kept registration managed by Vagrant. This PR removes this 
redundancy.

Also revert the workaround implemented in #331 / #338. TBH I didn't look at exactly why, but this seems to be not needed anymore (fix merged upstream in vagrant) and with current F22 version (1.7.2 based) provision doesn't work with that workaround in place, and it does without it.

Let me know if you want to treat the network part in a separate pr after some proper investigation.