### PR TITLE
Group name as per hosts.origin.example

### DIFF
--- a/README_AEP.md
+++ b/README_AEP.md
@@ -98,6 +98,8 @@ aep3-node[1:2].example.com
 The hostnames above should resolve both from the hosts themselves and
 the host where ansible is running (if different).
 
+A more complete example inventory file ([hosts.aep.example](https://github.com/openshift/openshift-ansible/blob/master/inventory/byo/hosts.aep.example)) is available under the [`/inventory/byo`](https://github.com/openshift/openshift-ansible/tree/master/inventory/byo) directory.
+
 ## Running the ansible playbooks
 From the openshift-ansible checkout run:
 ```sh

--- a/README_OSE.md
+++ b/README_OSE.md
@@ -105,6 +105,8 @@ ose3-node[1:2].example.com
 The hostnames above should resolve both from the hosts themselves and
 the host where ansible is running (if different).
 
+A more complete example inventory file ([hosts.ose.example](https://github.com/openshift/openshift-ansible/blob/master/inventory/byo/hosts.ose.example)) is available under the [`/inventory/byo`](https://github.com/openshift/openshift-ansible/tree/master/inventory/byo) directory.
+
 ## Running the ansible playbooks
 From the openshift-ansible checkout run:
 ```sh

--- a/README_origin.md
+++ b/README_origin.md
@@ -59,12 +59,12 @@ option to ansible-playbook.
 # This is an example of a bring your own (byo) host inventory
 
 # Create an OSEv3 group that contains the masters and nodes groups
-[OSv3:children]
+[OSEv3:children]
 masters
 nodes
 
 # Set variables common for all OSEv3 hosts
-[OSv3:vars]
+[OSEv3:vars]
 
 # SSH user, this user should allow ssh based auth without requiring a password
 ansible_ssh_user=root
@@ -94,6 +94,8 @@ osv3-lb.example.com
 
 The hostnames above should resolve both from the hosts themselves and
 the host where ansible is running (if different).
+
+A more complete example inventory file ([hosts.origin.example](https://github.com/openshift/openshift-ansible/blob/master/inventory/byo/hosts.origin.example)) is available under the [`/inventory/byo`](https://github.com/openshift/openshift-ansible/tree/master/inventory/byo) directory.
 
 ## Running the ansible playbooks
 From the openshift-ansible checkout run:


### PR DESCRIPTION
The example inventory file does not currently work and fails with:

```
PLAY [Gather Cluster facts] ***************************************************
skipping: no hosts matched

PLAY RECAP ********************************************************************
```

this is because the group name is actually `OSEv3` (inline with [hosts.origin.example](https://github.com/openshift/openshift-ansible/blob/master/inventory/byo/hosts.origin.example#L4)) and not `OSv3`.

Also added reference to inventory/byo/hosts.origin.example for more complete example.
Perhaps the basic example above should be removed and replaced with a reference to [inventory/byo/hosts.origin.example](https://github.com/openshift/openshift-ansible/blob/master/inventory/byo/hosts.origin.example) instead?