### PR TITLE
Bug 1324371: needn't install atomic-openshift packages on nfs server

### DIFF
--- a/roles/openshift_storage_nfs/README.md
+++ b/roles/openshift_storage_nfs/README.md
@@ -21,23 +21,22 @@ From this role:
 | openshift_hosted_registry_storage_volume_name   | registry              | Registry volume within openshift_hosted_registry_volume_dir |
 | openshift_hosted_registry_storage_nfs_options   | *(rw,root_squash)     | NFS options for configured exports.                         |
 
-
-From openshift_common:
-| Name                          | Default Value  |                                        |
-|-------------------------------|----------------|----------------------------------------|
-| openshift_debug_level         | 2              | Global openshift debug log verbosity   |
-
-
 Dependencies
 ------------
+
+* os_firewall
+* openshift_facts
+* openshift_repos
 
 Example Playbook
 ----------------
 
+```
 - name: Configure nfs hosts
   hosts: oo_nfs_to_config
   roles:
   - role: openshift_storage_nfs
+```
 
 License
 -------

--- a/roles/openshift_storage_nfs/meta/main.yml
+++ b/roles/openshift_storage_nfs/meta/main.yml
@@ -11,5 +11,5 @@ galaxy_info:
     - 7
 dependencies:
 - { role: os_firewall }
-- { role: openshift_common }
+- { role: openshift_facts }
 - { role: openshift_repos }


### PR DESCRIPTION
Removes unnecessary openshift_common dep from openshift_storage_nfs.

https://bugzilla.redhat.com/show_bug.cgi?id=1324371
