### PR TITLE
Fix RHN subscription by explicitly attaching to the right pool

### DIFF
--- a/roles/rhel_subscribe/tasks/main.yml
+++ b/roles/rhel_subscribe/tasks/main.yml
@@ -4,6 +4,7 @@
 #       to make it able to enable repositories
 
 - set_fact:
+    rhel_subscription_pool: "{{ lookup('oo_option', 'rhel_subscription_pool') | default(rhsub_pool, True) | default('OpenShift Enterprise, Premium*', True) }}"
     rhel_subscription_user: "{{ lookup('oo_option', 'rhel_subscription_user') | default(rhsub_user, True) | default(omit, True) }}"
     rhel_subscription_pass: "{{ lookup('oo_option', 'rhel_subscription_pass') | default(rhsub_pass, True) | default(omit, True) }}"
     rhel_subscription_server: "{{ lookup('oo_option', 'rhel_subscription_server') | default(rhsub_server) }}"
@@ -30,7 +31,14 @@
   redhat_subscription:
     username: "{{ rhel_subscription_user }}"
     password: "{{ rhel_subscription_pass }}"
-    autosubscribe: yes
+
+- name: Retrieve the OpenShift Pool ID
+  command: subscription-manager list --available --matches="{{ rhel_subscription_pool }}" --pool-only
+  register: openshift_pool_id
+  changed_when: False
+
+- name: Attach to OpenShift Pool
+  command: subscription-manager subscribe --pool {{ openshift_pool_id.stdout_lines[0] }}
 
 - include: enterprise.yml
   when: deployment_type == 'enterprise'


### PR DESCRIPTION
Depending on the user RHN account, attempting to spawn an OpenShift cluster can result in the following error:

```
TASK: [rhel_subscribe | Enable RHEL repositories] ***************************** 
failed: [lenaic-master-e8f6d] => {"changed": true, "cmd": ["subscription-manager", "repos", "--enable=rhel-7-server-rpms", "--enable=rhel-7-server-extras-rpms", "--enable=rhel-7-server-ose-3.0-rpms"], "delta": "0:00:12.185557", "end": "2016-01-05 11:07:45.918421", "rc": 1, "start": "2016-01-05 11:07:33.732864", "warnings": []}
stdout: Error: rhel-7-server-ose-3.0-rpms is not a valid repository ID. Use --list option to see valid repositories.
Repository 'rhel-7-server-rpms' is enabled for this system.
Repository 'rhel-7-server-extras-rpms' is enabled for this system.
failed: [lenaic-node-compute-224b8] => {"changed": true, "cmd": ["subscription-manager", "repos", "--enable=rhel-7-server-rpms", "--enable=rhel-7-server-extras-rpms", "--enable=rhel-7-server-ose-3.0-rpms"], "delta": "0:00:12.342549", "end": "2016-01-05 11:07:46.796444", "rc": 1, "start": "2016-01-05 11:07:34.453895", "warnings": []}
stdout: Error: rhel-7-server-ose-3.0-rpms is not a valid repository ID. Use --list option to see valid repositories.
Repository 'rhel-7-server-rpms' is enabled for this system.
Repository 'rhel-7-server-extras-rpms' is enabled for this system.

FATAL: all hosts have already failed -- aborting
```

It seems that “auto-subscription” is not always magically working, so I want to be more explicit about the pool to attach to.

I tried the `pool` attribute of the `redhat_subscription` ansible module this way:
```
- name: RedHat subscriptions
  redhat_subscription:
    username: "{{ rhel_subscription_user }}"
    password: "{{ rhel_subscription_pass }}"
    pool: "^OpenShift Enterprise, Premium"
```
but I got the following error:
```
TASK: [rhel_subscribe | RedHat subscriptions] ********************************* 
failed: [lenaic-master-842f4] => {"failed": true}
msg: Failed to register with 'subscription.rhn.redhat.com': 'RhsmPool' object has no attribute 'PoolId'
failed: [lenaic-node-compute-4184b] => {"failed": true}
msg: Failed to register with 'subscription.rhn.redhat.com': 'RhsmPool' object has no attribute 'PoolId'
```

That’s why I had to “manually” invoke `subscription_manager`.