### PR TITLE
Make cockpit require openshift_docker

### DIFF
--- a/roles/cockpit/meta/main.yml
+++ b/roles/cockpit/meta/main.yml
@@ -13,3 +13,4 @@ galaxy_info:
   - cloud
 dependencies:
   - { role: os_firewall }
+  - { role: openshift_docker }


### PR DESCRIPTION
Cockpit is installed on masters, which
must also be nodes, so it's ok for now to call openshift_docker there