### PR TITLE
Allow libvirt cluster to be restarted after host is rebooted

### DIFF
--- a/playbooks/libvirt/openshift-cluster/rehydrate.yml
+++ b/playbooks/libvirt/openshift-cluster/rehydrate.yml
@@ -1,0 +1,17 @@
+---
+- name: Rehydrate dormant OpenShift cluster
+  hosts: localhost
+  gather_facts: no
+  vars_files:
+  - vars.yml
+  vars:
+    os_libvirt_storage_pool: "{{ libvirt_storage_pool | default('images') }}"
+    os_libvirt_storage_pool_path: "{{ libvirt_storage_pool_path | default('/var/lib/libvirt/images') }}"
+    os_libvirt_network: "{{ libvirt_network | default('default') }}"
+    image_url: "{{ deployment_vars[deployment_type].image.url }}"
+    image_sha256: "{{ deployment_vars[deployment_type].image.sha256 }}"
+    image_name: "{{ deployment_vars[deployment_type].image.name }}"
+  tasks:
+  - include: tasks/configure_libvirt.yml
+
+


### PR DESCRIPTION
This change is specific to running OpenShift on a cluster of VMs managed through **libvirt**.  Currently, if you restart your host machine and attempt to restart your VMs the the **libvirt** Virtual Machine Manager UI, the VMs fail to start stating that the network is missing.

I created a YML file for Ansible that configures libvirt and allows the VMs to be restarted.  The YML file is called rehydrate.yml, because the purpose of the file is to allow the cluster to be restarted (rehydration).

It would have been easier for the user to run this command if it was integrated into the **bin/cluster** script; however I didn't do that because rehydration is specific to the **libvirt** provider and not applicable to the other providers.

Once the host is rebooted and the VMs no longer start, run the following from the same place you would run bin/cluster:

```
    ansible-playbook playbooks/libvirt/openshift-cluster/rehydrate.yml
```

The YML file re-executes only the LIBVIRT Configuration tasks, allowing the VMs to be restarted through the libvirt Virtual Machine Manager.
