### PR TITLE
Enable Ansible ssh pipelining to speedup deployment

### DIFF
--- a/bin/cluster
+++ b/bin/cluster
@@ -34,6 +34,8 @@ class Cluster(object):
             os.environ['ANSIBLE_HOST_KEY_CHECKING'] = 'False'
             # TODO: A more secure way to proceed would consist in dynamically
             # retrieving the ssh host public keys from the IaaS interface
+        if 'ANSIBLE_SSH_PIPELINING' not in os.environ:
+            os.environ['ANSIBLE_SSH_PIPELINING'] = 'True'
 
     def get_deployment_type(self, args):
         """
@@ -284,7 +286,20 @@ if __name__ == '__main__':
     cluster = Cluster()
 
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description='Python wrapper to ensure proper configuration for OpenShift ansible playbooks',
+        epilog='''\
+This wrapper is overriding the following ansible variables:
+
+  * ANSIBLE_SSH_ARGS:
+      If not set in the environment, this wrapper will use the following value:
+      `-o ForwardAgent=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ControlMaster=auto -o ControlPersist=600s`
+      If set in the environment, the environment variable value is left untouched and used.
+
+  * ANSIBLE_SSH_PIPELINING:
+      If not set in the environment, this wrapper will set it to `True`.
+      If you experience issue with Ansible ssh pipelining, you can disable it by explicitely set this environment variable to `False`.
+'''
     )
     parser.add_argument('-v', '--verbose', action='count',
                         help='Multiple -v options increase the verbosity')

--- a/playbooks/openstack/openshift-cluster/files/heat_stack.yaml
+++ b/playbooks/openstack/openshift-cluster/files/heat_stack.yaml
@@ -598,6 +598,10 @@ resources:
               template: |
                 #cloud-config
                 write_files:
+                  - path: /etc/sudoers.d/00-openshift-no-requiretty
+                    permissions: 440
+                    content: |
+                      Defaults:openshift !requiretty
                   - path: /etc/sysconfig/network-scripts/ifcfg-eth0
                     content: |
                       DEVICE="eth0"

--- a/playbooks/openstack/openshift-cluster/files/user-data
+++ b/playbooks/openstack/openshift-cluster/files/user-data
@@ -5,3 +5,9 @@ system_info:
   default_user:
     name: openshift
     sudo: ["ALL=(ALL) NOPASSWD: ALL"]
+
+write_files:
+  - path: /etc/sudoers.d/00-openshift-no-requiretty
+    permissions: 440
+    content: |
+      Defaults:openshift !requiretty


### PR DESCRIPTION
https://docs.ansible.com/ansible/intro_configuration.html#pipelining

This requires `sudo` to not `requiretty`. As the `requiretty` option is in the default RHEL `sudoers` file, it has to be explicitly disabled.

This was already the case for [libvirt](https://github.com/openshift/openshift-ansible/blob/master/playbooks/libvirt/openshift-cluster/templates/user-data#L25) and [AWS](https://github.com/openshift/openshift-ansible/blob/master/playbooks/aws/openshift-cluster/templates/user_data.j2#L48). So, just did the same thing for OpenStack.