### PR TITLE
Lock down permissions on named certificates

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -311,13 +311,14 @@
     file:
       path: "{{ named_certs_dir }}"
       state: directory
+      mode: 0700
     when: named_certs_specified | bool
   - name: Land named certificates
     copy: src="{{ item.certfile }}" dest="{{ named_certs_dir }}"
     with_items: openshift_master_named_certificates
     when: named_certs_specified | bool
   - name: Land named certificate keys
-    copy: src="{{ item.keyfile }}" dest="{{ named_certs_dir }}"
+    copy: src="{{ item.keyfile }}" dest="{{ named_certs_dir }}" mode=0600
     with_items: openshift_master_named_certificates
     when: named_certs_specified | bool
 


### PR DESCRIPTION
The `named_certificates` directory is created with mode `0755`, and all the files inside it are given mode `0644`, because these are the defaults. SSL private keys, however, are sensitive and should not be world-readable. This changes the permissions of the `named_certificates` directory to `0700` and the private keys to `0600`. It does not change the permissions of the SSL certificates themselves, as those are non-sensitive and provided by the web server anyway.