### PR TITLE
Use masterCount=1 with pacemaker ha

### DIFF
--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -83,7 +83,7 @@ kubernetesMasterConfig:
 {% endif %}
   apiServerArguments: {{ api_server_args if api_server_args is defined else 'null' }}
   controllerArguments: {{ controller_args if controller_args is defined else 'null' }}
-  masterCount: {{ openshift.master.master_count }}
+  masterCount: {{ openshift.master.master_count if openshift.master.cluster_method | default(None) == 'native' else 1 }}
   masterIP: {{ openshift.common.ip }}
   podEvictionTimeout: ""
   proxyClientInfo:


### PR DESCRIPTION
Only one master runs at a time using the pacemaker method for ha so this config makes more sense but also has some benefits w/ the controller and kubernetes service/endpoints.

The controller will modify the endpoints for the kubernetes service to contain the IP of masters. If we were to fail over, a masterCount of 1 would mean that the new master IP should be added to the endpoint and the old master IP should be removed because IPs start getting removed when the number of addresses is greater than the master count.

With a higher master count, the controller will leave all master IPs up to the count in the endpoints which is not good.

This change will also stop the controller from updating the endpoints every loop iteration but this behavior will also be fixed incidentally by https://github.com/openshift/origin/pull/6163.

If statement in the config is ugly but we rely on this count outside of the template to indicate that we're dealing with HA.

@detiber @brenton 