### PR TITLE
Bring back g_all_hosts deprecation warnings.

### DIFF
--- a/playbooks/aws/openshift-cluster/config.yml
+++ b/playbooks/aws/openshift-cluster/config.yml
@@ -6,7 +6,7 @@
   - add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
-    with_items: "{{ g_all_hosts | default([]) }}"
+    with_items: g_all_hosts | default([])
 
 - hosts: l_oo_all_hosts
   gather_facts: no

--- a/playbooks/byo/openshift-cluster/config.yml
+++ b/playbooks/byo/openshift-cluster/config.yml
@@ -8,7 +8,7 @@
   - add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
-    with_items: "{{ g_all_hosts | default([]) }}"
+    with_items: g_all_hosts | default([])
 
 - hosts: l_oo_all_hosts
   gather_facts: no

--- a/playbooks/common/openshift-cluster/evaluate_groups.yml
+++ b/playbooks/common/openshift-cluster/evaluate_groups.yml
@@ -35,7 +35,7 @@
       groups: oo_all_hosts
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_become: "{{ g_sudo | default(omit) }}"
-    with_items: "{{ g_all_hosts | default([]) }}"
+    with_items: g_all_hosts | default([])
 
   - name: Evaluate oo_masters
     add_host:

--- a/playbooks/gce/openshift-cluster/config.yml
+++ b/playbooks/gce/openshift-cluster/config.yml
@@ -9,7 +9,7 @@
       groups: l_oo_all_hosts
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_become: "{{ deployment_vars[deployment_type].become }}"
-    with_items: "{{ g_all_hosts | default([]) }}"
+    with_items: g_all_hosts | default([])
 
 - hosts: l_oo_all_hosts
   gather_facts: no

--- a/playbooks/libvirt/openshift-cluster/config.yml
+++ b/playbooks/libvirt/openshift-cluster/config.yml
@@ -10,7 +10,7 @@
   - add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
-    with_items: "{{ g_all_hosts | default([]) }}"
+    with_items: g_all_hosts | default([])
 
 - hosts: l_oo_all_hosts
   gather_facts: no

--- a/playbooks/openstack/openshift-cluster/config.yml
+++ b/playbooks/openstack/openshift-cluster/config.yml
@@ -7,7 +7,7 @@
   - add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
-    with_items: "{{ g_all_hosts | default([]) }}"
+    with_items: g_all_hosts | default([])
 
 - hosts: l_oo_all_hosts
   gather_facts: no


### PR DESCRIPTION
Resolving these deprecation warnings prevents ansible 1.9.x users from seeing the ansible version error message.

Fixes https://github.com/openshift/openshift-ansible/issues/2182