### PR TITLE
Fix multi-word arguments & cli wrapper stdin plumbing

### DIFF
--- a/roles/openshift_cli/templates/openshift.j2
+++ b/roles/openshift_cli/templates/openshift.j2
@@ -6,11 +6,4 @@ cmd=`basename $0`
 user=`id -u`
 group=`id -g`
 
-# docker can only split stderr and stdin when run without -t
-# https://github.com/docker/docker/issues/725
-# ansible checks various streams DO NOT CROSS THE STREAMS
-if [ -z $TERM ]; then
-  $t = '-it'
-fi
-
-docker run ${t} -a STDERR -a STDOUT -a STDIN --privileged --net=host --user=${user}:${group} -v ~/.kube:/root/.kube -v /tmp:/tmp -v {{ openshift.common.config_base}}:{{ openshift.common.config_base }} -e KUBECONFIG=/root/.kube/config --entrypoint ${cmd} --rm {{ openshift.common.cli_image }} ${@}
+docker run -i -a STDERR -a STDOUT -a STDIN --privileged --net=host --user=${user}:${group} -v ~/.kube:/root/.kube -v /tmp:/tmp -v {{ openshift.common.config_base}}:{{ openshift.common.config_base }} -e KUBECONFIG=/root/.kube/config --entrypoint ${cmd} --rm {{ openshift.common.cli_image }} "${@}"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/1295677
Fixes `echo "foo" | oc create -f -` by removing -t option entirely