### PR TITLE
Install and start one etcd server before the others.

### DIFF
--- a/playbooks/common/openshift-etcd/config.yml
+++ b/playbooks/common/openshift-etcd/config.yml
@@ -68,8 +68,32 @@
       validate_checksum: yes
     with_items: etcd_needing_server_certs
 
-- name: Configure etcd hosts
-  hosts: oo_etcd_to_config
+# Configure a first etcd host to avoid conflicts in choosing a leader
+# if other members come online too quickly.
+- name: Configure first etcd host
+  hosts: oo_first_etcd
+  vars:
+    sync_tmpdir: "{{ hostvars.localhost.g_etcd_mktemp.stdout }}"
+    etcd_url_scheme: https
+    etcd_peer_url_scheme: https
+    etcd_peers_group: oo_etcd_to_config
+  pre_tasks:
+  - name: Ensure certificate directory exists
+    file:
+      path: "{{ etcd_cert_config_dir }}"
+      state: directory
+  - name: Unarchive the tarball on the etcd host
+    unarchive:
+      src: "{{ sync_tmpdir }}/{{ etcd_cert_subdir }}.tgz"
+      dest: "{{ etcd_cert_config_dir }}"
+    when: etcd_server_certs_missing
+  roles:
+  - etcd
+  - role: nickhammond.logrotate
+
+# Configure the remaining etcd hosts, skipping the first one we dealt with above.
+- name: Configure remaining etcd hosts
+  hosts: oo_etcd_to_config:!oo_first_etcd
   vars:
     sync_tmpdir: "{{ hostvars.localhost.g_etcd_mktemp.stdout }}"
     etcd_url_scheme: https


### PR DESCRIPTION
This might need some discussion but I believe we have a bug with etcd cluster setup in faster environments, all the cluster members appear to come up at roughly the same time when using all local vms (within a second or two) and one or two of my three will fail to make it to the cluster. 

When this bug happens a failed member's etcd logs will look like:

http://fpaste.org/296258/89844131/

Whereas one of the member's that made it up will look like: 

http://fpaste.org/296239/14489825/

Logging into those members and removing the etcd data dir and restarting the service will get that member to cluster up.

Adding members one at a time appears to be recommended best practice at least for cluster recovery, which is essentially the same thing: https://github.com/coreos/etcd/blob/master/Documentation/runtime-configuration.md#restart-cluster-from-majority-failure

Serializing the etcd setup to one server at a time appears to correct this problem, the cluster comes up healthy.

I suspect this hasn't surfaced in cloud environments just due to the delays in communicating with them and the nodes have time to come up individually.

