### PR TITLE
Fix client and admin wrapper pathing for non-root user install.

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1031,6 +1031,10 @@ def set_container_facts_if_unset(facts):
         if 'ovs_image' not in facts['node']:
             facts['node']['ovs_image'] = ovs_image
 
+    if facts['common']['is_containerized']:
+        facts['common']['admin_binary'] = '/usr/local/bin/oadm'
+        facts['common']['client_binary'] = '/usr/local/bin/oc'
+
     return facts
 
 


### PR DESCRIPTION
The `oc` and `oadm` wrappers located in `/usr/local/bin` aren't in `PATH` for non-root user containerized installs. There may be a cleaner way to ensure that our path includes `/usr/local/bin` but this seems like an alright way to go about it... if we know a host is containerized we can use these paths.

https://bugzilla.redhat.com/show_bug.cgi?id=1299742

@brenton @detiber PTAL