### PR TITLE
Use cluster hostname while generating certificate on the master nodes

### DIFF
--- a/roles/nuage_master/tasks/certificates.yml
+++ b/roles/nuage_master/tasks/certificates.yml
@@ -10,7 +10,7 @@
 
 - name: Create the req file
   command: >
-    openssl req -key "{{ nuage_ca_master_rest_server_key }}" -new -out "{{ nuage_mon_rest_server_crt_dir }}/restServer.req" -subj "/CN={{ ansible_nodename }}"
+    openssl req -key "{{ nuage_ca_master_rest_server_key }}" -new -out "{{ nuage_mon_rest_server_crt_dir }}/restServer.req" -subj "/CN={{ nuage_mon_rest_server_host }}"
   delegate_to: "{{ nuage_ca_master }}"
 
 - name: Generate the crt file

--- a/roles/nuage_master/vars/main.yaml
+++ b/roles/nuage_master/vars/main.yaml
@@ -17,6 +17,8 @@ nuage_mon_rest_server_crt_dir: "{{ nuage_ca_master_crt_dir }}/{{ ansible_nodenam
 nuage_ca_master_rest_server_key: "{{ nuage_mon_rest_server_crt_dir }}/nuageMonServer.key"
 nuage_ca_master_rest_server_crt: "{{ nuage_mon_rest_server_crt_dir }}/nuageMonServer.crt" 
 
+nuage_mon_rest_server_host: "{{ openshift.master.cluster_hostname | default(openshift.common.hostname) }}"
+
 nuage_master_crt_dir : /usr/share/nuage-openshift-monitor
 nuage_service_account: system:serviceaccount:default:nuage
 


### PR DESCRIPTION
@detiber @abutcher Changes as per our discussion in the PR1905


