### PR TITLE
Squash pcs install into one task.

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -267,13 +267,8 @@
   when: openshift_master_ha | bool and openshift.master.cluster_method == 'native'
 
 - name: Install cluster packages
-  yum: pkg=pcs state=present
-  when: (ansible_pkg_mgr == "yum") and openshift_master_ha | bool and openshift.master.cluster_method == 'pacemaker'
-  register: install_result
-
-- name: Install cluster packages
-  dnf: pkg=pcs state=present
-  when: (ansible_pkg_mgr == "dnf") and openshift_master_ha | bool and openshift.master.cluster_method == 'pacemaker'
+  action: "{{ansible_pkg_mgr}} pkg=pcs state=present"
+  when: openshift_master_ha | bool and openshift.master.cluster_method == 'pacemaker'
   register: install_result
 
 - name: Start and enable cluster service


### PR DESCRIPTION
Use `action: "{{ ansible_pkg_mgr }}"` to squash pcs install into a single task. We should probably do this in all places where we have a yum task and a dnf task but I'm making the change for this particular task because the `install_result` for dnf is interfering with setting the cluster password for pacemaker.

On skipped tasks, variables are overwritten with a value of `{'skipped': True}`.

https://bugzilla.redhat.com/show_bug.cgi?id=1288481

@sdodson @brenton 