### PR TITLE
Correct parsing of ec2_security_groups env variable

### DIFF
--- a/playbooks/aws/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/aws/openshift-cluster/tasks/launch_instances.yml
@@ -34,26 +34,22 @@
 
 - set_fact:
     ec2_instance_type: "{{ ec2_master_instance_type | default(lookup('env', 'ec2_master_instance_type') | default(lookup('env', 'ec2_instance_type') | default(deployment_vars[deployment_type].type, true), true), true) }}"
-    ec2_security_groups: "{{ ec2_master_security_groups
-                    | default(deployment_vars[deployment_type].security_groups, true) }}"
+    ec2_security_groups: "{{ ec2_master_security_groups | default(lookup('env', 'ec2_master_security_groups') | default(lookup('env', 'ec2_security_groups') | default(deployment_vars[deployment_type].security_groups, true), true), true) }}"
   when: host_type == "master" and sub_host_type == "default"
 
 - set_fact:
     ec2_instance_type: "{{ ec2_etcd_instance_type | default(lookup('env', 'ec2_etcd_instance_type') | default(lookup('env', 'ec2_instance_type') | default(deployment_vars[deployment_type].type, true), true), true) }}"
-    ec2_security_groups: "{{ ec2_etcd_security_groups
-                    | default(deployment_vars[deployment_type].security_groups, true)}}"
+    ec2_security_groups: "{{ ec2_etcd_security_groups | default(lookup('env', 'ec2_etcd_security_groups') | default(lookup('env', 'ec2_security_groups') | default(deployment_vars[deployment_type].security_groups, true), true), true) }}"
   when: host_type == "etcd" and sub_host_type == "default"
 
 - set_fact:
     ec2_instance_type: "{{ ec2_infra_instance_type | default(lookup('env', 'ec2_infra_instance_type') | default(lookup('env', 'ec2_instance_type') | default(deployment_vars[deployment_type].type, true), true), true) }}"
-    ec2_security_groups: "{{ ec2_infra_security_groups
-                    | default(deployment_vars[deployment_type].security_groups, true) }}"
+    ec2_security_groups: "{{ ec2_infra_security_groups | default(lookup('env', 'ec2_infra_security_groups') | default(lookup('env', 'ec2_security_groups') | default(deployment_vars[deployment_type].security_groups, true), true), true) }}"
   when: host_type == "node" and sub_host_type == "infra"
 
 - set_fact:
     ec2_instance_type: "{{ ec2_node_instance_type | default(lookup('env', 'ec2_node_instance_type') | default(lookup('env', 'ec2_instance_type') | default(deployment_vars[deployment_type].type, true), true), true) }}"
-    ec2_security_groups: "{{ ec2_node_security_groups
-                    | default(deployment_vars[deployment_type].security_groups, true) }}"
+    ec2_security_groups: "{{ ec2_node_security_groups | default(lookup('env', 'ec2_node_security_groups') | default(lookup('env', 'ec2_security_groups') | default(deployment_vars[deployment_type].security_groups, true), true), true) }}"
   when: host_type == "node" and sub_host_type == "compute"
 
 - set_fact:
@@ -61,8 +57,7 @@
                           | default(deployment_vars[deployment_type].type, true) }}"
   when: ec2_instance_type is not defined
 - set_fact:
-    ec2_security_groups: "{{ lookup('env', 'ec2_security_groups')
-                    | default(deployment_vars[deployment_type].security_groups, true) }}"
+    ec2_security_groups: "{{ lookup('env', 'ec2_security_groups') | default(deployment_vars[deployment_type].security_groups, true) }}"
   when: ec2_security_groups is not defined
 
 - name: Find amis for deployment_type


### PR DESCRIPTION
Similar to pull request #918 which fixed the parsing og the ec2_instance_type env. variable.

The `README_AWS.md` specifies that `export ec2_security_groups="['public']"` can be used to declare the security groups the instances will belong to. However, this is currently disregarded in the implementation and instead the default deployment_vars are always used.

This fix aligns the population of the `ec2_security_groups` with the  `ec2_instance_type` environment variable.
