### PR TITLE
Require ansible-2.1.0.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ they may in the future.
 - Install base dependencies:
   - Fedora:
   ```
-    dnf install -y ansible-1.9.4 pyOpenSSL python-cryptography
+    dnf install -y ansible-2.1.0.0 pyOpenSSL python-cryptography
   ```
    - OSX:
   ```
-    # Install ansible 1.9.4 and python 2
+    # Install ansible 2.1.0.0 and python 2
     brew install ansible python
   ```
 - Setup for a specific cloud:

--- a/README_AEP.md
+++ b/README_AEP.md
@@ -10,7 +10,7 @@
 * [Overriding detected ip addresses and hostnames](#overriding-detected-ip-addresses-and-hostnames)
 
 ## Requirements
-* ansible 1.9.4
+* ansible 2.1.0.0
   * Available in Fedora channels
   * Available for EL with EPEL and Optional channel
 * One or more RHEL 7.1 VMs

--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -13,7 +13,7 @@ URL:            https://github.com/openshift/openshift-ansible
 Source0:        https://github.com/openshift/openshift-ansible/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-Requires:      ansible >= 1.9.4
+Requires:      ansible >= 2.1.0.0
 Requires:      python2
 Requires:      openshift-ansible-docs = %{version}-%{release}
 

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- name: Verify Ansible version is greater than or equal to 1.9.4
+- name: Verify Ansible version is greater than or equal to 2.1.0.0
   fail:
-    msg: "Unsupported ansible version: {{ ansible_version }} found"
-  when: not ansible_version.full | version_compare('1.9.4', 'ge')
+    msg: "Unsupported ansible version: {{ ansible_version.full }} found"
+  when: not ansible_version.full | version_compare('2.1.0.0', 'ge')
 
 - name: Detecting Operating System
   stat:


### PR DESCRIPTION
Require ansible-2.1.0.0 for openshift-ansible master. `enterprise-3.2` and `enterprise-3.1` branches have been created to maintain 1.9.4 compat for the current release.