### PR TITLE
remove netaddr dependency

### DIFF
--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -6,10 +6,9 @@
     - ansible_version | version_compare('1.9.0', 'ne')
     - ansible_version | version_compare('1.9.0.1', 'ne')
 
-- name: Ensure python-netaddr and PyYaml are installed
+- name: Ensure PyYaml is installed
   yum: pkg={{ item }} state=installed
   with_items:
-    - python-netaddr
     - PyYAML
 
 - name: Gather Cluster facts


### PR DESCRIPTION
Python's netaddr module is not available on most atomic hosts. For upcoming openshift-in-docker-on-atomic-hosts support this has to be worked around.

This removes the netaddr dependency by doing the ip calculation by hand.