### PR TITLE
Remove hacluster user during uninstall.

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -79,6 +79,8 @@
         - tuned-profiles-openshift-node
         - tuned-profiles-origin-node
 
+    - user: name=hacluster state=absent
+
     - dnf: name={{ item }} state=absent
       when: ansible_pkg_mgr == "dnf" and not is_atomic | bool
       with_items:


### PR DESCRIPTION
This was tripping me up with the password skipping.

@brenton 
