### PR TITLE
Bug 1358723 - openshift_hosted_router_replicas option didn't work

### DIFF
--- a/roles/openshift_hosted/tasks/registry/registry.yml
+++ b/roles/openshift_hosted/tasks/registry/registry.yml
@@ -9,7 +9,7 @@
   when: openshift.hosted.registry.replicas | default(none) is none
 
 - set_fact:
-    replicas: "{{ openshift.hosted.registry.replicas | default(((openshift_hosted_registry_nodes_json.stdout | from_json)['items'] | length) if openshift.hosted.registry.storage.kind | default(none) is not none else 1) }}"
+    replicas: "{{ openshift.hosted.registry.replicas | default(((openshift_hosted_registry_nodes_json.stdout | default('{\"items\":[]}') | from_json)['items'] | length) if openshift.hosted.registry.storage.kind | default(none) is not none else 1) }}"
 
 - name: Create OpenShift registry
   command: >

--- a/roles/openshift_hosted/tasks/router/router.yml
+++ b/roles/openshift_hosted/tasks/router/router.yml
@@ -44,7 +44,7 @@
   when: openshift.hosted.router.replicas | default(none) is none
 
 - set_fact:
-    replicas: "{{ openshift.hosted.router.replicas | default((openshift_hosted_router_nodes_json.stdout | from_json)['items'] | length) }}"
+    replicas: "{{ openshift.hosted.router.replicas | default((openshift_hosted_router_nodes_json.stdout | default('{\"items\":[]}') | from_json)['items'] | length) }}"
 
 - name: Create OpenShift router
   command: >


### PR DESCRIPTION
Default list of nodes matching selector when not retrieved.

@detiber PTAL. ~~I also noticed that we will create a router/registry with replicas=0 when there are no infrastructure nodes. Should we base creation on replicas >= 1?~~

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1358723