### PR TITLE
Unmask services

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -53,6 +53,14 @@
         - pcsd
       failed_when: false
 
+    - name: unmask services
+      command: systemctl unmask "{{ item }}"
+      changed_when: False
+      failed_when: False
+      with_items:
+        - etcd
+        - firewalld
+
     - name: Stop additional atomic services
       service: name={{ item }} state=stopped
       when: is_containerized | bool


### PR DESCRIPTION
Unmasking etcd is is important when switching from containerized installs to
RPM installs