### PR TITLE
Bug 1337425 - [ansible-2.0] installer failed if yum-utils wasn't installed

### DIFF
--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -19,6 +19,10 @@
   action: "{{ ansible_pkg_mgr }} name=PyYAML state=present"
   when: not l_is_atomic | bool
 
+- name: Ensure yum-utils is installed
+  action: "{{ ansible_pkg_mgr }} name=yum-utils state=present"
+  when: not l_is_atomic | bool
+
 - name: Gather Cluster facts and set is_containerized if needed
   openshift_facts:
     role: common


### PR DESCRIPTION
yum-utils is no longer pulled in by ansible so we need to install it for minimal RHEL.

https://bugzilla.redhat.com/show_bug.cgi?id=1337425