### PR TITLE
a-o-i: Populate groups for openshift_facts

### DIFF
--- a/playbooks/byo/openshift_facts.yml
+++ b/playbooks/byo/openshift_facts.yml
@@ -1,4 +1,14 @@
 ---
+- name: Cluster hosts
+  hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tasks:
+  - include_vars: openshift-cluster/cluster_hosts.yml
+
+- include: ../common/openshift-cluster/evaluate_groups.yml
+
 - name: Gather Cluster facts
   hosts: OSEv3
   roles:

--- a/playbooks/common/openshift-cluster/evaluate_groups.yml
+++ b/playbooks/common/openshift-cluster/evaluate_groups.yml
@@ -35,7 +35,7 @@
       groups: oo_all_hosts
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_become: "{{ g_sudo | default(omit) }}"
-    with_items: "{{ g_all_hosts | default([]) }}"
+    with_items: g_all_hosts | default([])
 
   - name: Evaluate oo_masters
     add_host:


### PR DESCRIPTION
openshift_facts is currently failing because it doesn't properly set up groups
after the proxy changes we made. This fixes that.