### PR TITLE
Fix openshift_repos role to support paths with spaces

### DIFF
--- a/roles/openshift_repos/tasks/main.yaml
+++ b/roles/openshift_repos/tasks/main.yaml
@@ -46,19 +46,19 @@
   with_fileglob:
   - '*/repos/*'
   when: not (item | search("/files/fedora-" ~ openshift_deployment_type ~ "/repos")) and
-        (ansible_distribution == "Fedora") 
+        (ansible_distribution == "Fedora")
         and not openshift.common.is_containerized | bool
   notify: refresh cache
 
 - name: Configure gpg keys if needed
-  copy: src={{ item }} dest=/etc/pki/rpm-gpg/
+  copy: src="{{ item }}" dest=/etc/pki/rpm-gpg/
   with_fileglob:
   - "{{ openshift_deployment_type }}/gpg_keys/*"
   notify: refresh cache
   when: not openshift.common.is_containerized | bool
 
 - name: Configure yum repositories RHEL/CentOS
-  copy: src={{ item }} dest=/etc/yum.repos.d/
+  copy: src="{{ item }}" dest=/etc/yum.repos.d/
   with_fileglob:
   - "{{ openshift_deployment_type }}/repos/*"
   notify: refresh cache
@@ -66,7 +66,7 @@
         and not openshift.common.is_containerized | bool
 
 - name: Configure yum repositories Fedora
-  copy: src={{ item }} dest=/etc/yum.repos.d/
+  copy: src="{{ item }}" dest=/etc/yum.repos.d/
   with_fileglob:
   - "fedora-{{ openshift_deployment_type }}/repos/*"
   notify: refresh cache


### PR DESCRIPTION
The copy tasks in the openshift_repos fail when it is run from a path containing spaces. Surrounding the `{{item}}` argument with quotes fixes the jinja2 expansion

Example: Running `bin/cluster aws create 'clustername' ` in `/Users/dmat/Google Drive/openshift-ansible`.

_Before_

The tasks fail because the jinja template expands

````
src={{ item }} dest=/etc/pki/rpm-gpg/
````

to 

```
src=/Users/dmat/Google Drive/openshift-ansible  dest=/etc/pki/rpm-gpg/
```

which means ansible goes looking in /Users/dmat/Google and doesn't find anything.


_After_

```
src="/Users/dmat/Google Drive/openshift-ansible"  dest=/etc/pki/rpm-gpg/
```

and ansible looks in the correct location