### PR TITLE
Fix mistaken quotes on proxy sysconfig variables.

### DIFF
--- a/roles/openshift_master/templates/atomic-openshift-master.j2
+++ b/roles/openshift_master/templates/atomic-openshift-master.j2
@@ -12,11 +12,11 @@ AWS_SECRET_ACCESS_KEY={{ openshift.cloudprovider.aws.secret_key }}
 # Proxy configuration
 # See https://docs.openshift.com/enterprise/latest/install_config/install/advanced_install.html#configuring-global-proxy
 {% if 'http_proxy' in openshift.common %}
-HTTP_PROXY='{{ openshift.common.http_proxy | default('') }}'
+HTTP_PROXY={{ openshift.common.http_proxy | default('') }}
 {% endif %}
 {% if 'https_proxy' in openshift.common %}
-HTTPS_PROXY='{{ openshift.common.https_proxy | default('')}}'
+HTTPS_PROXY={{ openshift.common.https_proxy | default('')}}
 {% endif %}
 {% if 'no_proxy' in openshift.common %}
-NO_PROXY='{{ openshift.common.no_proxy | default('') | join(',') }},{{ openshift.common.portal_net }},{{ openshift.master.sdn_cluster_network_cidr }}'
+NO_PROXY={{ openshift.common.no_proxy | default('') | join(',') }},{{ openshift.common.portal_net }},{{ openshift.master.sdn_cluster_network_cidr }}
 {% endif %}

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
@@ -12,11 +12,11 @@ AWS_SECRET_ACCESS_KEY={{ openshift.cloudprovider.aws.secret_key }}
 # Proxy configuration
 # See https://docs.openshift.com/enterprise/latest/install_config/install/advanced_install.html#configuring-global-proxy
 {% if 'http_proxy' in openshift.common %}
-HTTP_PROXY='{{ openshift.common.http_proxy | default('') }}'
+HTTP_PROXY={{ openshift.common.http_proxy | default('') }}
 {% endif %}
 {% if 'https_proxy' in openshift.common %}
-HTTPS_PROXY='{{ openshift.common.https_proxy | default('')}}'
+HTTPS_PROXY={{ openshift.common.https_proxy | default('')}}
 {% endif %}
 {% if 'no_proxy' in openshift.common %}
-NO_PROXY='{{ openshift.common.no_proxy | default('') | join(',') }},{{ openshift.common.portal_net }},{{ openshift.master.sdn_cluster_network_cidr }}'
+NO_PROXY={{ openshift.common.no_proxy | default('') | join(',') }},{{ openshift.common.portal_net }},{{ openshift.master.sdn_cluster_network_cidr }}
 {% endif %}

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.j2
@@ -12,11 +12,11 @@ AWS_SECRET_ACCESS_KEY={{ openshift.cloudprovider.aws.secret_key }}
 # Proxy configuration
 # See https://docs.openshift.com/enterprise/latest/install_config/install/advanced_install.html#configuring-global-proxy
 {% if 'http_proxy' in openshift.common %}
-HTTP_PROXY='{{ openshift.common.http_proxy | default('') }}'
+HTTP_PROXY={{ openshift.common.http_proxy | default('') }}
 {% endif %}
 {% if 'https_proxy' in openshift.common %}
-HTTPS_PROXY='{{ openshift.common.https_proxy | default('')}}'
+HTTPS_PROXY={{ openshift.common.https_proxy | default('')}}
 {% endif %}
 {% if 'no_proxy' in openshift.common %}
-NO_PROXY='{{ openshift.common.no_proxy | default('') | join(',') }},{{ openshift.common.portal_net }},{{ openshift.master.sdn_cluster_network_cidr }}'
+NO_PROXY={{ openshift.common.no_proxy | default('') | join(',') }},{{ openshift.common.portal_net }},{{ openshift.master.sdn_cluster_network_cidr }}
 {% endif %}


### PR DESCRIPTION
Only need double quotes if preserving whitespace, and never singles.

CC @sdodson who looked at this too and discovered the rules regarding quoting in sysconfig env var files.