### PR TITLE
Speed up copying OpenShift examples

### DIFF
--- a/roles/openshift_examples/tasks/main.yml
+++ b/roles/openshift_examples/tasks/main.yml
@@ -1,8 +1,45 @@
 ---
-- name: Copy openshift examples
-  copy:
-    src: "examples/{{ content_version }}/"
+######################################################################
+# Copying Examples
+#
+# We used to use the copy module to transfer the openshift examples to
+# the remote. Then it started taking more than a minute to transfer
+# the files. As noted in the module:
+#
+#   "The 'copy' module recursively copy facility does not scale to
+#   lots (>hundreds) of files."
+#
+# The `synchronize` module is suggested as an alternative, we can't
+# use it either due to changes introduced in Ansible 2.x.
+- name: Create local temp dir for OpenShift examples copy
+  local_action: command mktemp -d /tmp/openshift-ansible-XXXXXXX
+  become: False
+  register: copy_examples_mktemp
+  run_once: True
+
+- name: Create tar of OpenShift examples
+  local_action: command tar -C "{{ role_path }}/files/examples/{{ content_version }}/" -cvf "{{ copy_examples_mktemp.stdout }}/openshift-examples.tar" .
+  become: False
+  register: copy_examples_tar
+
+- name: Create the remote OpenShift examples directory
+  file:
+    dest: "{{ examples_base }}"
+    state: directory
+    mode: 0755
+
+- name: Unarchive the OpenShift examples on the remote
+  unarchive:
+    src: "{{ copy_examples_mktemp.stdout }}/openshift-examples.tar"
     dest: "{{ examples_base }}/"
+
+- name: Cleanup the OpenShift Examples temp dir
+  become: False
+  local_action: file dest="{{ copy_examples_mktemp.stdout }}" state=absent
+
+# Done copying examples
+######################################################################
+# Begin image streams
 
 - name: Modify registry paths if registry_url is not registry.access.redhat.com
   shell: >


### PR DESCRIPTION
This is a work in progress of a change to try and speed up the example copying process:

* The `copy` module does not scale to hundreds of files
* Ultimately we'll replace `copy` with `unarchive`

Testing with the `profile_tasks` callback showed that copying the ~80 files from `roles/openshift_examples/files/examples/{{ content_version }}` was taking aroud 70 seconds+ on a speedy broadband connection to an EC2 instance.

Switching to the `unarchive` approach reduced the total time down to ~2 seconds. Testing with the [synchronize module](http://docs.ansible.com/ansible/synchronize_module.html) attempted first, however due to behavior changes introduced in Ansible 2.x+ we had to ditch that approach (issues with `become`, google for it if you're interested).

**WIP** Because this is still incomplete (need to erase the temp dir, etc) and I would like feedback on my approach to some references. For example, when creating a tarball of the examples this change uses the `-C` option and tell it to switch into the examples directory as

    tar -C "roles/openshift_examples/files/examples/{{ content_version }}/" ...

Is there a better way to determine that path? 