### PR TITLE
Make image stream munging optional

### DIFF
--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -79,6 +79,9 @@ deployment_type=atomic-enterprise
 # only need to inject your own registry you may want to consider
 # openshift_docker_additional_registries instead
 #oreg_url=example.com/aep3/aep-${component}:${version}
+# If oreg_url points to a registry other than registry.access.redhat.com we can
+# modify image streams to point at that registry by setting the following to true
+#openshift_examples_modify_imagestreams=True
 
 # Additional yum repos to install
 #openshift_additional_repos=[{'id': 'aep-devel', 'name': 'aep-devel', 'baseurl': 'http://example.com/puddle/build/AtomicOpenShift/3.1/latest/RH7-RHOSE-3.0/$basearch/os', 'enabled': 1, 'gpgcheck': 0}]

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -80,6 +80,10 @@ deployment_type=origin
 # only need to inject your own registry you may want to consider
 # openshift_docker_additional_registries instead
 #oreg_url=example.com/openshift3/ose-${component}:${version}
+# If oreg_url points to a registry other than registry.access.redhat.com we can
+# modify image streams to point at that registry by setting the following to true
+#openshift_examples_modify_imagestreams=True
+
 
 # Origin copr repo
 #openshift_additional_repos=[{'id': 'openshift-origin-copr', 'name': 'OpenShift Origin COPR', 'baseurl': 'https://copr-be.cloud.fedoraproject.org/results/maxamillion/origin-next/epel-7-$basearch/', 'enabled': 1, 'gpgcheck': 1, gpgkey: 'https://copr-be.cloud.fedoraproject.org/results/maxamillion/origin-next/pubkey.gpg'}]

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -79,6 +79,9 @@ deployment_type=openshift-enterprise
 # only need to inject your own registry you may want to consider
 # openshift_docker_additional_registries instead
 #oreg_url=example.com/openshift3/ose-${component}:${version}
+# If oreg_url points to a registry other than registry.access.redhat.com we can
+# modify image streams to point at that registry by setting the following to true
+#openshift_examples_modify_imagestreams=True
 
 # Additional yum repos to install
 #openshift_additional_repos=[{'id': 'ose-devel', 'name': 'ose-devel', 'baseurl': 'http://example.com/puddle/build/AtomicOpenShift/3.1/latest/RH7-RHOSE-3.0/$basearch/os', 'enabled': 1, 'gpgcheck': 0}]

--- a/roles/openshift_examples/tasks/main.yml
+++ b/roles/openshift_examples/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Modify registry paths if registry_url is not registry.access.redhat.com
   shell: >
     find {{ examples_base }} -type f | xargs -n 1 sed -i 's|registry.access.redhat.com|{{ registry_host | quote }}|g'
-  when: registry_host != ''
+  when: registry_host != '' and openshift_examples_modify_imagestreams | default(False) | bool
 
 # RHEL and Centos image streams are mutually exclusive
 - name: Import RHEL streams


### PR DESCRIPTION
Because we don't currently support also modifying image streams to add insecure annotation or secrets required to pull from a private authenticated registry we should make this an opt-in change.