### PR TITLE
atomic-openshift-installer: Remove question for container install

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -112,13 +112,15 @@ http://docs.openshift.com/enterprise/latest/architecture/infrastructure_componen
         host_props['master'] = click.confirm('Will this host be an OpenShift Master?')
         host_props['node'] = True
 
-        rpm_or_container = click.prompt('Will this host be RPM or Container based (rpm/container)?',
-                                        type=click.Choice(['rpm', 'container']),
-                                        default='rpm')
-        if rpm_or_container == 'container':
-            host_props['containerized'] = True
-        else:
-            host_props['containerized'] = False
+        #TODO: Reenable this option once container installs are out of tech preview
+        #rpm_or_container = click.prompt('Will this host be RPM or Container based (rpm/container)?',
+        #                                type=click.Choice(['rpm', 'container']),
+        #                                default='rpm')
+        #if rpm_or_container == 'container':
+        #    host_props['containerized'] = True
+        #else:
+        #    host_props['containerized'] = False
+        host_props['containerized'] = False
 
         host = Host(**host_props)
 

--- a/utils/test/cli_installer_tests.py
+++ b/utils/test/cli_installer_tests.py
@@ -332,7 +332,7 @@ class AttendedCliTests(OOCliFixture):
             for (host, is_master) in hosts:
                 inputs.append(host)
                 inputs.append('y' if is_master else 'n')
-                inputs.append('rpm')
+                #inputs.append('rpm')
                 if i < len(hosts) - 1:
                     inputs.append('y')  # Add more hosts
                 else:
@@ -349,7 +349,7 @@ class AttendedCliTests(OOCliFixture):
             for (host, is_master) in add_nodes:
                 inputs.append(host)
                 inputs.append('y' if is_master else 'n')
-                inputs.append('rpm')
+                #inputs.append('rpm')
                 if i < len(add_nodes) - 1:
                     inputs.append('y')  # Add more hosts
                 else:


### PR DESCRIPTION
Removing the option for a container-based install from the quick
installer with it is in tech preview.