### PR TITLE
Ensure openssl present for etcd_ca

### DIFF
--- a/roles/etcd_ca/tasks/main.yml
+++ b/roles/etcd_ca/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Install openssl
+  action: "{{ ansible_pkg_mgr }} name=openssl state=present"
+  when: not openshift.common.is_atomic | bool
+
 - file:
     path: "{{ item }}"
     state: directory


### PR DESCRIPTION
Previously we assumed that openssl was present on the host machine. Now we at least test the package is present: fixes https://github.com/openshift/openshift-ansible/issues/1268