### PR TITLE
atomic-openshift-installer: connect_to error handling

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -8,6 +8,7 @@ import re
 import sys
 from ooinstall import openshift_ansible
 from ooinstall import OOConfig
+from ooinstall.oo_config import OOConfigInvalidHostError
 from ooinstall.oo_config import Host
 from ooinstall.variants import find_variant, get_variant_version_combos
 
@@ -447,7 +448,11 @@ def cli(ctx, unattended, configuration, ansible_playbook_directory, ansible_conf
     ctx.obj['ansible_log_path'] = ansible_log_path
     ctx.obj['verbose'] = verbose
 
-    oo_cfg = OOConfig(ctx.obj['configuration'])
+    try:
+        oo_cfg = OOConfig(ctx.obj['configuration'])
+    except OOConfigInvalidHostError as e:
+        click.echo(e)
+        sys.exit(1)
 
     # If no playbook dir on the CLI, check the config:
     if not ansible_playbook_directory:

--- a/utils/test/cli_installer_tests.py
+++ b/utils/test/cli_installer_tests.py
@@ -499,10 +499,10 @@ class UnattendedCliTests(OOCliFixture):
             'ooinstall.conf'), BAD_CONFIG % 'openshift-enterprise')
 
         self.cli_args.extend(["-c", config_file, "install"])
-        self.runner.invoke(cli.cli, self.cli_args)
+        result = self.runner.invoke(cli.cli, self.cli_args)
 
-        # proving here that we didn't generate an exception from the bad config
-        assert True
+        assert result.exit_code == 1
+        assert result.output == "You must specify either and 'ip' or 'hostname' to connect to.\n"
 
 class AttendedCliTests(OOCliFixture):
 

--- a/utils/test/cli_installer_tests.py
+++ b/utils/test/cli_installer_tests.py
@@ -67,6 +67,29 @@ hosts:
     node: true
 """
 
+BAD_CONFIG = """
+variant: %s
+ansible_ssh_user: root
+hosts:
+  - connect_to: 10.0.0.1
+    ip: 10.0.0.1
+    hostname: master-private.example.com
+    public_ip: 24.222.0.1
+    public_hostname: master.example.com
+    master: true
+    node: true
+  - ip: 10.0.0.2
+    hostname: node1-private.example.com
+    public_ip: 24.222.0.2
+    public_hostname: node1.example.com
+    node: true
+  - connect_to: 10.0.0.3
+    ip: 10.0.0.3
+    hostname: node2-private.example.com
+    public_ip: 24.222.0.3
+    public_hostname: node2.example.com
+    node: true
+"""
 
 class OOCliFixture(OOInstallFixture):
 
@@ -465,6 +488,21 @@ class UnattendedCliTests(OOCliFixture):
             self.assertTrue('ANSIBLE_CONFIG' not in env_vars or
                 env_vars['ANSIBLE_CONFIG'] == cli.DEFAULT_ANSIBLE_CONFIG)
 
+    # unattended with bad config file and no installed hosts (without --force)
+    @patch('ooinstall.openshift_ansible.run_main_playbook')
+    @patch('ooinstall.openshift_ansible.load_system_facts')
+    def test_bad_config(self, load_facts_mock, run_playbook_mock):
+        load_facts_mock.return_value = (MOCK_FACTS, 0)
+        run_playbook_mock.return_value = 0
+
+        config_file = self.write_config(os.path.join(self.work_dir,
+            'ooinstall.conf'), BAD_CONFIG % 'openshift-enterprise')
+
+        self.cli_args.extend(["-c", config_file, "install"])
+        self.runner.invoke(cli.cli, self.cli_args)
+
+        # proving here that we didn't generate an exception from the bad config
+        assert True
 
 class AttendedCliTests(OOCliFixture):
 

--- a/utils/test/oo_config_tests.py
+++ b/utils/test/oo_config_tests.py
@@ -73,6 +73,29 @@ hosts:
     node: true
 """
 
+CONFIG_BAD = """
+variant: openshift-enterprise
+ansible_ssh_user: root
+hosts:
+  - connect_to: master-private.example.com
+    ip: 10.0.0.1
+    hostname: master-private.example.com
+    public_ip: 24.222.0.1
+    public_hostname: master.example.com
+    master: true
+    node: true
+  - ip: 10.0.0.2
+    hostname: node1-private.example.com
+    public_ip: 24.222.0.2
+    public_hostname: node1.example.com
+    node: true
+  - connect_to: node2-private.example.com
+    ip: 10.0.0.3
+    hostname: node2-private.example.com
+    public_ip: 24.222.0.3
+    public_hostname: node2.example.com
+    node: true
+"""
 
 class OOInstallFixture(unittest.TestCase):
 
@@ -160,6 +183,17 @@ class OOConfigTests(OOInstallFixture):
 
         self.assertEquals('openshift-enterprise', ooconfig.settings['variant'])
         self.assertEquals('v1', ooconfig.settings['version'])
+
+    def test_load_bad_config(self):
+
+        cfg_path = self.write_config(os.path.join(self.work_dir,
+            'ooinstall.conf'), CONFIG_BAD)
+        try:
+            OOConfig(cfg_path)
+            assert False
+        except OOConfigInvalidHostError:
+            assert True
+
 
     def test_load_complete_facts(self):
         cfg_path = self.write_config(os.path.join(self.work_dir,


### PR DESCRIPTION
Catch the exception that happens when connect_to isn't specified in installer.cfg.yaml

for: https://bugzilla.redhat.com/show_bug.cgi?id=1281728