### PR TITLE
Fix issues when docker is not pre-installed.

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -28,6 +28,8 @@
 # seems a package install/upgrade/downgrade has rebooted docker and crashed it.
 - name: Reset docker service state
   command: systemctl reset-failed docker.service
+  # This will error if the package was just installed and the service is not loaded.
+  ignore_errors: yes
 
 - name: enable and start the docker service
   service:


### PR DESCRIPTION
A docker run command was recently guarded to only be run when docker is
installed, this change does the same for an additional docker exec.

Adjusted some logic that might make for inaccurate openshift version
reporting when containerized is true, but for some reason openshift is
installed on the main OS.

Fixed an additional failure where a recent fix to reload the docker
service would run after the docker rpm was just installed, and the
service is not yet loaded. Due to it's nature as a workaround, it does
not look like it can be moved to a better location, so ignoring errors
appears to be the best solution.