### PR TITLE
Add missing `type` node labels on OpenStack and libvirt

### DIFF
--- a/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
@@ -94,6 +94,16 @@
 - set_fact:
     ips: "{{ scratch_ip.results | default([]) | oo_collect('stdout') }}"
 
+- set_fact:
+    node_label:
+      type: "{{ g_sub_host_type }}"
+  when: instances | length > 0 and type == "node"
+
+- set_fact:
+    node_label:
+      type: "{{ type }}"
+  when: instances | length > 0 and type != "node"
+
 - name: Add new instances
   add_host:
     hostname: '{{ item.0 }}'
@@ -101,6 +111,7 @@
     ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
     ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
     groups: "tag_environment-{{ cluster_env }}, tag_host-type-{{ type }}, tag_sub-host-type-{{ g_sub_host_type }}, tag_clusterid-{{ cluster_id }}"
+    openshift_node_labels: "{{ node_label }}"
   with_together:
     - instances
     - ips

--- a/playbooks/openstack/openshift-cluster/launch.yml
+++ b/playbooks/openstack/openshift-cluster/launch.yml
@@ -75,6 +75,8 @@
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
       groups: 'tag_environment_{{ cluster_env }}, tag_host-type_etcd, tag_sub-host-type_default, tag_clusterid_{{ cluster_id }}'
+      openshift_node_labels:
+        type: "etcd"
     with_together:
       - parsed_outputs.etcd_names
       - parsed_outputs.etcd_ips
@@ -87,6 +89,8 @@
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
       groups: 'tag_environment_{{ cluster_env }}, tag_host-type_master, tag_sub-host-type_default, tag_clusterid_{{ cluster_id }}'
+      openshift_node_labels:
+        type: "master"
     with_together:
       - parsed_outputs.master_names
       - parsed_outputs.master_ips
@@ -99,6 +103,8 @@
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
       groups: 'tag_environment_{{ cluster_env }}, tag_host-type_node, tag_sub-host-type_compute, tag_clusterid_{{ cluster_id }}'
+      openshift_node_labels:
+        type: "compute"
     with_together:
       - parsed_outputs.node_names
       - parsed_outputs.node_ips
@@ -111,6 +117,8 @@
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_sudo: "{{ deployment_vars[deployment_type].sudo }}"
       groups: 'tag_environment_{{ cluster_env }}, tag_host-type_node, tag_sub-host-type_infra, tag_clusterid_{{ cluster_id }}'
+      openshift_node_labels:
+        type: "infra"
     with_together:
       - parsed_outputs.infra_names
       - parsed_outputs.infra_ips


### PR DESCRIPTION
This fixes, for example, the fact that the OpenShift router was not starting on OpenStack and libvirt.