### PR TITLE
Revert "Speed up copying OpenShift examples"

### DIFF
--- a/roles/openshift_examples/tasks/main.yml
+++ b/roles/openshift_examples/tasks/main.yml
@@ -1,45 +1,8 @@
 ---
-######################################################################
-# Copying Examples
-#
-# We used to use the copy module to transfer the openshift examples to
-# the remote. Then it started taking more than a minute to transfer
-# the files. As noted in the module:
-#
-#   "The 'copy' module recursively copy facility does not scale to
-#   lots (>hundreds) of files."
-#
-# The `synchronize` module is suggested as an alternative, we can't
-# use it either due to changes introduced in Ansible 2.x.
-- name: Create local temp dir for OpenShift examples copy
-  local_action: command mktemp -d /tmp/openshift-ansible-XXXXXXX
-  become: False
-  register: copy_examples_mktemp
-  run_once: True
-
-- name: Create tar of OpenShift examples
-  local_action: command tar -C "{{ role_path }}/files/examples/{{ content_version }}/" -cvf "{{ copy_examples_mktemp.stdout }}/openshift-examples.tar" .
-  become: False
-  register: copy_examples_tar
-
-- name: Create the remote OpenShift examples directory
-  file:
-    dest: "{{ examples_base }}"
-    state: directory
-    mode: 0755
-
-- name: Unarchive the OpenShift examples on the remote
-  unarchive:
-    src: "{{ copy_examples_mktemp.stdout }}/openshift-examples.tar"
+- name: Copy openshift examples
+  copy:
+    src: "examples/{{ content_version }}/"
     dest: "{{ examples_base }}/"
-
-- name: Cleanup the OpenShift Examples temp dir
-  become: False
-  local_action: file dest="{{ copy_examples_mktemp.stdout }}" state=absent
-
-# Done copying examples
-######################################################################
-# Begin image streams
 
 - name: Modify registry paths if registry_url is not registry.access.redhat.com
   shell: >


### PR DESCRIPTION
Reverts openshift/openshift-ansible#2087

This change requires ansible 2.0+ so we will re-merge once we require 2.1. :full_moon_with_face: 