### PR TITLE
Only mask etcd service for containerized installls when it's installed

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -36,8 +36,12 @@
     state: stopped
     enabled: no
 
+- name: Check for etcd service presence
+  command: systemctl show etcd.service
+  register: etcd_show
+  
 - name: Mask system etcd when containerized
-  when: openshift.common.is_containerized | bool
+  when: openshift.common.is_containerized | bool and 'LoadState=not-found' not in etcd_show.stdout
   command: systemctl mask etcd
 
 - name: Reload systemd units


### PR DESCRIPTION
Proposed fix for https://bugzilla.redhat.com/show_bug.cgi?id=1317734
I'm assuming they're installing containerized onto a host that does not have etcd installed.