### PR TITLE
Cluster dns provided by dnsmasq

### DIFF
--- a/filter_plugins/openshift_node.py
+++ b/filter_plugins/openshift_node.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# vim: expandtab:tabstop=4:shiftwidth=4
+'''
+Custom filters for use in openshift-node
+'''
+from ansible import errors
+
+class FilterModule(object):
+    ''' Custom ansible filters for use by openshift_node role'''
+
+    @staticmethod
+    def get_dns_ip(openshift_dns_ip, hostvars):
+        ''' Navigates the complicated logic of when to set dnsIP
+
+            In all situations if they've set openshift_dns_ip use that
+            For 1.0/3.0 installs we use the openshift_master_cluster_vip, openshift_node_first_master_ip, else None
+            For 1.1/3.1 installs we use openshift_master_cluster_vip, else None (product will use kube svc ip)
+            For 1.2/3.2+ installs we set to the node's default interface ip
+        '''
+
+        if not issubclass(type(hostvars), dict):
+            raise errors.AnsibleFilterError("|failed expects hostvars is a dict")
+
+        # We always use what they've specified if they've specified a value
+        if openshift_dns_ip != None:
+            return openshift_dns_ip
+
+        if bool(hostvars['openshift']['common']['version_gte_3_2_or_1_2']):
+            return hostvars['ansible_default_ipv4']['address']
+        elif bool(hostvars['openshift']['common']['version_gte_3_1_or_1_1']):
+            if 'openshift_master_cluster_vip' in hostvars:
+                return hostvars['openshift_master_cluster_vip']
+        else:
+            if 'openshift_master_cluster_vip' in hostvars:
+                return hostvars['openshift_master_cluster_vip']
+            elif 'openshift_node_first_master_ip' in hostvars:
+                return hostvars['openshift_node_first_master_ip']
+        return None
+
+    def filters(self):
+        ''' returns a mapping of filters to methods '''
+        return {'get_dns_ip': self.get_dns_ip}

--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -336,6 +336,12 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Setting this variable to true will override that check.
 #openshift_override_hostname_check=true
 
+# Configure dnsmasq for cluster dns, switch the host's local resolver to use dnsmasq
+# and configure node's dnsIP to point at the node's local dnsmasq instance. Defaults
+# to True for Origin 1.2 and OSE 3.2. False for 1.1 / 3.1 installs, this cannot
+# be used with 1.0 and 3.0.
+# openshift_node_dnsmasq=False
+
 # host group for masters
 [masters]
 aep3-master[1:3]-ansible.test.example.com

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -341,6 +341,12 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Setting this variable to true will override that check.
 #openshift_override_hostname_check=true
 
+# Configure dnsmasq for cluster dns, switch the host's local resolver to use dnsmasq
+# and configure node's dnsIP to point at the node's local dnsmasq instance. Defaults
+# to True for Origin 1.2 and OSE 3.2. False for 1.1 / 3.1 installs, this cannot
+# be used with 1.0 and 3.0.
+# openshift_node_dnsmasq=False
+
 # host group for masters
 [masters]
 ose3-master[1:3]-ansible.test.example.com

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -337,6 +337,12 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Setting this variable to true will override that check.
 #openshift_override_hostname_check=true
 
+# Configure dnsmasq for cluster dns, switch the host's local resolver to use dnsmasq
+# and configure node's dnsIP to point at the node's local dnsmasq instance. Defaults
+# to True for Origin 1.2 and OSE 3.2. False for 1.1 / 3.1 installs, this cannot
+# be used with 1.0 and 3.0.
+# openshift_node_dnsmasq=False
+
 # host group for masters
 [masters]
 ose3-master[1:3]-ansible.test.example.com

--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -232,6 +232,9 @@
         - /usr/local/bin/oadm
         - /usr/local/bin/oc
         - /usr/local/bin/kubectl
+        - /etc/NetworkManager/dispatcher.d/99-origin-dns.sh
+        - /etc/dnsmasq.d/origin-dns.conf
+        - /etc/dnsmasq.d/origin-upstream-dns.conf
 
     # Since we are potentially removing the systemd unit files for separated
     # master-api and master-controllers services, so we need to reload the
@@ -244,3 +247,5 @@
   tasks:
     - name: restart docker
       service: name=docker state=restarted
+    - name: restart NetworkManager
+      service: name=NetworkManager state=restarted

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -53,7 +53,6 @@
         console_url: "{{ openshift_master_console_url | default(None) }}"
         console_use_ssl: "{{ openshift_master_console_use_ssl | default(None) }}"
         public_console_url: "{{ openshift_master_public_console_url | default(None) }}"
-        portal_net: "{{ openshift_master_portal_net | default(None) }}"
         ha: "{{ openshift_master_ha | default(groups.oo_masters | length > 1) }}"
         master_count: "{{ openshift_master_count | default(groups.oo_masters | length) }}"
   - openshift_facts:

--- a/roles/flannel_register/README.md
+++ b/roles/flannel_register/README.md
@@ -14,7 +14,7 @@ Role Variables
 
 | Name                | Default value                                      | Description                                     |
 |---------------------|----------------------------------------------------|-------------------------------------------------|
-| flannel_network     | {{ openshift.master.portal_net }} or 172.16.1.1/16 | interface to use for inter-host communication   |
+| flannel_network     | {{ openshift.common.portal_net }} or 172.16.1.1/16 | interface to use for inter-host communication   |
 | flannel_min_network | {{ min_network }} or 172.16.5.0                    | beginning of IP range for the subnet allocation |
 | flannel_subnet_len  | /openshift.com/network                             | size of the subnet allocated to each host       |
 | flannel_etcd_key    | /openshift.com/network                             | etcd prefix                                     |

--- a/roles/flannel_register/defaults/main.yaml
+++ b/roles/flannel_register/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-flannel_network: "{{ openshift.master.portal_net | default('172.30.0.0/16', true) }}"
+flannel_network: "{{ openshift.common.portal_net | default('172.30.0.0/16', true) }}"
 flannel_min_network: 172.30.5.0
 flannel_subnet_len: 24
 flannel_etcd_key: /openshift.com/network

--- a/roles/openshift_common/README.md
+++ b/roles/openshift_common/README.md
@@ -20,6 +20,7 @@ Role Variables
 | openshift_ip              | UNDEF             | Internal IP address to use for this host    |
 | openshift_public_hostname | UNDEF             | Public hostname to use for this host        |
 | openshift_public_ip       | UNDEF             | Public IP address to use for this host      |
+| openshift_portal_net      | UNDEF             | Service IP CIDR |
 
 Dependencies
 ------------

--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -27,6 +27,7 @@
       use_nuage: "{{ openshift_use_nuage | default(None) }}"
       use_manageiq: "{{ openshift_use_manageiq | default(None) }}"
       data_dir: "{{ openshift_data_dir | default(None) }}"
+      portal_net: "{{ openshift_master_portal_net | default(None) }}"
 
 # Using oo_image_tag_to_rpm_version here is a workaround for how
 # openshift_version is set.  That value is computed based on either RPM

--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -27,7 +27,8 @@
       use_nuage: "{{ openshift_use_nuage | default(None) }}"
       use_manageiq: "{{ openshift_use_manageiq | default(None) }}"
       data_dir: "{{ openshift_data_dir | default(None) }}"
-      portal_net: "{{ openshift_master_portal_net | default(None) }}"
+      portal_net: "{{ openshift_portal_net | default(openshift_master_portal_net) | default(None) }}"
+      use_dnsmasq: "{{ openshift_use_dnsmasq | default(None) }}"
 
 # Using oo_image_tag_to_rpm_version here is a workaround for how
 # openshift_version is set.  That value is computed based on either RPM

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -9,10 +9,10 @@ os_firewall_allow:
   port: "{{ openshift.master.api_port }}/tcp"
 - service: api controllers https
   port: "{{ openshift.master.controllers_port }}/tcp"
-- service: dns tcp
-  port: 53/tcp
-- service: dns udp
-  port: 53/udp
+- service: skydns tcp
+  port: "{{ openshift.master.dns_port }}/tcp"
+- service: skydns udp
+  port: "{{ openshift.master.dns_port }}/udp"
 - service: Fluentd td-agent tcp
   port: 24224/tcp
 - service: Fluentd td-agent udp

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -123,7 +123,7 @@ kubernetesMasterConfig:
     keyFile: master.proxy-client.key
   schedulerConfigFile: {{ openshift_master_scheduler_conf }}
   servicesNodePortRange: ""
-  servicesSubnet: {{ openshift.master.portal_net }}
+  servicesSubnet: {{ openshift.common.portal_net }}
   staticNodeNames: {{ openshift_node_ips | default([], true) }}
 {% endif %}
 masterClients:
@@ -138,7 +138,7 @@ networkConfig:
   networkPluginName: {{ openshift.common.sdn_network_plugin_name }}
 {% endif %}
 # serviceNetworkCIDR must match kubernetesMasterConfig.servicesSubnet
-  serviceNetworkCIDR: {{ openshift.master.portal_net }}
+  serviceNetworkCIDR: {{ openshift.common.portal_net }}
 oauthConfig:
 {% if 'oauth_always_show_provider_selection' in openshift.master %}
   alwaysShowProviderSelection: {{ openshift.master.oauth_always_show_provider_selection }}

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -30,10 +30,10 @@
       embedded_etcd: "{{ openshift_master_embedded_etcd | default(None) }}"
       embedded_kube: "{{ openshift_master_embedded_kube | default(None) }}"
       embedded_dns: "{{ openshift_master_embedded_dns | default(None) }}"
+      # defaults to 8053 when using dnsmasq in 1.2/3.2
       dns_port: "{{ openshift_master_dns_port | default(None) }}"
       bind_addr: "{{ openshift_master_bind_addr | default(None) }}"
       pod_eviction_timeout: "{{ openshift_master_pod_eviction_timeout | default(None) }}"
-      portal_net: "{{ openshift_master_portal_net | default(None) }}"
       session_max_seconds: "{{ openshift_master_session_max_seconds | default(None) }}"
       session_name: "{{ openshift_master_session_name | default(None) }}"
       session_secrets_file: "{{ openshift_master_session_secrets_file | default(None) }}"

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -16,6 +16,7 @@
       dns_ip: "{{ openshift_dns_ip
                   | default(openshift_master_cluster_vip
                   | default(None if openshift.common.version_gte_3_1_or_1_1 | bool else openshift_node_first_master_ip | default(None, true), true), true) }}"
+      portal_net: "{{ openshift_portal_net | default(openshift_master_portal_net) | default(None) }}"
   - role: node
     local_facts:
       annotations: "{{ openshift_node_annotations | default(none) }}"

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -9,14 +9,6 @@
     role: "{{ item.role }}"
     local_facts: "{{ item.local_facts }}"
   with_items:
-  - role: common
-    local_facts:
-      # TODO: Replace this with a lookup or filter plugin.
-      # TODO: Move this to the node role
-      dns_ip: "{{ openshift_dns_ip
-                  | default(openshift_master_cluster_vip
-                  | default(None if openshift.common.version_gte_3_1_or_1_1 | bool else openshift_node_first_master_ip | default(None, true), true), true) }}"
-      portal_net: "{{ openshift_portal_net | default(openshift_master_portal_net) | default(None) }}"
   - role: node
     local_facts:
       annotations: "{{ openshift_node_annotations | default(none) }}"
@@ -33,6 +25,7 @@
       ovs_image: "{{ osn_ovs_image | default(None) }}"
       proxy_mode: "{{ openshift_node_proxy_mode | default('iptables') }}"
       local_quota_per_fsgroup: "{{ openshift_node_local_quota_per_fsgroup | default(None) }}"
+      dns_ip: "{{ openshift_dns_ip | default(none) | get_dns_ip(hostvars[inventory_hostname])}}"
 
 # We have to add tuned-profiles in the same transaction otherwise we run into depsolving
 # problems because the rpms don't pin the version properly. This was fixed in 3.1 packaging.

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -1,8 +1,8 @@
 allowDisabledDocker: false
 apiVersion: v1
 dnsDomain: {{ openshift.common.dns_domain }}
-{% if 'dns_ip' in openshift.common %}
-dnsIP: {{ openshift.common.dns_ip }}
+{% if 'dns_ip' in openshift.node %}
+dnsIP: {{ openshift.node.dns_ip }}
 {% endif %}
 dockerConfig:
   execHandlerName: ""

--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -x
+
+# This NetworkManager dispatcher script replicates the functionality of
+# NetworkManager's dns=dnsmasq  however, rather than hardcoding the listening
+# address and /etc/resolv.conf to 127.0.0.1 it pulls the IP address from the
+# interface that owns the default route. This enables us to then configure pods
+# to use this IP address as their only resolver, where as using 127.0.0.1 inside
+# a pod would fail.
+#
+# To use this,
+# Drop this script in /etc/NetworkManager/dispatcher.d/
+# systemctl restart NetworkManager
+# Configure node-config.yaml to set dnsIP: to the ip address of this
+# node
+#
+# Test it:
+# host kubernetes.default.svc.cluster.local
+# host google.com
+#
+# TODO: I think this would be easy to add as a config option in NetworkManager
+# natively, look at hacking that up
+
+cd /etc/sysconfig/network-scripts
+. ./network-functions
+
+[ -f ../network ] && . ../network
+
+if [[ $2 =~ ^(up|dhcp4-change)$ ]]; then
+  # couldn't find an existing method to determine if the interface owns the 
+  # default route
+  def_route=$(/sbin/ip route list match 0.0.0.0/0 | awk '{print $3 }')
+  def_route_int=$(/sbin/ip route get to ${def_route} | awk '{print $3}')
+  def_route_ip=$(/sbin/ip route get to ${def_route} | awk '{print $5}')
+  if [[ ${DEVICE_IFACE} == ${def_route_int} ]]; then
+    if [ ! -f /etc/dnsmasq.d/origin-dns.conf ]; then
+      cat << EOF > /etc/dnsmasq.d/origin-dns.conf
+strict-order
+no-resolv
+domain-needed
+server=/cluster.local/172.30.0.1
+server=/30.172.in-addr.arpa/172.30.0.1
+EOF
+    fi
+    # zero out our upstream servers list and feed it into dnsmasq
+    echo '' > /etc/dnsmasq.d/origin-upstream-dns.conf
+    for ns in ${DHCP4_DOMAIN_NAME_SERVERS}; do
+       echo "server=${ns}" >> /etc/dnsmasq.d/origin-upstream-dns.conf
+    done
+    echo "listen-address=${def_route_ip}" >> /etc/dnsmasq.d/origin-upstream-dns.conf
+    systemctl restart dnsmasq
+
+    sed -i 's/^nameserver.*$/nameserver '"${def_route_ip}"'/g' /etc/resolv.conf
+    echo "# nameserver updated by /etc/NetworkManager/dispatcher.d/99-origin-dns.sh" >> /etc/resolv.conf
+  fi
+fi

--- a/roles/openshift_node_dnsmasq/handlers/main.yml
+++ b/roles/openshift_node_dnsmasq/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart NetworkManager
+  service: 
+    name: NetworkManager
+    state: restarted

--- a/roles/openshift_node_dnsmasq/meta/main.yml
+++ b/roles/openshift_node_dnsmasq/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
-  author: Jhon Honce
-  description: OpenShift Node
+  author: Scott Dodson
+  description: OpenShift Node DNSMasq support
   company: Red Hat, Inc.
   license: Apache License, Version 2.0
   min_ansible_version: 1.7
@@ -12,9 +12,4 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
-- role: openshift_docker
-- role: openshift_cloud_provider
 - role: openshift_common
-- role: openshift_node_dnsmasq
-  when: openshift.common.use_dnsmasq
-

--- a/roles/openshift_node_dnsmasq/tasks/main.yml
+++ b/roles/openshift_node_dnsmasq/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Check for NetworkManager service
+  command: >
+    systemctl show NetworkManager
+  register: nm_show
+  
+- name: Set fact using_network_manager
+  set_fact:
+    network_manager_active: "{{ True if 'ActiveState=active' in nm_show.stdout else False }}"
+    
+- name: Install dnsmasq
+  action: "{{ ansible_pkg_mgr }} name=dnsmasq state=installed"
+  when: not openshift.common.is_atomic | bool
+  
+- name: Install dnsmasq configuration
+  template:
+    src: origin-dns.conf.j2
+    dest: /etc/dnsmasq.d/origin-dns.conf
+
+# Dynamic NetworkManager based dispatcher
+- include: ./network-manager.yml
+  when: network_manager_active | bool
+  
+# Relies on ansible in order to configure static config
+- include: ./no-network-manager.yml
+  when: not network_manager_active | bool
+  

--- a/roles/openshift_node_dnsmasq/tasks/network-manager.yml
+++ b/roles/openshift_node_dnsmasq/tasks/network-manager.yml
@@ -1,0 +1,9 @@
+---
+- name: Install network manager dispatch script
+  copy:
+    src: networkmanager/99-origin-dns.sh
+    dest: /etc/NetworkManager/dispatcher.d/
+    mode: 0755
+  notify: restart NetworkManager
+
+- meta: flush_handlers

--- a/roles/openshift_node_dnsmasq/tasks/no-network-manager.yml
+++ b/roles/openshift_node_dnsmasq/tasks/no-network-manager.yml
@@ -1,0 +1,2 @@
+---
+- fail: msg="Not implemented"

--- a/roles/openshift_node_dnsmasq/templates/origin-dns.conf.j2
+++ b/roles/openshift_node_dnsmasq/templates/origin-dns.conf.j2
@@ -1,0 +1,4 @@
+strict-order
+no-resolv
+domain-needed
+server=/{{ openshift.common.dns_domain }}/{{ openshift.common.kube_svc_ip }}


### PR DESCRIPTION
This pull request installs dnsmasq on each node for two purposes 
 - Provide resolution of resources stored in skydns on the node itself which facilitates docker daemon pushing to the integrated registry via hostname rather than IP address
 - Ensures that the pod's first resolver works for all hostnames while not relying on skydns for recursion