### PR TITLE
OSE/Origin < 3.2/1.2 should not get Docker 1.9

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,7 +1,31 @@
 ---
 # tasks file for docker
+
+# Avoid docker 1.9 when installing origin < 1.2 or OSE < 3.2 on RHEL/Centos and
+# See: https://bugzilla.redhat.com/show_bug.cgi?id=1304038
+
+- name: Default to latest docker for 1.2/3.2 or Fedora
+  set_fact:
+    docker_version: ''
+  when: openshift.common.version_gte_3_2_or_1_2 | bool or ansible_distribution == 'Fedora'
+
+- name: Gather latest version of docker
+  shell: >
+    yum list available -e 0 -q "docker" 2>&1 | tail -n +2 | awk '{ print $2 }' | sort -r | tr '\n' ' ' | tail -n 1
+  register: latest_docker
+  when: not openshift.common.version_gte_3_2_or_1_2 | bool and ansible_distribution != 'Fedora'
+
+- name: Check if Docker 1.9 is the latest
+  set_fact:
+    docker19_is_latest: "{{ True if '1.9' in latest_docker.stdout else False }}"
+  when: not openshift.common.version_gte_3_2_or_1_2 | bool and ansible_distribution != 'Fedora'
+
+- set_fact:
+    docker_version: "{{ '-1.8.2' if docker19_is_latest | bool else ''}}"
+  when: not openshift.common.version_gte_3_2_or_1_2 | bool and ansible_distribution != 'Fedora'
+
 - name: Install docker
-  action: "{{ ansible_pkg_mgr }} name=docker state=present"
+  action: "{{ ansible_pkg_mgr }} name=docker{{ docker_version }} state=present"
   when: not openshift.common.is_atomic | bool
 
 - name: enable and start the docker service


### PR DESCRIPTION
RHEL and Centos docker-1.9 RPMs will have a Conflicts for origin and
atomic-openshift < 3.2. If we left yum to its own devices we'd get a mess when
trying to install these packages with earlier versions of Origin or OSE.
So avoid installing docker-1.9 on Origin/OSE < 1.2/3.2.
See: https://bugzilla.redhat.com/show_bug.cgi?id=1304038

Fedora doesn't keep old packages in repos so we just get the latest there.
Docker 1.10 should be fine if and when it becomes available.