### PR TITLE
Rename openshift_node_dnsmasq to openshift_use_dnsmasq where applicable

### DIFF
--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -340,7 +340,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # and configure node's dnsIP to point at the node's local dnsmasq instance. Defaults
 # to True for Origin 1.2 and OSE 3.2. False for 1.1 / 3.1 installs, this cannot
 # be used with 1.0 and 3.0.
-# openshift_node_dnsmasq=False
+# openshift_use_dnsmasq=False
 
 # host group for masters
 [masters]

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -345,7 +345,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # and configure node's dnsIP to point at the node's local dnsmasq instance. Defaults
 # to True for Origin 1.2 and OSE 3.2. False for 1.1 / 3.1 installs, this cannot
 # be used with 1.0 and 3.0.
-# openshift_node_dnsmasq=False
+# openshift_use_dnsmasq=False
 
 # host group for masters
 [masters]

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -341,7 +341,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # and configure node's dnsIP to point at the node's local dnsmasq instance. Defaults
 # to True for Origin 1.2 and OSE 3.2. False for 1.1 / 3.1 installs, this cannot
 # be used with 1.0 and 3.0.
-# openshift_node_dnsmasq=False
+# openshift_use_dnsmasq=False
 
 # host group for masters
 [masters]

--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -214,7 +214,7 @@ Atomic OpenShift Utilities includes
 - Fix router selector fact migration and match multiple selectors when counting
   nodes. (abutcher@redhat.com)
 - Fixing the spec for PR 1734 (bleanhar@redhat.com)
-- Add openshift_node_dnsmasq (sdodson@redhat.com)
+- Add openshift_use_dnsmasq (sdodson@redhat.com)
 - Promote portal_net to openshift.common, add kube_svc_ip (sdodson@redhat.com)
 - Add example inventories to docs, install docs by default (sdodson@redhat.com)
 - Fix use of JSON inventory vars with raw booleans. (dgoodwin@redhat.com)


### PR DESCRIPTION
As per https://github.com/openshift/openshift-ansible/issues/1795#issuecomment-213873564, renamed `openshift_node_dnsmasq` to `openshift_use_dnsmasq` where applicable. Fixes #1795