### PR TITLE
Require pyOpenSSL

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -211,6 +211,7 @@ BuildArch:     noarch
 Summary:       Openshift and Atomic Enterprise Ansible filter plugins
 Requires:      %{name}
 BuildArch:     noarch
+Requires:      pyOpenSSL
 
 %description filter-plugins
 %{summary}.


### PR DESCRIPTION
required by oo_filters

Fixes
```
import OpenSSL.crypto
No module named OpenSSL.crypto
```