### PR TITLE
Stop dumping debug output, re-try startng the node once

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -118,14 +118,10 @@
   service: name={{ openshift.common.service_type }}-node enabled=yes state=started
   register: node_start_result
   ignore_errors: yes
-
-- name: Check logs on failure
-  command: journalctl -xe
-  register: node_failure
-  when: node_start_result | failed
-
-- name: Dump failure information
-  debug: var=node_failure
+  
+- name: Start and enable node again
+  service: name={{ openshift.common.service_type }}-node enabled=yes state=started
+  register: node_start_result
   when: node_start_result | failed
 
 - set_fact:

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -119,6 +119,11 @@
   register: node_start_result
   ignore_errors: yes
   
+- name: Wait 30 seconds for docker initialization whenever node has failed
+  pause:
+    seconds: 30
+  when: node_start_result | failed
+  
 - name: Start and enable node again
   service: name={{ openshift.common.service_type }}-node enabled=yes state=started
   register: node_start_result


### PR DESCRIPTION
When we dump the logs from a failed node it contains control characters that break the quick installer. While dumping this information is useful for CI jobs where it's often hard to determine why something has failed it's more important that if a percentage of the nodes fail to install with the quick installer that things progress normally on those nodes that haven't failed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1347209