### PR TITLE
Reverse 'is-active' check in restart playbook

### DIFF
--- a/playbooks/common/openshift-master/restart.yml
+++ b/playbooks/common/openshift-master/restart.yml
@@ -77,13 +77,6 @@
     when: openshift.master.cluster_method | default(None) == 'pacemaker'
     failed_when: false
     changed_when: false
-  # Any master which did not report 'active' or 'inactive' is likely
-  # unhealthy.  Other possible states are 'unknown' or 'failed'.
-  - fail:
-      msg: >
-        Got invalid service state from {{ openshift.common.service_type }}-master
-        on {{ inventory_hostname }}. Please verify pacemaker cluster.
-    when: openshift.master.cluster_method | default(None) == 'pacemaker' and active_check_output.stdout not in ['active', 'inactive']
   - set_fact:
       is_active: "{{ active_check_output.stdout == 'active' }}"
     when: openshift.master.cluster_method | default(None) == 'pacemaker'
@@ -92,6 +85,13 @@
   hosts: localhost
   become: no
   tasks:
+  - fail:
+      msg: >
+        Did not receive active status from any masters. Please verify pacemaker cluster.
+    when: "{{ hostvars[groups.oo_first_master.0].openshift.master.cluster_method | default(None) == 'pacemaker' and 'True' not in (hostvars
+              | oo_select_keys(groups['oo_masters_to_config'])
+              | oo_collect('is_active')
+              | list) }}"
   - name: Evaluate oo_active_masters
     add_host:
       name: "{{ item }}"


### PR DESCRIPTION
Fail when master restart playbook finds no active masters rather than any failed masters. To succeed at this gate, at least one master must report `active` from `systemctl is-active atomic-openshift-master`.

I've found that `failed` is a completely valid state but we want at least one master to be `active`.

Log from a pacemaker restart: http://file.rdu.redhat.com/abutcher/ansible.2.bz1298803.txt

@brenton @detiber ptal