### PR TITLE
Add missing atomic- and openshift-enterprise

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     libvirt.memory = 1024
     libvirt.driver = 'kvm'
     case deployment_type
-    when "enterprise"
+    when "openshift-enterprise"
+      override.vm.box = "rhel-7"
+    when "atomic-enterprise"
       override.vm.box = "rhel-7"
     when "origin"
       override.vm.box = "centos/7"

--- a/playbooks/aws/openshift-cluster/terminate.yml
+++ b/playbooks/aws/openshift-cluster/terminate.yml
@@ -18,7 +18,7 @@
   hosts: oo_hosts_to_terminate
   roles:
   - role: rhel_unsubscribe
-    when: deployment_type == "enterprise" and
+    when: deployment_type in ['atomic-enterprise', 'enterprise', 'openshift-enterprise'] and
           ansible_distribution == "RedHat" and
           lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
             default('no', True) | lower in ['no', 'false']

--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -4,7 +4,7 @@
     openshift_deployment_type: "{{ deployment_type }}"
   roles:
   - role: rhel_subscribe
-    when: deployment_type == "enterprise" and
+    when: deployment_type in ['atomic-enterprise', 'enterprise', 'openshift-enterprise'] and
           ansible_distribution == "RedHat" and
           lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
           default('no', True) | lower in ['no', 'false']

--- a/playbooks/gce/openshift-cluster/terminate.yml
+++ b/playbooks/gce/openshift-cluster/terminate.yml
@@ -20,7 +20,7 @@
   - vars.yml
   roles:
   - role: rhel_unsubscribe
-    when: deployment_type == "enterprise" and
+    when: deployment_type in ['atomic-enterprise', 'enterprise', 'openshift-enterprise'] and
           ansible_distribution == "RedHat" and
           lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
             default('no', True) | lower in ['no', 'false']

--- a/playbooks/libvirt/openshift-cluster/terminate.yml
+++ b/playbooks/libvirt/openshift-cluster/terminate.yml
@@ -23,7 +23,7 @@
   - vars.yml
   roles:
   - role: rhel_unsubscribe
-    when: deployment_type == "enterprise" and
+    when: deployment_type in ['atomic-enterprise', 'enterprise', 'openshift-enterprise'] and
           ansible_distribution == "RedHat" and
           lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
             default('no', True) | lower in ['no', 'false']

--- a/playbooks/openstack/openshift-cluster/terminate.yml
+++ b/playbooks/openstack/openshift-cluster/terminate.yml
@@ -19,7 +19,7 @@
   - vars.yml
   roles:
   - role: rhel_unsubscribe
-    when: deployment_type == "enterprise" and
+    when: deployment_type in ['atomic-enterprise', 'enterprise', 'openshift-enterprise'] and
           ansible_distribution == "RedHat" and
           lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
             default('no', True) | lower in ['no', 'false']


### PR DESCRIPTION
Some checks related to enterprise deployments were still only looking for "enterprise" deployment_type.
Update them to cover "atomic-enterprise" and "openshift-enterprise" for deployment type.
