### PR TITLE
add unit in seconds for metrics resolution

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -46,7 +46,7 @@
       openshift_hosted_metrics_duration: "{{ lookup('oo_option', 'openshift_hosted_metrics_duration') | default(7) }}"
     when: openshift_hosted_metrics_duration is not defined
   - set_fact:
-      openshift_hosted_metrics_resolution: "{{ lookup('oo_option', 'openshift_hosted_metrics_resolution') | default(10) }}"
+      openshift_hosted_metrics_resolution: "{{ lookup('oo_option', 'openshift_hosted_metrics_resolution') | default('10s', true) }}"
     when: openshift_hosted_metrics_resolution is not defined
   roles:
   - openshift_facts

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1727,7 +1727,7 @@ class OpenShiftFacts(object):
                 metrics=dict(
                     deploy=False,
                     duration=7,
-                    resolution=10,
+                    resolution='10s',
                     storage=dict(
                         kind=None,
                         volume=dict(

--- a/roles/openshift_metrics/README.md
+++ b/roles/openshift_metrics/README.md
@@ -21,7 +21,7 @@ From this role:
 | openshift_hosted_metrics_storage_volume_size    | 10Gi                  | Metrics volume size                                         |
 | openshift_hosted_metrics_storage_nfs_options    | *(rw,root_squash)     | NFS options for configured exports.                         |
 | openshift_hosted_metrics_duration               | 7                     | Metrics query duration                                      |
-| openshift_hosted_metrics_resolution             | 10                    | Metrics resolution                                          |
+| openshift_hosted_metrics_resolution             | 10s                   | Metrics resolution                                          |
 
 
 From openshift_common:


### PR DESCRIPTION
unit was missing in METRIC_RESOLUTION={{ openshift.hosted.metrics.resolution }}s