### PR TITLE
Use 'openshift3/' as IMAGE_PREFIX for enterprise logging and metrics

### DIFF
--- a/roles/openshift_examples/files/examples/v1.2/infrastructure-templates/enterprise/metrics-deployer.yaml
+++ b/roles/openshift_examples/files/examples/v1.2/infrastructure-templates/enterprise/metrics-deployer.yaml
@@ -79,7 +79,7 @@ parameters:
 -
   description: 'Specify prefix for metrics components; e.g. for "openshift/origin-metrics-deployer:latest", set prefix "openshift/origin-"'
   name: IMAGE_PREFIX
-  value: "openshift/origin-"
+  value: "registry.access.redhat.com/openshift3/"
 -
   description: 'Specify version for metrics components; e.g. for "openshift/origin-metrics-deployer:latest", set version "latest"'
   name: IMAGE_VERSION


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1326446

Minimal fix, still need to address upstream enterprise content source for metrics or we'll just re-introduce the problem at a later date.