### PR TITLE
Fix openshift_generate_no_proxy_hosts boolean

### DIFF
--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -367,7 +367,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # etcd hosts. So automatically add those hostnames to the openshift_no_proxy list.
 # If all of your hosts share a common domain you may wish to disable this and 
 # specify that domain above.
-#openshift_generate_no_proxy_hosts: True
+#openshift_generate_no_proxy_hosts=True
 #
 # These options configure the BuildDefaults admission controller which injects
 # environment variables into Builds. These values will default to their

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -372,7 +372,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # etcd hosts. So automatically add those hostnames to the openshift_no_proxy list.
 # If all of your hosts share a common domain you may wish to disable this and 
 # specify that domain above.
-#openshift_generate_no_proxy_hosts: True
+#openshift_generate_no_proxy_hosts=True
 #
 # These options configure the BuildDefaults admission controller which injects
 # environment variables into Builds. These values will default to their

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -368,7 +368,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # etcd hosts. So automatically add those hostnames to the openshift_no_proxy list.
 # If all of your hosts share a common domain you may wish to disable this and 
 # specify that domain above.
-#openshift_generate_no_proxy_hosts: True
+#openshift_generate_no_proxy_hosts=True
 #
 # These options configure the BuildDefaults admission controller which injects
 # environment variables into Builds. These values will default to their

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -499,12 +499,12 @@ def set_dnsmasq_facts_if_unset(facts):
     """
 
     if 'common' in facts:
-        if 'use_dnsmasq' not in facts['common'] and facts['common']['version_gte_3_2_or_1_2']:
+        if 'use_dnsmasq' not in facts['common'] and safe_get_bool(facts['common']['version_gte_3_2_or_1_2']):
             facts['common']['use_dnsmasq'] = True
         else:
             facts['common']['use_dnsmasq'] = False
         if 'master' in facts and 'dns_port' not in facts['master']:
-            if facts['common']['use_dnsmasq']:
+            if safe_get_bool(facts['common']['use_dnsmasq']):
                 facts['master']['dns_port'] = 8053
             else:
                 facts['master']['dns_port'] = 53
@@ -1369,18 +1369,19 @@ def set_proxy_facts(facts):
     if 'common' in facts:
         common = facts['common']
         if 'http_proxy' in common or 'https_proxy' in common:
+            if 'no_proxy' in common and \
+                isinstance(common['no_proxy'], basestring):
+                common['no_proxy'] = common['no_proxy'].split(",")
+            elif 'no_proxy' not in common:
+                common['no_proxy'] = []
             if 'generate_no_proxy_hosts' in common and \
-                    common['generate_no_proxy_hosts']:
-                if 'no_proxy' in common and \
-                    isinstance(common['no_proxy'], basestring):
-                    common['no_proxy'] = common['no_proxy'].split(",")
-                else:
-                    common['no_proxy'] = []
+                safe_get_bool(common['generate_no_proxy_hosts']):
                 if 'no_proxy_internal_hostnames' in common:
                     common['no_proxy'].extend(common['no_proxy_internal_hostnames'].split(','))
                 common['no_proxy'].append('.' + common['dns_domain'])
-                common['no_proxy'].append(common['hostname'])
-                common['no_proxy'] = sort_unique(common['no_proxy'])
+            # We always add ourselves no matter what
+            common['no_proxy'].append(common['hostname'])
+            common['no_proxy'] = sort_unique(common['no_proxy'])
         facts['common'] = common
 
     if 'builddefaults' in facts:


### PR DESCRIPTION
- Fix example hosts files
- Fix openshift_generate_no_proxy_hosts boolean handling
  - When this was fixed it became obvious that we should add the current host to the no_proxy list regardless of whether or not they've disabled the generation of the full host list because without this a master cannot talk to etcd on the same host and I don't believe admins should be expected to account for that.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1330934
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1330920

I'd say this is a P2, both bugs have been marked upcoming release. The first is more substantial than the second.