### PR TITLE
update adhoc scripts for new oso version

### DIFF
--- a/playbooks/adhoc/create_pv/create_pv.yaml
+++ b/playbooks/adhoc/create_pv/create_pv.yaml
@@ -150,7 +150,7 @@
 
   # We have to use the shell module because we can't set env vars with the command module.
   - name: "Place PV into oc"
-    shell: "KUBECONFIG=/etc/openshift/master/admin.kubeconfig oc create -f {{ pv_template | quote }}"
+    shell: "KUBECONFIG=/etc/origin/master/admin.kubeconfig oc create -f {{ pv_template | quote }}"
     register: oc_output
 
   - debug: var=oc_output

--- a/playbooks/adhoc/s3_registry/s3_registry.yml
+++ b/playbooks/adhoc/s3_registry/s3_registry.yml
@@ -1,12 +1,12 @@
 ---
 # This playbook creates an S3 bucket named after your cluster and configures the docker-registry service to use the bucket as its backend storage.
 # Usage:
-#  ansible-playbook s3_registry.yml -e clusterid="mycluster"
+#  ansible-playbook s3_registry.yml -e clusterid=<clusterid> -e master=<master-host-name>
 #
 # The AWS access/secret keys should be the keys of a separate user (not your main user), containing only the necessary S3 access role.
 # The 'clusterid' is the short name of your cluster.
 
-- hosts: tag_clusterid_{{ clusterid }}:&tag_host-type_openshift-master
+- hosts: "{{ master }}"
   remote_user: root
   gather_facts: False
 


### PR DESCRIPTION
Updated scripts to work with version 3.1 and multiple masters. Use static master since dynamic inventory yields unreliable results.