### PR TITLE
a-o-i: Support openshift_image_tag

### DIFF
--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -130,7 +130,9 @@ def write_inventory_vars(base_inventory, multiple_masters, proxy):
     if CFG.settings.get('master_routingconfig_subdomain', False):
         base_inventory.write(
             "openshift_master_default_subdomain={}\n".format(CFG.settings['master_routingconfig_subdomain']))
-
+    if CFG.settings.get('variant_version', None) == '3.1':
+        #base_inventory.write('openshift_image_tag=v{}\n'.format(CFG.settings.get('variant_version')))
+        base_inventory.write('openshift_image_tag=v{}\n'.format('3.1.1.6'))
 
 
 def write_host(host, inventory, schedulable=None):


### PR DESCRIPTION
Somewhat hacky solution to let users install containerized 3.1.
A more flexible version will be forthcoming once we settle tagging
issues.