### PR TITLE
Add support for templating master admissionConfig.

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1118,12 +1118,21 @@ def merge_facts(orig, new, additive_facts_to_overwrite, protected_facts_to_overw
     """
     additive_facts = ['named_certificates']
     protected_facts = ['ha', 'master_count']
+
+    # Facts we do not ever want to merge. These originate in inventory variables
+    # and typically contain JSON dicts. We don't ever want to trigger a merge
+    # here, just completely overwrite with the new if they are present there.
+    overwrite_facts = ['admission_plugin_config',
+                       'kube_admission_plugin_config']
+
     facts = dict()
     for key, value in orig.iteritems():
         # Key exists in both old and new facts.
         if key in new:
+            if key in overwrite_facts:
+                facts[key] = copy.deepcopy(new[key])
             # Continue to recurse if old and new fact is a dictionary.
-            if isinstance(value, dict) and isinstance(new[key], dict):
+            elif isinstance(value, dict) and isinstance(new[key], dict):
                 # Collect the subset of additive facts to overwrite if
                 # key matches. These will be passed to the subsequent
                 # merge_facts call.

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -837,6 +837,25 @@ def set_sdn_facts_if_unset(facts, system_facts):
 
     return facts
 
+def migrate_oauth_template_facts(facts):
+    """
+    Migrate an old oauth template fact to a newer format if it's present.
+
+    The legacy 'oauth_template' fact was just a filename, and assumed you were
+    setting the 'login' template.
+
+    The new pluralized 'oauth_templates' fact is a dict mapping the template
+    name to a filename.
+
+    Simplify the code after this by merging the old fact into the new.
+    """
+    if 'master' in facts and 'oauth_template' in facts['master']:
+        if 'oauth_templates' not in facts['master']:
+            facts['master']['oauth_templates'] = {"login": facts['master']['oauth_template']}
+        elif 'login' not in facts['master']['oauth_templates']:
+            facts['master']['oauth_templates']['login'] = facts['master']['oauth_template']
+    return facts
+
 def format_url(use_ssl, hostname, port, path=''):
     """ Format url based on ssl flag, hostname, port and path
 
@@ -1450,6 +1469,7 @@ class OpenShiftFacts(object):
                             local_facts,
                             additive_facts_to_overwrite,
                             protected_facts_to_overwrite)
+        facts = migrate_oauth_template_facts(facts)
         facts['current_config'] = get_current_config(facts)
         facts = set_url_facts_if_unset(facts)
         facts = set_project_cfg_facts_if_unset(facts)

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -1,3 +1,10 @@
+admissionConfig:
+{% if 'admission_plugin_order' in openshift.master %}
+  pluginOrderOverride:{{ openshift.master.admission_plugin_order | to_padded_yaml(level=2) }}
+{% endif %}
+{% if 'admission_plugin_config' in openshift.master %}
+  pluginConfig:{{ openshift.master.admission_plugin_config | to_padded_yaml(level=2) }}
+{% endif %}
 apiLevels:
 {% if not openshift.common.version_gte_3_1_or_1_1 | bool %}
 - v1beta3
@@ -95,6 +102,13 @@ kubernetesMasterConfig:
   apiLevels:
   - v1beta3
   - v1
+{% endif %}
+  admissionConfig:
+{% if 'kube_admission_plugin_order' in openshift.master %}
+    pluginOrderOverride:{{ openshift.master.kube_admission_plugin_order | to_padded_yaml(level=3) }}
+{% endif %}
+{% if 'kube_admission_plugin_config' in openshift.master %}
+    pluginConfig:{{ openshift.master.kube_admission_plugin_config | to_padded_yaml(level=3) }}
 {% endif %}
   apiServerArguments: {{ openshift.master.api_server_args | default(None) | to_padded_yaml( level=2 ) }}
   controllerArguments: {{ openshift.master.controller_args | default(None) | to_padded_yaml( level=2 ) }}

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -137,9 +137,11 @@ networkConfig:
 # serviceNetworkCIDR must match kubernetesMasterConfig.servicesSubnet
   serviceNetworkCIDR: {{ openshift.master.portal_net }}
 oauthConfig:
-{% if 'oauth_template' in openshift.master %}
-  templates:
-    login: {{ openshift.master.oauth_template }}
+{% if 'oauth_always_show_provider_selection' in openshift.master %}
+  alwaysShowProviderSelection: {{ openshift.master.oauth_always_show_provider_selection }}
+{% endif %}
+{% if 'oauth_templates' in openshift.master %}
+  templates:{{ openshift.master.oauth_templates | to_padded_yaml(level=2) }}
 {% endif %}
   assetPublicURL: {{ openshift.master.public_console_url }}/
   grantConfig:

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -69,3 +69,6 @@
       admission_plugin_config: "{{openshift_master_admission_plugin_config | default(None) }}"
       kube_admission_plugin_order: "{{openshift_master_kube_admission_plugin_order | default(None) }}"
       kube_admission_plugin_config: "{{openshift_master_kube_admission_plugin_config | default(None) }}"
+      oauth_template: "{{ openshift_master_oauth_template | default(None) }}" # deprecated in origin 1.2 / OSE 3.2
+      oauth_templates: "{{ openshift_master_oauth_templates | default(None) }}"
+      oauth_always_show_provider_selection: "{{ openshift_master_oauth_always_show_provider_selection | default(None) }}"

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -65,3 +65,7 @@
       master_image: "{{ osm_image | default(None) }}"
       scheduler_predicates: "{{ openshift_master_scheduler_predicates | default(None) }}"
       scheduler_priorities: "{{ openshift_master_scheduler_priorities | default(None) }}"
+      admission_plugin_order: "{{openshift_master_admission_plugin_order | default(None) }}"
+      admission_plugin_config: "{{openshift_master_admission_plugin_config | default(None) }}"
+      kube_admission_plugin_order: "{{openshift_master_kube_admission_plugin_order | default(None) }}"
+      kube_admission_plugin_config: "{{openshift_master_kube_admission_plugin_config | default(None) }}"


### PR DESCRIPTION
Adds two new inventory variables for setting sections in admissionConfig.

openshift_master_admission_plugin_order allows configuring the list of
admission controller plugins to enable and what order to run them in. This must
be a JSON formatted list of strings:

openshift_master_admission_plugin_order=["RunOnceDuration", "NamespaceLifecycle", "OriginPodNodeEnvironment", "ClusterResourceOverride", "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "ResourceQuota", "SCCExecRestrictions"]

openshift_master_admission_plugin_config allows setting free-form configuration stanzas that match up with enabled admission controller plugins. This must be a JSON formatted hash:

openshift_master_admission_plugin_config={"RunOnceDuration":{"configuration":{"apiVersion":"v1","kind":"RunOnceDurationConfig","activeDeadlineSecondsOverride":3600}},"ClusterResourceOverride":{"configuration":{"apiVersion":"v1","kind":"ClusterResourceOverrideConfig","limitCPUToMemoryPercent":200,"cpuRequestToLimitPercent":6,"memoryRequestToLimitPercent":60}}}

If neither is specified the template will generate an empty admissionConfig section:

```
kubernetesMasterConfig:
  admissionConfig:
```

If these variables are set output will be:

```
kubernetesMasterConfig:
  admissionConfig:
    pluginOrderOverride:
      - RunOnceDuration
      - NamespaceLifecycle
      - OriginPodNodeEnvironment
      - ClusterResourceOverride
      - LimitRanger
      - ServiceAccount
      - SecurityContextConstraint
      - ResourceQuota
      - SCCExecRestrictions
    pluginConfig:
      ClusterResourceOverride:
        configuration:
          apiVersion: v1
          cpuRequestToLimitPercent: 6
          kind: ClusterResourceOverrideConfig
          limitCPUToMemoryPercent: 200
          memoryRequestToLimitPercent: 60
      RunOnceDuration:
        configuration:
          activeDeadlineSecondsOverride: 3600
          apiVersion: v1
          kind: RunOnceDurationConfig
```