### PR TITLE
Downgrade to docker 1.8.2 if installing < 1.2/3.2

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+docker_version: ''

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,32 +1,29 @@
 ---
 # tasks file for docker
 
-# Avoid docker 1.9 when installing origin < 1.2 or OSE < 3.2 on RHEL/Centos and
-# See: https://bugzilla.redhat.com/show_bug.cgi?id=1304038
+- name: Get current installed version if docker_version is specified
+  command: "{{ repoquery_cmd }} --installed --qf '%{version}' docker"
+  when:  not openshift.common.is_atomic | bool and docker_version != ''
+  register: docker_version_result
+  changed_when: false
 
-- name: Default to latest docker for 1.2/3.2 or Fedora
-  set_fact:
-    docker_version: ''
-  when: openshift.common.version_gte_3_2_or_1_2 | bool or ansible_distribution == 'Fedora'
-
-- name: Gather latest version of docker
-  shell: >
-    yum list available -e 0 -q "docker" 2>&1 | tail -n +2 | awk '{ print $2 }' | sort -r | tr '\n' ' ' | tail -n 1
-  register: latest_docker
-  when: not openshift.common.version_gte_3_2_or_1_2 | bool and ansible_distribution != 'Fedora'
-
-- name: Check if Docker 1.9 is the latest
-  set_fact:
-    docker19_is_latest: "{{ True if '1.9' in latest_docker.stdout else False }}"
-  when: not openshift.common.version_gte_3_2_or_1_2 | bool and ansible_distribution != 'Fedora'
-
-- set_fact:
-    docker_version: "{{ '-1.8.2' if docker19_is_latest | bool else ''}}"
-  when: not openshift.common.version_gte_3_2_or_1_2 | bool and ansible_distribution != 'Fedora'
+- name: Downgrade docker if necessary
+  command: "{{ ansible_pkg_mgr }} downgrade -y docker-{{ docker_version }}"
+  register: docker_downgrade_result
+  when: not docker_version_result | skipped and docker_version_result | default('0.0', True) | version_compare(docker_version, 'gt')
 
 - name: Install docker
-  action: "{{ ansible_pkg_mgr }} name=docker{{ docker_version }} state=present"
-  when: not openshift.common.is_atomic | bool
+  action: "{{ ansible_pkg_mgr }} name=docker{{ '-' + docker_version if docker_version != '' else '' }} state=present"
+  when: not openshift.common.is_atomic | bool and not docker_downgrade_result | changed
+
+- stat: path=/etc/sysconfig/docker
+  register: docker_check
+  when: docker_downgrade_result | changed
+
+- name: Remove deferred deletion for downgrades from 1.9
+  command: >
+    sed -i 's/--storage-opt dm.use_deferred_deletion=true//' /etc/sysconfig/docker-storage
+  when: docker_downgrade_result | changed and docker_check.stat.exists | bool and docker_version_result | default('0.0', True) | version_compare('1.9', '>=') and docker_version | version_compare('1.9', '<')
 
 - name: enable and start the docker service
   service:

--- a/roles/openshift_cli/meta/main.yml
+++ b/roles/openshift_cli/meta/main.yml
@@ -13,6 +13,5 @@ galaxy_info:
   - cloud
 dependencies:
 - role: openshift_docker
-  when: openshift.common.is_containerized | bool
 - role: openshift_common
 - role: openshift_cli_facts

--- a/roles/openshift_docker/meta/main.yml
+++ b/roles/openshift_docker/meta/main.yml
@@ -12,5 +12,6 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
+- role: openshift_repos
 - role: openshift_docker_facts
 - role: docker

--- a/roles/openshift_docker_facts/tasks/main.yml
+++ b/roles/openshift_docker_facts/tasks/main.yml
@@ -37,3 +37,19 @@
 - set_fact:
     docker_options: "{{ openshift.docker.options | default(omit) }}"
   when: not openshift.docker.hosted_registry_insecure | default(False) | bool
+
+# Avoid docker 1.9 when installing origin < 1.2 or OSE < 3.2 on RHEL/Centos and
+# See: https://bugzilla.redhat.com/show_bug.cgi?id=1304038
+- name: Gather common package version
+  command: >
+    {{ repoquery_cmd }} --qf '%{version}' "{{ openshift.common.service_type}}"
+  register: common_version
+  failed_when: false
+  changed_when: false
+  when: not openshift.common.is_atomic | bool
+
+- name: Set docker version to be installed
+  set_fact:
+    docker_version: "{{ '1.8.2' }}"
+  when: " ( common_version.stdout | default('0.0', True) | version_compare('3.2','<') and openshift.common.service_type == 'atomic-openshift' ) or
+          ( common_version.stdout | default('0.0', True) | version_compare('1.2','<') and openshift.common.service_type == 'origin' )"

--- a/roles/openshift_docker_facts/vars/main.yml
+++ b/roles/openshift_docker_facts/vars/main.yml
@@ -1,3 +1,2 @@
 ---
 repoquery_cmd: "{{ 'dnf repoquery --latest-limit 1 -d 0' if ansible_pkg_mgr == 'dnf' else 'repoquery' }}"
-udevw_udevd_dir: /etc/systemd/system/systemd-udevd.service.d

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -15,7 +15,7 @@
 - set_fact:
     l_is_atomic: "{{ ostree_output.rc == 0 }}"
 - set_fact:
-    l_is_containerized: "{{ l_is_atomic or containerized | default(false) | bool }}"
+    l_is_containerized: "{{ (l_is_atomic | bool) or (containerized | default(false) | bool) }}"
 
 - name: Ensure PyYaml is installed
   action: "{{ ansible_pkg_mgr }} name=PyYAML state=present"

--- a/roles/openshift_master/meta/main.yml
+++ b/roles/openshift_master/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
+- role: openshift_docker
 - role: openshift_cli
 - role: openshift_cloud_provider
 - role: openshift_master_facts


### PR DESCRIPTION
This ignores the situation of Origin by way of only working when version is 3.0 or 3.1. The current version of origin should be fine with docker-1.9.

I've tested
- [x] Installing 3.1.x without docker installed, you get docker-1.8.2
- [x] Installing 3.1.x with docker-1.9 installed, downgrades to 1.8.2
- [x] Upgrading to 3.2 using playbooks/byo/openshift-cluster/upgrades/...
- [x] Installing 3.2 without docker installed, it installs docker-1.9.1 as that's the latest.
- [x] Installing 3.2 with docker-1.8.2 installed, upgrades to 1.9.1 due to RPM deps
- [x] Installing 3.2 with docker-1.9 installed