### PR TITLE
Specify default namespace when creating router

### DIFF
--- a/roles/openshift_router/tasks/main.yml
+++ b/roles/openshift_router/tasks/main.yml
@@ -3,6 +3,7 @@
   command: >
     {{ openshift.common.admin_binary }} router
     --create --replicas={{ openshift.master.infra_nodes | length }}
+    --namespace=default
     --service-account=router {{ ortr_selector }}
     --credentials={{ openshift_master_config_dir }}/openshift-router.kubeconfig {{ ortr_images }}
   register: ortr_results


### PR DESCRIPTION
In case we have switched projects before running ansible.