### PR TITLE
Fix use of JSON inventory vars with raw booleans.

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1154,7 +1154,7 @@ def merge_facts(orig, new, additive_facts_to_overwrite, protected_facts_to_overw
             if key in inventory_json_facts:
                 # Watchout for JSON facts that sometimes load as strings.
                 # (can happen if the JSON contains a boolean)
-                if isinstance(new[key], str):
+                if isinstance(new[key], basestring):
                     facts[key] = yaml.safe_load(new[key])
                 else:
                     facts[key] = copy.deepcopy(new[key])


### PR DESCRIPTION
Thought this was fixed in recent patch but somehow backed out a critical
change to the isinstance, we need to check for basestring to also have
this work with unicode strings.