### PR TITLE
Fix hostvars key in openshift_master_certificates

### DIFF
--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -35,4 +35,4 @@
     force: true
   with_nested:
   - masters_needing_certs
-  - "{{ hostvars[openshift.common.hostname] | certificates_to_synchronize }}"
+  - "{{ hostvars[inventory_hostname] | certificates_to_synchronize }}"


### PR DESCRIPTION
This should have been using `inventory_hostname` rather than `openshift.common.hostname`.

Resolves #1517 
Resolves #1518 

@brenton 