### PR TITLE
a-o-i: Support for unattended upgrades

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -762,6 +762,9 @@ def uninstall(ctx):
     oo_cfg = ctx.obj['oo_cfg']
     verbose = ctx.obj['verbose']
 
+    upgrade_mappings = {'3.0':'3.1',
+                        '3.1':'3.2'}
+
     if len(oo_cfg.hosts) == 0:
         click.echo("No hosts defined in: %s" % oo_cfg.config_path)
         sys.exit(1)
@@ -802,8 +805,7 @@ def upgrade(ctx):
     resp = click.prompt("(1) Update to latest {} (2) Migrate to next relese".format(old_version))
 
     if resp == "2":
-        # TODO: Make this a lot more flexible
-        new_version = "3.1"
+        new_version = upgrade_mappings.get(old_version)
         # Update config to reflect the version we're targetting, we'll write
         # to disk once ansible completes successfully, not before.
         if oo_cfg.settings['variant'] == 'enterprise':

--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -251,18 +251,10 @@ def run_uninstall_playbook(verbose=False):
     return run_ansible(playbook, inventory_file, facts_env, verbose)
 
 
-def run_upgrade_playbook(old_version, new_version, verbose=False):
-    # TODO: do not hardcode the upgrade playbook, add ability to select the
-    # right playbook depending on the type of upgrade.
-    old_version = old_version.replace('.', '_')
-    new_version = old_version.replace('.', '_')
-    if old_version == new_version:
-        playbook = os.path.join(CFG.settings['ansible_playbook_directory'],
-            'playbooks/byo/openshift-cluster/upgrades/v{}_minor/upgrade.yml'.format(new_version))
-    else:
-        playbook = os.path.join(CFG.settings['ansible_playbook_directory'],
-            'playbooks/byo/openshift-cluster/upgrades/v{}_to_v{}/upgrade.yml'.format(old_version,
-                                                                                     new_version))
+def run_upgrade_playbook(playbook, verbose=False):
+    playbook = os.path.join(CFG.settings['ansible_playbook_directory'],
+            'playbooks/byo/openshift-cluster/upgrades/{}'.format(playbook))
+
     # TODO: Upgrade inventory for upgrade?
     inventory_file = generate_inventory(CFG.hosts)
     facts_env = os.environ.copy()

--- a/utils/src/ooinstall/variants.py
+++ b/utils/src/ooinstall/variants.py
@@ -36,6 +36,7 @@ class Variant(object):
 # WARNING: Keep the versions ordered, most recent last:
 OSE = Variant('openshift-enterprise', 'OpenShift Enterprise',
     [
+        Version('3.2', 'openshift-enterprise'),
         Version('3.1', 'openshift-enterprise'),
         Version('3.0', 'enterprise')
     ]
@@ -43,6 +44,7 @@ OSE = Variant('openshift-enterprise', 'OpenShift Enterprise',
 
 AEP = Variant('atomic-enterprise', 'Atomic Enterprise Platform',
     [
+        Version('3.2', 'atomic-enterprise'),
         Version('3.1', 'atomic-enterprise')
     ]
 )
@@ -74,4 +76,3 @@ def get_variant_version_combos():
         for ver in variant.versions:
             combos.append((variant, ver))
     return combos
-

--- a/utils/test/cli_installer_tests.py
+++ b/utils/test/cli_installer_tests.py
@@ -480,7 +480,7 @@ class UnattendedCliTests(OOCliFixture):
         self.assertEquals('openshift-enterprise', written_config['variant'])
         # We didn't specify a version so the latest should have been assumed,
         # and written to disk:
-        self.assertEquals('3.1', written_config['variant_version'])
+        self.assertEquals('3.2', written_config['variant_version'])
 
         # Make sure the correct value was passed to ansible:
         inventory = ConfigParser.ConfigParser(allow_no_value=True)
@@ -960,12 +960,13 @@ class AttendedCliTests(OOCliFixture):
         cli_input = build_input(hosts=[
             ('10.0.0.1', True, False)],
                                       ssh_user='root',
-                                      variant_num=2,
+                                      variant_num=3,
                                       confirm_facts='y')
         self.cli_args.append("install")
         result = self.runner.invoke(cli.cli, self.cli_args,
             input=cli_input)
         self.assert_result(result, 0)
+        print result.output
         self.assertTrue("NOTE: Add a total of 3 or more Masters to perform an HA installation."
             not in result.output)
 


### PR DESCRIPTION
Adds the ability to perform upgrades without any user input through:

atomic-openshift-installer --unattended upgrade --next-major
or
atomic-openshift-installer --unattended upgrade --latest-minor