### PR TITLE
Fix issue with master.proxy-client.{crt,key} and omit.

### DIFF
--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -6,13 +6,9 @@
     mode: 0700
   with_items: masters_needing_certs
 
-- file:
-    src: "{{ openshift_master_config_dir }}/{{ item.1 }}"
-    dest: "{{ openshift_generated_configs_dir }}/{{ item.0.master_cert_subdir }}/{{ item.1 }}"
-    state: hard
-  with_nested:
-  - masters_needing_certs
-  - - ca.crt
+- set_fact:
+    master_certificates:
+    - ca.crt
     - ca.key
     - ca.serial.txt
     - admin.crt
@@ -20,8 +16,6 @@
     - admin.kubeconfig
     - master.kubelet-client.crt
     - master.kubelet-client.key
-    - "{{ 'master.proxy-client.crt' if openshift.common.version_greater_than_3_1_or_1_1 else omit }}"
-    - "{{ 'master.proxy-client.key' if openshift.common.version_greater_than_3_1_or_1_1 else omit }}"
     - openshift-master.crt
     - openshift-master.key
     - openshift-master.kubeconfig
@@ -33,6 +27,17 @@
     - openshift-router.kubeconfig
     - serviceaccounts.private.key
     - serviceaccounts.public.key
+    master_31_certificates:
+    - master.proxy-client.crt
+    - master.proxy-client.key
+
+- file:
+    src: "{{ openshift_master_config_dir }}/{{ item.1 }}"
+    dest: "{{ openshift_generated_configs_dir }}/{{ item.0.master_cert_subdir }}/{{ item.1 }}"
+    state: hard
+  with_nested:
+  - masters_needing_certs
+  - "{{ master_certificates | union(master_31_certificates) if openshift.common.version_greater_than_3_1_or_1_1 | bool else master_certificates }}"
 
 
 - name: Create the master certificates if they do not already exist


### PR DESCRIPTION
3.0 multi-master installations are failing to locate omitted files `/etc/openshift/master/__omit_place_holder__72c70516c86edc8cd99110b1daf346c7f6be099d`.

Omit is causing issues so I've swapped this section to combine lists of certs. Tested with multi-master `3.0.2.0-20-g656dc3e` and `3.0.2.905`.

There were some [reported inconsistencies](https://bugzilla.redhat.com/show_bug.cgi?id=1276395) with the `version_greater_than_3_1_or_1_1` fact but I cannot reproduce them. I'd appreciate it if someone else can give this a test with 3.0 multi-master.

@brenton @detiber @sdodson 