### PR TITLE
Add pyOpenSSL to dependencies for Fedora.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo contains Ansible code for OpenShift and Atomic Enterprise.
 - Install base dependencies:
   - Fedora:
   ```
-    yum install -y ansible rubygem-thor rubygem-parseconfig util-linux
+    yum install -y ansible rubygem-thor rubygem-parseconfig util-linux pyOpenSSL
   ```
    - OSX:
   ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo contains Ansible code for OpenShift and Atomic Enterprise.
 - Install base dependencies:
   - Fedora:
   ```
-    yum install -y ansible rubygem-thor rubygem-parseconfig util-linux pyOpenSSL
+    dnf install -y ansible rubygem-thor rubygem-parseconfig util-linux pyOpenSSL libffi-devel python-cryptography
   ```
    - OSX:
   ```


### PR DESCRIPTION
pyOpenSSL is required by `filter_plugins/oo_filters.py` at least but isn't installed on Fedora 22 by default.