### PR TITLE
Fix docker 1.10 upgrade on embedded etcd masters.

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -59,7 +59,7 @@
       - "{{ openshift.common.service_type }}-master-api"
       - "{{ openshift.common.service_type }}-master-controllers"
       - "{{ openshift.common.service_type }}-node"
-      - etcd
+      - etcd_container
       - openvswitch
     failed_when: false
     when: docker_upgrade is defined and docker_upgrade | bool and openshift.common.is_containerized | bool
@@ -77,7 +77,7 @@
   - name: Restart containerized services
     service: name={{ item }} state=started
     with_items:
-      - etcd
+      - etcd_container
       - openvswitch
       - "{{ openshift.common.service_type }}-master"
       - "{{ openshift.common.service_type }}-master-api"


### PR DESCRIPTION
The tasks were attempting to stop/start etcd, which would be fine on the
stop but on start could actually kick the non-containerized etcd service
which happens to be layed down even though it's unused.

When the service was requested to start again it would claim the port
embedded etcd needs and the master would then fail to come up.

Instead use the correct etcd_container service.