### PR TITLE
Check that openshift_hostname resolves to an ip on our host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ gce.ini
 multi_ec2.yaml
 multi_inventory.yaml
 .vagrant
+.tags*

--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -210,6 +210,13 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # See: https://github.com/nickhammond/ansible-logrotate
 #logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
+# openshift-ansible will wait indefinitely for your input when it detects that the
+# value of openshift_hostname resolves to an IP address not bound to any local
+# interfaces. This mis-configuration is problematic for any pod leveraging host
+# networking and liveness or readiness probes. 
+# Setting this variable to true will override that check.
+#openshift_override_hostname_check=true
+
 # host group for masters
 [masters]
 aep3-master[1:3]-ansible.test.example.com

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -220,6 +220,13 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # See: https://github.com/nickhammond/ansible-logrotate
 #logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
+# openshift-ansible will wait indefinitely for your input when it detects that the
+# value of openshift_hostname resolves to an IP address not bound to any local
+# interfaces. This mis-configuration is problematic for any pod leveraging host
+# networking and liveness or readiness probes. 
+# Setting this variable to true will override that check.
+#openshift_override_hostname_check=true
+
 # host group for masters
 [masters]
 ose3-master[1:3]-ansible.test.example.com

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -210,6 +210,13 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # See: https://github.com/nickhammond/ansible-logrotate
 #logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
+# openshift-ansible will wait indefinitely for your input when it detects that the
+# value of openshift_hostname resolves to an IP address not bound to any local
+# interfaces. This mis-configuration is problematic for any pod leveraging host
+# networking and liveness or readiness probes. 
+# Setting this variable to true will override that check.
+#openshift_override_hostname_check=true
+
 # host group for masters
 [masters]
 ose3-master[1:3]-ansible.test.example.com

--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -1,6 +1,8 @@
 ---
 - include: evaluate_groups.yml
 
+- include: validate_hostnames.yml
+
 - include: ../openshift-docker/config.yml
 
 - include: ../openshift-etcd/config.yml

--- a/playbooks/common/openshift-cluster/validate_hostnames.yml
+++ b/playbooks/common/openshift-cluster/validate_hostnames.yml
@@ -1,0 +1,26 @@
+---
+- include: evaluate_groups.yml
+
+- name: Gather and set facts for node hosts
+  hosts: oo_nodes_to_config
+  roles:
+  - openshift_facts
+  tasks:
+  - openshift_facts:
+      role: "{{ item.role }}"
+      local_facts: "{{ item.local_facts }}"
+    with_items:
+      - role: common
+        local_facts:
+          hostname: "{{ openshift_hostname | default(None) }}"
+          public_hostname: "{{ openshift_public_hostname | default(None) }}"
+  - shell:
+      getent ahostsv4 {{ openshift.common.hostname }} | head -n 1 | awk '{ print $1 }'
+    register: lookupip
+    changed_when: false
+    failed_when: false
+  - name: Warn user about bad openshift_hostname values
+    pause:
+       prompt: "The hostname \"{{ openshift.common.hostname }}\" for \"{{ ansible_nodename }}\" doesn't resolve to an ip address owned by this host. Please set openshift_hostname variable to a hostname that when resolved on the host in question resolves to an IP address matching an interface on this host. This host will fail liveness checks for pods utilizing hostPorts, press CTRL-C to continue."
+       seconds: "{{ 10 if openshift_override_hostname_check | default(false) | bool else omit }}"
+    when: lookupip.stdout not in ansible_all_ipv4_addresses


### PR DESCRIPTION
Check to see if openshift_hostname resolves to an ip on our host in order to avoid problems in public/private IP environments where liveness and readiness probes are assigned to pods utilzing host networking.

See https://bugzilla.redhat.com/show_bug.cgi?id=1293578 for more details