### PR TITLE
Install base package in openshift_common for version facts

### DIFF
--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -24,6 +24,12 @@
       use_flannel: "{{ openshift_use_flannel | default(None) }}"
       use_manageiq: "{{ openshift_use_manageiq | default(None) }}"
 
+- name: Install the base package for versioning
+  action: "{{ ansible_pkg_mgr }} name={{ openshift.common.service_type }}{{ openshift_version | default('') }} state=present"
+
+- name: Set version facts
+  openshift_facts:
+
   # For enterprise versions < 3.1 and origin versions < 1.1 we want to set the
   # hostname by default.
 - set_fact:


### PR DESCRIPTION
Install the base package earlier to make use of `openshift.common.version_greater_than_3_1_or_1_1` in `openshift_common` and for nodes prior to installing the node package.

`openshift_common` is a requirement for:
* `openshift_examples`
* `openshift_master`
* `openshift_node`

https://bugzilla.redhat.com/show_bug.cgi?id=1275395
https://bugzilla.redhat.com/show_bug.cgi?id=1246458

@sdodson @detiber @brenton 
