### PR TITLE
Fix bug after portal_net move from master to common role.

### DIFF
--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -119,7 +119,7 @@
     # hostvars[groups.oo_first_master.0].openshift.hosted.registry instead of
     # hardcoding
     openshift_docker_hosted_registry_insecure: True
-    openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.master.portal_net }}"
+    openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
   roles:
   - openshift_node
 
@@ -132,7 +132,7 @@
     # hostvars[groups.oo_first_master.0].openshift.hosted.registry instead of
     # hardcoding
     openshift_docker_hosted_registry_insecure: True
-    openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.master.portal_net }}"
+    openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
   roles:
   - openshift_node
 


### PR DESCRIPTION
Use of the variable was still pointing to the master role location
causing the default insecure registry subnet to be used rather than the
expected one.

Looks like an addition required for #1588 

CC @sdodson for verification this is right