### PR TITLE
Reconcile roles in additive-only mode on upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_0_minor/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_0_minor/upgrade.yml
@@ -42,10 +42,10 @@
 - name: Update cluster policy
   hosts: oo_first_master
   tasks:
-    - name: oadm policy reconcile-cluster-roles --confirm
+    - name: oadm policy reconcile-cluster-roles --additive-only=true --confirm
       command: >
         {{ openshift.common.admin_binary}} --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-        policy reconcile-cluster-roles --confirm
+        policy reconcile-cluster-roles --additive-only=true --confirm
 
 - name: Upgrade default router
   hosts: oo_first_master

--- a/playbooks/common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
@@ -490,7 +490,7 @@
   - name: Reconcile Cluster Roles
     command: >
       {{ openshift.common.admin_binary}} --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-      policy reconcile-cluster-roles --confirm
+      policy reconcile-cluster-roles --additive-only=true --confirm
     run_once: true
 
   - name: Reconcile Cluster Role Bindings

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_minor/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_minor/upgrade.yml
@@ -103,7 +103,7 @@
   - name: Reconcile Cluster Roles
     command: >
       {{ openshift.common.admin_binary}} --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-      policy reconcile-cluster-roles --confirm
+      policy reconcile-cluster-roles --additive-only=true --confirm
     run_once: true
 
   - name: Reconcile Cluster Role Bindings

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
@@ -148,7 +148,7 @@
   - name: Reconcile Cluster Roles
     command: >
       {{ openshift.common.admin_binary}} --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-      policy reconcile-cluster-roles --confirm
+      policy reconcile-cluster-roles --additive-only=true --confirm
     run_once: true
 
   - name: Reconcile Cluster Role Bindings


### PR DESCRIPTION
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1328822 by changing the automatic role reconcile up upgrade to leave existing permissions alone. Cluster admins can still run `oadm policy reconcile-cluster-roles --additive-only=false` to tighten permissions to the current defaults post-upgrade, if they want.