### PR TITLE
wait metrics-deployer complete (need to configure nodes before hosted…

### DIFF
--- a/playbooks/common/openshift-cluster/additional_config.yml
+++ b/playbooks/common/openshift-cluster/additional_config.yml
@@ -28,25 +28,4 @@
   - role: flannel_register
     when: openshift.common.use_flannel | bool
 
-- name: Create persistent volumes and create hosted services
-  hosts: oo_first_master
-  vars:
-    attach_registry_volume: "{{ openshift.hosted.registry.storage.kind != None }}"
-    deploy_infra: "{{ openshift.master.infra_nodes | default([]) | length > 0 }}"
-    persistent_volumes: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volumes(groups) }}"
-    persistent_volume_claims: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volume_claims }}"
-  roles:
-  - role: openshift_persistent_volumes
-    when: persistent_volumes | length > 0 or persistent_volume_claims | length > 0
-  - role: openshift_serviceaccounts
-    openshift_serviceaccounts_names:
-    - router
-    - registry
-    openshift_serviceaccounts_namespace: default
-    openshift_serviceaccounts_sccs:
-    - privileged
-  - role: openshift_registry
-    registry_volume_claim: "{{ openshift.hosted.registry.storage.volume.name }}-claim"
-    when: deploy_infra | bool and attach_registry_volume | bool
-  - role: openshift_metrics
-    when: openshift.hosted.metrics.deploy | bool
+

--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -1,3 +1,26 @@
+- name: Create persistent volumes and create hosted services
+  hosts: oo_first_master
+  vars:
+    attach_registry_volume: "{{ openshift.hosted.registry.storage.kind != None }}"
+    deploy_infra: "{{ openshift.master.infra_nodes | default([]) | length > 0 }}"
+    persistent_volumes: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volumes(groups) }}"
+    persistent_volume_claims: "{{ hostvars[groups.oo_first_master.0] | oo_persistent_volume_claims }}"
+  roles:
+  - role: openshift_persistent_volumes
+    when: persistent_volumes | length > 0 or persistent_volume_claims | length > 0
+  - role: openshift_serviceaccounts
+    openshift_serviceaccounts_names:
+    - router
+    - registry
+    openshift_serviceaccounts_namespace: default
+    openshift_serviceaccounts_sccs:
+    - privileged
+  - role: openshift_registry
+    registry_volume_claim: "{{ openshift.hosted.registry.storage.volume.name }}-claim"
+    when: deploy_infra | bool and attach_registry_volume | bool
+  - role: openshift_metrics
+    when: openshift.hosted.metrics.deploy | bool
+
 - name: Create Hosted Resources
   hosts: oo_first_master
   roles:

--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -54,3 +54,11 @@
   command: >
     rm -rf {{hawkular_tmp_conf}}
   changed_when: false
+
+- name: "Wait for image pull and deployer pod"
+  shell:  "{{ openshift.common.client_binary }} get pods -n openshift-infra | grep metrics-deployer.*Completed"
+  register: result
+  until: result.rc == 0
+  retries: 60
+  delay: 10
+


### PR DESCRIPTION
Resolves https://github.com/openshift/openshift-ansible/issues/1851

I move metrics deployer to openshift-hosted to be started after the nodes installation, and then wait that the metrics-deployer complete.