### PR TITLE
[WIP] Nodes resolve cluster.local via dnsmasq

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -162,6 +162,8 @@
       file: path={{ item }} state=absent
       with_items:
         - "~{{ ansible_ssh_user }}/.kube"
+        - /etc/NetworkManager/conf.d/origin-cluster-resolver.conf
+        - /etc/NetworkManager/dnsmasq.d/origin-dns.conf
         - /etc/ansible/facts.d/openshift.fact
         - /etc/atomic-enterprise
         - /etc/corosync
@@ -212,6 +214,9 @@
     # systemd configuration manager
     - name: Reload systemd manager configuration
       command: systemctl daemon-reload
+      
+    - name: Restart NetworkManager to revert cluster dns
+      service: name=NetworkManager state=restarted
 
 - hosts: nodes
   sudo: yes

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -173,6 +173,15 @@
       dest: "{{ node_cert_dir }}"
     when: certs_missing
 
+- name: Configure node dnsmasq
+  hosts: oo_nodes_to_config:!oo_containerized_master_nodes
+  vars:
+    dns_domain: "{{ openshift.common.dns_domain }}"
+    kube_svc_ip: "{{ hostvars[groups.oo_first_master.0].openshift.master.kube_svc_ip }}"
+    portal_net: "{{ openshift.node.portal_net }}"
+  roles:
+    - openshift_node_dns
+
 - name: Evaluate node groups
   hosts: localhost
   become: no

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -178,7 +178,7 @@
   vars:
     dns_domain: "{{ openshift.common.dns_domain }}"
     kube_svc_ip: "{{ hostvars[groups.oo_first_master.0].openshift.master.kube_svc_ip }}"
-    portal_net: "{{ openshift.node.portal_net }}"
+    portal_net: "{{ openshift.common.portal_net }}"
   roles:
     - openshift_node_dns
 

--- a/roles/flannel_register/README.md
+++ b/roles/flannel_register/README.md
@@ -14,7 +14,7 @@ Role Variables
 
 | Name                | Default value                                      | Description                                     |
 |---------------------|----------------------------------------------------|-------------------------------------------------|
-| flannel_network     | {{ openshift.master.portal_net }} or 172.16.1.1/16 | interface to use for inter-host communication   |
+| flannel_network     | {{ openshift.common.portal_net }} or 172.16.1.1/16 | interface to use for inter-host communication   |
 | flannel_min_network | {{ min_network }} or 172.16.5.0                    | beginning of IP range for the subnet allocation |
 | flannel_subnet_len  | /openshift.com/network                             | size of the subnet allocated to each host       |
 | flannel_etcd_key    | /openshift.com/network                             | etcd prefix                                     |

--- a/roles/flannel_register/defaults/main.yaml
+++ b/roles/flannel_register/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-flannel_network: "{{ openshift.master.portal_net | default('172.30.0.0/16', true) }}"
+flannel_network: "{{ openshift.common.portal_net | default('172.30.0.0/16', true) }}"
 flannel_min_network: 172.30.5.0
 flannel_subnet_len: 24
 flannel_etcd_key: /openshift.com/network

--- a/roles/openshift_docker/tasks/main.yml
+++ b/roles/openshift_docker/tasks/main.yml
@@ -10,9 +10,9 @@
       docker_additional_registries: "{{ docker_additional_registries }}"
       docker_insecure_registries: "{{ docker_insecure_registries }}"
       docker_blocked_registries: "{{ docker_blocked_registries }}"
+      portal_net: "{{ openshift_master_portal_net | default(None) }}"
   - role: node
     local_facts:
-      portal_net: "{{ openshift_master_portal_net | default(None) }}"
       docker_log_driver:  "{{ lookup( 'oo_option' , 'docker_log_driver'  )  | default('',True) }}"
       docker_log_options: "{{ lookup( 'oo_option' , 'docker_log_options' )  | default('',True) }}"
 
@@ -44,7 +44,7 @@
   lineinfile:
     dest: /etc/sysconfig/docker
     regexp: '^OPTIONS=.*$'
-    line: "OPTIONS='--insecure-registry={{ openshift.node.portal_net }} \
+    line: "OPTIONS='--insecure-registry={{ openshift.common.portal_net }} \
       {% if ansible_selinux and ansible_selinux.status == '''enabled''' %}--selinux-enabled{% endif %} \
       {% if openshift.node.docker_log_driver is defined  %} --log-driver {{ openshift.node.docker_log_driver }}  {% endif %} \
       {% if openshift.node.docker_log_options is defined %}   {{ openshift.node.docker_log_options |  oo_split() | oo_prepend_strings_in_list('--log-opt ') | join(' ')}}  {% endif %} '"

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -573,9 +573,11 @@ def set_aggregate_facts(facts):
             first_svc_ip = first_ip(facts['master']['portal_net'])
             all_hostnames.add(first_svc_ip)
             internal_hostnames.add(first_svc_ip)
+            facts['common']['kube_svc_ip'] = first_svc_ip
 
         facts['common']['all_hostnames'] = list(all_hostnames)
         facts['common']['internal_hostnames'] = list(internal_hostnames)
+
 
     return facts
 
@@ -1194,7 +1196,7 @@ class OpenShiftFacts(object):
                           console_port='8443', etcd_use_ssl=True, etcd_hosts='',
                           etcd_port='4001', portal_net='172.30.0.0/16',
                           embedded_etcd=True, embedded_kube=True,
-                          embedded_dns=True, dns_port='53',
+                          embedded_dns=True, dns_port='8053',
                           bind_addr='0.0.0.0', session_max_seconds=3600,
                           session_name='ssn', session_secrets_file='',
                           access_token_max_seconds=86400,

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -549,11 +549,13 @@ def set_aggregate_facts(facts):
     """
     all_hostnames = set()
     internal_hostnames = set()
+    kube_svc_ip = first_ip(facts['common']['portal_net'])
     if 'common' in facts:
         all_hostnames.add(facts['common']['hostname'])
         all_hostnames.add(facts['common']['public_hostname'])
         all_hostnames.add(facts['common']['ip'])
         all_hostnames.add(facts['common']['public_ip'])
+        faces['common']['kube_svc_ip'] = kube_svc_ip
 
         internal_hostnames.add(facts['common']['hostname'])
         internal_hostnames.add(facts['common']['ip'])
@@ -570,10 +572,8 @@ def set_aggregate_facts(facts):
                          'kubernetes.default.svc', 'kubernetes.default.svc.' + cluster_domain]
             all_hostnames.update(svc_names)
             internal_hostnames.update(svc_names)
-            first_svc_ip = first_ip(facts['master']['portal_net'])
-            all_hostnames.add(first_svc_ip)
-            internal_hostnames.add(first_svc_ip)
-            facts['common']['kube_svc_ip'] = first_svc_ip
+            all_hostnames.add(kube_svc_ip)
+            internal_hostnames.add(kube_svc_ip)
 
         facts['common']['all_hostnames'] = list(all_hostnames)
         facts['common']['internal_hostnames'] = list(internal_hostnames)
@@ -1183,7 +1183,7 @@ class OpenShiftFacts(object):
 
         common = dict(use_openshift_sdn=True, ip=ip_addr, public_ip=ip_addr,
                       deployment_type='origin', hostname=hostname,
-                      public_hostname=hostname)
+                      public_hostname=hostname, portal_net='172.30.0.0/16')
         common['client_binary'] = 'oc'
         common['admin_binary'] = 'oadm'
         common['dns_domain'] = 'cluster.local'

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1194,7 +1194,7 @@ class OpenShiftFacts(object):
             master = dict(api_use_ssl=True, api_port='8443', controllers_port='8444',
                           console_use_ssl=True, console_path='/console',
                           console_port='8443', etcd_use_ssl=True, etcd_hosts='',
-                          etcd_port='4001', portal_net='172.30.0.0/16',
+                          etcd_port='4001',
                           embedded_etcd=True, embedded_kube=True,
                           embedded_dns=True, dns_port='8053',
                           bind_addr='0.0.0.0', session_max_seconds=3600,
@@ -1205,7 +1205,7 @@ class OpenShiftFacts(object):
             defaults['master'] = master
 
         if 'node' in roles:
-            node = dict(labels={}, annotations={}, portal_net='172.30.0.0/16',
+            node = dict(labels={}, annotations={},
                         iptables_sync_period='5s', set_node_ip=False)
             defaults['node'] = node
 

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -25,7 +25,13 @@
 
 - name: Set master facts
   openshift_facts:
-    role: master
+    role: "{{ item.role }}"
+    local_facts: "{{ item.local_facts }}"
+  with_items:
+  - role: common
+    local_facts:
+      portal_net: "{{ openshift_master_portal_net | default(None) }}"
+  - role: master
     local_facts:
       cluster_method: "{{ openshift_master_cluster_method | default(None) }}"
       cluster_hostname: "{{ openshift_master_cluster_hostname | default(None) }}"
@@ -57,7 +63,6 @@
       dns_port: "{{ openshift_master_dns_port | default(None) }}"
       bind_addr: "{{ openshift_master_bind_addr | default(None) }}"
       pod_eviction_timeout: "{{ openshift_master_pod_eviction_timeout | default(None) }}"
-      portal_net: "{{ openshift_master_portal_net | default(None) }}"
       session_max_seconds: "{{ openshift_master_session_max_seconds | default(None) }}"
       session_name: "{{ openshift_master_session_name | default(None) }}"
       session_secrets_file: "{{ openshift_master_session_secrets_file | default(None) }}"

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -106,7 +106,7 @@ kubernetesMasterConfig:
     keyFile: master.proxy-client.key
   schedulerConfigFile: {{ openshift_master_scheduler_conf }}
   servicesNodePortRange: ""
-  servicesSubnet: {{ openshift.master.portal_net }}
+  servicesSubnet: {{ openshift.common.portal_net }}
   staticNodeNames: {{ openshift_node_ips | default([], true) }}
 {% endif %}
 masterClients:
@@ -121,7 +121,7 @@ networkConfig:
   networkPluginName: {{ openshift.common.sdn_network_plugin_name }}
 {% endif %}
 # serviceNetworkCIDR must match kubernetesMasterConfig.servicesSubnet
-  serviceNetworkCIDR: {{ openshift.master.portal_net }}
+  serviceNetworkCIDR: {{ openshift.common.portal_net }}
 oauthConfig:
 {% if 'oauth_template' in openshift.master %}
   templates:

--- a/roles/openshift_node_dns/README.md
+++ b/roles/openshift_node_dns/README.md
@@ -1,0 +1,59 @@
+OpenShift/Atomic Enterprise Node
+================================
+
+Node service installation
+
+Requirements
+------------
+
+One or more Master servers.
+
+A RHEL 7.1 host pre-configured with access to the rhel-7-server-rpms,
+rhel-7-server-extras-rpms, and rhel-7-server-ose-3.0-rpms repos.
+
+Role Variables
+--------------
+From this role:
+| Name                                     | Default value         |                                                        |
+|------------------------------------------|-----------------------|--------------------------------------------------------|
+| openshift_node_debug_level               | openshift_debug_level | Verbosity of the debug logs for node |
+| oreg_url                                 | UNDEF (Optional)      | Default docker registry to use                         |
+
+From openshift_common:
+| Name                          |  Default Value      |                     |
+|-------------------------------|---------------------|---------------------|
+| openshift_debug_level         | 2                   | Global openshift debug log verbosity |
+| openshift_public_ip           | UNDEF (Required)    | Public IP address to use for this host |
+| openshift_hostname            | UNDEF (Required)    | hostname to use for this instance |
+
+Dependencies
+------------
+
+openshift_common
+
+Example Playbook
+----------------
+
+Notes
+-----
+
+Currently we support re-labeling nodes but we don't re-schedule running pods nor remove existing labels. That means you will have to trigger the re-schedulling manually. To re-schedule your pods, just follow the steps below:
+
+```
+oadm manage-node --schedulable=false ${NODE}
+oadm manage-node --evacuate ${NODE}
+oadm manage-node --schedulable=true ${NODE}
+````
+
+
+TODO
+
+License
+-------
+
+Apache License, Version 2.0
+
+Author Information
+------------------
+
+TODO

--- a/roles/openshift_node_dns/defaults/main.yml
+++ b/roles/openshift_node_dns/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+dns_domain: "cluster.local"
+kube_svc_ip: "172.30.0.1"
+portal_net: "172.30.0.0/16"

--- a/roles/openshift_node_dns/defaults/main.yml
+++ b/roles/openshift_node_dns/defaults/main.yml
@@ -1,4 +1,0 @@
----
-dns_domain: "cluster.local"
-kube_svc_ip: "172.30.0.1"
-portal_net: "172.30.0.0/16"

--- a/roles/openshift_node_dns/files/origin-cluster-resolver.conf
+++ b/roles/openshift_node_dns/files/origin-cluster-resolver.conf
@@ -1,0 +1,2 @@
+[main]
+dns=dnsmasq

--- a/roles/openshift_node_dns/meta/main.yml
+++ b/roles/openshift_node_dns/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: Scott Dodosn
+  description:
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 1.8
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+  - system
+dependencies:
+- { role: openshift_facts }

--- a/roles/openshift_node_dns/tasks/main.yml
+++ b/roles/openshift_node_dns/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: Install NetworkManager
+  action: "{{ ansible_pkg_mgr }} name=NetworkManager state=present"
+  
+- name: Switch resolver to dnsmasq
+  copy:
+    src: origin-cluster-resolver.conf
+    dest: /etc/NetworkManager/conf.d/
+    owner: root
+    group: root
+    mode: 0644
+    
+- name: Configure cluster dns
+  template:
+    src: origin-cluster-dnsmasq.conf.j2
+    dest: /etc/NetworkManager/dnsmasq.d/origin-dns.conf
+    owner: root
+    group: root
+    mode: 0644
+  
+- name: Enable Network Manager
+  service: name=NetworkManager state=started enabled=yes
+    

--- a/roles/openshift_node_dns/templates/origin-cluster-dnsmasq.conf.j2
+++ b/roles/openshift_node_dns/templates/origin-cluster-dnsmasq.conf.j2
@@ -1,0 +1,5 @@
+strict-order
+domain-needed
+server=/{{ dns_domain }}/{{ kube_svc_ip }}#{{ dns_port }}
+#server=/portal_net_reversed.in-addr.arpa/{{ kube_svc_ip }}
+

--- a/roles/openshift_node_dns/vars/main.yml
+++ b/roles/openshift_node_dns/vars/main.yml
@@ -1,0 +1,5 @@
+---
+dns_domain: "cluster.local"
+kube_svc_ip: "172.30.0.1"
+dns_port: "53"
+portal_net: "172.30.0.0/16"


### PR DESCRIPTION
Resolve cluster dns on nodes by configuring dnsmasq and configuring NetworkManager to use it.

TODO:
- [ ] Add a task to move skydns to 8053 and restart master
- [ ] Either configure /etc/resolv.conf with default interface's ip or configure kubelet to add the node ip to the resolver