### PR TITLE
99-origin-dns.sh adds a comment to /etc/resolv.conf on every execution of NetworkManager dispatcher

### DIFF
--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -51,7 +51,6 @@ EOF
     done
     systemctl restart dnsmasq
 
-    sed -i 's/^nameserver.*$/nameserver '"${def_route_ip}"'/g' /etc/resolv.conf
-    echo "# nameserver updated by /etc/NetworkManager/dispatcher.d/99-origin-dns.sh" >> /etc/resolv.conf
+    sed -i 's/^nameserver.*$/nameserver '"${def_route_ip}"' # updated by \/etc\/NetworkManager\/dispatcher.d\/99-origin-dns.sh/g' /etc/resolv.conf
   fi
 fi


### PR DESCRIPTION
In an Openstack environment dhcp is used to obtain floating IP's. 
dhcp operations result in NetworkManager kicking off the dispatcher who will run /etc/NetworkManager/dispatcher.d/99-origin-dns.sh

In the current implementation 99-origin-dns.sh will add a new line to /etc/resolv.conf every time it is executed.

An inline comment instead could solve that problem and still inform that the change was made by 99-origin-dns.sh