### PR TITLE
Refactor dns options and facts

### DIFF
--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -154,6 +154,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # entries for the interfaces attached to the host.
 #openshift_set_hostname=True
 
+# Configure dnsIP in the node config
+#openshift_dns_ip=172.30.0.1
+
 # host group for masters
 [masters]
 ose3-master[1:3]-ansible.test.example.com

--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -6,6 +6,3 @@
 - include: ../openshift-master/config.yml
 
 - include: ../openshift-node/config.yml
-  vars:
-    osn_cluster_dns_domain: "{{ hostvars[groups.oo_first_master.0].openshift.dns.domain }}"
-    osn_cluster_dns_ip: "{{ hostvars[groups.oo_first_master.0].cluster_dns_ip }}"

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -353,22 +353,6 @@
   - role: openshift_cluster_metrics
     when: openshift.common.use_cluster_metrics | bool
 
-  # TODO: Setting the cluster dns ip should be pushed into openshift-facts
-- name: Determine cluster dns ip
-  hosts: oo_first_master
-  tasks:
-  - name: Get master service ip
-    # This command has to be on a single line.
-    command: "{{ openshift.common.client_binary }} -n default --config={{ openshift.common.config_base }}/master/admin.kubeconfig get -o template svc kubernetes --template=\\{\\{.spec.clusterIP\\}\\} --output-version=v1"
-    register: master_service_ip_output
-    when: openshift.common.version_greater_than_3_1_or_1_1 | bool
-  - set_fact:
-      cluster_dns_ip: "{{ hostvars[groups.oo_first_master.0].openshift.dns.ip }}"
-    when: not openshift.common.version_greater_than_3_1_or_1_1 | bool
-  - set_fact:
-      cluster_dns_ip: "{{ master_service_ip_output.stdout }}"
-    when: openshift.common.version_greater_than_3_1_or_1_1 | bool
-
 - name: Enable cockpit
   hosts: oo_first_master
   vars:

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -528,9 +528,9 @@ def set_aggregate_facts(facts):
         internal_hostnames.add(facts['common']['hostname'])
         internal_hostnames.add(facts['common']['ip'])
 
+        cluster_domain = facts['common']['dns_domain']
+
         if 'master' in facts:
-            # FIXME: not sure why but facts['dns']['domain'] fails
-            cluster_domain = 'cluster.local'
             if 'cluster_hostname' in facts['master']:
                 all_hostnames.add(facts['master']['cluster_hostname'])
             if 'cluster_public_hostname' in facts['master']:
@@ -985,7 +985,7 @@ class OpenShiftFacts(object):
         Raises:
             OpenShiftFactsUnsupportedRoleError:
     """
-    known_roles = ['common', 'master', 'node', 'master_sdn', 'node_sdn', 'dns', 'etcd']
+    known_roles = ['common', 'master', 'node', 'master_sdn', 'node_sdn', 'etcd']
 
     def __init__(self, role, filename, local_facts, additive_facts_to_overwrite=False):
         self.changed = False
@@ -1056,6 +1056,7 @@ class OpenShiftFacts(object):
                       public_hostname=hostname)
         common['client_binary'] = 'oc' if os.path.isfile('/usr/bin/oc') else 'osc'
         common['admin_binary'] = 'oadm' if os.path.isfile('/usr/bin/oadm') else 'osadm'
+        common['dns_domain'] = 'cluster.local'
         defaults['common'] = common
 
         if 'master' in roles:
@@ -1076,7 +1077,6 @@ class OpenShiftFacts(object):
             node = dict(labels={}, annotations={}, portal_net='172.30.0.0/16',
                         iptables_sync_period='5s', set_node_ip=False)
             defaults['node'] = node
-
         return defaults
 
     def guess_host_provider(self):

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -81,14 +81,8 @@
   yum: pkg={{ openshift.common.service_type }}-master{{ openshift_version  }} state=present
   register: install_result
 
-# TODO: These values need to be configurable
-- name: Set dns facts
+- name: Re-gather package dependent master facts
   openshift_facts:
-    role: dns
-    local_facts:
-      ip: "{{ openshift_master_cluster_vip | default(openshift.common.ip, true) | default(None) }}"
-      domain: cluster.local
-  when: openshift.master.embedded_dns
 
 - name: Create config parent directory if it does not exist
   file:

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -1,12 +1,6 @@
 ---
 # TODO: allow for overriding default ports where possible
 - fail:
-    msg: This role requres that osn_cluster_dns_domain is set
-  when: osn_cluster_dns_domain is not defined or not osn_cluster_dns_domain
-- fail:
-    msg: This role requres that osn_cluster_dns_ip is set
-  when: osn_cluster_dns_ip is not defined or not osn_cluster_dns_ip
-- fail:
     msg: "SELinux is disabled, This deployment type requires that SELinux is enabled."
   when: (not ansible_selinux or ansible_selinux.status != 'enabled') and deployment_type in ['enterprise', 'online', 'atomic-enterprise', 'openshift-enterprise']
 
@@ -20,6 +14,7 @@
       hostname: "{{ openshift_hostname | default(none) }}"
       public_hostname: "{{ openshift_public_hostname | default(none) }}"
       deployment_type: "{{ openshift_deployment_type }}"
+      dns_ip: "{{ openshift_dns_ip | default(openshift_master_cluster_vip | default(None, true), true) }}"
   - role: node
     local_facts:
       annotations: "{{ openshift_node_annotations | default(none) }}"

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -1,7 +1,9 @@
 allowDisabledDocker: false
 apiVersion: v1
-dnsDomain: {{ osn_cluster_dns_domain }}
-dnsIP: {{ osn_cluster_dns_ip }}
+dnsDomain: {{ openshift.common.dns_domain }}
+{% if 'dns_ip' in openshift.common %}
+dnsIP: {{ openshift.common.dns_ip }}
+{% endif %}
 dockerConfig:
   execHandlerName: ""
 iptablesSyncPeriod: "{{ openshift.node.iptables_sync_period }}"


### PR DESCRIPTION
* Allows overriding node `dnsIP` via `openshift_dns_ip`.
* `dnsIP` is no longer configured for nodes unless `openshift_dns_ip` is provided. OpenShift will default to using the right thing  (kubernetes service ip post 3.1, first master ip pre 3.1).
* Pacemaker installs will use `openshift_master_cluster_vip` as the `dnsIP` but `openshift_dns_ip` will override.
* DNS facts used by master/nodes are using the `common` facts role instead of `dns`. Makes more sense to me but I'm cool with either...

https://bugzilla.redhat.com/show_bug.cgi?id=1246458

@detiber 