### PR TITLE
Increase timeout on Wait for Node Registration

### DIFF
--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -4,7 +4,7 @@
   register: omd_get_node
   until: omd_get_node.rc == 0
   retries: 20
-  delay: 5
+  delay: 30
   changed_when: false
   with_items: openshift_nodes
 

--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -3,8 +3,8 @@
       {{ openshift.common.client_binary }} get node {{ item | lower }}
   register: omd_get_node
   until: omd_get_node.rc == 0
-  retries: 20
-  delay: 30
+  retries: 50
+  delay: 5
   changed_when: false
   with_items: openshift_nodes
 


### PR DESCRIPTION
The "Wait for Node Registration task" in the openshift_manage_node task fails often when deploying a cluster to AWS. (using the `bin/cluster` script)

When re-applying the role a few minutes later, there are never issues.

Hence, I would propose to increase the timeout. The setting below works reliably for me.