### PR TITLE
replace yum with dnf

### DIFF
--- a/roles/openshift_cli/tasks/main.yml
+++ b/roles/openshift_cli/tasks/main.yml
@@ -6,7 +6,7 @@
       cli_image: "{{ osm_image | default(None) }}"
       
 - name: Install clients
-  yum: pkg={{ openshift.common.service_type }}-clients state=installed
+  action: "{{ ansible_pkg_mgr }} name={{ openshift.common.service_type }}-clients state=present"
   when: not openshift.common.is_containerized | bool
   
 - name: Pull CLI Image


### PR DESCRIPTION
The yum module is not installed following the directions for installation on Fedora (23) and causes the byo playbook to fail.