### PR TITLE
Fix data_dir for 3.0 deployments

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -551,6 +551,8 @@ def set_deployment_facts_if_unset(facts):
             facts['common']['config_base'] = config_base
         if 'data_dir' not in facts['common']:
             data_dir = '/var/lib/origin'
+            if deployment_type in ['enterprise', 'online']:
+                data_dir = '/var/lib/openshift'
             facts['common']['data_dir'] = data_dir
 
     for role in ('master', 'node'):


### PR DESCRIPTION
@abutcher This was causing 3.0 deployments to use /var/lib/origin instead of /var/lib/openshift

@brenton we'll want this one ASAP