### PR TITLE
Named CA Certificates

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -37,6 +37,9 @@ class FilterModule(object):
     def get_attr(data, attribute=None):
         """ This looks up dictionary attributes of the form a.b.c and returns
             the value.
+
+            If the key isn't present, None is returned.
+
             Ex: data = {'a': {'b': {'c': 5}}}
                 attribute = "a.b.c"
                 returns 5
@@ -46,7 +49,11 @@ class FilterModule(object):
 
         ptr = data
         for attr in attribute.split('.'):
-            ptr = ptr[attr]
+            if attr in ptr:
+                ptr = ptr[attr]
+            else:
+                ptr = None
+                break
 
         return ptr
 
@@ -138,6 +145,7 @@ class FilterModule(object):
         else:
             retval = [FilterModule.get_attr(d, attribute) for d in data]
 
+        retval = [val for val in retval if val != None]
         return retval
 
     @staticmethod
@@ -474,16 +482,20 @@ class FilterModule(object):
         """ Parses names from list of certificate hashes.
 
             Ex: certificates = [{ "certfile": "/root/custom1.crt",
-                                  "keyfile": "/root/custom1.key" },
+                                  "keyfile": "/root/custom1.key",
+                                   "cafile": "/root/custom-ca1.crt" },
                                 { "certfile": "custom2.crt",
-                                  "keyfile": "custom2.key" }]
+                                  "keyfile": "custom2.key",
+                                  "cafile": "custom-ca2.crt" }]
 
                 returns [{ "certfile": "/etc/origin/master/named_certificates/custom1.crt",
                            "keyfile": "/etc/origin/master/named_certificates/custom1.key",
+                           "cafile": "/etc/origin/master/named_certificates/custom-ca1.crt",
                            "names": [ "public-master-host.com",
                                       "other-master-host.com" ] },
                          { "certfile": "/etc/origin/master/named_certificates/custom2.crt",
                            "keyfile": "/etc/origin/master/named_certificates/custom2.key",
+                           "cafile": "/etc/origin/master/named_certificates/custom-ca-2.crt",
                            "names": [ "some-hostname.com" ] }]
         """
         if not isinstance(named_certs_dir, basestring):
@@ -514,17 +526,20 @@ class FilterModule(object):
                 raise errors.AnsibleFilterError(("|failed to parse certificate '%s', " % certificate['certfile'] +
                                                  "please specify certificate names in host inventory"))
 
-            certificate['names'] = [name for name in certificate['names'] if name not in internal_hostnames]
-            certificate['names'] = list(set(certificate['names']))
-            if not certificate['names']:
-                raise errors.AnsibleFilterError(("|failed to parse certificate '%s' or " % certificate['certfile'] +
-                                                 "detected a collision with internal hostname, please specify " +
-                                                 "certificate names in host inventory"))
+            if 'cafile' not in certificate:
+                certificate['names'] = [name for name in certificate['names'] if name not in internal_hostnames]
+                certificate['names'] = list(set(certificate['names']))
+                if not certificate['names']:
+                    raise errors.AnsibleFilterError(("|failed to parse certificate '%s' or " % certificate['certfile'] +
+                                                     "detected a collision with internal hostname, please specify " +
+                                                     "certificate names in host inventory"))
 
         for certificate in certificates:
             # Update paths for configuration
             certificate['certfile'] = os.path.join(named_certs_dir, os.path.basename(certificate['certfile']))
             certificate['keyfile'] = os.path.join(named_certs_dir, os.path.basename(certificate['keyfile']))
+            if 'cafile' in certificate:
+                certificate['cafile'] = os.path.join(named_certs_dir, os.path.basename(certificate['cafile']))
         return certificates
 
     @staticmethod

--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -345,15 +345,20 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # NOTE: openshift_master_named_certificates is cached on masters and is an
 # additive fact, meaning that each run with a different set of certificates
 # will add the newly provided certificates to the cached set of certificates.
+#
+# An optional CA may be specified for each named certificate. CAs will
+# be added to the OpenShift CA bundle which allows for the named
+# certificate to be served for internal cluster communication.
+#
 # If you would like openshift_master_named_certificates to be overwritten with
 # the provided value, specify openshift_master_overwrite_named_certificates.
 #openshift_master_overwrite_named_certificates=true
 #
 # Provide local certificate paths which will be deployed to masters
-#openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key"}]
+#openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key", "cafile": "/path/to/custom-ca1.crt"}]
 #
 # Detected names may be overridden by specifying the "names" key
-#openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key", "names": ["public-master-host.com"]}]
+#openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key", "names": ["public-master-host.com"], "cafile": "/path/to/custom-ca1.crt"}]
 
 # Session options
 #openshift_master_session_name=ssn

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -353,15 +353,20 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # NOTE: openshift_master_named_certificates is cached on masters and is an
 # additive fact, meaning that each run with a different set of certificates
 # will add the newly provided certificates to the cached set of certificates.
+#
+# An optional CA may be specified for each named certificate. CAs will
+# be added to the OpenShift CA bundle which allows for the named
+# certificate to be served for internal cluster communication.
+#
 # If you would like openshift_master_named_certificates to be overwritten with
 # the provided value, specify openshift_master_overwrite_named_certificates.
 #openshift_master_overwrite_named_certificates=true
 #
 # Provide local certificate paths which will be deployed to masters
-#openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key"}]
+#openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key", "cafile": "/path/to/custom-ca1.crt"}]
 #
 # Detected names may be overridden by specifying the "names" key
-#openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key", "names": ["public-master-host.com"]}]
+#openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key", "names": ["public-master-host.com"], "cafile": "/path/to/custom-ca1.crt"}]
 
 # Session options
 #openshift_master_session_name=ssn

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -347,15 +347,20 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # NOTE: openshift_master_named_certificates is cached on masters and is an
 # additive fact, meaning that each run with a different set of certificates
 # will add the newly provided certificates to the cached set of certificates.
+#
+# An optional CA may be specified for each named certificate. CAs will
+# be added to the OpenShift CA bundle which allows for the named
+# certificate to be served for internal cluster communication.
+#
 # If you would like openshift_master_named_certificates to be overwritten with
 # the provided value, specify openshift_master_overwrite_named_certificates.
 #openshift_master_overwrite_named_certificates=true
 #
 # Provide local certificate paths which will be deployed to masters
-#openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key"}]
+#openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key", "cafile": "/path/to/custom-ca1.crt"}]
 #
 # Detected names may be overridden by specifying the "names" key
-#openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key", "names": ["public-master-host.com"]}]
+#openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key", "names": ["public-master-host.com"], "cafile": "/path/to/custom-ca1.crt"}]
 
 # Session options
 #openshift_master_session_name=ssn

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -183,54 +183,6 @@
         session_encryption_secrets: "{{ g_session_encryption_secrets }}"
     when: not g_session_secrets_present | bool
 
-- name: Parse named certificates
-  hosts: localhost
-  connection: local
-  become: no
-  vars:
-    internal_hostnames: "{{ hostvars[groups.oo_first_master.0].openshift.common.internal_hostnames }}"
-    named_certificates: "{{ hostvars[groups.oo_first_master.0].openshift_master_named_certificates | default([]) }}"
-    named_certificates_dir: "{{ hostvars[groups.oo_first_master.0].openshift.common.config_base }}/master/named_certificates/"
-  tasks:
-  - set_fact:
-      parsed_named_certificates: "{{ named_certificates | oo_parse_named_certificates(named_certificates_dir, internal_hostnames) }}"
-    when: named_certificates | length > 0
-
-- name: Deploy named certificates
-  hosts: oo_masters_to_config
-  vars:
-    named_certs_dir: "{{ openshift.common.config_base }}/master/named_certificates/"
-    named_certs_specified: "{{ openshift_master_named_certificates is defined }}"
-    overwrite_named_certs: "{{ openshift_master_overwrite_named_certificates | default(false) }}"
-  roles:
-  - role: openshift_facts
-  post_tasks:
-  - openshift_facts:
-      role: master
-      local_facts:
-        named_certificates: "{{ hostvars.localhost.parsed_named_certificates | default([]) }}"
-      additive_facts_to_overwrite:
-      - "{{ 'master.named_certificates' if overwrite_named_certs | bool else omit }}"
-  - name: Clear named certificates
-    file:
-      path: "{{ named_certs_dir }}"
-      state: absent
-    when: overwrite_named_certs | bool
-  - name: Ensure named certificate directory exists
-    file:
-      path: "{{ named_certs_dir }}"
-      state: directory
-      mode: 0700
-    when: named_certs_specified | bool
-  - name: Land named certificates
-    copy: src="{{ item.certfile }}" dest="{{ named_certs_dir }}"
-    with_items: "{{ openshift_master_named_certificates }}"
-    when: named_certs_specified | bool
-  - name: Land named certificate keys
-    copy: src="{{ item.keyfile }}" dest="{{ named_certs_dir }}" mode=0600
-    with_items: "{{ openshift_master_named_certificates }}"
-    when: named_certs_specified | bool
-
 - name: Configure masters
   hosts: oo_masters_to_config
   any_errors_fatal: true

--- a/playbooks/common/openshift-master/scaleup.yml
+++ b/playbooks/common/openshift-master/scaleup.yml
@@ -33,7 +33,12 @@
     service: name={{ openshift.common.service_type }}-master-controllers state=restarted
   - name: verify api server
     command: >
-      curl --silent --cacert {{ openshift.common.config_base }}/master/ca.crt
+      curl --silent
+      {% if openshift.common.version_gte_3_2_or_1_2 | bool %}
+      --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+      {% else %}
+      --cacert {{ openshift.common.config_base }}/master/ca.crt
+      {% endif %}
       {{ openshift.master.api_url }}/healthz/ready
     register: api_available_output
     until: api_available_output.stdout == 'ok'

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -245,7 +245,12 @@
     # Using curl here since the uri module requires python-httplib2 and
     # wait_for port doesn't provide health information.
     command: >
-      curl --silent --cacert {{ openshift.common.config_base }}/master/ca.crt
+      curl --silent
+      {% if openshift.common.version_gte_3_2_or_1_2 | bool %}
+      --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+      {% else %}
+      --cacert {{ openshift.common.config_base }}/master/ca.crt
+      {% endif %}
       {{ openshift.master.api_url }}/healthz/ready
     register: api_available_output
     until: api_available_output.stdout == 'ok'

--- a/roles/openshift_ca/meta/main.yml
+++ b/roles/openshift_ca/meta/main.yml
@@ -15,3 +15,4 @@ galaxy_info:
 dependencies:
 - role: openshift_repos
 - role: openshift_cli
+- role: openshift_named_certificates

--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -28,6 +28,7 @@
     path: "{{ openshift_ca_config_dir }}/{{ item }}"
   register: g_master_ca_stat_result
   with_items:
+  - ca-bundle.crt
   - ca.crt
   - ca.key
   delegate_to: "{{ openshift_ca_host }}"
@@ -43,11 +44,14 @@
 - name: Create the master certificates if they do not already exist
   command: >
     {{ openshift.common.admin_binary }} create-master-certs
-      --hostnames={{ openshift_master_hostnames | join(',') }}
-      --master={{ openshift.master.api_url }}
-      --public-master={{ openshift.master.public_api_url }}
-      --cert-dir={{ openshift_ca_config_dir }}
-      --overwrite=false
+    {% for named_ca_certificate in openshift.master.named_certificates | default([]) | oo_collect('cafile') %}
+    --certificate-authority {{ named_ca_certificate }}
+    {% endfor %}
+    --hostnames={{ openshift_master_hostnames | join(',') }}
+    --master={{ openshift.master.api_url }}
+    --public-master={{ openshift.master.public_api_url }}
+    --cert-dir={{ openshift_ca_config_dir }}
+    --overwrite=false
   when: hostvars[openshift_ca_host].master_ca_missing | bool
   delegate_to: "{{ openshift_ca_host }}"
   run_once: true

--- a/roles/openshift_master/handlers/main.yml
+++ b/roles/openshift_master/handlers/main.yml
@@ -17,7 +17,12 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent --cacert {{ openshift.common.config_base }}/master/ca.crt
+    curl --silent
+    {% if openshift.common.version_gte_3_2_or_1_2 | bool %}
+    --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+    {% else %}
+    --cacert {{ openshift.common.config_base }}/master/ca.crt
+    {% endif %}
     {{ openshift.master.api_url }}/healthz/ready
   register: api_available_output
   until: api_available_output.stdout == 'ok'

--- a/roles/openshift_master/meta/main.yml
+++ b/roles/openshift_master/meta/main.yml
@@ -12,4 +12,3 @@ galaxy_info:
   categories:
   - cloud
 dependencies: []
-

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -224,7 +224,12 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent --cacert {{ openshift.common.config_base }}/master/ca.crt
+    curl --silent
+    {% if openshift.common.version_gte_3_2_or_1_2 | bool %}
+    --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+    {% else %}
+    --cacert {{ openshift.common.config_base }}/master/ca.crt
+    {% endif %}
     {{ openshift.master.api_url }}/healthz/ready
   register: api_available_output
   until: api_available_output.stdout == 'ok'

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -156,7 +156,11 @@ oauthConfig:
 {% for line in translated_identity_providers.splitlines() %}
   {{ line }}
 {% endfor %}
-  masterCA: ca.crt
+{% if openshift.common.version_gte_3_2_or_1_2 | bool %}
+  masterCA: ca-bundle.crt
+{% else %}
+  masterCA: ca.rt
+{% endif %}
   masterPublicURL: {{ openshift.master.public_api_url }}
   masterURL: {{ openshift.master.api_url }}
   sessionConfig:
@@ -189,7 +193,11 @@ serviceAccountConfig:
   - default
   - builder
   - deployer
-  masterCA: ca.crt
+{% if openshift.common.version_gte_3_2_or_1_2 | bool %}
+  masterCA: ca-bundle.crt
+{% else %}
+  masterCA: ca.rt
+{% endif %}
   privateKeyFile: serviceaccounts.private.key
   publicKeyFiles:
   - serviceaccounts.public.key
@@ -201,7 +209,7 @@ servingInfo:
   keyFile: master.server.key
   maxRequestsInFlight: {{ openshift.master.max_requests_inflight }}
   requestTimeoutSeconds: 3600
-{% if openshift.master.named_certificates %}
+{% if openshift.master.named_certificates | default([]) | length > 0 %}
   namedCertificates:
 {% for named_certificate in openshift.master.named_certificates %}
   - certFile: {{ named_certificate['certfile'] }}

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -49,11 +49,14 @@
 - name: Create the master certificates if they do not already exist
   command: >
     {{ openshift.common.admin_binary }} create-master-certs
-      --hostnames={{ openshift.common.all_hostnames | join(',') }}
-      --master={{ openshift.master.api_url }}
-      --public-master={{ openshift.master.public_api_url }}
-      --cert-dir={{ openshift_master_generated_config_dir }}
-      --overwrite=false
+    {% for named_ca_certificate in openshift.master.named_certificates | default([]) | oo_collect('cafile') %}
+    --certificate-authority {{ named_ca_certificate }}
+    {% endfor %}
+    --hostnames={{ openshift.common.all_hostnames | join(',') }}
+    --master={{ openshift.master.api_url }}
+    --public-master={{ openshift.master.public_api_url }}
+    --cert-dir={{ openshift_master_generated_config_dir }}
+    --overwrite=false
   when: master_certs_missing | bool
   delegate_to: "{{ openshift_ca_host }}"
 

--- a/roles/openshift_named_certificates/README.md
+++ b/roles/openshift_named_certificates/README.md
@@ -1,0 +1,32 @@
+OpenShift Named Certificates
+============================
+
+TODO
+
+Requirements
+------------
+
+Role Variables
+--------------
+
+TODO
+
+Dependencies
+------------
+
+TODO
+
+Example Playbook
+----------------
+
+TODO
+
+License
+-------
+
+Apache License Version 2.0
+
+Author Information
+------------------
+
+Andrew Butcher <abutcher@redhat.com>

--- a/roles/openshift_named_certificates/meta/main.yml
+++ b/roles/openshift_named_certificates/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
-  author: Jason DeTiberus
-  description: OpenShift Master Certificates
+  author: Andrew Butcher
+  description: OpenShift Named Certificates
   company: Red Hat, Inc.
   license: Apache License, Version 2.0
   min_ansible_version: 2.1
@@ -13,5 +13,4 @@ galaxy_info:
   - cloud
   - system
 dependencies:
-- role: openshift_master_facts
-- role: openshift_ca
+- role: openshift_facts

--- a/roles/openshift_named_certificates/tasks/main.yml
+++ b/roles/openshift_named_certificates/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+- set_fact:
+    parsed_named_certificates: "{{ named_certificates | oo_parse_named_certificates(named_certs_dir, internal_hostnames) }}"
+  when: named_certificates | length > 0
+  delegate_to: localhost
+  become: no
+  run_once: true
+
+- openshift_facts:
+    role: master
+    local_facts:
+      named_certificates: "{{ parsed_named_certificates | default([]) }}"
+    additive_facts_to_overwrite:
+    - "{{ 'master.named_certificates' if overwrite_named_certs | bool else omit }}"
+
+- name: Clear named certificates
+  file:
+    path: "{{ named_certs_dir }}"
+    state: absent
+  when: overwrite_named_certs | bool
+
+- name: Ensure named certificate directory exists
+  file:
+    path: "{{ named_certs_dir }}"
+    state: directory
+    mode: 0700
+
+- name: Land named certificates
+  copy:
+    src: "{{ item.certfile }}"
+    dest: "{{ named_certs_dir }}"
+  with_items: "{{ named_certificates }}"
+
+- name: Land named certificate keys
+  copy:
+    src: "{{ item.keyfile }}"
+    dest: "{{ named_certs_dir }}"
+    mode: 0600
+  with_items: "{{ named_certificates }}"
+
+- name: Land named CA certificates
+  copy:
+    src: "{{ item }}"
+    dest: "{{ named_certs_dir }}"
+    mode: 0600
+  with_items: "{{ named_certificates | oo_collect('cafile') }}"

--- a/roles/openshift_named_certificates/tasks/named_certificates.yml
+++ b/roles/openshift_named_certificates/tasks/named_certificates.yml
@@ -1,0 +1,32 @@
+---
+- name: Clear named certificates
+  file:
+    path: "{{ named_certs_dir }}"
+    state: absent
+  when: overwrite_named_certs | bool
+
+- name: Ensure named certificate directory exists
+  file:
+    path: "{{ named_certs_dir }}"
+    state: directory
+    mode: 0700
+
+- name: Land named certificates
+  copy:
+    src: "{{ item.certfile }}"
+    dest: "{{ named_certs_dir }}"
+  with_items: "{{ openshift_master_named_certificates | default([]) }}"
+
+- name: Land named certificate keys
+  copy:
+    src: "{{ item.keyfile }}"
+    dest: "{{ named_certs_dir }}"
+    mode: 0600
+  with_items: "{{ openshift_master_named_certificates | default([]) }}"
+
+- name: Land named CA certificates
+  copy:
+    src: "{{ item }}"
+    dest: "{{ named_certs_dir }}"
+    mode: 0600
+  with_items: "{{ openshift_master_named_certificates | default([]) | oo_collect('cafile') }}"

--- a/roles/openshift_named_certificates/vars/main.yml
+++ b/roles/openshift_named_certificates/vars/main.yml
@@ -1,0 +1,11 @@
+---
+openshift_ca_config_dir: "{{ openshift.common.config_base }}/master"
+openshift_ca_cert: "{{ openshift_ca_config_dir }}/ca.crt"
+openshift_ca_key: "{{ openshift_ca_config_dir }}/ca.key"
+openshift_ca_serial: "{{ openshift_ca_config_dir }}/ca.serial.txt"
+openshift_version: "{{ openshift_pkg_version | default('') }}"
+
+overwrite_named_certs: "{{ openshift_master_overwrite_named_certificates | default(false) }}"
+named_certs_dir: "{{ openshift.common.config_base }}/master/named_certificates/"
+internal_hostnames: "{{ openshift.common.internal_hostnames }}"
+named_certificates: "{{ openshift_master_named_certificates | default([]) }}"

--- a/roles/openshift_node_certificates/tasks/main.yml
+++ b/roles/openshift_node_certificates/tasks/main.yml
@@ -42,6 +42,9 @@
 - name: Generate the node client config
   command: >
     {{ openshift.common.admin_binary }} create-api-client-config
+      {% for named_ca_certificate in hostvars[openshift_ca_host].openshift.master.named_certificates | default([]) | oo_collect('cafile') %}
+      --certificate-authority {{ named_ca_certificate }}
+      {% endfor %}
       --certificate-authority={{ openshift_ca_cert }}
       --client-dir={{ openshift_node_generated_config_dir }}
       --groups=system:nodes


### PR DESCRIPTION
Builds on #1990

```
# Configure custom named certificates
# NOTE: openshift_master_named_certificates is cached on masters and is an
# additive fact, meaning that each run with a different set of certificates
# will add the newly provided certificates to the cached set of certificates.
#
# An optional CA may be specified for each named certificate. CAs will
# be added to the OpenShift CA bundle which allows for the named
# certificate to be served for internal cluster communication.
#
# If you would like openshift_master_named_certificates to be overwritten with
# the provided value, specify openshift_master_overwrite_named_certificates.
#openshift_master_overwrite_named_certificates=true
#
# Provide local certificate paths which will be deployed to masters
#openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key", "cafile": "/path/to/custom-ca1.crt"}]
#
# Detected names may be overridden by specifying the "names" key
#openshift_master_named_certificates=[{"certfile": "/path/to/custom1.crt", "keyfile": "/path/to/custom1.key", "names": ["public-master-host.com"], "cafile": "/path/to/custom-ca1.crt"}]
```

Provide named certificate, key and CA to test. Also set internal and external cluster_hostname variables so that master/node communication will receive the custom certificates. Example:

```
openshift_master_named_certificates=[{"certfile": "/home/abutcher/wildcard-flibberty-jibbet.com.crt", "keyfile": "/home/abutcher/wildcard-flibberty-jibbet.com.key", "cafile": "/home/abutcher/wildcard-ca.crt"}]
openshift_master_cluster_hostname=master.flibberty-jibbet.com                                                                                                                                                      
openshift_master_cluster_public_hostname=master.flibberty-jibbet.com
```

```
# curl --cacert /etc/origin/node/ca.crt https://master.flibberty-jibbet.com:8443/
{
  "paths": [
    "/api",
    "/api/v1",
    "/apis",
    "/controllers",
    "/healthz",
    "/healthz/ping",
    "/healthz/ready",
    "/metrics",
    "/oapi",
    "/oapi/v1",
    "/swaggerapi/"
  ]
}

# curl --cacert /etc/origin/master/ca-bundle.crt https://master.flibberty-jibbet.com:8443/
{
  "paths": [
    "/api",
    "/api/v1",
    "/apis",
    "/controllers",
    "/healthz",
    "/healthz/ping",
    "/healthz/ready",
    "/metrics",
    "/oapi",
    "/oapi/v1",
    "/swaggerapi/"
  ]
}
```

Resolves #1535 
