### PR TITLE
Fix use of older image tag version during upgrade.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/containerized_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/containerized_upgrade.yml
@@ -1,7 +1,7 @@
 - include_vars: ../../../../../roles/openshift_node/vars/main.yml
 
 - name: Update systemd units
-  include: ../../../../../roles/openshift_node/tasks/systemd_units.yml openshift_version=v{{ g_aos_versions.avail_version }}
+  include: ../../../../../roles/openshift_node/tasks/systemd_units.yml openshift_version=v{{ g_new_version }}
 
 - name: Verifying the correct version was configured
   shell: grep {{ verify_upgrade_version }} {{ item }}

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
@@ -161,14 +161,14 @@
     when: inventory_hostname in groups.oo_masters_to_config
 
   - name: Update systemd units
-    include: ../../../../../roles/openshift_master/tasks/systemd_units.yml openshift_version=v{{ g_aos_versions.curr_version }}
+    include: ../../../../../roles/openshift_master/tasks/systemd_units.yml openshift_version=v{{ g_new_version }}
     when: inventory_hostname in groups.oo_masters_to_config
 
   - include_vars: ../../../../../roles/openshift_node/vars/main.yml
     when: inventory_hostname in groups.oo_nodes_to_config
 
   - name: Update systemd units
-    include: ../../../../../roles/openshift_node/tasks/systemd_units.yml openshift_version=v{{g_aos_versions.curr_version}}
+    include: ../../../../../roles/openshift_node/tasks/systemd_units.yml openshift_version=v{{ g_new_version }}
     when: inventory_hostname in groups.oo_nodes_to_config
 
   # Note: the version number is hardcoded here in hopes of catching potential

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
@@ -50,7 +50,7 @@
   - include_vars: ../../../../../roles/openshift_master/vars/main.yml
 
   - name: Update systemd units
-    include: ../../../../../roles/openshift_master/tasks/systemd_units.yml openshift_version=v{{ g_aos_versions.avail_version }}
+    include: ../../../../../roles/openshift_master/tasks/systemd_units.yml openshift_version=v{{ g_new_version }}
 
 #  - name: Upgrade master configuration
 #    openshift_upgrade_config:
@@ -130,6 +130,7 @@
 ###############################################################################
 # Reconcile Cluster Roles, Cluster Role Bindings and Security Context Constraints
 ###############################################################################
+
 - name: Reconcile Cluster Roles and Cluster Role Bindings and Security Context Constraints
   hosts: oo_masters_to_config
   roles:


### PR DESCRIPTION
If doing an upgrade with a 3.2.0.x version that was older than the
latest, the upgrade would actually use the latest in the systemd unit
files and thus the actual containers that get used. (despite pulling
down the correct version first)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1326642