### PR TITLE
Fix version fact on containerized installs

### DIFF
--- a/roles/openshift_docker/tasks/main.yml
+++ b/roles/openshift_docker/tasks/main.yml
@@ -25,5 +25,5 @@
   - role: docker
     local_facts:
       openshift_image_tag: "{{ l_image_tag | default(None) }}"
-      openshift_version: "{{ l_image_tag.split('-')[0] if l_image_tag is defined else '' | oo_image_tag_to_rpm_version }}"
+      openshift_version: "{{ l_image_tag.split('-')[0] | oo_image_tag_to_rpm_version if l_image_tag is defined else '' }}"
   when: openshift.common.is_containerized is defined and openshift.common.is_containerized | bool


### PR DESCRIPTION
Prior to this change we weren't stripping v from openshift.docker.openshift_version which cascaded into lots of other problems, namely all our version comparison stuff failed.

```
>>> from distutils.version import LooseVersion
>>> LooseVersion('v3.1.1.6') >= LooseVersion('3.2.0')
True
>>> LooseVersion('3.1.1.6') >= LooseVersion('3.2.0') 
False
>>> 
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1330935