### PR TITLE
Fix for providing cloud-provider arguments with multiline yaml capability

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -12,6 +12,8 @@ import os
 import pdb
 import re
 import json
+import yaml
+from ansible.utils.unicode import to_unicode
 
 class FilterModule(object):
     ''' Custom ansible filters '''
@@ -474,6 +476,16 @@ class FilterModule(object):
         secret = os.urandom(num_bytes)
         return secret.encode('base-64').strip()
 
+    @staticmethod
+    def to_padded_yaml(data, level=0, indent=2, **kw):
+        ''' returns a yaml snippet padded to match the indent level you specify '''
+        try:
+            transformed = yaml.safe_dump(data, indent=indent, allow_unicode=True, default_flow_style=False, **kw)
+            padded = "\n".join([" " * level * indent + line for line in transformed.splitlines()])
+            return to_unicode("\n{0}".format(padded))
+        except Exception as my_e:
+            raise errors.AnsibleFilterError('Failed to convert: %s', my_e)
+
     def filters(self):
         ''' returns a mapping of filters to methods '''
         return {
@@ -493,5 +505,6 @@ class FilterModule(object):
             "oo_parse_named_certificates": self.oo_parse_named_certificates,
             "oo_haproxy_backend_masters": self.oo_haproxy_backend_masters,
             "oo_pretty_print_cluster": self.oo_pretty_print_cluster,
-            "oo_generate_secret": self.oo_generate_secret
+            "oo_generate_secret": self.oo_generate_secret,
+            "to_padded_yaml": self.to_padded_yaml,
         }

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -87,8 +87,8 @@ kubernetesMasterConfig:
   - v1beta3
   - v1
 {% endif %}
-  apiServerArguments: {{ openshift.master.api_server_args | default(None) | to_json }}
-  controllerArguments: {{ openshift.master.controller_args | default(None) | to_json }}
+  apiServerArguments: {{ openshift.master.api_server_args | default(None) | to_padded_yaml( level=2 ) }}
+  controllerArguments: {{ openshift.master.controller_args | default(None) | to_padded_yaml( level=2 ) }}
   masterCount: {{ openshift.master.master_count if openshift.master.cluster_method | default(None) == 'native' else 1 }}
   masterIP: {{ openshift.common.ip }}
   podEvictionTimeout: ""

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -11,9 +11,7 @@ imageConfig:
   format: {{ openshift.node.registry_url }}
   latest: false
 kind: NodeConfig
-{% if openshift.node.kubelet_args is defined and openshift.node.kubelet_args %}
-kubeletArguments: {{ openshift.node.kubelet_args | to_json }}
-{% endif %}
+kubeletArguments: {{ openshift.node.kubelet_args | default(None) | to_padded_yaml(level=1) }}
 masterKubeConfig: system:node:{{ openshift.common.hostname }}.kubeconfig
 {% if openshift.common.use_openshift_sdn %}
 networkPluginName: {{ openshift.common.sdn_network_plugin_name }}


### PR DESCRIPTION
We do need a custom filter to support multi line yaml expansion. There is an initial indentation level that we need to pass to the filter. This code works with my content and produces an additional line that is aligned as it should be. 

I would need more complex examples to test further. 
The passing of indent to the yaml.safe_dump might do nothing, bit this would need to be tested.