### PR TITLE
Fix 1.1.1 upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_minor/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_minor/pre.yml
@@ -41,7 +41,7 @@
       g_new_service_name: "{{ 'origin' if deployment_type =='origin' else 'atomic-openshift' }}"
 
   - name: Determine available versions
-    script: ../files/versions.sh {{ g_new_service_name }} openshift
+    script: ../files/versions.sh {{ g_new_service_name }}
     register: g_versions_result
 
   - set_fact:


### PR DESCRIPTION
The playbook doesn't work for origin installs. The reason is because copr mirror has some packages that are conflicting the parser.

<pre>
failed: [origintest0] => {"failed": true}
msg: Upgrade packages not found
failed: [origintest1] => {"failed": true}
msg: Upgrade packages not found

FATAL: all hosts have already failed -- aborting
</pre>

<pre>

[root@origintest0 ~]# ./versions.sh origin openshift
---
curr_version: 1.1.0.1-0.git.7334.2c6ff4b.el7.centos
avail_version: 1.0.5-4.git.5411.3eee7d2.el7.centos 1.1.1-0.git.0.54a57ff.el7.centos

</pre>


I see two solutions:
1) Get rid of the old packages from copr (since they are named with  openshift prefix)
2) Merge this patch

I still not sure if this broken OSE install, so PTAL!