### PR TITLE
Increase OpenStack stack creation/deletion timeout

### DIFF
--- a/playbooks/openstack/openshift-cluster/launch.yml
+++ b/playbooks/openstack/openshift-cluster/launch.yml
@@ -29,6 +29,7 @@
 
   - name: Create or Update OpenStack Stack
     command: 'heat {{ heat_stack_action }} -f {{ openstack_infra_heat_stack }}
+             --timeout 3 --enable-rollback
              -P cluster_env={{ cluster_env }}
              -P cluster_id={{ cluster_id }}
              -P cidr={{ openstack_network_cidr }}
@@ -56,7 +57,7 @@
     register: stack_show_status_result
     until: stack_show_status_result.stdout not in ['CREATE_IN_PROGRESS', 'UPDATE_IN_PROGRESS']
     retries: 30
-    delay: 1
+    delay: 5
     failed_when: stack_show_status_result.stdout not in ['CREATE_COMPLETE', 'UPDATE_COMPLETE']
 
   - name: Read OpenStack Stack outputs

--- a/playbooks/openstack/openshift-cluster/terminate.yml
+++ b/playbooks/openstack/openshift-cluster/terminate.yml
@@ -43,6 +43,6 @@
     register: stack_show_result
     until: stack_show_result.stdout != 'DELETE_IN_PROGRESS'
     retries: 60
-    delay: 1
+    delay: 5
     failed_when: '"Stack not found" not in stack_show_result.stderr and
                    stack_show_result.stdout != "DELETE_COMPLETE"'


### PR DESCRIPTION
The OpenStack instance I have access to is a little bit too slow for the timeout values that are currently used.
In practice, each time it takes more than 30 seconds to create a HEAT stack or more than 60 seconds to delete it, `bin/cluster` exits in failure saying that the OpenStack stack is still in `CREATE_IN_PROGRESS`/`DELETE_IN_PROGRESS`.

Increasing the `sleep` value has 2 effects:
* effectively increasing the timeout value;
* reducing the polling frequency at which Ansible polls OpenStack so that it reduces the stress on the OpenStack controllers.