### PR TITLE
[openshift_master_certificates] Fix variable master.all_hostnames

### DIFF
--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -34,9 +34,6 @@
     - serviceaccounts.private.key
     - serviceaccounts.public.key
 
-- debug: msg="{{ item.openshift.common.all_hostnames | join (',') }}"
-  with_items: masters_needing_certs
-
 - name: Create the master certificates if they do not already exist
   command: >
     {{ openshift.common.admin_binary }} create-master-certs

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -34,7 +34,7 @@
     - serviceaccounts.private.key
     - serviceaccounts.public.key
 
-- debug: msg="{{ item.openshift.master.all_hostnames | join (',') }}"
+- debug: msg="{{ item.openshift.common.all_hostnames | join (',') }}"
   with_items: masters_needing_certs
 
 - name: Create the master certificates if they do not already exist


### PR DESCRIPTION
My ansible with 2 masters won't deploy with an undefined master.all_hostnames.
It is used into a debug task and we use common.all_hostnames into the command.

I assume it have to be changed.