### PR TITLE
Unmask atomic-openshift-master on uninstall

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -60,6 +60,7 @@
       with_items:
         - etcd
         - firewalld
+        - atomic-openshift-master
 
     - name: Stop additional atomic services
       service: name={{ item }} state=stopped


### PR DESCRIPTION
If you'd installed HA cluster this service would've been masked. If you then
uninstalled and installed a non HA cluster you run into atomic-openshift-master
service not being loaded.