### PR TITLE
Use more specific enterprise version for version_greater_than_3_1

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -534,7 +534,7 @@ def set_deployment_facts_if_unset(facts):
             if deployment_type == 'origin':
                 version_gt_3_1_or_1_1 = LooseVersion(version) > LooseVersion('1.0.6')
             else:
-                version_gt_3_1_or_1_1 = LooseVersion(version) > LooseVersion('3.0.2')
+                version_gt_3_1_or_1_1 = LooseVersion(version) > LooseVersion('3.0.2.900')
         else:
             version_gt_3_1_or_1_1 = True
         facts['common']['version_greater_than_3_1_or_1_1'] = version_gt_3_1_or_1_1


### PR DESCRIPTION
This fact is currently based on `> 3.0.2` but `> 3.0.2.900` is what we've been using for 3.1 release candidates.

Tested with `3.0.2.901-0` and `3.0.2.0-0`.

https://bugzilla.redhat.com/show_bug.cgi?id=1276395

/cc @codificat @sdodson @brenton 