### PR TITLE
Package the default ansible.cfg with atomic-openshift-utils.

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -82,6 +82,8 @@ pushd utils
 %{__python} setup.py install --skip-build --root %{buildroot}
 # Remove this line once the name change has happened
 mv -f %{buildroot}%{_bindir}/oo-install %{buildroot}%{_bindir}/atomic-openshift-installer
+mkdir -p %{buildroot}%{_datadir}/atomic-openshift-utils/
+cp etc/ansible.cfg %{buildroot}%{_datadir}/atomic-openshift-utils/ansible.cfg
 popd
 
 # Base openshift-ansible files
@@ -252,6 +254,7 @@ Atomic OpenShift Utilities includes
 %files -n atomic-openshift-utils
 %{python_sitelib}/ooinstall*
 %{_bindir}/atomic-openshift-installer
+%{_datadir}/atomic-openshift-utils/ansible.cfg
 
 
 %changelog

--- a/playbooks/adhoc/upgrades/upgrade.yml
+++ b/playbooks/adhoc/upgrades/upgrade.yml
@@ -226,7 +226,7 @@
     when: inventory_hostname != groups.masters.0
 
   - name: Restart master services
-    service: name="{{ openshift.common.service_type}}-master" state=restarted
+    service: name="{{ openshift.common.service_type}}-master" enabled=yes state=restarted
     when: not openshift_master_ha | bool
 
 - name: Destroy cluster
@@ -250,7 +250,7 @@
     openshift_master_ha: "{{ groups['masters'] | length > 1 }}"
   tasks:
   - name: Start pcsd
-    service: name=pcsd state=started
+    service: name=pcsd enabled=yes state=started
     when: openshift_master_ha | bool
 
 - name: Re-create cluster
@@ -281,7 +281,7 @@
     - name: Upgrade node packages
       command: yum update -y {{ openshift.common.service_type }}-node{{ openshift_version }}
     - name: Restart node services
-      service: name="{{ openshift.common.service_type }}-node" state=restarted
+      service: name="{{ openshift.common.service_type }}-node" enabled=yes state=restarted
 
 - name: Update cluster policy and policy bindings
   hosts: masters[0]
@@ -311,7 +311,7 @@
     openshift_master_ha: "{{ groups['masters'] | length > 1 }}"
   tasks:
     - name: Restart master services
-      service: name="{{ openshift.common.service_type}}-master" state=restarted
+      service: name="{{ openshift.common.service_type}}-master" enabled=yes state=restarted
       when: not openshift_master_ha | bool
 
 - name: Restart cluster post reconcile

--- a/playbooks/adhoc/upgrades/upgrade.yml
+++ b/playbooks/adhoc/upgrades/upgrade.yml
@@ -226,7 +226,7 @@
     when: inventory_hostname != groups.masters.0
 
   - name: Restart master services
-    service: name="{{ openshift.common.service_type}}-master" enabled=yes state=restarted
+    service: name="{{ openshift.common.service_type}}-master" state=restarted
     when: not openshift_master_ha | bool
 
 - name: Destroy cluster
@@ -281,7 +281,7 @@
     - name: Upgrade node packages
       command: yum update -y {{ openshift.common.service_type }}-node{{ openshift_version }}
     - name: Restart node services
-      service: name="{{ openshift.common.service_type }}-node" enabled=yes state=restarted
+      service: name="{{ openshift.common.service_type }}-node" state=restarted
 
 - name: Update cluster policy and policy bindings
   hosts: masters[0]
@@ -311,7 +311,7 @@
     openshift_master_ha: "{{ groups['masters'] | length > 1 }}"
   tasks:
     - name: Restart master services
-      service: name="{{ openshift.common.service_type}}-master" enabled=yes state=restarted
+      service: name="{{ openshift.common.service_type}}-master" state=restarted
       when: not openshift_master_ha | bool
 
 - name: Restart cluster post reconcile
@@ -389,3 +389,19 @@
     openshift_deployment_type: "{{ deployment_type }}"
   roles:
     - openshift_examples
+
+- name: Ensure master services enabled
+  hosts: masters
+  vars:
+    openshift_master_ha: "{{ groups['masters'] | length > 1 }}"
+  tasks:
+  - name: Enable master services
+    service: name="{{ openshift.common.service_type}}-master" state=started enabled=yes
+    when: not openshift_master_ha | bool
+
+- name: Ensure node services enabled
+  hosts: nodes
+  tasks:
+    - name: Restart node services
+      service: name="{{ openshift.common.service_type }}-node" state=started enabled=yes
+

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -604,10 +604,16 @@ def set_deployment_facts_if_unset(facts):
             config_base = '/etc/origin'
             if deployment_type in ['enterprise', 'online']:
                 config_base = '/etc/openshift'
+            # Handle upgrade scenarios when symlinks don't yet exist:
+            if not os.path.exists(config_base) and os.path.exists('/etc/openshift'):
+                config_base = '/etc/openshift'
             facts['common']['config_base'] = config_base
         if 'data_dir' not in facts['common']:
             data_dir = '/var/lib/origin'
             if deployment_type in ['enterprise', 'online']:
+                data_dir = '/var/lib/openshift'
+            # Handle upgrade scenarios when symlinks don't yet exist:
+            if not os.path.exists(data_dir) and os.path.exists('/var/lib/openshift'):
                 data_dir = '/var/lib/openshift'
             facts['common']['data_dir'] = data_dir
 

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -34,7 +34,6 @@ corsAllowedOrigins:
 disabledFeatures: {{ openshift.master.disabled_features | to_json }}
 {% endif %}
 {% if openshift.master.embedded_dns | bool %}
-disabledFeatures: null
 dnsConfig:
   bindAddress: {{ openshift.master.bind_addr }}:{{ openshift.master.dns_port }}
   bindNetwork: tcp4

--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -11,7 +11,7 @@ from ooinstall import OOConfig
 from ooinstall.oo_config import Host
 from ooinstall.variants import find_variant, get_variant_version_combos
 
-DEFAULT_ANSIBLE_CONFIG = '/usr/share/atomic-openshift-util/ansible.cfg'
+DEFAULT_ANSIBLE_CONFIG = '/usr/share/atomic-openshift-utils/ansible.cfg'
 DEFAULT_PLAYBOOK_DIR = '/usr/share/ansible/openshift-ansible/'
 
 def validate_ansible_dir(path):


### PR DESCRIPTION
Package ansible.cfg in /usr/share/atomic-openshift-utils/. If this file exists on disk, the installer will use it if the user didn't specify an ansible config file on the CLI. Rename share directory to match the rpm name. (utils vs util)

Fix a broken upgrade due to missing etcd_data_dir fact. Caused by config_base resolving to /etc/origin on the host during upgrade, which doesn't yet exist. Catch this situation where we want /etc/origin, but it doesn't exist, and /etc/openshift does. (same for /var/lib)

Ensure all services are enabled after upgrade. 

Fix apparent leftover disabledFeatures line in config template.