### PR TITLE
Fix infra_node deployment

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -397,7 +397,7 @@
   hosts: oo_first_master
   vars:
     attach_registry_volume: "{{ openshift.hosted.registry.storage.kind != None }}"
-    deploy_infra: "{{ openshift.master.infra_nodes | default(0) | length > 0 }}"
+    deploy_infra: "{{ openshift.master.infra_nodes | default([]) | length > 0 }}"
     persistent_volumes: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volumes(groups) }}"
     persistent_volume_claims: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volume_claims }}"
   roles:

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -360,6 +360,8 @@
 - name: Additional master configuration
   hosts: oo_first_master
   vars:
+    cockpit_plugins: "{{ osm_cockpit_plugins | default(['cockpit-kubernetes']) }}"
+    etcd_urls: "{{ openshift.master.etcd_urls }}"
     openshift_master_ha: "{{ groups.oo_masters_to_config | length > 1 }}"
     omc_cluster_hosts: "{{ groups.oo_masters_to_config | join(' ')}}"
   roles:
@@ -371,30 +373,16 @@
     when: openshift.common.use_cluster_metrics | bool
   - role: openshift_manageiq
     when: openshift.common.use_manageiq | bool
-
-- name: Enable cockpit
-  hosts: oo_first_master
-  vars:
-    cockpit_plugins: "{{ osm_cockpit_plugins | default(['cockpit-kubernetes']) }}"
-  roles:
   - role: cockpit
     when: not openshift.common.is_atomic and ( deployment_type in ['atomic-enterprise','openshift-enterprise'] ) and
       (osm_use_cockpit | bool or osm_use_cockpit is undefined )
-
-- name: Configure flannel
-  hosts: oo_first_master
-  vars:
-    etcd_urls: "{{ openshift.master.etcd_urls }}"
-  roles:
   - role: flannel_register
     when: openshift.common.use_flannel | bool
+  - role: pods
+    when: openshift.common.deployment_type == 'online'
+  - role: os_env_extras
+    when: openshift.common.deployment_type == 'online'
 
-# Additional instance config for online deployments
-- name: Additional instance config
-  hosts: oo_masters_deployment_type_online
-  roles:
-  - pods
-  - os_env_extras
 
 - name: Delete temporary directory on localhost
   hosts: localhost
@@ -405,27 +393,16 @@
   - file: name={{ g_master_mktemp.stdout }} state=absent
     changed_when: False
 
-- name: Create persistent volumes
+- name: Create persistent volumes and create hosted services
   hosts: oo_first_master
   vars:
+    attach_registry_volume: "{{ openshift.hosted.registry.storage.kind != None }}"
+    deploy_infra: "{{ openshift.master.infra_nodes | default(0) | length > 0 }}"
     persistent_volumes: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volumes(groups) }}"
     persistent_volume_claims: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volume_claims }}"
-  pre_tasks:
-  - set_fact:
-      nfs_host: "{{ groups.oo_nfs_to_config.0 }}"
-      registry_volume_path: "{{ hostvars[groups.oo_nfs_to_config.0].openshift.nfs.exports_dir + '/' + hostvars[groups.oo_nfs_to_config.0].openshift.nfs.registry_volume }}"
-    when: attach_registry_volume | bool
   roles:
   - role: openshift_persistent_volumes
     when: persistent_volumes | length > 0 or persistent_volume_claims | length > 0
-
-- name: Create hosted infrastructure services
-  hosts: oo_first_master
-  vars:
-    accounts: ["router", "registry"]
-    attach_registry_volume: "{{ openshift.hosted.registry.storage.kind != None }}"
-    deploy_infra: "{{ openshift.master.infra_nodes | default(0) | length > 0 }}"
-  roles:
   - role: openshift_serviceaccounts
     openshift_serviceaccounts_names:
     - router
@@ -437,3 +414,4 @@
     when: deploy_infra | bool
   - role: openshift_registry
     when: deploy_infra | bool and attach_registry_volume | bool
+

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -170,10 +170,10 @@
       master_cert_subdir: master-{{ openshift.common.hostname }}
       master_cert_config_dir: "{{ openshift.common.config_base }}/master"
   - set_fact:
-      openshift_infra_nodes: "{{ hostvars | oo_select_keys(groups['nodes'])
+      openshift_infra_nodes: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config'])
                                  | oo_nodes_with_label('region', 'infra')
                                  | oo_collect('inventory_hostname') }}"
-    when: openshift_infra_nodes is not defined
+    when: openshift_infra_nodes is not defined and groups.oo_nodes_to_config | default([]) | length > 0
 
 - name: Configure master certificates
   hosts: oo_first_master
@@ -408,7 +408,6 @@
 - name: Configure service accounts
   hosts: oo_first_master
   vars:
-    accounts: ["router", "registry"]
   roles:
   - openshift_serviceaccounts
 
@@ -417,10 +416,17 @@
   vars:
     persistent_volumes: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volumes(groups) }}"
     persistent_volume_claims: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volume_claims }}"
+    attach_registry_volume: "{{ openshift.hosted.registry.storage.kind != None }}"
+    deploy_infra: "{{ openshift.master.infra_nodes | default(0) | length > 0 }}"
+  pre_tasks:
+  - set_fact:
+      nfs_host: "{{ groups.oo_nfs_to_config.0 }}"
+      registry_volume_path: "{{ hostvars[groups.oo_nfs_to_config.0].openshift.nfs.exports_dir + '/' + hostvars[groups.oo_nfs_to_config.0].openshift.nfs.registry_volume }}"
+    when: attach_registry_volume | bool
   roles:
   - role: openshift_persistent_volumes
     when: persistent_volumes | length > 0 or persistent_volume_claims | length > 0
   - role: openshift_router
-    when: openshift.master.infra_nodes is defined
+    when: deploy_infra | bool
   - role: openshift_registry
-    when: openshift.master.infra_nodes is defined and openshift.hosted.registry.storage.kind != None
+    when: deploy_infra | bool and attach_registry_volume | bool

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -405,19 +405,11 @@
   - file: name={{ g_master_mktemp.stdout }} state=absent
     changed_when: False
 
-- name: Configure service accounts
-  hosts: oo_first_master
-  vars:
-  roles:
-  - openshift_serviceaccounts
-
-- name: Create persistent volumes and services
+- name: Create persistent volumes
   hosts: oo_first_master
   vars:
     persistent_volumes: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volumes(groups) }}"
     persistent_volume_claims: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volume_claims }}"
-    attach_registry_volume: "{{ openshift.hosted.registry.storage.kind != None }}"
-    deploy_infra: "{{ openshift.master.infra_nodes | default(0) | length > 0 }}"
   pre_tasks:
   - set_fact:
       nfs_host: "{{ groups.oo_nfs_to_config.0 }}"
@@ -426,6 +418,21 @@
   roles:
   - role: openshift_persistent_volumes
     when: persistent_volumes | length > 0 or persistent_volume_claims | length > 0
+
+- name: Create hosted infrastructure services
+  hosts: oo_first_master
+  vars:
+    accounts: ["router", "registry"]
+    attach_registry_volume: "{{ openshift.hosted.registry.storage.kind != None }}"
+    deploy_infra: "{{ openshift.master.infra_nodes | default(0) | length > 0 }}"
+  roles:
+  - role: openshift_serviceaccounts
+    openshift_serviceaccounts_names:
+    - router
+    - registry
+    openshift_serviceaccounts_namespace: default
+    openshift_serviceaccounts_sccs:
+    - privileged
   - role: openshift_router
     when: deploy_infra | bool
   - role: openshift_registry

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -176,6 +176,7 @@
 - name: Evaluate node groups
   hosts: localhost
   become: no
+  connection: local
   tasks:
   - name: Evaluate oo_containerized_master_nodes
     add_host:

--- a/roles/fluentd_master/meta/main.yml
+++ b/roles/fluentd_master/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: OpenShift Red Hat
-  description: OpenShift Embedded Docker Registry
+  description: Fluentd Master
   company: Red Hat, Inc.
   license: Apache License, Version 2.0
   min_ansible_version: 1.9
@@ -10,6 +10,6 @@ galaxy_info:
     versions:
     - 7
   categories:
-  - cloud
+  - monitoring
   dependencies:
   - openshift_facts

--- a/roles/openshift_registry/README.md
+++ b/roles/openshift_registry/README.md
@@ -17,12 +17,6 @@ From this role:
 |--------------------|-------------------------------------------------------|---------------------|
 |                    |                                                       |                     |
 
-From openshift_common:
-
-| Name                  | Default value |                                      |
-|-----------------------|---------------|--------------------------------------|
-| openshift_debug_level | 2             | Global openshift debug log verbosity |
-
 
 Dependencies
 ------------

--- a/roles/openshift_router/README.md
+++ b/roles/openshift_router/README.md
@@ -16,11 +16,6 @@ From this role:
 |--------------------|-------------------------------------------------------|---------------------|
 |                    |                                                       |                     |
 
-From openshift_common:
-| Name                  | Default value |                                      |
-|-----------------------|---------------|--------------------------------------|
-| openshift_debug_level | 2             | Global openshift debug log verbosity |
-
 Dependencies
 ------------
 

--- a/roles/openshift_router/meta/main.yml
+++ b/roles/openshift_router/meta/main.yml
@@ -4,10 +4,12 @@ galaxy_info:
   description: OpenShift Embedded Router
   company: Red Hat, Inc.
   license: Apache License, Version 2.0
-  min_ansible_version: 1.7
+  min_ansible_version: 1.9
   platforms:
   - name: EL
     versions:
     - 7
   categories:
   - cloud
+  dependencies:
+  - openshift_facts

--- a/roles/openshift_serviceaccounts/meta/main.yml
+++ b/roles/openshift_serviceaccounts/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: OpenShift Operations
+  description: OpenShift Service Accounts
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 1.9
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+dependencies:
+- { role: openshift_facts }

--- a/roles/openshift_serviceaccounts/tasks/main.yml
+++ b/roles/openshift_serviceaccounts/tasks/main.yml
@@ -1,36 +1,33 @@
-- name: tmp dir for openshift
-  file:
-    path: /tmp/openshift
-    state: directory
-    owner: root
-    mode: 700
-
-- name: Create service account configs
-  template:
-    src: serviceaccount.j2
-    dest: "/tmp/openshift/{{ item }}-serviceaccount.yaml"
-  with_items: accounts
-
-- name: Create {{ item }} service account
+- name: test if service accounts exists
   command: >
-    {{ openshift.common.client_binary }} create -f "/tmp/openshift/{{ item }}-serviceaccount.yaml"
-  with_items: accounts
-  register: _sa_result
-  failed_when: "'serviceaccounts \"{{ item }}\" already exists' not in _sa_result.stderr and _sa_result.rc != 0"
-  changed_when: "'serviceaccounts \"{{ item }}\" already exists' not in _sa_result.stderr and _sa_result.rc == 0"
-
-- name: Get current security context constraints
-  shell: >
-    {{ openshift.common.client_binary }} get scc privileged -o yaml
-    --output-version=v1 > /tmp/openshift/scc.yaml
+      {{ openshift.common.client_binary }} get sa {{ item }} -n {{ openshift_serviceaccounts_namespace }}
+  with_items: openshift_serviceaccounts_names
+  failed_when: false
   changed_when: false
+  register: account_test
 
-- name: Add security context constraint for {{ item }}
-  lineinfile:
-    dest: /tmp/openshift/scc.yaml
-    line: "- system:serviceaccount:default:{{ item }}"
-    insertafter: "^users:$"
-  with_items: accounts
+- name: create the service account
+  shell: >
+       echo {{ lookup('template', '../templates/serviceaccount.j2')
+               | from_yaml | to_json | quote }} | {{ openshift.common.client_binary }}  create -f -
+  when: item.1.rc != 0
+  with_together:
+  - openshift_serviceaccounts_names
+  - account_test.results
 
-- name: Apply new scc rules for service accounts
-  command: "{{ openshift.common.client_binary }} update -f /tmp/openshift/scc.yaml --api-version=v1"
+- name: test if scc needs to be updated
+  command: >
+      {{ openshift.common.client_binary }} get scc {{ item }} -o yaml
+  changed_when: false
+  failed_when: false
+  register: scc_test
+  with_items: openshift_serviceaccounts_sccs
+
+- name: Grant the user access to the privileged scc
+  command: >
+      {{ openshift.common.admin_binary }} policy add-scc-to-user
+      privileged system:serviceaccount:{{ openshift_serviceaccounts_namespace }}:{{ item.0 }}
+  when: "item.1.rc == 0 and 'system:serviceaccount:{{ openshift_serviceaccounts_namespace }}:{{ item.0 }}' not in {{ (item.1.stdout | from_yaml).users }}"
+  with_nested:
+  - openshift_serviceaccounts_names
+  - scc_test.results

--- a/roles/openshift_serviceaccounts/templates/serviceaccount.j2
+++ b/roles/openshift_serviceaccounts/templates/serviceaccount.j2
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ item }}
+  name: {{ item.0 }}


### PR DESCRIPTION
- Do not deploy the router/registry when the infra_nodes variable is present
  but does not contain a list of infra nodes.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1303939

- Reorganize the master playbook a bit
  - Move service account creation near the router/registry roles where they are consumed.
  - Consolidate much of the oo_first_master post-installation config instead of having many separate plays

- Fix missing dependencies on openshift_facts for some roles
- cleanup service account creation to use oadm policy add-scc-to-user instead of dumping, editing, and re-loading the yaml.