### PR TITLE
Add support for supplying a dnsmasq.conf file

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -381,7 +381,10 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # and configure node's dnsIP to point at the node's local dnsmasq instance. Defaults
 # to True for Origin 1.2 and OSE 3.2. False for 1.1 / 3.1 installs, this cannot
 # be used with 1.0 and 3.0.
-# openshift_use_dnsmasq=False
+#openshift_use_dnsmasq=False
+# Define an additional dnsmasq.conf file to deploy to /etc/dnsmasq.d/openshift-ansible.conf
+# This is useful for POC environments where DNS may not actually be available yet.
+#openshift_node_dnsmasq_additional_config_file=/home/bob/ose-dnsmasq.conf
 
 # Global Proxy Configuration
 # These options configure HTTP_PROXY, HTTPS_PROXY, and NOPROXY environment

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -376,7 +376,10 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # and configure node's dnsIP to point at the node's local dnsmasq instance. Defaults
 # to True for Origin 1.2 and OSE 3.2. False for 1.1 / 3.1 installs, this cannot
 # be used with 1.0 and 3.0.
-# openshift_use_dnsmasq=False
+#openshift_use_dnsmasq=False
+# Define an additional dnsmasq.conf file to deploy to /etc/dnsmasq.d/openshift-ansible.conf
+# This is useful for POC environments where DNS may not actually be available yet.
+#openshift_node_dnsmasq_additional_config_file=/home/bob/ose-dnsmasq.conf
 
 # Global Proxy Configuration
 # These options configure HTTP_PROXY, HTTPS_PROXY, and NOPROXY environment

--- a/roles/openshift_node_dnsmasq/handlers/main.yml
+++ b/roles/openshift_node_dnsmasq/handlers/main.yml
@@ -1,5 +1,10 @@
 ---
 - name: restart NetworkManager
-  service: 
+  service:
     name: NetworkManager
+    state: restarted
+
+- name: restart dnsmasq
+  service:
+    name: dnsmasq
     state: restarted

--- a/roles/openshift_node_dnsmasq/tasks/main.yml
+++ b/roles/openshift_node_dnsmasq/tasks/main.yml
@@ -18,6 +18,16 @@
     src: origin-dns.conf.j2
     dest: /etc/dnsmasq.d/origin-dns.conf
 
+- name: Deploy additional dnsmasq.conf
+  template:
+   src: "{{ openshift_node_dnsmasq_additional_config_file }}"
+   dest: /etc/dnsmasq.d/openshift-ansible.conf
+   owner: root
+   group: root
+   mode: 0644
+  when: openshift_node_dnsmasq_additional_config_file is defined
+  notify: restart dnsmasq
+
 # Dynamic NetworkManager based dispatcher
 - include: ./network-manager.yml
   when: network_manager_active | bool

--- a/roles/openshift_node_dnsmasq/tasks/main.yml
+++ b/roles/openshift_node_dnsmasq/tasks/main.yml
@@ -17,6 +17,7 @@
   template:
     src: origin-dns.conf.j2
     dest: /etc/dnsmasq.d/origin-dns.conf
+  notify: restart dnsmasq
 
 - name: Deploy additional dnsmasq.conf
   template:


### PR DESCRIPTION
Useful for POC environments where DNS may not actually be setup yet. Make sure
you don't define anything that would conflict with the default configuration.
You have been warned.