### PR TITLE
Default to OSE 3.1 in interactive installer instead of 3.0.

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -458,7 +458,8 @@ def cli(ctx, unattended, configuration, ansible_playbook_directory, ansible_conf
 
     if ctx.obj['ansible_config']:
         oo_cfg.settings['ansible_config'] = ctx.obj['ansible_config']
-    elif os.path.exists(DEFAULT_ANSIBLE_CONFIG):
+    elif 'ansible_config' not in oo_cfg.settings and \
+        os.path.exists(DEFAULT_ANSIBLE_CONFIG):
         # If we're installed by RPM this file should exist and we can use it as our default:
         oo_cfg.settings['ansible_config'] = DEFAULT_ANSIBLE_CONFIG
 

--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -205,6 +205,7 @@ def get_variant_and_version():
         message = "%s\n(%s) %s %s" % (message, i, variant.description,
             version.name)
         i = i + 1
+    message = "%s\n" % message
 
     click.echo(message)
     response = click.prompt("Choose a variant from above: ", default=1)

--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -432,7 +432,8 @@ def get_hosts_to_run_on(oo_cfg, callback_facts, unattended, force, verbose):
 # Main CLI entrypoint, not much we can do about too many arguments.
 def cli(ctx, unattended, configuration, ansible_playbook_directory, ansible_config, ansible_log_path, verbose):
     """
-    atomic-openshift-installer makes the process for installing OSE or AEP easier by interactively gathering the data needed to run on each host.
+    atomic-openshift-installer makes the process for installing OSE or AEP
+    easier by interactively gathering the data needed to run on each host.
     It can also be run in unattended mode if provided with a configuration file.
 
     Further reading: https://docs.openshift.com/enterprise/latest/install_config/install/quick_install.html

--- a/utils/src/ooinstall/variants.py
+++ b/utils/src/ooinstall/variants.py
@@ -30,14 +30,14 @@ class Variant(object):
         self.versions = versions
 
     def latest_version(self):
-        return self.versions[-1]
+        return self.versions[0]
 
 
 # WARNING: Keep the versions ordered, most recent last:
 OSE = Variant('openshift-enterprise', 'OpenShift Enterprise',
     [
-        Version('3.0', 'enterprise'),
-        Version('3.1', 'openshift-enterprise')
+        Version('3.1', 'openshift-enterprise'),
+        Version('3.0', 'enterprise')
     ]
 )
 

--- a/utils/test/cli_installer_tests.py
+++ b/utils/test/cli_installer_tests.py
@@ -284,7 +284,9 @@ class UnattendedCliTests(OOCliFixture):
             '.ansible/callback_facts.yaml'),
             env_vars['OO_INSTALL_CALLBACK_FACTS_YAML'])
         self.assertEqual('/tmp/ansible.log', env_vars['ANSIBLE_LOG_PATH'])
-        self.assertTrue('ANSIBLE_CONFIG' not in env_vars)
+        # If user running test has rpm installed, this might be set to default:
+        self.assertTrue('ANSIBLE_CONFIG' not in env_vars or
+            env_vars['ANSIBLE_CONFIG'] == cli.DEFAULT_ANSIBLE_CONFIG)
 
         # Make sure we ran on the expected masters and nodes:
         hosts = run_playbook_mock.call_args[0][0]
@@ -450,14 +452,18 @@ class UnattendedCliTests(OOCliFixture):
         if expected_result:
             self.assertEquals(expected_result, facts_env_vars['ANSIBLE_CONFIG'])
         else:
-            self.assertFalse('ANSIBLE_CONFIG' in facts_env_vars)
+            # If user running test has rpm installed, this might be set to default:
+            self.assertTrue('ANSIBLE_CONFIG' not in facts_env_vars or
+                facts_env_vars['ANSIBLE_CONFIG'] == cli.DEFAULT_ANSIBLE_CONFIG)
 
         # Test the env vars for main playbook:
         env_vars = run_ansible_mock.call_args[0][2]
         if expected_result:
             self.assertEquals(expected_result, env_vars['ANSIBLE_CONFIG'])
         else:
-            self.assertFalse('ANSIBLE_CONFIG' in env_vars)
+            # If user running test has rpm installed, this might be set to default:
+            self.assertTrue('ANSIBLE_CONFIG' not in env_vars or
+                env_vars['ANSIBLE_CONFIG'] == cli.DEFAULT_ANSIBLE_CONFIG)
 
 
 class AttendedCliTests(OOCliFixture):


### PR DESCRIPTION
Also includes commit to fix unit tests on developer systems where the openshift-ansible rpms are installed.