### PR TITLE
Symlink ansible 2.x locations to ansible 1.9 locations

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -70,6 +70,16 @@ cp -rp filter_plugins %{buildroot}%{_datadir}/ansible_plugins/
 # openshift-ansible-lookup-plugins install
 cp -rp lookup_plugins %{buildroot}%{_datadir}/ansible_plugins/
 
+# create symlinks from /usr/share/ansible/plugins/lookup ->
+# /usr/share/ansible_plugins/lookup_plugins
+pushd %{buildroot}%{_datadir}
+mkdir -p ansible/plugins
+pushd ansible/plugins
+ln -s ../../ansible_plugins/lookup_plugins lookup
+ln -s ../../ansible_plugins/filter_plugins filter
+popd
+popd
+
 # atomic-openshift-utils install
 pushd utils
 %{__python} setup.py install --skip-build --root %{buildroot}
@@ -168,6 +178,7 @@ Requires:      pyOpenSSL
 
 %files filter-plugins
 %{_datadir}/ansible_plugins/filter_plugins
+%{_datadir}/ansible/plugins/filter
 
 
 # ----------------------------------------------------------------------------------
@@ -183,6 +194,7 @@ BuildArch:     noarch
 
 %files lookup-plugins
 %{_datadir}/ansible_plugins/lookup_plugins
+%{_datadir}/ansible/plugins/lookup
 
 # ----------------------------------------------------------------------------------
 # atomic-openshift-utils subpackage


### PR DESCRIPTION
Ansible 2.x has moved the plugin path from /usr/share/ansible_plugins/{filter,lookup}_plugins to /usr/share/plugins/{filter,lookup,...} we will try to accommodate both versions.