### PR TITLE
Fix version interrogation on containerized installs

### DIFF
--- a/roles/openshift_cli/tasks/main.yml
+++ b/roles/openshift_cli/tasks/main.yml
@@ -46,3 +46,7 @@
     - /usr/local/bin/oc
     - /usr/local/bin/kubectl
   when: openshift.common.is_containerized | bool
+  
+- name: Reload common facts
+  openshift_facts:
+    role: common


### PR DESCRIPTION
 * get_openshift_version now searches the PATH for 'openshift'
 * client_binary and admin_binary also search the PATH for 'oc' and 'oadm'
 * openshift_cli reloads facts after installing cli wrappers