### PR TITLE
Check router certificate contents when securing router

### DIFF
--- a/roles/openshift_hosted/tasks/router/router.yml
+++ b/roles/openshift_hosted/tasks/router/router.yml
@@ -32,7 +32,7 @@
     content: "{{ openshift.hosted.router.certificate.contents }}"
     dest: "{{ openshift_master_config_dir }}/openshift-router.pem"
     mode: 0600
-  when: openshift.hosted.router.certificate | default(none) is not none
+  when: "'certificate' in openshift.hosted.router and 'contents' in openshift.hosted.router.certificate"
 
 - name: Retrieve list of openshift nodes matching router selector
   command: >
@@ -53,7 +53,7 @@
     {% if replicas > 1 -%}
     --replicas={{ replicas }}
     {% endif -%}
-    {% if openshift.hosted.router.certificate | default(none) is not none -%}
+    {% if 'certificate' in openshift.hosted.router and 'contents' in openshift.hosted.router.certificate -%}
     --default-cert={{ openshift_master_config_dir }}/openshift-router.pem
     {% endif -%}
     --namespace={{ openshift.hosted.router.namespace | default('default') }}


### PR DESCRIPTION
Allow removing `openshift_hosted_router_certificate` inventory variable after encountering the following error which indicates that required keys are missing.

```ruby
TASK [openshift_hosted : fail] *************************************************
Tuesday 19 July 2016  14:03:27 -0400 (0:00:01.532)       0:20:36.661 **********
fatal: [master4.example.com]: FAILED! => {"changed": false, "failed": true, "msg": "'certfile', 'keyfile' and 'cafile' keys must be specified when supplying the openshift_hosted_router_certificate variable."}
```

These errors would halt install after the variable is removed due to partially defined `openshift.hosted.router.certificate` from the first attempt.

```ruby
TASK [openshift_hosted : Create PEM certificate] *******************************
Tuesday 19 July 2016  14:33:11 -0400 (0:00:03.468)       0:18:38.285 **********
fatal: [master4.example.com]: FAILED! => {"failed": true, "msg": "'dict object' has no attribute 'contents'"}
```

```ruby
TASK [openshift_hosted : Create OpenShift router] ******************************
Tuesday 19 July 2016  15:11:58 -0400 (0:00:05.065)       0:20:02.040 **********
fatal: [master4.example.com]: FAILED! => {"changed": true, "cmd": ["oadm", "router", "--create", "--config=/tmp/openshift-ansible-i6I8Jd/admin.kubeconfig", "--replicas=1", "--default-cert=/etc/origin/master/openshift-router.pem", "--namespace=default", "--force-subdomain=${name}-${namespace}.apps.example.com", "--service-account=router", "--selector=region=infra", "--images=openshift3/ose-${component}:${version}"], "delta": "0:00:00.228457", "end": "2016-07-19 15:11:58.497564", "failed": true, "failed_when_result": true, "rc": 1, "start": "2016-07-19 15:11:58.269107", "stderr": "error: router could not be created; error reading default certificate file: open /etc/origin/master/openshift-router.pem: no such file or directory", "stdout": "", "stdout_lines": [], "warnings": []}
```

So, ensure that `openshift.hosted.router.certificate.contents` are defined (and router certificate file exists). The `"contents"` key will only be filled if `openshift_hosted_router_certificate` defined from the inventory and required keys are present.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1357801