### PR TITLE
Fixes for openshift_docker_hosted_registry_insecure var.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
@@ -100,7 +100,6 @@
   hosts: oo_masters_to_config:oo_nodes_to_config
   vars:
     target_version: "{{ '1.2' if deployment_type == 'origin' else '3.1.1.900' }}"
-    openshift_docker_hosted_registry_insecure: True
     openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
   handlers:
   - include: ../../../../../roles/openshift_master/handlers/main.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
@@ -27,6 +27,8 @@
   hosts: oo_masters_to_config:oo_nodes_to_config
   roles:
   - { role: openshift_docker_facts }
+  vars:
+    openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
   tasks:
   - name: Pull Images
     command: >
@@ -128,7 +130,6 @@
   vars:
     origin_reconcile_bindings: "{{ deployment_type == 'origin' and g_new_version | version_compare('1.0.6', '>') }}"
     ent_reconcile_bindings: true
-    openshift_docker_hosted_registry_insecure: True
     openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
   tasks:
   - name: Verifying the correct commandline tools are available

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -204,6 +204,7 @@
                                | oo_collect('openshift.common.all_hostnames')
                                | oo_flatten | unique }}"
     sync_tmpdir: "{{ hostvars.localhost.g_master_mktemp.stdout }}"
+    openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
   roles:
   - openshift_master_certificates
   post_tasks:
@@ -346,6 +347,7 @@
     openshift_master_count: "{{ openshift.master.master_count }}"
     openshift_master_session_auth_secrets: "{{ hostvars[groups.oo_first_master.0].openshift.master.session_auth_secrets }}"
     openshift_master_session_encryption_secrets: "{{ hostvars[groups.oo_first_master.0].openshift.master.session_encryption_secrets }}"
+    openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
   pre_tasks:
   - name: Ensure certificate directory exists
     file:

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -115,10 +115,6 @@
   vars:
     openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
     openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
-    # TODO: configure these based on
-    # hostvars[groups.oo_first_master.0].openshift.hosted.registry instead of
-    # hardcoding
-    openshift_docker_hosted_registry_insecure: "{{ openshift.docker.hosted_registry_insecure | default(True) }}"
     openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
   roles:
   - openshift_node
@@ -128,10 +124,6 @@
   vars:
     openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
     openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
-    # TODO: configure these based on
-    # hostvars[groups.oo_first_master.0].openshift.hosted.registry instead of
-    # hardcoding
-    openshift_docker_hosted_registry_insecure: "{{ openshift.docker.hosted_registry_insecure | default(True) }}"
     openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
   roles:
   - openshift_node

--- a/roles/openshift_docker_facts/tasks/main.yml
+++ b/roles/openshift_docker_facts/tasks/main.yml
@@ -35,7 +35,7 @@
     docker_options: >
       --insecure-registry={{ openshift.docker.hosted_registry_network }}
       {{ openshift.docker.options | default ('') }}
-  when: openshift.docker.hosted_registry_insecure | default(False) | bool
+  when: openshift.docker.hosted_registry_insecure | default(False) | bool and openshift.docker.hosted_registry_network is defined
 
 - set_fact:
     docker_options: "{{ openshift.docker.options | default(omit) }}"

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1710,7 +1710,7 @@ class OpenShiftFacts(object):
                                     set_node_ip=False)
 
         if 'docker' in roles:
-            docker = dict(disable_push_dockerhub=False)
+            docker = dict(disable_push_dockerhub=False, hosted_registry_insecure=True)
             version_info = get_docker_version_info()
             if version_info is not None:
                 docker['api_version'] = version_info['api_version']


### PR DESCRIPTION
Fixes a failure on masters if you explicitly set
openshift_docker_hosted_registry_insecure=true. This is the default but
if you tried to set it an error would trigger as a relevant variable was
not passed in the master playbooks.

Fixes setting the variable to false being ignored.
master/node playbooks were referencing the docker fact, which was not
set at that point and thus we were always getting the default of true,
regardless what was in your inventory.

It felt like in playbooks we should instead reference inventory vars,
rather than rely on more fact loading. This however led to a circular
reference because the variable was being passed as the same name as the
inventory variable. As such the internal variable name has been changed
to avoid this.