### PR TITLE
V2 iptables overrides

### DIFF
--- a/roles/cockpit/defaults/main.yml
+++ b/roles/cockpit/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-os_firewall_use_firewalld: false
 os_firewall_allow:
 - service: cockpit-ws
   port: 9090/tcp

--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -15,7 +15,6 @@ etcd_listen_client_urls: "{{ etcd_url_scheme }}://{{ etcd_ip }}:{{ etcd_client_p
 
 etcd_data_dir: /var/lib/etcd/
 
-os_firewall_use_firewalld: False
 os_firewall_allow:
 - service: etcd
   port: "{{etcd_client_port}}/tcp"

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -15,7 +15,6 @@ haproxy_backends:
     address: 127.0.0.1:9000
     opts: check
 
-os_firewall_use_firewalld: False
 os_firewall_allow:
 - service: haproxy stats
   port: "9000/tcp"

--- a/roles/openshift_common/vars/main.yml
+++ b/roles/openshift_common/vars/main.yml
@@ -1,7 +1,0 @@
----
-# TODO: Upstream kubernetes only supports iptables currently, if this changes,
-# then these variable should be moved to defaults
-# TODO: it might be possible to still use firewalld if we wire up the created
-# chains with the public zone (or the zone associated with the correct
-# interfaces)
-os_firewall_use_firewalld: False

--- a/roles/openshift_storage_nfs/defaults/main.yml
+++ b/roles/openshift_storage_nfs/defaults/main.yml
@@ -16,7 +16,6 @@ openshift:
           options: "*(rw,root_squash)"
         volume:
           name: "metrics"
-os_firewall_use_firewalld: False
 os_firewall_allow:
 - service: nfs
   port: "2049/tcp"

--- a/roles/os_firewall/defaults/main.yml
+++ b/roles/os_firewall/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
 os_firewall_enabled: True
-os_firewall_use_firewalld: True
+# TODO: Upstream kubernetes only supports iptables currently
+# TODO: it might be possible to still use firewalld if we wire up the created
+# chains with the public zone (or the zone associated with the correct
+# interfaces)
+os_firewall_use_firewalld: False
 os_firewall_allow: []
 os_firewall_deny: []

--- a/roles/os_firewall/tasks/firewall/firewalld.yml
+++ b/roles/os_firewall/tasks/firewall/firewalld.yml
@@ -24,6 +24,18 @@
   command: systemctl daemon-reload
   when: install_result | changed
 
+- name: Determine if firewalld service masked
+  command: >
+    systemctl is-enabled firewalld
+  register: os_firewall_firewalld_masked_output
+  changed_when: false
+  failed_when: false
+
+- name: Unmask firewalld service
+  command: >
+    systemctl unmask firewalld
+  when: os_firewall_firewalld_masked_output.stdout == "masked"
+
 - name: Start and enable firewalld service
   service:
     name: firewalld

--- a/roles/os_firewall/tasks/firewall/iptables.yml
+++ b/roles/os_firewall/tasks/firewall/iptables.yml
@@ -32,6 +32,24 @@
   command: systemctl daemon-reload
   when: install_result | changed
 
+- name: Determine if iptables service masked
+  command: >
+    systemctl is-enabled {{ item }}
+  with_items:
+  - iptables
+  - ip6tables
+  register: os_firewall_iptables_masked_output
+  changed_when: false
+  failed_when: false
+
+- name: Unmask iptables service
+  command: >
+    systemctl unmask {{ item }}
+  with_items:
+  - iptables
+  - ip6tables
+  when: "'masked' in os_firewall_iptables_masked_output.results | map(attribute='stdout')"
+
 - name: Start and enable iptables service
   service:
     name: iptables


### PR DESCRIPTION
Working towards #686 

* Default to using iptables in `os_firewall` and remove overrides from roles which depend on `os_firewall` (defaults won't override other defaults in ansible v2).
* Check and unmask iptables/firewalld if masked.