### PR TITLE
In s3_registry playbook, modified the host group for tagged master instances

### DIFF
--- a/playbooks/adhoc/s3_registry/s3_registry.yml
+++ b/playbooks/adhoc/s3_registry/s3_registry.yml
@@ -6,7 +6,7 @@
 # The AWS access/secret keys should be the keys of a separate user (not your main user), containing only the necessary S3 access role.
 # The 'clusterid' is the short name of your cluster.
 
-- hosts: tag_clusterid_{{ clusterid }}:&tag_host-type_openshift-master
+- hosts: tag_clusterid_{{ clusterid }}:&tag_host_type_openshift_master
   remote_user: root
   gather_facts: False
 


### PR DESCRIPTION
According to http://docs.ansible.com/ansible/intro_dynamic_inventory.html#example-aws-ec2-external-inventory-script under "Tags", host group names would have dashes converted to underscores