### PR TITLE
Add extra parameters for S3 registry: delete file, create bucket.

### DIFF
--- a/playbooks/adhoc/s3_registry/s3_registry.yml
+++ b/playbooks/adhoc/s3_registry/s3_registry.yml
@@ -15,6 +15,8 @@
     aws_secret_key: "{{ lookup('env', 'S3_SECRET_ACCESS_KEY') }}"
     aws_bucket_name: "{{ aws_bucket | default(clusterid ~ '-docker') }}"
     aws_bucket_region: "{{ aws_region | default(lookup('env', 'S3_REGION') | default('us-east-1', true)) }}"
+    aws_create_bucket: "{{ aws_create | default(True) }}"
+    aws_delete_after_run: "{{ aws_delete_temp | default(True) }}"
 
   tasks:
 
@@ -30,6 +32,7 @@
     command: oc scale --replicas=0 dc/docker-registry
 
   - name: Create S3 bucket
+    when: aws_create_bucket | bool
     local_action:
       module: s3 bucket="{{ aws_bucket_name }}" mode=create
 
@@ -71,3 +74,4 @@
 
   - name: Delete temporary config file
     file: path=/root/config.yml state=absent
+    when: aws_delete_after_run | bool

--- a/playbooks/adhoc/s3_registry/s3_registry.yml
+++ b/playbooks/adhoc/s3_registry/s3_registry.yml
@@ -16,7 +16,8 @@
     aws_bucket_name: "{{ aws_bucket | default(clusterid ~ '-docker') }}"
     aws_bucket_region: "{{ aws_region | default(lookup('env', 'S3_REGION') | default('us-east-1', true)) }}"
     aws_create_bucket: "{{ aws_create | default(True) }}"
-    aws_delete_after_run: "{{ aws_delete_temp | default(True) }}"
+    aws_tmp_path: "{{ aws_tmp_pathfile | default('/root/config.yml')}}"
+    aws_delete_tmp_file: "{{ aws_delete_tmp | default(True) }}"
 
   tasks:
 
@@ -73,5 +74,5 @@
     command: oc scale --replicas=1 dc/docker-registry
 
   - name: Delete temporary config file
-    file: path=/root/config.yml state=absent
-    when: aws_delete_after_run | bool
+    file: path={{ aws_tmp_path }} state=absent
+    when: aws_delete_tmp_file | bool


### PR DESCRIPTION
Thought it would be nice to have options to be able to:
* Delete or not the temporary config file - so that it can be check/modified directly
* Create or not the bucket, as you might not have the right to do so
* Configure the path - to avoid issue if not ran as root

This commit allows those things, without changing the default behavior of the playbook.