### PR TITLE
For s3_registry backing, only generate secret on one master

### DIFF
--- a/playbooks/adhoc/s3_registry/s3_registry.yml
+++ b/playbooks/adhoc/s3_registry/s3_registry.yml
@@ -5,8 +5,10 @@
 #
 # The AWS access/secret keys should be the keys of a separate user (not your main user), containing only the necessary S3 access role.
 # The 'clusterid' is the short name of your cluster.
+#
+# This playbook should be limited to one openshift master
 
-- hosts: tag_clusterid_{{ clusterid }}:&tag_host-type_openshift-master
+- hosts: tag_clusterid_{{ clusterid }}:&tag_host-type_openshift-master[0]
   remote_user: root
   gather_facts: False
 
@@ -57,7 +59,6 @@
 
   - name: Add secrets to registry service account
     command: oc secrets add serviceaccount/registry secrets/dockerregistry
-    run_once: true
     when: "'dockerregistry' not in serviceaccount.stdout"
 
   - name: Determine if deployment config contains secrets

--- a/playbooks/adhoc/s3_registry/s3_registry.yml
+++ b/playbooks/adhoc/s3_registry/s3_registry.yml
@@ -8,7 +8,16 @@
 #
 # This playbook should be limited to one openshift master
 
-- hosts: tag_clusterid_{{ clusterid }}:&tag_host-type_openshift-master[0]
+- hosts: tag_clusterid_{{ clusterid }}:&tag_host-type_openshift-master
+  remote_user: root
+  tasks:
+  - add_host:
+      name: hostvars[item].name
+      group: oo_first_master
+    with_items: "{{ play_hosts[0] }}"
+
+
+- hosts: oo_first_master
   remote_user: root
   gather_facts: False
 

--- a/playbooks/adhoc/s3_registry/s3_registry.yml
+++ b/playbooks/adhoc/s3_registry/s3_registry.yml
@@ -8,13 +8,13 @@
 #
 # This playbook should be limited to one openshift master
 
-- hosts: tag_clusterid_{{ clusterid }}:&tag_host-type_openshift-master
-  remote_user: root
+- hosts: localhost
+  gather_facts: no
+  become: no
   tasks:
   - add_host:
-      name: hostvars[item].name
+      name: "{{ (groups['tag_clusterid_' ~ clusterid] | union(groups['tag_host-type_openshift-master']))[0] }}"
       group: oo_first_master
-    with_items: "{{ play_hosts[0] }}"
 
 
 - hosts: oo_first_master

--- a/playbooks/adhoc/s3_registry/s3_registry.yml
+++ b/playbooks/adhoc/s3_registry/s3_registry.yml
@@ -57,6 +57,7 @@
 
   - name: Add secrets to registry service account
     command: oc secrets add serviceaccount/registry secrets/dockerregistry
+    run_once: true
     when: "'dockerregistry' not in serviceaccount.stdout"
 
   - name: Determine if deployment config contains secrets


### PR DESCRIPTION
Running secret creation on multiple masters simultaneously causes those actions after the first secret is created to fail since it already exists.  Adding "run_once" forces ansible to only create the registry secret on the first master and move along.
