### PR TITLE
Fix docker 1.10 upgrade on embedded etcd masters.

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -59,7 +59,7 @@
       - "{{ openshift.common.service_type }}-master-api"
       - "{{ openshift.common.service_type }}-master-controllers"
       - "{{ openshift.common.service_type }}-node"
-      - etcd
+      - etcd_container
       - openvswitch
     failed_when: false
     when: docker_upgrade is defined and docker_upgrade | bool and openshift.common.is_containerized | bool
@@ -77,7 +77,7 @@
   - name: Restart containerized services
     service: name={{ item }} state=started
     with_items:
-      - etcd
+      - etcd_container
       - openvswitch
       - "{{ openshift.common.service_type }}-master"
       - "{{ openshift.common.service_type }}-master-api"


### PR DESCRIPTION
The tasks were attempting to stop/start etcd on containerized hosts, but the actual service is etcd_container, and yet the etcd service can also still exist. When we stopped services everything was fine, but attempting to start any services that ar e present would kick off the 'etcd' service that is not expected to be running. It would claim a port, and then when the master came up it's embedded etcd was unable to run taking the master out.

Using the correct etcd_container service should cover this, as it does not exist on an embedded master host.

In future however we might have to be more careful with start/stopping services here, and only attempt to do so based on facts and a lot of logic.