### PR TITLE
Fix 'pcs status' validation filter

### DIFF
--- a/filter_plugins/openshift_master.py
+++ b/filter_plugins/openshift_master.py
@@ -478,8 +478,8 @@ class FilterModule(object):
                            'master3.example.com']
                returns True
         '''
-        if not issubclass(type(data), str):
-            raise errors.AnsibleFilterError("|failed expects data is a string")
+        if not issubclass(type(data), basestring):
+            raise errors.AnsibleFilterError("|failed expects data is a string or unicode")
         if not issubclass(type(masters), list):
             raise errors.AnsibleFilterError("|failed expects masters is a list")
         valid = True


### PR DESCRIPTION
Input `data` should be tested for instance of `basestring` (`str` and `unicode`) instead of `str`.

https://bugzilla.redhat.com/show_bug.cgi?id=1298803
