### PR TITLE
Default sdn_cluster_network_cidr changed to 10.128.0.0/14

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -909,7 +909,7 @@ def set_sdn_facts_if_unset(facts, system_facts):
 
     if 'master' in facts:
         if 'sdn_cluster_network_cidr' not in facts['master']:
-            facts['master']['sdn_cluster_network_cidr'] = '10.1.0.0/16'
+            facts['master']['sdn_cluster_network_cidr'] = '10.128.0.0/14'
         if 'sdn_host_subnet_length' not in facts['master']:
             facts['master']['sdn_host_subnet_length'] = '8'
 


### PR DESCRIPTION
Documentation says the default sdn cluster network cidr in OSE 3.2.X has changed to 10.128.0.0/14.
https://docs.openshift.com/enterprise/3.2/install_config/install/advanced_install.html#configuring-cluster-variables 

There is also a open bug: https://bugzilla.redhat.com/show_bug.cgi?id=1320952
