### PR TITLE
Enable docker before potentially resetting the failure

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -24,12 +24,21 @@
   action: "{{ ansible_pkg_mgr }} name=docker{{ '-' + docker_version if docker_version is defined and docker_version != '' else '' }} state=present"
   when: not openshift.common.is_atomic | bool and not docker_version_result | skipped and docker_version_result.stdout | default('0.0', True) | version_compare(docker_version, 'lt')
 
+# Enable docker and record if it was changed, if it was changed then we have no
+# need to reset-failed.
+- name: Enable the docker service
+  service:
+    name: docker
+    enabled: yes
+  register: docker_enabled
+
 # We're getting ready to start docker.  This is a workaround for cases where it
 # seems a package install/upgrade/downgrade has rebooted docker and crashed it.
 - name: Reset docker service state
   command: systemctl reset-failed docker.service
+  when: not docker_enabled | changed
 
-- name: enable and start the docker service
+- name: Start the docker service
   service:
     name: docker
     enabled: yes

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -24,26 +24,29 @@
   action: "{{ ansible_pkg_mgr }} name=docker{{ '-' + docker_version if docker_version is defined and docker_version != '' else '' }} state=present"
   when: not openshift.common.is_atomic | bool and not docker_version_result | skipped and docker_version_result.stdout | default('0.0', True) | version_compare(docker_version, 'lt')
 
-# Enable docker and record if it was changed, if it was changed then we have no
-# need to reset-failed.
-- name: Enable the docker service
-  service:
-    name: docker
-    enabled: yes
-  register: docker_enabled
-
-# We're getting ready to start docker.  This is a workaround for cases where it
-# seems a package install/upgrade/downgrade has rebooted docker and crashed it.
-- name: Reset docker service state
-  command: systemctl reset-failed docker.service
-  when: not docker_enabled | changed
-
 - name: Start the docker service
   service:
     name: docker
     enabled: yes
     state: started
   register: start_result
+  ignore_errors: yes
+
+# If docker were enabled and started before we downgraded it there's a real possibility
+# that it's marked failed, so if our first attempt to start it fails reset the failure
+# and start it again.
+- name: Reset docker service state
+  command: systemctl reset-failed docker.service
+  when: start_result | failed
+  register: reset_failed
+
+- name: Start the docker service if it had failed
+  service:
+    name: docker
+    enabled: yes
+    state: started
+  register: start_result
+  when: reset_failed | changed
 
 - set_fact:
     docker_service_status_changed: start_result | changed


### PR DESCRIPTION
If docker isn't enabled we need it to be enabled, fixes

```
06:45:15 TASK: [docker | Reset docker service state] *********************************** 
06:45:15 failed: [10.8.171.105] => {"changed": true, "cmd": ["systemctl", "reset-failed", "docker.service"], "delta": "0:00:00.015313", "end": "2016-04-14 10:54:52.908223", "rc": 1, "start": "2016-04-14 10:54:52.892910", "warnings": []}
06:45:15 stderr: Failed to reset failed state of unit docker.service: Unit docker.service is not loaded.
```