### PR TITLE
Add the new metrics and logging urls v2

### DIFF
--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -27,6 +27,14 @@ deployment_type=atomic-enterprise
 # Enable cluster metrics
 #use_cluster_metrics=true
 
+# Configure metricsPublicURL in the master config for cluster metrics
+# See: https://docs.openshift.com/enterprise/latest/install_config/cluster_metrics.html
+#openshift_master_metrics_public_url=https://hawkular-metrics.example.com/hawkular/metrics
+
+# Configure loggingPublicURL in the master config for aggregate logging
+# See: https://docs.openshift.com/enterprise/latest/install_config/aggregate_logging.html
+#openshift_master_logging_public_url=https://kibana.example.com
+
 # Add additional, insecure, and blocked registries to global docker configuration
 # For enterprise deployment types we ensure that registry.access.redhat.com is
 # included if you do not include it

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -27,6 +27,14 @@ deployment_type=origin
 # Enable cluster metrics
 #use_cluster_metrics=true
 
+# Configure metricsPublicURL in the master config for cluster metrics
+# See: https://docs.openshift.org/latest/install_config/cluster_metrics.html
+#openshift_master_metrics_public_url=https://hawkular-metrics.example.com/hawkular/metrics
+
+# Configure loggingPublicURL in the master config for aggregate logging
+# See: https://docs.openshift.org/latest/install_config/aggregate_logging.html
+#openshift_master_logging_public_url=https://kibana.example.com
+
 # Add additional, insecure, and blocked registries to global docker configuration
 # For enterprise deployment types we ensure that registry.access.redhat.com is
 # included if you do not include it

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -27,6 +27,14 @@ deployment_type=openshift-enterprise
 # Enable cluster metrics
 #use_cluster_metrics=true
 
+# Configure metricsPublicURL in the master config for cluster metrics
+# See: https://docs.openshift.com/enterprise/latest/install_config/cluster_metrics.html
+#openshift_master_metrics_public_url=https://hawkular-metrics.example.com/hawkular/metrics
+
+# Configure loggingPublicURL in the master config for aggregate logging
+# See: https://docs.openshift.com/enterprise/latest/install_config/aggregate_logging.html
+#openshift_master_logging_public_url=https://kibana.example.com
+
 # Add additional, insecure, and blocked registries to global docker configuration
 # For enterprise deployment types we ensure that registry.access.redhat.com is
 # included if you do not include it

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -38,6 +38,8 @@
       console_url: "{{ openshift_master_console_url | default(None) }}"
       console_use_ssl: "{{ openshift_master_console_use_ssl | default(None) }}"
       public_console_url: "{{ openshift_master_public_console_url | default(None) }}"
+      logging_public_url: "{{ openshift_master_logging_public_url | default(None) }}"
+      metrics_public_url: "{{ openshift_master_metrics_public_url | default(None) }}"
       etcd_hosts: "{{ openshift_master_etcd_hosts | default(None)}}"
       etcd_port: "{{ openshift_master_etcd_port | default(None) }}"
       etcd_use_ssl: "{{ openshift_master_etcd_use_ssl | default(None) }}"

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -8,6 +8,12 @@ assetConfig:
   logoutURL: ""
   masterPublicURL: {{ openshift.master.public_api_url }}
   publicURL: {{ openshift.master.public_console_url }}/
+{% if 'logging_public_url' in openshift.master %}
+  loggingPublicURL: {{ openshift.master.logging_public_url }}
+{% endif %}
+{% if 'metrics_public_url' in openshift.master %}
+  metricsPublicURL: {{ openshift.master.metrics_public_url }}
+{% endif %}
   servingInfo:
     bindAddress: {{ openshift.master.bind_addr }}:{{ openshift.master.console_port }}
     bindNetwork: tcp4


### PR DESCRIPTION
When you add the 2 new possibility

https://docs.openshift.org/latest/install_config/cluster_metrics.html
https://docs.openshift.org/latest/install_config/aggregate_logging.html

and then run the playbook again the both urls are gone.
With this PR you can add both urls in the hosts file and don't need to add in the new file the urls.