### PR TITLE
Improve pacemaker 'is-active' check.

### DIFF
--- a/playbooks/common/openshift-master/restart.yml
+++ b/playbooks/common/openshift-master/restart.yml
@@ -68,14 +68,22 @@
 
 - name: Determine which masters are currently active
   hosts: oo_masters_to_config
+  any_errors_fatal: true
   tasks:
   - name: Check master service status
     command: >
       systemctl is-active {{ openshift.common.service_type }}-master
     register: active_check_output
     when: openshift.master.cluster_method | default(None) == 'pacemaker'
-    failed_when: active_check_output.stdout not in ['active', 'inactive', 'unknown']
+    failed_when: false
     changed_when: false
+  # Any master which did not report 'active' or 'inactive' is likely
+  # unhealthy.  Other possible states are 'unknown' or 'failed'.
+  - fail:
+      msg: >
+        Got invalid service state from {{ openshift.common.service_type }}-master
+        on {{ inventory_hostname }}. Please verify pacemaker cluster.
+    when: openshift.master.cluster_method | default(None) == 'pacemaker' and active_check_output.stdout not in ['active', 'inactive']
   - set_fact:
       is_active: "{{ active_check_output.stdout == 'active' }}"
     when: openshift.master.cluster_method | default(None) == 'pacemaker'


### PR DESCRIPTION
* Provide an error message when the 'is-active' service check comes back with a bad state during pacemaker restart. 
* Use `any_errors_fatal: true` on the active masters play so that any failures stop playbook execution.

@detiber PTAL

https://bugzilla.redhat.com/show_bug.cgi?id=1298803

The hosts in the attached BZ fail in this check before reaching pacemaker cluster validation.

```
PLAY [Determine which masters are currently active] *************************** 

GATHERING FACTS *************************************************************** 
ok: [master1.example.com]
ok: [master3.example.com]
ok: [master2.example.com]

TASK: [Check master service status] ******************************************* 
ok: [master2.example.com]
cmd:['systemctl', 'is-active', 'atomic-openshift-master']
stdout:inactive
stderr:
ok: [master1.example.com]
cmd:['systemctl', 'is-active', 'atomic-openshift-master']
stdout:inactive
stderr:
ok: [master3.example.com]
cmd:['systemctl', 'is-active', 'atomic-openshift-master']
stdout:failed
stderr:

TASK: [fail ] ***************************************************************** 
skipping: [master1.example.com]
skipping: [master2.example.com]
failed: [master3.example.com] => {"failed": true}
msg: Got invalid service state from atomic-openshift-master on master3.example.com. Please verify pacemaker cluster.

FATAL: all hosts have already failed -- aborting

PLAY RECAP ******************************************************************** 
           to retry, use: --limit @/home/abutcher/restart.retry

localhost                  : ok=9    changed=0    unreachable=0    failed=0   
master1.example.com        : ok=13   changed=0    unreachable=0    failed=0   
master2.example.com        : ok=13   changed=0    unreachable=0    failed=0   
master3.example.com        : ok=13   changed=0    unreachable=0    failed=1
```