### PR TITLE
Bug 1316761 - Skip the available version check if openshift_image_tag…

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
@@ -116,10 +116,9 @@
       msg: This playbook requires Atomic Enterprise Platform/OpenShift Enterprise 3.1 or later
     when: deployment_type == 'atomic-openshift' and g_aos_versions.curr_version | version_compare('3.1','<')
 
-  # TODO: this may only make sense for RPM installs.  We probably need another check for containerized installs.
   - fail:
       msg: Upgrade packages not found
-    when: (g_aos_versions.avail_version | default(g_aos_versions.curr_version, true) | version_compare(target_version, '<'))
+    when: openshift_image_tag is not defined and (g_aos_versions.avail_version | default(g_aos_versions.curr_version, true) | version_compare(target_version, '<'))
 
   - name: Determine available Docker
     script: ../files/rpm_versions.sh docker

--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -38,10 +38,10 @@ def generate_inventory(hosts):
     base_inventory.write('deployment_type={}\n'.format(ver.ansible_key))
 
     if 'OO_INSTALL_ADDITIONAL_REGISTRIES' in os.environ:
-        base_inventory.write('cli_docker_additional_registries={}\n'
+        base_inventory.write('openshift_docker_additional_registries={}\n'
           .format(os.environ['OO_INSTALL_ADDITIONAL_REGISTRIES']))
     if 'OO_INSTALL_INSECURE_REGISTRIES' in os.environ:
-        base_inventory.write('cli_docker_insecure_registries={}\n'
+        base_inventory.write('openshift_docker_insecure_registries={}\n'
           .format(os.environ['OO_INSTALL_INSECURE_REGISTRIES']))
     if 'OO_INSTALL_PUDDLE_REPO' in os.environ:
         # We have to double the '{' here for literals


### PR DESCRIPTION
… is defined.

We already have a check in pre.yml to make sure openshift_image_tag is set to a
range that is allowed.  This is an advanced setting and should be used to
override whatever is returned by the 'latest' image in a given registry.