### PR TITLE
Native ha port fixes

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -219,6 +219,7 @@
   hosts: oo_lb_to_config
   vars:
     sync_tmpdir: "{{ hostvars.localhost.g_master_mktemp.stdout }}"
+    haproxy_frontend_port: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_port }}"
     haproxy_frontends:
     - name: atomic-openshift-api
       mode: tcp

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+haproxy_frontend_port: 80
+
 haproxy_frontends:
 - name: main
   binds:
@@ -18,4 +20,4 @@ os_firewall_allow:
 - service: haproxy stats
   port: "9000/tcp"
 - service: haproxy balance
-  port: "8443/tcp"
+  port: "{{ haproxy_frontend_port }}/tcp"

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
@@ -1,4 +1,4 @@
-OPTIONS=--loglevel={{ openshift.master.debug_level }} --listen={{ 'https' if openshift.master.api_use_ssl else 'http' }}://{{ openshift.master.bind_addr }}:{{ openshift.master.api_port }} --master={{ openshift.master.loopback_api_url }}:{{ openshift.master.api_port }}
+OPTIONS=--loglevel={{ openshift.master.debug_level }} --listen={{ 'https' if openshift.master.api_use_ssl else 'http' }}://{{ openshift.master.bind_addr }}:{{ openshift.master.api_port }} --master={{ openshift.master.loopback_api_url }}
 CONFIG_FILE={{ openshift_master_config_file }}
 
 # Proxy configuration


### PR DESCRIPTION
* Remove extra port from the master url.
* Add an `haproxy_frontend_port` var so we can use it for `os_firewall`.

@detiber PTAL