### PR TITLE
Set node IMAGE_VERSION to use image_tag instead

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -110,7 +110,7 @@
     - regex: '^CONFIG_FILE='
       line: "CONFIG_FILE={{ openshift_node_config_file }}"
     - regex: '^IMAGE_VERSION='
-      line: "IMAGE_VERSION=v{{ openshift.common.version.split('-')[0] }}"
+      line: "IMAGE_VERSION={{ openshift.common.image_tag }}"
   notify:
   - restart node
 


### PR DESCRIPTION
@brenton This broke my install for (CentOS 7.2 atomic), I don't think the openshift.common.version is set in some cases? I had to update the line for my install to work

Logs:
Mar 07 02:11:52 docker[19687]: Unable to find image 'openshift/node:v{# openshift.common.version.split('-')[0] #}' locally
Mar 07 02:11:57 docker[19687]: Trying to pull repository docker.io/openshift/node ... not found
Mar 07 02:11:57 docker[19687]: Tag v{# openshift.common.version.split('-')[0] #} not found in repository docker.io/openshift/node
