### PR TITLE
Allow compression option to be set to empty for non compressed images

### DIFF
--- a/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
@@ -13,15 +13,27 @@
   get_url:
     url: '{{ image_url }}'
     sha256sum: '{{ image_sha256 }}'
-    dest: '{{ os_libvirt_storage_pool_path }}/{{ [image_name, image_compression] | join(".") }}'
+    dest: '{{ os_libvirt_storage_pool_path }}/{{ [image_name, image_compression] | reject("equalto", "") | join(".") }}'
   when: '{{ ( lookup("oo_option", "skip_image_download") | default("no", True) | lower ) in ["false", "no"] }}'
   register: downloaded_image
 
-- name: Uncompress Base Cloud image
+- name: Uncompress xz compressed base cloud image
   command: 'unxz -kf {{ os_libvirt_storage_pool_path }}/{{ [image_name, image_compression] | join(".") }}'
   args:
     creates: '{{ os_libvirt_storage_pool_path }}/{{ image_name }}'
   when: image_compression in ["xz"] and downloaded_image.changed
+
+- name: Uncompress tgz compressed base cloud image
+  command: 'tar zxvf {{ os_libvirt_storage_pool_path }}/{{ [image_name, image_compression] | join(".") }}'
+  args:
+    creates: '{{ os_libvirt_storage_pool_path }}/{{ image_name }}'
+  when: image_compression in ["tgz"] and downloaded_image.changed
+
+- name: Uncompress gzip compressed base cloud image
+  command: 'gunzip {{ os_libvirt_storage_pool_path }}/{{ [image_name, image_compression] | join(".") }}'
+  args:
+    creates: '{{ os_libvirt_storage_pool_path }}/{{ image_name }}'
+  when: image_compression in ["gz"] and downloaded_image.changed
 
 - name: Create the cloud-init config drive path
   file:

--- a/playbooks/libvirt/openshift-cluster/vars.yml
+++ b/playbooks/libvirt/openshift-cluster/vars.yml
@@ -15,6 +15,7 @@ deployment_rhel7_ent_base:
                 default('rhel-guest-image-7.2-20151102.0.x86_64.qcow2', True) }}"
     sha256: "{{ lookup('oo_option', 'image_sha256') |
                 default('25f880767ec6bf71beb532e17f1c45231640bbfdfbbb1dffb79d2c1b328388e0', True) }}"
+    compression: ""
   ssh_user: openshift
   sudo: yes
 
@@ -41,3 +42,5 @@ deployment_vars:
   enterprise: "{{ deployment_rhel7_ent_base }}"
   openshift-enterprise: "{{ deployment_rhel7_ent_base }}"
   atomic-enterprise: "{{ deployment_rhel7_ent_base }}"
+
+


### PR DESCRIPTION
Enteprise or custom images deployment may not use a compressed image and hence the playbook crashes when the compression attribute is not defined.
This change allows to have a compression defined to empty string. And thus, the stored image will have no additional extension.

At the same time, support for tgz compression has been added for other images.
