### PR TITLE
Bug 1315564 - Containerized installs require a running environment

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/files/openshift_container_versions.sh
+++ b/playbooks/common/openshift-cluster/upgrades/files/openshift_container_versions.sh
@@ -4,7 +4,7 @@
 # We just need to know the version of one of them.
 unit_file=$(ls /etc/systemd/system/${1}*.service | head -n1)
 installed_container_name=$(basename -s .service ${unit_file})
-installed=$(docker exec ${installed_container_name} openshift version | grep openshift | awk '{ print $2 }' | cut -f1 -d"-" | tr -d 'v')
+installed=$(docker exec ${installed_container_name} openshift version 2> /dev/null | grep openshift | awk '{ print $2 }' | cut -f1 -d"-" | tr -d 'v')
 
 if [ ${1} == "origin" ]; then
     image_name="openshift/origin"
@@ -15,7 +15,7 @@ elif grep openshift3 $unit_file 2>&1 > /dev/null; then
 fi
 
 docker pull ${image_name} 2>&1 > /dev/null
-available=$(docker run --rm ${image_name} version | grep openshift | awk '{ print $2 }' | cut -f1 -d"-" | tr -d 'v')
+available=$(docker run --rm ${image_name} version 2> /dev/null | grep openshift | awk '{ print $2 }' | cut -f1 -d"-" | tr -d 'v')
 
 echo "---"
 echo "curr_version: ${installed}"

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
@@ -47,6 +47,26 @@
     when: openshift_image_tag is defined and openshift_image_tag.split('v',1).1 | version_compare(target_version ,'<')
 
 - name: Verify upgrade can proceed
+  hosts: oo_masters_to_config
+  tasks:
+  - name: Ensure Master is running
+    service:
+      name: "{{ openshift.common.service_type }}-master"
+      state: started
+      enabled: yes
+    when: openshift.common.is_containerized | bool
+
+- name: Verify upgrade can proceed
+  hosts: oo_nodes_to_config
+  tasks:
+  - name: Ensure Node is running
+    service:
+      name: "{{ openshift.common.service_type }}-node"
+      state: started
+      enabled: yes
+    when: openshift.common.is_containerized | bool
+
+- name: Verify upgrade can proceed
   hosts: oo_masters_to_config:oo_nodes_to_config
   vars:
     target_version: "{{ '1.2' if deployment_type == 'origin' else '3.1.1.900' }}"

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
@@ -24,7 +24,6 @@
 - name: Verify upgrade can proceed
   hosts: oo_first_master
   vars:
-    openshift_master_ha: "{{ groups.oo_masters_to_config | length > 1 }}"
     target_version: "{{ '1.2' if deployment_type == 'origin' else '3.1.1.900' }}"
   gather_facts: no
   tasks:
@@ -48,13 +47,29 @@
 
 - name: Verify upgrade can proceed
   hosts: oo_masters_to_config
+  vars:
+    openshift_master_ha: "{{ groups.oo_masters_to_config | length > 1 }}"
   tasks:
   - name: Ensure Master is running
     service:
       name: "{{ openshift.common.service_type }}-master"
       state: started
       enabled: yes
-    when: openshift.common.is_containerized | bool
+    when: not openshift_master_ha | bool and openshift.common.is_containerized | bool
+
+  - name: Ensure HA Master is running
+    service:
+      name: "{{ openshift.common.service_type }}-master-api"
+      state: started
+      enabled: yes
+    when: openshift_master_ha | bool and openshift.common.is_containerized | bool
+
+  - name: Ensure HA Master is running
+    service:
+      name: "{{ openshift.common.service_type }}-master-controllers"
+      state: started
+      enabled: yes
+    when: openshift_master_ha | bool and openshift.common.is_containerized | bool
 
 - name: Verify upgrade can proceed
   hosts: oo_nodes_to_config


### PR DESCRIPTION
If the master or node aren't running we can't determine the correct version
that is currently installed.