### PR TITLE
Add the new metrics and logging urls

### DIFF
--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -8,6 +8,12 @@ assetConfig:
   logoutURL: ""
   masterPublicURL: {{ openshift.master.public_api_url }}
   publicURL: {{ openshift.master.public_console_url }}/
+{% if openshift.master.loggingPublicURL %}
+  loggingPublicURL: {{ openshift.master.loggingPublicURL }}
+{% endif %}
+{% if openshift.master.metricsPublicURL %}
+  metricsPublicURL: {{ openshift.master.metricsPublicURL }}
+{% endif %}
   servingInfo:
     bindAddress: {{ openshift.master.bind_addr }}:{{ openshift.master.console_port }}
     bindNetwork: tcp4


### PR DESCRIPTION
When you add the 2 new possibility

https://docs.openshift.org/latest/install_config/cluster_metrics.html
https://docs.openshift.org/latest/install_config/aggregate_logging.html

and then run the playbook again the both urls are gone.
With this PR you can add both urls in the hosts file and don't need to add in the new file the urls.