### PR TITLE
[WIP] Option to install ntpd

### DIFF
--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -270,6 +270,18 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Setting this variable to true will override that check.
 #openshift_override_hostname_check=true
 
+# Configure clock management method
+# Specify the method used to manage system clocks.
+# none   - Do not manage with openshift-ansible.
+# auto   - Automatically choose method based on host type.
+# ntpd   - Use ntpd (not available for atomic hosts).
+#openshift_manage_clock_method=none
+
+# Configure clock synchronization requirement
+# Specifify if atomic-ansible should fail if the specified clock management
+# method fails to synchronise clocks.
+#openshift_require_clock_sync=false
+
 # host group for masters
 [masters]
 aep3-master[1:3]-ansible.test.example.com

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -275,6 +275,18 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Setting this variable to true will override that check.
 #openshift_override_hostname_check=true
 
+# Configure clock management method
+# Specify the method used to manage system clocks.
+# none   - Do not manage with openshift-ansible.
+# auto   - Automatically choose method based on host type.
+# ntpd   - Use ntpd (not available for atomic hosts).
+#openshift_manage_clock_method=none
+
+# Configure clock synchronization requirement
+# Specifify if atomic-ansible should fail if the specified clock management
+# method fails to synchronise clocks.
+#openshift_require_clock_sync=false
+
 # host group for masters
 [masters]
 ose3-master[1:3]-ansible.test.example.com

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -271,6 +271,18 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Setting this variable to true will override that check.
 #openshift_override_hostname_check=true
 
+# Configure clock management method
+# Specify the method used to manage system clocks.
+# none   - Do not manage with openshift-ansible.
+# auto   - Automatically choose method based on host type.
+# ntpd   - Use ntpd (not available for atomic hosts).
+#openshift_manage_clock_method=none
+
+# Configure clock synchronization requirement
+# Specifify if atomic-ansible should fail if the specified clock management
+# method fails to synchronise clocks.
+#openshift_require_clock_sync=false
+
 # host group for masters
 [masters]
 ose3-master[1:3]-ansible.test.example.com

--- a/playbooks/common/openshift-cluster/additional_config.yml
+++ b/playbooks/common/openshift-cluster/additional_config.yml
@@ -1,3 +1,13 @@
+- name: Configure ntp
+  hosts:
+    - oo_nodes_to_config
+    - oo_etcd_to_config
+  vars:
+    ntp_require_clock_sync: "{{ openshift_require_clock_sync | default(false) | bool }}"
+  roles:
+    - role: ntp
+      when: not openshift.common.is_containerized | bool and openshift_manage_clock_method is defined and
+        ( openshift_manage_clock_method == "ntpd" or openshift_manage_clock_method == "auto" )
 - name: Configure flannel
   hosts: oo_first_master
   vars:

--- a/roles/ntp/meta/main.yml
+++ b/roles/ntp/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  author: OpenShift
+  description: ntp package install
+  company: Red Hat, Inc
+  license: ASL 2.0
+  min_ansible_version: 1.2
+  platforms:
+  - name: EL
+    versions:
+    - 7
+dependencies: []

--- a/roles/ntp/tasks/main.yml
+++ b/roles/ntp/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+# tasks file for ntp
+- name: Install ntp
+  action: "{{ ansible_pkg_mgr }} name=ntp state=present"
+
+- name: Enable and (re)start the ntpd service
+  service:
+    name: ntpd
+    enabled: yes
+    state: restarted
+
+- name: Pause to give ntpd a chance to start and sync
+  pause: seconds=5
+  when: (ntp_require_clock_sync is defined) and ntp_require_clock_sync | bool
+
+- name: Restart ntpd again to recalculate sync status.
+  service:
+    name: ntpd
+    state: restarted
+  when: (ntp_require_clock_sync is defined) and ntp_require_clock_sync | bool
+
+- name: Wait for ntp to become synchronized
+  shell: ntpstat
+  ignore_errors: True
+  register: ntp_ntpstat_result
+  until: ntp_ntpstat_result.rc == 0
+  retries: 5
+  delay: 1
+  when: (ntp_require_clock_sync is defined) and ntp_require_clock_sync | bool
+
+- fail:
+    msg: "ntpd failed to synchronize clock."
+  when: (ntp_ntpstat_result is defined) and ntp_ntpstat_result.rc != 0


### PR DESCRIPTION
Allows ntpd to be installed, enabled, and started. Gives a choice to fail if ntpd is unable to synchronize clocks. Can be enabled by setting openshift_manage_clock_method to ntpd or auto. Can be configured to fail if unable to synchronize clocks by setting openshift_require_clock_sync=True. Cannot install on container hosts and will automatically skip if is_containierized. Does not currently maintain ntp configuration file. Can easily be extended to do so and to allow for other methods such as chrony.

