### PR TITLE
Fix unsafe boolean handling on use_dnsmasq

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -499,12 +499,12 @@ def set_dnsmasq_facts_if_unset(facts):
     """
 
     if 'common' in facts:
-        if 'use_dnsmasq' not in facts['common'] and facts['common']['version_gte_3_2_or_1_2']:
+        if 'use_dnsmasq' not in facts['common'] and safe_get_bool(facts['common']['version_gte_3_2_or_1_2']):
             facts['common']['use_dnsmasq'] = True
         else:
             facts['common']['use_dnsmasq'] = False
         if 'master' in facts and 'dns_port' not in facts['master']:
-            if facts['common']['use_dnsmasq']:
+            if safe_get_bool(facts['common']['use_dnsmasq']):
                 facts['master']['dns_port'] = 8053
             else:
                 facts['master']['dns_port'] = 53

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -13,6 +13,14 @@ os_firewall_allow:
   port: "{{ openshift.master.dns_port }}/tcp"
 - service: skydns udp
   port: "{{ openshift.master.dns_port }}/udp"
+# On HA masters version_gte facts are not properly set so open port 53
+# whenever we're not certain of the need
+- service: legacy skydns tcp
+  port: "53/tcp"
+  when: "{{ 'version' not in openshift.common or openshift.common.version == None }}"
+- service: legacy skydns udp
+  port: "53/udp"
+  when: "{{ 'version' not in openshift.common or openshift.common.version == None }}"
 - service: Fluentd td-agent tcp
   port: 24224/tcp
 - service: Fluentd td-agent udp


### PR DESCRIPTION
Some installs seem to be getting openshift.master.dns_port = 8053 here https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_master/defaults/main.yml#L12-L15 but in the template openshift.master.dns_port = 53 https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_master/templates/master.yaml.v1.j2#L57

Before this change see that iptables and config mismatch
```
$ iptables -nL | grep 53 && grep -e 53 -e dns /etc/origin/master/master-config.yaml /etc/ansible/facts.d/openshift.fact"
master1
  ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0            state NEW tcp dpt:8053
  ACCEPT     udp  --  0.0.0.0/0            0.0.0.0/0            state NEW udp dpt:8053
  /etc/origin/master/master-config.yaml:dnsConfig:
  /etc/origin/master/master-config.yaml:  bindAddress: 0.0.0.0:53
master2
  ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0            state NEW tcp dpt:8053
  ACCEPT     udp  --  0.0.0.0/0            0.0.0.0/0            state NEW udp dpt:8053
  /etc/origin/master/master-config.yaml:dnsConfig:
  /etc/origin/master/master-config.yaml:  bindAddress: 0.0.0.0:53
master3
  ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0            state NEW tcp dpt:53
  ACCEPT     udp  --  0.0.0.0/0            0.0.0.0/0            state NEW udp dpt:53
  /etc/origin/master/master-config.yaml:dnsConfig:
  /etc/origin/master/master-config.yaml:  bindAddress: 0.0.0.0:53
```

After this change (apply patch, re-run config playbook)
```
master1
    ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0            state NEW tcp dpt:8053
    ACCEPT     udp  --  0.0.0.0/0            0.0.0.0/0            state NEW udp dpt:8053
    ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0            state NEW tcp dpt:53
    ACCEPT     udp  --  0.0.0.0/0            0.0.0.0/0            state NEW udp dpt:53
    /etc/origin/master/master-config.yaml:dnsConfig:
    /etc/origin/master/master-config.yaml:  bindAddress: 0.0.0.0:53
master2
    ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0            state NEW tcp dpt:53
    ACCEPT     udp  --  0.0.0.0/0            0.0.0.0/0            state NEW udp dpt:53
    /etc/origin/master/master-config.yaml:dnsConfig:
    /etc/origin/master/master-config.yaml:  bindAddress: 0.0.0.0:53
master3
    ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0            state NEW tcp dpt:8053
    ACCEPT     udp  --  0.0.0.0/0            0.0.0.0/0            state NEW udp dpt:8053
    ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0            state NEW tcp dpt:53
    ACCEPT     udp  --  0.0.0.0/0            0.0.0.0/0            state NEW udp dpt:53
    /etc/origin/master/master-config.yaml:dnsConfig:
    /etc/origin/master/master-config.yaml:  bindAddress: 0.0.0.0:53
```