### PR TITLE
Bug 1348127 - [ansibe-2.1] Can't re-install/upgrade ha Environment 2 masters and 3 etcds

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
@@ -266,7 +266,7 @@
 - name: Backup etcd
   hosts: etcd_hosts_to_backup
   vars:
-    embedded_etcd: "{{ openshift.master.embedded_etcd }}"
+    embedded_etcd: "{{ hostvars[groups.oo_first_master.0].openshift.master.embedded_etcd }}"
     timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
   roles:
   - openshift_facts


### PR DESCRIPTION
An embedded_etcd play var in upgrade was based on master facts but was being pulled from etcd hosts.

```
fatal: [ha1master3.example.com]: FAILED! => {"failed": true, "msg": "The conditional check 'embedded_etcd | bool' failed. The error was: error while evaluating conditional (embedded_etcd | bool): {{ openshift.master.embedded_etcd }}: 'dict object' has no attribute 'master'\n\nThe error appears to have been in '/root/openshift-ansible/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml': line 297, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  # TODO: replace shell module with command and update later checks\n  - name: Check current embedded etcd disk usage\n    ^ here\n"}
```

In playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml

```
 - name: Backup etcd
   hosts: etcd_hosts_to_backup
   vars:
     embedded_etcd: "{{ openshift.master.embedded_etcd }}"
     timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
   roles:
   - openshift_facts
```

https://bugzilla.redhat.com/show_bug.cgi?id=1348127

@dgoodwin @sdodson ptal