### PR TITLE
Fix libvirt cluster creation

### DIFF
--- a/playbooks/libvirt/openshift-cluster/templates/user-data
+++ b/playbooks/libvirt/openshift-cluster/templates/user-data
@@ -3,7 +3,6 @@ disable_root: true
 
 hostname: {{ item[0] }}
 fqdn: {{ item[0] }}.example.com
-manage_etc_hosts: true
 
 users:
   - default


### PR DESCRIPTION
Doing a `bin/cluster create libvirt …` fails with the following error:

```
TASK: [Warn user about bad openshift_hostname values] *************************
[lenaic-node-compute-cf3fb, lenaic-node-compute-f39d3, lenaic-node-infra-0407f, lenaic-master-fc5f9]
The hostname "lenaic-node-compute-cf3fb.example.com" for "lenaic-node-compute-cf3fb.example.com" doesn't resolve to an ip address owned by this host. Please set openshift_hostname variable to a hostname that when resolved on the host in question resolves to an IP address matching an interface on this host. This host will fail liveness checks for pods utilizing hostPorts, press CTRL-C to continue.:
```

because the `/etc/hosts` of the VM is containing:

```
[openshift@lenaic-node-compute-cf3fb ~]$ cat /etc/hosts
# Your system has configured 'manage_etc_hosts' as True.
# As a result, if you wish for changes to this file to persist
# then you will need to either
# a.) make changes to the master file in /etc/cloud/templates/hosts.redhat.tmpl
# b.) change or remove the value of 'manage_etc_hosts' in
#     /etc/cloud/cloud.cfg or cloud-config from user-data
#
# The following lines are desirable for IPv4 capable hosts
127.0.0.1 lenaic-node-compute-cf3fb.example.com lenaic-node-compute-cf3fb
127.0.0.1 localhost.localdomain localhost
127.0.0.1 localhost4.localdomain4 localhost4

# The following lines are desirable for IPv6 capable hosts
::1 lenaic-node-compute-cf3fb.example.com lenaic-node-compute-cf3fb
::1 localhost.localdomain localhost
::1 localhost6.localdomain6 localhost6
```

Disabling `manage_etc_hosts` removes the lines for `lenaic-node-compute-cf3fb` from `/etc/hosts`
and makes that name resolved by the DNS to its real IP.