### PR TITLE
Don't automatically give additional permissions to all OAuth users on upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
@@ -501,6 +501,7 @@
       {{ openshift.common.admin_binary}} --config={{ openshift.common.config_base }}/master/admin.kubeconfig
       policy reconcile-cluster-role-bindings
       --exclude-groups=system:authenticated
+      --exclude-groups=system:authenticated:oauth
       --exclude-groups=system:unauthenticated
       --exclude-users=system:anonymous
       --additive-only=true --confirm

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_minor/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_minor/upgrade.yml
@@ -109,6 +109,7 @@
       {{ openshift.common.admin_binary}} --config={{ openshift.common.config_base }}/master/admin.kubeconfig
       policy reconcile-cluster-role-bindings
       --exclude-groups=system:authenticated
+      --exclude-groups=system:authenticated:oauth
       --exclude-groups=system:unauthenticated
       --exclude-users=system:anonymous
       --additive-only=true --confirm


### PR DESCRIPTION
OAuth-authenticated users have the `system:authenticated:oauth` group as of https://github.com/openshift/origin/pull/7054, which is what the bootstrap policy gives permission to request projects (to ensure service accounts cannot create new projects by default).

We should exclude that group from automatically gaining new permissions on upgrades, or a cluster-admin's decision to remove project request access would be reverted.

The exclude is a no-op if the group doesn't exist.