### PR TITLE
Add a banner to CLI wrapper instructing users that it's only for boot…

### DIFF
--- a/roles/openshift_cli/templates/openshift.j2
+++ b/roles/openshift_cli/templates/openshift.j2
@@ -6,4 +6,18 @@ cmd=`basename $0`
 user=`id -u`
 group=`id -g`
 
-docker run -i -a STDERR -a STDOUT -a STDIN --privileged --net=host --user=${user}:${group} -v ~/.kube:/root/.kube -v /tmp:/tmp -v {{ openshift.common.config_base}}:{{ openshift.common.config_base }} -e KUBECONFIG=/root/.kube/config --entrypoint ${cmd} --rm {{ openshift.common.cli_image }} "${@}"
+>&2 echo """
+================================================================================
+ATTENTION: You are running ${cmd} via a wrapper around 'docker run {{ openshift.common.cli_image }}'.
+This wrapper is intended only to be used to bootstrap an environment. Please
+install client tools on another host once you have granted cluster-admin
+privileges to a user. 
+{% if openshift.common.deployment_type in ['openshift-enterprise','atomic-enterprise'] %}
+See https://docs.openshift.com/enterprise/latest/cli_reference/get_started_cli.html
+{% else %}
+See https://docs.openshift.org/latest/cli_reference/get_started_cli.html
+{% endif %}
+=================================================================================
+"""
+
+docker run -i --privileged --net=host --user=${user}:${group} -v ~/.kube:/root/.kube -v /tmp:/tmp -v {{ openshift.common.config_base}}:{{ openshift.common.config_base }} -e KUBECONFIG=/root/.kube/config --entrypoint ${cmd} --rm {{ openshift.common.cli_image }} "${@}"


### PR DESCRIPTION
…strapping

Also remove -a STDIN,STDOUT,STDERR that's the default
The banner is sent to STDERR so it doesn't pollute STDIN when used to dump json/yaml then import it later.