### PR TITLE
Use systemctl restart docker instead of ansible service.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/docker_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/docker_upgrade.yml
@@ -10,5 +10,6 @@
   register: docker_upgrade
 
 - name: Restart Docker
-  service: name=docker state=restarted
+  command: systemctl restart docker
   when: docker_upgrade | changed
+


### PR DESCRIPTION
Ansible is doing a full service stop and then start, which does not
allow systemd to keep the containerized services up and running.
Switching to this will cause the related services to come back within a
few seconds.