### PR TITLE
Add libselinux-python as a dependency for the installation process

### DIFF
--- a/README_libvirt.md
+++ b/README_libvirt.md
@@ -22,6 +22,7 @@ Install dependencies
 8.	[Grant libvirt access to your user¹](https://libvirt.org/aclpolkit.html)
 9.	Check that your `$HOME` is accessible to the qemu user²
 10.	Configure dns resolution on the host³
+11.	Install libselinux-python
 
 #### ¹ Depending on your distribution, libvirt access may be denied by default or may require a password at each access.
 


### PR DESCRIPTION
On fedora 23, cluster creation fails with the following error
$] bin/cluster create libvirt lenaic
....
TASK: [Create network xml file] *********************************************** 
failed: [localhost] => {"failed": true}
msg: Aborting, target uses selinux but python bindings (libselinux-python) aren't installed!

FATAL: all hosts have already failed -- aborting

installing libselinux-python solves the problem.