### PR TITLE
Adding openshift_metrics role

### DIFF
--- a/roles/openshift_metrics/README.md
+++ b/roles/openshift_metrics/README.md
@@ -1,0 +1,11 @@
+###Required vars:
+
+- metrics_hostname: metrics-ose.example.com
+- metrics_pv_size: 5G "Persistant storage size for Cassandra"
+
+
+###OPTIONAL
+
+- target_registry: registry.example.com:5000 "Registry to use instead of registry.access.redhat.com"
+- openshift_infra_selector: 'nodetype=infra' "Will annotate the openshift-infra namespace to only deploy infrastructure pods od the nodes with teh provided node-selector"
+- metrics_secret_vars: (defaults to: nothing=/dev/null) "key=value key=value ..." pairs to give the metrics deployer

--- a/roles/openshift_metrics/files/metrics-deployer-sa.yaml
+++ b/roles/openshift_metrics/files/metrics-deployer-sa.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-deployer
+secrets:
+- name: metrics-deployer

--- a/roles/openshift_metrics/files/metrics.yaml
+++ b/roles/openshift_metrics/files/metrics.yaml
@@ -1,0 +1,100 @@
+
+
+apiVersion: "v1"
+kind: "Template"
+metadata:
+  name: metrics-deployer-template
+  annotations:
+    description: "Template for deploying the required Metrics integration. Requires cluster-admin 'metrics-deployer' service account and 'metrics-deployer' secret."
+    tags: "infrastructure"
+labels:
+  metrics-infra: deployer
+  provider: openshift
+  component: deployer
+objects:
+-
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    generateName: metrics-deployer-
+  spec:
+    containers:
+    - image: ${IMAGE_PREFIX}metrics-deployer:${IMAGE_VERSION}
+      name: deployer
+      volumeMounts:
+      - name: secret
+        mountPath: /secret
+        readOnly: true
+      - name: empty
+        mountPath: /etc/deploy
+      env:
+        - name: PROJECT
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: IMAGE_PREFIX
+          value: ${IMAGE_PREFIX}
+        - name: IMAGE_VERSION
+          value: ${IMAGE_VERSION}
+        - name: PUBLIC_MASTER_URL
+          value: ${PUBLIC_MASTER_URL}
+        - name: MASTER_URL
+          value: ${MASTER_URL}
+        - name: REDEPLOY
+          value: ${REDEPLOY}
+        - name: USE_PERSISTENT_STORAGE
+          value: ${USE_PERSISTENT_STORAGE}
+        - name: HAWKULAR_METRICS_HOSTNAME
+          value: ${HAWKULAR_METRICS_HOSTNAME}
+        - name: CASSANDRA_NODES
+          value: ${CASSANDRA_NODES}
+        - name: CASSANDRA_PV_SIZE
+          value: ${CASSANDRA_PV_SIZE}
+        - name: METRIC_DURATION
+          value: ${METRIC_DURATION}
+    dnsPolicy: ClusterFirst
+    restartPolicy: Never
+    serviceAccount: metrics-deployer
+    volumes:
+    - name: empty
+      emptyDir: {}
+    - name: secret
+      secret:
+        secretName: metrics-deployer
+parameters:
+-
+  description: 'Specify prefix for metrics components; e.g. for "openshift/origin-metrics-deployer:v3.1", set prefix "openshift/origin-"'
+  name: IMAGE_PREFIX
+  value: "openshift/origin-"
+-
+  description: 'Specify version for metrics components; e.g. for "openshift/origin-metrics-deployer:v3.1", set version "v1.1"'
+  name: IMAGE_VERSION
+  value: "latest"
+-
+  description: "Internal URL for the master, for authentication retrieval"
+  name: MASTER_URL
+  value: "https://kubernetes.default.svc:443"
+-
+  description: "External hostname where clients will reach Hawkular Metrics"
+  name: HAWKULAR_METRICS_HOSTNAME
+  required: true
+-
+  description: "If set to true the deployer will try and delete all the existing components before trying to redeploy."
+  name: REDEPLOY
+  value: "false"
+-
+  description: "Set to true for persistent storage, set to false to use non persistent storage"
+  name: USE_PERSISTENT_STORAGE
+  value: "true"
+-
+  description: "The number of Cassandra Nodes to deploy for the initial cluster"
+  name: CASSANDRA_NODES
+  value: "1"
+-
+  description: "The persistent volume size for each of the Cassandra nodes"
+  name: CASSANDRA_PV_SIZE
+  value: "10Gi"
+-
+  description: "How many days metrics should be stored for."
+  name: METRIC_DURATION
+  value: "7"

--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -1,0 +1,59 @@
+---
+
+  - fail: msg="Please maker sure the following required variables are defined: metrics_hostname, metrics_pv_size"
+    when: metrics_hostname is not defined or
+          metrics_pv_size is not defined
+
+  - name: "Change to openshift-infra"
+    command: oc project openshift-infra
+
+  - name: "Check for available PV"
+    shell: oc get pv | grep Available
+    register: pv_out
+    ignore_erros: yes
+
+  - fail: msg="Please ensure you have a Persistant volume created and available for Cassandra"
+    when: pv_out.rc == 1
+
+  - name: "annotate openshift-infra to box infrastructure on infra nodes"
+    command: "oc annotate --overwrite namespace openshift-infra openshift.io/node-selector={{ openshift_infra_selector }}"
+    when: openshift_infra_selector is defined
+
+  - name: "copy sa file"
+    copy: dest=/tmp/metrics-deployer-sa.yaml
+          src={{role_path}}/files/metrics-deployer-sa.yaml
+          force=yes
+
+  - name: "copy metrics file"
+    copy: dest=/tmp/metrics.yaml
+          src={{ role_path }}/files/metrics.yaml
+          force=yes
+
+  - name: "delete existing metrics service accounts"
+    command: oc delete --ignore-not-found sa hawkular cassandra heapster metrics-deployer
+
+  - name: "Create metrics service account"
+    shell: "oc create -f /tmp/metrics-deployer-sa.yaml"
+    register: sa_out
+    failed_when: "sa_out.rc == 1 and 'exists' not in sa_out.stderr"
+
+  - name: "Give sa account privileges to deploy components"
+    command: oadm policy add-role-to-user edit system:serviceaccount:openshift-infra:metrics-deployer
+    register: deployer_priv_out
+    failed_when: deployer_priv_out.rc == 1
+
+  - name: "Give heapster sa privileges to access metrics"
+    command: oadm policy add-cluster-role-to-user cluster-reader system:serviceaccount:openshift-infra:heapster
+
+  - name: "creating deployer secret"
+    command: "oc secrets new metrics-deployer {{ metrics_secret_vars | default('nothing=/dev/null') }}"
+    register: secret_out
+    failed_when: "secret_out.rc == 1 and 'exists' not in secret_out.stderr"
+
+  - name: "Create metrics-deployer template with custom registry"
+    shell: "oc process -f /tmp/metrics.yaml -v HAWKULAR_METRICS_HOSTNAME={{ metrics_hostname | quote }} -v CASSANDRA_PV_SIZE={{ metrics_pv_size | quote }},REDEPLOY=true,IMAGE_VERSION={{ img_version | quote }},IMAGE_PREFIX={{ target_registry | quote }}/openshift3/ | oc create -f -"
+    when: target_registry is defined
+
+  - name: "Create metrics-deployer template with default registry"
+    shell: "oc process -f /tmp/metrics.yaml -v HAWKULAR_METRICS_HOSTNAME={{ metrics_hostname | quote }} -v CASSANDRA_PV_SIZE={{ metrics_pv_size | quote }},IMAGE_VERSION={{ img_version | quote }},REDEPLOY=true | oc create -f -"
+    when: target_registry is not defined


### PR DESCRIPTION
This role automates the container metrics setup within openshift. This will setup the Hawkular metrics within an installation of Openshift so that metrics can be viewed in the openshift web console. See roles/openshift_metrics/README.md for required variables.   

cc: @etsauer @detiber 