### PR TITLE
Restart Playbook Fixes

### DIFF
--- a/playbooks/common/openshift-master/restart.yml
+++ b/playbooks/common/openshift-master/restart.yml
@@ -73,12 +73,12 @@
     command: >
       systemctl is-active {{ openshift.common.service_type }}-master
     register: active_check_output
-    when: openshift.master.cluster_method == 'pacemaker'
+    when: openshift.master.cluster_method | default(None) == 'pacemaker'
     failed_when: active_check_output.stdout not in ['active', 'inactive']
     changed_when: false
   - set_fact:
       is_active: "{{ active_check_output.stdout == 'active' }}"
-    when: openshift.master.cluster_method == 'pacemaker'
+    when: openshift.master.cluster_method | default(None) == 'pacemaker'
 
 - name: Evaluate master groups
   hosts: localhost

--- a/playbooks/common/openshift-master/restart.yml
+++ b/playbooks/common/openshift-master/restart.yml
@@ -74,7 +74,7 @@
       systemctl is-active {{ openshift.common.service_type }}-master
     register: active_check_output
     when: openshift.master.cluster_method | default(None) == 'pacemaker'
-    failed_when: active_check_output.stdout not in ['active', 'inactive']
+    failed_when: active_check_output.stdout not in ['active', 'inactive', 'unknown']
     changed_when: false
   - set_fact:
       is_active: "{{ active_check_output.stdout == 'active' }}"


### PR DESCRIPTION
* Fix cluster_method check in master restart playbook.
* Add 'unknown' to possible output with pacemaker is-active check.

@brenton first commit is for the issue with single master env :full_moon_with_face: 