### PR TITLE
Fix VM drive cleanup during terminate on libvirt

### DIFF
--- a/playbooks/libvirt/openshift-cluster/tasks/configure_libvirt_storage_pool.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/configure_libvirt_storage_pool.yml
@@ -4,13 +4,17 @@
     dest: "{{ libvirt_storage_pool_path }}"
     state: directory
 
+# We need to set permissions on the directory and any items created under the directory, so we need to call the acl module with and without default set.
 - acl:
-    default: yes
+    default: "{{ item }}"
     entity: kvm
     etype: group
     name: "{{ libvirt_storage_pool_path }}"
     permissions: rwx
     state: present
+  with_items:
+    - no
+    - yes
 
 - name: Test if libvirt storage pool for openshift already exists
   command: "virsh -c {{ libvirt_uri }} pool-info {{ libvirt_storage_pool }}"


### PR DESCRIPTION
Doing `bin/cluster create libvirt lenaic` followed by `bin/cluster terminate libvirt lenaic` may result in the following error:
```
TASK: [Delete VMs drives] ***************************************************** 
failed: [localhost] => (item=lenaic-master-dba61) => {"changed": true, "cmd": ["virsh", "-c", "qemu:///system", "vol-delete", "--pool", "openshift-ansible", "lenaic-master-dba61.qcow2"], "delta": "0:00:00.019190", "end": "2016-01-06 15:37:06.800769", "item": "lenaic-master-dba61", "rc": 1, "start": "2016-01-06 15:37:06.781579", "warnings": []}
stderr: error: Failed to delete vol lenaic-master-dba61.qcow2
error: cannot unlink file '/home/lenaic/libvirt-storage-pool-openshift-ansible/lenaic-master-dba61.qcow2': Permission non accordée
failed: [localhost] => (item=lenaic-node-compute-02cc3) => {"changed": true, "cmd": ["virsh", "-c", "qemu:///system", "vol-delete", "--pool", "openshift-ansible", "lenaic-node-compute-02cc3.qcow2"], "delta": "0:00:00.014805", "end": "2016-01-06 15:37:06.876784", "item": "lenaic-node-compute-02cc3", "rc": 1, "start": "2016-01-06 15:37:06.861979", "warnings": []}
stderr: error: Failed to delete vol lenaic-node-compute-02cc3.qcow2
error: cannot unlink file '/home/lenaic/libvirt-storage-pool-openshift-ansible/lenaic-node-compute-02cc3.qcow2': Permission non accordée
```

This comes from the fact that the `virsh […] vol-delete […]` command attempts to delete the VM drive as `nobody:kvm` and it hasn’t the privileges to do that.

We used to set the *default* ACL `d:g:kvm:rwx` to `~/libvirt-storage-pool-openshift-ansible` so that the files created there by ansible are writable by the qemu processes running as `nobody:kvm`.
But in order to delete the VM drive files standing in this directory, write permissions on the files is not enough, `nobody:kvm` needs write permission on the directory itself.