### PR TITLE
Exclude 'system' & 'manager' lines from yum output.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/files/versions.sh
+++ b/playbooks/common/openshift-cluster/upgrades/files/versions.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-yum_installed=$(yum list installed "$@" 2>&1 | tail -n +2 | grep -v 'Installed Packages' | grep -v 'Red Hat Subscription Management' | grep -v 'Error:' | awk '{ print $2 }' | tr '\n' ' ')
+yum_installed=$(yum list installed "$@" 2>&1 | tail -n +2 | grep -v 'Installed Packages' | grep -v 'Red Hat Subscription Management' | grep -v 'Error:' | grep -v 'system' | grep -v 'manager' | awk '{ print $2 }' | tr '\n' ' ')
 
-yum_available=$(yum list available -q "$@" 2>&1 | tail -n +2 | grep -v 'Available Packages' | grep -v 'Red Hat Subscription Management' | grep -v 'el7ose' | grep -v 'Error:' | awk '{ print $2 }' | tr '\n' ' ')
+yum_available=$(yum list available -q "$@" 2>&1 | tail -n +2 | grep -v 'Available Packages' | grep -v 'Red Hat Subscription Management' | grep -v 'el7ose' | grep -v 'Error:' | grep -v 'system' | grep -v 'manager' | awk '{ print $2 }' | tr '\n' ' ')
 
 
 echo "---"


### PR DESCRIPTION
Temporary fix for #1072. This versions script will likely be replaced soon.

@detiber @sdodson 