### PR TITLE
libvirt: Upgrade to CentOS-7-x86_64-GenericCloud-1602.

### DIFF
--- a/README_libvirt.md
+++ b/README_libvirt.md
@@ -118,7 +118,7 @@ The following options can be passed via the `-o` flag of the `create` command or
 * `image_url` (default to `http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2.xz`): URL of the QCOW2 image to download
 * `image_name` (default to `CentOS-7-x86_64-GenericCloud.qcow2`): Name of the QCOW2 image to boot the VMs on
 * `image_compression` (default to `xz`): Source QCOW2 compression (only xz supported at this time)
-* `image_sha256` (default to `9461006300d65172f5668d8875f2aad7b54f7ba4e9c5435d65a84a5a2d66e39b`): Expected SHA256 checksum of the downloaded image
+* `image_sha256` (default to `dd0f5e610e7c5ffacaca35ed7a78a19142a588f4543da77b61c1fb0d74400471`): Expected SHA256 checksum of the downloaded image
 * `skip_image_download` (default to `no`): Skip QCOW2 image download. This requires the `image_name` QCOW2 image to be already present in `$HOME/libvirt-storage-pool-openshift-ansible`
 
 Creating a cluster

--- a/playbooks/libvirt/openshift-cluster/vars.yml
+++ b/playbooks/libvirt/openshift-cluster/vars.yml
@@ -23,13 +23,13 @@ deployment_vars:
   origin:
     image:
       url:    "{{ lookup('oo_option', 'image_url') |
-                  default('http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1510.qcow2.xz', True) }}"
+                  default('http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1602.qcow2.xz', True) }}"
       compression:   "{{ lookup('oo_option', 'image_compression') |
                          default('xz', True) }}"
       name:   "{{ lookup('oo_option', 'image_name') |
                   default('CentOS-7-x86_64-GenericCloud.qcow2', True) }}"
       sha256: "{{ lookup('oo_option', 'image_sha256') |
-                  default('9461006300d65172f5668d8875f2aad7b54f7ba4e9c5435d65a84a5a2d66e39b', True) }}"
+                  default('dd0f5e610e7c5ffacaca35ed7a78a19142a588f4543da77b61c1fb0d74400471', True) }}"
     ssh_user: openshift
     sudo: yes
   online:
@@ -42,5 +42,3 @@ deployment_vars:
   enterprise: "{{ deployment_rhel7_ent_base }}"
   openshift-enterprise: "{{ deployment_rhel7_ent_base }}"
   atomic-enterprise: "{{ deployment_rhel7_ent_base }}"
-
-

--- a/playbooks/libvirt/openshift-cluster/vars.yml
+++ b/playbooks/libvirt/openshift-cluster/vars.yml
@@ -23,7 +23,7 @@ deployment_vars:
   origin:
     image:
       url:    "{{ lookup('oo_option', 'image_url') |
-                  default('http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2.xz', True) }}"
+                  default('http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1510.qcow2.xz', True) }}"
       compression:   "{{ lookup('oo_option', 'image_compression') |
                          default('xz', True) }}"
       name:   "{{ lookup('oo_option', 'image_name') |


### PR DESCRIPTION
Closes #1384.
`bin/cluster create libvirt` worked for me with both -1510 and -1602 images.
