### PR TITLE
Fix a docker-storage sysconfig bug.

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -16,14 +16,13 @@
   action: "{{ ansible_pkg_mgr }} name=docker{{ '-' + docker_version if docker_version != '' else '' }} state=present"
   when: not openshift.common.is_atomic | bool and not docker_downgrade_result | changed
 
-- stat: path=/etc/sysconfig/docker
-  register: docker_check
-  when: docker_downgrade_result | changed
+- stat: path=/etc/sysconfig/docker-storage
+  register: docker_storage_check
 
 - name: Remove deferred deletion for downgrades from 1.9
   command: >
     sed -i 's/--storage-opt dm.use_deferred_deletion=true//' /etc/sysconfig/docker-storage
-  when: docker_downgrade_result | changed and docker_check.stat.exists | bool and docker_version_result.stdout | default('0.0', True) | version_compare('1.9', '>=') and docker_version | version_compare('1.9', '<')
+  when: docker_downgrade_result | changed and docker_storage_check.stat.exists | bool and docker_version_result.stdout | default('0.0', True) | version_compare('1.9', '>=') and docker_version | version_compare('1.9', '<')
 
 - name: enable and start the docker service
   service:


### PR DESCRIPTION
On behalf of @sdodson we noticed a bug here, docker_check register was being used twice, the first stat was checking the wrong file and using the same register name when it shouldn't.