### PR TITLE
Don't upgrade docker on non-containerized etcd.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
@@ -6,7 +6,7 @@
 - include: ../../../../byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
 
 - name: Update Docker facts
-  hosts: oo_masters_to_config:oo_nodes_to_config:oo_etcd_to_config
+  hosts: oo_masters_to_config:oo_nodes_to_config
   roles:
   - openshift_facts
   tasks:


### PR DESCRIPTION
Backports #2082 -- needed refactored to work with enterprise-3.2. I've brought in only the changes necessary for upgrades to work with external etcd.