### PR TITLE
Re-align the OpenStack firewall rules with the iptables rules

### DIFF
--- a/playbooks/openstack/openshift-cluster/files/heat_stack.yaml
+++ b/playbooks/openstack/openshift-cluster/files/heat_stack.yaml
@@ -280,6 +280,10 @@ resources:
           port_range_max: 8443
         - direction: ingress
           protocol: tcp
+          port_range_min: 8444
+          port_range_max: 8444
+        - direction: ingress
+          protocol: tcp
           port_range_min: 53
           port_range_max: 53
         - direction: ingress
@@ -302,6 +306,22 @@ resources:
           protocol: udp
           port_range_min: 24224
           port_range_max: 24224
+        - direction: ingress
+          protocol: tcp
+          port_range_min: 2224
+          port_range_max: 2224
+        - direction: ingress
+          protocol: udp
+          port_range_min: 5404
+          port_range_max: 5404
+        - direction: ingress
+          protocol: udp
+          port_range_min: 5405
+          port_range_max: 5405
+        - direction: ingress
+          protocol: tcp
+          port_range_min: 9090
+          port_range_max: 9090
 
   etcd-secgrp:
     type: OS::Neutron::SecurityGroup
@@ -357,6 +377,16 @@ resources:
           protocol: tcp
           port_range_min: 10250
           port_range_max: 10250
+          remote_mode: remote_group_id
+        - direction: ingress
+          protocol: tcp
+          port_range_min: 10255
+          port_range_max: 10255
+          remote_mode: remote_group_id
+        - direction: ingress
+          protocol: udp
+          port_range_min: 10255
+          port_range_max: 10255
           remote_mode: remote_group_id
         - direction: ingress
           protocol: udp


### PR DESCRIPTION
Some new firewall rules have been added in iptables.
This PR just opens the same ports in the OpenStack firewall.