### PR TITLE
Fix pylint import errors for utils/test/.

### DIFF
--- a/git/pylint.sh
+++ b/git/pylint.sh
@@ -40,6 +40,8 @@ for PY_FILE in $PY_DIFF; do
   fi
 done
 
+export PYTHONPATH=${WORKSPACE}/utils/src/:${WORKSPACE}/utils/test/
+
 if [ "${FILES_TO_TEST}" != "" ]; then
   echo "Testing files: ${FILES_TO_TEST}"
   exec ${PYTHON} -m pylint --rcfile ${WORKSPACE}/git/.pylintrc ${FILES_TO_TEST}


### PR DESCRIPTION
pylint is unable to import the modules in src as they are not on the path.