### PR TITLE
Allow containerized deployment of dns role

### DIFF
--- a/roles/dns/README.md
+++ b/roles/dns/README.md
@@ -16,6 +16,7 @@ Role Variables
 | `dns_zones` | Mandatory | DNS zones in which we must find the hosts |
 | `dns_forwarders` | If not set, the DNS will be a recursive non-forwarding DNS server | DNS forwarders to delegate the requests for hosts outside of `dns_zones` |
 | `dns_all_hosts` | Mandatory | Exhaustive list of hosts |
+| `base_docker_image` | Optional | Base docker image to build Bind image from, used only in containerized deployments |
 
 Dependencies
 ------------
@@ -31,6 +32,7 @@ Example Playbook
         dns_forwarders: [ '8.8.8.8', '8.8.4.4' ]
         dns_zones: [ novalocal, openstacklocal ]
         dns_all_hosts: "{{ g_all_hosts }}"
+        base_docker_image: 'centos:centos7'
 
 License
 -------

--- a/roles/dns/defaults/main.yml
+++ b/roles/dns/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+base_docker_image: "{{ 'centos:centos7' if openshift.common.deployment_type == 'origin' else 'rhel7' }}"

--- a/roles/dns/meta/main.yml
+++ b/roles/dns/meta/main.yml
@@ -4,4 +4,5 @@ galaxy_info:
   description: Deploy and configure a DNS server
   company: Amadeus SAS
   license: ASL 2.0
-dependencies: []
+dependencies:
+- { role: openshift_facts }

--- a/roles/dns/tasks/main.yml
+++ b/roles/dns/tasks/main.yml
@@ -1,18 +1,46 @@
 - name: Install Bind
   action: "{{ ansible_pkg_mgr }} name=bind"
+  when: not openshift.common.is_containerized | bool
+
+- name: Create docker build dir
+  file: path=/tmp/dockerbuild state=directory
+  when: openshift.common.is_containerized | bool
+
+- name: Install dockerfile
+  template:
+    dest: "/tmp/dockerbuild/Dockerfile"
+    src: Dockerfile
+  register: install_result
+  when: openshift.common.is_containerized | bool
+
+- name: Build Bind image
+  docker_image: path="/tmp/dockerbuild" name="bind" state=present
+  when: openshift.common.is_containerized | bool
+
+- name: Install bind service file
+  template:
+    dest: "/etc/systemd/system/named.service"
+    src: named.service.j2
+  register: install_result
+  when: openshift.common.is_containerized | bool
+
+- name: reload systemd
+  command: /usr/bin/systemctl --system daemon-reload
+  when: openshift.common.is_containerized | bool and install_result | changed
+
+- name: Create bind zone dir
+  file: path=/var/named state=directory
+  when: openshift.common.is_containerized | bool
 
 - name: Configure Bind
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
-    validate: "{{ item.validate }}"
   with_items:
     - src: openshift-cluster.zone
       dest: /var/named/openshift-cluster.zone
-      validate: "named-checkzone {{ dns_zones[0] }} %s"
     - src: named.conf
       dest: /etc/named.conf
-      validate: "named-checkconf %s"
   notify: restart bind
 
 - name: Enable Bind

--- a/roles/dns/templates/Dockerfile
+++ b/roles/dns/templates/Dockerfile
@@ -1,0 +1,11 @@
+FROM {{ base_docker_image }}
+MAINTAINER Jan Provaznik <jprovazn@redhat.com>
+
+# install main packages:
+RUN yum -y update; yum clean all;
+RUN yum -y install bind-utils bind
+
+EXPOSE 53
+
+# start services:
+CMD ["/usr/sbin/named", "-f"]

--- a/roles/dns/templates/named.service.j2
+++ b/roles/dns/templates/named.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Requires=docker.service
+After=docker.service
+PartOf=docker.service
+
+[Service]
+Type=simple
+TimeoutStartSec=5m
+ExecStartPre=/usr/bin/docker run --rm -v /etc/named.conf:/etc/named.conf -v /var/named:/var/named:z bind named-checkconf -z /etc/named.conf
+ExecStartPre=-/usr/bin/docker rm -f bind
+ExecStart=/usr/bin/docker run --name bind -p 53:53/udp -v /var/log:/var/log -v /etc/named.conf:/etc/named.conf -v /var/named:/var/named:z bind
+ExecStop=/usr/bin/docker stop bind
+
+[Install]
+WantedBy=docker.service


### PR DESCRIPTION
If containerized, docker image for bind service is built during
ansible run. Zone and conf file validation is disabled because
named-check* utils are not present on atomic host.