### PR TITLE
Specify docker_version before calling docker role so we don't downgra…

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
@@ -17,6 +17,7 @@
     with_items:
     - role: docker
       local_facts:
+        docker_version: '1.9'
         openshift_image_tag: "v{{ g_new_version }}"
         openshift_version: "{{ g_new_version }}"
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1337253

We're not passing in docker_version so we're downgrading it. I think maybe we should be calling openshift_docker here instead?