### PR TITLE
Bump ansible requirement to 1.9.4

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -13,7 +13,7 @@ URL:            https://github.com/openshift/openshift-ansible
 Source0:        https://github.com/openshift/openshift-ansible/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-Requires:      ansible >= 1.9.3
+Requires:      ansible >= 1.9.4
 Requires:      python2
 
 %description


### PR DESCRIPTION
We'll be shipping Ansible 1.9.4 with the updated installer. We may as well require it to reduce the matrix of possible environments.