### PR TITLE
Set any_errors_fatal for etcd facts play

### DIFF
--- a/playbooks/common/openshift-cluster/initialize_facts.yml
+++ b/playbooks/common/openshift-cluster/initialize_facts.yml
@@ -1,6 +1,7 @@
 ---
 - name: Initialize host facts
   hosts: oo_all_hosts
+  any_errors_fatal: true
   roles:
   - openshift_facts
   tasks:

--- a/playbooks/common/openshift-etcd/config.yml
+++ b/playbooks/common/openshift-etcd/config.yml
@@ -1,6 +1,7 @@
 ---
 - name: Set etcd facts needed for generating certs
   hosts: oo_etcd_to_config
+  any_errors_fatal: true
   roles:
   - openshift_facts
   tasks:


### PR DESCRIPTION
This PR sets `any_errors_fatal` for etcd facts play so that if the facts play fails for any reason, playbook execution will halt and we won't attempt to use those facts later.

https://bugzilla.redhat.com/show_bug.cgi?id=1348846