### PR TITLE
Preserve proxy config if it exists in the sysconfig files but is undefined in our config

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_0_to_v3_1/upgrade.yml
@@ -54,7 +54,7 @@
   - script: ../files/pre-upgrade-check
 
 
-- name: Verify upgrade can proceed
+- name: Verify upgrade targets
   hosts: oo_masters_to_config:oo_nodes_to_config
   vars:
     target_version: "{{ '1.1' if deployment_type == 'origin' else '3.1' }}"

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_minor/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_minor/pre.yml
@@ -29,7 +29,7 @@
         valid version for a {{ target_version }} upgrade
     when: openshift_pkg_version is defined and openshift_pkg_version.split('-',1).1 | version_compare(target_version ,'<')
 
-- name: Verify upgrade can proceed
+- name: Verify upgrade targets
   hosts: oo_masters_to_config:oo_nodes_to_config
   vars:
     target_version: "{{ '1.1.1' if deployment_type == 'origin' else '3.1.1' }}"

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
@@ -53,7 +53,7 @@
         valid version for a {{ target_version }} upgrade
     when: openshift_image_tag is defined and openshift_image_tag.split('v',1).1 | version_compare(target_version ,'<')
 
-- name: Verify upgrade can proceed
+- name: Verify master processes
   hosts: oo_masters_to_config
   roles:
   - openshift_facts
@@ -84,7 +84,7 @@
       enabled: yes
     when: openshift.master.ha is defined and openshift.master.ha | bool and openshift.common.is_containerized | bool
 
-- name: Verify upgrade can proceed
+- name: Verify node processes
   hosts: oo_nodes_to_config
   roles:
   - openshift_facts
@@ -96,7 +96,7 @@
       enabled: yes
     when: openshift.common.is_containerized | bool
 
-- name: Verify upgrade can proceed
+- name: Verify upgrade targets
   hosts: oo_masters_to_config:oo_nodes_to_config
   vars:
     target_version: "{{ '1.2' if deployment_type == 'origin' else '3.1.1.900' }}"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -85,6 +85,7 @@
       reg_fact_val: "{{ docker_no_proxy | default('') | join(',') }}"
   notify:
     - restart docker
+  when: "{{ 'http_proxy' in openshift.common or 'https_proxy' in openshift.common and docker_check.stat.isreg }}"
 
 - name: Set various docker options
   lineinfile:

--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -38,6 +38,13 @@
   when: create_ha_unit_files | changed
 # end workaround for missing systemd unit files
 
+- name: Preserve Master API Proxy Config options
+  command: grep PROXY /etc/sysconfig/{{ openshift.common.service_type }}-master-api
+  register: master_api_proxy
+  when: openshift.master.ha is defined and openshift.master.ha | bool and openshift_master_cluster_method == "native"
+  failed_when: false
+  changed_when: false
+
 - name: Create the master api service env file
   template:
     src: "{{ ha_svc_template_path }}/atomic-openshift-master-api.j2"
@@ -46,6 +53,21 @@
   when: openshift.master.ha is defined and openshift.master.ha | bool and openshift_master_cluster_method == "native"
   notify:
   - restart master api
+
+- name: Restore Master API Proxy Config Options
+  when: openshift.master.ha is defined and openshift.master.ha | bool and openshift_master_cluster_method == "native"
+      and master_api_proxy.rc == 0 and 'http_proxy' not in openshift.common and 'https_proxy' not in openshift.common
+  lineinfile:
+    dest: /etc/sysconfig/{{ openshift.common.service_type }}-master-api
+    line: "{{ item }}"
+  with_items: "{{ master_api_proxy.stdout_lines | default([]) }}"
+
+- name: Preserve Master Controllers Proxy Config options
+  command: grep PROXY /etc/sysconfig/{{ openshift.common.service_type }}-master-api
+  register: master_controllers_proxy
+  when: openshift.master.ha is defined and openshift.master.ha | bool and openshift_master_cluster_method == "native"
+  failed_when: false
+  changed_when: false
 
 - name: Create the master controllers service env file
   template:
@@ -56,12 +78,26 @@
   notify:
   - restart master controllers
 
+- name: Restore Master Controllers Proxy Config Options
+  lineinfile:
+    dest: /etc/sysconfig/{{ openshift.common.service_type }}-master-controllers
+    line: "{{ item }}"
+  with_items: "{{ master_controllers_proxy.stdout_lines | default([]) }}"
+  when: openshift.master.ha is defined and openshift.master.ha | bool and openshift_master_cluster_method == "native"
+        and master_controllers_proxy.rc == 0 and 'http_proxy' not in openshift.common and 'https_proxy' not in openshift.common 
+
 - name: Install Master docker service file
   template:
     dest: "/etc/systemd/system/{{ openshift.common.service_type }}-master.service"
     src: docker/master.docker.service.j2
   register: install_result
   when: openshift.common.is_containerized | bool and openshift.master.ha is defined and not openshift.master.ha | bool
+
+- name: Preserve Master Proxy Config options
+  command: grep PROXY /etc/sysconfig/{{ openshift.common.service_type }}-master
+  register: master_proxy
+  failed_when: false
+  changed_when: false
 
 - name: Create the master service env file
   template:
@@ -70,3 +106,10 @@
     backup: true
   notify:
   - restart master
+
+- name: Restore Master Proxy Config Options
+  lineinfile:
+    dest: /etc/sysconfig/{{ openshift.common.service_type }}-master
+    line: "{{ item }}"
+  with_items: "{{ master_proxy.stdout_lines | default([]) }}"
+  when: master_proxy.rc == 0 and 'http_proxy' not in openshift.common and 'https_proxy' not in openshift.common

--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -42,6 +42,7 @@
   template:
     src: "{{ ha_svc_template_path }}/atomic-openshift-master-api.j2"
     dest: /etc/sysconfig/{{ openshift.common.service_type }}-master-api
+    backup: true
   when: openshift.master.ha is defined and openshift.master.ha | bool and openshift_master_cluster_method == "native"
   notify:
   - restart master api
@@ -50,6 +51,7 @@
   template:
     src: "{{ ha_svc_template_path }}/atomic-openshift-master-controllers.j2"
     dest: /etc/sysconfig/{{ openshift.common.service_type }}-master-controllers
+    backup: true
   when: openshift.master.ha is defined and openshift.master.ha | bool and openshift_master_cluster_method == "native"
   notify:
   - restart master controllers
@@ -65,5 +67,6 @@
   template:
     src: "atomic-openshift-master.j2"
     dest: /etc/sysconfig/{{ openshift.common.service_type }}-master
+    backup: true
   notify:
   - restart master


### PR DESCRIPTION
Preserves existing PROXY variables in /etc/sysconfig/docker and /etc/sysconfig/*master-* whenever `openshift.common.http_proxy` and `openshift.common.https_proxy` are not defined.

This will gratuitously restart master/docker services if the template applies no changes other than removing proxy settings and then we restore the proxy settings.