### PR TITLE
Two small upgrade related fixes

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -37,7 +37,7 @@
 # Docker 1.10 upgrade playbook to accomplish this.
 - name: Error out if attempting to upgrade Docker across the 1.10 boundary
   fail:
-    msg: "Cannot upgrade Docker to >= 1.10, please use the Docker upgrade playbook for this."
+    msg: "Cannot upgrade Docker to >= 1.10, please upgrade or remove Docker manually, or use the Docker upgrade playbook if OpenShift is already installed."
   when: not curr_docker_version | skipped and curr_docker_version.stdout != '' and curr_docker_version.stdout | version_compare('1.10', '<') and docker_version is defined and docker_version | version_compare('1.10', '>=') and not docker_protect_installed_version | bool
 
 # Make sure Docker is installed, but does not update a running version.

--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -830,11 +830,11 @@ def upgrade(ctx, latest_minor, next_major):
     # upgrade for what you're currently running.
     upgrade_mappings = {
                         '3.1':{
-                               'major_playbook':'v3_1_to_v3_2/upgrade.yml',
+                               'major_playbook':'v3_2/upgrade.yml',
                                'major_version' :'3.2',
                             },
                         '3.2':{
-                               'minor_playbook':'v3_1_to_v3_2/upgrade.yml',
+                               'minor_playbook':'v3_2/upgrade.yml',
 # Uncomment these when we're ready to support 3.3.
 #                               'major_version' :'3.3',
 #                               'major_playbook':'v3_1_to_v3_2/upgrade.yml',


### PR DESCRIPTION
Quick install 3.2 is pointing to wrong location for the playbooks, and adjusting an error message at QE's request.