### PR TITLE
Fixes For Docker Log Options

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -259,8 +259,11 @@ class FilterModule(object):
 
     @staticmethod
     def oo_split(string, separator=','):
-        """ This splits the input string into a list
+        """ This splits the input string into a list. If the input string is
+        already a list we will return it as is.
         """
+        if isinstance(string, list):
+            return string
         return string.split(separator)
 
     @staticmethod

--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -75,7 +75,7 @@ deployment_type=atomic-enterprise
 #openshift_docker_options="-l warn --ipv6=false"
 # Deprecated methods to set --log-driver and --log-opts flags, use openshift_docker_options instead
 #openshift_docker_log_driver=json
-#openshift_docker_log_options="tag=mailer"
+#openshift_docker_log_options=["tag=mailer"]
 
 # Alternate image format string. If you're not modifying the format string and
 # only need to inject your own registry you may want to consider

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -76,7 +76,7 @@ deployment_type=origin
 #openshift_docker_options="-l warn --ipv6=false"
 # Deprecated methods to set --log-driver and --log-opts flags, use openshift_docker_options instead
 #openshift_docker_log_driver=json
-#openshift_docker_log_options="tag=mailer"
+#openshift_docker_log_options=["tag=mailer"]
 
 # Alternate image format string. If you're not modifying the format string and
 # only need to inject your own registry you may want to consider

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -75,7 +75,7 @@ deployment_type=openshift-enterprise
 #openshift_docker_options="-l warn --ipv6=false"
 # Deprecated methods to set --log-driver and --log-opts flags, use openshift_docker_options instead
 #openshift_docker_log_driver=json
-#openshift_docker_log_options="tag=mailer"
+#openshift_docker_log_options=["tag=mailer"]
 
 
 # Alternate image format string. If you're not modifying the format string and

--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -4,7 +4,7 @@
 - include: validate_hostnames.yml
 
 - name: Set oo_options
-  hosts: oo_hosts_to_config
+  hosts: oo_all_hosts
   tasks:
   - set_fact:
       openshift_docker_additional_registries: "{{ lookup('oo_option', 'docker_additional_registries') }}"


### PR DESCRIPTION
Legacy cli_docker_log_options (from bin/cluster) was not working due to use of an outdated host group that was since refactored.

Previously we expected openshift_docker_log_options to be a comma separated list, but you'd never really know this without documentation so instead we moved to an explicit JSON list which will make this very clear in examples and docs.

NOTE: This will break backward compat with cli_docker_log_options or anyone using custom docker log options in the wild. 

@detiber keep an eye on this just to make sure I understood you correctly that this was safe. ^^