### PR TITLE
Bug 1355702 - ansible installaton failed when enable aws s3 backend storage.

### DIFF
--- a/roles/openshift_hosted/tasks/registry/storage/object_storage.yml
+++ b/roles/openshift_hosted/tasks/registry/storage/object_storage.yml
@@ -24,10 +24,10 @@
   failed_when: false
 
 - set_fact:
-    registry_config: "{{ lookup('template', '../templates/registry_config.j2') | b64encode }}"
+    registry_config: "{{ lookup('template', 'registry_config.j2') | b64encode }}"
 
 - set_fact:
-    registry_config_secret: "{{ lookup('template', '../templates/registry_config_secret.j2') | from_yaml }}"
+    registry_config_secret: "{{ lookup('template', 'registry_config_secret.j2') | from_yaml }}"
 
 - set_fact:
     same_storage_provider: "{{ (secrets.stdout|from_json)['metadata']['annotations']['provider'] | default(none) == openshift.hosted.registry.storage.provider }}"
@@ -111,4 +111,4 @@
     --config={{ openshift_hosted_kubeconfig }}
     --namespace={{ openshift.hosted.registry.namespace | default('default') }}
     deploy dc/docker-registry --latest
-  when: secrets.rc == 0 and update_config_secret.rc == 0 and same_storage_provider | bool
+  when: secrets.rc == 0 and not update_config_secret | skipped and update_config_secret.rc == 0 and same_storage_provider | bool

--- a/roles/openshift_hosted/tasks/registry/storage/registry_config.j2
+++ b/roles/openshift_hosted/tasks/registry/storage/registry_config.j2
@@ -1,0 +1,1 @@
+../../../templates/registry_config.j2

--- a/roles/openshift_hosted/tasks/registry/storage/registry_config_secret.j2
+++ b/roles/openshift_hosted/tasks/registry/storage/registry_config_secret.j2
@@ -1,0 +1,1 @@
+../../../templates/registry_config_secret.j2


### PR DESCRIPTION
* Remove relative lookup for registry config. ansible will look in role templates by default in 2.x.
* Temporarily duplicate registry config templates for ansible 1.9.x support.
* Check for skipped update in redeploy registry conditional.

https://bugzilla.redhat.com/show_bug.cgi?id=1355702
