### PR TITLE
adhoc s3 registry - add auth part in the registry config sample

### DIFF
--- a/playbooks/adhoc/s3_registry/s3_registry.j2
+++ b/playbooks/adhoc/s3_registry/s3_registry.j2
@@ -15,6 +15,9 @@ storage:
     secure: true
     v4auth: true
     rootdirectory: /registry
+auth:
+  openshift:
+    realm: openshift
 middleware:
   repository:
     - name: openshift


### PR DESCRIPTION
Hello,

We had an issue using the `playbooks/adhoc/s3_registry/s3_registry.yml` 

Regarding the redhat case : https://access.redhat.com/support/cases/#/case/01571362

The auth part seems meeting in the `s3_registry.j2` config sample.

Without the auth part, after spawning the registry we were not able to do an auth.

```
docker login -u .. -p ...  172.30.234.98:5000
Error response from daemon: no successful auth challenge forhttp://172.30.234.98:5000/v2/ - errors: []
```

This commit simply add this part in the registry config sample