### PR TITLE
Add support for Openstack based persistent volumes

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -693,21 +693,22 @@ class FilterModule(object):
         if 'hosted' in hostvars['openshift']:
             for component in hostvars['openshift']['hosted']:
                 if 'storage' in hostvars['openshift']['hosted'][component]:
-                    kind = hostvars['openshift']['hosted'][component]['storage']['kind']
-                    create_pv = hostvars['openshift']['hosted'][component]['storage']['create_pv']
+                    params = hostvars['openshift']['hosted'][component]['storage']
+                    kind = params['kind']
+                    create_pv = params['create_pv']
                     if kind != None and create_pv:
                         if kind == 'nfs':
-                            host = hostvars['openshift']['hosted'][component]['storage']['host']
+                            host = params['host']
                             if host == None:
                                 if len(groups['oo_nfs_to_config']) > 0:
                                     host = groups['oo_nfs_to_config'][0]
                                 else:
                                     raise errors.AnsibleFilterError("|failed no storage host detected")
-                            directory = hostvars['openshift']['hosted'][component]['storage']['nfs']['directory']
-                            volume = hostvars['openshift']['hosted'][component]['storage']['volume']['name']
+                            directory = params['nfs']['directory']
+                            volume = params['volume']['name']
                             path = directory + '/' + volume
-                            size = hostvars['openshift']['hosted'][component]['storage']['volume']['size']
-                            access_modes = hostvars['openshift']['hosted'][component]['storage']['access_modes']
+                            size = params['volume']['size']
+                            access_modes = params['access_modes']
                             persistent_volume = dict(
                                 name="{0}-volume".format(volume),
                                 capacity=size,
@@ -716,6 +717,21 @@ class FilterModule(object):
                                     nfs=dict(
                                         server=host,
                                         path=path)))
+                            persistent_volumes.append(persistent_volume)
+                        elif kind == 'openstack':
+                            volume = params['volume']['name']
+                            size = params['volume']['size']
+                            access_modes = params['access_modes']
+                            filesystem = params['openstack']['filesystem']
+                            volume_id = params['openstack']['volumeID']
+                            persistent_volume = dict(
+                                name="{0}-volume".format(volume),
+                                capacity=size,
+                                access_modes=access_modes,
+                                storage=dict(
+                                    cinder=dict(
+                                        fsType=filesystem,
+                                        volumeID=volume_id)))
                             persistent_volumes.append(persistent_volume)
                         else:
                             msg = "|failed invalid storage kind '{0}' for component '{1}'".format(

--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -294,8 +294,21 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 ##
 ## Storage Kind
 ## Specifies which storage kind will be used for the registry.
-## "nfs" is the only supported kind at this time.
+## "nfs" and "openstack" are supported kinds at this time.
 ##openshift_hosted_registry_storage_kind=nfs
+##
+## Persistent Volume Access Mode
+## When using the 'openstack' storage kind, this has to be 'ReadWriteOnce'
+##openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
+##
+## Registry Volume Name
+## Specify the storage volume name. This directory will be created
+## within openshift_hosted_registry_storage_nfs_directory if
+## specifying an [nfs] group. Ex. /exports/registry
+## This variable must be supplied if using a pre-existing nfs server.
+##openshift_hosted_registry_storage_volume_name=registry
+##
+## NFS Specific Options
 ##
 ## Storage Host
 ## This variable can be used to identify a pre-existing storage host
@@ -312,15 +325,19 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 ## This variable must be supplied if using a pre-existing nfs server.
 ##openshift_hosted_registry_storage_nfs_directory=/exports
 ##
-## Registry Volume Name
-## Specify the storage volume name. This directory will be created
-## within openshift_hosted_registry_storage_nfs_directory if
-## specifying an [nfs] group. Ex. /exports/registry
-## This variable must be supplied if using a pre-existing nfs server.
-##openshift_hosted_registry_storage_volume_name=registry
+## Openstack Specific Options
 ##
-## Persistent Volume Access Mode
-##openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
+## Openstack Volume ID
+## Specify the identifier of the volume to use for the registry.
+## At this time, the volume has to be created manually by the administrator.
+##openshift_hosted_registry_storage_openstack_volumeID=3a650b4f-c8c5-4e0a-8ca5-eaee11f16c57
+##
+## Openstack Volume Size
+##openshift_hosted_registry_storage_volume_size=10Gi
+##
+## Openstack Volume Filesystem
+## Specify the filesystem that will be used when formatting the volume
+##openshift_hosted_registry_storage_openstack_filesystem=ext4
 
 # Configure node kubelet arguments
 #openshift_node_kubelet_args={'max-pods': ['40'], 'image-gc-high-threshold': ['90'], 'image-gc-low-threshold': ['80']}

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -299,8 +299,21 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 ##
 ## Storage Kind
 ## Specifies which storage kind will be used for the registry.
-## nfs is the only supported kind at this time.
+## "nfs" and "openstack" are supported kinds at this time.
 ##openshift_hosted_registry_storage_kind=nfs
+##
+## Persistent Volume Access Mode
+## When using the 'openstack' storage kind, this has to be 'ReadWriteOnce'
+##openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
+##
+## Registry Volume Name
+## Specify the storage volume name. This directory will be created
+## within openshift_hosted_registry_storage_nfs_directory if
+## specifying an [nfs] group. Ex. /exports/registry
+## This variable must be supplied if using a pre-existing nfs server.
+##openshift_hosted_registry_storage_volume_name=registry
+##
+## NFS Specific Options
 ##
 ## Storage Host
 ## This variable can be used to identify a pre-existing storage host
@@ -317,15 +330,19 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 ## This variable must be supplied if using a pre-existing nfs server.
 ##openshift_hosted_registry_storage_nfs_directory=/exports
 ##
-## Registry Volume Name
-## Specify the storage volume name. This directory will be created
-## within openshift_hosted_registry_storage_nfs_directory if
-## specifying an [nfs] group. Ex: /exports/registry
-## This variable must be supplied if using a pre-existing nfs server.
-##openshift_hosted_registry_storage_volume_name=registry
+## Openstack Specific Options
 ##
-## Persistent Volume Access Mode
-##openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
+## Openstack Volume ID
+## Specify the identifier of the volume to use for the registry.
+## At this time, the volume has to be created manually by the administrator.
+##openshift_hosted_registry_storage_openstack_volumeID=3a650b4f-c8c5-4e0a-8ca5-eaee11f16c57
+##
+## Openstack Volume Size
+##openshift_hosted_registry_storage_volume_size=10Gi
+##
+## Openstack Volume Filesystem
+## Specify the filesystem that will be used when formatting the volume
+##openshift_hosted_registry_storage_openstack_filesystem=ext4
 
 # Configure node kubelet arguments
 #openshift_node_kubelet_args={'max-pods': ['40'], 'image-gc-high-threshold': ['90'], 'image-gc-low-threshold': ['80']}

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -295,8 +295,21 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 ##
 ## Storage Kind
 ## Specifies which storage kind will be used for the registry.
-## "nfs" is the only supported kind at this time.
+## "nfs" and "openstack" are supported kinds at this time.
 ##openshift_hosted_registry_storage_kind=nfs
+##
+## Persistent Volume Access Mode
+## When using the 'openstack' storage kind, this has to be 'ReadWriteOnce'
+##openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
+##
+## Registry Volume Name
+## Specify the storage volume name. This directory will be created
+## within openshift_hosted_registry_storage_nfs_directory if
+## specifying an [nfs] group. Ex. /exports/registry
+## This variable must be supplied if using a pre-existing nfs server.
+##openshift_hosted_registry_storage_volume_name=registry
+##
+## NFS Specific Options
 ##
 ## Storage Host
 ## This variable can be used to identify a pre-existing storage host
@@ -313,15 +326,19 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 ## This variable must be supplied if using a pre-existing nfs server.
 ##openshift_hosted_registry_storage_nfs_directory=/exports
 ##
-## Registry Volume Name
-## Specify the storage volume name. This directory will be created
-## within openshift_hosted_registry_storage_nfs_directory if
-## specifying an [nfs] group Ex: /exports/registry
-## This variable must be supplied if using a pre-existing nfs server.
-##openshift_hosted_registry_storage_volume_name=registry
+## Openstack Specific Options
 ##
-## Persistent Volume Access Mode
-##openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
+## Openstack Volume ID
+## Specify the identifier of the volume to use for the registry.
+## At this time, the volume has to be created manually by the administrator.
+##openshift_hosted_registry_storage_openstack_volumeID=3a650b4f-c8c5-4e0a-8ca5-eaee11f16c57
+##
+## Openstack Volume Size
+##openshift_hosted_registry_storage_volume_size=10Gi
+##
+## Openstack Volume Filesystem
+## Specify the filesystem that will be used when formatting the volume
+##openshift_hosted_registry_storage_openstack_filesystem=ext4
 
 # Configure node kubelet arguments
 #openshift_node_kubelet_args={'max-pods': ['40'], 'image-gc-high-threshold': ['90'], 'image-gc-low-threshold': ['80']}

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1653,6 +1653,9 @@ class OpenShiftFacts(object):
                         nfs=dict(
                             directory='/exports',
                             options='*(rw,root_squash)'),
+                        openstack=dict(
+                            filesystem='ext4',
+                            volumeID='123'),
                         host=None,
                         access_modes=['ReadWriteMany'],
                         create_pv=True


### PR DESCRIPTION
This PR adds an `openshift_storage_cinder` role similar to the `openshift_storage_nfs_lvm`. It creates Openstack Cinder volumes, formats them and creates associated PersistentVolume and PersistentVolumeClaim.