### PR TITLE
Update master facts prior to upgrading from 3.0 to 3.1

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
@@ -161,6 +161,16 @@
       local_facts:
         deployment_type: "{{ deployment_type }}"
 
+- name: Update master facts
+  hosts: oo_masters_to_config
+  roles:
+  - openshift_facts
+  post_tasks:
+  - openshift_facts:
+      role: master
+      local_facts:
+        cluster_method: "{{ openshift_master_cluster_method | default(None) }}"
+
 - name: Upgrade master packages and configuration
   hosts: oo_masters_to_config
   vars:


### PR DESCRIPTION
* Addresses issue with upgrade where certain local facts (`cluster_method`) will be missing from masters originally installed with `v3.0` openshift-ansible.
* ~~Facts required by `openshift_master_ca` and `openshift_master_certificates` roles are added in case cached facts are missing entirely on masters to be upgraded.~~

https://bugzilla.redhat.com/show_bug.cgi?id=1280230

PTAL @detiber @dgoodwin 