### PR TITLE
Configure default docker logging options.

### DIFF
--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -72,10 +72,8 @@ deployment_type=atomic-enterprise
 # Disable pushing to dockerhub
 #openshift_docker_disable_push_dockerhub=True
 # Items added, as is, to end of /etc/sysconfig/docker OPTIONS
+# Default value: "--log-driver=json-file --log-opt max-size=50m"
 #openshift_docker_options="-l warn --ipv6=false"
-# Deprecated methods to set --log-driver and --log-opts flags, use openshift_docker_options instead
-#openshift_docker_log_driver=json
-#openshift_docker_log_options=["tag=mailer"]
 
 # Alternate image format string. If you're not modifying the format string and
 # only need to inject your own registry you may want to consider

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -73,10 +73,8 @@ deployment_type=origin
 # Disable pushing to dockerhub
 #openshift_docker_disable_push_dockerhub=True
 # Items added, as is, to end of /etc/sysconfig/docker OPTIONS
+# Default value: "--log-driver=json-file --log-opt max-size=50m"
 #openshift_docker_options="-l warn --ipv6=false"
-# Deprecated methods to set --log-driver and --log-opts flags, use openshift_docker_options instead
-#openshift_docker_log_driver=json
-#openshift_docker_log_options=["tag=mailer"]
 
 # Alternate image format string. If you're not modifying the format string and
 # only need to inject your own registry you may want to consider

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -72,11 +72,8 @@ deployment_type=openshift-enterprise
 # Disable pushing to dockerhub
 #openshift_docker_disable_push_dockerhub=True
 # Items added, as is, to end of /etc/sysconfig/docker OPTIONS
+# Default value: "--log-driver=json-file --log-opt max-size=50m"
 #openshift_docker_options="-l warn --ipv6=false"
-# Deprecated methods to set --log-driver and --log-opts flags, use openshift_docker_options instead
-#openshift_docker_log_driver=json
-#openshift_docker_log_options=["tag=mailer"]
-
 
 # Alternate image format string. If you're not modifying the format string and
 # only need to inject your own registry you may want to consider

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1714,7 +1714,9 @@ class OpenShiftFacts(object):
                                     set_node_ip=False)
 
         if 'docker' in roles:
-            docker = dict(disable_push_dockerhub=False, hosted_registry_insecure=True)
+            docker = dict(disable_push_dockerhub=False,
+                          hosted_registry_insecure=True,
+                          options='--log-driver=json-file --log-opt max-size=50m')
             version_info = get_docker_version_info()
             if version_info is not None:
                 docker['api_version'] = version_info['api_version']


### PR DESCRIPTION
* Adds `"--log-driver=json-file --log-opt max-size=50m"` to docker options by default ([docs](https://docs.docker.com/engine/admin/logging/overview/#json-file-options)).
* Removes deprecated `openshift_docker_log_driver` and `openshift_docker_log_options` from example inventories to encourage use of `openshift_docker_options`. Also show the default value in example inventories.

The [advanced installation docs](https://docs.openshift.com/enterprise/3.2/install_config/install/advanced_install.html#configuring-host-variables) do not mention `openshift_docker_options` but do mention `openshift_docker_log_options` so an issue should be created to swap them.

Resolves #1887
https://bugzilla.redhat.com/show_bug.cgi?id=1335939