### PR TITLE
Remove references to multi_ec2.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@
 .DS_Store
 gce.ini
 multi_ec2.yaml
+multi_inventory.yaml
 .vagrant

--- a/bin/openshift_ansible/multi_ec2.py
+++ b/bin/openshift_ansible/multi_ec2.py
@@ -1,1 +1,0 @@
-../../inventory/multi_ec2.py

--- a/bin/openshift_ansible/multi_inventory.py
+++ b/bin/openshift_ansible/multi_inventory.py
@@ -1,0 +1,1 @@
+../../inventory/multi_inventory.py


### PR DESCRIPTION
Addresses https://github.com/openshift/openshift-ansible/issues/856

Also adds multi_inventory.yaml to .gitignore