### PR TITLE
atomic-openshift-installer: Remove containerized install for 3.0

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -127,14 +127,13 @@ http://docs.openshift.com/enterprise/latest/architecture/infrastructure_componen
                     masters_set = True
         host_props['node'] = True
 
-        #TODO: Reenable this option once container installs are out of tech preview
-        rpm_or_container = click.prompt('Will this host be RPM or Container based (rpm/container)?',
-                                        type=click.Choice(['rpm', 'container']),
-                                        default='rpm')
-        if rpm_or_container == 'container':
-            host_props['containerized'] = True
-        else:
-            host_props['containerized'] = False
+        host_props['containerized'] = False
+        if oo_cfg.settings['variant_version'] != '3.0':
+            rpm_or_container = click.prompt('Will this host be RPM or Container based (rpm/container)?',
+                                            type=click.Choice(['rpm', 'container']),
+                                            default='rpm')
+            if rpm_or_container == 'container':
+                host_props['containerized'] = True
 
         if existing_env:
             host_props['new_host'] = True


### PR DESCRIPTION
This removes the option to specify a containerized install when
installing 3.0 in interactive mode.

For: https://bugzilla.redhat.com/show_bug.cgi?id=1299321