### PR TITLE
Remove lb from docker hosts.

### DIFF
--- a/playbooks/common/openshift-docker/config.yml
+++ b/playbooks/common/openshift-docker/config.yml
@@ -1,5 +1,5 @@
 - name: Configure docker hosts
-  hosts: oo_masters_to_config:oo_nodes_to_config:oo_etcd_to_config:oo_lb_to_config
+  hosts: oo_masters_to_config:oo_nodes_to_config:oo_etcd_to_config
   vars:
     docker_additional_registries: "{{ lookup('oo_option', 'docker_additional_registries') | oo_split }}"
     docker_insecure_registries: "{{ lookup('oo_option',  'docker_insecure_registries') | oo_split }}"

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -232,6 +232,7 @@
       balance: source
       servers: "{{ hostvars.localhost.haproxy_backend_servers }}"
   roles:
+  - role: openshift_facts
   - role: haproxy
     when: groups.oo_masters_to_config | length > 1
 


### PR DESCRIPTION
@sdodson PTAL, I removed the `is_containerized | bool` from the haproxy package install since we assume it will never be containerized. Do you think that will be sufficient or should we guard the lb hosts by setting `is_containerized: false` when we gather facts for lbs?