### PR TITLE
Rename env into clusterid and add environment in the OpenStack VMs tags

### DIFF
--- a/playbooks/openstack/openshift-cluster/files/heat_stack.yaml
+++ b/playbooks/openstack/openshift-cluster/files/heat_stack.yaml
@@ -4,6 +4,11 @@ description: OpenShift cluster
 
 parameters:
 
+  cluster_env:
+    type: string
+    label: Cluster environment
+    description: Environment of the cluster
+
   cluster_id:
     type: string
     label: Cluster ID
@@ -345,13 +350,14 @@ resources:
               params:
                 cluster_id: { get_param: cluster_id }
                 k8s_type: etcd
-          cluster_id: { get_param: cluster_id }
-          type:       etcd
-          image:      { get_param: etcd_image }
-          flavor:     { get_param: etcd_flavor }
-          key_name:   { get_resource: keypair }
-          net:        { get_resource: net }
-          subnet:     { get_resource: subnet }
+          cluster_env: { get_param: cluster_env }
+          cluster_id:  { get_param: cluster_id }
+          type:        etcd
+          image:       { get_param: etcd_image }
+          flavor:      { get_param: etcd_flavor }
+          key_name:    { get_resource: keypair }
+          net:         { get_resource: net }
+          subnet:      { get_resource: subnet }
           secgrp:
             - { get_resource: etcd-secgrp }
           floating_network: { get_param: floating_ip_pool }
@@ -375,13 +381,14 @@ resources:
               params:
                 cluster_id: { get_param: cluster_id }
                 k8s_type: master
-          cluster_id: { get_param: cluster_id }
-          type:       master
-          image:      { get_param: master_image }
-          flavor:     { get_param: master_flavor }
-          key_name:   { get_resource: keypair }
-          net:        { get_resource: net }
-          subnet:     { get_resource: subnet }
+          cluster_env: { get_param: cluster_env }
+          cluster_id:  { get_param: cluster_id }
+          type:        master
+          image:       { get_param: master_image }
+          flavor:      { get_param: master_flavor }
+          key_name:    { get_resource: keypair }
+          net:         { get_resource: net }
+          subnet:      { get_resource: subnet }
           secgrp:
             - { get_resource: master-secgrp }
           floating_network: { get_param: floating_ip_pool }
@@ -406,14 +413,15 @@ resources:
                 cluster_id: { get_param: cluster_id }
                 k8s_type: node
                 sub_host_type: compute
-          cluster_id: { get_param: cluster_id }
-          type:       node
-          subtype:    compute
-          image:      { get_param: node_image }
-          flavor:     { get_param: node_flavor }
-          key_name:   { get_resource: keypair }
-          net:        { get_resource: net }
-          subnet:     { get_resource: subnet }
+          cluster_env: { get_param: cluster_env }
+          cluster_id:  { get_param: cluster_id }
+          type:        node
+          subtype:     compute
+          image:       { get_param: node_image }
+          flavor:      { get_param: node_flavor }
+          key_name:    { get_resource: keypair }
+          net:         { get_resource: net }
+          subnet:      { get_resource: subnet }
           secgrp:
             - { get_resource: node-secgrp }
           floating_network: { get_param: floating_ip_pool }
@@ -438,14 +446,15 @@ resources:
                 cluster_id: { get_param: cluster_id }
                 k8s_type: node
                 sub_host_type: infra
-          cluster_id: { get_param: cluster_id }
-          type:       node
-          subtype:    infra
-          image:      { get_param: infra_image }
-          flavor:     { get_param: infra_flavor }
-          key_name:   { get_resource: keypair }
-          net:        { get_resource: net }
-          subnet:     { get_resource: subnet }
+          cluster_env: { get_param: cluster_env }
+          cluster_id:  { get_param: cluster_id }
+          type:        node
+          subtype:     infra
+          image:       { get_param: infra_image }
+          flavor:      { get_param: infra_flavor }
+          key_name:    { get_resource: keypair }
+          net:         { get_resource: net }
+          subnet:      { get_resource: subnet }
           secgrp:
             - { get_resource: node-secgrp }
             - { get_resource: infra-secgrp }

--- a/playbooks/openstack/openshift-cluster/files/heat_stack_server.yaml
+++ b/playbooks/openstack/openshift-cluster/files/heat_stack_server.yaml
@@ -9,6 +9,11 @@ parameters:
     label: Name
     description: Name
 
+  cluster_env:
+    type: string
+    label: Cluster environment
+    description: Environment of the cluster
+
   cluster_id:
     type: string
     label: Cluster ID
@@ -105,7 +110,8 @@ resources:
       user_data: { get_file: user-data }
       user_data_format: RAW
       metadata:
-        env: { get_param: cluster_id }
+        environment: { get_param: cluster_env }
+        clusterid: { get_param: cluster_id }
         host-type: { get_param: type }
         sub-host-type:    { get_param: subtype }
 

--- a/playbooks/openstack/openshift-cluster/launch.yml
+++ b/playbooks/openstack/openshift-cluster/launch.yml
@@ -29,6 +29,7 @@
 
   - name: Create or Update OpenStack Stack
     command: 'heat {{ heat_stack_action }} -f {{ openstack_infra_heat_stack }}
+             -P cluster_env={{ cluster_env }}
              -P cluster_id={{ cluster_id }}
              -P cidr={{ openstack_network_cidr }}
              -P dns_nameservers={{ openstack_network_dns | join(",") }}


### PR DESCRIPTION
The meta-tags attached to VMs that are used to generate Ansible groups have changed:
* `env` has been renamed `clusterid`;
* `environment` has been introduced.

This patch applies those changes on the OpenStack VMs.