### PR TITLE
exclude atomic-openshift-installer from bin subpackage

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -104,6 +104,7 @@ Scripts to make it nicer when working with hosts that are defined only by metada
 
 %files bin
 %{_bindir}/*
+%exclude %{_bindir}/atomic-openshift-installer
 %{python_sitelib}/openshift_ansible/
 /etc/bash_completion.d/*
 %config(noreplace) /etc/openshift_ansible/


### PR DESCRIPTION
Currently both openshift-ansible-bin and atomic-openshift-utils have /usr/bin/atomic-openshift-installer

It was supposed to only be in utils.  This pull request fixes that problem.
