### PR TITLE
Rework setting of hostname

### DIFF
--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -149,6 +149,11 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # interface other than the default network interface.
 #openshift_node_set_node_ip=True
 
+# Force setting of system hostname when configuring OpenShift
+# This works around issues related to installations that do not have valid dns
+# entries for the interfaces attached to the host.
+#openshift_set_hostname=True
+
 # host group for masters
 [masters]
 ose3-master[1:3]-ansible.test.example.com

--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -3,6 +3,10 @@
     msg: Flannel can not be used with openshift sdn
   when: openshift_use_openshift_sdn | default(false) | bool and openshift_use_flannel | default(false) | bool
 
+- fail:
+    msg: openshift_hostname must be 64 characters or less
+  when: openshift_hostname is defined and openshift_hostname | length > 64
+
 - name: Set common Cluster facts
   openshift_facts:
     role: common
@@ -18,3 +22,12 @@
       deployment_type: "{{ openshift_deployment_type }}"
       use_fluentd: "{{ openshift_use_fluentd | default(None) }}"
       use_flannel: "{{ openshift_use_flannel | default(None) }}"
+
+  # For enterprise versions < 3.1 and origin versions < 1.1 we want to set the
+  # hostname by default.
+- set_fact:
+    set_hostname_default: "{{ not openshift.common.version_greater_than_3_1_or_1_1 }}"
+
+- name: Set hostname
+  hostname: name={{ openshift.common.hostname }}
+  when: openshift_set_hostname | default(set_hostname_default) | bool


### PR DESCRIPTION
- set the hostname for all installs < 3.1 or 1.1
- provide a new variable openshift_set_hostname to override default behavior