### PR TITLE
Fix terminate.yml on OpenStack

### DIFF
--- a/playbooks/openstack/openshift-cluster/terminate.yml
+++ b/playbooks/openstack/openshift-cluster/terminate.yml
@@ -11,7 +11,7 @@
       groups: oo_hosts_to_terminate
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
-    with_items: (groups['tag_environment_' ~ cluster_env]|default([])) | groups['tag_clusterid_' ~ cluster_id ] | default([])
+    with_items: (groups['tag_environment_' ~ cluster_env]|default([])) | intersect(groups['tag_clusterid_' ~ cluster_id ]|default([]))
 
 - name: Unsubscribe VMs
   hosts: oo_hosts_to_terminate


### PR DESCRIPTION
Trying to invoke `bin/cluster terminate […] openstack […]` causes the following error:
```
PLAY [Terminate instance(s)] ************************************************** 

TASK: [add_host ] ************************************************************* 
fatal: [localhost] => with_items expects a list or a set

FATAL: all hosts have already failed -- aborting
```

It looks like the `with_items` clause is bogus. If my understanding is correct, we’re looking for the hosts that mach both the `environment` and the `clusterid`.