### PR TITLE
make docker service want ose containerized services

### DIFF
--- a/roles/etcd/templates/etcd.docker.service
+++ b/roles/etcd/templates/etcd.docker.service
@@ -13,4 +13,4 @@ SyslogIdentifier=etcd_container
 Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=docker.service

--- a/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-api.service.j2
+++ b/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-api.service.j2
@@ -22,5 +22,5 @@ SyslogIdentifier={{ openshift.common.service_type }}-master-api
 Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=docker.service
 WantedBy={{ openshift.common.service_type }}-node.service

--- a/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-controllers.service.j2
+++ b/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-controllers.service.j2
@@ -21,4 +21,4 @@ SyslogIdentifier={{ openshift.common.service_type }}-master-controllers
 Restart=on-failure
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=docker.service

--- a/roles/openshift_master/templates/docker/master.docker.service.j2
+++ b/roles/openshift_master/templates/docker/master.docker.service.j2
@@ -14,4 +14,4 @@ ExecStop=/usr/bin/docker stop {{ openshift.common.service_type }}-master
 Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=docker.service

--- a/roles/openshift_node/templates/openshift.docker.node.service
+++ b/roles/openshift_node/templates/openshift.docker.node.service
@@ -19,4 +19,4 @@ SyslogIdentifier={{ openshift.common.service_type }}-node
 Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=docker.service

--- a/roles/openshift_node/templates/openvswitch.docker.service
+++ b/roles/openshift_node/templates/openvswitch.docker.service
@@ -13,4 +13,4 @@ SyslogIdentifier=openvswitch
 Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=docker.service


### PR DESCRIPTION
There are points where the docker service is restarted during
the install.  Sometimes the services that are PartOf docker.service
do not get restarted when docker is restarted.

https://bugzilla.redhat.com/show_bug.cgi?id=1318948

Systemd documentation recommends using "wants" as the perferred
means of creating startup linkages between units.  This
patch makes the ose services wanted by the docker service rather
than multi-user.target.

This creates a downward link from the docker service to the ose
containerized services.