### PR TITLE
Add flag to manage htpasswd, or not.

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -93,7 +93,7 @@
     src: htpasswd.j2
     mode: 0600
     backup: yes
-  when: item.kind == 'HTPasswdPasswordIdentityProvider'
+  when: item.kind == 'HTPasswdPasswordIdentityProvider' and openshift.master.manage_htpasswd | bool
   with_items: "{{ openshift.master.identity_providers }}"
 
 - name: Create the ldap ca file if needed

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -91,9 +91,17 @@
   template:
     dest: "{{ item.filename }}"
     src: htpasswd.j2
-    mode: 0600
     backup: yes
   when: item.kind == 'HTPasswdPasswordIdentityProvider' and openshift.master.manage_htpasswd | bool
+  with_items: "{{ openshift.master.identity_providers }}"
+
+- name: Ensure htpasswd file exists
+  copy:
+    dest: "{{ item.filename }}"
+    force: no
+    content: ""
+    mode: 0600
+  when: item.kind == 'HTPasswdPasswordIdentityProvider'
   with_items: "{{ openshift.master.identity_providers }}"
 
 - name: Create the ldap ca file if needed

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -42,6 +42,7 @@
       auth_token_max_seconds: "{{ openshift_master_auth_token_max_seconds | default(None) }}"
       identity_providers: "{{ openshift_master_identity_providers | default(None) }}"
       htpasswd_users: "{{ openshift_master_htpasswd_users | default(lookup('file', openshift_master_htpasswd_file) | oo_htpasswd_users_from_file if openshift_master_htpasswd_file is defined else None) }}"
+      manage_htpasswd: "{{ openshift_master_manage_htpasswd | default(true) }}"
       ldap_ca: "{{ openshift_master_ldap_ca | default(lookup('file', openshift_master_ldap_ca_file) if openshift_master_ldap_ca_file is defined else None) }}"
       openid_ca: "{{ openshift_master_openid_ca | default(lookup('file', openshift_master_openid_ca_file) if openshift_master_openid_ca_file is defined else None) }}"
       request_header_ca: "{{ openshift_master_request_header_ca | default(lookup('file', openshift_master_request_header_ca_file) if openshift_master_request_header_ca_file is defined else None) }}"


### PR DESCRIPTION
Setting `openshift_master_manage_htpasswd` falsy will disable managing
the htpasswd file. It won't get overwritten/generated.