### PR TITLE
Change etcd deamon name for atomic-host in playbooks/adhoc/uninstall.yml

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -53,6 +53,13 @@
         - pcsd
       failed_when: false
 
+    - name: Stop additional atomic services
+      service: name={{ item }} state=stopped
+      when: is_atomic | bool
+      with_items:
+        - etcd_container
+      failed_when: false
+
     - name: Remove packages
       action: "{{ ansible_pkg_mgr }} name={{ item }} state=absent"
       when: not is_atomic | bool


### PR DESCRIPTION
On atomic host the "rm /var/lib/etcd" fail because etcd still running. The "deamon" name is not etcd

```bash
systemctl -l | grep etcd
  etcd_container.service                                                                    loaded active running   The Etcd Server container
```
Updated to add a different name of service between rhel and atomic host