### PR TITLE
Load openshift ca.crt into ca-trust

### DIFF
--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -7,3 +7,8 @@
   service: name={{ openshift.common.service_type }}-node state=restarted
   when: not (node_service_status_changed | default(false) | bool)
 
+- name: restart docker
+  service:
+    name: docker
+    state: restarted
+  when: default(false)

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -124,5 +124,18 @@
   debug: var=node_failure
   when: node_start_result | failed
 
+- name: Load OpenShift ca certificate into ca-trust
+  command: cp {{ openshift.common.config_base }}/node/ca.crt /etc/pki/ca-trust/source/anchors/openshift-ca.crt
+  register: openshift_ca_trust
+  args:
+    creates: "/etc/pki/ca-trust/source/anchors/openshift-ca.crt"
+
+- name: Update CA Trust
+  command: >
+    update-ca-trust
+  when: openshift_ca_trust.changed
+  notify:
+  - restart docker
+
 - set_fact:
     node_service_status_changed: "{{ node_start_result | changed }}"


### PR DESCRIPTION
This avoids me having to load the openshift cert manually on every node host after securing the docker registry. I'm not sure how relevant this may be to other configurations.. 