### PR TITLE
Improve scaleup playbook

### DIFF
--- a/playbooks/byo/openshift-cluster/scaleup.yml
+++ b/playbooks/byo/openshift-cluster/scaleup.yml
@@ -1,0 +1,10 @@
+---
+- include: ../../common/openshift-cluster/scaleup.yml
+  vars:
+    g_etcd_group: "{{ 'etcd' }}"
+    g_masters_group: "{{ 'masters' }}"
+    g_new_nodes_group: "{{ 'new_nodes' }}"
+    g_lb_group: "{{ 'lb' }}"
+    openshift_cluster_id: "{{ cluster_id | default('default') }}"
+    openshift_debug_level: 2
+    openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/common/openshift-cluster/evaluate_groups.yml
+++ b/playbooks/common/openshift-cluster/evaluate_groups.yml
@@ -12,8 +12,8 @@
     when: g_masters_group is not defined
 
   - fail:
-      msg: This playbook requires g_nodes_group to be set
-    when: g_nodes_group is not defined
+      msg: This playbook requires g_nodes_group or g_new_nodes_group to be set
+    when: g_nodes_group is not defined and g_new_nodes_group is not defined
 
   - fail:
       msg: This playbook requires g_lb_group to be set
@@ -35,13 +35,9 @@
       ansible_sudo: "{{ g_sudo | default(omit) }}"
     with_items: groups[g_masters_group] | default([])
 
-  - name: Evaluate oo_nodes_to_config
-    add_host:
-      name: "{{ item }}"
-      groups: oo_nodes_to_config
-      ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
-      ansible_sudo: "{{ g_sudo | default(omit) }}"
-    with_items: groups[g_nodes_group] | default([])
+  # Use g_new_nodes_group if it exists otherwise g_nodes_group
+  - set_fact:
+      g_nodes_to_config: "{{ g_new_nodes_group | default(g_nodes_group | default([])) }}"
 
   - name: Evaluate oo_nodes_to_config
     add_host:
@@ -49,8 +45,17 @@
       groups: oo_nodes_to_config
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_sudo: "{{ g_sudo | default(omit) }}"
+    with_items: groups[g_nodes_to_config] | default([])
+
+  # Skip adding the master to oo_nodes_to_config when g_new_nodes_group is
+  - name: Evaluate oo_nodes_to_config
+    add_host:
+      name: "{{ item }}"
+      groups: oo_nodes_to_config
+      ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
+      ansible_sudo: "{{ g_sudo | default(omit) }}"
     with_items: groups[g_masters_group] | default([])
-    when: g_nodeonmaster is defined and g_nodeonmaster == true
+    when: g_nodeonmaster | default(false) == true and g_new_nodes_group is not defined
 
   - name: Evaluate oo_first_etcd
     add_host:

--- a/playbooks/common/openshift-cluster/scaleup.yml
+++ b/playbooks/common/openshift-cluster/scaleup.yml
@@ -1,13 +1,5 @@
 ---
 - include: evaluate_groups.yml
-  vars:
-    g_etcd_group: "{{ 'etcd' }}"
-    g_masters_group: "{{ 'masters' }}"
-    g_nodes_group: "{{ 'nodes' }}"
-    g_lb_group: "{{ 'lb' }}"
-    openshift_cluster_id: "{{ cluster_id | default('default') }}"
-    openshift_debug_level: 2
-    openshift_deployment_type: "{{ deployment_type }}"
 
 - include: ../openshift-node/config.yml
   vars:


### PR DESCRIPTION
- modify evaluate host to set oo_nodes_to_config to a new variable
  g_new_nodes_group if defined rather than g_nodes_group and also skip adding
  the master when g_new_nodes_group is set.
- Remove byo specific naming from  playbooks/common/openshift-cluster/scaleup.yml
  and created a new playbooks/byo/openshift-cluster/scaleup.yml playbook.