### PR TITLE
Pass registry claim to openshift_registry.

### DIFF
--- a/playbooks/common/openshift-cluster/additional_config.yml
+++ b/playbooks/common/openshift-cluster/additional_config.yml
@@ -52,4 +52,5 @@
   - role: openshift_router
     when: deploy_infra | bool
   - role: openshift_registry
+    registry_volume_claim: "{{ openshift.hosted.registry.storage.volume.name }}-claim"
     when: deploy_infra | bool and attach_registry_volume | bool


### PR DESCRIPTION
`openshift_registry` was relying on the default registry claim name. Passing the claim name allows user to override.

```
openshift_hosted_registry_storage_volume_name=registry123
```

```
# oc get pv
NAME                 LABELS    CAPACITY   ACCESSMODES   STATUS    CLAIM                       REASON    AGE
registry123-volume   <none>    5Gi        RWX           Bound     default/registry123-claim             22m

# oc get pvc
NAME                LABELS    STATUS    VOLUME               CAPACITY   ACCESSMODES   AGE
registry123-claim   <none>    Bound     registry123-volume   5Gi        RWX           22m

# oc get dc/docker-registry -o yaml | grep claim
          claimName: registry123-claim
```

https://bugzilla.redhat.com/show_bug.cgi?id=1311410