### PR TITLE
Fix path to cacert on /healthz/ready check

### DIFF
--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -256,7 +256,7 @@
     # Using curl here since the uri module requires python-httplib2 and
     # wait_for port doesn't provide health information.
     command: >
-      curl --silent --cacert {{ openshift.master.config_dir }}/master/ca.crt
+      curl --silent --cacert {{ openshift.common.config_base }}/master/ca.crt
       {{ openshift.master.api_url }}/healthz/ready
     register: api_available_output
     until: api_available_output.stdout == 'ok'


### PR DESCRIPTION
Fixes 

```
TASK: [Wait for master API to become available before proceeding] *************                                 
fatal: [ose3-master.example.com] => One or more undefined variables: 'dict object' has no attribute 'config_dir'
```