### PR TITLE
s3_registry no filter named 'lookup'

### DIFF
--- a/playbooks/adhoc/s3_registry/s3_registry.yml
+++ b/playbooks/adhoc/s3_registry/s3_registry.yml
@@ -14,7 +14,7 @@
     aws_access_key: "{{ lookup('env', 'S3_ACCESS_KEY_ID') }}"
     aws_secret_key: "{{ lookup('env', 'S3_SECRET_ACCESS_KEY') }}"
     aws_bucket_name: "{{ aws_bucket | default(clusterid ~ '-docker') }}"
-    aws_bucket_region: "{{ aws_region | lookup('env', 'S3_REGION') | default('us-east-1') }}"
+    aws_bucket_region: "{{ aws_region | default(lookup('env', 'S3_REGION') | default('us-east-1', true)) }}"
 
   tasks:
 


### PR DESCRIPTION
Issue with the default param syntaxe.

```bash
 [WARNING]: non fatal error while trying to template play variables: Failed to
template {{ aws_region | lookup('env', 'S3_REGION') | default('us-east-1') }}:
template error while templating string: no filter named 'lookup'
```

  * Added a default function for the lookup.
  * According to [1] added default(,true) to avoid empty string

 [1] https://github.com/openshift/openshift-ansible/blob/master/docs/best_practices_guide.adoc#filters