### PR TITLE
Fix subpackage dependencies

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -170,6 +170,9 @@ Ansible Inventories for GCE used with the openshift-ansible scripts and playbook
 %package playbooks
 Summary:       Openshift and Atomic Enterprise Ansible Playbooks
 Requires:      %{name}
+Requires:      %{name}-roles
+Requires:      %{name}-lookup-plugins
+Requires:      %{name}-filter-plugins
 BuildArch:     noarch
 
 %description playbooks
@@ -185,6 +188,8 @@ BuildArch:     noarch
 %package roles
 Summary:       Openshift and Atomic Enterprise Ansible roles
 Requires:      %{name}
+Requires:      %{name}-lookup-plugins
+Requires:      %{name}-filter-plugins
 BuildArch:     noarch
 
 %description roles


### PR DESCRIPTION
@tdawson Our -roles and -playbooks subpackages need to have dependencies on -lookup-plugins and -filter-plugins.

Also, -playbooks needs -roles.

We'll also need to kick off a new build following this change.