### PR TITLE
No Package matching 'atomic-openshift3.2.0.46'

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -24,7 +24,7 @@
   when: openshift_master_ha | bool and openshift_master_cluster_method == "pacemaker" and openshift.common.is_containerized | bool
 
 - name: Install Master package
-  action: "{{ ansible_pkg_mgr }} name={{ openshift.common.service_type }}-master{{ openshift_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }} state=present"
+  action: "{{ ansible_pkg_mgr }} name={{ openshift.common.service_type }}-master-{{ openshift_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }} state=present"
   when: not openshift.common.is_containerized | bool
 
 - name: Pull master image


### PR DESCRIPTION
I need to install a dedicated version `openshift_version=3.2.0.46`

I tried it and got the following error.

```
TASK: [openshift_common | Install the base package for versioning] ************
failed: [<IP>] => {"changed": false, "failed": true, "rc": 0, "results": []}
msg: No Package matching 'atomic-openshift3.2.0.46' found available, installed or updated
```

To be able to install a dedicated version you need to use the following syntax

`atomic-openshift-3.2.0.46`
