### PR TITLE
Move common common facts to openshift_facts

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
@@ -212,13 +212,10 @@
 
 - name: Update deployment type
   hosts: oo_masters_to_config:oo_nodes_to_config:oo_etcd_to_config
+  vars:
+    openshift_deployment_type: "{{ deployment_type }}"
   roles:
   - openshift_facts
-  post_tasks:
-  - openshift_facts:
-      role: common
-      local_facts:
-        deployment_type: "{{ deployment_type }}"
 
 - name: Update master facts
   hosts: oo_masters_to_config

--- a/playbooks/common/openshift-cluster/validate_hostnames.yml
+++ b/playbooks/common/openshift-cluster/validate_hostnames.yml
@@ -6,14 +6,6 @@
   roles:
   - openshift_facts
   tasks:
-  - openshift_facts:
-      role: "{{ item.role }}"
-      local_facts: "{{ item.local_facts }}"
-    with_items:
-      - role: common
-        local_facts:
-          hostname: "{{ openshift_hostname | default(None) }}"
-          public_hostname: "{{ openshift_public_hostname | default(None) }}"
   - shell:
       getent ahostsv4 {{ openshift.common.hostname }} | head -n 1 | awk '{ print $1 }'
     register: lookupip

--- a/playbooks/common/openshift-etcd/config.yml
+++ b/playbooks/common/openshift-etcd/config.yml
@@ -5,17 +5,9 @@
   - openshift_facts
   tasks:
   - openshift_facts:
-      role: "{{ item.role }}"
-      local_facts: "{{ item.local_facts }}"
-    with_items:
-      - role: common
-        local_facts:
-          hostname: "{{ openshift_hostname | default(None) }}"
-          public_hostname: "{{ openshift_public_hostname | default(None) }}"
-          deployment_type: "{{ openshift_deployment_type }}"
-      - role: etcd
-        local_facts:
-          etcd_image: "{{ osm_etcd_image | default(None) }}"
+      role: etcd
+      local_facts:
+        etcd_image: "{{ osm_etcd_image | default(None) }}"
   - name: Check status of etcd certificates
     stat:
       path: "{{ item }}"

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -39,33 +39,23 @@
   - openshift_facts
   post_tasks:
   - openshift_facts:
-      role: "{{ item.role }}"
-      local_facts: "{{ item.local_facts }}"
-    with_items:
-      - role: common
-        local_facts:
-          hostname: "{{ openshift_hostname | default(None) }}"
-          ip: "{{ openshift_ip | default(None) }}"
-          public_hostname: "{{ openshift_public_hostname | default(None) }}"
-          public_ip: "{{ openshift_public_ip | default(None) }}"
-          deployment_type: "{{ openshift_deployment_type }}"
-      - role: master
-        local_facts:
-          api_port: "{{ openshift_master_api_port | default(None) }}"
-          api_url: "{{ openshift_master_api_url | default(None) }}"
-          api_use_ssl: "{{ openshift_master_api_use_ssl | default(None) }}"
-          controllers_port: "{{ openshift_master_controllers_port | default(None) }}"
-          public_api_url: "{{ openshift_master_public_api_url | default(None) }}"
-          cluster_hostname: "{{ openshift_master_cluster_hostname | default(None) }}"
-          cluster_public_hostname: "{{ openshift_master_cluster_public_hostname | default(None) }}"
-          console_path: "{{ openshift_master_console_path | default(None) }}"
-          console_port: "{{ openshift_master_console_port | default(None) }}"
-          console_url: "{{ openshift_master_console_url | default(None) }}"
-          console_use_ssl: "{{ openshift_master_console_use_ssl | default(None) }}"
-          public_console_url: "{{ openshift_master_public_console_url | default(None) }}"
-          portal_net: "{{ openshift_master_portal_net | default(None) }}"
-          ha: "{{ openshift_master_ha | default(groups.oo_masters | length > 1) }}"
-          master_count: "{{ openshift_master_count | default(groups.oo_masters | length) }}"
+      role: master
+      local_facts:
+        api_port: "{{ openshift_master_api_port | default(None) }}"
+        api_url: "{{ openshift_master_api_url | default(None) }}"
+        api_use_ssl: "{{ openshift_master_api_use_ssl | default(None) }}"
+        controllers_port: "{{ openshift_master_controllers_port | default(None) }}"
+        public_api_url: "{{ openshift_master_public_api_url | default(None) }}"
+        cluster_hostname: "{{ openshift_master_cluster_hostname | default(None) }}"
+        cluster_public_hostname: "{{ openshift_master_cluster_public_hostname | default(None) }}"
+        console_path: "{{ openshift_master_console_path | default(None) }}"
+        console_port: "{{ openshift_master_console_port | default(None) }}"
+        console_url: "{{ openshift_master_console_url | default(None) }}"
+        console_use_ssl: "{{ openshift_master_console_use_ssl | default(None) }}"
+        public_console_url: "{{ openshift_master_public_console_url | default(None) }}"
+        portal_net: "{{ openshift_master_portal_net | default(None) }}"
+        ha: "{{ openshift_master_ha | default(groups.oo_masters | length > 1) }}"
+        master_count: "{{ openshift_master_count | default(groups.oo_masters | length) }}"
   - openshift_facts:
       role: hosted
       openshift_env:

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -14,20 +14,11 @@
   # configured, we need to make sure to set the node properties beforehand if
   # we do not want the defaults
   - openshift_facts:
-      role: "{{ item.role }}"
-      local_facts: "{{ item.local_facts }}"
-    with_items:
-      - role: common
-        local_facts:
-          hostname: "{{ openshift_hostname | default(None) }}"
-          public_hostname: "{{ openshift_public_hostname | default(None) }}"
-          deployment_type: "{{ openshift_deployment_type }}"
-          use_flannel: "{{ openshift_use_flannel | default(None) }}"
-      - role: node
-        local_facts:
-          labels: "{{ openshift_node_labels | default(None) }}"
-          annotations: "{{ openshift_node_annotations | default(None) }}"
-          schedulable: "{{ openshift_schedulable | default(openshift_scheduleable) | default(None) }}"
+      role: node
+      local_facts:
+        labels: "{{ openshift_node_labels | default(None) }}"
+        annotations: "{{ openshift_node_annotations | default(None) }}"
+        schedulable: "{{ openshift_schedulable | default(openshift_scheduleable) | default(None) }}"
   - name: Check status of node certificates
     stat:
       path: "{{ openshift.common.config_base }}/node/{{ item }}"
@@ -45,22 +36,6 @@
       node_subdir: node-{{ openshift.common.hostname }}
       config_dir: "{{ openshift.common.config_base }}/generated-configs/node-{{ openshift.common.hostname }}"
       node_cert_dir: "{{ openshift.common.config_base }}/node"
-  - name: Check status of flannel external etcd certificates
-    stat:
-      path: "{{ openshift.common.config_base }}/node/{{ item }}"
-    with_items:
-    - node.etcd-client.crt
-    - node.etcd-ca.crt
-    register: g_external_etcd_flannel_cert_stat_result
-    when: groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config and (openshift.common.use_flannel | bool)
-  - set_fact:
-      etcd_client_flannel_certs_missing: "{{ g_external_etcd_flannel_cert_stat_result.results
-                                             | oo_collect(attribute='stat.exists')
-                                             | list | intersect([false])}}"
-      etcd_cert_subdir: openshift-node-{{ openshift.common.hostname }}
-      etcd_cert_config_dir: "{{ openshift.common.config_base }}/node"
-      etcd_cert_prefix: node.etcd-
-    when: groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config and (openshift.common.use_flannel | bool)
 
 - name: Create temp directory for syncing certs
   hosts: localhost
@@ -72,65 +47,6 @@
     local_action: command mktemp -d /tmp/openshift-ansible-XXXXXXX
     register: mktemp
     changed_when: False
-
-- name: Configure flannel etcd certificates
-  hosts: oo_first_etcd
-  vars:
-    etcd_generated_certs_dir: /etc/etcd/generated_certs
-    sync_tmpdir: "{{ hostvars.localhost.mktemp.stdout }}"
-  pre_tasks:
-  - set_fact:
-      etcd_needing_client_certs: "{{ hostvars
-                                   | oo_select_keys(groups['oo_nodes_to_config'])
-                                   | oo_filter_list(filter_attr='etcd_client_flannel_certs_missing') | default([]) }}"
-    when: etcd_client_flannel_certs_missing is defined and etcd_client_flannel_certs_missing
-  roles:
-  - role: etcd_certificates
-    when: openshift_use_flannel | default(false) | bool
-  post_tasks:
-  - name: Create a tarball of the etcd flannel certs
-    command: >
-      tar -czvf {{ etcd_generated_certs_dir }}/{{ item.etcd_cert_subdir }}.tgz
-        -C {{ etcd_generated_certs_dir }}/{{ item.etcd_cert_subdir }} .
-    args:
-      creates: "{{ etcd_generated_certs_dir }}/{{ item.etcd_cert_subdir }}.tgz"
-    with_items: etcd_needing_client_certs
-    when: etcd_client_flannel_certs_missing is defined and etcd_client_flannel_certs_missing
-  - name: Retrieve the etcd cert tarballs
-    fetch:
-      src: "{{ etcd_generated_certs_dir }}/{{ item.etcd_cert_subdir }}.tgz"
-      dest: "{{ sync_tmpdir }}/"
-      flat: yes
-      fail_on_missing: yes
-      validate_checksum: yes
-    with_items: etcd_needing_client_certs
-    when: etcd_client_flannel_certs_missing is defined and etcd_client_flannel_certs_missing
-
-- name: Copy the external etcd flannel certs to the nodes
-  hosts: oo_nodes_to_config
-  vars:
-    sync_tmpdir: "{{ hostvars.localhost.mktemp.stdout }}"
-  tasks:
-  - name: Ensure certificate directory exists
-    file:
-      path: "{{ openshift.common.config_base }}/node"
-      state: directory
-    when: etcd_client_flannel_certs_missing is defined and etcd_client_flannel_certs_missing
-  - name: Unarchive the tarball on the master
-    unarchive:
-      src: "{{ sync_tmpdir }}/{{ etcd_cert_subdir }}.tgz"
-      dest: "{{ etcd_cert_config_dir }}"
-    when: etcd_client_flannel_certs_missing is defined and etcd_client_flannel_certs_missing
-  - file:
-      path: "{{ etcd_cert_config_dir }}/{{ item }}"
-      owner: root
-      group: root
-      mode: 0600
-    with_items:
-    - node.etcd-client.crt
-    - node.etcd-client.key
-    - node.etcd-ca.crt
-    when: etcd_client_flannel_certs_missing is defined and etcd_client_flannel_certs_missing
 
 - name: Create node certificates
   hosts: oo_first_master
@@ -209,6 +125,86 @@
     openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
   roles:
   - openshift_node
+
+- name: Gather and set facts for flannel certificatess
+  hosts: oo_nodes_to_config
+  tasks:
+  - name: Check status of flannel external etcd certificates
+    stat:
+      path: "{{ openshift.common.config_base }}/node/{{ item }}"
+    with_items:
+    - node.etcd-client.crt
+    - node.etcd-ca.crt
+    register: g_external_etcd_flannel_cert_stat_result
+    when: groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config and (openshift.common.use_flannel | bool)
+  - set_fact:
+      etcd_client_flannel_certs_missing: "{{ g_external_etcd_flannel_cert_stat_result.results
+                                             | oo_collect(attribute='stat.exists')
+                                             | list | intersect([false])}}"
+      etcd_cert_subdir: openshift-node-{{ openshift.common.hostname }}
+      etcd_cert_config_dir: "{{ openshift.common.config_base }}/node"
+      etcd_cert_prefix: node.etcd-
+    when: groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config and (openshift.common.use_flannel | bool)
+
+- name: Configure flannel etcd certificates
+  hosts: oo_first_etcd
+  vars:
+    etcd_generated_certs_dir: /etc/etcd/generated_certs
+    sync_tmpdir: "{{ hostvars.localhost.mktemp.stdout }}"
+  pre_tasks:
+  - set_fact:
+      etcd_needing_client_certs: "{{ hostvars
+                                   | oo_select_keys(groups['oo_nodes_to_config'])
+                                   | oo_filter_list(filter_attr='etcd_client_flannel_certs_missing') | default([]) }}"
+    when: etcd_client_flannel_certs_missing is defined and etcd_client_flannel_certs_missing
+  roles:
+  - role: etcd_certificates
+    when: openshift_use_flannel | default(false) | bool
+  post_tasks:
+  - name: Create a tarball of the etcd flannel certs
+    command: >
+      tar -czvf {{ etcd_generated_certs_dir }}/{{ item.etcd_cert_subdir }}.tgz
+        -C {{ etcd_generated_certs_dir }}/{{ item.etcd_cert_subdir }} .
+    args:
+      creates: "{{ etcd_generated_certs_dir }}/{{ item.etcd_cert_subdir }}.tgz"
+    with_items: etcd_needing_client_certs
+    when: etcd_client_flannel_certs_missing is defined and etcd_client_flannel_certs_missing
+  - name: Retrieve the etcd cert tarballs
+    fetch:
+      src: "{{ etcd_generated_certs_dir }}/{{ item.etcd_cert_subdir }}.tgz"
+      dest: "{{ sync_tmpdir }}/"
+      flat: yes
+      fail_on_missing: yes
+      validate_checksum: yes
+    with_items: etcd_needing_client_certs
+    when: etcd_client_flannel_certs_missing is defined and etcd_client_flannel_certs_missing
+
+- name: Copy the external etcd flannel certs to the nodes
+  hosts: oo_nodes_to_config
+  vars:
+    sync_tmpdir: "{{ hostvars.localhost.mktemp.stdout }}"
+  tasks:
+  - name: Ensure certificate directory exists
+    file:
+      path: "{{ openshift.common.config_base }}/node"
+      state: directory
+    when: etcd_client_flannel_certs_missing is defined and etcd_client_flannel_certs_missing
+  - name: Unarchive the tarball on the master
+    unarchive:
+      src: "{{ sync_tmpdir }}/{{ etcd_cert_subdir }}.tgz"
+      dest: "{{ etcd_cert_config_dir }}"
+    when: etcd_client_flannel_certs_missing is defined and etcd_client_flannel_certs_missing
+  - file:
+      path: "{{ etcd_cert_config_dir }}/{{ item }}"
+      owner: root
+      group: root
+      mode: 0600
+    with_items:
+    - node.etcd-client.crt
+    - node.etcd-client.key
+    - node.etcd-ca.crt
+    when: etcd_client_flannel_certs_missing is defined and etcd_client_flannel_certs_missing
+
 
 - name: Additional node config
   hosts: oo_nodes_to_config

--- a/roles/openshift_cli/meta/main.yml
+++ b/roles/openshift_cli/meta/main.yml
@@ -12,6 +12,6 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
+- role: openshift_common
 - role: openshift_docker
   when: openshift.common.is_containerized | bool
-- role: openshift_common

--- a/roles/openshift_cli/tasks/main.yml
+++ b/roles/openshift_cli/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
+# TODO: move this to a new 'cli' role
 - openshift_facts:
     role: common
     local_facts:
-      deployment_type: "{{ openshift_deployment_type }}"
       cli_image: "{{ osm_image | default(None) }}"
 
 - name: Install clients

--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -19,16 +19,10 @@
   openshift_facts:
     role: common
     local_facts:
-      cluster_id: "{{ openshift_cluster_id | default('default') }}"
       debug_level: "{{ openshift_debug_level | default(2) }}"
-      hostname: "{{ openshift_hostname | default(None) }}"
       install_examples: "{{ openshift_install_examples | default(True) }}"
-      ip: "{{ openshift_ip | default(None) }}"
-      public_hostname: "{{ openshift_public_hostname | default(None) }}"
-      public_ip: "{{ openshift_public_ip | default(None) }}"
       use_openshift_sdn: "{{ openshift_use_openshift_sdn | default(None) }}"
       sdn_network_plugin_name: "{{ os_sdn_network_plugin_name | default(None) }}"
-      deployment_type: "{{ openshift_deployment_type }}"
       use_flannel: "{{ openshift_use_flannel | default(None) }}"
       use_nuage: "{{ openshift_use_nuage | default(None) }}"
       use_manageiq: "{{ openshift_use_manageiq | default(None) }}"

--- a/roles/openshift_docker_facts/tasks/main.yml
+++ b/roles/openshift_docker_facts/tasks/main.yml
@@ -4,9 +4,6 @@
     role: "{{ item.role }}"
     local_facts: "{{ item.local_facts }}"
   with_items:
-  - role: common
-    local_facts:
-      deployment_type: "{{ openshift_deployment_type }}"
   - role: docker
     local_facts:
       additional_registries: "{{ openshift_docker_additional_registries | default(None) }}"

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -25,4 +25,10 @@
   openshift_facts:
     role: common
     local_facts:
+      deployment_type: "{{ openshift_deployment_type }}"
+      cluster_id: "{{ openshift_cluster_id | default('default') }}"
+      hostname: "{{ openshift_hostname | default(None) }}"
+      ip: "{{ openshift_ip | default(None) }}"
       is_containerized: "{{ containerized | default(None) }}"
+      public_hostname: "{{ openshift_public_hostname | default(None) }}"
+      public_ip: "{{ openshift_public_ip | default(None) }}"

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -11,10 +11,8 @@
   with_items:
   - role: common
     local_facts:
-      hostname: "{{ openshift_hostname | default(none) }}"
-      public_hostname: "{{ openshift_public_hostname | default(none) }}"
-      deployment_type: "{{ openshift_deployment_type }}"
       # TODO: Replace this with a lookup or filter plugin.
+      # TODO: Move this to the node role
       dns_ip: "{{ openshift_dns_ip
                   | default(openshift_master_cluster_vip
                   | default(None if openshift.common.version_gte_3_1_or_1_1 | bool else openshift_node_first_master_ip | default(None, true), true), true) }}"

--- a/roles/os_firewall/meta/main.yml
+++ b/roles/os_firewall/meta/main.yml
@@ -11,4 +11,5 @@ galaxy_info:
     - 7
   categories:
   - system
-dependencies: []
+dependencies:
+- { role: openshift_facts }


### PR DESCRIPTION
- Prevents roles that need common facts from needing to require
  openshift_common, which pulls in the openshift binary.
- Add dependency on openshift_facts to os_firewall, since it uses
  openshift.common facts