### PR TITLE
Add a wait before node registration to ensure the master is available

### DIFF
--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -215,13 +215,15 @@
                          | oo_collect('openshift.common.hostname') }}"
     openshift_node_vars: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']) }}"
   pre_tasks:
+  # Necessary because when you're on a node that's also a master the master will be
+  # restarted after the node restarts docker and it will take up to 60 seconds for
+  # systemd to start the master again
   - name: Wait for master to become available before proceeding
     wait_for:
       host: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
       port: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_port }}"
       state: started
       timeout: 180
-      delay: 10
     when: openshift.common.is_containerized | bool
   roles:
   - openshift_manage_node

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -215,6 +215,13 @@
                          | oo_collect('openshift.common.hostname') }}"
     openshift_node_vars: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']) }}"
   pre_tasks:
-
+  - name: Wait for master to become available before proceeding
+    wait_for:
+      host: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
+      port: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_port }}"
+      state: started
+      timeout: 180
+      delay: 10
+    when: openshift.common.is_containerized | bool
   roles:
   - openshift_manage_node

--- a/roles/openshift_master/handlers/main.yml
+++ b/roles/openshift_master/handlers/main.yml
@@ -2,11 +2,20 @@
 - name: restart master
   service: name={{ openshift.common.service_type }}-master state=restarted
   when: (not openshift_master_ha | bool) and (not (master_service_status_changed | default(false) | bool))
+  notify: Verify API Server
 
 - name: restart master api
   service: name={{ openshift.common.service_type }}-master-api state=restarted
   when: (openshift_master_ha | bool) and (not (master_api_service_status_changed | default(false) | bool)) and openshift.master.cluster_method == 'native'
+  notify: Verify API Server
 
 - name: restart master controllers
   service: name={{ openshift.common.service_type }}-master-controllers state=restarted
   when: (openshift_master_ha | bool) and (not (master_controllers_service_status_changed | default(false) | bool)) and openshift.master.cluster_method == 'native'
+
+- name: Verify API Server
+  wait_for:
+    host: "{{ openshift.common.ip }}"
+    port: "{{ openshift.master.api_port }}"
+    state: started
+    timeout: 180

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -269,6 +269,7 @@
   service: name={{ openshift.common.service_type }}-master enabled=yes state=started
   when: not openshift_master_ha | bool
   register: start_result
+  notify: Verify API Server
 
 - name: Stop and disable non HA master when running HA
   service: name={{ openshift.common.service_type }}-master enabled=no state=stopped
@@ -282,6 +283,7 @@
   service: name={{ openshift.common.service_type }}-master-api enabled=yes state=started
   when: openshift_master_ha | bool and openshift.master.cluster_method == 'native'
   register: start_result
+  notify: Verify API Server
 
 - set_fact:
     master_api_service_status_changed: "{{ start_result | changed }}"


### PR DESCRIPTION
This is necessary because on containerized installs restarting the node often triggers restarting the master and there's up to 60 seconds of delay before systemd restarts the master.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1293826