### PR TITLE
Check API prior to starting node

### DIFF
--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -229,9 +229,5 @@
     delay: 1
     changed_when: false
     when: openshift.common.is_containerized | bool
-  - fail:
-      msg: >
-        Unable to contact master API at {{ openshift.master.api_url }}
-    when: openshift.common.is_containerized | bool and api_available_output.stdout.find("200 OK") == -1
   roles:
   - openshift_manage_node

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -103,6 +103,21 @@
 - name: Additional storage plugin configuration
   include: storage_plugins/main.yml
 
+# Necessary because when you're on a node that's also a master the master will be
+# restarted after the node restarts docker and it will take up to 60 seconds for
+# systemd to start the master again
+- name: Wait for master API to become available before proceeding
+  # Using curl here since the uri module requires python-httplib2 and
+  # wait_for port doesn't provide health information.
+  command: >
+    curl -k --head --silent {{ openshift_node_master_api_url }}
+  register: api_available_output
+  until: api_available_output.stdout.find("200 OK") != -1
+  retries: 120
+  delay: 1
+  changed_when: false
+  when: openshift.common.is_containerized | bool
+
 - name: Start and enable node
   service: name={{ openshift.common.service_type }}-node enabled=yes state=started
   register: start_result


### PR DESCRIPTION
This PR adds an API check prior to starting the node so that we can ensure the node will start properly.

I was able to reproduce [BZ#1293826](https://bugzilla.redhat.com/show_bug.cgi?id=1293826) prior to this change with a 1 master, 2 node containerized install and I'm getting happy nodes consistently with the additional API check.

Also removing a fail that will never occur since the previous task would have failed before we reach it.

@brenton @detiber PTAL