### PR TITLE
[WIP] Add OpenStack cloud provider

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -23,6 +23,14 @@
     msg: "Pacemaker based HA is not supported at this time when used with containerized installs"
   when: openshift_master_ha | bool and openshift_master_cluster_method == "pacemaker" and openshift.common.is_containerized | bool
 
+- set_fact:
+    args_cloud:
+      cloud-provider:
+        - "openstack"
+      cloud-config:
+        - "/etc/cloud.conf"
+  when: openshift.provider.name == 'openstack'
+
 - name: Set master facts
   openshift_facts:
     role: master
@@ -74,8 +82,8 @@
       uid_allocator_range: "{{ osm_uid_allocator_range | default(None) }}"
       router_selector: "{{ openshift_router_selector | default(None) }}"
       registry_selector: "{{ openshift_registry_selector | default(None) }}"
-      api_server_args: "{{ osm_api_server_args | default(None) }}"
-      controller_args: "{{ osm_controller_args | default(None) }}"
+      api_server_args: "{{ args_cloud | oo_combine(osm_api_server_args) | default(None) }}"
+      controller_args: "{{ args_cloud | oo_combine(osm_controller_args) | default(None) }}"
       infra_nodes: "{{ num_infra | default(None) }}"
       disabled_features: "{{ osm_disabled_features | default(None) }}"
       master_count: "{{ openshift_master_count | default(None) }}"
@@ -211,6 +219,17 @@
 
 - set_fact:
     translated_identity_providers: "{{ openshift.master.identity_providers | translate_idps('v1') }}"
+
+- name: Create the OpenStack config
+  template:
+    dest: /etc/cloud.conf
+    src: cloud.conf.j2
+    mode: 0400
+  notify:
+  - restart master
+  - restart master api
+  - restart master controllers
+  when: openshift.provider.name == 'openstack'
 
 # TODO: add the validate parameter when there is a validation command to run
 - name: Create master config

--- a/roles/openshift_master/templates/cloud.conf.j2
+++ b/roles/openshift_master/templates/cloud.conf.j2
@@ -1,0 +1,11 @@
+[Global]
+auth-url = {{ lookup('env', 'OS_AUTH_URL') }}
+username = {{ lookup('env', 'OS_USERNAME') }}
+password = {{ lookup('env', 'OS_PASSWORD') }}
+tenant-id = {{ lookup('env', 'OS_TENANT_ID') }}
+region = {{ lookup('env', 'OS_REGION_NAME') }}
+{% if openstack_uuid_load_balancer_subnet is defined %}
+
+[LoadBalancer]
+subnet-id = {{ openstack_uuid_load_balancer_subnet }}
+{% endif %}

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -4,6 +4,14 @@
     msg: "SELinux is disabled, This deployment type requires that SELinux is enabled."
   when: (not ansible_selinux or ansible_selinux.status != 'enabled') and deployment_type in ['enterprise', 'online', 'atomic-enterprise', 'openshift-enterprise']
 
+- set_fact:
+    args_cloud:
+      cloud-provider:
+        - "openstack"
+      cloud-config:
+        - "/etc/cloud.conf"
+  when: openshift.provider.name == 'openstack'
+
 - name: Set node facts
   openshift_facts:
     role: "{{ item.role }}"
@@ -23,7 +31,7 @@
       annotations: "{{ openshift_node_annotations | default(none) }}"
       debug_level: "{{ openshift_node_debug_level | default(openshift.common.debug_level) }}"
       iptables_sync_period: "{{ openshift_node_iptables_sync_period | default(None) }}"
-      kubelet_args: "{{ openshift_node_kubelet_args | default(None) }}"
+      kubelet_args: "{{ args_cloud | oo_combine(openshift_node_kubelet_args | default(None)) }}"
       labels: "{{ lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true) }}"
       portal_net: "{{ openshift_master_portal_net | default(None) }}"
       registry_url: "{{ oreg_url | default(none) }}"
@@ -76,6 +84,15 @@
 - name: Start and enable openvswitch docker service
   service: name=openvswitch.service enabled=yes state=started
   when: openshift.common.is_containerized | bool and openshift.common.use_openshift_sdn | bool
+
+- name: Create the OpenStack config
+  template:
+    dest: /etc/cloud.conf
+    src: cloud.conf.j2
+    mode: 0400
+  notify:
+  - restart node
+  when: openshift.provider.name == 'openstack'
 
 # TODO: add the validate parameter when there is a validation command to run
 - name: Create the Node config

--- a/roles/openshift_node/templates/cloud.conf.j2
+++ b/roles/openshift_node/templates/cloud.conf.j2
@@ -1,0 +1,11 @@
+[Global]
+auth-url = {{ lookup('env', 'OS_AUTH_URL') }}
+username = {{ lookup('env', 'OS_USERNAME') }}
+password = {{ lookup('env', 'OS_PASSWORD') }}
+tenant-id = {{ lookup('env', 'OS_TENANT_ID') }}
+region = {{ lookup('env', 'OS_REGION_NAME') }}
+{% if openstack_uuid_load_balancer_subnet is defined %}
+
+[LoadBalancer]
+subnet-id = {{ openstack_uuid_load_balancer_subnet }}
+{% endif %}


### PR DESCRIPTION
Enable the OpenStack cloud provider as described on:
https://docs.openshift.org/latest/install_config/configuring_openstack.html

In order for the cloud provider to work, the `nodeName` of the nodes has to match their name in Nova, otherwise, we get the following error:
```
Jan 18 14:02:02 lenaic-node-infra-0.novalocal atomic-openshift-node[20039]: E0118 14:02:02.708995   20039 kubelet.go:925] Unable to construct api.Node object for kubelet: failed to get external ID from cloud provider: Failed to find object
```
That’s why #1206 is a prerequisite to this PR.