### PR TITLE
Fix libvirt provider for Ansible 2.1.0.0

### DIFF
--- a/lookup_plugins/oo_option.py
+++ b/lookup_plugins/oo_option.py
@@ -33,15 +33,6 @@ except ImportError:
             def get_basedir(self, variables):
                 return self.basedir
 
-# pylint: disable=no-name-in-module,import-error
-try:
-    # ansible-2.0
-    from ansible import template
-except ImportError:
-    # ansible 1.9.x
-    from ansible.utils import template
-
-
 # Reason: disable too-few-public-methods because the `run` method is the only
 #     one required by the Ansible API
 # Status: permanently disabled
@@ -65,28 +56,16 @@ class LookupModule(LookupBase):
     #     which is not used
     # Status: permanently disabled unless Ansible API evolves
     # pylint: disable=unused-argument
-    def run(self, terms, inject=None, **kwargs):
+    def run(self, terms, variables, **kwargs):
         ''' Main execution path '''
-
-        try:
-            terms = template.template(self.basedir, terms, inject)
-        # Reason: disable broad-except to really ignore any potential exception
-        #         This is inspired by the upstream "env" lookup plugin:
-        #         https://github.com/ansible/ansible/blob/devel/v1/ansible/runner/lookup_plugins/env.py#L29
-        # pylint: disable=broad-except
-        except Exception:
-            pass
-
-        if isinstance(terms, basestring):
-            terms = [terms]
 
         ret = []
 
         for term in terms:
             option_name = term.split()[0]
             cli_key = 'cli_' + option_name
-            if inject and cli_key in inject:
-                ret.append(inject[cli_key])
+            if 'vars' in variables and cli_key in variables['vars']:
+                ret.append(variables['vars'][cli_key])
             elif option_name in os.environ:
                 ret.append(os.environ[option_name])
             else:

--- a/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
@@ -39,14 +39,14 @@
   file:
     dest: '{{ libvirt_storage_pool_path }}/{{ item }}_configdrive/'
     state: directory
-  with_items: instances
+  with_items: '{{ instances }}'
 
 - name: Create the cloud-init config drive files
   template:
     src: '{{ item[1] }}'
     dest: '{{ libvirt_storage_pool_path }}/{{ item[0] }}_configdrive/{{ item[1] }}'
   with_nested:
-    - instances
+    - '{{ instances }}'
     - [ user-data, meta-data ]
 
 - name: Create the cloud-init config drive
@@ -54,18 +54,18 @@
   args:
     chdir: '{{ libvirt_storage_pool_path }}/{{ item }}_configdrive/'
     creates: '{{ libvirt_storage_pool_path }}/{{ item }}_cloud-init.iso'
-  with_items: instances
+  with_items: '{{ instances }}'
 
 - name: Refresh the libvirt storage pool for openshift
   command: 'virsh -c {{ libvirt_uri }} pool-refresh {{ libvirt_storage_pool }}'
 
 - name: Create VM drives
   command: 'virsh -c {{ libvirt_uri }} vol-create-as {{ libvirt_storage_pool }} {{ item }}.qcow2 10G --format qcow2 --backing-vol {{ image_name }} --backing-vol-format qcow2'
-  with_items: instances
+  with_items: '{{ instances }}'
 
 - name: Create VM docker drives
   command: 'virsh -c {{ libvirt_uri }} vol-create-as {{ libvirt_storage_pool }} {{ item }}-docker.qcow2 10G --format qcow2 --allocation 0'
-  with_items: instances
+  with_items: '{{ instances }}'
 
 - name: Create VMs
   virt:
@@ -73,14 +73,14 @@
     command: define
     xml: "{{ lookup('template', '../templates/domain.xml') }}"
     uri: '{{ libvirt_uri }}'
-  with_items: instances
+  with_items: '{{ instances }}'
 
 - name: Start VMs
   virt:
     name: '{{ item }}'
     state: running
     uri: '{{ libvirt_uri }}'
-  with_items: instances
+  with_items: '{{ instances }}'
 
 - name: Wait for the VMs to get an IP
   shell: 'virsh -c {{ libvirt_uri }} net-dhcp-leases {{ libvirt_network }} | egrep -c ''{{ instances | join("|") }}'''
@@ -93,7 +93,7 @@
 - name: Collect IP addresses of the VMs
   shell: 'virsh -c {{ libvirt_uri }} net-dhcp-leases {{ libvirt_network }} | awk ''$6 == "{{ item }}" {gsub(/\/.*/, "", $5); print $5}'''
   register: scratch_ip
-  with_items: instances
+  with_items: '{{ instances }}'
 
 - set_fact:
     ips: "{{ scratch_ip.results | default([]) | oo_collect('stdout') }}"
@@ -117,14 +117,14 @@
     groups: "tag_environment-{{ cluster_env }}, tag_host-type-{{ type }}, tag_sub-host-type-{{ g_sub_host_type }}, tag_clusterid-{{ cluster_id }}"
     openshift_node_labels: "{{ node_label }}"
   with_together:
-    - instances
-    - ips
+    - '{{ instances }}'
+    - '{{ ips }}'
 
 - name: Wait for ssh
   wait_for:
     host: '{{ item }}'
     port: 22
-  with_items: ips
+  with_items: '{{ ips }}'
 
 - name: Wait for openshift user setup
   command: 'ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null openshift@{{ item.1 }} echo openshift user is setup'
@@ -133,5 +133,5 @@
   retries: 30
   delay: 1
   with_together:
-  - instances
-  - ips
+  - '{{ instances }}'
+  - '{{ ips }}'

--- a/playbooks/libvirt/openshift-cluster/templates/domain.xml
+++ b/playbooks/libvirt/openshift-cluster/templates/domain.xml
@@ -19,6 +19,9 @@
     <apic/>
     <pae/>
   </features>
+  <cpu mode='host-model'>
+    <model fallback='allow'/>
+  </cpu>
   <clock offset='utc'>
     <timer name='rtc' tickpolicy='catchup'/>
     <timer name='pit' tickpolicy='delay'/>

--- a/playbooks/libvirt/openshift-cluster/terminate.yml
+++ b/playbooks/libvirt/openshift-cluster/terminate.yml
@@ -15,7 +15,7 @@
       groups: oo_hosts_to_terminate
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_become: "{{ deployment_vars[deployment_type].become }}"
-    with_items: groups[cluster_group] | default([])
+    with_items: '{{ groups[cluster_group] | default([]) }}'
 
 - name: Unsubscribe VMs
   hosts: oo_hosts_to_terminate
@@ -42,30 +42,30 @@
       command: '{{ item[1] }}'
       uri: '{{ libvirt_uri }}'
     with_nested:
-    - groups['oo_hosts_to_terminate']
+    - "{{ groups['oo_hosts_to_terminate'] }}"
     - [ destroy, undefine ]
 
   - name: Delete VM drives
     command: 'virsh -c {{ libvirt_uri }} vol-delete --pool {{ libvirt_storage_pool }} {{ item }}.qcow2'
     args:
       removes: '{{ libvirt_storage_pool_path }}/{{ item }}.qcow2'
-    with_items: groups['oo_hosts_to_terminate']
+    with_items: "{{ groups['oo_hosts_to_terminate'] }}"
 
   - name: Delete VM docker drives
     command: 'virsh -c {{ libvirt_uri }} vol-delete --pool {{ libvirt_storage_pool }} {{ item }}-docker.qcow2'
     args:
       removes: '{{ libvirt_storage_pool_path }}/{{ item }}-docker.qcow2'
-    with_items: groups['oo_hosts_to_terminate']
+    with_items: "{{ groups['oo_hosts_to_terminate'] }}"
 
   - name: Delete the VM cloud-init image
     file:
       path: '{{ libvirt_storage_pool_path }}/{{ item }}_cloud-init.iso'
       state: absent
-    with_items: groups['oo_hosts_to_terminate']
+    with_items: "{{ groups['oo_hosts_to_terminate'] }}"
 
   - name: Remove the cloud-init config directory
     file:
       path: '{{ libvirt_storage_pool_path }}/{{ item }}_configdrive/'
       state: absent
-    with_items: groups['oo_hosts_to_terminate']
+    with_items: "{{ groups['oo_hosts_to_terminate'] }}"
 

--- a/playbooks/libvirt/openshift-cluster/update.yml
+++ b/playbooks/libvirt/openshift-cluster/update.yml
@@ -7,7 +7,7 @@
   - add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
-    with_items: g_all_hosts
+    with_items: '{{ g_all_hosts }}'
 
 - hosts: l_oo_all_hosts
   gather_facts: no
@@ -30,7 +30,7 @@
       groups: oo_hosts_to_update
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_become: "{{ deployment_vars[deployment_type].become }}"
-    with_items: g_all_hosts | default([])
+    with_items: '{{ g_all_hosts | default([]) }}'
 
 - include: ../../common/openshift-cluster/update_repos_and_packages.yml
 


### PR DESCRIPTION
* The change of Ansible API requires to update the `oo_option` lookup plugin;
* Some variables now need to be enclosed inside `{{…}}`.