### PR TITLE
Per-service environment variables

### DIFF
--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -410,6 +410,15 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Configure usage of openshift_clock role.
 #openshift_clock_enabled=true
 
+# OpenShift Per-Service Environment Variables
+# Environment variables are added to /etc/sysconfig files for
+# each OpenShift service: node, master (api and controllers).
+# API and controllers environment variables are merged in single
+# master environments.
+#openshift_master_api_env_vars={"ENABLE_HTTP2": "true"}
+#openshift_master_controllers_env_vars={"ENABLE_HTTP2": "true"}
+#openshift_node_env_vars={"ENABLE_HTTP2": "true"}
+
 # host group for masters
 [masters]
 aep3-master[1:3]-ansible.test.example.com

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -415,6 +415,15 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Configure usage of openshift_clock role.
 #openshift_clock_enabled=true
 
+# OpenShift Per-Service Environment Variables
+# Environment variables are added to /etc/sysconfig files for
+# each OpenShift service: node, master (api and controllers).
+# API and controllers environment variables are merged in single
+# master environments.
+#openshift_master_api_env_vars={"ENABLE_HTTP2": "true"}
+#openshift_master_controllers_env_vars={"ENABLE_HTTP2": "true"}
+#openshift_node_env_vars={"ENABLE_HTTP2": "true"}
+
 # host group for masters
 [masters]
 ose3-master[1:3]-ansible.test.example.com

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -410,6 +410,15 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Configure usage of openshift_clock role.
 #openshift_clock_enabled=true
 
+# OpenShift Per-Service Environment Variables
+# Environment variables are added to /etc/sysconfig files for
+# each OpenShift service: node, master (api and controllers).
+# API and controllers environment variables are merged in single
+# master environments.
+#openshift_master_api_env_vars={"ENABLE_HTTP2": "true"}
+#openshift_master_controllers_env_vars={"ENABLE_HTTP2": "true"}
+#openshift_node_env_vars={"ENABLE_HTTP2": "true"}
+
 # host group for masters
 [masters]
 ose3-master[1:3]-ansible.test.example.com

--- a/roles/openshift_master/templates/atomic-openshift-master.j2
+++ b/roles/openshift_master/templates/atomic-openshift-master.j2
@@ -9,6 +9,12 @@ AWS_ACCESS_KEY_ID={{ openshift.cloudprovider.aws.access_key }}
 AWS_SECRET_ACCESS_KEY={{ openshift.cloudprovider.aws.secret_key }}
 {% endif %}
 
+{% if 'api_env_vars' in openshift.master or 'controllers_env_vars' in openshift.master -%}
+{% for key, value in openshift.master.api_env_vars.items() | default([]) | union(openshift.master.controllers_env_vars.items() | default([])) -%}
+{{ key }}={{ value }}
+{% endfor -%}
+{% endif -%}
+
 # Proxy configuration
 # See https://docs.openshift.com/enterprise/latest/install_config/install/advanced_install.html#configuring-global-proxy
 {% if 'http_proxy' in openshift.common %}

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
@@ -9,6 +9,12 @@ AWS_ACCESS_KEY_ID={{ openshift.cloudprovider.aws.access_key }}
 AWS_SECRET_ACCESS_KEY={{ openshift.cloudprovider.aws.secret_key }}
 {% endif %}
 
+{% if 'api_env_vars' in openshift.master -%}
+{% for key, value in openshift.master.api_env_vars.items() -%}
+{{ key }}={{ value }}
+{% endfor -%}
+{% endif -%}
+
 # Proxy configuration
 # See https://docs.openshift.com/enterprise/latest/install_config/install/advanced_install.html#configuring-global-proxy
 {% if 'http_proxy' in openshift.common %}

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.j2
@@ -9,6 +9,12 @@ AWS_ACCESS_KEY_ID={{ openshift.cloudprovider.aws.access_key }}
 AWS_SECRET_ACCESS_KEY={{ openshift.cloudprovider.aws.secret_key }}
 {% endif %}
 
+{% if 'controllers_env_vars' in openshift.master -%}
+{% for key, value in openshift.master.controllers_env_vars.items() -%}
+{{ key }}={{ value }}
+{% endfor -%}
+{% endif -%}
+
 # Proxy configuration
 # See https://docs.openshift.com/enterprise/latest/install_config/install/advanced_install.html#configuring-global-proxy
 {% if 'http_proxy' in openshift.common %}

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -78,3 +78,5 @@
       image_policy_config: "{{ openshift_master_image_policy_config | default(None) }}"
       dynamic_provisioning_enabled: "{{ openshift_master_dynamic_provisioning_enabled | default(None) }}"
       max_requests_inflight: "{{ openshift_master_max_requests_inflight | default(None) }}"
+      api_env_vars: "{{ openshift_master_api_env_vars | default(None) }}"
+      controllers_env_vars: "{{ openshift_master_controllers_env_vars | default(None) }}"

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -26,6 +26,7 @@
       proxy_mode: "{{ openshift_node_proxy_mode | default('iptables') }}"
       local_quota_per_fsgroup: "{{ openshift_node_local_quota_per_fsgroup | default(None) }}"
       dns_ip: "{{ openshift_dns_ip | default(none) | get_dns_ip(hostvars[inventory_hostname])}}"
+      env_vars: "{{ openshift_node_env_vars | default(None) }}"
 
 # We have to add tuned-profiles in the same transaction otherwise we run into depsolving
 # problems because the rpms don't pin the version properly. This was fixed in 3.1 packaging.
@@ -88,6 +89,16 @@
     - regex: '^AWS_SECRET_ACCESS_KEY='
       line: "AWS_SECRET_ACCESS_KEY={{ openshift.cloudprovider.aws.secret_key }}"
   when: "'cloudprovider' in openshift and 'aws' in openshift.cloudprovider and 'kind' in openshift.cloudprovider and openshift.cloudprovider.kind == 'aws' and 'access_key' in openshift.cloudprovider.aws and 'secret_key' in openshift.cloudprovider.aws"
+  notify:
+  - restart node
+
+- name: Configure Node Environment Variables
+  lineinfile:
+    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
+    regexp: "^{{ item.key }}="
+    line: "{{ item.key }}={{ item.value }}"
+    create: true
+  with_dict: "{{ openshift.node.env_vars | default({}) }}"
   notify:
   - restart node
 


### PR DESCRIPTION
```
# OpenShift Per-Service Environment Variables
# Environment variables are added to /etc/sysconfig files for
# each OpenShift service: node, master (api and controllers).
# API and controllers environment variables are merged in single
# master environments.
#openshift_master_api_env_vars={"ENABLE_HTTP2": "true"}
#openshift_master_controllers_env_vars={"ENABLE_HTTP2": "true"}
#openshift_node_env_vars={"ENABLE_HTTP2": "true"}
```

@detiber @timothysc PTAL
Resolves: #2018