### PR TITLE
Fix issue when there are no infra nodes

### DIFF
--- a/playbooks/aws/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/aws/openshift-cluster/cluster_hosts.yml
@@ -12,6 +12,6 @@ g_master_hosts:  "{{ g_all_hosts | intersect(groups['tag_host-type_master'] | de
 
 g_node_hosts:    "{{ g_all_hosts | intersect(groups['tag_host-type_node'] | default([])) }}"
 
-g_infra_hosts:   "{{ g_node_hosts | intersect(groups['tag_sub-host-type_infra']) | default([]) }}"
+g_infra_hosts:   "{{ g_node_hosts | intersect(groups['tag_sub-host-type_infra'] | default([])) }}"
 
-g_compute_hosts: "{{ g_node_hosts | intersect(groups['tag_sub-host-type_compute']) | default([]) }}"
+g_compute_hosts: "{{ g_node_hosts | intersect(groups['tag_sub-host-type_compute'] | default([])) }}"

--- a/playbooks/gce/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/gce/openshift-cluster/cluster_hosts.yml
@@ -12,6 +12,6 @@ g_master_hosts:  "{{ g_all_hosts | intersect(groups['tag_host-type-master'] | de
 
 g_node_hosts:    "{{ g_all_hosts | intersect(groups['tag_host-type-node'] | default([])) }}"
 
-g_infra_hosts:   "{{ g_node_hosts | intersect(groups['tag_sub-host-type-infra']) | default([]) }}"
+g_infra_hosts:   "{{ g_node_hosts | intersect(groups['tag_sub-host-type-infra'] | default([])) }}"
 
-g_compute_hosts: "{{ g_node_hosts | intersect(groups['tag_sub-host-type-compute']) | default([]) }}"
+g_compute_hosts: "{{ g_node_hosts | intersect(groups['tag_sub-host-type-compute'] | default([])) }}"

--- a/playbooks/libvirt/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/libvirt/openshift-cluster/cluster_hosts.yml
@@ -12,6 +12,6 @@ g_master_hosts:  "{{ g_all_hosts | intersect(groups['tag_host-type-master'] | de
 
 g_node_hosts:    "{{ g_all_hosts | intersect(groups['tag_host-type-node'] | default([])) }}"
 
-g_infra_hosts:   "{{ g_node_hosts | intersect(groups['tag_sub-host-type-infra']) | default([]) }}"
+g_infra_hosts:   "{{ g_node_hosts | intersect(groups['tag_sub-host-type-infra'] | default([])) }}"
 
-g_compute_hosts: "{{ g_node_hosts | intersect(groups['tag_sub-host-type-compute']) | default([]) }}"
+g_compute_hosts: "{{ g_node_hosts | intersect(groups['tag_sub-host-type-compute'] | default([])) }}"

--- a/playbooks/openstack/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/openstack/openshift-cluster/cluster_hosts.yml
@@ -12,6 +12,6 @@ g_master_hosts:  "{{ g_all_hosts | intersect(groups['tag_host-type_master'] | de
 
 g_node_hosts:    "{{ g_all_hosts | intersect(groups['tag_host-type_node'] | default([])) }}"
 
-g_infra_hosts:   "{{ g_node_hosts | intersect(groups['tag_sub-host-type_infra']) | default([]) }}"
+g_infra_hosts:   "{{ g_node_hosts | intersect(groups['tag_sub-host-type_infra'] | default([])) }}"
 
-g_compute_hosts: "{{ g_node_hosts | intersect(groups['tag_sub-host-type_compute']) | default([]) }}"
+g_compute_hosts: "{{ g_node_hosts | intersect(groups['tag_sub-host-type_compute'] | default([])) }}"


### PR DESCRIPTION
It seems that a parenthesis was not at the same place in the definition of `g_{all,etcd,lb,nfs,master,node}_hosts` and in the definition of `g_{infra,compute}_hosts`.
It is problematic when there is no `infra` node at all. As soon as there is one `infra` node somewhere, the error will remain hidden, even if the cluster being spawned has no `infra` node.