### PR TITLE
Fix Docker restart handling

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -12,7 +12,7 @@
   register: start_result
 
 - set_fact:
-    docker_service_status_changed = start_result | changed
+    docker_service_status_changed: start_result | changed
 
 - include: udev_workaround.yml
   when: docker_udev_workaround | default(False)

--- a/roles/openshift_docker/handlers/main.yml
+++ b/roles/openshift_docker/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: restart openshift_docker
+  service:
+    name: docker
+    state: restarted

--- a/roles/openshift_docker/tasks/main.yml
+++ b/roles/openshift_docker/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - stat: path=/etc/sysconfig/docker
   register: docker_check
-  
+
 - name: Set registry params
   lineinfile:
     dest: /etc/sysconfig/docker
@@ -36,7 +36,7 @@
     reg_fact_val: "{{ openshift.common.docker_insecure_registries }}"
     reg_flag: --insecure-registry
   notify:
-  - restart docker
+  - restart openshift_docker
 
 # TODO: Enable secure registry when code available in origin
 # TODO: perhaps move this to openshift_docker?
@@ -50,4 +50,4 @@
       {% if openshift.node.docker_log_options is defined %}   {{ openshift.node.docker_log_options |  oo_split() | oo_prepend_strings_in_list('--log-opt ') | join(' ')}}  {% endif %} '"
   when: docker_check.stat.isreg
   notify:
-    - restart docker
+    - restart openshift_docker


### PR DESCRIPTION
* Fixes typo assigning docker_service_status_changed which leads to misinterpretation in handler.
* Fixes Docker restart handling to ensure openshift_docker role does restart Docker on change.

The docker role has a typo setting `docker_service_status_changed` (c.f. #1057 where this was fixed for master/node restarts).

If we just fix this typo bluntly, the configuration changes (e.g. additional registries) made subsequently in the `openshift_docker` role will only take effect by chance thanks to the openshift-node SDN setup script performing a docker restart (and therefore only on nodes I suppose).  Indeed, the `docker` role having started the service, it sets `docker_service_status_changed`, so any `restart docker` notifications signalled in `openshift_docker` are skipped.

I have 2 proposals to fix this:

1. Change the docker service start+enable task to only enable it, notify `restart docker` and remove the `docker_service_status_changed` business.  I dislike this option as it means we no longer guarantee that docker is in state started at some point.
2. Introduce a 2nd `restart docker` handler (with a different name since "[If two handler tasks have the same name, only one will run. *](http://docs.ansible.com/ansible/playbooks_intro.html)") specifically to be used by the openshift_docker role.

This PR implements option 2.