### PR TITLE
Fix loopback cluster name, context name, and user

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -525,10 +525,11 @@ def set_url_facts_if_unset(facts):
                                                                    ports[prefix]))
 
 
-        r_lhn = "{0}:{1}".format(api_hostname, ports['api']).replace('.', '-')
+        r_lhn = "{0}:{1}".format(hostname, ports['api']).replace('.', '-')
+        r_lhu = "system:openshift-master/{0}:{1}".format(api_hostname, ports['api']).replace('.', '-')
         facts['master'].setdefault('loopback_cluster_name', r_lhn)
         facts['master'].setdefault('loopback_context_name', "default/{0}/system:openshift-master".format(r_lhn))
-        facts['master'].setdefault('loopback_user', "system:openshift-master/{0}".format(r_lhn))
+        facts['master'].setdefault('loopback_user', r_lhu)
 
         prefix_hosts = [('console', api_hostname), ('public_console', api_public_hostname)]
         for prefix, host in prefix_hosts:

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -737,9 +737,9 @@ def set_version_facts_if_unset(facts):
                 version_gte_3_1_1_or_1_1_1 = LooseVersion(version) >= LooseVersion('1.1.1')
                 version_gte_3_2_or_1_2 = LooseVersion(version) >= LooseVersion('1.1.2')
             else:
-                version_gte_3_1_or_1_1 = LooseVersion(version) >= LooseVersion('3.1.0')
+                version_gte_3_1_or_1_1 = LooseVersion(version) >= LooseVersion('3.0.2.905')
                 version_gte_3_1_1_or_1_1_1 = LooseVersion(version) >= LooseVersion('3.1.1')
-                version_gte_3_2_or_1_2 = LooseVersion(version) >= LooseVersion('3.2.0')
+                version_gte_3_2_or_1_2 = LooseVersion(version) >= LooseVersion('3.1.1.901')
         else:
             version_gte_3_1_or_1_1 = True
             version_gte_3_1_1_or_1_1_1 = True

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -240,36 +240,8 @@
   - restart master api
   - restart master controllers
 
-- name: Test local loopback context
-  command: >
-    {{ openshift.common.client_binary }} config view
-    --config={{ openshift_master_loopback_config }}
-  changed_when: false
-  register: loopback_config
-
-- command: >
-    {{ openshift.common.client_binary }} config set-cluster
-    --certificate-authority={{ openshift_master_config_dir }}/ca.crt
-    --embed-certs=true --server={{ openshift.master.loopback_api_url }}
-    {{ openshift.master.loopback_cluster_name }}
-    --config={{ openshift_master_loopback_config }}
-  when: loopback_context_string not in loopback_config.stdout
-  register: set_loopback_cluster
-
-- command: >
-    {{ openshift.common.client_binary }} config set-context
-    --cluster={{ openshift.master.loopback_cluster_name }}
-    --namespace=default --user={{ openshift.master.loopback_user }}
-    {{ openshift.master.loopback_context_name }}
-    --config={{ openshift_master_loopback_config }}
-  when: set_loopback_cluster | changed
-  register: set_loopback_context
-
-- command: >
-    {{ openshift.common.client_binary }} config use-context {{ openshift.master.loopback_context_name }}
-    --config={{ openshift_master_loopback_config }}
-  when: set_loopback_context | changed
-  register: set_current_context
+- include: set_loopback_context.yml
+  when: openshift.common.version_gte_3_2_or_1_2
 
 - name: Start and enable master
   service: name={{ openshift.common.service_type }}-master enabled=yes state=started

--- a/roles/openshift_master/tasks/set_loopback_context.yml
+++ b/roles/openshift_master/tasks/set_loopback_context.yml
@@ -1,0 +1,31 @@
+---
+- name: Test local loopback context
+  command: >
+    {{ openshift.common.client_binary }} config view
+    --config={{ openshift_master_loopback_config }}
+  changed_when: false
+  register: loopback_config
+
+- command: >
+    {{ openshift.common.client_binary }} config set-cluster
+    --certificate-authority={{ openshift_master_config_dir }}/ca.crt
+    --embed-certs=true --server={{ openshift.master.loopback_api_url }}
+    {{ openshift.master.loopback_cluster_name }}
+    --config={{ openshift_master_loopback_config }}
+  when: loopback_context_string not in loopback_config.stdout
+  register: set_loopback_cluster
+
+- command: >
+    {{ openshift.common.client_binary }} config set-context
+    --cluster={{ openshift.master.loopback_cluster_name }}
+    --namespace=default --user={{ openshift.master.loopback_user }}
+    {{ openshift.master.loopback_context_name }}
+    --config={{ openshift_master_loopback_config }}
+  when: set_loopback_cluster | changed
+  register: set_loopback_context
+
+- command: >
+    {{ openshift.common.client_binary }} config use-context {{ openshift.master.loopback_context_name }}
+    --config={{ openshift_master_loopback_config }}
+  when: set_loopback_context | changed
+  register: set_current_context


### PR DESCRIPTION
This PR fixes the loopback config for a multi-master setup, where previously it was still using the internal clustered DNS name. 

Currently blocked on the following bug: https://bugzilla.redhat.com/show_bug.cgi?id=1306011

Will need to be conditionalized to not use the loopback config unless the version includes the fix from the above BZ.