### PR TITLE
libvirt cluster variables cleanup

### DIFF
--- a/README_libvirt.md
+++ b/README_libvirt.md
@@ -10,7 +10,7 @@ This makes `libvirt` useful to develop, test and debug OpenShift and openshift-a
 Install dependencies
 --------------------
 
-1.      Install [ansible](http://www.ansible.com/)
+1.	Install [ansible](http://www.ansible.com/)
 2.	Install [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html)
 3.	Install [ebtables](http://ebtables.netfilter.org/)
 4.	Install [qemu and qemu-system-x86](http://wiki.qemu.org/Main_Page)
@@ -121,6 +121,11 @@ The following options can be passed via the `-o` flag of the `create` command or
 * `image_name` (default to `CentOS-7-x86_64-GenericCloud.qcow2`): Name of the QCOW2 image to boot the VMs on
 * `image_compression` (default to `xz`): Source QCOW2 compression (only xz supported at this time)
 * `image_sha256` (default to `dd0f5e610e7c5ffacaca35ed7a78a19142a588f4543da77b61c1fb0d74400471`): Expected SHA256 checksum of the downloaded image
+* `libvirt_storage_pool` (default to `openshift-ansible`): name of the libvirt storage pool for the VM images. It will be created if it does not exist
+* `libvirt_storage_pool_path` (default to `$HOME/libvirt-storage-pool-openshift-ansible`): path to `libvirt_storage_pool`, i.e. where the VM images are stored
+* `libvirt_network` (default to `openshift-ansible`): name of the libvirt network that the VMs will use. It will be created if it does not exist
+* `libvirt_instance_memory_mib` (default to `1024`): memory of the VMs in MiB
+* `libvirt_instance_vcpu` (default to `2`): number of vCPUs of the VMs
 * `skip_image_download` (default to `no`): Skip QCOW2 image download. This requires the `image_name` QCOW2 image to be already present in `$HOME/libvirt-storage-pool-openshift-ansible`
 
 Creating a cluster

--- a/playbooks/libvirt/openshift-cluster/launch.yml
+++ b/playbooks/libvirt/openshift-cluster/launch.yml
@@ -7,11 +7,6 @@
   vars_files:
   - vars.yml
   vars:
-    os_libvirt_storage_pool: "{{ libvirt_storage_pool | default('images') }}"
-    os_libvirt_storage_pool_path: "{{ libvirt_storage_pool_path | default('/var/lib/libvirt/images') }}"
-    os_libvirt_network: "{{ libvirt_network | default('default') }}"
-    os_libvirt_instance_memory_mib: "{{ lookup('oo_option', 'libvirt_instance_memory_mib') | default(1024) }}"
-    os_libvirt_instance_vcpu: "{{ lookup('oo_option', 'libvirt_instance_vcpu') | default(2) }}"
     image_url: "{{ deployment_vars[deployment_type].image.url }}"
     image_sha256: "{{ deployment_vars[deployment_type].image.sha256 }}"
     image_name: "{{ deployment_vars[deployment_type].image.name }}"

--- a/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
@@ -13,58 +13,58 @@
   get_url:
     url: '{{ image_url }}'
     sha256sum: '{{ image_sha256 }}'
-    dest: '{{ os_libvirt_storage_pool_path }}/{{ [image_name, image_compression] | difference([""]) | join(".") }}'
+    dest: '{{ libvirt_storage_pool_path }}/{{ [image_name, image_compression] | difference([""]) | join(".") }}'
   when: '{{ ( lookup("oo_option", "skip_image_download") | default("no", True) | lower ) in ["false", "no"] }}'
   register: downloaded_image
 
 - name: Uncompress xz compressed base cloud image
-  command: 'unxz -kf {{ os_libvirt_storage_pool_path }}/{{ [image_name, image_compression] | join(".") }}'
+  command: 'unxz -kf {{ libvirt_storage_pool_path }}/{{ [image_name, image_compression] | join(".") }}'
   args:
-    creates: '{{ os_libvirt_storage_pool_path }}/{{ image_name }}'
+    creates: '{{ libvirt_storage_pool_path }}/{{ image_name }}'
   when: image_compression in ["xz"] and downloaded_image.changed
 
 - name: Uncompress tgz compressed base cloud image
-  command: 'tar zxvf {{ os_libvirt_storage_pool_path }}/{{ [image_name, image_compression] | join(".") }}'
+  command: 'tar zxvf {{ libvirt_storage_pool_path }}/{{ [image_name, image_compression] | join(".") }}'
   args:
-    creates: '{{ os_libvirt_storage_pool_path }}/{{ image_name }}'
+    creates: '{{ libvirt_storage_pool_path }}/{{ image_name }}'
   when: image_compression in ["tgz"] and downloaded_image.changed
 
 - name: Uncompress gzip compressed base cloud image
-  command: 'gunzip {{ os_libvirt_storage_pool_path }}/{{ [image_name, image_compression] | join(".") }}'
+  command: 'gunzip {{ libvirt_storage_pool_path }}/{{ [image_name, image_compression] | join(".") }}'
   args:
-    creates: '{{ os_libvirt_storage_pool_path }}/{{ image_name }}'
+    creates: '{{ libvirt_storage_pool_path }}/{{ image_name }}'
   when: image_compression in ["gz"] and downloaded_image.changed
 
 - name: Create the cloud-init config drive path
   file:
-    dest: '{{ os_libvirt_storage_pool_path }}/{{ item }}_configdrive/'
+    dest: '{{ libvirt_storage_pool_path }}/{{ item }}_configdrive/'
     state: directory
   with_items: instances
 
 - name: Create the cloud-init config drive files
   template:
     src: '{{ item[1] }}'
-    dest: '{{ os_libvirt_storage_pool_path }}/{{ item[0] }}_configdrive/{{ item[1] }}'
+    dest: '{{ libvirt_storage_pool_path }}/{{ item[0] }}_configdrive/{{ item[1] }}'
   with_nested:
     - instances
     - [ user-data, meta-data ]
 
 - name: Create the cloud-init config drive
-  command: 'genisoimage -output {{ os_libvirt_storage_pool_path }}/{{ item }}_cloud-init.iso -volid cidata -joliet -rock user-data meta-data'
+  command: 'genisoimage -output {{ libvirt_storage_pool_path }}/{{ item }}_cloud-init.iso -volid cidata -joliet -rock user-data meta-data'
   args:
-    chdir: '{{ os_libvirt_storage_pool_path }}/{{ item }}_configdrive/'
-    creates: '{{ os_libvirt_storage_pool_path }}/{{ item }}_cloud-init.iso'
+    chdir: '{{ libvirt_storage_pool_path }}/{{ item }}_configdrive/'
+    creates: '{{ libvirt_storage_pool_path }}/{{ item }}_cloud-init.iso'
   with_items: instances
 
 - name: Refresh the libvirt storage pool for openshift
   command: 'virsh -c {{ libvirt_uri }} pool-refresh {{ libvirt_storage_pool }}'
 
 - name: Create VM drives
-  command: 'virsh -c {{ libvirt_uri }} vol-create-as {{ os_libvirt_storage_pool }} {{ item }}.qcow2 10G --format qcow2 --backing-vol {{ image_name }} --backing-vol-format qcow2'
+  command: 'virsh -c {{ libvirt_uri }} vol-create-as {{ libvirt_storage_pool }} {{ item }}.qcow2 10G --format qcow2 --backing-vol {{ image_name }} --backing-vol-format qcow2'
   with_items: instances
 
 - name: Create VM docker drives
-  command: 'virsh -c {{ libvirt_uri }} vol-create-as {{ os_libvirt_storage_pool }} {{ item }}-docker.qcow2 10G --format qcow2 --allocation 0'
+  command: 'virsh -c {{ libvirt_uri }} vol-create-as {{ libvirt_storage_pool }} {{ item }}-docker.qcow2 10G --format qcow2 --allocation 0'
   with_items: instances
 
 - name: Create VMs

--- a/playbooks/libvirt/openshift-cluster/templates/domain.xml
+++ b/playbooks/libvirt/openshift-cluster/templates/domain.xml
@@ -1,6 +1,6 @@
 <domain type='kvm' id='8'>
   <name>{{ item }}</name>
-  <memory unit='MiB'>{{ os_libvirt_instance_memory_mib }}</memory>
+  <memory unit='MiB'>{{ libvirt_instance_memory_mib }}</memory>
   <metadata xmlns:ansible="https://github.com/ansible/ansible">
     <ansible:tags>
       <ansible:tag>environment-{{ cluster_env }}</ansible:tag>
@@ -9,7 +9,7 @@
       <ansible:tag>sub-host-type-{{ g_sub_host_type }}</ansible:tag>
     </ansible:tags>
   </metadata>
-  <vcpu placement='static'>{{ os_libvirt_instance_vcpu }}</vcpu>
+  <vcpu placement='static'>{{ libvirt_instance_vcpu }}</vcpu>
   <os>
     <type arch='x86_64' machine='pc'>hvm</type>
     <boot dev='hd'/>
@@ -31,23 +31,23 @@
     <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
-      <source file='{{ os_libvirt_storage_pool_path }}/{{ item }}.qcow2'/>
+      <source file='{{ libvirt_storage_pool_path }}/{{ item }}.qcow2'/>
       <target dev='vda' bus='virtio'/>
     </disk>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
-      <source file='{{ os_libvirt_storage_pool_path }}/{{ item }}-docker.qcow2'/>
+      <source file='{{ libvirt_storage_pool_path }}/{{ item }}-docker.qcow2'/>
       <target dev='vdb' bus='virtio'/>
     </disk>
     <disk type='file' device='cdrom'>
       <driver name='qemu' type='raw'/>
-      <source file='{{ os_libvirt_storage_pool_path }}/{{ item }}_cloud-init.iso'/>
+      <source file='{{ libvirt_storage_pool_path }}/{{ item }}_cloud-init.iso'/>
       <target dev='vdc' bus='virtio'/>
       <readonly/>
     </disk>
     <controller type='usb' index='0' />
     <interface type='network'>
-      <source network='{{ os_libvirt_network }}'/>
+      <source network='{{ libvirt_network }}'/>
       <model type='virtio'/>
     </interface>
     <serial type='pty'>

--- a/playbooks/libvirt/openshift-cluster/vars.yml
+++ b/playbooks/libvirt/openshift-cluster/vars.yml
@@ -1,8 +1,11 @@
 ---
-libvirt_storage_pool_path: "{{ lookup('env','HOME') }}/libvirt-storage-pool-openshift-ansible"
-libvirt_storage_pool: 'openshift-ansible'
-libvirt_network: openshift-ansible
-libvirt_uri: 'qemu:///system'
+default_pool_path: "{{ lookup('env','HOME') }}/libvirt-storage-pool-openshift-ansible"
+libvirt_storage_pool_path: "{{ lookup('oo_option', 'libvirt_storage_pool_path') | default(default_pool_path, True) }}"
+libvirt_storage_pool: "{{ lookup('oo_option', 'libvirt_storage_pool') | default('openshift-ansible', True) }}"
+libvirt_network: "{{ lookup('oo_option', 'libvirt_network') | default('openshift-ansible', True) }}"
+libvirt_instance_memory_mib: "{{ lookup('oo_option', 'libvirt_instance_memory_mib') | default(1024, True) }}"
+libvirt_instance_vcpu: "{{ lookup('oo_option', 'libvirt_instance_vcpu') | default(2, True) }}"
+libvirt_uri: "{{ lookup('oo_option', 'libvirt_uri') | default('qemu:///system', True) }}"
 debug_level: 2
 
 # Automatic download of the qcow2 image for RHEL cannot be done directly from the RedHat portal because it requires authentication.


### PR DESCRIPTION
An install of a libvirt cluster was failing if the `libvirt_instance_memory_mib` option introduced in #1578 (d4fa9b2) was not specified.

While investigating this I saw that there were several `os_libvirt_*` variables that were apparently redundant: they seemed to be meant to have default values, but they were actually always getting the values of their corresponding `libvirt_*` counterparts. Moreover, these ones were hard-coded with different values than the intended default values for `os_libvirt_*`.

This patch cleans that up by removing the various `os_libvirt_*` and having all the `libvirt_*` in `vars.yaml` configurable.

It's unclear to me what the purpose of these `os_libvirt_*` was, so please let me know if that was the wrong approach.


