### PR TITLE
Remove vars_files for byo, scaleup and restart playbooks.

### DIFF
--- a/playbooks/byo/openshift-cluster/config.yml
+++ b/playbooks/byo/openshift-cluster/config.yml
@@ -1,7 +1,21 @@
 ---
+- hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+  - add_host:
+      name: "{{ item }}"
+      groups: l_oo_all_hosts
+    with_items: g_all_hosts
+
+- hosts: l_oo_all_hosts
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+
 - include: ../../common/openshift-cluster/config.yml
-  vars_files:
-  - ../../byo/openshift-cluster/cluster_hosts.yml
   vars:
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
     openshift_debug_level: "{{ debug_level | default(2) }}"

--- a/playbooks/byo/openshift-master/restart.yml
+++ b/playbooks/byo/openshift-master/restart.yml
@@ -1,4 +1,18 @@
 ---
+- hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+  - add_host:
+      name: "{{ item }}"
+      groups: l_oo_all_hosts
+    with_items: g_all_hosts
+
+- hosts: l_oo_all_hosts
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+
 - include: ../../common/openshift-master/restart.yml
-  vars_files:
-  - ../../byo/openshift-cluster/cluster_hosts.yml

--- a/playbooks/byo/openshift-master/scaleup.yml
+++ b/playbooks/byo/openshift-master/scaleup.yml
@@ -1,7 +1,21 @@
 ---
+- hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+  - add_host:
+      name: "{{ item }}"
+      groups: l_oo_all_hosts
+    with_items: g_all_hosts
+
+- hosts: l_oo_all_hosts
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+
 - include: ../../common/openshift-master/scaleup.yml
-  vars_files:
-  - ../../byo/openshift-cluster/cluster_hosts.yml
   vars:
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
     openshift_debug_level: "{{ debug_level | default(2) }}"

--- a/playbooks/byo/openshift-node/scaleup.yml
+++ b/playbooks/byo/openshift-node/scaleup.yml
@@ -1,7 +1,21 @@
 ---
+- hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+  - add_host:
+      name: "{{ item }}"
+      groups: l_oo_all_hosts
+    with_items: g_all_hosts
+
+- hosts: l_oo_all_hosts
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+
 - include: ../../common/openshift-node/scaleup.yml
-  vars_files:
-  - ../../byo/openshift-cluster/cluster_hosts.yml
   vars:
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
     openshift_debug_level: "{{ debug_level | default(2) }}"

--- a/playbooks/byo/openshift_facts.yml
+++ b/playbooks/byo/openshift_facts.yml
@@ -1,8 +1,16 @@
 ---
-- name: Cluster hosts
-  hosts: localhost
+- hosts: localhost
   connection: local
   become: no
+  gather_facts: no
+  tasks:
+  - include_vars: openshift-cluster/cluster_hosts.yml
+  - add_host:
+      name: "{{ item }}"
+      groups: l_oo_all_hosts
+    with_items: g_all_hosts
+
+- hosts: l_oo_all_hosts
   gather_facts: no
   tasks:
   - include_vars: openshift-cluster/cluster_hosts.yml

--- a/playbooks/common/openshift-node/scaleup.yml
+++ b/playbooks/common/openshift-node/scaleup.yml
@@ -1,6 +1,11 @@
 ---
 - include: ../openshift-cluster/evaluate_groups.yml
 
+- name: Gather facts
+  hosts: oo_etcd_to_config:oo_masters_to_config:oo_nodes_to_config
+  roles:
+  - openshift_facts
+
 - name: Configure docker hosts
   hosts: oo_nodes_to_config
   vars:


### PR DESCRIPTION
Working towards #686.

Testing
- :white_check_mark: byo
- ✅  master scaleup
- :white_check_mark: node scaleup
- ✅  master restart

Upgrade playbooks have been removed from this PR and will be addressed separately.