### PR TITLE
Host group should be OSEv3 not OSv3

### DIFF
--- a/playbooks/adhoc/bootstrap-fedora.yml
+++ b/playbooks/adhoc/bootstrap-fedora.yml
@@ -1,4 +1,4 @@
-- hosts: OSv3
+- hosts: OSEv3
   gather_facts: false
   tasks:
     - name: install python and deps for ansible modules


### PR DESCRIPTION
Following on from #1107 the host group's name is [OSEv3](https://github.com/openshift/openshift-ansible/blob/master/inventory/byo/hosts.origin.example#L4) and not OSv3