### PR TITLE
atomic-openshift-installer: Generate inventory off hosts_to_run_on

### DIFF
--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -127,7 +127,7 @@ def default_facts(hosts, verbose=False):
 
 def run_main_playbook(hosts, hosts_to_run_on, verbose=False):
     global CFG
-    inventory_file = generate_inventory(hosts)
+    inventory_file = generate_inventory(hosts_to_run_on)
     if len(hosts_to_run_on) != len(hosts):
         main_playbook_path = os.path.join(CFG.ansible_playbook_directory,
                                           'playbooks/common/openshift-cluster/scaleup.yml')


### PR DESCRIPTION
This generates the ansible inventory based on the pruned list of non-installed
hosts we've created rather than the full host list provided in installer.cfg.yaml