### PR TITLE
Support setting local storage perFSGroup quota in node config.

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1407,6 +1407,7 @@ class OpenShiftFacts(object):
         if 'node' in roles:
             defaults['node'] = dict(labels={}, annotations={},
                                     iptables_sync_period='5s',
+                                    local_quota_per_fsgroup="",
                                     set_node_ip=False)
 
         if 'docker' in roles:

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -31,6 +31,7 @@
       node_image: "{{ osn_image | default(None) }}"
       ovs_image: "{{ osn_ovs_image | default(None) }}"
       proxy_mode: "{{ openshift_node_proxy_mode | default('iptables') }}"
+      local_quota_per_fsgroup: "{{ openshift_node_local_quota_per_fsgroup | default(None) }}"
 
 # We have to add tuned-profiles in the same transaction otherwise we run into depsolving
 # problems because the rpms don't pin the version properly. This was fixed in 3.1 packaging.

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -38,3 +38,6 @@ volumeDirectory: {{ openshift.common.data_dir }}/openshift.local.volumes
 proxyArguments:
   proxy-mode:
      - {{ openshift.node.proxy_mode }}
+volumeConfig:
+  localQuota:
+    perFSGroup: {{ openshift.node.local_quota_per_fsgroup }}


### PR DESCRIPTION
Adds a new inventory var "openshift_node_local_quota_per_fsgroup", which will
set the new perFSGroup quota in node-config.yaml.

This will leave the property empty if not specified in your inventory, origin interprets this correctly as "do not enable this feature".

To test, your volumeDirectory must be on an XFS filesystem mounted with grpquota option. 

NOTE: On first run for a fresh node, the node will fail to start with latest builds due to an unanticipated bug with doing some checks on the volumeDirectory's filesystem, before it's actually been created. This will be addressed in https://github.com/openshift/origin/pull/8193.

To workaround this just create /var/lib/origin/openshift.local.volumes, and re-run the config playbook.




