### PR TITLE
Allow flag to uninstall playbook to preserve images.

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -143,11 +143,13 @@
     - registry\.qe\.openshift\.com/.*
     - registry\.access\..*redhat\.com/rhel7/etcd
     - docker.io/openshift
+    when: openshift_uninstall_images | default(True) | bool
 
   - shell:  "docker rmi -f {{ item.stdout_lines | join(' ') }}"
     changed_when: False
     failed_when: False
     with_items: "{{ images_to_delete.results }}"
+    when: openshift_uninstall_images | default(True) | bool
 
   - name: Remove sdn drop files
     file:

--- a/roles/openshift_examples/files/examples/v1.2/infrastructure-templates/enterprise/metrics-deployer.yaml
+++ b/roles/openshift_examples/files/examples/v1.2/infrastructure-templates/enterprise/metrics-deployer.yaml
@@ -97,7 +97,7 @@ parameters:
   name: HAWKULAR_METRICS_HOSTNAME
   required: true
 -
-  description: "Can be set to: 'deploy' to perform an initial deployment; 'refresh' to delete and redeploy all components but to keep persisted data and routes; 'redeploy' to delete and redeploy everything (losing all data in the process)
+  description: "Can be set to: 'deploy' to perform an initial deployment; 'refresh' to delete and redeploy all components but to keep persisted data and routes; 'redeploy' to delete and redeploy everything (losing all data in the process)"
   name: MODE
   value: "deploy"
 -


### PR DESCRIPTION
Default is still True, but allow devs to specify False in inventory to
avoid having to re-download all images. With upcoming changes the actual
images present on the system will have no effect on what gets run.