### PR TITLE
Install bash-completion package for the oc/oadm tools

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -27,6 +27,9 @@
   action: "{{ ansible_pkg_mgr }} name={{ openshift.common.service_type }}-master{{ openshift_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }} state=present"
   when: not openshift.common.is_containerized | bool
 
+- name: Install bash completion for oc tools
+  action: "{{ ansible_pkg_mgr }} name=bash-completion state=present"
+
 - name: Pull master image
   command: >
     docker pull {{ openshift.master.master_image }}{{ ':' + openshift_version if openshift_version is defined and openshift_version != '' else '' }}


### PR DESCRIPTION
I'd like the bash-completion package installed by default on masters after an installation. Adding bash-completion to the default install enables use of the completion scripts already installed by the master packages.