### PR TITLE
Add lower case proxy variables

### DIFF
--- a/roles/openshift_builddefaults/vars/main.yml
+++ b/roles/openshift_builddefaults/vars/main.yml
@@ -13,3 +13,9 @@ builddefaults_yaml:
         value: "{{ openshift.builddefaults.https_proxy | default('', true) }}"
       - name: NO_PROXY
         value: "{{ openshift.builddefaults.no_proxy | default('', true) | join(',') }}"
+      - name: http_proxy
+        value: "{{ openshift.builddefaults.http_proxy | default('', true) }}"
+      - name: https_proxy
+        value: "{{ openshift.builddefaults.https_proxy | default('', true) }}"
+      - name: no_proxy
+        value: "{{ openshift.builddefaults.no_proxy | default('', true) | join(',') }}"

--- a/roles/openshift_master_facts/vars/main.yml
+++ b/roles/openshift_master_facts/vars/main.yml
@@ -12,3 +12,9 @@ builddefaults_yaml:
         value: "{{ openshift.master.builddefaults_https_proxy | default(omit, true) }}"
       - name: NO_PROXY
         value: "{{ openshift.master.builddefaults_no_proxy | default(omit, true) | join(',') }}"
+      - name: http_proxy
+        value: "{{ openshift.master.builddefaults_http_proxy | default(omit, true) }}"
+      - name: https_proxy
+        value: "{{ openshift.master.builddefaults_https_proxy | default(omit, true) }}"
+      - name: no_proxy
+        value: "{{ openshift.master.builddefaults_no_proxy | default(omit, true) | join(',') }}"


### PR DESCRIPTION
Some applications expect the *_PROXY variables to be lower case.
To support this too inject them in addition to the upper case ones.

Signed-off-by: Pascal Bach <pascal.bach@siemens.com>
Reviewed-by: Fabio Huser <fabio.huser@siemens.com>