### PR TITLE
Remove newline from docker_options template string.

### DIFF
--- a/roles/openshift_docker_facts/tasks/main.yml
+++ b/roles/openshift_docker_facts/tasks/main.yml
@@ -32,9 +32,7 @@
     docker_no_proxy: "{{ openshift.common.no_proxy | default(omit) }}"
 
 - set_fact:
-    docker_options: >
-      --insecure-registry={{ openshift.docker.hosted_registry_network }}
-      {{ openshift.docker.options | default ('') }}
+    docker_options: "--insecure-registry={{ openshift.docker.hosted_registry_network }} {{ openshift.docker.options | default ('') }}"
   when: openshift.docker.hosted_registry_insecure | default(False) | bool and openshift.docker.hosted_registry_network is defined
 
 - set_fact:


### PR DESCRIPTION
This newline in the `docker_options` template string was causing extra quotes to be added to `/etc/sysconfig/docker` each run.

For example:
```
# /etc/sysconfig/docker

# Modify these options if you want to change the way the docker daemon runs
OPTIONS=' --selinux-enabled --insecure-registry=172.30.0.0/16
'
'
'
```

https://bugzilla.redhat.com/show_bug.cgi?id=1337438
Closes #1922 