### PR TITLE
Include sdn-ovs in upgrade commands to avoid pulling in newer packages

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_minor/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_minor/upgrade.yml
@@ -12,7 +12,7 @@
     openshift_version: "{{ openshift_pkg_version | default('') }}"
   tasks:
   - name: Upgrade master packages
-    command: "{{ ansible_pkg_mgr}} update -y {{ openshift.common.service_type }}-master{{ openshift_version }}"
+    command: "{{ ansible_pkg_mgr}} update-to -y {{ openshift.common.service_type }}-master{{ openshift_version }} {{ openshift.common.service_type }}-sdn-ovs{{ openshift_version }}"
     when: not openshift.common.is_containerized | bool
 
   - name: Ensure python-yaml present for config upgrade
@@ -63,7 +63,7 @@
   - openshift_facts
   tasks:
   - name: Upgrade node packages
-    command: "{{ ansible_pkg_mgr }} update -y {{ openshift.common.service_type }}-node{{ openshift_version }}"
+    command: "{{ ansible_pkg_mgr }} update-to -y {{ openshift.common.service_type }}-node{{ openshift_version }} {{ openshift.common.service_type }}-sdn-ovs{{ openshift_version }}"
     when: not openshift.common.is_containerized | bool
 
   - name: Restart node service


### PR DESCRIPTION
If the package isn't installed yum just ignores it.

Fixes #1435 