### PR TITLE
remove hard reference to registry.access.redhat.com for etcd_image

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1431,7 +1431,7 @@ def set_container_facts_if_unset(facts):
         cli_image = master_image
         node_image = 'openshift3/node'
         ovs_image = 'openshift3/openvswitch'
-        etcd_image = 'registry.access.redhat.com/rhel7/etcd'
+        etcd_image = 'rhel7/etcd'
         pod_image = 'openshift3/ose-pod'
         router_image = 'openshift3/ose-haproxy-router'
         registry_image = 'openshift3/ose-docker-registry'
@@ -1441,7 +1441,7 @@ def set_container_facts_if_unset(facts):
         cli_image = master_image
         node_image = 'aep3_beta/node'
         ovs_image = 'aep3_beta/openvswitch'
-        etcd_image = 'registry.access.redhat.com/rhel7/etcd'
+        etcd_image = 'rhel7/etcd'
         pod_image = 'aep3_beta/aep-pod'
         router_image = 'aep3_beta/aep-haproxy-router'
         registry_image = 'aep3_beta/aep-docker-registry'
@@ -1451,7 +1451,7 @@ def set_container_facts_if_unset(facts):
         cli_image = master_image
         node_image = 'openshift/node'
         ovs_image = 'openshift/openvswitch'
-        etcd_image = 'registry.access.redhat.com/rhel7/etcd'
+        etcd_image = 'rhel7/etcd'
         pod_image = 'openshift/origin-pod'
         router_image = 'openshift/origin-haproxy-router'
         registry_image = 'openshift/origin-docker-registry'


### PR DESCRIPTION
This change removes the hardcoded path to the etcd_image.
It may come from a local registry and not  registry.access.redhat.com
See https://github.com/openshift/openshift-ansible/issues/1915
