### PR TITLE
Clean up idempotency issues with session secrets.

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -8,11 +8,10 @@ Custom filters for use in openshift-ansible
 from ansible import errors
 from operator import itemgetter
 import OpenSSL.crypto
-import os.path
+import os
 import pdb
 import re
 import json
-
 
 class FilterModule(object):
     ''' Custom ansible filters '''
@@ -366,9 +365,6 @@ class FilterModule(object):
                            "keyfile": "/etc/origin/master/named_certificates/custom2.key",
                            "names": [ "some-hostname.com" ] }]
         '''
-        if not issubclass(type(certificates), list):
-            raise errors.AnsibleFilterError("|failed expects certificates is a list")
-
         if not issubclass(type(named_certs_dir), unicode):
             raise errors.AnsibleFilterError("|failed expects named_certs_dir is unicode")
 
@@ -468,6 +464,16 @@ class FilterModule(object):
                 pass
         return clusters
 
+    @staticmethod
+    def oo_generate_secret(num_bytes):
+        ''' generate a session secret '''
+
+        if not issubclass(type(num_bytes), int):
+            raise errors.AnsibleFilterError("|failed expects num_bytes is int")
+
+        secret = os.urandom(num_bytes)
+        return secret.encode('base-64').strip()
+
     def filters(self):
         ''' returns a mapping of filters to methods '''
         return {
@@ -486,5 +492,6 @@ class FilterModule(object):
             "oo_parse_heat_stack_outputs": self.oo_parse_heat_stack_outputs,
             "oo_parse_named_certificates": self.oo_parse_named_certificates,
             "oo_haproxy_backend_masters": self.oo_haproxy_backend_masters,
-            "oo_pretty_print_cluster": self.oo_pretty_print_cluster
+            "oo_pretty_print_cluster": self.oo_pretty_print_cluster,
+            "oo_generate_secret": self.oo_generate_secret
         }

--- a/filter_plugins/openshift_master.py
+++ b/filter_plugins/openshift_master.py
@@ -463,34 +463,6 @@ class FilterModule(object):
         IdentityProviderBase.validate_idp_list(idp_list)
         return yaml.safe_dump([idp.to_dict() for idp in idp_list], default_flow_style=False)
 
-    @staticmethod
-    def validate_auth_secrets(secrets):
-        ''' validate type and length '''
-
-        if not issubclass(type(secrets), list):
-            raise errors.AnsibleFilterError("|failed expects openshift_master_session_auth_secrets is a list")
-
-        for secret in secrets:
-            if len(secret) < 32:
-                return False
-        return True
-
-    @staticmethod
-    def validate_encryption_secrets(secrets):
-        ''' validate type and length '''
-
-        if not issubclass(type(secrets), list):
-            raise errors.AnsibleFilterError("|failed expects openshift_master_session_encryption_secrets is a list")
-
-        for secret in secrets:
-            if len(secret) not in [16, 24, 32]:
-                return False
-        return True
-
     def filters(self):
         ''' returns a mapping of filters to methods '''
-        return {
-            "translate_idps": self.translate_idps,
-            "validate_auth_secrets": self.validate_auth_secrets,
-            "validate_encryption_secrets": self.validate_encryption_secrets
-        }
+        return {"translate_idps": self.translate_idps}

--- a/filter_plugins/openshift_master.py
+++ b/filter_plugins/openshift_master.py
@@ -463,7 +463,34 @@ class FilterModule(object):
         IdentityProviderBase.validate_idp_list(idp_list)
         return yaml.safe_dump([idp.to_dict() for idp in idp_list], default_flow_style=False)
 
+    @staticmethod
+    def validate_auth_secrets(secrets):
+        ''' validate type and length '''
+
+        if not issubclass(type(secrets), list):
+            raise errors.AnsibleFilterError("|failed expects openshift_master_session_auth_secrets is a list")
+
+        for secret in secrets:
+            if len(secret) < 32:
+                return False
+        return True
+
+    @staticmethod
+    def validate_encryption_secrets(secrets):
+        ''' validate type and length '''
+
+        if not issubclass(type(secrets), list):
+            raise errors.AnsibleFilterError("|failed expects openshift_master_session_encryption_secrets is a list")
+
+        for secret in secrets:
+            if len(secret) not in [16, 24, 32]:
+                return False
+        return True
 
     def filters(self):
         ''' returns a mapping of filters to methods '''
-        return {"translate_idps": self.translate_idps}
+        return {
+            "translate_idps": self.translate_idps,
+            "validate_auth_secrets": self.validate_auth_secrets,
+            "validate_encryption_secrets": self.validate_encryption_secrets
+        }

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -247,14 +247,6 @@
       msg: >
         openshift_master_session_auth_secrets and openshift_master_encryption_secrets must be equal length
     when: (openshift_master_session_auth_secrets is defined and openshift_master_session_encryption_secrets is defined) and (openshift_master_session_auth_secrets | length != openshift_master_session_encryption_secrets | length)
-  - fail:
-      msg: >
-        Invalid secret length in openshift_master_session_auth_secrets: secrets must be at least 32 characters
-    when: openshift_master_session_auth_secrets is defined and not openshift_master_session_auth_secrets | validate_auth_secrets | bool
-  - fail:
-      msg: >
-        Invalid secret length in openshift_master_session_encryption_secrets: secrets must be 16, 24, or 32 characters
-    when: openshift_master_session_encryption_secrets is defined and not openshift_master_session_encryption_secrets | validate_encryption_secrets | bool
   roles:
   - role: openshift_facts
   post_tasks:

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -236,29 +236,39 @@
   - role: haproxy
     when: groups.oo_masters_to_config | length > 1
 
-- name: Generate master session keys
+- name: Check for cached session secrets
   hosts: oo_first_master
-  tasks:
+  pre_tasks:
   - fail:
       msg: "Both openshift_master_session_auth_secrets and openshift_master_session_encryption_secrets must be provided if either variable is set"
     when: (openshift_master_session_auth_secrets is defined and openshift_master_session_encryption_secrets is not defined) or (openshift_master_session_encryption_secrets is defined and openshift_master_session_auth_secrets is not defined)
   - fail:
       msg: "openshift_master_session_auth_secrets and openshift_master_encryption_secrets must be equal length"
     when: (openshift_master_session_auth_secrets is defined and openshift_master_session_encryption_secrets is defined) and (openshift_master_session_auth_secrets | length != openshift_master_session_encryption_secrets | length)
-  - name: Install OpenSSL package
-    action: "{{ ansible_pkg_mgr }} name=openssl state=present"
-    when: not openshift.common.is_atomic | bool
-  - name: Generate session authentication key
-    command: /usr/bin/openssl rand -base64 24
-    register: session_auth_output
-    when: openshift_master_session_auth_secrets is undefined
-  - name: Generate session encryption key
-    command: /usr/bin/openssl rand -base64 24
-    register: session_encryption_output
-    when: openshift_master_session_encryption_secrets is undefined
-  - set_fact:
-      session_auth_secret: "{{ openshift_master_session_auth_secrets | default([session_auth_output.stdout]) }}"
-      session_encryption_secret: "{{ openshift_master_session_encryption_secrets | default([session_encryption_output.stdout]) }}"
+  roles:
+  - role: openshift_facts
+  post_tasks:
+  - openshift_facts:
+      role: master
+      local_facts:
+          session_auth_secrets: "{{ openshift_master_session_auth_secrets | default(openshift.master.session_auth_secrets | default(None)) }}"
+          session_encryption_secrets: "{{ openshift_master_session_encryption_secrets | default(openshift.master.session_encryption_secrets | default(None)) }}"
+
+- name: Generate master session secrets
+  hosts: oo_first_master
+  vars:
+    g_session_secrets_present: "{{ (openshift.master.session_auth_secrets | default([]) and openshift.master.session_encryption_secrets | default([])) | length > 0 }}"
+    g_session_auth_secrets: "{{ [ 24 | oo_generate_secret ] }}"
+    g_session_encryption_secrets: "{{ [ 24 | oo_generate_secret ] }}"
+  roles:
+  - role: openshift_facts
+  tasks:
+  - openshift_facts:
+      role: master
+      local_facts:
+        session_auth_secrets: "{{ g_session_auth_secrets }}"
+        session_encryption_secrets: "{{ g_session_encryption_secrets }}"
+    when: not g_session_secrets_present | bool
 
 - name: Parse named certificates
   hosts: localhost
@@ -314,8 +324,8 @@
     sync_tmpdir: "{{ hostvars.localhost.g_master_mktemp.stdout }}"
     openshift_master_ha: "{{ groups.oo_masters_to_config | length > 1 }}"
     openshift_master_count: "{{ groups.oo_masters_to_config | length }}"
-    openshift_master_session_auth_secrets: "{{ hostvars[groups['oo_first_master'][0]]['session_auth_secret'] }}"
-    openshift_master_session_encryption_secrets: "{{ hostvars[groups['oo_first_master'][0]]['session_encryption_secret'] }}"
+    openshift_master_session_auth_secrets: "{{ hostvars[groups.oo_first_master.0].openshift.master.session_auth_secrets }}"
+    openshift_master_session_encryption_secrets: "{{ hostvars[groups.oo_first_master.0].openshift.master.session_encryption_secrets }}"
   pre_tasks:
   - name: Ensure certificate directory exists
     file:

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -238,15 +238,6 @@
 
 - name: Check for cached session secrets
   hosts: oo_first_master
-  pre_tasks:
-  - fail:
-      msg: >
-        Both openshift_master_session_auth_secrets and openshift_master_session_encryption_secrets must be provided if either variable is set
-    when: (openshift_master_session_auth_secrets is defined and openshift_master_session_encryption_secrets is not defined) or (openshift_master_session_encryption_secrets is defined and openshift_master_session_auth_secrets is not defined)
-  - fail:
-      msg: >
-        openshift_master_session_auth_secrets and openshift_master_encryption_secrets must be equal length
-    when: (openshift_master_session_auth_secrets is defined and openshift_master_session_encryption_secrets is defined) and (openshift_master_session_auth_secrets | length != openshift_master_session_encryption_secrets | length)
   roles:
   - role: openshift_facts
   post_tasks:

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -240,11 +240,21 @@
   hosts: oo_first_master
   pre_tasks:
   - fail:
-      msg: "Both openshift_master_session_auth_secrets and openshift_master_session_encryption_secrets must be provided if either variable is set"
+      msg: >
+        Both openshift_master_session_auth_secrets and openshift_master_session_encryption_secrets must be provided if either variable is set
     when: (openshift_master_session_auth_secrets is defined and openshift_master_session_encryption_secrets is not defined) or (openshift_master_session_encryption_secrets is defined and openshift_master_session_auth_secrets is not defined)
   - fail:
-      msg: "openshift_master_session_auth_secrets and openshift_master_encryption_secrets must be equal length"
+      msg: >
+        openshift_master_session_auth_secrets and openshift_master_encryption_secrets must be equal length
     when: (openshift_master_session_auth_secrets is defined and openshift_master_session_encryption_secrets is defined) and (openshift_master_session_auth_secrets | length != openshift_master_session_encryption_secrets | length)
+  - fail:
+      msg: >
+        Invalid secret length in openshift_master_session_auth_secrets: secrets must be at least 32 characters
+    when: openshift_master_session_auth_secrets is defined and not openshift_master_session_auth_secrets | validate_auth_secrets | bool
+  - fail:
+      msg: >
+        Invalid secret length in openshift_master_session_encryption_secrets: secrets must be 16, 24, or 32 characters
+    when: openshift_master_session_encryption_secrets is defined and not openshift_master_session_encryption_secrets | validate_encryption_secrets | bool
   roles:
   - role: openshift_facts
   post_tasks:

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -11,11 +11,21 @@
 
 # Session Options Validation
 - fail:
-    msg: "Both openshift_master_session_auth_secrets and openshift_master_session_encryption_secrets must be provided if either variable is set"
+    msg: >
+      Both openshift_master_session_auth_secrets and openshift_master_session_encryption_secrets must be provided if either variable is set
   when: (openshift_master_session_auth_secrets is defined and openshift_master_session_encryption_secrets is not defined) or (openshift_master_session_encryption_secrets is defined and openshift_master_session_auth_secrets is not defined)
 - fail:
-    msg: "openshift_master_session_auth_secrets and openshift_master_encryption_secrets must be equal length"
+    msg: >
+      openshift_master_session_auth_secrets and openshift_master_encryption_secrets must be equal length
   when: (openshift_master_session_auth_secrets is defined and openshift_master_session_encryption_secrets is defined) and (openshift_master_session_auth_secrets | length != openshift_master_session_encryption_secrets | length)
+- fail:
+    msg: >
+      Invalid secret length in openshift_master_session_auth_secrets: secrets must be at least 32 characters
+  when: openshift_master_session_auth_secrets is defined and not openshift_master_session_auth_secrets | validate_auth_secrets | bool
+- fail:
+    msg: >
+      Invalid secret length in openshift_master_session_encryption_secrets: secrets must be 16, 24, or 32 characters
+  when: openshift_master_session_encryption_secrets is defined and not openshift_master_session_encryption_secrets | validate_encryption_secrets | bool
 
 # HA Variable Validation
 - fail:

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -18,14 +18,6 @@
     msg: >
       openshift_master_session_auth_secrets and openshift_master_encryption_secrets must be equal length
   when: (openshift_master_session_auth_secrets is defined and openshift_master_session_encryption_secrets is defined) and (openshift_master_session_auth_secrets | length != openshift_master_session_encryption_secrets | length)
-- fail:
-    msg: >
-      Invalid secret length in openshift_master_session_auth_secrets: secrets must be at least 32 characters
-  when: openshift_master_session_auth_secrets is defined and not openshift_master_session_auth_secrets | validate_auth_secrets | bool
-- fail:
-    msg: >
-      Invalid secret length in openshift_master_session_encryption_secrets: secrets must be 16, 24, or 32 characters
-  when: openshift_master_session_encryption_secrets is defined and not openshift_master_session_encryption_secrets | validate_encryption_secrets | bool
 
 # HA Variable Validation
 - fail:

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -9,6 +9,13 @@
       Invalid OAuth grant method: {{ openshift_master_oauth_grant_method }}
   when: openshift_master_oauth_grant_method is defined and openshift_master_oauth_grant_method not in openshift_master_valid_grant_methods
 
+# Session Options Validation
+- fail:
+    msg: "Both openshift_master_session_auth_secrets and openshift_master_session_encryption_secrets must be provided if either variable is set"
+  when: (openshift_master_session_auth_secrets is defined and openshift_master_session_encryption_secrets is not defined) or (openshift_master_session_encryption_secrets is defined and openshift_master_session_auth_secrets is not defined)
+- fail:
+    msg: "openshift_master_session_auth_secrets and openshift_master_encryption_secrets must be equal length"
+  when: (openshift_master_session_auth_secrets is defined and openshift_master_session_encryption_secrets is defined) and (openshift_master_session_auth_secrets | length != openshift_master_session_encryption_secrets | length)
 
 # HA Variable Validation
 - fail:
@@ -55,9 +62,9 @@
       portal_net: "{{ openshift_master_portal_net | default(None) }}"
       session_max_seconds: "{{ openshift_master_session_max_seconds | default(None) }}"
       session_name: "{{ openshift_master_session_name | default(None) }}"
+      session_secrets_file: "{{ openshift_master_session_secrets_file | default(None) }}"
       session_auth_secrets: "{{ openshift_master_session_auth_secrets | default(None) }}"
       session_encryption_secrets: "{{ openshift_master_session_encryption_secrets | default(None) }}"
-      session_secrets_file: "{{ openshift_master_session_secrets_file | default(None) }}"
       access_token_max_seconds: "{{ openshift_master_access_token_max_seconds | default(None) }}"
       auth_token_max_seconds: "{{ openshift_master_auth_token_max_seconds | default(None) }}"
       identity_providers: "{{ openshift_master_identity_providers | default(None) }}"
@@ -221,7 +228,7 @@
   template:
     dest: "{{ openshift.master.session_secrets_file }}"
     src: sessionSecretsFile.yaml.v1.j2
-    force: no
+  when: openshift.master.session_auth_secrets is defined and openshift.master.session_encryption_secrets is defined
   notify:
   - restart master
   - restart master api

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -9,16 +9,6 @@
       Invalid OAuth grant method: {{ openshift_master_oauth_grant_method }}
   when: openshift_master_oauth_grant_method is defined and openshift_master_oauth_grant_method not in openshift_master_valid_grant_methods
 
-# Session Options Validation
-- fail:
-    msg: >
-      Both openshift_master_session_auth_secrets and openshift_master_session_encryption_secrets must be provided if either variable is set
-  when: (openshift_master_session_auth_secrets is defined and openshift_master_session_encryption_secrets is not defined) or (openshift_master_session_encryption_secrets is defined and openshift_master_session_auth_secrets is not defined)
-- fail:
-    msg: >
-      openshift_master_session_auth_secrets and openshift_master_encryption_secrets must be equal length
-  when: (openshift_master_session_auth_secrets is defined and openshift_master_session_encryption_secrets is defined) and (openshift_master_session_auth_secrets | length != openshift_master_session_encryption_secrets | length)
-
 # HA Variable Validation
 - fail:
     msg: "openshift_master_cluster_method must be set to either 'native' or 'pacemaker' for multi-master installations"

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -127,7 +127,9 @@ oauthConfig:
   sessionConfig:
     sessionMaxAgeSeconds: {{ openshift.master.session_max_seconds }}
     sessionName: {{ openshift.master.session_name }}
+{% if openshift.master.session_auth_secrets is defined and openshift.master.session_encryption_secrets is defined %}
     sessionSecretsFile: {{ openshift.master.session_secrets_file }}
+{% endif %}
   tokenConfig:
     accessTokenMaxAgeSeconds: {{ openshift.master.access_token_max_seconds }}
     authorizeTokenMaxAgeSeconds: {{ openshift.master.auth_token_max_seconds }}

--- a/roles/openshift_master/templates/sessionSecretsFile.yaml.v1.j2
+++ b/roles/openshift_master/templates/sessionSecretsFile.yaml.v1.j2
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: SessionSecrets
 secrets:
-{% for secret in openshift_master_session_auth_secrets %}
-- authentication: "{{ openshift_master_session_auth_secrets[loop.index0] }}"
-  encryption: "{{ openshift_master_session_encryption_secrets[loop.index0] }}"
+{% for secret in openshift.master.session_auth_secrets %}
+- authentication: "{{ openshift.master.session_auth_secrets[loop.index0] }}"
+  encryption: "{{ openshift.master.session_encryption_secrets[loop.index0] }}"
 {% endfor %}


### PR DESCRIPTION
* Session secrets are now cached.
* Playbooks will generate session secrets if they were not passed in via inventory variables and were not found in the first master's cache.
* Use the generated or overridden secrets on the other masters.
* Session secrets file is a template. Overriding after an initial install with generated secrets will rewrite the session secrets file.

Fixes #953 