### PR TITLE
Fix case where no version of docker is installed

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Fail if Docker upgrade is required
   fail:
     msg: "Docker {{ curr_docker_version.stdout }} must be upgraded to Docker 1.10 or greater"
-  when: not upgrading | bool and not curr_docker_version | skipped and curr_docker_version.stdout | default('0.0', True) | version_compare('1.10', '<')
+  when: not upgrading | bool and not curr_docker_version | skipped and not curr_docker_version.stdout == "" and curr_docker_version.stdout | default('0.0', True) | version_compare('1.10', '<')
 
 - name: Get latest available version of Docker
   command: >


### PR DESCRIPTION
Hopefully fix the case where not version of docker is currently installed.
```
TASK: [docker | Get current installed Docker version] ************************* 
ok: [10.35.48.23]

TASK: [docker | debug var=curr_docker_version] ******************************** 
ok: [10.35.48.23] => {
    "var": {
        "curr_docker_version": {
            "changed": false, 
            "cmd": [
                "repoquery", 
                "--installed", 
                "--qf", 
                "%{version}", 
                "docker"
            ], 
            "delta": "0:00:00.932418", 
            "end": "2016-06-27 09:08:55.354957", 
            "invocation": {
                "module_args": "repoquery --installed --qf '%{version}' docker", 
                "module_complex_args": {}, 
                "module_name": "command"
            }, 
            "rc": 0, 
            "start": "2016-06-27 09:08:54.422539", 
            "stderr": "", 
            "stdout": "", 
            "stdout_lines": [], 
            "warnings": []
        }
    }
}

TASK: [docker | Fail if Docker upgrade is required] *************************** 
failed: [10.35.48.23] => {"failed": true}
msg: Docker  must be upgraded to Docker 1.10 or greater

FATAL: all hosts have already failed -- aborting

```