### PR TITLE
Update README_origin.md

### DIFF
--- a/README_origin.md
+++ b/README_origin.md
@@ -60,6 +60,8 @@ option to ansible-playbook.
 [OSEv3:children]
 masters
 nodes
+etcd
+lb
 
 # Set variables common for all OSEv3 hosts
 [OSEv3:vars]


### PR DESCRIPTION
Added etcd and lb to the OSEv3:children group in the example host inventory. The playbook fails with a SSH exception if you're running the playbook with other users than root.