### PR TITLE
fix systemctl reset-failed docker

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -28,6 +28,7 @@
 # seems a package install/upgrade/downgrade has rebooted docker and crashed it.
 - name: Reset docker service state
   command: systemctl reset-failed docker.service
+  ignore_errors: yes
 
 - name: enable and start the docker service
   service:


### PR DESCRIPTION
This commit fix the playbook when docker has never been run yet (first run, new install e.g.).
The error is :

```stderr: Failed to reset failed state of unit docker.service: Unit docker.service is not loaded.```