### PR TITLE
Make bin/cluster able to spawn an OSE 3.1 cluster

### DIFF
--- a/bin/cluster
+++ b/bin/cluster
@@ -294,11 +294,8 @@ if __name__ == '__main__':
         meta_parser.add_argument('cluster_id', help='prefix for cluster VM names')
 
     meta_parser.add_argument('-t', '--deployment-type',
-                             choices=['origin', 'online', 'enterprise'],
+                             choices=['origin', 'online', 'enterprise', 'atomic-enterprise', 'openshift-enterprise'],
                              help='Deployment type. (default: origin)')
-    meta_parser.add_argument('-T', '--product-type',
-                             choices=['openshift', 'atomic-enterprise'],
-                             help='Product type. (default: openshift)')
     meta_parser.add_argument('-o', '--option', action='append',
                              help='options')
 

--- a/playbooks/aws/openshift-cluster/vars.yml
+++ b/playbooks/aws/openshift-cluster/vars.yml
@@ -1,5 +1,19 @@
 ---
 debug_level: 2
+
+deployment_rhel7_ent_base:
+  # rhel-7.1, requires cloud access subscription
+  image: ami-10663b78
+  image_name:
+  region: us-east-1
+  ssh_user: ec2-user
+  sudo: yes
+  keypair: libra
+  type: m4.large
+  security_groups: [ 'public' ]
+  vpc_subnet:
+  assign_public_ip:
+
 deployment_vars:
   origin:
     # centos-7, requires marketplace
@@ -25,15 +39,6 @@ deployment_vars:
     security_groups: [ 'public' ]
     vpc_subnet:
     assign_public_ip:
-  enterprise:
-    # rhel-7.1, requires cloud access subscription
-    image: ami-10663b78
-    image_name:
-    region: us-east-1
-    ssh_user: ec2-user
-    sudo: yes
-    keypair: libra
-    type: m4.large
-    security_groups: [ 'public' ]
-    vpc_subnet:
-    assign_public_ip:
+  enterprise: "{{ deployment_rhel7_ent_base }}"
+  openshift-enterprise: "{{ deployment_rhel7_ent_base }}"
+  atomic-enterprise: "{{ deployment_rhel7_ent_base }}"

--- a/playbooks/common/openshift-cluster/update_repos_and_packages.yml
+++ b/playbooks/common/openshift-cluster/update_repos_and_packages.yml
@@ -4,7 +4,7 @@
     openshift_deployment_type: "{{ deployment_type }}"
   roles:
   - role: rhel_subscribe
-    when: deployment_type == "enterprise" and
+    when: deployment_type in ["enterprise", "atomic-enterprise", "openshift-enterprise"] and
           ansible_distribution == "RedHat" and
           lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
             default('no', True) | lower in ['no', 'false']

--- a/playbooks/gce/openshift-cluster/vars.yml
+++ b/playbooks/gce/openshift-cluster/vars.yml
@@ -3,6 +3,13 @@ do_we_use_openshift_sdn: true
 sdn_network_plugin: redhat/openshift-ovs-subnet
 debug_level: 2
 # os_sdn_network_plugin_name can be ovssubnet or multitenant, see https://docs.openshift.org/latest/architecture/additional_concepts/sdn.html#ovssubnet-plugin-operation
+
+deployment_rhel7_ent_base:
+  image: rhel-7
+  machine_type: n1-standard-1
+  ssh_user:
+  sudo: yes
+
 deployment_vars:
   origin:
     image: preinstalled-slave-50g-v5
@@ -14,8 +21,6 @@ deployment_vars:
     machine_type: n1-standard-1
     ssh_user: root
     sudo: no
-  enterprise:
-    image: rhel-7
-    machine_type: n1-standard-1
-    ssh_user:
-    sudo: yes
+  enterprise: "{{ deployment_rhel7_ent_base }}"
+  openshift-enterprise: "{{ deployment_rhel7_ent_base }}"
+  atomic-enterprise: "{{ deployment_rhel7_ent_base }}"

--- a/playbooks/libvirt/openshift-cluster/vars.yml
+++ b/playbooks/libvirt/openshift-cluster/vars.yml
@@ -5,6 +5,19 @@ libvirt_network: openshift-ansible
 libvirt_uri: 'qemu:///system'
 debug_level: 2
 
+# Automatic download of the qcow2 image for RHEL cannot be done directly from the RedHat portal because it requires authentication.
+# The default value of image_url for enterprise and openshift-enterprise deployment types below won't work.
+deployment_rhel7_ent_base:
+  image:
+    url:    "{{ lookup('oo_option', 'image_url') |
+                default('https://access.cdn.redhat.com//content/origin/files/sha256/25/25f880767ec6bf71beb532e17f1c45231640bbfdfbbb1dffb79d2c1b328388e0/rhel-guest-image-7.2-20151102.0.x86_64.qcow2', True) }}"
+    name:   "{{ lookup('oo_option', 'image_name') |
+                default('rhel-guest-image-7.2-20151102.0.x86_64.qcow2', True) }}"
+    sha256: "{{ lookup('oo_option', 'image_sha256') |
+                default('25f880767ec6bf71beb532e17f1c45231640bbfdfbbb1dffb79d2c1b328388e0', True) }}"
+  ssh_user: openshift
+  sudo: yes
+
 deployment_vars:
   origin:
     image:
@@ -25,18 +38,6 @@ deployment_vars:
       sha256:
     ssh_user: root
     sudo: no
-  enterprise:
-    image:
-      url:    "{{ lookup('oo_option', 'image_url') |
-                  default('https://access.cdn.redhat.com//content/origin/files/sha256/ff/ff8198653cfd9c39411fc57077451ac291b3a605d305e905932fd6d5b1890bf3/rhel-guest-image-7.1-20150224.0.x86_64.qcow2', True) }}"
-      name:   "{{ lookup('oo_option', 'image_name') |
-                  default('rhel-guest-image-7.1-20150224.0.x86_64.qcow2', True) }}"
-      sha256: "{{ lookup('oo_option', 'image_sha256') |
-                  default('ff8198653cfd9c39411fc57077451ac291b3a605d305e905932fd6d5b1890bf3', True) }}"
-    ssh_user: openshift
-    sudo: yes
-#  origin:
-#    fedora:
-#      url: "http://download.fedoraproject.org/pub/fedora/linux/releases/21/Cloud/Images/x86_64/Fedora-Cloud-Base-20141203-21.x86_64.qcow2"
-#      name: Fedora-Cloud-Base-20141203-21.x86_64.qcow2
-#      sha256: 3a99bb89f33e3d4ee826c8160053cdb8a72c80cd23350b776ce73cd244467d86
+  enterprise: "{{ deployment_rhel7_ent_base }}"
+  openshift-enterprise: "{{ deployment_rhel7_ent_base }}"
+  atomic-enterprise: "{{ deployment_rhel7_ent_base }}"

--- a/playbooks/openstack/openshift-cluster/vars.yml
+++ b/playbooks/openstack/openshift-cluster/vars.yml
@@ -20,6 +20,11 @@ openstack_flavor:
   infra:  "{{ lookup('oo_option', 'infra_flavor'     ) | default('m1.small',  True) }}"
   node:   "{{ lookup('oo_option', 'node_flavor'      ) | default('m1.medium', True) }}"
 
+deployment_rhel7_ent_base:
+  image: "{{ lookup('oo_option', 'image_name') | default('rhel-guest-image-7.2-20151102.0.x86_64', True) }}"
+  ssh_user: openshift
+  sudo: yes
+
 deployment_vars:
   origin:
     image: "{{ lookup('oo_option', 'image_name') | default('centos-70-raw', True) }}"
@@ -29,7 +34,6 @@ deployment_vars:
     image:
     ssh_user: root
     sudo: no
-  enterprise:
-    image: "{{ lookup('oo_option', 'image_name') | default('rhel-guest-image-7.1-20150224.0.x86_64', True) }}"
-    ssh_user: openshift
-    sudo: yes
+  enterprise: "{{ deployment_rhel7_ent_base }}"
+  openshift-enterprise: "{{ deployment_rhel7_ent_base }}"
+  atomic-enterprise: "{{ deployment_rhel7_ent_base }}"

--- a/roles/rhel_subscribe/tasks/enterprise.yml
+++ b/roles/rhel_subscribe/tasks/enterprise.yml
@@ -2,8 +2,24 @@
 - name: Disable all repositories
   command: subscription-manager repos --disable="*"
 
+- set_fact:
+    default_ose_version: '3.0'
+  when: deployment_type == 'enterprise'
+
+- set_fact:
+    default_ose_version: '3.1'
+  when: deployment_type in ['atomic-enterprise', 'openshift-enterprise']
+
+- set_fact:
+    ose_version: "{{ lookup('oo_option', 'ose_version') | default(default_ose_version, True) }}"
+
+- fail:
+    msg: "{{ ose_version }} is not a valid version for {{ deployment_type }} deployment type"
+  when: ( deployment_type == 'enterprise' and ose_version not in ['3.0'] ) or
+        ( deployment_type in ['atomic-enterprise', 'openshift-enterprise'] and ose_version not in ['3.1'] )
+
 - name: Enable RHEL repositories
   command: subscription-manager repos \
                --enable="rhel-7-server-rpms" \
                --enable="rhel-7-server-extras-rpms" \
-               --enable="rhel-7-server-ose-3.0-rpms"
+               --enable="rhel-7-server-ose-{{ ose_version }}-rpms"

--- a/roles/rhel_subscribe/tasks/main.yml
+++ b/roles/rhel_subscribe/tasks/main.yml
@@ -33,4 +33,4 @@
     autosubscribe: yes
 
 - include: enterprise.yml
-  when: deployment_type == 'enterprise'
+  when: deployment_type in [ 'enterprise', 'atomic-enterprise', 'openshift-enterprise' ]


### PR DESCRIPTION
This patch contains the changes required to ask `bin/cluster` to create an OSE cluster with the `openshift-enterprise` deployment type.