### PR TITLE
Differentiate machine types on GCE (master and nodes)

### DIFF
--- a/README_GCE.md
+++ b/README_GCE.md
@@ -43,7 +43,11 @@ Mandatory customization variables (check the values according to your tenant):
 * zone = europe-west1-d
 * network = default
 * gce_machine_type = n1-standard-2
+* gce_machine_master_type = n1-standard-1
+* gce_machine_node_type = n1-standard-2
 * gce_machine_image = preinstalled-slave-50g-v5
+* gce_machine_master_image = preinstalled-slave-50g-v5
+* gce_machine_node_image = preinstalled-slave-50g-v5
 
 
 1. vi ~/.gce/gce.ini
@@ -56,7 +60,11 @@ gce_project_id = project_id
 zone = europe-west1-d
 network = default
 gce_machine_type = n1-standard-2
+gce_machine_master_type = n1-standard-1
+gce_machine_node_type = n1-standard-2
 gce_machine_image = preinstalled-slave-50g-v5
+gce_machine_master_image = preinstalled-slave-50g-v5
+gce_machine_node_image = preinstalled-slave-50g-v5
 
 ```
 1. Define the environment variable GCE_INI_PATH so gce.py can pick it up and bin/cluster can also read it

--- a/playbooks/gce/openshift-cluster/launch.yml
+++ b/playbooks/gce/openshift-cluster/launch.yml
@@ -16,6 +16,8 @@
       cluster: "{{ cluster_id }}"
       type: "{{ k8s_type }}"
       g_sub_host_type: "default"
+      gce_machine_type: "{{ lookup('env', 'gce_machine_master_type') | default(lookup('env', 'gce_machine_type'), true) }}"
+      gce_machine_image: "{{ lookup('env', 'gce_machine_master_image') | default(lookup('env', 'gce_machine_image'), true) }}"
 
   - include: ../../common/openshift-cluster/tasks/set_node_launch_facts.yml
     vars:
@@ -27,6 +29,8 @@
       cluster: "{{ cluster_id }}"
       type: "{{ k8s_type }}"
       g_sub_host_type: "{{ sub_host_type }}"
+      gce_machine_type: "{{ lookup('env', 'gce_machine_node_type') | default(lookup('env', 'gce_machine_type'), true) }}"
+      gce_machine_image: "{{ lookup('env', 'gce_machine_node_image') | default(lookup('env', 'gce_machine_image'), true) }}"
 
   - include: ../../common/openshift-cluster/tasks/set_node_launch_facts.yml
     vars:

--- a/playbooks/gce/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/gce/openshift-cluster/tasks/launch_instances.yml
@@ -5,8 +5,8 @@
 - name: Launch instance(s)
   gce:
     instance_names: "{{ instances }}"
-    machine_type: "{{ lookup('env', 'gce_machine_type') | default('n1-standard-1', true) }}"
-    image: "{{ lookup('env', 'gce_machine_image') | default(deployment_vars[deployment_type].image, true) }}"
+    machine_type: "{{ gce_machine_type | default(deployment_vars[deployment_type].machine_type, true) }}"
+    image: "{{ gce_machine_image | default(deployment_vars[deployment_type].image, true) }}"
     service_account_email: "{{ lookup('env', 'gce_service_account_email_address') }}"
     pem_file: "{{ lookup('env', 'gce_service_account_pem_file_path') }}"
     project_id: "{{ lookup('env', 'gce_project_id') }}"

--- a/playbooks/gce/openshift-cluster/vars.yml
+++ b/playbooks/gce/openshift-cluster/vars.yml
@@ -5,13 +5,16 @@ sdn_network_plugin: redhat/openshift-ovs-subnet
 deployment_vars:
   origin:
     image: preinstalled-slave-50g-v5
+    machine_type: n1-standard-1
     ssh_user: root
     sudo: yes
   online:
     image: libra-rhel7
+    machine_type: n1-standard-1
     ssh_user: root
     sudo: no
   enterprise:
     image: rhel-7
+    machine_type: n1-standard-1
     ssh_user:
     sudo: yes


### PR DESCRIPTION
Be able to differentiate machine type for master and nodes on GCE.
Still using the old behaviour as default is nothing is specified in conf