### PR TITLE
a quick fix for providing cloud-provider arguments

### DIFF
--- a/filter_plugins/padded_yaml.py
+++ b/filter_plugins/padded_yaml.py
@@ -1,0 +1,44 @@
+#
+# This filter allows you to expand vars into 
+#   multi line yaml snippets 
+#   the first line is positioned with in the template
+#   the following lines are padded to level * indent spaces
+#  
+# author Lutz Lange <llange@redhat.com>
+# 
+# example filter " ... | to_padded_yaml( level=2 )
+# ToDo : - test with more complex structures. 
+#        - test indentitation feature ( level=2, indent=4 )
+#
+
+import yaml
+from ansible.utils.unicode import to_unicode
+
+def to_padded_yaml(*a, **kw):
+  ''' pad all the yaml content with level spaces exempt the first line '''
+  # remove level from **kw if it exsists
+  level = 0
+  indent = 2
+  if kw.has_key('level'):
+    level = kw['level']
+    kw.pop('level')
+  if kw.has_key('indent'):
+    indent = kw.pop('indent')
+  transformed = yaml.safe_dump(*a, indent=indent, allow_unicode=True, default_flow_style=False, **kw)
+  # first line without padding to allow for correct indent of first line
+  padded = transformed.split('\n', 1)[0]
+  # pad all following lines
+  for line in filter(None, transformed.split('\n')[1:]):
+    padded += "\n" + " " * level * indent + line
+  return to_unicode(padded)
+
+class FilterModule(object):
+  ''' Additional yaml Filter to expand multi line yaml snippets '''
+
+  def filters(self):
+    return {
+      # extra nice yaml
+      'to_padded_yaml': to_padded_yaml,
+    }
+
+

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -87,8 +87,10 @@ kubernetesMasterConfig:
   - v1beta3
   - v1
 {% endif %}
-  apiServerArguments: {{ openshift.master.api_server_args | default(None) | to_json }}
-  controllerArguments: {{ openshift.master.controller_args | default(None) | to_json }}
+  apiServerArguments: 
+    {{ openshift.master.api_server_args | default(None) | to_yaml }}
+  controllerArguments: 
+    {{ openshift.master.controller_args | default(None) | to_yaml }}
   masterCount: {{ openshift.master.master_count if openshift.master.cluster_method | default(None) == 'native' else 1 }}
   masterIP: {{ openshift.common.ip }}
   podEvictionTimeout: ""

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -88,9 +88,9 @@ kubernetesMasterConfig:
   - v1
 {% endif %}
   apiServerArguments: 
-    {{ openshift.master.api_server_args | default(None) | to_yaml }}
+    {{ openshift.master.api_server_args | default(None) | to_padded_yaml( level=2, indent=2 ) }}
   controllerArguments: 
-    {{ openshift.master.controller_args | default(None) | to_yaml }}
+    {{ openshift.master.controller_args | default(None) | to_padded_yaml( level=2, indent=2 ) }}
   masterCount: {{ openshift.master.master_count if openshift.master.cluster_method | default(None) == 'native' else 1 }}
   masterIP: {{ openshift.common.ip }}
   podEvictionTimeout: ""

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -12,7 +12,7 @@ imageConfig:
   latest: false
 kind: NodeConfig
 kubeletArguments: 
-  {{ openshift.node.kubelet_args | default(None) | to_yaml }}
+  {{ openshift.node.kubelet_args | default(None) | to_padded_yaml(level=1, indent=2) }}
 masterKubeConfig: system:node:{{ openshift.common.hostname }}.kubeconfig
 {% if openshift.common.use_openshift_sdn %}
 networkPluginName: {{ openshift.common.sdn_network_plugin_name }}

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -11,9 +11,8 @@ imageConfig:
   format: {{ openshift.node.registry_url }}
   latest: false
 kind: NodeConfig
-{% if openshift.node.kubelet_args is defined and openshift.node.kubelet_args %}
-kubeletArguments: {{ openshift.node.kubelet_args | to_json }}
-{% endif %}
+kubeletArguments: 
+  {{ openshift.node.kubelet_args | default(None) | to_yaml }}
 masterKubeConfig: system:node:{{ openshift.common.hostname }}.kubeconfig
 {% if openshift.common.use_openshift_sdn %}
 networkPluginName: {{ openshift.common.sdn_network_plugin_name }}


### PR DESCRIPTION
It might not be beautiful, but it works. I'm open for suggestions on improving this.

I used these settings in my inventory. It would be nice to have an example config in the byo inventory directory as that is the playbook that was used to test this.

osm_controller_args={'cloud-provider': ['gce']}
osm_api_server_args={'cloud-provider': ['gce']}
openshift_node_kubelet_args={'cloud-provider': ['gce']}
