### PR TITLE
Improve scaleup playbook

### DIFF
--- a/bin/cluster
+++ b/bin/cluster
@@ -67,6 +67,21 @@ class Cluster(object):
 
         self.action(args, inventory, env, playbook)
 
+    def addNodes(self, args):
+        """
+        Add nodes to an existing cluster for given provider
+        :param args: command line arguments provided by user
+        """
+        env = {'cluster_id': args.cluster_id,
+               'deployment_type': self.get_deployment_type(args)}
+        playbook = "playbooks/{0}/openshift-cluster/addNodes.yml".format(args.provider)
+        inventory = self.setup_provider(args.provider)
+
+        env['num_nodes'] = args.nodes
+        env['num_infra'] = args.infra
+
+        self.action(args, inventory, env, playbook)
+
     def terminate(self, args):
         """
         Destroy OpenShift cluster
@@ -291,6 +306,16 @@ if __name__ == '__main__':
     create_parser.add_argument('-e', '--etcd', default=0, type=int,
                                help='number of external etcd hosts to create in cluster')
     create_parser.set_defaults(func=cluster.create)
+
+
+    create_parser = action_parser.add_parser('addNodes', help='Add nodes to a cluster',
+                                             parents=[meta_parser])
+    create_parser.add_argument('-n', '--nodes', default=1, type=int,
+                               help='number of nodes to add to the cluster')
+    create_parser.add_argument('-i', '--infra', default=1, type=int,
+                               help='number of infra nodes to add to the cluster')
+    create_parser.set_defaults(func=cluster.addNodes)
+
 
     config_parser = action_parser.add_parser('config',
                                              help='Configure or reconfigure a cluster',

--- a/playbooks/aws/openshift-cluster/addNodes.yml
+++ b/playbooks/aws/openshift-cluster/addNodes.yml
@@ -1,0 +1,58 @@
+---
+- name: Launch instance(s)
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  vars_files:
+  - vars.yml
+  - ["vars.{{ deployment_type }}.{{ cluster_id }}.yml", vars.defaults.yml]
+  tasks:
+  - fail:
+      msg: Deployment type not supported for aws provider yet
+    when: deployment_type == 'enterprise'
+
+  - include: ../../common/openshift-cluster/tasks/set_etcd_launch_facts.yml
+  - include: tasks/launch_instances.yml
+    vars:
+      instances: "{{ etcd_names }}"
+      cluster: "{{ cluster_id }}"
+      type: "{{ k8s_type }}"
+      g_sub_host_type: "default"
+
+  - include: ../../common/openshift-cluster/tasks/set_master_launch_facts.yml
+  - include: tasks/launch_instances.yml
+    vars:
+      instances: "{{ master_names }}"
+      cluster: "{{ cluster_id }}"
+      type: "{{ k8s_type }}"
+      g_sub_host_type: "default"
+
+  - include: ../../common/openshift-cluster/tasks/set_node_launch_facts.yml
+    vars:
+      type: "compute"
+      count: "{{ num_nodes }}"
+  - include: tasks/launch_instances.yml
+    vars:
+      instances: "{{ node_names }}"
+      cluster: "{{ cluster_id }}"
+      type: "{{ k8s_type }}"
+      g_sub_host_type: "{{ sub_host_type }}"
+
+  - include: ../../common/openshift-cluster/tasks/set_node_launch_facts.yml
+    vars:
+      type: "infra"
+      count: "{{ num_infra }}"
+  - include: tasks/launch_instances.yml
+    vars:
+      instances: "{{ node_names }}"
+      cluster: "{{ cluster_id }}"
+      type: "{{ k8s_type }}"
+      g_sub_host_type: "{{ sub_host_type }}"
+
+  - add_host:
+      name: "{{ master_names.0 }}"
+      groups: service_master
+    when: master_names is defined and master_names.0 is defined
+
+- include: update.yml
+- include: list.yml

--- a/playbooks/aws/openshift-cluster/addNodes.yml
+++ b/playbooks/aws/openshift-cluster/addNodes.yml
@@ -11,22 +11,6 @@
       msg: Deployment type not supported for aws provider yet
     when: deployment_type == 'enterprise'
 
-  - include: ../../common/openshift-cluster/tasks/set_etcd_launch_facts.yml
-  - include: tasks/launch_instances.yml
-    vars:
-      instances: "{{ etcd_names }}"
-      cluster: "{{ cluster_id }}"
-      type: "{{ k8s_type }}"
-      g_sub_host_type: "default"
-
-  - include: ../../common/openshift-cluster/tasks/set_master_launch_facts.yml
-  - include: tasks/launch_instances.yml
-    vars:
-      instances: "{{ master_names }}"
-      cluster: "{{ cluster_id }}"
-      type: "{{ k8s_type }}"
-      g_sub_host_type: "default"
-
   - include: ../../common/openshift-cluster/tasks/set_node_launch_facts.yml
     vars:
       type: "compute"
@@ -49,10 +33,5 @@
       type: "{{ k8s_type }}"
       g_sub_host_type: "{{ sub_host_type }}"
 
-  - add_host:
-      name: "{{ master_names.0 }}"
-      groups: service_master
-    when: master_names is defined and master_names.0 is defined
-
-- include: update.yml
+- include: scaleup.yml
 - include: list.yml

--- a/playbooks/aws/openshift-cluster/addNodes.yml
+++ b/playbooks/aws/openshift-cluster/addNodes.yml
@@ -6,6 +6,8 @@
   vars_files:
   - vars.yml
   - ["vars.{{ deployment_type }}.{{ cluster_id }}.yml", vars.defaults.yml]
+  vars:
+    oo_extend_env: True
   tasks:
   - fail:
       msg: Deployment type not supported for aws provider yet

--- a/playbooks/aws/openshift-cluster/scaleup.yml
+++ b/playbooks/aws/openshift-cluster/scaleup.yml
@@ -14,7 +14,7 @@
       groups: oo_hosts_to_update
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
-    with_items: groups.nodes_to_add
+    with_items: "{{ groups.nodes_to_add }}"
 
 - include: ../../common/openshift-cluster/update_repos_and_packages.yml
 

--- a/playbooks/aws/openshift-cluster/scaleup.yml
+++ b/playbooks/aws/openshift-cluster/scaleup.yml
@@ -1,0 +1,25 @@
+---
+
+- hosts: localhost
+  gather_facts: no
+  vars_files:
+  - vars.yml
+  tasks:
+  - set_fact:
+      g_ssh_user_tmp: "{{ deployment_vars[deployment_type].ssh_user }}"
+      g_sudo_tmp: "{{ deployment_vars[deployment_type].sudo }}"
+
+- include: ../../common/openshift-cluster/scaleup.yml
+  vars:
+    g_etcd_group: "{{ 'tag_env-host-type_' ~ cluster_id ~ '-openshift-etcd' }}"
+    g_lb_group: "{{ 'tag_env-host-type_' ~ cluster_id ~ '-openshift-lb' }}"
+    g_masters_group: "{{ 'tag_env-host-type_' ~ cluster_id ~ '-openshift-master' }}"
+    g_new_nodes_group: 'nodes_to_add'
+    g_ssh_user: "{{ hostvars.localhost.g_ssh_user_tmp }}"
+    g_sudo: "{{ hostvars.localhost.g_sudo_tmp }}"
+    g_nodeonmaster: true
+    openshift_cluster_id: "{{ cluster_id }}"
+    openshift_debug_level: 2
+    openshift_deployment_type: "{{ deployment_type }}"
+    openshift_hostname: "{{ ec2_private_ip_address }}"
+    openshift_public_hostname: "{{ ec2_ip_address }}"

--- a/playbooks/aws/openshift-cluster/scaleup.yml
+++ b/playbooks/aws/openshift-cluster/scaleup.yml
@@ -8,6 +8,15 @@
   - set_fact:
       g_ssh_user_tmp: "{{ deployment_vars[deployment_type].ssh_user }}"
       g_sudo_tmp: "{{ deployment_vars[deployment_type].sudo }}"
+  - name: Evaluate oo_hosts_to_update
+    add_host:
+      name: "{{ item }}"
+      groups: oo_hosts_to_update
+      ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+      ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
+    with_items: groups.nodes_to_add
+
+- include: ../../common/openshift-cluster/update_repos_and_packages.yml
 
 - include: ../../common/openshift-cluster/scaleup.yml
   vars:

--- a/playbooks/aws/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/aws/openshift-cluster/tasks/launch_instances.yml
@@ -190,6 +190,22 @@
   - instances
   - ec2.instances
 
+- name: Add new instances to nodes_to_add group if needed
+  add_host:
+    hostname: "{{ item.0 }}"
+    ansible_ssh_host: "{{ item.1.dns_name }}"
+    ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+    ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
+    groups: nodes_to_add
+    ec2_private_ip_address: "{{ item.1.private_ip }}"
+    ec2_ip_address: "{{ item.1.public_ip }}"
+    openshift_node_labels: "{{ node_label }}"
+    logrotate_scripts: "{{ logrotate }}"
+  with_together:
+  - instances
+  - ec2.instances
+  when: oo_extend_env is defined and oo_extend_env | bool
+
 - name: Wait for ssh
   wait_for: "port=22 host={{ item.dns_name }}"
   with_items: ec2.instances

--- a/playbooks/byo/openshift-cluster/scaleup.yml
+++ b/playbooks/byo/openshift-cluster/scaleup.yml
@@ -1,0 +1,10 @@
+---
+- include: ../../common/openshift-cluster/scaleup.yml
+  vars:
+    g_etcd_group: "{{ 'etcd' }}"
+    g_masters_group: "{{ 'masters' }}"
+    g_new_nodes_group: "{{ 'new_nodes' }}"
+    g_lb_group: "{{ 'lb' }}"
+    openshift_cluster_id: "{{ cluster_id | default('default') }}"
+    openshift_debug_level: 2
+    openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/common/openshift-cluster/evaluate_groups.yml
+++ b/playbooks/common/openshift-cluster/evaluate_groups.yml
@@ -12,8 +12,8 @@
     when: g_masters_group is not defined
 
   - fail:
-      msg: This playbook requires g_nodes_group to be set
-    when: g_nodes_group is not defined
+      msg: This playbook requires g_nodes_group or g_new_nodes_group to be set
+    when: g_nodes_group is not defined and g_new_nodes_group is not defined
 
   - fail:
       msg: This playbook requires g_lb_group to be set
@@ -35,13 +35,9 @@
       ansible_sudo: "{{ g_sudo | default(omit) }}"
     with_items: groups[g_masters_group] | default([])
 
-  - name: Evaluate oo_nodes_to_config
-    add_host:
-      name: "{{ item }}"
-      groups: oo_nodes_to_config
-      ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
-      ansible_sudo: "{{ g_sudo | default(omit) }}"
-    with_items: groups[g_nodes_group] | default([])
+  # Use g_new_nodes_group if it exists otherwise g_nodes_group
+  - set_fact:
+      g_nodes_to_config: "{{ g_new_nodes_group | default(g_nodes_group | default([])) }}"
 
   - name: Evaluate oo_nodes_to_config
     add_host:
@@ -49,8 +45,17 @@
       groups: oo_nodes_to_config
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_sudo: "{{ g_sudo | default(omit) }}"
+    with_items: groups[g_nodes_to_config] | default([])
+
+  # Skip adding the master to oo_nodes_to_config when g_new_nodes_group is
+  - name: Evaluate oo_nodes_to_config
+    add_host:
+      name: "{{ item }}"
+      groups: oo_nodes_to_config
+      ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
+      ansible_sudo: "{{ g_sudo | default(omit) }}"
     with_items: groups[g_masters_group] | default([])
-    when: g_nodeonmaster is defined and g_nodeonmaster == true
+    when: g_nodeonmaster | default(false) == true and g_new_nodes_group is not defined
 
   - name: Evaluate oo_first_etcd
     add_host:

--- a/playbooks/common/openshift-cluster/scaleup.yml
+++ b/playbooks/common/openshift-cluster/scaleup.yml
@@ -1,13 +1,5 @@
 ---
 - include: evaluate_groups.yml
-  vars:
-    g_etcd_group: "{{ 'etcd' }}"
-    g_masters_group: "{{ 'masters' }}"
-    g_nodes_group: "{{ 'nodes' }}"
-    g_lb_group: "{{ 'lb' }}"
-    openshift_cluster_id: "{{ cluster_id | default('default') }}"
-    openshift_debug_level: 2
-    openshift_deployment_type: "{{ deployment_type }}"
 
 - include: ../openshift-node/config.yml
   vars:

--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -130,10 +130,10 @@ def run_main_playbook(hosts, hosts_to_run_on, verbose=False):
     inventory_file = generate_inventory(hosts_to_run_on)
     if len(hosts_to_run_on) != len(hosts):
         main_playbook_path = os.path.join(CFG.ansible_playbook_directory,
-                                          'playbooks/common/openshift-cluster/scaleup.yml')
+                                          'playbooks/byo/openshift-cluster/scaleup.yml')
     else:
         main_playbook_path = os.path.join(CFG.ansible_playbook_directory,
-                                          'playbooks/byo/config.yml')
+                                          'playbooks/byo/openshift-cluster/config.yml')
     facts_env = os.environ.copy()
     if 'ansible_log_path' in CFG.settings:
         facts_env['ANSIBLE_LOG_PATH'] = CFG.settings['ansible_log_path']


### PR DESCRIPTION
- modify evaluate host to set oo_nodes_to_config to a new variable
  g_new_nodes_group if defined rather than g_nodes_group and also skip adding
  the master when g_new_nodes_group is set.
- Remove byo specific naming from  playbooks/common/openshift-cluster/scaleup.yml
  and created a new playbooks/byo/openshift-cluster/scaleup.yml playbook.