### PR TITLE
BZ1315151: Support openshift_image_tag

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
@@ -40,6 +40,12 @@
         valid version for a {{ target_version }} upgrade
     when: openshift_pkg_version is defined and openshift_pkg_version.split('-',1).1 | version_compare(target_version ,'<')
 
+  - fail:
+      msg: >
+        openshift_image_tag is {{ openshift_image_tag }} which is not a
+        valid version for a {{ target_version }} upgrade
+    when: openshift_image_tag is defined and openshift_image_tag.split('v',1).1 | version_compare(target_version ,'<')
+
 - name: Verify upgrade can proceed
   hosts: oo_masters_to_config:oo_nodes_to_config
   vars:
@@ -76,13 +82,17 @@
       g_new_version: "{{ g_aos_versions.curr_version.split('-', 1).0 if g_aos_versions.avail_version is none else g_aos_versions.avail_version.split('-', 1).0 }}"
     when: openshift_pkg_version is not defined
 
-  - fail:
-      msg: Verifying the correct version was found
-    when: verify_upgrade_version is defined and g_new_version != verify_upgrade_version
-
   - set_fact:
       g_new_version: "{{ openshift_pkg_version | replace('-','') }}"
     when: openshift_pkg_version is defined
+
+  - set_fact:
+      g_new_version: "{{ openshift_image_tag | replace('v','') }}"
+    when: openshift_image_tag is defined
+
+  - fail:
+      msg: Verifying the correct version was found
+    when: verify_upgrade_version is defined and g_new_version != verify_upgrade_version
 
   - name: Update systemd units
     script: ../files/ensure_system_units_have_version.sh {{ openshift.common.service_type }} {{ openshift.common.deployment_type }} {{ g_aos_versions.curr_version }}

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
@@ -95,7 +95,7 @@
 - name: Reconcile Cluster Roles and Cluster Role Bindings and Security Context Constraints
   hosts: oo_masters_to_config
   roles:
-  - { role: openshift_cli, image_tag: "v{{ g_new_version }}"  }
+  - { role: openshift_cli, openshift_image_tag: "v{{ g_new_version }}"  }
   vars:
     origin_reconcile_bindings: "{{ deployment_type == 'origin' and g_new_version | version_compare('1.0.6', '>') }}"
     ent_reconcile_bindings: true

--- a/roles/cockpit/tasks/main.yml
+++ b/roles/cockpit/tasks/main.yml
@@ -14,3 +14,4 @@
     name: cockpit.socket
     enabled: true
     state: started
+  when: not openshift.common.is_containerized | bool

--- a/roles/openshift_cli/templates/openshift.j2
+++ b/roles/openshift_cli/templates/openshift.j2
@@ -5,7 +5,7 @@ fi
 cmd=`basename $0`
 user=`id -u`
 group=`id -g`
-image_tag={{ image_tag | default(openshift.common.image_tag) }}
+image_tag={{ openshift_version }}
 
 >&2 echo """
 ================================================================================

--- a/roles/openshift_cli/vars/main.yml
+++ b/roles/openshift_cli/vars/main.yml
@@ -1,0 +1,2 @@
+---
+openshift_version: "{{ openshift_image_tag | default(openshift.common.image_tag) | default('') }}"

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -916,7 +916,7 @@ def get_openshift_version(facts, cli_image=None):
 
         if container is not None:
             exit_code, output, _ = module.run_command(['docker', 'exec', container, 'openshift', 'version'])
-            # if for some reason the container is installed by not running
+            # if for some reason the container is installed but not running
             # we'll fall back to using docker run later in this method.
             if exit_code == 0:
                 version = parse_openshift_version(output)

--- a/roles/openshift_master/templates/atomic-openshift-master.j2
+++ b/roles/openshift_master/templates/atomic-openshift-master.j2
@@ -1,7 +1,7 @@
 OPTIONS=--loglevel={{ openshift.master.debug_level }}
 CONFIG_FILE={{ openshift_master_config_file }}
 {% if openshift.common.is_containerized %}
-IMAGE_VERSION={{ openshift.common.image_tag }}
+IMAGE_VERSION={{ openshift_version }}
 {% endif %}
 
 # Proxy configuration

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
@@ -1,7 +1,7 @@
 OPTIONS=--loglevel={{ openshift.master.debug_level }} --listen={{ 'https' if openshift.master.api_use_ssl else 'http' }}://{{ openshift.master.bind_addr }}:{{ openshift.master.api_port }} --master={{ openshift.master.loopback_api_url }}
 CONFIG_FILE={{ openshift_master_config_file }}
 {% if openshift.common.is_containerized %}
-IMAGE_VERSION={{ openshift.common.image_tag }}
+IMAGE_VERSION={{ openshift_version }}
 {% endif %}
 
 # Proxy configuration

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.j2
@@ -1,7 +1,7 @@
 OPTIONS=--loglevel={{ openshift.master.debug_level }} --listen={{ 'https' if openshift.master.api_use_ssl else 'http' }}://{{ openshift.master.bind_addr }}:{{ openshift.master.controllers_port }}
 CONFIG_FILE={{ openshift_master_config_file }}
 {% if openshift.common.is_containerized %}
-IMAGE_VERSION={{ openshift.common.image_tag }}
+IMAGE_VERSION={{ openshift_version }}
 {% endif %}
 
 # Proxy configuration

--- a/roles/openshift_master/vars/main.yml
+++ b/roles/openshift_master/vars/main.yml
@@ -6,7 +6,7 @@ loopback_context_string: "current-context: {{ openshift.master.loopback_context_
 openshift_master_scheduler_conf: "{{ openshift_master_config_dir }}/scheduler.json"
 openshift_master_session_secrets_file: "{{ openshift_master_config_dir }}/session-secrets.yaml"
 openshift_master_policy: "{{ openshift_master_config_dir }}/policy.json"
-openshift_version: "{{ openshift_pkg_version | default('') }}"
+openshift_version: "{{ openshift_pkg_version | default(openshift_image_tag) | default(openshift.common.image_tag) | default('') }}"
 
 ha_svc_template_path: "{{ 'docker-cluster' if openshift.common.is_containerized | bool else 'native-cluster' }}"
 ha_svc_svc_dir: "{{ '/etc/systemd/system' if openshift.common.is_containerized | bool else '/usr/lib/systemd/system' }}"

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -110,7 +110,7 @@
     - regex: '^CONFIG_FILE='
       line: "CONFIG_FILE={{ openshift_node_config_file }}"
     - regex: '^IMAGE_VERSION='
-      line: "IMAGE_VERSION=v{{ openshift.common.version.split('-')[0] }}"
+      line: "IMAGE_VERSION={{ openshift_version }}"
   notify:
   - restart node
 

--- a/roles/openshift_node/templates/openvswitch.sysconfig.j2
+++ b/roles/openshift_node/templates/openvswitch.sysconfig.j2
@@ -1,1 +1,1 @@
-IMAGE_VERSION={{ openshift.common.image_tag }}
+IMAGE_VERSION={{ openshift_version }}

--- a/roles/openshift_node/vars/main.yml
+++ b/roles/openshift_node/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 openshift_node_config_dir: "{{ openshift.common.config_base }}/node"
 openshift_node_config_file: "{{ openshift_node_config_dir }}/node-config.yaml"
-openshift_version: "{{ openshift_pkg_version | default('') }}"
+openshift_version: "{{ openshift_pkg_version | default(openshift_image_tag) | default(openshift.common.image_tag) | default('') }}"


### PR DESCRIPTION
This is the containerized openshift_pkg_version equivalent.  Originally I was hoping to reuse openshift_pkg_version for containerized installs but the fact that it's very coupled to yum made that pretty ugly.                                          
                                                                             
However, I did opt to rely on the previously existing 'openshift_version' variable.  Containerized and RPM installs can both use that variable and it will be set appropriately if either openshift_pkg_version or openshift_image_tag are set.  I suspect someday containerized installs will be the only option and I didn't can to have thinkgs like openshift_pkg_version and openshift_image_tag in the playbooks anymore the necessary.
