### PR TITLE
Fix uninstall.yml indentation for deamon-reload

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -288,11 +288,11 @@
     - /usr/local/bin/oc
     - /usr/local/bin/kubectl
 
-    # Since we are potentially removing the systemd unit files for separated
-    # master-api and master-controllers services, so we need to reload the
-    # systemd configuration manager
-    - name: Reload systemd manager configuration
-      command: systemctl daemon-reload
+  # Since we are potentially removing the systemd unit files for separated
+  # master-api and master-controllers services, so we need to reload the
+  # systemd configuration manager
+  - name: Reload systemd manager configuration
+    command: systemctl daemon-reload
 
 - hosts: etcd
   become: yes


### PR DESCRIPTION
Fix wrong indentation in playbooks/adhoc/uninstall.yml

Issue

```
ok: [master1.floshift.com] => (item=/usr/local/bin/openshift)
ok: [master2.floshift.com] => (item=/usr/local/bin/oc)
ok: [master2.floshift.com] => (item=/usr/local/bin/kubectl)
ok: [master1.floshift.com] => (item=/usr/local/bin/oadm)
failed: [master2.floshift.com] => (item={'command': 'systemctl daemon-reload', 'name': 'Reload systemd manager configuration'}) => {"failed": true, "item": {"command": "systemctl daemon-reload", "name": "Reload systemd manager configuration"}}
msg: this module requires key=value arguments (['path={command:', 'systemctl daemon-reload,', 'name:', 'Reload systemd manager configuration}', 'state=absent'])
ok: [master1.floshift.com] => (item=/usr/local/bin/oc)
ok: [master1.floshift.com] => (item=/usr/local/bin/kubectl)
failed: [master1.floshift.com] => (item={'command': 'systemctl daemon-reload', 'name': 'Reload systemd manager configuration'}) => {"failed": true, "item": {"command": "systemctl daemon-reload", "name": "Reload systemd manager configuration"}}
msg: this module requires key=value arguments (['path={command:', 'systemctl daemon-reload,', 'name:', 'Reload systemd manager configuration}', 'state=absent'])

FATAL: all hosts have already failed -- aborting
```

command: systemctl daemon-reload need to be at the task level, not in the with_items