### PR TITLE
atomic-openshift-installer: Error handling for unicode hostnames

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -33,9 +33,7 @@ def is_valid_hostname(hostname):
 def validate_prompt_hostname(hostname):
     if '' == hostname or is_valid_hostname(hostname):
         return hostname
-    raise click.BadParameter('"{}" appears to be an invalid hostname. ' \
-                             'Please double-check this value i' \
-                             'and re-enter it.'.format(hostname))
+    raise click.BadParameter('Invalid hostname. Please double-check this value and re-enter it.')
 
 def get_ansible_ssh_user():
     click.clear()


### PR DESCRIPTION
Fix error handling for invalid hostnames. Previously we were trying to print
the offending hostname out, which caused errors due to python's handling
of unicode strings. Seeing as how the user's input stays on the screen
directly above the error there is no need to try and print it and we can
avoid this problem entirely.

For https://bugzilla.redhat.com/show_bug.cgi?id=1284086