### PR TITLE
Test for oo_nfs_to_config in groups when determining storage host

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -660,7 +660,7 @@ class FilterModule(object):
                         if kind == 'nfs':
                             host = params['host']
                             if host == None:
-                                if len(groups['oo_nfs_to_config']) > 0:
+                                if 'oo_nfs_to_config' in groups and len(groups['oo_nfs_to_config']) > 0:
                                     host = groups['oo_nfs_to_config'][0]
                                 else:
                                     raise errors.AnsibleFilterError("|failed no storage host detected")


### PR DESCRIPTION
Fix error when registry storage kind set to nfs but no `[nfs]` host group defined and no nfs host defined in the inventory.

```
TASK [openshift_facts : Verify Ansible version is greater than or equal to 2.1.0.0] ***
Tuesday 19 July 2016  15:54:44 +0000 (0:00:01.005)       1:11:24.007 **********
fatal: [ec2-xxxxxxxx.us-west-2.compute.amazonaws.com]: FAILED! => {"failed": true, "msg": "The conditional check 'persistent_volumes | length > 0 or persistent_volume_claims | length > 0' failed. The error was: u'{{ hostvars[groups.oo_first_master.0] | oo_persistent_volumes(groups) }}: oo_nfs_to_config'"}
```