### PR TITLE
[WIP][DO NOT MERGE] Add /etc/sysconfig/docker to node mounts

### DIFF
--- a/roles/openshift_node/templates/openshift.docker.node.dep.service
+++ b/roles/openshift_node/templates/openshift.docker.node.dep.service
@@ -6,6 +6,6 @@ Before={{ openshift.common.service_type }}-node.service
 
 
 [Service]
-ExecStart=/bin/bash -c "if [[ -f /usr/bin/docker-current ]]; then echo \"DOCKER_ADDTL_BIND_MOUNTS=--volume=/usr/bin/docker-current:/usr/bin/docker-current:ro\" > /etc/sysconfig/{{ openshift.common.service_type }}-node-dep; else echo \"#DOCKER_ADDTL_BIND_MOUNTS=\" > /etc/sysconfig/{{ openshift.common.service_type }}-node-dep; fi"
+ExecStart=/bin/bash -c "if [[ -f /usr/bin/docker-current ]]; then echo \"DOCKER_ADDTL_BIND_MOUNTS=--volume=/usr/bin/docker-current:/usr/bin/docker-current:ro --volume=/etc/sysconfig/docker:/etc/sysconfig/docker:ro\" > /etc/sysconfig/{{ openshift.common.service_type }}-node-dep; else echo \"#DOCKER_ADDTL_BIND_MOUNTS=\" > /etc/sysconfig/{{ openshift.common.service_type }}-node-dep; fi"
 ExecStop=
 SyslogIdentifier={{ openshift.common.service_type }}-node-dep


### PR DESCRIPTION
The origin image doesn't have docker installed in the container, or at least not
a version that has /etc/sysconfig/docker so when running docker inside that
container it will fail to load /etc/sysconfig/docker. This is an additional
workaround for the fallout of docker and docker-latest.