### PR TITLE
Switch to repoquery, enable plugins for satellite support

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/files/rpm_versions.sh
+++ b/playbooks/common/openshift-cluster/upgrades/files/rpm_versions.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
-
-installed=$(yum list installed -e 0 -q "$@" 2>&1 | tail -n +2 | awk '{ print $2 }' | sort -r | tr '\n' ' ')
-available=$(yum list available -e 0 -q "$@" 2>&1 | tail -n +2 | grep -v 'el7ose' | awk '{ print $2 }' | sort -r | tr '\n' ' ')
+if [ `which dnf 2> /dev/null` ]; then
+  installed=$(dnf repoquery --installed --latest-limit 1 -d 0 --qf '%{version}-%{release}' "${@}" 2> /dev/null)
+  installed=$(dnf repoquery --available --latest-limit 1 -d 0 --qf '%{version}-%{release}' "${@}" 2> /dev/null)
+else
+  installed=$(repoquery --plugins --pkgnarrow=installed --qf '%{version}-%{release}' "${@}" 2> /dev/null)
+  available=$(repoquery --plugins --pkgnarrow=available --qf '%{version}-%{release}' "${@}" 2> /dev/null)
+fi
 
 echo "---"
 echo "curr_version: ${installed}"

--- a/roles/docker/vars/main.yml
+++ b/roles/docker/vars/main.yml
@@ -1,3 +1,2 @@
 ---
-repoquery_cmd: "{{ 'dnf repoquery --latest-limit 1 -d 0' if ansible_pkg_mgr == 'dnf' else 'repoquery' }}"
 udevw_udevd_dir: /etc/systemd/system/systemd-udevd.service.d

--- a/roles/openshift_docker_facts/vars/main.yml
+++ b/roles/openshift_docker_facts/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-repoquery_cmd: "{{ 'dnf repoquery --latest-limit 1 -d 0' if ansible_pkg_mgr == 'dnf' else 'repoquery' }}"
+repoquery_cmd: "{{ 'dnf repoquery --latest-limit 1 -d 0' if ansible_pkg_mgr == 'dnf' else 'repoquery --plugins' }}"


### PR DESCRIPTION
Before this fix we get stuff like this when various yum plugins are enabled.
```
# ./rpm_versions.sh atomic-openshift 
---
curr_version: Packages Hat can 3.1.1.6-1.git.0.b57e8bd.el7aos
avail_version: Packages Hat can 3.2.0.46-1.git.0.dd5b27b.el7
```

After the fix 

```
./rpm_versions.sh.1 atomic-openshift
---
curr_version: 3.1.1.6-4.git.32.adf8ec9.el7aos
avail_version: 3.2.0.46-1.git.0.dd5b27b.el7
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1350981