### PR TITLE
Update repos per inventory before upgrading

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
@@ -2,10 +2,11 @@
 ###############################################################################
 # Evaluate host groups and gather facts
 ###############################################################################
-- name: Load openshift_facts
+- name: Load openshift_facts and update repos
   hosts: oo_masters_to_config:oo_nodes_to_config:oo_etcd_to_config:oo_lb_to_config
   roles:
   - openshift_facts
+  - openshift_repos
 
 - name: Evaluate additional groups for upgrade
   hosts: localhost


### PR DESCRIPTION
Useful for me when i have to include pre-release repos during upgrades. PErhaps we should just make openshift_repos a dependency of openshift_facts instead?