### PR TITLE
Fix 'recursive loop detected in template string' for upgrading variable.

### DIFF
--- a/roles/openshift_cli/meta/main.yml
+++ b/roles/openshift_cli/meta/main.yml
@@ -12,6 +12,6 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
-- { role: openshift_docker, upgrading: "{{ upgrading | default(False) }}" }
+- role: openshift_docker
 - role: openshift_common
 - role: openshift_cli_facts

--- a/roles/openshift_docker/defaults/main.yml
+++ b/roles/openshift_docker/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+upgrading: False

--- a/roles/openshift_docker/tasks/main.yml
+++ b/roles/openshift_docker/tasks/main.yml
@@ -2,11 +2,6 @@
 # It's important that we don't explicitly pull this image here.  Otherwise we
 # could result in upgrading a preinstalled environment.  We'll have to set
 # openshift_image_tag correctly for upgrades.
-
-- set_fact:
-    upgrading: False
-  when: upgrading is not defined
-
 - set_fact:
     is_containerized: "{{ openshift.common.is_containerized | default(False) | bool }}"
     # Does the host already have an image tag fact, used to determine if it's a new node


### PR DESCRIPTION
Always default `updrading` to `False` within the `openshift_docker` role. The `upgrading` playbook variable will take precedence when upgrading.

@dgoodwin PTAL

Resolves #1902