### PR TITLE
Fix update_repos_and_packages playbook which now needs openshift_facts

### DIFF
--- a/playbooks/common/openshift-cluster/update_repos_and_packages.yml
+++ b/playbooks/common/openshift-cluster/update_repos_and_packages.yml
@@ -8,6 +8,5 @@
           ansible_distribution == "RedHat" and
           lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
             default('no', True) | lower in ['no', 'false']
-          and not openshift.common.is_atomic | bool
   - openshift_repos
   - os_update_latest

--- a/roles/rhel_subscribe/meta/main.yml
+++ b/roles/rhel_subscribe/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - openshift_facts

--- a/roles/rhel_subscribe/tasks/main.yml
+++ b/roles/rhel_subscribe/tasks/main.yml
@@ -41,4 +41,5 @@
   command: subscription-manager subscribe --pool {{ openshift_pool_id.stdout_lines[0] }}
 
 - include: enterprise.yml
-  when: deployment_type in [ 'enterprise', 'atomic-enterprise', 'openshift-enterprise' ]
+  when: deployment_type in [ 'enterprise', 'atomic-enterprise', 'openshift-enterprise' ] and
+        not openshift.common.is_atomic | bool


### PR DESCRIPTION
The `update_repos_and_packages` playbook is failing with the following error:
```
TASK: [rhel_subscribe | set_fact ] ******************************************** 
fatal: [lenaic-master-6b224] => error while evaluating conditional: deployment_type == "enterprise" and ansible_distribution == "RedHat" and lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) | default('no', True) | lower in ['no', 'false'] and not openshift.common.is_atomic | bool
fatal: [lenaic-node-compute-351cd] => error while evaluating conditional: deployment_type == "enterprise" and ansible_distribution == "RedHat" and lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) | default('no', True) | lower in ['no', 'false'] and not openshift.common.is_atomic | bool
```

I suspected that it was the openshift facts which were missing in that case and indeed, adding `openshift_facts` solved this issue.