### PR TITLE
Add default deployment_type to openshift_facts.

### DIFF
--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -25,7 +25,8 @@
   openshift_facts:
     role: common
     local_facts:
-      deployment_type: "{{ openshift_deployment_type }}"
+      # TODO: Deprecate deployment_type in favor of openshift_deployment_type
+      deployment_type: "{{ openshift_deployment_type | default(deployment_type) }}"
       cluster_id: "{{ openshift_cluster_id | default('default') }}"
       hostname: "{{ openshift_hostname | default(None) }}"
       ip: "{{ openshift_ip | default(None) }}"


### PR DESCRIPTION
`openshift_docker_deployment` will not be set when not using the playbooks so we should default to using `deployment_type` for compat. ~~If neither are available then set `deployment_type = 'origin'`.~~

@detiber PTAL. We could instead use `deployment_type` throughout playbooks/roles and add a fail task to the openshift_facts role when `deployment_type` is missing.