### PR TITLE
Fix bin/cluster openstack related error

### DIFF
--- a/playbooks/openstack/openshift-cluster/dns.yml
+++ b/playbooks/openstack/openshift-cluster/dns.yml
@@ -35,6 +35,11 @@
   - vars.yml
   - cluster_hosts.yml
   roles:
+    # Explicitly calling openshift_facts because it appears that when
+    # rhel_subscribe is skipped that the openshift_facts dependency for
+    # openshift_repos is also skipped (this is the case at least for Ansible
+    # 2.0.2)
+    - openshift_facts
     - role: rhel_subscribe
       when: deployment_type in ["enterprise", "atomic-enterprise", "openshift-enterprise"] and
             ansible_distribution == "RedHat" and


### PR DESCRIPTION
It looks like spawning a cluster with `bin/cluster` on OpenStack is suffering from the same issue as the one that @detiber fixed in #1969.
So, I just applied the same fix.