### PR TITLE
atomic-openshift-installer: Update nopwd sudo test

### DIFF
--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -82,7 +82,7 @@ def write_host(host, inventory, scheduleable=True):
     if installer_host in [host.connect_to, host.hostname, host.public_hostname]:
         facts += ' ansible_connection=local'
         if os.geteuid() != 0:
-            no_pwd_sudo = subprocess.call(['sudo', '-v', '-n'])
+            no_pwd_sudo = subprocess.call(['sudo', '-n', 'echo openshift'])
             if no_pwd_sudo == 1:
                 print 'The atomic-openshift-installer requires sudo access without a password.'
                 sys.exit(1)


### PR DESCRIPTION
This is an update to the no password sudo test meant to address some
weirdness around group vs. user permissions.