### PR TITLE
roles/openshift_docker_facts: add missing --installed option to repoquery

### DIFF
--- a/roles/openshift_docker_facts/tasks/main.yml
+++ b/roles/openshift_docker_facts/tasks/main.yml
@@ -43,7 +43,7 @@
 # See: https://bugzilla.redhat.com/show_bug.cgi?id=1304038
 - name: Gather common package version
   command: >
-    {{ repoquery_cmd }} --qf '%{version}' "{{ openshift.common.service_type}}"
+    {{ repoquery_cmd }} --installed --qf '%{version}' "{{ openshift.common.service_type}}"
   register: common_version
   failed_when: false
   changed_when: false


### PR DESCRIPTION
Running on RHEL7.2 cluster the ``repoquery --qf '%{version}' origin`` returns empty line. With ``--installed`` option, it returns version of installed origin rpm.

Not sure if this is intended or not. Thought, this fixes the docker installation for me.