### PR TITLE
Refactors Docker setup to own role to avoid race in SDN setup

### DIFF
--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -2,6 +2,7 @@
 
 - name: restart docker
   service: name=docker state=restarted
+  when: not docker_service_status_changed | default(false)
 
 - name: restart udev
   service:

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,10 +1,88 @@
 ---
 # tasks file for docker
+
+- name: Set node facts applicable to docker
+  openshift_facts:
+    role: "{{ item.role }}"
+    local_facts: "{{ item.local_facts }}"
+  with_items:
+  - role: common
+    local_facts:
+      deployment_type: "{{ openshift_deployment_type }}"
+  - role: node
+    local_facts:
+      docker_log_driver:  "{{ lookup( 'oo_option' , 'docker_log_driver'  )  | default('',True) }}"
+      docker_log_options: "{{ lookup( 'oo_option' , 'docker_log_options' )  | default('',True) }}"
+      portal_net: "{{ openshift_master_portal_net | default(None) }}"
+
 - name: Install docker
   action: "{{ ansible_pkg_mgr }} name=docker state=present"
-  
+
+- stat: path=/etc/sysconfig/docker
+  register: docker_check
+
+  # TODO: Enable secure registry when code available in origin
+- name: Secure Registry and Logs Options
+  lineinfile:
+    dest: /etc/sysconfig/docker
+    regexp: '^OPTIONS=.*$'
+    line: "OPTIONS='--insecure-registry={{ openshift.node.portal_net }} \
+{% if ansible_selinux and ansible_selinux.status == '''enabled''' %}--selinux-enabled{% endif %} \
+{% if openshift.node.docker_log_driver is defined %} --log-driver {{ openshift.node.docker_log_driver }}  {% endif %} \
+{% if openshift.node.docker_log_options is defined %}   {{ openshift.node.docker_log_options |  oo_split() | oo_prepend_strings_in_list('--log-opt ') | join(' ')}}  {% endif %} '"
+  when: docker_check.stat.isreg
+  notify:
+    - restart docker
+
+- set_fact:
+    docker_additional_registries: "{{ lookup('oo_option', 'docker_additional_registries')
+                                      | oo_split() | union(['registry.access.redhat.com'])
+                                      | difference(['']) }}"
+  when: openshift.common.deployment_type == 'enterprise'
+
+- set_fact:
+    docker_additional_registries: "{{ lookup('oo_option', 'docker_additional_registries')
+                                      | oo_split() | difference(['']) }}"
+  when: openshift.common.deployment_type != 'enterprise'
+
+- name: Add personal registries
+  lineinfile:
+    dest: /etc/sysconfig/docker
+    regexp: '^ADD_REGISTRY=.*$'
+    line: "ADD_REGISTRY='{{ docker_additional_registries
+                            | oo_prepend_strings_in_list('--add-registry ') | join(' ') }}'"
+  when: docker_check.stat.isreg and docker_additional_registries
+  notify:
+    - restart docker
+
+- name: Block registries
+  lineinfile:
+    dest: /etc/sysconfig/docker
+    regexp: '^BLOCK_REGISTRY=.*$'
+    line: "BLOCK_REGISTRY='{{ lookup('oo_option', 'docker_blocked_registries') | oo_split()
+                              | oo_prepend_strings_in_list('--block-registry ') | join(' ') }}'"
+  when: docker_check.stat.isreg and
+        lookup('oo_option', 'docker_blocked_registries') != ''
+  notify:
+    - restart docker
+
+- name: Grant access to additional insecure registries
+  lineinfile:
+    dest: /etc/sysconfig/docker
+    regexp: '^INSECURE_REGISTRY=.*'
+    line: "INSECURE_REGISTRY='{{ lookup('oo_option', 'docker_insecure_registries') | oo_split()
+                              | oo_prepend_strings_in_list('--insecure-registry ') | join(' ') }}'"
+  when: docker_check.stat.isreg and
+        lookup('oo_option', 'docker_insecure_registries') != ''
+  notify:
+    - restart docker
+
 - name: enable and start the docker service
   service: name=docker enabled=yes state=started
+  register: start_result
+
+- set_fact:
+    docker_service_status_changed: start_result | changed
 
 - include: udev_workaround.yml
   when: docker_udev_workaround | default(False)

--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -2,6 +2,3 @@
 - name: restart node
   service: name={{ openshift.common.service_type }}-node state=restarted
   when: not node_service_status_changed | default(false)
-
-- name: restart docker
-  service: name=docker state=restarted

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -50,7 +50,7 @@
     src: node.yaml.v1.j2
     backup: true
   notify:
-  - restart node
+    - restart node
 
 - name: Configure Node settings
   lineinfile:
@@ -63,65 +63,7 @@
     - regex: '^CONFIG_FILE='
       line: "CONFIG_FILE={{ openshift_node_config_file }}"
   notify:
-  - restart node
-
-- stat: path=/etc/sysconfig/docker
-  register: docker_check
-
-  # TODO: Enable secure registry when code available in origin
-- name: Secure Registry and Logs Options
-  lineinfile:
-    dest: /etc/sysconfig/docker
-    regexp: '^OPTIONS=.*$'
-    line: "OPTIONS='--insecure-registry={{ openshift.node.portal_net }} \
-{% if ansible_selinux and ansible_selinux.status == '''enabled''' %}--selinux-enabled{% endif %} \
-{% if openshift.node.docker_log_driver is defined  %} --log-driver {{ openshift.node.docker_log_driver }}  {% endif %} \
-{% if openshift.node.docker_log_options is defined %}   {{ openshift.node.docker_log_options |  oo_split() | oo_prepend_strings_in_list('--log-opt ') | join(' ')}}  {% endif %} '"
-  when: docker_check.stat.isreg
-  notify:
-    - restart docker
-
-- set_fact:
-    docker_additional_registries: "{{ lookup('oo_option', 'docker_additional_registries')
-                                      | oo_split() | union(['registry.access.redhat.com'])
-                                      | difference(['']) }}"
-  when: openshift.common.deployment_type in ['enterprise', 'openshift-enterprise', 'atomic-enterprise']
-- set_fact:
-    docker_additional_registries: "{{ lookup('oo_option', 'docker_additional_registries')
-                                      | oo_split() | difference(['']) }}"
-  when: openshift.common.deployment_type not in ['enterprise', 'openshift-enterprise', 'atomic-enterprise']
-
-- name: Add personal registries
-  lineinfile:
-    dest: /etc/sysconfig/docker
-    regexp: '^ADD_REGISTRY=.*$'
-    line: "ADD_REGISTRY='{{ docker_additional_registries
-                            | oo_prepend_strings_in_list('--add-registry ') | join(' ') }}'"
-  when: docker_check.stat.isreg and docker_additional_registries
-  notify:
-    - restart docker
-
-- name: Block registries
-  lineinfile:
-    dest: /etc/sysconfig/docker
-    regexp: '^BLOCK_REGISTRY=.*$'
-    line: "BLOCK_REGISTRY='{{ lookup('oo_option', 'docker_blocked_registries') | oo_split()
-                              | oo_prepend_strings_in_list('--block-registry ') | join(' ') }}'"
-  when: docker_check.stat.isreg and
-        lookup('oo_option', 'docker_blocked_registries') != ''
-  notify:
-    - restart docker
-
-- name: Grant access to additional insecure registries
-  lineinfile:
-    dest: /etc/sysconfig/docker
-    regexp: '^INSECURE_REGISTRY=.*'
-    line: "INSECURE_REGISTRY='{{ lookup('oo_option', 'docker_insecure_registries') | oo_split()
-                              | oo_prepend_strings_in_list('--insecure-registry ') | join(' ') }}'"
-  when: docker_check.stat.isreg and
-        lookup('oo_option', 'docker_insecure_registries') != ''
-  notify:
-    - restart docker
+    - restart node
 
 - name: Additional storage plugin configuration
   include: storage_plugins/main.yml


### PR DESCRIPTION
Refactors Docker setup to its own role to avoid race between start/stop and SDN setup that also restarts Docker.

What o-a does:

* docker role
    * tasks start docker
    * handler restarts docker and udevd
* openshift_node role
    * tasks start node
    * handler:
        * restarts node (if wasn't started by tasks, per #1057)
        * restarts docker

openshift-node runs openshift-sdn-kube-subnet-setup.sh on startup.  Amongst other things it:

* runs systemctl daemon-reload
* restarts docker

The docker restart above races with the one in the openshift_node role's handler, leading to the setup script exiting prematurely due to systemctl cancelling conflicting jobs relating to intertwined docker start/stop actions:

```
[root@192 ~]# journalctl | grep -E "Docker Application|ansible-service|Starting OpenShift|Output of setup script|Job for"
Dec 16 08:52:07 acs-e2e-test-eric-10340-node-compute-0.novalocal ansible-service[10372]: Invoked with name=iptables pattern=None enabled=True state=started sleep=None arguments= runlevel=default
Dec 16 08:52:37 192.168.243.4 ansible-service[11531]: Invoked with name=docker pattern=None enabled=True state=started sleep=None arguments= runlevel=default
Dec 16 08:52:37 192.168.243.4 systemd[1]: Starting Docker Application Container Engine...
Dec 16 08:52:37 192.168.243.4 systemd[1]: Started Docker Application Container Engine.
Dec 16 08:52:49 192.168.243.4 ansible-service[12281]: Invoked with name=openshift-node pattern=None enabled=True state=started sleep=None arguments= runlevel=default
Dec 16 08:52:49 192.168.243.4 systemd[1]: Starting OpenShift Node...
Dec 16 08:52:52 192.168.243.4 systemd[1]: Stopping Docker Application Container Engine...
Dec 16 08:52:52 192.168.243.4 ansible-service[12576]: Invoked with name=docker pattern=None enabled=None state=restarted sleep=None arguments= runlevel=default
Dec 16 08:52:52 192.168.243.4 systemd[1]: Starting Docker Application Container Engine...
Dec 16 08:52:52 192.168.243.4 openshift-node[12348]: I1216 08:52:52.371431   12348 kube.go:29] Output of setup script:
Dec 16 08:52:52 192.168.243.4 openshift-node[12348]: Job for docker.service canceled.
Dec 16 08:52:52 192.168.243.4 systemd[1]: Stopped Docker Application Container Engine.
Dec 16 08:52:52 192.168.243.4 openshift-node[12348]: Job for docker.service canceled.
Dec 16 08:52:52 192.168.243.4 systemd[1]: Starting Docker Application Container Engine...
Dec 16 08:52:52 192.168.243.4 systemd[1]: Started Docker Application Container Engine.
Dec 16 08:52:52 192.168.243.4 systemd[1]: Starting OpenShift Node...
Dec 16 08:52:53 192.168.243.4 openshift-node[12711]: I1216 08:52:53.138953   12711 kube.go:29] Output of setup script:
```

On the 2nd start of openshift-node, the setup script aborts claiming nothing needs to be done.

Other folks are seeing this too it seems - c.f. #780.

Objective of this PR is to refactor the docker config that is done in the openshift_node role, to the docker role.  This should eliminate the race.

With this patch:

```
openshift@eric-node-compute-8048a ~]$ sudo journalctl | grep -E "Docker Application|ansible-service|Starting OpenShift|Output of setup script|Job for"
Dec 16 16:01:38 eric-node-compute-8048a.example.com ansible-service[11134]: Invoked with name=iptables pattern=None enabled=True state=started sleep=None arguments= runlevel=default
Dec 16 16:01:55 eric-node-compute-8048a.example.com ansible-service[12383]: Invoked with name=docker pattern=None enabled=True state=started sleep=None arguments= runlevel=default
Dec 16 16:01:55 eric-node-compute-8048a.example.com systemd[1]: Starting Docker Application Container Engine...
Dec 16 16:01:56 eric-node-compute-8048a.example.com systemd[1]: Started Docker Application Container Engine.
Dec 16 16:01:59 eric-node-compute-8048a.example.com ansible-service[13051]: Invoked with name=openshift-node pattern=None enabled=True state=started sleep=None arguments= runlevel=default
Dec 16 16:02:00 eric-node-compute-8048a.example.com systemd[1]: Starting OpenShift Node...
Dec 16 16:02:03 eric-node-compute-8048a.example.com systemd[1]: Stopping Docker Application Container Engine...
Dec 16 16:02:03 eric-node-compute-8048a.example.com systemd[1]: Starting Docker Application Container Engine...
Dec 16 16:02:04 eric-node-compute-8048a.example.com systemd[1]: Started Docker Application Container Engine.
Dec 16 16:02:04 eric-node-compute-8048a.example.com openshift-node[13118]: I1216 16:02:04.092320   13118 kube.go:29] Output of setup script:
```
