### PR TITLE
Fix no proxy hostnames during upgrade.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
@@ -8,6 +8,18 @@
   - openshift_facts
   - openshift_repos
 
+- name: Set openshift_no_proxy_internal_hostnames
+  hosts: oo_masters_to_config:oo_nodes_to_config
+  tasks:
+  - set_fact:
+      openshift_no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']
+                                                    | union(groups['oo_masters_to_config'])
+                                                    | union(groups['oo_etcd_to_config'] | default([])))
+                                                | oo_collect('openshift.common.hostname') | default([]) | join (',')
+                                                }}"
+    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
+            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+
 - name: Evaluate additional groups for upgrade
   hosts: localhost
   connection: local


### PR DESCRIPTION
This value not being set was causing missing hostnames in the sysconfig
files with NO_PROXY.

This is not the same way we set it during config playbooks, they use
vars definitions but this is too difficult in upgrade as there are too
many roles that might need it set.