### PR TITLE
Bug 1328119 - router selector not obeyed

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -650,7 +650,9 @@ class FilterModule(object):
 
     @staticmethod
     def oo_openshift_env(hostvars):
-        ''' Return facts which begin with "openshift_"
+        ''' Return facts which begin with "openshift_" and translate
+            legacy facts to their openshift_env counterparts.
+
             Ex: hostvars = {'openshift_fact': 42,
                             'theyre_taking_the_hobbits_to': 'isengard'}
                 returns  = {'openshift_fact': 42}
@@ -663,6 +665,11 @@ class FilterModule(object):
         for key in hostvars:
             if regex.match(key):
                 facts[key] = hostvars[key]
+
+        migrations = {'openshift_router_selector': 'openshift_hosted_router_selector'}
+        for old_fact, new_fact in migrations.iteritems():
+            if old_fact in facts and new_fact not in facts:
+                facts[new_fact] = facts[old_fact]
         return facts
 
     @staticmethod

--- a/playbooks/aws/openshift-cluster/config.yml
+++ b/playbooks/aws/openshift-cluster/config.yml
@@ -11,7 +11,7 @@
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_public_hostname: "{{ ec2_ip_address }}"
     openshift_registry_selector: 'type=infra'
-    openshift_router_selector: 'type=infra'
+    openshift_hosted_router_selector: 'type=infra'
     openshift_infra_nodes: "{{ g_infra_hosts }}"
     openshift_node_labels: '{"region": "{{ ec2_region }}", "type": "{{ hostvars[inventory_hostname]["ec2_tag_sub-host-type"] if inventory_hostname in groups["tag_host-type_node"] else hostvars[inventory_hostname]["ec2_tag_host-type"] }}"}'
     openshift_master_cluster_method: 'native'

--- a/playbooks/gce/openshift-cluster/config.yml
+++ b/playbooks/gce/openshift-cluster/config.yml
@@ -12,7 +12,7 @@
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_hostname: "{{ gce_private_ip }}"
     openshift_registry_selector: 'type=infra'
-    openshift_router_selector: 'type=infra'
+    openshift_hosted_router_selector: 'type=infra'
     openshift_infra_nodes: "{{ g_infra_hosts }}"
     openshift_master_cluster_method: 'native'
     openshift_use_openshift_sdn: "{{ lookup('oo_option', 'use_openshift_sdn') }}"

--- a/playbooks/libvirt/openshift-cluster/config.yml
+++ b/playbooks/libvirt/openshift-cluster/config.yml
@@ -14,7 +14,7 @@
     openshift_debug_level: "{{ debug_level }}"
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_registry_selector: 'type=infra'
-    openshift_router_selector: 'type=infra'
+    openshift_hosted_router_selector: 'type=infra'
     openshift_infra_nodes: "{{ g_infra_hosts }}"
     openshift_master_cluster_method: 'native'
     openshift_use_openshift_sdn: "{{ lookup('oo_option', 'use_openshift_sdn') }}"

--- a/playbooks/openstack/openshift-cluster/config.yml
+++ b/playbooks/openstack/openshift-cluster/config.yml
@@ -11,7 +11,7 @@
     openshift_debug_level: "{{ debug_level }}"
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_registry_selector: 'type=infra'
-    openshift_router_selector: 'type=infra'
+    openshift_hosted_router_selector: 'type=infra'
     openshift_infra_nodes: "{{ g_infra_hosts }}"
     openshift_master_cluster_method: 'native'
     openshift_use_openshift_sdn: "{{ lookup('oo_option', 'use_openshift_sdn') }}"

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -95,6 +95,7 @@ def migrate_local_facts(facts):
     migrated_facts = migrate_docker_facts(migrated_facts)
     migrated_facts = migrate_common_facts(migrated_facts)
     migrated_facts = migrate_node_facts(migrated_facts)
+    migrated_facts = migrate_hosted_facts(migrated_facts)
     return migrated_facts
 
 def migrate_hosted_facts(facts):

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1837,14 +1837,7 @@ class OpenShiftFacts(object):
                         val = [x.strip() for x in val.split(',')]
                     new_local_facts['docker'][key] = list(set(val) - set(['']))
 
-        for facts in new_local_facts.values():
-            keys_to_delete = []
-            if isinstance(facts, dict):
-                for fact, value in facts.iteritems():
-                    if value == "" or value is None:
-                        keys_to_delete.append(fact)
-                for key in keys_to_delete:
-                    del facts[key]
+        new_local_facts = self.remove_empty_facts(new_local_facts)
 
         if new_local_facts != local_facts:
             self.validate_local_facts(new_local_facts)
@@ -1854,6 +1847,23 @@ class OpenShiftFacts(object):
 
         self.changed = changed
         return new_local_facts
+
+    def remove_empty_facts(self, facts=None):
+        """ Remove empty facts
+
+            Args:
+                facts (dict): facts to clean
+        """
+        facts_to_remove = []
+        for fact, value in facts.iteritems():
+            if isinstance(facts[fact], dict):
+                facts[fact] = self.remove_empty_facts(facts[fact])
+            else:
+                if value == "" or value is None:
+                    facts_to_remove.append(fact)
+        for fact in facts_to_remove:
+            del facts[fact]
+        return facts
 
     def validate_local_facts(self, facts=None):
         """ Validate local facts

--- a/roles/openshift_hosted/tasks/router.yml
+++ b/roles/openshift_hosted/tasks/router.yml
@@ -32,6 +32,7 @@
     {{ openshift.common.client_binary }} --api-version='v1' -o json
     get nodes -n default --config={{ openshift.common.config_base }}/master/admin.kubeconfig
   register: openshift_hosted_router_nodes_json
+  changed_when: false
   when: openshift.hosted.router.replicas | default(None) == None
 
 - name: Collect nodes matching router selector

--- a/roles/openshift_hosted_facts/tasks/main.yml
+++ b/roles/openshift_hosted_facts/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
-- name: Set legacy hosted facts
-  openshift_facts:
-    role: hosted
-    openshift_env:
-      openshift_hosted_router_selector: "{{ openshift_router_selector | default(None) }}"
-
 - name: Set hosted facts
   openshift_facts:
     role: hosted

--- a/roles/openshift_hosted_facts/tasks/main.yml
+++ b/roles/openshift_hosted_facts/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Set legacy hosted facts
+  openshift_facts:
+    role: hosted
+    openshift_env:
+      openshift_hosted_router_selector: "{{ openshift_router_selector | default(None) }}"
+
 - name: Set hosted facts
   openshift_facts:
     role: hosted

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -54,7 +54,6 @@
       mcs_allocator_range: "{{ osm_mcs_allocator_range | default(None) }}"
       mcs_labels_per_project: "{{ osm_mcs_labels_per_project | default(None) }}"
       uid_allocator_range: "{{ osm_uid_allocator_range | default(None) }}"
-      router_selector: "{{ openshift_router_selector | default(None) }}"
       registry_selector: "{{ openshift_registry_selector | default(None) }}"
       api_server_args: "{{ osm_api_server_args | default(None) }}"
       controller_args: "{{ osm_controller_args | default(None) }}"


### PR DESCRIPTION
* Fix router selector fact migration.
* Nodes matching selector filter wasn't addressing multiple selectors ie. `region=infra,zone=router`
* Fix empty fact removal for nested dictionaries.

@akostadinov @detiber PTAL

https://bugzilla.redhat.com/show_bug.cgi?id=1328119