### PR TITLE
Fix typos that cause master/node restarts which break openshift SDN setup

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -228,7 +228,7 @@
   register: start_result
 
 - set_fact:
-    master_service_status_changed = start_result | changed
+    master_service_status_changed: start_result | changed
   when: not openshift_master_ha | bool
 
 - name: Start and enable master api
@@ -237,7 +237,7 @@
   register: start_result
 
 - set_fact:
-    master_api_service_status_changed = start_result | changed
+    master_api_service_status_changed: start_result | changed
   when: openshift_master_ha | bool and openshift.master.cluster_method == 'native'
 
 - name: Start and enable master controller
@@ -246,7 +246,7 @@
   register: start_result
 
 - set_fact:
-    master_controllers_service_status_changed = start_result | changed
+    master_controllers_service_status_changed: start_result | changed
   when: openshift_master_ha | bool and openshift.master.cluster_method == 'native'
 
 - name: Install cluster packages

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -131,4 +131,4 @@
   register: start_result
 
 - set_fact:
-    node_service_status_changed = start_result | changed
+    node_service_status_changed: start_result | changed


### PR DESCRIPTION
Fixes typo when setting facts to record whether master/node has been restarted already, to decide whether notify handler should restart services or not.

Currently, this causes random SDN network setup failures as openshift-node gets restarted while the setup script is running, and the subsequent start fails to configure the SDN because it thinks it's already done.

For instance:
```
##### Ansible starts openshift-node
Dec 11 08:06:39 192.168.105.4 ansible-service[12218]: Invoked with name=openshift-node pattern=None enabled=True state=started sleep=None arguments= runlevel=default
...
##### We see traces that the openshift-sdn setup script is running
Dec 11 08:06:43 192.168.105.4 ovs-vsctl[12549]: ovs|00001|vsctl|INFO|Called as ovs-vsctl add-port br0 vovsbr -- set Interface vovsbr ofport_request=9
...
##### Ansible does a restart of openshift-node
Dec 11 08:06:44 192.168.105.4 ansible-service[12675]: Invoked with name=openshift-node pattern=None enabled=None state=restarted sleep=None arguments= runlevel=default
...
##### openshift-sdn script is relaunched, however it thinks setup is done:
Dec 11 08:06:45 192.168.105.4 openshift-node[12773]: I1211 08:06:45.824998   12773 kube.go:29] Output of setup script:
Dec 11 08:06:45 192.168.105.4 openshift-node[12773]: + lock_file=/var/lock/openshift-sdn.lock
...
Dec 11 08:06:45 192.168.105.4 openshift-node[12773]: + return 1
Dec 11 08:06:45 192.168.105.4 openshift-node[12773]: + echo 'SDN setup not required.'
Dec 11 08:06:45 192.168.105.4 openshift-node[12773]: SDN setup not required.
Dec 11 08:06:45 192.168.105.4 openshift-node[12773]: + exit 140
```

Before this change:
```
TASK: [openshift_node | Start and enable node] ********************************
changed: [eric-node-compute-c93b9]
changed: [eric-node-infra-87f90]
changed: [eric-node-compute-273b0]

TASK: [openshift_node | set_fact node_service_status_changed = start_result | changed] ***
ok: [eric-node-compute-c93b9]
ok: [eric-node-infra-87f90]
ok: [eric-node-compute-273b0]

...

NOTIFIED: [openshift_node | restart node] *************************************
changed: [eric-node-compute-c93b9]
changed: [eric-node-compute-273b0]
changed: [eric-node-infra-87f90]
```

With this change:
```
TASK: [openshift_node | Start and enable node] ********************************
changed: [eric-node-compute-645be]
changed: [eric-node-infra-e32d2]
changed: [eric-node-compute-3f6af]

TASK: [openshift_node | set_fact ] ********************************************
ok: [eric-node-compute-3f6af]
ok: [eric-node-compute-645be]
ok: [eric-node-infra-e32d2]

...

NOTIFIED: [openshift_node | restart node] *************************************
skipping: [eric-node-compute-3f6af]
skipping: [eric-node-compute-645be]
skipping: [eric-node-infra-e32d2]
```
