### PR TITLE
Add local machine name in /etc/hosts on OpenStack

### DIFF
--- a/playbooks/openstack/openshift-cluster/launch.yml
+++ b/playbooks/openstack/openshift-cluster/launch.yml
@@ -133,6 +133,14 @@
       - parsed_outputs.node_floating_ips
       - parsed_outputs.infra_floating_ips
 
+- name: Add self in /etc/hosts because OpenStack may lack DNS
+  hosts: "tag_clusterid_{{ cluster_id }}"
+  tasks:
+  - name: Update /etc/hosts
+    lineinfile:
+      line: "{{ ansible_default_ipv4.address }} {{ ansible_nodename }}"
+      dest: /etc/hosts
+
 - include: update.yml
 
 - include: list.yml


### PR DESCRIPTION
The OpenStack instance I am using doesn’t provide any DNS. As a consequence, my OpenStack VMs are using external DNS servers which are not fed by the DHCP servers that allocated the IPs to the VMs.

The result is that the VMs have names which are not solvable by DNS. Ex:
```
[root@lenaic-master-0 ~]# hostname
lenaic-master-0.novalocal
[root@lenaic-master-0 ~]# dig +short lenaic-master-0.novalocal
[root@lenaic-master-0 ~]#
```

This could be fixed by migrating to an OpenStack version which implements DNS or by having `openshift-ansible` deploy a DNS server and its own DHCP server replacing the one provided by OpenStack but I would rather stick with a simpler solution.

What is done so far is that we use IPs rather than DNS names.

Still, with OpenShift 3.1, I have the following error:
```
Jan 08 06:01:01 lenaic-master-0.novalocal atomic-openshift-master[78306]: E0108 06:01:01.371587   78306 common.go:722] Failed to lookup IP address for node lenaic-master-0.novalocal: lookup lenaic-master-0.novalocal: no such host
Jan 08 06:01:01 lenaic-master-0.novalocal atomic-openshift-master[78306]: F0108 06:01:01.371623   78306 flatsdn.go:27] SDN initialization failed: lookup lenaic-master-0.novalocal: no such host
Jan 08 06:01:01 lenaic-master-0.novalocal systemd[1]: atomic-openshift-master.service: main process exited, code=exited, status=255/n/a
Jan 08 06:01:01 lenaic-master-0.novalocal systemd[1]: Unit atomic-openshift-master.service entered failed state.
Jan 08 06:01:01 lenaic-master-0.novalocal systemd[1]: atomic-openshift-master.service failed.
Jan 08 06:01:01 lenaic-master-0.novalocal systemd[1]: atomic-openshift-master.service holdoff time over, scheduling restart.
```

The `Failed to lookup IP address for […]` error message is coming from [netutils.GetNodeIP](https://github.com/openshift/openshift-sdn/blob/master/pkg/netutils/common.go#L72) which is called from [osdn.BaseInit](https://github.com/openshift/openshift-sdn/blob/master/plugins/osdn/common.go#L65) which is feeding GetNodeIP with the output of `uname -n`.
So, the hostname openshift-sdn tries to resolve here is not coming from a configuration file where we could have put directly an IP instead.

To conclude, in order to have the OVS SDN plugin of OpenShift able to start, it must be possible to do:
```
getent hosts $(uname -n)
```
(This is the bash equivalent of what is done [there](https://github.com/openshift/openshift-sdn/blob/master/plugins/osdn/common.go#L56) and [there](https://github.com/openshift/openshift-sdn/blob/master/pkg/netutils/common.go#L72))

In the absence of DNS able to resolve the OpenStack VMs hostname, amending `/etc/hosts` is a way to make the above commands work.

