### PR TITLE
Add openshift_clock role

### DIFF
--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -408,6 +408,8 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # masterConfig.volumeConfig.dynamicProvisioningEnabled, configurable as of 1.2/3.2, enabled by default
 #openshift_master_dynamic_provisioning_enabled=False
 
+# Configure usage of openshift_clock role.
+#openshift_clock_enabled=true
 
 # host group for masters
 [masters]

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -413,6 +413,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # masterConfig.volumeConfig.dynamicProvisioningEnabled, configurable as of 1.2/3.2, enabled by default
 #openshift_master_dynamic_provisioning_enabled=False
 
+# Configure usage of openshift_clock role.
+#openshift_clock_enabled=true
+
 # host group for masters
 [masters]
 ose3-master[1:3]-ansible.test.example.com

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -409,6 +409,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # masterConfig.volumeConfig.dynamicProvisioningEnabled, configurable as of 1.2/3.2, enabled by default
 #openshift_master_dynamic_provisioning_enabled=False
 
+# Configure usage of openshift_clock role.
+#openshift_clock_enabled=true
+
 # host group for masters
 [masters]
 ose3-master[1:3]-ansible.test.example.com

--- a/roles/openshift_clock/meta/main.yml
+++ b/roles/openshift_clock/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: Jeremiah Stuever
+  description: OpenShift Clock
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 1.9
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+dependencies:
+- { role: openshift_facts }

--- a/roles/openshift_clock/tasks/main.yaml
+++ b/roles/openshift_clock/tasks/main.yaml
@@ -1,0 +1,14 @@
+---
+- name: Set clock facts
+  openshift_facts:
+    role: clock
+    local_facts:
+      enabled: "{{ openshift_clock_enabled | default(None) }}"
+
+- name: Install ntp package
+  action: "{{ ansible_pkg_mgr }} name=ntp state=present"
+  when: openshift.clock.enabled | bool and not openshift.clock.chrony_installed | bool
+
+- name: Start and enable ntpd/chronyd
+  shell: timedatectl set-ntp true
+  when: openshift.clock.enabled | bool

--- a/roles/openshift_etcd/meta/main.yml
+++ b/roles/openshift_etcd/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
   - cloud
 dependencies:
 - role: openshift_etcd_facts
+- role: openshift_clock
 - role: openshift_docker
   when: openshift.common.is_containerized | bool
 - role: etcd

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1549,6 +1549,7 @@ class OpenShiftFacts(object):
             OpenShiftFactsUnsupportedRoleError:
     """
     known_roles = ['builddefaults',
+                   'clock',
                    'cloudprovider',
                    'common',
                    'docker',
@@ -1718,6 +1719,16 @@ class OpenShiftFacts(object):
                 docker['api_version'] = version_info['api_version']
                 docker['version'] = version_info['version']
             defaults['docker'] = docker
+
+        if 'clock' in roles:
+            exit_code, _, _ = module.run_command(['rpm', '-q', 'chrony'])
+            if exit_code == 0:
+                chrony_installed = True
+            else:
+                chrony_installed = False
+            defaults['clock'] = dict(
+                enabled=True,
+                chrony_installed=chrony_installed)
 
         if 'cloudprovider' in roles:
             defaults['cloudprovider'] = dict(kind=None)

--- a/roles/openshift_master/meta/main.yml
+++ b/roles/openshift_master/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
+- role: openshift_clock
 - role: openshift_docker
 - role: openshift_cli
 - role: openshift_cloud_provider

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
+- role: openshift_clock
 - role: openshift_docker
 - role: openshift_cloud_provider
 - role: openshift_common


### PR DESCRIPTION
- openshift_clock role to manage system clock
- Can be enabled in inventory: openshift_clock_enabled=true
- Installs ntp when enabled and chrony is not installed
- Starts and enables ntpd or chronyd via: timedatectl set-ntp true
- Enabled by default.

resolves #1675
resolves #1041
resolves #961