### PR TITLE
Convert openshift_release and openshift_version to strings for starts…

### DIFF
--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -17,6 +17,10 @@
   when: openshift_release is defined and openshift_release[0] == 'v'
 
 - set_fact:
+    openshift_release: "{{ openshift_release | string }}"
+  when: openshift_release is defined
+
+- set_fact:
     openshift_image_tag: "{{ 'v' + openshift_image_tag }}"
   when: openshift_image_tag is defined and openshift_image_tag[0] != 'v'
 
@@ -26,7 +30,7 @@
 
 # Make sure we copy this to a fact if given a var:
 - set_fact:
-    openshift_version: "{{ openshift_version }}"
+    openshift_version: "{{ openshift_version | string }}"
   when: openshift_version is defined
 
 # Protect the installed version by default unless explicitly told not to, or given an


### PR DESCRIPTION
…with

Fixes : startswith first arg must be str, unicode, or tuple, not float
```
TASK [openshift_version : fail] ************************************************
fatal: [ose3-master.example.com]: FAILED! => {"failed": true, "msg": "The conditional check 'not is_containerized | bool and openshift_release is defined and not openshift_version.startswith(openshift_release) | bool' failed. The error was: Unexpected templating type error occurred on ({% if not is_containerized | bool and openshift_release is defined and not openshift_version.startswith(openshift_release) | bool %} True {% else %} False {% endif %}): startswith first arg must be str, unicode, or tuple, not float\n\nThe error appears to have been in '/home/rdu/sdodson/git/Openshift/openshift-ansible/roles/openshift_version/tasks/main.yml': line 77, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n# the rpm version we looked up matches the release requested and error out if not.\n- fail:\n  ^ here\n"}
```