### PR TITLE
Add a DNS server on OpenStack clusters

### DIFF
--- a/playbooks/openstack/openshift-cluster/config.yml
+++ b/playbooks/openstack/openshift-cluster/config.yml
@@ -10,7 +10,6 @@
     openshift_cluster_id: "{{ cluster_id }}"
     openshift_debug_level: "{{ debug_level }}"
     openshift_deployment_type: "{{ deployment_type }}"
-    openshift_hostname: "{{ ansible_default_ipv4.address }}"
     openshift_registry_selector: 'type=infra'
     openshift_router_selector: 'type=infra'
     openshift_infra_nodes: "{{ g_infra_hosts }}"

--- a/playbooks/openstack/openshift-cluster/dns.yml
+++ b/playbooks/openstack/openshift-cluster/dns.yml
@@ -1,0 +1,47 @@
+- name: Populate oo_dns_hosts_to_update group
+  hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  vars_files:
+  - vars.yml
+  - cluster_hosts.yml
+  tasks:
+  - name: Evaluate oo_dns_hosts_to_update
+    add_host:
+      name: "{{ item }}"
+      groups: oo_dns_hosts_to_update
+      ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+      ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
+    with_items: "{{ groups[cluster_id ~ '-dns'] }}"
+
+  - name: Evaluate oo_hosts_to_add_in_dns
+    add_host:
+      name: "{{ item }}"
+      groups: oo_hosts_to_add_in_dns
+      ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+      ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
+    with_items: "{{ groups['tag_clusterid_' ~ cluster_id] }}"
+
+- name: Gather facts
+  hosts: oo_hosts_to_add_in_dns
+  vars_files:
+  - vars.yml
+  - cluster_hosts.yml
+
+- name: Configure the DNS
+  hosts: oo_dns_hosts_to_update
+  vars_files:
+  - vars.yml
+  - cluster_hosts.yml
+  roles:
+    - role: rhel_subscribe
+      when: deployment_type in ["enterprise", "atomic-enterprise", "openshift-enterprise"] and
+            ansible_distribution == "RedHat" and
+            lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
+              default('no', True) | lower in ['no', 'false']
+
+    - { role: dns,
+        dns_forwarders: "{{ openstack_network_dns }}",
+        dns_zones: [ novalocal, openstacklocal ],
+        dns_all_hosts: "{{ g_all_hosts }}" }

--- a/playbooks/openstack/openshift-cluster/files/heat_stack.yaml
+++ b/playbooks/openstack/openshift-cluster/files/heat_stack.yaml
@@ -14,10 +14,10 @@ parameters:
     label: Cluster ID
     description: Identifier of the cluster
 
-  cidr:
+  subnet_24_prefix:
     type: string
-    label: CIDR
-    description: CIDR of the network of the cluster
+    label: subnet /24 prefix
+    description: /24 subnet prefix of the network of the cluster (dot separated number triplet)
 
   dns_nameservers:
     type: comma_delimited_list
@@ -28,12 +28,6 @@ parameters:
     type: string
     label: External network
     description: Name of the external network
-    default: external
-
-  floating_ip_pool:
-    type: string
-    label: Floating IP pool
-    description: Floating IP pools
     default: external
 
   ssh_public_key:
@@ -88,6 +82,11 @@ parameters:
     label: Infra image
     description: Name of the image for the infra node servers
 
+  dns_image:
+    type: string
+    label: DNS image
+    description: Name of the image for the DNS server
+
   etcd_flavor:
     type: string
     label: Etcd flavor
@@ -107,6 +106,11 @@ parameters:
     type: string
     label: Infra flavor
     description: Flavor of the infra node servers
+
+  dns_flavor:
+    type: string
+    label: DNS flavor
+    description: Flavor of the DNS server
 
 outputs:
 
@@ -158,6 +162,26 @@ outputs:
     description: Floating IPs of the nodes
     value: { get_attr: [ infra_nodes, floating_ip ] }
 
+  dns_name:
+    description: Name of the DNS
+    value:
+      get_attr:
+        - dns
+        - name
+
+  dns_floating_ip:
+    description: Floating IP of the DNS
+    value:
+      get_attr:
+        - dns
+        - addresses
+        - str_replace:
+            template: openshift-ansible-cluster_id-net
+            params:
+              cluster_id: { get_param: cluster_id }
+        - 1
+        - addr
+
 resources:
 
   net:
@@ -178,8 +202,27 @@ resources:
           params:
             cluster_id: { get_param: cluster_id }
       network: { get_resource: net }
-      cidr: { get_param: cidr }
-      dns_nameservers: { get_param: dns_nameservers }
+      cidr:
+        str_replace:
+          template: subnet_24_prefix.0/24
+          params:
+            subnet_24_prefix: { get_param: subnet_24_prefix }
+      allocation_pools:
+        - start:
+            str_replace:
+              template: subnet_24_prefix.3
+              params:
+                subnet_24_prefix: { get_param: subnet_24_prefix }
+          end:
+            str_replace:
+              template: subnet_24_prefix.254
+              params:
+                subnet_24_prefix: { get_param: subnet_24_prefix }
+      dns_nameservers:
+        - str_replace:
+            template: subnet_24_prefix.2
+            params:
+              subnet_24_prefix: { get_param: subnet_24_prefix }
 
   router:
     type: OS::Neutron::Router
@@ -337,6 +380,44 @@ resources:
           port_range_min: 443
           port_range_max: 443
 
+  dns-secgrp:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      name:
+        str_replace:
+          template: openshift-ansible-cluster_id-dns-secgrp
+          params:
+            cluster_id: { get_param: cluster_id }
+      description:
+        str_replace:
+          template: Security group for cluster_id cluster DNS
+          params:
+            cluster_id: { get_param: cluster_id }
+      rules:
+        - direction: ingress
+          protocol: tcp
+          port_range_min: 22
+          port_range_max: 22
+          remote_ip_prefix: { get_param: ssh_incoming }
+        - direction: ingress
+          protocol: udp
+          port_range_min: 53
+          port_range_max: 53
+          remote_mode: remote_group_id
+          remote_group_id: { get_resource: etcd-secgrp }
+        - direction: ingress
+          protocol: udp
+          port_range_min: 53
+          port_range_max: 53
+          remote_mode: remote_group_id
+          remote_group_id: { get_resource: master-secgrp }
+        - direction: ingress
+          protocol: udp
+          port_range_min: 53
+          port_range_max: 53
+          remote_mode: remote_group_id
+          remote_group_id: { get_resource: node-secgrp }
+
   etcd:
     type: OS::Heat::ResourceGroup
     properties:
@@ -360,13 +441,14 @@ resources:
           subnet:      { get_resource: subnet }
           secgrp:
             - { get_resource: etcd-secgrp }
-          floating_network: { get_param: floating_ip_pool }
+          floating_network: { get_param: external_net }
           net_name:
             str_replace:
               template: openshift-ansible-cluster_id-net
               params:
                 cluster_id: { get_param: cluster_id }
-    depends_on: interface
+    depends_on:
+      - interface
 
   masters:
     type: OS::Heat::ResourceGroup
@@ -391,13 +473,14 @@ resources:
           subnet:      { get_resource: subnet }
           secgrp:
             - { get_resource: master-secgrp }
-          floating_network: { get_param: floating_ip_pool }
+          floating_network: { get_param: external_net }
           net_name:
             str_replace:
               template: openshift-ansible-cluster_id-net
               params:
                 cluster_id: { get_param: cluster_id }
-    depends_on: interface
+    depends_on:
+      - interface
 
   compute_nodes:
     type: OS::Heat::ResourceGroup
@@ -424,13 +507,14 @@ resources:
           subnet:      { get_resource: subnet }
           secgrp:
             - { get_resource: node-secgrp }
-          floating_network: { get_param: floating_ip_pool }
+          floating_network: { get_param: external_net }
           net_name:
             str_replace:
               template: openshift-ansible-cluster_id-net
               params:
                 cluster_id: { get_param: cluster_id }
-    depends_on: interface
+    depends_on:
+      - interface
 
   infra_nodes:
     type: OS::Heat::ResourceGroup
@@ -458,10 +542,77 @@ resources:
           secgrp:
             - { get_resource: node-secgrp }
             - { get_resource: infra-secgrp }
-          floating_network: { get_param: floating_ip_pool }
+          floating_network: { get_param: external_net }
           net_name:
             str_replace:
               template: openshift-ansible-cluster_id-net
               params:
                 cluster_id: { get_param: cluster_id }
-    depends_on: interface
+    depends_on:
+      - interface
+
+  dns:
+    type: OS::Nova::Server
+    properties:
+      name:
+        str_replace:
+          template: cluster_id-dns
+          params:
+            cluster_id: { get_param: cluster_id }
+      key_name: { get_resource: keypair }
+      image:    { get_param: dns_image }
+      flavor:   { get_param: dns_flavor }
+      networks:
+        - port: { get_resource: dns-port }
+      user_data: { get_resource: dns-config }
+      user_data_format: RAW
+
+  dns-port:
+    type: OS::Neutron::Port
+    properties:
+      network: { get_resource: net }
+      fixed_ips:
+        - subnet: { get_resource: subnet }
+          ip_address:
+            str_replace:
+              template: subnet_24_prefix.2
+              params:
+                subnet_24_prefix: { get_param: subnet_24_prefix }
+      security_groups:
+        - { get_resource: dns-secgrp }
+
+  dns-floating-ip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: { get_param: external_net }
+      port_id: { get_resource: dns-port }
+
+  dns-config:
+    type: OS::Heat::MultipartMime
+    properties:
+      parts:
+        - config: { get_file: user-data }
+        - config:
+            str_replace:
+              template: |
+                #cloud-config
+                write_files:
+                  - path: /etc/sysconfig/network-scripts/ifcfg-eth0
+                    content: |
+                      DEVICE="eth0"
+                      BOOTPROTO="dhcp"
+                      DNS1="$dns1"
+                      DNS2="$dns2"
+                      PEERDNS="no"
+                      ONBOOT="yes"
+                runcmd:
+                  - [ "/usr/bin/systemctl", "restart", "network" ]
+              params:
+                $dns1:
+                  get_param:
+                    - dns_nameservers
+                    - 0
+                $dns2:
+                  get_param:
+                    - dns_nameservers
+                    - 1

--- a/playbooks/openstack/openshift-cluster/launch.yml
+++ b/playbooks/openstack/openshift-cluster/launch.yml
@@ -32,10 +32,9 @@
              --timeout 3 --enable-rollback
              -P cluster_env={{ cluster_env }}
              -P cluster_id={{ cluster_id }}
-             -P cidr={{ openstack_network_cidr }}
+             -P subnet_24_prefix={{ openstack_subnet_24_prefix }}
              -P dns_nameservers={{ openstack_network_dns | join(",") }}
              -P external_net={{ openstack_network_external_net }}
-             -P floating_ip_pool={{ openstack_floating_ip_pool }}
              -P ssh_public_key="{{ openstack_ssh_public_key }}"
              -P ssh_incoming={{ openstack_ssh_access_from }}
              -P num_etcd={{ num_etcd }}
@@ -46,10 +45,12 @@
              -P master_image={{ deployment_vars[deployment_type].image }}
              -P node_image={{ deployment_vars[deployment_type].image }}
              -P infra_image={{ deployment_vars[deployment_type].image }}
+             -P dns_image={{ deployment_vars[deployment_type].image }}
              -P etcd_flavor={{ openstack_flavor["etcd"] }}
              -P master_flavor={{ openstack_flavor["master"] }}
              -P node_flavor={{ openstack_flavor["node"] }}
              -P infra_flavor={{ openstack_flavor["infra"] }}
+             -P dns_flavor=m1.small
              openshift-ansible-{{ cluster_id }}-stack'
 
   - name: Wait for OpenStack Stack readiness
@@ -115,6 +116,14 @@
       - parsed_outputs.infra_ips
       - parsed_outputs.infra_floating_ips
 
+  - name: Add DNS groups and variables
+    add_host:
+      hostname: '{{ parsed_outputs.dns_name }}'
+      ansible_ssh_host: '{{ parsed_outputs.dns_floating_ip }}'
+      ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+      ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
+      groups: '{{ cluster_id }}-dns'
+
   - name: Wait for ssh
     wait_for:
       host: '{{ item }}'
@@ -123,6 +132,7 @@
       - parsed_outputs.master_floating_ips
       - parsed_outputs.node_floating_ips
       - parsed_outputs.infra_floating_ips
+      - parsed_outputs.dns_floating_ip
 
   - name: Wait for user setup
     command: 'ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null {{ deployment_vars[deployment_type].ssh_user }}@{{ item }} echo {{ deployment_vars[deployment_type].ssh_user }} user is setup'
@@ -134,6 +144,7 @@
       - parsed_outputs.master_floating_ips
       - parsed_outputs.node_floating_ips
       - parsed_outputs.infra_floating_ips
+      - parsed_outputs.dns_floating_ip
 
 - include: update.yml
 

--- a/playbooks/openstack/openshift-cluster/update.yml
+++ b/playbooks/openstack/openshift-cluster/update.yml
@@ -1,4 +1,6 @@
 ---
+- include: dns.yml
+
 - name: Populate oo_hosts_to_update group
   hosts: localhost
   connection: local

--- a/playbooks/openstack/openshift-cluster/vars.yml
+++ b/playbooks/openstack/openshift-cluster/vars.yml
@@ -2,11 +2,9 @@
 debug_level: 2
 openstack_infra_heat_stack:     "{{ lookup('oo_option', 'infra_heat_stack' ) |
                                     default('files/heat_stack.yaml',         True) }}"
-openstack_network_cidr:         "{{ lookup('oo_option', 'net_cidr'         ) |
-                                    default('192.168.' + ( ( 1048576 | random % 256 ) | string() ) + '.0/24', True) }}"
+openstack_subnet_24_prefix:     "{{ lookup('oo_option', 'subnet_24_prefix'         ) |
+                                    default('192.168.' + ( ( 1048576 | random % 256 ) | string() ), True) }}"
 openstack_network_external_net: "{{ lookup('oo_option', 'external_net'     ) |
-                                    default('external',                      True) }}"
-openstack_floating_ip_pool:     "{{ lookup('oo_option', 'floating_ip_pool' ) |
                                     default('external',                      True) }}"
 openstack_network_dns:          "{{ lookup('oo_option', 'dns'              ) |
                                     default('8.8.8.8,8.8.4.4',               True) | oo_split() }}"

--- a/roles/dns/README.md
+++ b/roles/dns/README.md
@@ -1,0 +1,43 @@
+dns
+===
+
+Configure a DNS server serving IPs of all the nodes of the cluster
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+| Name | Mandatory / Optional | Description |
+|------|----------------------|-------------|
+| `dns_zones` | Mandatory | DNS zones in which we must find the hosts |
+| `dns_forwarders` | If not set, the DNS will be a recursive non-forwarding DNS server | DNS forwarders to delegate the requests for hosts outside of `dns_zones` |
+| `dns_all_hosts` | Mandatory | Exhaustive list of hosts |
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+    - hosts: dns_hosts
+      roles:
+      - role: dns
+        dns_forwarders: [ '8.8.8.8', '8.8.4.4' ]
+        dns_zones: [ novalocal, openstacklocal ]
+        dns_all_hosts: "{{ g_all_hosts }}"
+
+License
+-------
+
+ASL 2.0
+
+Author Information
+------------------
+
+OpenShift operations, Red Hat, Inc

--- a/roles/dns/handlers/main.yml
+++ b/roles/dns/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: restart bind
+  service:
+    name: named
+    state: restarted

--- a/roles/dns/meta/main.yml
+++ b/roles/dns/meta/main.yml
@@ -1,0 +1,7 @@
+---
+galaxy_info:
+  author: Lénaïc Huard
+  description: Deploy and configure a DNS server
+  company: Amadeus SAS
+  license: ASL 2.0
+dependencies: []

--- a/roles/dns/tasks/main.yml
+++ b/roles/dns/tasks/main.yml
@@ -1,0 +1,22 @@
+- name: Install Bind
+  action: "{{ ansible_pkg_mgr }} name=bind"
+
+- name: Configure Bind
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    validate: "{{ item.validate }}"
+  with_items:
+    - src: openshift-cluster.zone
+      dest: /var/named/openshift-cluster.zone
+      validate: "named-checkzone {{ dns_zones[0] }} %s"
+    - src: named.conf
+      dest: /etc/named.conf
+      validate: "named-checkconf %s"
+  notify: restart bind
+
+- name: Enable Bind
+  service:
+    name: named
+    state: started
+    enabled: yes

--- a/roles/dns/templates/named.conf
+++ b/roles/dns/templates/named.conf
@@ -1,0 +1,23 @@
+options
+{
+    directory "/var/named";
+
+    allow-query { {{ ansible_default_ipv4.network }}/24; };
+
+    recursion yes;
+
+{% if dns_forwarders is defined %}
+    forwarders {
+        {% for dns in dns_forwarders %}
+        {{ dns }};
+        {% endfor %}
+    };
+{% endif %}
+};
+{% for zone in dns_zones %}
+
+zone "{{ zone }}" IN {
+    type master;
+    file "openshift-cluster.zone";
+};
+{% endfor %}

--- a/roles/dns/templates/openshift-cluster.zone
+++ b/roles/dns/templates/openshift-cluster.zone
@@ -1,0 +1,14 @@
+$TTL 1d
+@               IN      SOA     {{ ansible_hostname }} openshift (
+                                {{ ansible_date_time.epoch }}      ; Serial (To be fixed before 2039)
+                                12h     ; Refresh
+                                3m      ; Retry
+                                4w      ; Expire
+                                3h      ; TTL for negative replies
+                        )
+
+    IN NS {{ ansible_hostname }}
+{{ ansible_hostname }}  IN A  {{ ansible_default_ipv4.address }}
+{% for host in dns_all_hosts %}
+{{ hostvars[host].ansible_hostname }}  IN A  {{ hostvars[host]['ansible_default_ipv4'].address }}
+{% endfor %}


### PR DESCRIPTION
On OpenStack, VMs are assigned a name by Nova.
But in Kilo and previous versions of OpenStack, the network provided by Neutron doesn’t embed a DNS server. As a consequence, the VMs names are not resolvable by DNS from other VMs.

Having the VMs name resolvable by DNS from the other VMs is a feature of Liberty:
* https://blueprints.launchpad.net/neutron/+spec/internal-dns-resolution
* https://specs.openstack.org/openstack/neutron-specs/specs/liberty/internal-dns-resolution.html

For older versions of OpenStack, we have to live with the fact that VMs names are not simply resolvable.

We use to workaround this limitation in the openstack provider by overriding the hostname with their IP:
https://github.com/openshift/openshift-ansible/blob/master/playbooks/openstack/openshift-cluster/config.yml#L13
It is not a very nice solution:
* The output of `oc get nodes` shows IPs instead of meaningful node names.
* The machines are booted with their meaningful names (for ex.: `clusterid-master-0` (their domain being `novalocal`) and when they are rebooted, their hostname change. All the machines of the cluster have all the same hostname (`192`) and their are all in different domains (`168.0.1`, `168.0.2`, etc.). This clearly shows that we put the wrong data at the wrong place.
* In addition, this workaround won’t play nice with the activation of cloud provider (#1207) where the OpenShift cloud provider for OpenStack will check the nodeName against the Nova VM names.

In #1139, @detiber, you suggested that I should use `openshift_set_node_ip`, but it was not working well without the above mentioned trick. Would you have any pointer ? Is the issue in OpenShift itself ? Can it be worked around in openshift-ansible ?
Moreover, I tried to both override the hostnames with IPs and enable `openshift_set_node_ip`, but I still have the issue that the ovs sdn plugin on the master tries to resolve its hostname as described in #1139.

In order to have a chance to be able to enable the OpenStack cloud provider, we cannot override the hostnames.

This PR proposes to start a DNS server on a dedicated VM (named `<clusterid>-dns`) fed with the nova names of the VMs with their IPs in order to get rid of the hostname override trick.

All the other VMs are using `<clusterid>-dns` as DNS server. It acts as an authoritative server for the `.novalocal` and `.openstacklocal` domains and as a cache forwarder for everything else.