### PR TITLE
Task "Update router image to current version" failed, if router not in default namespace

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/post.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/post.yml
@@ -37,7 +37,7 @@
   - name: Update router image to current version
     when: all_routers.rc == 0
     command: >
-      {{ oc_cmd }} patch dc/{{ item['labels']['deploymentconfig'] }} -p
+      {{ oc_cmd }} patch dc/{{ item['labels']['deploymentconfig'] }} -n {{ item['namespace'] }} -p
       '{"spec":{"template":{"spec":{"containers":[{"name":"router","image":"{{ router_image }}","livenessProbe":{"tcpSocket":null,"httpGet":{"path": "/healthz", "port": 1936, "host": "localhost", "scheme": "HTTP"},"initialDelaySeconds":10,"timeoutSeconds":1}}]}}}}'
       --api-version=v1
     with_items: haproxy_routers
@@ -52,7 +52,7 @@
   - name: Update registry image to current version
     when: _default_registry.rc == 0
     command: >
-      {{ oc_cmd }} patch dc/docker-registry -p
+      {{ oc_cmd }} patch dc/docker-registry -p -n default
       '{"spec":{"template":{"spec":{"containers":[{"name":"registry","image":"{{ registry_image }}"}]}}}}'
       --api-version=v1
 


### PR DESCRIPTION

Also added hardcoded -n default to registry patch, since oc get has -n default, too.