### PR TITLE
Add ip addresses to node certificate

### DIFF
--- a/roles/openshift_node_certificates/tasks/main.yml
+++ b/roles/openshift_node_certificates/tasks/main.yml
@@ -25,7 +25,7 @@
   command: >
     {{ openshift.common.admin_binary }} create-server-cert
       --cert=server.crt --key=server.key --overwrite=true
-      --hostnames={{ item.openshift.common.all_hostnames |join(",") }}
+      --hostnames={{ item.openshift.common.all_hostnames | join(",") }},{{ item.openshift.common.ip }},{{ openshift.common.public_ip }}
       --signer-cert={{ openshift_master_ca_cert }}
       --signer-key={{ openshift_master_ca_key }}
       --signer-serial={{ openshift_master_ca_serial }}


### PR DESCRIPTION
This pull request adds the nodes ip addresses (internal/public) to the kubelet certificate in order to have trusted connections also for clients that are using the ip addresses.