### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+Jinja2==2.8
+MarkupSafe==0.23
+PyYAML==3.11
+ansible==1.9.4
+cffi==1.5.0
+cryptography==1.2.1
+ecdsa==0.13
+enum34==1.1.2
+idna==2.0
+ipaddress==1.0.16
+paramiko==1.16.0
+pyOpenSSL==0.15.1
+pyasn1==0.1.9
+pycparser==2.14
+pycrypto==2.6.1
+six==1.10.0
+wsgiref==0.1.2


### PR DESCRIPTION
For those of us who prefer to use ansible in a virtualenv this makes things nice and easy for us as we can just do pip install -r requirements.txt.

Steps to test:

```
virtualenv venv 
source venv/bin/activate
pip install -r requirements.txt
ansible-playbook -i your_inventory playbooks/path/to/playbook
```
