### PR TITLE
[WIP] Preserve registry ip on upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
@@ -7,16 +7,29 @@
   roles:
   - openshift_facts
   - openshift_repos
+  
+- name: Obtain registry service-ip
+  hosts: oo_first_master
+  tasks:
+  - name: Gather registry service-ip
+    command: "{{ openshift.common.client_binary }} get -n default svc/docker-registry -o=go-template=\\{\\{.spec.clusterIP}}"
+    register: registry_ip
+  - name: Record registry service-ip
+    set_fact:
+      registry_svc_ip: "{{registry_ip.stdout}}"
+    when: registry_ip.rc == 0
 
 - name: Set openshift_no_proxy_internal_hostnames
   hosts: oo_masters_to_config:oo_nodes_to_config
   tasks:
   - set_fact:
-      openshift_no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']
+      openshift_no_proxy_internal_hostnames: "{{ ( hostvars | oo_select_keys(groups['oo_nodes_to_config']
                                                     | union(groups['oo_masters_to_config'])
                                                     | union(groups['oo_etcd_to_config'] | default([])))
-                                                | oo_collect('openshift.common.hostname') | default([]) | join (',')
-                                                }}"
+                                                  | oo_collect('openshift.common.hostname') | default([])  + 
+                                                  [hostvars[groups.oo_first_master.0].registry_svc_ip | default(''),] )
+                                                | join (',')
+                                              }}"
     when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
             openshift_generate_no_proxy_hosts | default(True) | bool }}"
 


### PR DESCRIPTION
If a registry exists when upgrading then figure out what its IP address is and add it to the no_proxy list for docker.
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1347431
