### PR TITLE
Read etcd data dir from appropriate config file.

### DIFF
--- a/playbooks/adhoc/upgrades/upgrade.yml
+++ b/playbooks/adhoc/upgrades/upgrade.yml
@@ -150,7 +150,7 @@
 
     - name: Ensure python-yaml present for config upgrade
       yum:
-        pkg: python-yaml
+        pkg: PyYAML
         state: installed
 
     - name: Upgrade master configuration

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -6,8 +6,11 @@
     - ansible_version | version_compare('1.9.0', 'ne')
     - ansible_version | version_compare('1.9.0.1', 'ne')
 
-- name: Ensure python-netaddr is installed
-  yum: pkg=python-netaddr state=installed
+- name: Ensure python-netaddr and PyYaml are installed
+  yum: pkg={{ item }} state=installed
+  with_items:
+    - python-netaddr
+    - PyYAML
 
 - name: Gather Cluster facts
   openshift_facts:


### PR DESCRIPTION
Rather than assuming the etcd data dir, we now read if from master-config.yaml
if using embedded etcd, otherwise from etcd.conf.

Doing so now required use of PyYAML to parse config file when gathering facts.

Fixed discrepancy with data_dir fact and openshift-enterprise deployment_type.