### PR TITLE
Fix DNS problem on DNS server

### DIFF
--- a/playbooks/openstack/openshift-cluster/files/heat_stack.yaml
+++ b/playbooks/openstack/openshift-cluster/files/heat_stack.yaml
@@ -604,7 +604,7 @@ resources:
                       BOOTPROTO="dhcp"
                       DNS1="$dns1"
                       DNS2="$dns2"
-                      PEERDNS="no"
+                      PEERDNS="yes"
                       ONBOOT="yes"
                 runcmd:
                   - [ "/usr/bin/systemctl", "restart", "network" ]


### PR DESCRIPTION
Hi,

I think that is a solution to the #1512 issue.

With the actual interface configuration, the DNS server is using the dns resolvers in /etc/resolv.conf, which are obtained from DHCP, and are... itself... the problem is that the dns server need to install bind/named but is unable to resolv anything with such a configuration (chicken and egg problem).

With this change, the dns server only use the DNS servers which are defined in the interface configuration (which is obtained via cloud-init on boot), those are the DNS forwarders asked by the user (or 8.8.8.8 and 8.8.4.4 by default), so no problem to install the bind package and the rest of the installation process can go on.

I don't know if the DNS server should be able to resolv the other hosts after that, if that is the case the ansible tasks should change this parameter after the installation (and starting) of bind/named  and reload the network service.

Regards,
