### PR TITLE
Better structure the output of the list playbook

### DIFF
--- a/playbooks/gce/openshift-cluster/list.yml
+++ b/playbooks/gce/openshift-cluster/list.yml
@@ -18,9 +18,16 @@
       ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
     with_items: groups[scratch_group] | default([], true) | difference(['localhost']) | difference(groups.status_terminated | default([], true))
 
-- name: List instance(s)
+- name: List Hosts
   hosts: oo_list_hosts
+
+- name: List Hosts
+  hosts: localhost
+  become: no
+  connection: local
   gather_facts: no
+  vars_files:
+  - vars.yml
   tasks:
   - debug:
-      msg: "public ip: {{ hostvars[inventory_hostname].gce_public_ip }} private ip:{{ hostvars[inventory_hostname].gce_private_ip }}"
+      msg: "{{ hostvars | oo_select_keys(groups[scratch_group] | default([])) | oo_pretty_print_cluster }}"


### PR DESCRIPTION
The list playbook listed the IPs of the VMs without logging their role like:

```
PLAY [List instance(s)] *******************************************************

TASK: [debug ] ****************************************************************
ok: [lenaic-node-compute-cd81b] => {
    "msg": "public ip: 104.155.50.164 private ip:10.55.0.49"
}
ok: [lenaic-master-9e767] => {
    "msg": "public ip: 104.155.47.180 private ip:10.55.0.113"
}
ok: [lenaic-node-infra-ab7c8] => {
    "msg": "public ip: 104.155.11.34 private ip:10.55.0.131"
}
```

The list playbook now prints the information in a more structured way like:

```
PLAY [List Hosts] *************************************************************

TASK: [debug ] ****************************************************************
ok: [localhost] => {
    "msg": {
        "lenaic": {
            "master": {
                "default": [
                    {
                        "name": "lenaic-master-9e767",
                        "private IP": "10.55.0.113",
                        "public IP": "104.155.47.180"
                    }
                ]
            },
            "node": {
                "compute": [
                    {
                        "name": "lenaic-node-compute-cd81b",
                        "private IP": "10.55.0.49",
                        "public IP": "104.155.50.164"
                    }
                ],
                "infra": [
                    {
                        "name": "lenaic-node-infra-ab7c8",
                        "private IP": "10.55.0.131",
                        "public IP": "104.155.11.34"
                    }
                ]
            }
        }
    }
}
```

This change of the output of the list playbook was previously done for OpenStack and libvirt
in 332aa8c (#461).
This change makes the GCE output identical to OpenStack and libvirt’s one.