### PR TITLE
Safe patch

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
@@ -518,8 +518,7 @@
     - "'false' in _scc.stdout"
     command: >
       {{ oc_cmd }} patch scc/privileged -p
-      '{"allowHostPorts":true,"allowHostNetwork":true}' --loglevel=9
-      --api-version=v1
+      '{"allowHostPorts":true,"allowHostNetwork":true}' --api-version=v1
 
   - name: Update deployment config to 1.0.4/3.0.1 spec
     when: _default_router.rc == 0

--- a/playbooks/common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
@@ -517,24 +517,29 @@
     - _default_router.rc == 0
     - "'false' in _scc.stdout"
     command: >
-      {{ oc_cmd }} patch scc/privileged -p '{"allowHostPorts":true,"allowHostNetwork":true}' --loglevel=9
+      {{ oc_cmd }} patch scc/privileged -p
+      '{"allowHostPorts":true,"allowHostNetwork":true}' --loglevel=9
+      --api-version=v1
 
   - name: Update deployment config to 1.0.4/3.0.1 spec
     when: _default_router.rc == 0
     command: >
       {{ oc_cmd }} patch dc/router -p
       '{"spec":{"strategy":{"rollingParams":{"updatePercent":-10},"spec":{"serviceAccount":"router","serviceAccountName":"router"}}}}'
+      --api-version=v1
 
   - name: Switch to hostNetwork=true
     when: _default_router.rc == 0
     command: >
       {{ oc_cmd }} patch dc/router -p '{"spec":{"template":{"spec":{"hostNetwork":true}}}}'
+      --api-version=v1
 
   - name: Update router image to current version
     when: _default_router.rc == 0
     command: >
       {{ oc_cmd }} patch dc/router -p
       '{"spec":{"template":{"spec":{"containers":[{"name":"router","image":"{{ router_image }}"}]}}}}'
+      --api-version=v1
 
   - name: Check for default registry
     command: >
@@ -548,3 +553,4 @@
     command: >
       {{ oc_cmd }} patch dc/docker-registry -p
       '{"spec":{"template":{"spec":{"containers":[{"name":"registry","image":"{{ registry_image }}"}]}}}}'
+      --api-version=v1

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -353,11 +353,16 @@
   - role: openshift_cluster_metrics
     when: openshift.common.use_cluster_metrics | bool
 
+  # TODO: Setting the cluster dns ip should be pushed into openshift-facts
 - name: Determine cluster dns ip
   hosts: oo_first_master
   tasks:
   - name: Get master service ip
-    command: "{{ openshift.common.client_binary }} -n default --config={{ openshift.common.config_base }}/master/admin.kubeconfig get -o template svc kubernetes --template=\\{\\{.spec.clusterIP\\}\\}"
+    command: >
+      {{ openshift.common.client_binary }} -n default
+      --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      get -o template svc kubernetes --template=\\{\\{.spec.clusterIP\\}\\}
+      --output-version=v1
     register: master_service_ip_output
     when: openshift.common.version_greater_than_3_1_or_1_1 | bool
   - set_fact:

--- a/roles/openshift_cluster_metrics/tasks/main.yml
+++ b/roles/openshift_cluster_metrics/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Create InfluxDB Services
   command: >
-    {{ openshift.common.client_binary }} create -f 
+    {{ openshift.common.client_binary }} create -f
     /etc/openshift/cluster-metrics/influxdb.yaml
   register: oex_influxdb_services
   failed_when: "'already exists' not in oex_influxdb_services.stderr and oex_influxdb_services.rc != 0"
@@ -15,14 +15,14 @@
 
 - name: Create Heapster Service Account
   command: >
-    {{ openshift.common.client_binary }} create -f 
+    {{ openshift.common.client_binary }} create -f
     /etc/openshift/cluster-metrics/heapster-serviceaccount.yaml
   register: oex_heapster_serviceaccount
   failed_when: "'already exists' not in oex_heapster_serviceaccount.stderr and oex_heapster_serviceaccount.rc != 0"
   changed_when: false
 
 - name: Add cluster-reader role to Heapster
-  command: > 
+  command: >
     {{ openshift.common.admin_binary }} policy
     add-cluster-role-to-user
     cluster-reader

--- a/roles/openshift_serviceaccounts/tasks/main.yml
+++ b/roles/openshift_serviceaccounts/tasks/main.yml
@@ -13,7 +13,9 @@
   changed_when: "'serviceaccounts \"{{ item }}\" already exists' not in _sa_result.stderr and _sa_result.rc == 0"
 
 - name: Get current security context constraints
-  shell: "{{ openshift.common.client_binary }} get scc privileged -o yaml > /tmp/scc.yaml"
+  shell: >
+    {{ openshift.common.client_binary }} get scc privileged -o yaml
+    --output-version=v1 > /tmp/scc.yaml
 
 - name: Add security context constraint for {{ item }}
   lineinfile:
@@ -23,4 +25,4 @@
   with_items: accounts
 
 - name: Apply new scc rules for service accounts
-  command: "{{ openshift.common.client_binary }} update -f /tmp/scc.yaml"
+  command: "{{ openshift.common.client_binary }} update -f /tmp/scc.yaml --api-version=v1"


### PR DESCRIPTION
Use --api-version in patch commands and --output-version in any get commands where the output is compared or modified and api version would matter.