### PR TITLE
Fix validation for BasicAuthPasswordIdentityProvider

### DIFF
--- a/filter_plugins/openshift_master.py
+++ b/filter_plugins/openshift_master.py
@@ -290,8 +290,8 @@ class BasicAuthPasswordIdentityProvider(IdentityProviderBase):
     def __init__(self, api_version, idp):
         IdentityProviderBase.__init__(self, api_version, idp)
         self._allow_additional = False
-        self._required += [['ca'], ['certFile', 'cert_file'], ['keyFile', 'key_file']]
-        self._optional += [['key']]
+        self._required += [['url']]
+        self._optional += [['ca'], ['certFile', 'cert_file'], ['keyFile', 'key_file']]
 
 
 class IdentityProviderOauthBase(IdentityProviderBase):


### PR DESCRIPTION
The identity provider validation introduced in commit 3cbe7df8461e5514773e416d137980ce9bedf33d doesn't match the actual parameters of BasicAuthPasswordIdentityProvider, causing validation to always fail when a BasicAuthPasswordIdentityProvider is used. This pull requests fixes the validation.