### PR TITLE
add iscsi storage_plugin dependency

### DIFF
--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -142,7 +142,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 
 # default storage plugin dependencies to install, by default the ceph and
 # glusterfs plugin dependencies will be installed, if available.
-#osn_storage_plugin_deps=['ceph','glusterfs']
+#osn_storage_plugin_deps=['ceph','glusterfs','iscsi']
 
 # default selectors for router and registry services
 # openshift_router_selector='region=infra'

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -147,7 +147,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 
 # default storage plugin dependencies to install, by default the ceph and
 # glusterfs plugin dependencies will be installed, if available.
-#osn_storage_plugin_deps=['ceph','glusterfs']
+#osn_storage_plugin_deps=['ceph','glusterfs','iscsi']
 
 # default selectors for router and registry services
 # openshift_router_selector='region=infra'

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -711,7 +711,7 @@ def set_deployment_facts_if_unset(facts):
     if 'node' in facts:
         deployment_type = facts['common']['deployment_type']
         if 'storage_plugin_deps' not in facts['node']:
-            if deployment_type in ['openshift-enterprise', 'atomic-enterprise']:
+            if deployment_type in ['openshift-enterprise', 'atomic-enterprise', 'origin']:
                 facts['node']['storage_plugin_deps'] = ['ceph', 'glusterfs', 'iscsi']
             else:
                 facts['node']['storage_plugin_deps'] = []

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -712,7 +712,7 @@ def set_deployment_facts_if_unset(facts):
         deployment_type = facts['common']['deployment_type']
         if 'storage_plugin_deps' not in facts['node']:
             if deployment_type in ['openshift-enterprise', 'atomic-enterprise']:
-                facts['node']['storage_plugin_deps'] = ['ceph', 'glusterfs']
+                facts['node']['storage_plugin_deps'] = ['ceph', 'glusterfs', 'iscsi']
             else:
                 facts['node']['storage_plugin_deps'] = []
 

--- a/roles/openshift_node/tasks/storage_plugins/iscsi.yml
+++ b/roles/openshift_node/tasks/storage_plugins/iscsi.yml
@@ -1,0 +1,4 @@
+---
+- name: Install iSCSI storage plugin dependencies
+  action: "{{ ansible_pkg_mgr }} name=iscsi-initiator-utils state=present"
+  when: not openshift.common.is_atomic | bool

--- a/roles/openshift_node/tasks/storage_plugins/main.yml
+++ b/roles/openshift_node/tasks/storage_plugins/main.yml
@@ -11,3 +11,7 @@
 - name: Ceph storage plugin configuration
   include: ceph.yml
   when: "'ceph' in openshift.node.storage_plugin_deps"
+
+- name: iSCSI storage plugin configuration
+  include: iscsi.yml
+  when: "'iscsi' in openshift.node.storage_plugin_deps"


### PR DESCRIPTION
This adds a storage_plugin task for iSCSI dependency configurable using the existing openshift.node.storage_plugin_deps variable. This does not change the default value for this variable.