### PR TITLE
Attempt to fix containerized node start failure with Docker 1.10.

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -110,6 +110,10 @@
   changed_when: false
   when: openshift.common.is_containerized | bool
 
+- name: Start and enable node dep
+  service: name={{ openshift.common.service_type }}-node-dep enabled=yes state=started
+  when: openshift.common.is_containerized | bool
+
 - name: Start and enable node
   service: name={{ openshift.common.service_type }}-node enabled=yes state=started
   register: node_start_result


### PR DESCRIPTION
It appears that in some situations (can't reliably reproduce yet), node
will fail to start. This appears to be related to the node-dep service
and possibly it's environment file.

This file is also an EnvironmentFile for the node service, but it's only
created by the node-dep service, and it looks like it may try to read
it's environment before the node-dep service has fully started and
created the file.

Workaround with a an explicit service start.