### PR TITLE
[v2] Move os_firewall_allow from defaults to role dependencies.

### DIFF
--- a/playbooks/common/openshift-loadbalancer/config.yml
+++ b/playbooks/common/openshift-loadbalancer/config.yml
@@ -1,5 +1,7 @@
 ---
 - name: Configure load balancers
   hosts: oo_lb_to_config
+  vars:
+    haproxy_frontend_port: "{{ openshift_master_api_port | default(8443) }}"
   roles:
   - role: openshift_loadbalancer

--- a/roles/cockpit/defaults/main.yml
+++ b/roles/cockpit/defaults/main.yml
@@ -1,4 +1,0 @@
----
-os_firewall_allow:
-- service: cockpit-ws
-  port: 9090/tcp

--- a/roles/cockpit/meta/main.yml
+++ b/roles/cockpit/meta/main.yml
@@ -12,4 +12,7 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
-  - { role: os_firewall }
+- role: os_firewall
+  os_firewall_allow:
+  - service: cockpit-ws
+    port: 9090/tcp

--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -14,9 +14,3 @@ etcd_advertise_client_urls: "{{ etcd_url_scheme }}://{{ etcd_ip }}:{{ etcd_clien
 etcd_listen_client_urls: "{{ etcd_url_scheme }}://{{ etcd_ip }}:{{ etcd_client_port }}"
 
 etcd_data_dir: /var/lib/etcd/
-
-os_firewall_allow:
-- service: etcd
-  port: "{{etcd_client_port}}/tcp"
-- service: etcd peering
-  port: "{{ etcd_peer_port }}/tcp"

--- a/roles/etcd/meta/main.yml
+++ b/roles/etcd/meta/main.yml
@@ -16,5 +16,10 @@ galaxy_info:
   - cloud
   - system
 dependencies:
-- { role: os_firewall }
-- { role: etcd_common }
+- role: os_firewall
+  os_firewall_allow:
+  - service: etcd
+    port: "{{etcd_client_port}}/tcp"
+  - service: etcd peering
+    port: "{{ etcd_peer_port }}/tcp"
+- role: etcd_common

--- a/roles/openshift_loadbalancer/defaults/main.yml
+++ b/roles/openshift_loadbalancer/defaults/main.yml
@@ -1,10 +1,10 @@
 ---
-haproxy_frontend_port: 80
+haproxy_frontend_port: 8443
 
 haproxy_frontends:
 - name: main
   binds:
-  - "*:80"
+  - "*:8443"
   default_backend: default
 
 haproxy_backends:
@@ -14,9 +14,3 @@ haproxy_backends:
   - name: web01
     address: 127.0.0.1:9000
     opts: check
-
-os_firewall_allow:
-- service: haproxy stats
-  port: "9000/tcp"
-- service: haproxy balance
-  port: "{{ haproxy_frontend_port }}/tcp"

--- a/roles/openshift_loadbalancer/meta/main.yml
+++ b/roles/openshift_loadbalancer/meta/main.yml
@@ -12,4 +12,9 @@ galaxy_info:
 dependencies:
 - role: openshift_facts
 - role: os_firewall
+  os_firewall_allow:
+  - service: haproxy stats
+    port: "9000/tcp"
+  - service: haproxy balance
+    port: "{{ haproxy_frontend_port }}/tcp"
 - role: openshift_repos

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -1,16 +1,2 @@
 ---
-os_firewall_allow:
-- service: Kubernetes kubelet
-  port: 10250/tcp
-- service: http
-  port: 80/tcp
-- service: https
-  port: 443/tcp
-- service: Openshift kubelet ReadOnlyPort
-  port: 10255/tcp
-- service: Openshift kubelet ReadOnlyPort udp
-  port: 10255/udp
-- service: OpenShift OVS sdn
-  port: 4789/udp
-  when: openshift.node.use_openshift_sdn | bool
 openshift_version: "{{ openshift_pkg_version | default(openshift_image_tag | default(openshift.docker.openshift_image_tag | default(''))) }}"

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -19,4 +19,17 @@ dependencies:
 - role: openshift_node_dnsmasq
   when: openshift.common.use_dnsmasq
 - role: os_firewall
-
+  os_firewall_allow:
+  - service: Kubernetes kubelet
+    port: 10250/tcp
+  - service: http
+    port: 80/tcp
+  - service: https
+    port: 443/tcp
+  - service: Openshift kubelet ReadOnlyPort
+    port: 10255/tcp
+  - service: Openshift kubelet ReadOnlyPort udp
+    port: 10255/udp
+  - service: OpenShift OVS sdn
+    port: 4789/udp
+    when: openshift.node.use_openshift_sdn | bool

--- a/roles/openshift_storage_nfs/defaults/main.yml
+++ b/roles/openshift_storage_nfs/defaults/main.yml
@@ -16,6 +16,3 @@ openshift:
           options: "*(rw,root_squash)"
         volume:
           name: "metrics"
-os_firewall_allow:
-- service: nfs
-  port: "2049/tcp"

--- a/roles/openshift_storage_nfs/meta/main.yml
+++ b/roles/openshift_storage_nfs/meta/main.yml
@@ -11,5 +11,8 @@ galaxy_info:
     - 7
 dependencies:
 - role: os_firewall
+  os_firewall_allow:
+  - service: nfs
+    port: "2049/tcp"
 - role: openshift_hosted_facts
 - role: openshift_repos


### PR DESCRIPTION
* Move `os_firewall_allow` from defaults to role dependencies for all roles. These defaults were not being acted on.
* Fix issue with openshift-loadbalancer refactor, ensuring that `haproxy_frontend_port` is fed from the playbook to drive firewall configuration.

The loadbalancer refactor changes were merged post cut so, if we're doing backports for critical fixes, these changes shouldn't be included in the update since the update won't be impacted by them.

https://bugzilla.redhat.com/show_bug.cgi?id=1339431

@detiber PTAL