### PR TITLE
oo_filter: don't fail when attribute is not defined

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -275,7 +275,7 @@ class FilterModule(object):
             raise errors.AnsibleFilterError("|failed expects filter_attr is a str")
 
         # Gather up the values for the list of keys passed in
-        return [x for x in data if x[filter_attr]]
+        return [x for x in data if x.has_key(filter_attr) and x[filter_attr]]
 
     @staticmethod
     def oo_parse_heat_stack_outputs(data):


### PR DESCRIPTION
In `playbooks/common/openshift-node/config.yml:78` when no etcd certificates were missing, oo_filter_list failed because somehow `etcd_client_flannel_certs_missing` was not defined.

This is a functional change in that when a typo in an attribute occurs it will just skip the items instead of bailing loudly.