### PR TITLE
Containerized Upgrade Fixes

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
@@ -102,6 +102,7 @@
     target_version: "{{ '1.2' if deployment_type == 'origin' else '3.1.1.900' }}"
     openshift_docker_hosted_registry_insecure: True
     openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
+    upgrading: True
   handlers:
   - include: ../../../../../roles/openshift_master/handlers/main.yml
   - include: ../../../../../roles/openshift_node/handlers/main.yml
@@ -110,7 +111,7 @@
   # are modified to use the correct image tag.  However, this can trigger a
   # docker restart if new configuration is laid down which would immediately
   # pull the latest image and defeat the purpose of these tasks.
-  - openshift_cli
+  - { role: openshift_cli }
   pre_tasks:
   - name: Clean package cache
     command: "{{ ansible_pkg_mgr }} clean all"

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
@@ -130,6 +130,7 @@
     ent_reconcile_bindings: true
     openshift_docker_hosted_registry_insecure: True
     openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
+    upgrading: True
   tasks:
   - name: Verifying the correct commandline tools are available
     shell: grep {{ verify_upgrade_version }} {{ openshift.common.admin_binary}}

--- a/roles/openshift_cli/meta/main.yml
+++ b/roles/openshift_cli/meta/main.yml
@@ -12,6 +12,6 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
-- role: openshift_docker
+- { role: openshift_docker, upgrading: "{{ upgrading | default(False) }}" }
 - role: openshift_common
 - role: openshift_cli_facts

--- a/roles/openshift_docker/tasks/main.yml
+++ b/roles/openshift_docker/tasks/main.yml
@@ -2,20 +2,37 @@
 # It's important that we don't explicitly pull this image here.  Otherwise we
 # could result in upgrading a preinstalled environment.  We'll have to set
 # openshift_image_tag correctly for upgrades.
+
+- set_fact:
+    upgrading: False
+  when: upgrading is not defined
+
+- set_fact:
+    is_containerized: "{{ openshift.common.is_containerized | default(False) | bool }}"
+    # Does the host already have an image tag fact, used to determine if it's a new node
+    # in non-upgrade scenarios:
+    has_image_tag_fact: "{{ hostvars[inventory_hostname].openshift.docker.openshift_image_tag is defined }}"
+
 - name: Set version when containerized
   command: >
     docker run --rm {{ openshift.common.cli_image }} version
   register: cli_image_version
-  when: openshift.common.is_containerized is defined and openshift.common.is_containerized | bool and openshift_image_tag is not defined
+  when: is_containerized | bool and openshift_image_tag is not defined and (upgrading | bool or not has_image_tag_fact | bool)
+
+# Use the pre-existing image tag from system facts if present, and we're not upgrading.
+# Ignores explicit openshift_image_tag if it's in the inventory, as this isn't an upgrade.
+- set_fact:
+    l_image_tag: "{{ hostvars[inventory_hostname].openshift.docker.openshift_image_tag }}"
+  when: is_containerized | bool and not upgrading | bool and has_image_tag_fact | bool
 
 - set_fact:
     l_image_tag: "{{ cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0:2] | join('-') if openshift.common.deployment_type == 'origin' else
                      cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0] }}"
-  when: openshift.common.is_containerized is defined and openshift.common.is_containerized | bool and openshift_image_tag is not defined
+  when: is_containerized | bool and openshift_image_tag is not defined and (upgrading | bool or not has_image_tag_fact | bool)
 
 - set_fact:
     l_image_tag: "{{ openshift_image_tag }}"
-  when: openshift.common.is_containerized is defined and openshift.common.is_containerized | bool and openshift_image_tag is defined
+  when: is_containerized | bool and openshift_image_tag is defined and (upgrading | bool or not has_image_tag_fact | bool)
 
 - name: Set post docker install facts
   openshift_facts:
@@ -26,4 +43,4 @@
     local_facts:
       openshift_image_tag: "{{ l_image_tag | default(None) }}"
       openshift_version: "{{ l_image_tag.split('-')[0] | oo_image_tag_to_rpm_version if l_image_tag is defined else '' }}"
-  when: openshift.common.is_containerized is defined and openshift.common.is_containerized | bool
+  when: is_containerized | bool

--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -1,8 +1,9 @@
 ---
+- name: restart openvswitch
+  service: name=openvswitch state=restarted
+  when: not (ovs_service_status_changed | default(false) | bool)
+
 - name: restart node
   service: name={{ openshift.common.service_type }}-node state=restarted
   when: not (node_service_status_changed | default(false) | bool)
 
-- name: restart openvswitch
-  service: name=openvswitch state=restarted
-  when: not (ovs_service_status_changed | default(false) | bool)

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -14,6 +14,8 @@
     dest: /etc/sysconfig/openvswitch
   when: openshift.common.is_containerized | bool
   register: install_ovs_sysconfig
+  notify:
+  - restart openvswitch
 
 - name: Install OpenvSwitch docker service file
   template:


### PR DESCRIPTION
Fixes three issues: containers are upgraded during normal config playbook re-run, openvswitch will now be correctly restarted after upgrade (which is required to get the new container version), and a follow-up issue where the node is left down after this due to the ordering of the notification handlers. 

Some more details in the commits.

My testing procedure has been:

- launch 2 AWS atomic VMs.
- register and subscribe them
- install 3.1 prod
- add a custom registry that has 3.2 uploaded to it via Troy's scripts to the inventory, re-run config playbook
- run upgrade playbook
