### PR TITLE
Fix openshift_use_dnsmasq=False on 1.2/3.2 installs

### DIFF
--- a/filter_plugins/openshift_node.py
+++ b/filter_plugins/openshift_node.py
@@ -26,7 +26,7 @@ class FilterModule(object):
         if openshift_dns_ip != None:
             return openshift_dns_ip
 
-        if bool(hostvars['openshift']['common']['version_gte_3_2_or_1_2']):
+        if bool(hostvars['openshift']['common']['use_dnsmasq']):
             return hostvars['ansible_default_ipv4']['address']
         elif bool(hostvars['openshift']['common']['version_gte_3_1_or_1_1']):
             if 'openshift_master_cluster_vip' in hostvars:

--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -46,7 +46,6 @@ EOF
     for ns in ${DHCP4_DOMAIN_NAME_SERVERS}; do
        echo "server=${ns}" >> /etc/dnsmasq.d/origin-upstream-dns.conf
     done
-    echo "listen-address=${def_route_ip}" >> /etc/dnsmasq.d/origin-upstream-dns.conf
     systemctl restart dnsmasq
 
     sed -i 's/^nameserver.*$/nameserver '"${def_route_ip}"'/g' /etc/resolv.conf


### PR DESCRIPTION
- Fixes openshift_use_dnsmasq=False on 1.2/3.2 installs
- When using dnsmasq allow it to bind to all interfaces

Fixes #1837 