### PR TITLE
handle being passed an empty group list

### DIFF
--- a/roles/lib_zabbix/library/zbx_action.py
+++ b/roles/lib_zabbix/library/zbx_action.py
@@ -228,12 +228,12 @@ def get_user_groups(zapi, groups):
     '''get the mediatype id from the mediatype name'''
     user_groups = []
 
-    content = zapi.get_content('usergroup',
-                               'get',
-                               {'search': {'name': groups}})
-
-    for usr_grp in content['result']:
-        user_groups.append({'usrgrpid': usr_grp['usrgrpid']})
+    for group in groups:
+        content = zapi.get_content('usergroup',
+                                   'get',
+                                   {'search': {'name': group}})
+        for result in content['result']:
+            user_groups.append({'usrgrpid': result['usrgrpid']})
 
     return user_groups
 


### PR DESCRIPTION
Previous version would have the behavior where when an empty list is passed, the zbx API call would return a list of all groups. So an action with no groups defined would default to having all groups added to the operations.
Handle this by iterating one at a time through the list of provided groups. When an empty list is provided, and empty list is returned.