### PR TITLE
ManageIQ SA: Adding image-puller role

### DIFF
--- a/roles/openshift_manageiq/tasks/main.yaml
+++ b/roles/openshift_manageiq/tasks/main.yaml
@@ -18,9 +18,20 @@
   failed_when: "'already exists' not in osmiq_create_mi_project.stderr and osmiq_create_mi_project.rc != 0"
   changed_when: osmiq_create_mi_project.rc == 0
 
-- name: Create Service Account
+- name: Create Admin Service Account
   shell: >
     echo {{ manageiq_service_account | to_json | quote }} |
+    {{ openshift.common.client_binary }} create
+    -n management-infra
+    --config={{manage_iq_tmp_conf}}
+    -f -
+  register: osmiq_create_service_account
+  failed_when: "'already exists' not in osmiq_create_service_account.stderr and osmiq_create_service_account.rc != 0"
+  changed_when: osmiq_create_service_account.rc == 0
+
+- name: Create Image Inspector Service Account
+  shell: >
+    echo {{ manageiq_image_inspector_service_account | to_json | quote }} |
     {{ openshift.common.client_binary }} create
     -n management-infra
     --config={{manage_iq_tmp_conf}}

--- a/roles/openshift_manageiq/vars/main.yml
+++ b/roles/openshift_manageiq/vars/main.yml
@@ -15,6 +15,12 @@ manageiq_service_account:
     metadata:
       name: management-admin
 
+manageiq_image_inspector_service_account:
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: inspector-admin
+
 manage_iq_tmp_conf: /tmp/manageiq_admin.kubeconfig
 
 manage_iq_tasks:
@@ -22,3 +28,5 @@ manage_iq_tasks:
     - policy add-role-to-user -n management-infra management-infra-admin -z management-admin
     - policy add-cluster-role-to-user cluster-reader system:serviceaccount:management-infra:management-admin
     - policy add-scc-to-user privileged system:serviceaccount:management-infra:management-admin
+    - policy add-cluster-role-to-user system:image-puller system:serviceaccount:management-infra:inspector-admin
+    - policy add-scc-to-user privileged system:serviceaccount:management-infra:inspector-admin


### PR DESCRIPTION
This will allow ManageIQ to run image-inspector when the registry requires authentication.