### PR TITLE
Make the install of openshift_examples optional

### DIFF
--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -21,6 +21,9 @@ ansible_ssh_user=root
 # deployment type valid values are origin, online, atomic-enterprise, and openshift-enterprise
 deployment_type=atomic-enterprise
 
+# Install the openshift examples
+#openshift_install_examples=true
+
 # Enable cluster metrics
 #use_cluster_metrics=true
 

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -21,6 +21,9 @@ ansible_ssh_user=root
 # deployment type valid values are origin, online, atomic-enterprise and openshift-enterprise
 deployment_type=origin
 
+# Install the openshift examples
+#openshift_install_examples=true
+
 # Enable cluster metrics
 #use_cluster_metrics=true
 

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -21,6 +21,9 @@ ansible_ssh_user=root
 # deployment type valid values are origin, online, atomic-enterprise, and openshift-enterprise
 deployment_type=openshift-enterprise
 
+# Install the openshift examples
+#openshift_install_examples=true
+
 # Enable cluster metrics
 #use_cluster_metrics=true
 

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -349,7 +349,8 @@
   roles:
   - role: openshift_master_cluster
     when: openshift_master_ha | bool and openshift.master.cluster_method == "pacemaker"
-  - openshift_examples
+  - role: openshift_examples
+    when: openshift.common.install_examples | bool
   - role: openshift_cluster_metrics
     when: openshift.common.use_cluster_metrics | bool
   - role: openshift_manageiq

--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -14,6 +14,7 @@
       cluster_id: "{{ openshift_cluster_id | default('default') }}"
       debug_level: "{{ openshift_debug_level | default(2) }}"
       hostname: "{{ openshift_hostname | default(None) }}"
+      install_examples: "{{ openshift_install_examples | default(True) }}"
       ip: "{{ openshift_ip | default(None) }}"
       public_hostname: "{{ openshift_public_hostname | default(None) }}"
       public_ip: "{{ openshift_public_ip | default(None) }}"

--- a/roles/openshift_examples/README.md
+++ b/roles/openshift_examples/README.md
@@ -11,6 +11,13 @@ ansible.
 Requirements
 ------------
 
+Facts
+-----
+
+| Name                       | Default Value | Description                            |
+-----------------------------|---------------|----------------------------------------|
+| openshift_install_examples | true          | Runs the role with the below variables |
+
 Role Variables
 --------------
 
@@ -32,7 +39,7 @@ Example Playbook
 TODO
 ----
 Currently we use `oc create -f` against various files and we accept non zero return code as a success
-if (and only iff) stderr also contains the string 'already exists'. This means that if one object in the file exists already
+if (and only if) stderr also contains the string 'already exists'. This means that if one object in the file exists already
 but others fail to create you won't be aware of the failure. This also means that we do not currently support
 updating existing objects.
 

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1057,6 +1057,7 @@ class OpenShiftFacts(object):
         common['client_binary'] = 'oc' if os.path.isfile('/usr/bin/oc') else 'osc'
         common['admin_binary'] = 'oadm' if os.path.isfile('/usr/bin/oadm') else 'osadm'
         common['dns_domain'] = 'cluster.local'
+        common['install_examples'] = True
         defaults['common'] = common
 
         if 'master' in roles:


### PR DESCRIPTION
* Allows us to make it optional to run the role `openshift_examples`
* Defaults to true
* I would definitely recommend testing to ensure this goes down the path you guys would normally for something like this
* Addresses #1002 