### PR TITLE
Fix docker downgrade

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -16,7 +16,7 @@
   when: docker_storage_check.stat.exists | bool and not docker_version_result | skipped and docker_version_result.stdout | default('0.0', True) | version_compare('1.9', '>=') and docker_version | version_compare('1.9', '<')
 
 - name: Downgrade docker if necessary
-  command: "{{ ansible_pkg_mgr }} downgrade -y docker-{{ docker_version }}"
+  command: "{{ ansible_pkg_mgr }} swap -y docker-* docker-*{{ docker_version }}"
   register: docker_downgrade_result
   when: not docker_version_result | skipped and docker_version_result.stdout | default('0.0', True) | version_compare(docker_version, 'gt')
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1334187

```
TASK: [docker | Downgrade docker if necessary] ******************************** 
failed: [openshift-x.com] => {"changed": true, "cmd": ["yum", "downgrade", "-y", "docker-1.8.2"], "delta": "0:00:02.177351", "end": "2016-05-08 15:44:15.269851", "rc": 1, "start": "2016-05-08 15:44:13.092500", "warnings": ["Consider using yum module rather than running yum"]}
stderr: 

Transaction check error:
  file /etc/sysconfig/docker from install of docker-1.8.2-10.el7.x86_64 conflicts with file from package docker-common-1.9.1-40.el7.x86_64
  file /usr/bin/docker from install of docker-1.8.2-10.el7.x86_64 conflicts with file from package docker-common-1.9.1-40.el7.x86_64
```