### PR TITLE
Install iptables, iptables-services when not is_aotmic

### DIFF
--- a/roles/os_firewall/tasks/firewall/iptables.yml
+++ b/roles/os_firewall/tasks/firewall/iptables.yml
@@ -5,7 +5,7 @@
   - iptables
   - iptables-services
   register: install_result
-  when: not openshift.common.is_containerized | bool
+  when: not openshift.common.is_atomic | bool
 
 - name: Check if firewalld is installed
   command: rpm -q firewalld


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1292684

iptables and iptables-services are included in atomic-host already.