### PR TITLE
Bug 1315564 - upgrade to ose3.2 failed on Atomic Hosts

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/files/openshift_container_versions.sh
+++ b/playbooks/common/openshift-cluster/upgrades/files/openshift_container_versions.sh
@@ -10,7 +10,7 @@ if [ ${1} == "origin" ]; then
     image_name="openshift/origin"
 elif grep aep $unit_file 2>&1 > /dev/null; then
     image_name="aep3/aep"
-elif grep ose $unit_file 2>&1 > /dev/null; then
+elif grep openshift3 $unit_file 2>&1 > /dev/null; then
     image_name="openshift3/ose"
 fi
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/docker_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/docker_upgrade.yml
@@ -1,20 +1,14 @@
----
+- name: Check if Docker is installed
+  command: rpm -q docker
+  register: pkg_check
+  failed_when: pkg_check.rc > 1
+  changed_when: no
+
 - name: Upgrade Docker
-  hosts: oo_masters_to_config:oo_nodes_to_config:oo_etcd_to_config
-  vars:
-    openshift_version: "{{ openshift_pkg_version | default('') }}"
-  tasks:
-  - name: Check if Docker is installed
-    command: rpm -q docker
-    register: pkg_check
-    failed_when: pkg_check.rc > 1
-    changed_when: no
+  command: "{{ ansible_pkg_mgr}} update -y docker"
+  when: pkg_check.rc == 0 and g_docker_version.curr_version | version_compare('1.9','<')
+  register: docker_upgrade
 
-  - name: Upgrade Docker
-    command: "{{ ansible_pkg_mgr}} update -y docker"
-    when: pkg_check.rc == 0 and g_docker_version.curr_version | version_compare('1.9','<')
-    register: docker_upgrade
-
-  - name: Restart Docker
-    service: name=docker state=restarted
-    when: docker_upgrade | changed
+- name: Restart Docker
+  service: name=docker state=restarted
+  when: docker_upgrade | changed

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
@@ -3,14 +3,21 @@
 # The restart playbook should be run after this playbook completes.
 ###############################################################################
 
-- include: docker_upgrade.yml
-  when: not openshift.common.is_atomic | bool
+- name: Upgrade docker
+  hosts: oo_masters_to_config:oo_nodes_to_config:oo_etcd_to_config
+  roles:
+  - openshift_facts
+  tasks:
+  - include: docker_upgrade.yml
+    when: not openshift.common.is_atomic | bool
 
 ###############################################################################
 # Upgrade Masters
 ###############################################################################
 - name: Upgrade master
   hosts: oo_masters_to_config
+  roles:
+  - openshift_facts
   tasks:
   - include: rpm_upgrade.yml component=master
     when: not openshift.common.is_containerized | bool
@@ -54,6 +61,8 @@
 ###############################################################################
 - name: Upgrade nodes
   hosts: oo_nodes_to_config
+  roles:
+  - openshift_facts
   tasks:
   - include: rpm_upgrade.yml
     vars:


### PR DESCRIPTION
Previously I was greping for 'ose' in the systemd units.  That was only working
on my machine because my Nodes were also Masters.  It's safer to grep for
openshift3 since that would be present for Masters or Nodes.