### PR TITLE
Fix checking for update package availability

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/files/versions.sh
+++ b/playbooks/common/openshift-cluster/upgrades/files/versions.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-yum_installed=$(yum list installed -e 0 -q "$@" 2>&1 | tail -n +2 | awk '{ print $2 }' | tr '\n' ' ')
+yum_installed=$(yum list installed -e 0 -q "$@" 2>&1 | tail -n +2 | awk '{ print $2 }' | sort -r | tr '\n' ' ')
 
-yum_available=$(yum list available -e 0 -q "$@" 2>&1 | tail -n +2 | grep -v 'el7ose' | awk '{ print $2 }' | tr '\n' ' ')
+yum_available=$(yum list available -e 0 -q "$@" 2>&1 | tail -n +2 | grep -v 'el7ose' | awk '{ print $2 }' | sort -r | tr '\n' ' ')
 
 echo "---"
 echo "curr_version: ${yum_installed}"


### PR DESCRIPTION
Currently, if `yum list available` returns two versions, for whatever reason, no sorting is imposed. Therefore it's possible that an upgraded package version is available but is not being detected.

This patch sorts the version number list so that most recent version is always picked first.