### PR TITLE
Check for kind in cloudprovider facts prior to accessing.

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -924,12 +924,13 @@ def build_kubelet_args(facts):
     if 'node' in facts:
         kubelet_args = {}
         if 'cloudprovider' in facts:
-            if facts['cloudprovider']['kind'] == 'aws':
-                kubelet_args['cloud-provider'] = ['aws']
-                kubelet_args['cloud-config'] = [cloud_cfg_path + '/aws.conf']
-            if facts['cloudprovider']['kind'] == 'openstack':
-                kubelet_args['cloud-provider'] = ['openstack']
-                kubelet_args['cloud-config'] = [cloud_cfg_path + '/openstack.conf']
+            if 'kind' in facts['cloudprovider']:
+                if facts['cloudprovider']['kind'] == 'aws':
+                    kubelet_args['cloud-provider'] = ['aws']
+                    kubelet_args['cloud-config'] = [cloud_cfg_path + '/aws.conf']
+                if facts['cloudprovider']['kind'] == 'openstack':
+                    kubelet_args['cloud-provider'] = ['openstack']
+                    kubelet_args['cloud-config'] = [cloud_cfg_path + '/openstack.conf']
         if kubelet_args != {}:
             facts = merge_facts({'node': {'kubelet_args': kubelet_args}}, facts, [], [])
     return facts
@@ -941,12 +942,13 @@ def build_controller_args(facts):
     if 'master' in facts:
         controller_args = {}
         if 'cloudprovider' in facts:
-            if facts['cloudprovider']['kind'] == 'aws':
-                controller_args['cloud-provider'] = ['aws']
-                controller_args['cloud-config'] = [cloud_cfg_path + '/aws.conf']
-            if facts['cloudprovider']['kind'] == 'openstack':
-                controller_args['cloud-provider'] = ['openstack']
-                controller_args['cloud-config'] = [cloud_cfg_path + '/openstack.conf']
+            if 'kind' in facts['cloudprovider']:
+                if facts['cloudprovider']['kind'] == 'aws':
+                    controller_args['cloud-provider'] = ['aws']
+                    controller_args['cloud-config'] = [cloud_cfg_path + '/aws.conf']
+                if facts['cloudprovider']['kind'] == 'openstack':
+                    controller_args['cloud-provider'] = ['openstack']
+                    controller_args['cloud-config'] = [cloud_cfg_path + '/openstack.conf']
         if controller_args != {}:
             facts = merge_facts({'master': {'controller_args': controller_args}}, facts, [], [])
     return facts
@@ -958,12 +960,13 @@ def build_api_server_args(facts):
     if 'master' in facts:
         api_server_args = {}
         if 'cloudprovider' in facts:
-            if facts['cloudprovider']['kind'] == 'aws':
-                api_server_args['cloud-provider'] = ['aws']
-                api_server_args['cloud-config'] = [cloud_cfg_path + '/aws.conf']
-            if facts['cloudprovider']['kind'] == 'openstack':
-                api_server_args['cloud-provider'] = ['openstack']
-                api_server_args['cloud-config'] = [cloud_cfg_path + '/openstack.conf']
+            if 'kind' in facts['cloudprovider']:
+                if facts['cloudprovider']['kind'] == 'aws':
+                    api_server_args['cloud-provider'] = ['aws']
+                    api_server_args['cloud-config'] = [cloud_cfg_path + '/aws.conf']
+                if facts['cloudprovider']['kind'] == 'openstack':
+                    api_server_args['cloud-provider'] = ['openstack']
+                    api_server_args['cloud-config'] = [cloud_cfg_path + '/openstack.conf']
         if api_server_args != {}:
             facts = merge_facts({'master': {'api_server_args': api_server_args}}, facts, [], [])
     return facts

--- a/roles/openshift_master/templates/atomic-openshift-master.j2
+++ b/roles/openshift_master/templates/atomic-openshift-master.j2
@@ -4,7 +4,7 @@ CONFIG_FILE={{ openshift_master_config_file }}
 IMAGE_VERSION={{ openshift_version }}
 {% endif %}
 
-{% if 'cloudprovider' in openshift and 'aws' in openshift.cloudprovider and openshift.cloudprovider.kind == 'aws' and 'access_key' in openshift.cloudprovider.aws and 'secret_key' in openshift.cloudprovider.aws %}
+{% if 'cloudprovider' in openshift and 'aws' in openshift.cloudprovider and 'kind' in openshift.cloudprovider and openshift.cloudprovider.kind == 'aws' and 'access_key' in openshift.cloudprovider.aws and 'secret_key' in openshift.cloudprovider.aws %}
 AWS_ACCESS_KEY_ID={{ openshift.cloudprovider.aws.access_key }}
 AWS_SECRET_ACCESS_KEY={{ openshift.cloudprovider.aws.secret_key }}
 {% endif %}

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
@@ -4,7 +4,7 @@ CONFIG_FILE={{ openshift_master_config_file }}
 IMAGE_VERSION={{ openshift_version }}
 {% endif %}
 
-{% if 'cloudprovider' in openshift and 'aws' in openshift.cloudprovider and openshift.cloudprovider.kind == 'aws' and 'access_key' in openshift.cloudprovider.aws and 'secret_key' in openshift.cloudprovider.aws %}
+{% if 'cloudprovider' in openshift and 'aws' in openshift.cloudprovider and 'kind' in openshift.cloudprovider and openshift.cloudprovider.kind == 'aws' and 'access_key' in openshift.cloudprovider.aws and 'secret_key' in openshift.cloudprovider.aws %}
 AWS_ACCESS_KEY_ID={{ openshift.cloudprovider.aws.access_key }}
 AWS_SECRET_ACCESS_KEY={{ openshift.cloudprovider.aws.secret_key }}
 {% endif %}

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.j2
@@ -4,7 +4,7 @@ CONFIG_FILE={{ openshift_master_config_file }}
 IMAGE_VERSION={{ openshift_version }}
 {% endif %}
 
-{% if 'cloudprovider' in openshift and 'aws' in openshift.cloudprovider and openshift.cloudprovider.kind == 'aws' and 'access_key' in openshift.cloudprovider.aws and 'secret_key' in openshift.cloudprovider.aws %}
+{% if 'cloudprovider' in openshift and 'aws' in openshift.cloudprovider and 'kind' in openshift.cloudprovider and openshift.cloudprovider.kind == 'aws' and 'access_key' in openshift.cloudprovider.aws and 'secret_key' in openshift.cloudprovider.aws %}
 AWS_ACCESS_KEY_ID={{ openshift.cloudprovider.aws.access_key }}
 AWS_SECRET_ACCESS_KEY={{ openshift.cloudprovider.aws.secret_key }}
 {% endif %}

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -92,7 +92,7 @@
       line: "AWS_ACCESS_KEY_ID={{ openshift.cloudprovider.aws.access_key }}"
     - regex: '^AWS_SECRET_ACCESS_KEY='
       line: "AWS_SECRET_ACCESS_KEY={{ openshift.cloudprovider.aws.secret_key }}"
-  when: "'cloudprovider' in openshift and 'aws' in openshift.cloudprovider and openshift.cloudprovider.kind == 'aws' and 'access_key' in openshift.cloudprovider.aws and 'secret_key' in openshift.cloudprovider.aws"
+  when: "'cloudprovider' in openshift and 'aws' in openshift.cloudprovider and 'kind' in openshift.cloudprovider and openshift.cloudprovider.kind == 'aws' and 'access_key' in openshift.cloudprovider.aws and 'secret_key' in openshift.cloudprovider.aws"
   notify:
   - restart node
 


### PR DESCRIPTION
Allows things to continue along if a cloudprovider fact was set but openshift_cloudprovider_kind was not.