### PR TITLE
Adding openshift_efk role

### DIFF
--- a/roles/openshift_efk/README.md
+++ b/roles/openshift_efk/README.md
@@ -6,3 +6,4 @@
 #kibana_hostname: kibana.example.com
 #es_cluster_size: 1
 #master_url: https://localhost:8443
+deployer_secret_vars: kibana.crt=/etc/origin/master/ca.crt kibana.key=/etc/origin/master/ca.key ca.crt=/etc/origin/master/ca.crt ca.key=/etc/origin/master/ca.key

--- a/roles/openshift_efk/README.md
+++ b/roles/openshift_efk/README.md
@@ -1,0 +1,8 @@
+
+
+
+ Required vars:
+
+#kibana_hostname: kibana.example.com
+#es_cluster_size: 1
+#master_url: https://localhost:8443

--- a/roles/openshift_efk/files/logging-deployer-sa.yaml
+++ b/roles/openshift_efk/files/logging-deployer-sa.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: logging-deployer
+secrets:
+- name: logging-deployer

--- a/roles/openshift_efk/tasks/main.yaml
+++ b/roles/openshift_efk/tasks/main.yaml
@@ -1,0 +1,177 @@
+---
+
+  - fail: msg="This roel requires the following vars to be defined: master_url, kibana_hostname, es_cluster_size"
+    when: "kibana_hostname is not defined or es_cluster_size is not defined or master_url is not defined"
+
+  - name: "Checking for logging project"
+    command: oc get project logging
+    register: logging_project
+    failed_when: "'FAILED' in logging_project.stderr"
+    tags:
+      - cleanup
+
+  - name: "Create logging project"
+    command: oadm new-project logging
+    when: logging_project.rc != 0
+    tags:
+      - build
+  - name: "Changing projects"
+    command: oc project logging
+    tags:
+      - cleanup
+
+  - name: "Cleanup any previous logging infrastructure"
+    command: oc delete all --selector logging-infra={{ item }}
+    with_items:
+      - kibana
+      - fluentd
+      - elasticsearch
+    ignore_errors: yes
+    tags:
+      - cleanup
+
+  - name: "Cleanup existing support infrastructure"
+    command: oc delete all,sa,oauthclient --selector logging-infra=support
+    ignore_errors: yes
+    tags:
+      - cleanup
+
+  - name: "Cleanup existing secrets"
+    command: oc delete secret logging-fluentd logging-elasticsearch logging-es-proxy logging-kibana logging-kibana-proxy logging-kibana-ops-proxy
+    ignore_errors: yes
+    register: clean_result
+    failed_when: clean_result.rc == 1 and 'not found' not in clean_result.stderr
+    tags:
+      - cleanup
+
+  - name: "Cleanup existing logging deployers"
+    command: oc delete pods --all
+    tags:
+      - cleanup
+
+  - name: "Creating logging deployer secret"
+    command: oc secrets new logging-deployer kibana.crt=/etc/origin/master/ca.crt kibana.key=/etc/origin/master/ca.key ca.crt=/etc/origin/master/ca.crt ca.key=/etc/origin/master/ca.key
+    register: secret_output
+    failed_when: "secret_output.rc == 1 and 'exists' not in secret_output.stderr"
+    tags:
+      - build
+
+  - name: "Copy serviceAccount file"
+    copy: dest=/tmp/logging-deployer-sa.yaml
+          src={{role_path}}/files/logging-deployer-sa.yaml
+          force=yes
+    tags:
+      - build
+
+  - name: "Create logging-deployer service account"
+    shell: oc create -f  /tmp/logging-deployer-sa.yaml
+    register: deployer_output
+    failed_when: "deployer_output.rc == 1 and 'exists' not in deployer_output.stderr"
+    tags:
+      - build
+
+  - name: "Set permissions for logging-deployer service account"
+    command: oc policy add-role-to-user edit system:serviceaccount:logging:logging-deployer
+    register: permiss_output
+    failed_when: "permiss_output.rc == 1 and 'exists' not in permiss_output.stderr"
+    tags:
+      - build
+
+  - name: "Set permissions for fluentd"
+    command: oadm policy add-scc-to-user privileged system:serviceaccount:logging:aggregated-logging-fluentd
+    register: fluentd_output
+    failed_when: "fluentd_output.rc == 1 and 'exists' not in fluentd_output.stderr"
+    tags:
+      - build
+
+  - name: "Set additional permissions for fluentd"
+    command: oadm policy add-cluster-role-to-user cluster-reader system:serviceaccount:logging:aggregated-logging-fluentd
+    register: fluentd2_output
+    failed_when: "fluentd2_output.rc == 1 and 'exists' not in fluentd2_output.stderr"
+    tags:
+      - build
+
+  - name: "Make sure to remove stale deployer template"
+    command: oc delete template logging-deployer-template -n openshift
+    register: delete_ouput
+    failed_when: delete_ouput.rc == 1 and 'exists' not in delete_ouput.stderr
+    tags:
+      - build
+
+  - name: "Create deployer template"
+    command: oc create -f /usr/share/openshift/examples/infrastructure-templates/enterprise/logging-deployer.yaml -n openshift
+    register: template_output
+    failed_when: "template_output.rc == 1 and 'exists' not in template_output.stderr"
+    tags:
+      - build
+
+  - name: "Clear out any previous pods"
+    command: oc delete pods --all
+    tags:
+      - build
+
+  - name: "Process the deployer template with an registry other than registry.access.redhat.com"
+    shell: oc process logging-deployer-template -n openshift -v KIBANA_HOSTNAME={{ kibana_hostname | quote }},ES_CLUSTER_SIZE={{ es_cluster_size | quote }},PUBLIC_MASTER_URL={{ master_url | quote }},IMAGE_PREFIX={{ target_registry | quote }}/  | oc create -f -
+    when: target_registry is defined
+    tags:
+      - build
+
+  - name: "Process the default deployer template"
+    shell: oc process logging-deployer-template -n openshift -v KIBANA_HOSTNAME={{ kibana_hostname | quote }},ES_CLUSTER_SIZE={{ es_cluster_size | quote }},PUBLIC_MASTER_URL={{ master_url | quote }}  | oc create -f -
+    when: target_registry is not defined
+    tags:
+      - build
+
+  - name: "Wait for image pull and deployer pod"
+    action: shell oc get pods | grep logging-deployer.*Completed
+    register: result
+    until: result.rc == 0
+    retries: 15
+    delay: 10
+    tags:
+      - build
+
+  - name: "Process support template"
+    shell: oc process logging-support-template | oc create -f -
+    tags:
+      - build
+
+  - name: "Set insecured registry"
+    command: oc annotate is --all  openshift.io/image.insecureRepository=true --overwrite
+    when: "target_registry is defined and insecure_registry == 'true'"
+    tags:
+      - build
+
+  - name: "Scale fluentd deployment config"
+    command: oc scale dc/logging-fluentd --replicas={{ fluentd_replicas }}
+    tags:
+      - build
+
+  - name: "Wait for imagestreams to become available"
+    action: shell oc get is | grep logging-fluentd
+    register: result
+    until: result.rc == 0
+    failed_when: result.rc == 1 and 'not found' not in result.stderr
+    retries: 15
+    delay: 5
+    tags:
+      - build
+
+  - name: "Wait for replication controllers to become available"
+    action: shell oc get rc | grep logging-fluentd-1
+    register: result
+    until: result.rc == 0
+    failed_when: result.rc == 1 and 'not found' not in result.stderr
+    retries: 15
+    delay: 5
+    tags:
+      - build
+
+  - name: "Scale fluentd replication controller"
+    command: oc scale rc/logging-fluentd-1 --replicas={{ fluentd_replicas }}
+    tags:
+      - build
+
+  - debug: msg="Logging components deployed. Note persistant volume for elasticsearch must be setup manually"
+    tags:
+      - build

--- a/roles/openshift_efk/tasks/main.yaml
+++ b/roles/openshift_efk/tasks/main.yaml
@@ -1,7 +1,10 @@
 ---
 
   - fail: msg="This roel requires the following vars to be defined: master_url, kibana_hostname, es_cluster_size"
-    when: "kibana_hostname is not defined or es_cluster_size is not defined or master_url is not defined"
+    when: "deployer_secret_vars is not defined or 
+          kibana_hostname is not defined or
+          es_cluster_size is not defined or
+          master_url is not defined"
 
   - name: "Checking for logging project"
     command: oc get project logging
@@ -50,7 +53,7 @@
       - cleanup
 
   - name: "Creating logging deployer secret"
-    command: oc secrets new logging-deployer kibana.crt=/etc/origin/master/ca.crt kibana.key=/etc/origin/master/ca.key ca.crt=/etc/origin/master/ca.crt ca.key=/etc/origin/master/ca.key
+    command: oc secrets new logging-deployer {{ deployer_secret_vars }}
     register: secret_output
     failed_when: "secret_output.rc == 1 and 'exists' not in secret_output.stderr"
     tags:


### PR DESCRIPTION
This role is used to setup the internal aggregated logging solution within openshift. 
When including the role in a playbook the required variables needed to be passed in are:

-   kibana_hostname: name to use to acces the kibana console. (kibana.apps.example.com)
-   master_url: Url of the openshift master (https://master.example.com:84443)'
-   es_cluster_size: The number of elasticsearch instances in the cluster (3)

cc: @detiber @etsauer