### PR TITLE
Make libvirt’s VM use virtio-scsi insteal of virtio-blk

### DIFF
--- a/playbooks/libvirt/openshift-cluster/templates/domain.xml
+++ b/playbooks/libvirt/openshift-cluster/templates/domain.xml
@@ -30,22 +30,22 @@
   <devices>
     <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type='file' device='disk'>
-      <driver name='qemu' type='qcow2'/>
+      <driver name='qemu' type='qcow2' discard='unmap'/>
       <source file='{{ libvirt_storage_pool_path }}/{{ item }}.qcow2'/>
-      <target dev='vda' bus='virtio'/>
+      <target dev='sda' bus='scsi'/>
     </disk>
     <disk type='file' device='disk'>
-      <driver name='qemu' type='qcow2'/>
+      <driver name='qemu' type='qcow2' discard='unmap'/>
       <source file='{{ libvirt_storage_pool_path }}/{{ item }}-docker.qcow2'/>
-      <target dev='vdb' bus='virtio'/>
+      <target dev='sdb' bus='scsi'/>
     </disk>
     <disk type='file' device='cdrom'>
       <driver name='qemu' type='raw'/>
       <source file='{{ libvirt_storage_pool_path }}/{{ item }}_cloud-init.iso'/>
-      <target dev='vdc' bus='virtio'/>
+      <target dev='sdc' bus='scsi'/>
       <readonly/>
     </disk>
-    <controller type='usb' index='0' />
+    <controller type='scsi' model='virtio-scsi' />
     <interface type='network'>
       <source network='{{ libvirt_network }}'/>
       <model type='virtio'/>
@@ -56,17 +56,6 @@
     <console type='pty'>
       <target type='serial' port='0'/>
     </console>
-    <channel type='spicevmc'>
-      <target type='virtio' name='com.redhat.spice.0'/>
-    </channel>
-    <input type='tablet' bus='usb' />
-    <input type='mouse' bus='ps2'/>
-    <graphics type='spice' autoport='yes' />
-    <video>
-      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1'/>
-    </video>
-    <redirdev bus='usb' type='spicevmc'>
-    </redirdev>
     <memballoon model='virtio'>
     </memballoon>
   </devices>

--- a/playbooks/libvirt/openshift-cluster/templates/user-data
+++ b/playbooks/libvirt/openshift-cluster/templates/user-data
@@ -5,7 +5,7 @@ hostname: {{ item[0] }}
 fqdn: {{ item[0] }}.example.com
 
 mounts:
-- [ vdb ]
+- [ sdb ]
 
 users:
   - default
@@ -26,12 +26,18 @@ write_files:
     permissions: 440
     content: |
         Defaults:openshift !requiretty
-  - content: |
-      DEVS=/dev/vdb
-      VG=docker_vg
-    path: /etc/sysconfig/docker-storage-setup
+  - path: /etc/sysconfig/docker-storage-setup
     owner: root:root
     permissions: '0644'
+    content: |
+      DEVS=/dev/sdb
+      VG=docker_vg
+      EXTRA_DOCKER_STORAGE_OPTIONS='--storage-opt dm.blkdiscard=true'
+  - path: /etc/systemd/system/fstrim.timer.d/hourly.conf
+    content: |
+      [Timer]
+      OnCalendar=hourly
 
 runcmd:
   - NETWORK_CONFIG=/etc/sysconfig/network-scripts/ifcfg-eth0; if ! grep DHCP_HOSTNAME ${NETWORK_CONFIG}; then echo 'DHCP_HOSTNAME="{{ item[0] }}.example.com"' >> ${NETWORK_CONFIG}; fi; pkill -9 dhclient; service network restart
+  - systemctl enable --now fstrim.timer


### PR DESCRIPTION
The main advantage is that virtio-scsi honors TRIM so that deleting files
and/or docker images inside the VM now frees disk space on the host by
resparsifying the qcow2 file.