### PR TITLE
atomic-openshift-installer: Remove HA hint for 3.0 install

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -72,7 +72,7 @@ def delete_hosts(hosts):
                 click.echo("\"{}\" doesn't coorespond to any valid input.".format(del_idx))
     return hosts, None
 
-def collect_hosts(version=None, masters_set=False, print_summary=True):
+def collect_hosts(oo_cfg, masters_set=False, print_summary=True):
     """
         Collect host information from user. This will later be filled in using
         ansible.
@@ -125,7 +125,7 @@ http://docs.openshift.com/enterprise/latest/architecture/infrastructure_componen
                 host_props['master'] = True
                 num_masters += 1
 
-                if version == '3.0':
+                if oo_cfg.settings['variant_version'] == '3.0':
                     masters_set = True
         host_props['node'] = True
 
@@ -144,7 +144,7 @@ http://docs.openshift.com/enterprise/latest/architecture/infrastructure_componen
         hosts.append(host)
 
         if print_summary:
-            print_installation_summary(hosts)
+            print_installation_summary(hosts, oo_cfg.settings['variant_version'])
 
         # If we have one master, this is enough for an all-in-one deployment,
         # thus we can start asking if you wish to proceed. Otherwise we assume
@@ -158,7 +158,7 @@ http://docs.openshift.com/enterprise/latest/architecture/infrastructure_componen
     return hosts
 
 
-def print_installation_summary(hosts):
+def print_installation_summary(hosts, version=None):
     """
     Displays a summary of all hosts configured thus far, and what role each
     will play.
@@ -179,7 +179,7 @@ def print_installation_summary(hosts):
     click.echo('Total OpenShift Masters: %s' % len(masters))
     click.echo('Total OpenShift Nodes: %s' % len(nodes))
 
-    if len(masters) == 1:
+    if len(masters) == 1 and version != '3.0':
         ha_hint_message = """
 NOTE: Add a total of 3 or more Masters to perform an HA installation."""
         click.echo(ha_hint_message)
@@ -494,20 +494,20 @@ https://docs.openshift.com/enterprise/latest/admin_guide/install/prerequisites.h
         click.clear()
 
     if not oo_cfg.hosts:
-        oo_cfg.hosts = collect_hosts(version=oo_cfg.settings['variant_version'])
+        oo_cfg.hosts = collect_hosts(oo_cfg)
         click.clear()
 
     return oo_cfg
 
 
-def collect_new_nodes():
+def collect_new_nodes(oo_cfg):
     click.clear()
     click.echo('*** New Node Configuration ***')
     message = """
 Add new nodes here
     """
     click.echo(message)
-    return collect_hosts(masters_set=True, print_summary=False)
+    return collect_hosts(oo_cfg, masters_set=True, print_summary=False)
 
 def get_installed_hosts(hosts, callback_facts):
     installed_hosts = []
@@ -577,7 +577,7 @@ def get_hosts_to_run_on(oo_cfg, callback_facts, unattended, force, verbose):
                     sys.exit(1)
             else:
                 if not force:
-                    new_nodes = collect_new_nodes()
+                    new_nodes = collect_new_nodes(oo_cfg)
 
                     hosts_to_run_on.extend(new_nodes)
                     oo_cfg.hosts.extend(new_nodes)
@@ -752,7 +752,7 @@ def install(ctx, force):
 
     check_hosts_config(oo_cfg, ctx.obj['unattended'])
 
-    print_installation_summary(oo_cfg.hosts)
+    print_installation_summary(oo_cfg.hosts, oo_cfg.settings['variant_version'])
     click.echo('Gathering information from hosts...')
     callback_facts, error = openshift_ansible.default_facts(oo_cfg.hosts,
         verbose)

--- a/utils/test/cli_installer_tests.py
+++ b/utils/test/cli_installer_tests.py
@@ -913,6 +913,25 @@ class AttendedCliTests(OOCliFixture):
         self.assertEquals('True',
             inventory.get('nodes', '10.0.0.1  openshift_schedulable'))
 
+    #interactive 3.0 install confirm no HA hints
+    @patch('ooinstall.openshift_ansible.run_main_playbook')
+    @patch('ooinstall.openshift_ansible.load_system_facts')
+    def test_ha_hint(self, load_facts_mock, run_playbook_mock):
+        load_facts_mock.return_value = (MOCK_FACTS, 0)
+        run_playbook_mock.return_value = 0
+
+        cli_input = build_input(hosts=[
+            ('10.0.0.1', True)],
+                                      ssh_user='root',
+                                      variant_num=2,
+                                      confirm_facts='y')
+        self.cli_args.append("install")
+        result = self.runner.invoke(cli.cli, self.cli_args,
+            input=cli_input)
+        self.assert_result(result, 0)
+        self.assertTrue("NOTE: Add a total of 3 or more Masters to perform an HA installation."
+            not in result.output)
+
 # TODO: test with config file, attended add node
 # TODO: test with config file, attended new node already in config file
 # TODO: test with config file, attended new node already in config file, plus manually added nodes


### PR DESCRIPTION
Small update to remove the hint for multiple masters if we are doing
a 3.0 installation.

For https://bugzilla.redhat.com/show_bug.cgi?id=1289920