### PR TITLE
Add -q flag to remove unwantend output (such as mirror and cache information)

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/files/versions.sh
+++ b/playbooks/common/openshift-cluster/upgrades/files/versions.sh
@@ -2,9 +2,9 @@
 
 yum_installed=$(yum list installed "$@" 2>&1 | tail -n +2 | grep -v 'Installed Packages' | grep -v 'Red Hat Subscription Management' | grep -v 'Error:' | awk '{ print $2 }' | tr '\n' ' ')
 
-yum_available=$(yum list available "$@" 2>&1 | tail -n +2 | grep -v 'Available Packages' | grep -v 'Red Hat Subscription Management' | grep -v 'el7ose' | grep -v 'Error:' | awk '{ print $2 }' | tr '\n' ' ')
+yum_available=$(yum list available -q "$@" 2>&1 | tail -n +2 | grep -v 'Available Packages' | grep -v 'Red Hat Subscription Management' | grep -v 'el7ose' | grep -v 'Error:' | awk '{ print $2 }' | tr '\n' ' ')
 
 
 echo "---"
-echo "curr_version: ${yum_installed}" 
+echo "curr_version: ${yum_installed}"
 echo "avail_version: ${yum_available}"


### PR DESCRIPTION
This prevents ansible failures when trying to set version facts

E.g. without the -q flag the output looks as follows in my case:
```
yum list available origin openshift | tail -n +2 |  grep -v 'Available Packages' | grep -v 'Red Hat Subscription Management' | grep -v 'el7ose' | grep -v 'Error:'
Loading mirror speeds from cached hostfile
 * base: centosmirror.netcup.net
 * extras: pkg.adfinis-sygroup.ch
 * updates: mirror.softaculous.com
openshift.x86_64   1.0.5-4.git.5411.3eee7d2.el7.centos   maxamillion-origin-next
origin.x86_64      1.0.8-0.git.7227.8f1868d.el7.centos   maxamillion-origin-next
```