### PR TITLE
Configure node-masters before nodes in containerized install

### DIFF
--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -154,21 +154,15 @@
       validate_checksum: yes
     with_items: nodes_needing_certs
 
-- name: Configure node instances
+- name: Deploy node certificates
   hosts: oo_nodes_to_config
   vars:
     sync_tmpdir: "{{ hostvars.localhost.mktemp.stdout }}"
-    openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
-    # TODO: Prefix flannel role variables.
-    etcd_urls: "{{ hostvars[groups.oo_first_master.0].openshift.master.etcd_urls }}"
-    embedded_etcd: "{{ hostvars[groups.oo_first_master.0].openshift.master.embedded_etcd }}"
-    openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
-  pre_tasks:
+  tasks:
   - name: Ensure certificate directory exists
     file:
       path: "{{ node_cert_dir }}"
       state: directory
-
   # TODO: notify restart node
   # possibly test service started time against certificate/config file
   # timestamps in node to trigger notify
@@ -177,8 +171,44 @@
       src: "{{ sync_tmpdir }}/{{ node_subdir }}.tgz"
       dest: "{{ node_cert_dir }}"
     when: certs_missing
+
+- name: Evaluate node groups
+  hosts: localhost
+  become: no
+  tasks:
+  - name: Evaluate oo_containerized_master_nodes
+    add_host:
+      name: "{{ item }}"
+      groups: oo_containerized_master_nodes
+      ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
+      ansible_sudo: "{{ g_sudo | default(omit) }}"
+    with_items: "{{ groups.oo_nodes_to_config | default([]) }}"
+    when: hostvars[item].openshift.common.is_containerized | bool and (item in groups.oo_nodes_to_config and item in groups.oo_masters_to_config)
+
+- name: Configure node instances
+  hosts: oo_containerized_master_nodes
+  serial: 1
+  vars:
+    openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
+    openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
   roles:
   - openshift_node
+
+- name: Configure node instances
+  hosts: oo_nodes_to_config:!oo_containerized_master_nodes
+  vars:
+    openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
+    openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
+  roles:
+  - openshift_node
+
+- name: Additional node config
+  hosts: oo_nodes_to_config
+  vars:
+    # TODO: Prefix flannel role variables.
+    etcd_urls: "{{ hostvars[groups.oo_first_master.0].openshift.master.etcd_urls }}"
+    embedded_etcd: "{{ hostvars[groups.oo_first_master.0].openshift.master.embedded_etcd }}"
+  roles:
   - role: flannel
     when: openshift.common.use_flannel | bool
   - role: nickhammond.logrotate


### PR DESCRIPTION
Nodes which are also masters are configured serially before nodes are configured to avoid issues with docker restarting and taking down the API while nodes are starting.

https://bugzilla.redhat.com/show_bug.cgi?id=1293826

@detiber PTAL