### PR TITLE
Fix error with stopping services that may not exist.

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -28,17 +28,17 @@
     state: directory
     mode: 0700
 
-- name: Disable system etcd when containerized
-  when: etcd_is_containerized | bool
-  service:
-    name: etcd
-    state: stopped
-    enabled: no
-
 - name: Check for etcd service presence
   command: systemctl show etcd.service
   register: etcd_show
   changed_when: false
+
+- name: Disable system etcd when containerized
+  when: etcd_is_containerized | bool and 'LoadState=not-found' not in etcd_show.stdout
+  service:
+    name: etcd
+    state: stopped
+    enabled: no
 
 - name: Mask system etcd when containerized
   when: etcd_is_containerized | bool and 'LoadState=not-found' not in etcd_show.stdout

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -164,9 +164,14 @@
   register: start_result
   notify: Verify API Server
 
-- name: Stop and disable non HA master when running HA
+- name: Check for non-HA master service presence
+  command: systemctl show {{ openshift.common.service_type }}-master.service
+  register: master_svc_show
+  changed_when: false
+
+- name: Stop and disable non-HA master when running HA
   service: name={{ openshift.common.service_type }}-master enabled=no state=stopped
-  when: openshift_master_ha | bool
+  when: openshift_master_ha | bool and 'LoadState=not-found' not in master_svc_show.stdout
 
 - set_fact:
     master_service_status_changed: "{{ start_result | changed }}"


### PR DESCRIPTION
Causes a hard failure due to missing etcd/atomic-openshift-master
services. Instead, check that the services exist before ensuring they're
stopped/disabled.