### PR TITLE
Don't upgrade docker on non-containerized etcd.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/pre.yml
@@ -212,6 +212,9 @@
       msg: Upgrade packages not found
     when: openshift_image_tag is not defined and (g_aos_versions.avail_version | default(g_aos_versions.curr_version, true) | version_compare(target_version, '<'))
 
+- name: Verify docker upgrade targets
+  hosts: oo_masters_to_config:oo_nodes_to_config:oo_etcd_to_config
+  tasks:
   - name: Determine available Docker
     script: ../files/rpm_versions.sh docker
     register: g_docker_version_result

--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
@@ -4,7 +4,7 @@
 ###############################################################################
 
 - name: Upgrade docker
-  hosts: oo_masters_to_config:oo_nodes_to_config:oo_etcd_to_config
+  hosts: oo_masters_to_config:oo_nodes_to_config
   roles:
   - openshift_facts
   tasks:
@@ -19,6 +19,15 @@
       local_facts:
         openshift_image_tag: "v{{ g_new_version }}"
         openshift_version: "{{ g_new_version }}"
+
+- name: Upgrade docker
+  hosts: oo_etcd_to_config
+  roles:
+  - openshift_facts
+  tasks:
+  # Upgrade docker when host is not atomic and host is not a non-containerized etcd node
+  - include: docker_upgrade.yml
+    when: not openshift.common.is_atomic | bool and not ('oo_etcd_to_config' in group_names and not openshift.common.is_containerized)
 
 # The cli image is used by openshift_docker_facts to determine the currently installed
 # version.  We need to explicitly pull the latest image to handle cases where


### PR DESCRIPTION
```
TASK [Upgrade Docker] **********************************************************
Friday 24 June 2016  11:57:43 -0400 (0:00:00.444)       0:02:00.898 ***********
skipping: [master6.example.com]
skipping: [master4.example.com]
fatal: [master5.example.com]: FAILED! => {"failed": true, "msg": "The conditional check 'pkg_check.rc == 0 and g_docker_version.curr_version | version_compare('1.9','<')' failed. The error was: error while evaluating conditional (pkg_check.rc == 0 and g_docker_version.curr_version | version_compare('1.9','<')): 'g_docker_version' is undefined\n\nThe error appears to have been in '/home/abutcher/rhat/openshift-ansible/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/docker_upgrade.yml': line 7, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Upgrade Docker\n  ^ here\n"}
```

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1348127

@sdodson @dgoodwin PTAL