### PR TITLE
NFS Storage changes

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -575,14 +575,12 @@ class FilterModule(object):
 
     @staticmethod
     # pylint: disable=too-many-branches
-    def oo_persistent_volumes(hostvars, groups, persistent_volumes=None):
+    def oo_persistent_volumes(hostvars, persistent_volumes=None):
         """ Generate list of persistent volumes based on oo_openshift_env
             storage options set in host variables.
         """
         if not issubclass(type(hostvars), dict):
             raise errors.AnsibleFilterError("|failed expects hostvars is a dict")
-        if not issubclass(type(groups), dict):
-            raise errors.AnsibleFilterError("|failed expects groups is a dict")
         if persistent_volumes != None and not issubclass(type(persistent_volumes), list):
             raise errors.AnsibleFilterError("|failed expects persistent_volumes is a list")
 
@@ -595,10 +593,7 @@ class FilterModule(object):
                 if kind == 'nfs':
                     host = hostvars['openshift']['hosted'][component]['storage']['host']
                     if host == None:
-                        if len(groups['oo_nfs_to_config']) > 0:
-                            host = groups['oo_nfs_to_config'][0]
-                        else:
-                            raise errors.AnsibleFilterError("|failed no storage host detected")
+                        raise errors.AnsibleFilterError("|failed no storage host detected")
                     directory = hostvars['openshift']['hosted'][component]['storage']['nfs']['directory']
                     volume = hostvars['openshift']['hosted'][component]['storage']['volume']['name']
                     path = directory + '/' + volume

--- a/playbooks/common/openshift-cluster/additional_config.yml
+++ b/playbooks/common/openshift-cluster/additional_config.yml
@@ -37,7 +37,7 @@
   vars:
     attach_registry_volume: "{{ openshift.hosted.registry.storage.kind != None }}"
     deploy_infra: "{{ openshift.master.infra_nodes | default([]) | length > 0 }}"
-    persistent_volumes: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volumes(groups) }}"
+    persistent_volumes: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volumes }}"
     persistent_volume_claims: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volume_claims }}"
   roles:
   - role: openshift_persistent_volumes

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -56,11 +56,6 @@
         portal_net: "{{ openshift_master_portal_net | default(None) }}"
         ha: "{{ openshift_master_ha | default(groups.oo_masters | length > 1) }}"
         master_count: "{{ openshift_master_count | default(groups.oo_masters | length) }}"
-  - openshift_facts:
-      role: hosted
-      openshift_env:
-        openshift_hosted_registry_storage_kind: 'nfs'
-    when: openshift_hosted_registry_storage_kind is not defined and groups.oo_nfs_to_config is defined and groups.oo_nfs_to_config | length > 0
   - name: Check status of external etcd certificatees
     stat:
       path: "{{ openshift.common.config_base }}/master/{{ item }}"

--- a/playbooks/common/openshift-nfs/config.yml
+++ b/playbooks/common/openshift-nfs/config.yml
@@ -1,6 +1,7 @@
 ---
 - name: Configure nfs hosts
   hosts: oo_nfs_to_config
+  vars:
+    openshift_storage_delegate: "{{ groups.oo_first_master.0 }}"
   roles:
-  - role: openshift_facts
-  - role: openshift_storage_nfs
+  - openshift_storage_nfs

--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -36,8 +36,6 @@
 # for setting the hostname below.
 - name: openshift_facts
   openshift_facts:
-    role: hosted
-    openshift_env: "{{ hostvars[inventory_hostname] | oo_openshift_env }}"
 
 # For enterprise versions < 3.1 and origin versions < 1.1 we want to set the
 # hostname by default.

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1409,24 +1409,24 @@ class OpenShiftFacts(object):
         if 'docker' in roles:
             defaults['docker'] = dict(disable_push_dockerhub=False)
 
-        defaults['hosted'] = dict(
-            registry=dict(
-                storage=dict(
-                    kind=None,
-                    volume=dict(
-                        name='registry',
-                        size='5Gi'
-                    ),
-                    nfs=dict(
-                        directory='/exports',
-                        options='*(rw,root_squash)'),
-                    host=None,
-                    access_modes=['ReadWriteMany'],
-                    create_pv=True
+        if 'hosted' in roles:
+            defaults['hosted'] = dict(
+                registry=dict(
+                    storage=dict(
+                        kind=None,
+                        volume=dict(
+                            name='registry',
+                            size='5Gi'
+                        ),
+                        nfs=dict(
+                            directory='/exports',
+                            options='*(rw,root_squash)'),
+                        host=None,
+                        access_modes=['ReadWriteMany'],
+                        create_pv=True
+                    )
                 )
             )
-        )
-
 
         return defaults
 
@@ -1542,7 +1542,8 @@ class OpenShiftFacts(object):
                     continue
                 for key in keys:
                     if key == keys[-1]:
-                        current_level[key] = value
+                        if value is not None and value != "":
+                            current_level[key] = value
                     elif key not in current_level:
                         current_level[key] = dict()
                         current_level = current_level[key]

--- a/roles/openshift_storage_nfs/README.md
+++ b/roles/openshift_storage_nfs/README.md
@@ -22,12 +22,6 @@ From this role:
 | openshift_hosted_registry_storage_nfs_options   | *(rw,root_squash)     | NFS options for configured exports.                         |
 
 
-From openshift_common:
-| Name                          | Default Value  |                                        |
-|-------------------------------|----------------|----------------------------------------|
-| openshift_debug_level         | 2              | Global openshift debug log verbosity   |
-
-
 Dependencies
 ------------
 

--- a/roles/openshift_storage_nfs/defaults/main.yml
+++ b/roles/openshift_storage_nfs/defaults/main.yml
@@ -1,13 +1,4 @@
 ---
-openshift:
-  hosted:
-    registry:
-      storage:
-        nfs:
-          directory: "/exports"
-          options: "*(rw,root_squash)"
-        volume:
-          name: "registry"
 os_firewall_use_firewalld: False
 os_firewall_allow:
 - service: nfs

--- a/roles/openshift_storage_nfs/meta/main.yml
+++ b/roles/openshift_storage_nfs/meta/main.yml
@@ -10,6 +10,4 @@ galaxy_info:
     versions:
     - 7
 dependencies:
-- { role: os_firewall }
-- { role: openshift_common }
-- { role: openshift_repos }
+- { role: openshift_facts }

--- a/roles/openshift_storage_nfs/tasks/main.yml
+++ b/roles/openshift_storage_nfs/tasks/main.yml
@@ -1,4 +1,32 @@
 ---
+# TODO: when we migrate to ansible 2.0 this should be updated to set
+# delegate_facts: True
+# This task persists the hosted facts attributes to the first master host
+- name: Set hosted facts
+  openshift_facts:
+    role: hosted
+    openshift_env:
+      openshift_hosted_registry_storage_kind: nfs
+      openshift_hosted_registry_storage_host: "{{ hostvars[openshift_storage_delegate].openshift_hosted_registry_storage_host | default(openshift.common.hostname) }}"
+      openshift_hosted_registry_storage_nfs_options: "{{ hostvars[openshift_storage_delegate].openshift_hosted_registry_storage_nfs_options | default(None) }}"
+      openshift_hosted_registry_storage_nfs_directory: "{{ hostvars[openshift_storage_delegate].openshift_hosted_registry_storage_nfs_directory | default(None) }}"
+      openshift_hosted_registry_storage_volume_name: "{{ hostvars[openshift_storage_delegate].openshift_hosted_registry_storage_volume_name | default(None) }}"
+  delegate_to: "{{ openshift_storage_delegate }}"
+
+# TODO: when the above task starts using delegate_facts, then thjis will need
+# to be updated to set the values from groups.oo_first_master.0 instead of the
+# local facts
+# This task persists the hosted facts attributes to the nfs host
+- name: Set default hosted facts if necessary
+  openshift_facts:
+    role: hosted
+    openshift_env:
+      openshift_hosted_registry_storage_kind: nfs
+      openshift_hosted_registry_storage_host: "{{ openshift.hosted.registry.storage.host }}"
+      openshift_hosted_registry_storage_nfs_options: "{{ openshift.hosted.registry.storage.nfs.options }}"
+      openshift_hosted_registry_storage_nfs_directory: "{{ openshift.hosted.registry.storage.nfs.directory }}"
+      openshift_hosted_registry_storage_volume_name: "{{ openshift.hosted.registry.storage.volume.name }}"
+
 - name: Install nfs-utils
   action: "{{ ansible_pkg_mgr }} name=nfs-utils state=present"
 


### PR DESCRIPTION
- tweak the way we are setting openshift.hosted vars and only set them when
  the role is present on a host.
- do not persist empty values from openshift_env
- change openshift_storage_nfs to depend on openshift_facts rather than
  openshift_common (so that we do not pull in the openshift binary).
- better handle the case where the nfs server is not the master server.

Depends on: https://github.com/openshift/openshift-ansible/pull/1603
