### PR TITLE
Update for latest CentOS-7-x86_64-GenericCloud.

### DIFF
--- a/README_libvirt.md
+++ b/README_libvirt.md
@@ -115,9 +115,10 @@ Configuration
 
 The following options can be passed via the `-o` flag of the `create` command or as environment variables:
 
-* `image_url` (default to `http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2`): URL of the QCOW2 image to download
+* `image_url` (default to `http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2.xz`): URL of the QCOW2 image to download
 * `image_name` (default to `CentOS-7-x86_64-GenericCloud.qcow2`): Name of the QCOW2 image to boot the VMs on
-* `image_sha256` (default to `e324e3ab1d24a1bbf035ddb365e7f9058c0b454acf48d7aa15c5519fae5998ab`): Expected SHA256 checksum of the downloaded image
+* `image_compression` (default to `xz`): Source QCOW2 compression (only xz supported at this time)
+* `image_sha256` (default to `9461006300d65172f5668d8875f2aad7b54f7ba4e9c5435d65a84a5a2d66e39b`): Expected SHA256 checksum of the downloaded image
 * `skip_image_download` (default to `no`): Skip QCOW2 image download. This requires the `image_name` QCOW2 image to be already present in `$HOME/libvirt-storage-pool-openshift-ansible`
 
 Creating a cluster

--- a/playbooks/libvirt/openshift-cluster/launch.yml
+++ b/playbooks/libvirt/openshift-cluster/launch.yml
@@ -11,6 +11,7 @@
     image_url: "{{ deployment_vars[deployment_type].image.url }}"
     image_sha256: "{{ deployment_vars[deployment_type].image.sha256 }}"
     image_name: "{{ deployment_vars[deployment_type].image.name }}"
+    image_compression: "{{ deployment_vars[deployment_type].image.compression }}"
   tasks:
   - fail: msg="Deployment type not supported for libvirt provider yet"
     when: deployment_type == 'online'

--- a/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
@@ -13,8 +13,15 @@
   get_url:
     url: '{{ image_url }}'
     sha256sum: '{{ image_sha256 }}'
-    dest: '{{ os_libvirt_storage_pool_path }}/{{ image_name }}'
+    dest: '{{ os_libvirt_storage_pool_path }}/{{ [image_name, image_compression] | join(".") }}'
   when: '{{ ( lookup("oo_option", "skip_image_download") | default("no", True) | lower ) in ["false", "no"] }}'
+  register: downloaded_image
+
+- name: Uncompress Base Cloud image
+  command: 'unxz -kf {{ os_libvirt_storage_pool_path }}/{{ image_name }}.{{ image_compression }}'
+  args:
+    creates: '{{ os_libvirt_storage_pool_path }}/{{ image_name }}'
+  when: image_compression in ["xz"] and downloaded_image.changed
 
 - name: Create the cloud-init config drive path
   file:

--- a/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
@@ -18,7 +18,7 @@
   register: downloaded_image
 
 - name: Uncompress Base Cloud image
-  command: 'unxz -kf {{ os_libvirt_storage_pool_path }}/{{ image_name }}.{{ image_compression }}'
+  command: 'unxz -kf {{ os_libvirt_storage_pool_path }}/{{ [image_name, image_compression] | join(".") }}'
   args:
     creates: '{{ os_libvirt_storage_pool_path }}/{{ image_name }}'
   when: image_compression in ["xz"] and downloaded_image.changed

--- a/playbooks/libvirt/openshift-cluster/vars.yml
+++ b/playbooks/libvirt/openshift-cluster/vars.yml
@@ -8,11 +8,13 @@ deployment_vars:
   origin:
     image:
       url:    "{{ lookup('oo_option', 'image_url') |
-                  default('http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2', True) }}"
+                  default('http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2.xz', True) }}"
+      compression:   "{{ lookup('oo_option', 'image_compression') |
+                         default('xz', True) }}"
       name:   "{{ lookup('oo_option', 'image_name') |
                   default('CentOS-7-x86_64-GenericCloud.qcow2', True) }}"
       sha256: "{{ lookup('oo_option', 'image_sha256') |
-                  default('e324e3ab1d24a1bbf035ddb365e7f9058c0b454acf48d7aa15c5519fae5998ab', True) }}"
+                  default('9461006300d65172f5668d8875f2aad7b54f7ba4e9c5435d65a84a5a2d66e39b', True) }}"
     ssh_user: openshift
     sudo: yes
   online:


### PR DESCRIPTION
 - Use xz compressed image
 - Update sha256 for new image
 - Update docs to reflect new settings

The image was updated 2015-11-18 so the image_sha256 was not matching.
Moving to the xz image saves ~70% network download.