### PR TITLE
ops-docker-loopback-to-direct-lvm.yml: fix typo on the variable name "cli_name vs cli_host"

### DIFF
--- a/playbooks/adhoc/docker_loopback_to_lvm/ops-docker-loopback-to-direct-lvm.yml
+++ b/playbooks/adhoc/docker_loopback_to_lvm/ops-docker-loopback-to-direct-lvm.yml
@@ -16,7 +16,7 @@
 #  * You may need to re-deploy docker images after this is run (like monitoring)
 
 - name: Fix docker to have a provisioned iops drive
-  hosts: "{{ cli_name }}"
+  hosts: "{{ cli_host }}"
   user: root
   connection: ssh
   gather_facts: no


### PR DESCRIPTION
ops-docker-loopback-to-direct-lvm.yml: fix typo on the variable name `cli_name vs cli_host`