### PR TITLE
Fix cli_docker_additional_registries being erased during upgrade.

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
@@ -7,8 +7,33 @@
     g_nfs_hosts: "{{ groups.nfs | default([]) }}"
     g_node_hosts: "{{ groups.nodes | default([]) }}"
     g_lb_hosts: "{{ groups.lb | default([]) }}"
+    g_all_hosts: "{{ groups.masters | default([]) | union(groups.nodes | default([])) | union(groups.etcd | default([]))
+                    | union(groups.lb | default([])) | union(groups.nfs | default([])) }}"
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
     openshift_deployment_type: "{{ deployment_type }}"
+
+- name: Set oo_options
+  hosts: oo_all_hosts
+  tasks:
+  - set_fact:
+      openshift_docker_additional_registries: "{{ lookup('oo_option', 'docker_additional_registries') }}"
+    when: openshift_docker_additional_registries is not defined
+  - set_fact:
+      openshift_docker_insecure_registries: "{{ lookup('oo_option',  'docker_insecure_registries') }}"
+    when: openshift_docker_insecure_registries is not defined
+  - set_fact:
+      openshift_docker_blocked_registries: "{{ lookup('oo_option', 'docker_blocked_registries') }}"
+    when: openshift_docker_blocked_registries is not defined
+  - set_fact:
+      openshift_docker_options: "{{ lookup('oo_option', 'docker_options') }}"
+    when: openshift_docker_options is not defined
+  - set_fact:
+      openshift_docker_log_driver: "{{ lookup('oo_option', 'docker_log_driver') }}"
+    when: openshift_docker_log_driver is not defined
+  - set_fact:
+      openshift_docker_log_options: "{{ lookup('oo_option', 'docker_log_options') }}"
+    when: openshift_docker_log_options is not defined
+
 - include: ../../../../common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
   vars:
     openshift_deployment_type: "{{ deployment_type }}"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -69,7 +69,7 @@
     reg_flag: --insecure-registry
   notify:
   - restart docker
-  
+
 - name: Set Proxy Settings
   lineinfile:
     dest: /etc/sysconfig/docker


### PR DESCRIPTION
Legacy options (cli_*) were not being migrated during upgrade. Add the
oo_all_hosts group, and migrate the facts as we do in the normal cluster
playbooks.