### PR TITLE
Add missing is_atomic condition in the upgrade playbook

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_minor/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_minor/upgrade.yml
@@ -13,6 +13,7 @@
   tasks:
   - name: Upgrade master packages
     command: "{{ ansible_pkg_mgr}} update -y {{ openshift.common.service_type }}-master{{ openshift_version }}"
+    when: not openshift.common.is_atomic | bool
 
   - name: Ensure python-yaml present for config upgrade
     action: "{{ ansible_pkg_mgr }} name=PyYAML state=present"
@@ -63,6 +64,7 @@
   tasks:
   - name: Upgrade node packages
     command: "{{ ansible_pkg_mgr }} update -y {{ openshift.common.service_type }}-node{{ openshift_version }}"
+    when: not openshift.common.is_atomic | bool
 
   - name: Restart node service
     service: name="{{ openshift.common.service_type }}-node" state=restarted

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_minor/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_minor/upgrade.yml
@@ -13,11 +13,11 @@
   tasks:
   - name: Upgrade master packages
     command: "{{ ansible_pkg_mgr}} update -y {{ openshift.common.service_type }}-master{{ openshift_version }}"
-    when: not openshift.common.is_atomic | bool
+    when: not openshift.common.is_containerized | bool
 
   - name: Ensure python-yaml present for config upgrade
     action: "{{ ansible_pkg_mgr }} name=PyYAML state=present"
-    when: not openshift.common.is_atomic | bool
+    when: not openshift.common.is_containerized | bool
 
 # Currently 3.1.1 does not have any new configuration settings
 #
@@ -64,7 +64,7 @@
   tasks:
   - name: Upgrade node packages
     command: "{{ ansible_pkg_mgr }} update -y {{ openshift.common.service_type }}-node{{ openshift_version }}"
-    when: not openshift.common.is_atomic | bool
+    when: not openshift.common.is_containerized | bool
 
   - name: Restart node service
     service: name="{{ openshift.common.service_type }}-node" state=restarted


### PR DESCRIPTION
Update playbooks/common/openshift-cluster/upgrades/v3_1_minor/upgrade.yml

Add when not is_atomic on yum upgrade on master and node to be able to run the playbook on atomic host