### PR TITLE
Fix rhel_subscribe

### DIFF
--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -1,4 +1,8 @@
 ---
+- include: ../common/openshift-cluster/evaluate_groups.yml
+  vars_files:
+  - ../../byo/openshift-cluster/cluster_hosts.yml
+  
 - hosts: all
   vars:
     openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -1,7 +1,21 @@
 ---
-- include: ../common/openshift-cluster/evaluate_groups.yml
-  vars_files:
-  - ../../byo/openshift-cluster/cluster_hosts.yml
+- hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tasks:
+  - include_vars: openshift-cluster/cluster_hosts.yml
+  - add_host:
+      name: "{{ item }}"
+      groups: l_oo_all_hosts
+    with_items: g_all_hosts
+
+- hosts: l_oo_all_hosts
+  gather_facts: no
+  tasks:
+  - include_vars: openshift-cluster/cluster_hosts.yml
+  
+- include: ../common/openshift-cluster/evaluate_groups.yml 
   
 - hosts: all
   vars:

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -348,6 +348,13 @@
     openshift_master_session_auth_secrets: "{{ hostvars[groups.oo_first_master.0].openshift.master.session_auth_secrets }}"
     openshift_master_session_encryption_secrets: "{{ hostvars[groups.oo_first_master.0].openshift.master.session_encryption_secrets }}"
     openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
+    openshift_no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']
+                                                    | union(groups['oo_masters_to_config'])
+                                                    | union(groups['oo_etcd_to_config'] | default([])))
+                                                | oo_collect('openshift.common.hostname') | default([]) | join (',')
+                                                }}"
+    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and 
+            openshift_generate_no_proxy_hosts | default(True) | bool }}"
   pre_tasks:
   - name: Ensure certificate directory exists
     file:

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -116,6 +116,13 @@
     openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
     openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
     openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
+    openshift_no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']
+                                                    | union(groups['oo_masters_to_config'])
+                                                    | union(groups['oo_etcd_to_config'] | default([])))
+                                                | oo_collect('openshift.common.hostname') | default([]) | join (',')
+                                                }}"
+    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and 
+            openshift_generate_no_proxy_hosts | default(True) | bool }}"
   roles:
   - openshift_node
 
@@ -125,6 +132,13 @@
     openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
     openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
     openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
+    openshift_no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']
+                                                    | union(groups['oo_masters_to_config'])
+                                                    | union(groups['oo_etcd_to_config'] | default([])))
+                                                | oo_collect('openshift.common.hostname') | default([]) | join (',')
+                                                }}"
+    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and 
+            openshift_generate_no_proxy_hosts | default(True) | bool }}"
   roles:
   - openshift_node
 

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -42,8 +42,8 @@
       https_proxy: "{{ openshift_https_proxy | default(None) }}"
       no_proxy: "{{ openshift_no_proxy | default(None) }}"
       generate_no_proxy_hosts: "{{ openshift_generate_no_proxy_hosts | default(True) }}"
-      no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']
-                                                   | union(groups['oo_masters_to_config'])
+      no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config'] | default([]) 
+                                                   | union(groups['oo_masters_to_config'] | default([]) ) 
                                                    | union(groups['oo_etcd_to_config'] | default([])))
                                                | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                }}"

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -32,18 +32,8 @@
       public_hostname: "{{ openshift_public_hostname | default(None) }}"
       public_ip: "{{ openshift_public_ip | default(None) }}"
       portal_net: "{{ openshift_portal_net | default(openshift_master_portal_net) | default(None) }}"
-
-# had to be done outside of the above because hostname isn't yet set
-- name: Gather hostnames for proxy configuration
-  openshift_facts:
-    role: common
-    local_facts:
       http_proxy: "{{ openshift_http_proxy | default(None) }}"
       https_proxy: "{{ openshift_https_proxy | default(None) }}"
       no_proxy: "{{ openshift_no_proxy | default(None) }}"
       generate_no_proxy_hosts: "{{ openshift_generate_no_proxy_hosts | default(True) }}"
-      no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config'] | default([]) 
-                                                   | union(groups['oo_masters_to_config'] | default([]) ) 
-                                                   | union(groups['oo_etcd_to_config'] | default([])))
-                                               | oo_collect('openshift.common.hostname') | default([]) | join (',')
-                                               }}"
+      no_proxy_internal_hostnames: "{{ openshift_no_proxy_internal_hostnames | default(None) }}"


### PR DESCRIPTION
Fix this error and possibly some others
Fixes #1903 

```
ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/rhel_subscribe.yml -i /usr/share/ansible/openshift-ansible/rhel_subscribe_inventory.yaml

TASK: [openshift_facts | Gather hostnames for proxy configuration] ************
fatal: [10.35.4.199] => One or more undefined variables: 'dict object' has no attribute 'oo_nodes_to_config'
fatal: [10.35.4.178] => One or more undefined variables: 'dict object' has no attribute 'oo_nodes_to_config'
```