### PR TITLE
Fix pkg_version 

### DIFF
--- a/roles/openshift_common/vars/main.yml
+++ b/roles/openshift_common/vars/main.yml
@@ -5,3 +5,4 @@
 # chains with the public zone (or the zone associated with the correct
 # interfaces)
 os_firewall_use_firewalld: False
+openshift_version: "{{ openshift_pkg_version | default('') }}"


### PR DESCRIPTION
Ansible install the latest version despite the value we set at openshift_pkg_version. This patch intend to fix it.