### PR TITLE
[WIP] Check hosts for upcoming expiring certificates

### DIFF
--- a/playbooks/byo/openshift-cluster/check-cert-expiry.yaml
+++ b/playbooks/byo/openshift-cluster/check-cert-expiry.yaml
@@ -1,0 +1,18 @@
+---
+- hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+  - add_host:
+      name: "{{ item }}"
+      groups: l_oo_all_hosts
+    with_items: g_all_hosts
+
+- hosts: l_oo_all_hosts
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+
+- include: ../../common/openshift-cluster/check-cert-expiry.yaml

--- a/playbooks/common/openshift-cluster/check-cert-expiry.yaml
+++ b/playbooks/common/openshift-cluster/check-cert-expiry.yaml
@@ -1,0 +1,48 @@
+---
+- include: evaluate_groups.yml
+
+### Collect information about remote certificates
+- hosts: oo_first_master
+  become: yes
+  gather_facts: no
+  vars:
+    cert_expiry_days_warning: 30
+  tasks:
+  - name: Locate all certificate files
+    find:
+      paths:
+        - "/etc/origin/"
+        - "/etc/etcd/"
+      patterns: "*.crt"
+      get_checksum: yes
+      recurse: yes
+    register: files
+    changed_when: false
+
+  - name: Group certs by checksum to keep results unique
+    set_fact: collated_certs="{{ files.files | oo_collate_certificate_files }}"
+
+  - name: Get a list of unique certs
+    set_fact: unique_cert_paths="{{ collated_certs | oo_get_unique_certificate_files }}"
+
+  - name: Get the Subject and Expiry for the certs
+    shell: >
+      openssl x509 -in "{{ item }}" -noout -text | grep -oP '((?<=Not After : )(.*)|(?<=Subject: )(.*))'
+    with_items:
+      - "{{ unique_cert_paths }}"
+    register: expirys
+    changed_when: false
+
+  - name: Check for helathy, expired, and expiring certs
+    set_fact: certs_check_results="{{ expirys.results | oo_parse_subject_expirys | oo_check_expiry(warning_days=cert_expiry_days_warning)}}"
+
+  - name: Reminder of what the warning threshold is set to
+    debug:
+      msg: "Certificate expiration warning window is {{ cert_expiry_days_warning }} days"
+    run_once: true
+
+  - name: Notify admin if any certificates are within the expiration window
+    fail:
+      msg: "On host '{{ inventory_hostname }}' the cert {{ item.cert }} with CommonName {{ item.subject }} expires in {{ item.days_remaining }} days ({{ item.expiry }})"
+    with_items:
+      - "{{ certs_check_results.expiring_certs }}"


### PR DESCRIPTION
Identifies openshift related certificates on remote hosts, unique's them (some are in multiple locations on a single host), find their expiration dates, and then generates output per certificate that will expire within a defined expiration window (now + **X** days).

* This feature comes from https://trello.com/c/OpWOZ3rx/124-3-warn-admins-that-their-certificates-will-soon-expire

# Customizing

The expiration warning parameter can be set to your choice. For example, during testing you may want to set the "warning window" to a large number, like nearly 2 years in days (730). 

* In ``playbooks/byo/check-cert-expiry.yaml`` set ``cert_expiry_days_warning`` to the warning window. Certificates that are 'expiring' have an expiration date ``now < cert-expiration date <= now+warning-window days``

* In ``playbooks/byo/check-cert-expiry.yaml`` set ``hosts`` to whatever hostgroup you want to check

# Usage

Ideal situation, nothing is expiring soon:

```
$ ansible-playbook -v -i ./inventory/byo/hosts.tbielawa.cert-expiry-multi playbooks/adhoc/check-cert-expiry.yaml
Using /etc/ansible/ansible.cfg as config file

PLAY [all] *********************************************************************

TASK [find] ********************************************************************
Thursday 21 July 2016  11:36:19 -0400 (0:00:00.026)       0:00:00.026 *********

...

TASK [debug] *******************************************************************
Thursday 21 July 2016  11:37:37 -0400 (0:00:00.092)       0:00:10.466 ********* 
ok: [54.204.157.7] => {
    "msg": "Certificate expiration warning window is 30 days"
}

TASK [fail] ********************************************************************
Thursday 21 July 2016  11:37:37 -0400 (0:00:00.056)       0:00:10.523 ********* 

PLAY RECAP *********************************************************************
54.204.157.7               : ok=6    changed=0    unreachable=0    failed=0   
54.88.146.77               : ok=5    changed=0    unreachable=0    failed=0   
```

Assuming an unrealistically high warning window (730 days), we could run the playbook and get the warnings we're looking for

```
TASK [debug] *******************************************************************
Thursday 21 July 2016  11:39:11 -0400 (0:00:00.093)       0:00:11.935 *********
ok: [54.204.157.7] => {
    "msg": "Certificate expiration warning window is 730 days"
}
  
TASK [fail] ********************************************************************
Thursday 21 July 2016  11:39:11 -0400 (0:00:00.052)       0:00:11.988 *********
failed: [54.204.157.7] (item={'cert': u'/etc/origin/node/system:node:ec2-107-23-232-25.compute-1.amazonaws.com.crt', 'expiry': u'Jul 19 21:25:46 2018 GMT', 'days_remaining': 728, 'subject': u'O=system:nodes, CN=sy
stem:node:ec2-107-23-232-25.compute-1.amazonaws.com'}) => {"failed": true, "item": {"cert": "/etc/origin/node/system:node:ec2-107-23-232-25.compute-1.amazonaws.com.crt", "days_remaining": 728, "expiry": "Jul 19 21
:25:46 2018 GMT", "subject": "O=system:nodes, CN=system:node:ec2-107-23-232-25.compute-1.amazonaws.com"}, "msg": "On host '54.204.157.7' the cert /etc/origin/node/system:node:ec2-107-23-232-25.compute-1.amazonaws.
com.crt with CommonName O=system:nodes, CN=system:node:ec2-107-23-232-25.compute-1.amazonaws.com expires in 728 days (Jul 19 21:25:46 2018 GMT)"}
failed: [54.88.146.77] (item={'cert': u'/etc/origin/generated-configs/node-ec2-107-23-232-25.compute-1.amazonaws.com/system:node:ec2-107-23-232-25.compute-1.amazonaws.com.crt', 'expiry': u'Jul 19 21:25:46 2018 GMT
', 'days_remaining': 728, 'subject': u'O=system:nodes, CN=system:node:ec2-107-23-232-25.compute-1.amazonaws.com'}) => {"failed": true, "item": {"cert": "/etc/origin/generated-configs/node-ec2-107-23-232-25.compute
-1.amazonaws.com/system:node:ec2-107-23-232-25.compute-1.amazonaws.com.crt", "days_remaining": 728, "expiry": "Jul 19 21:25:46 2018 GMT", "subject": "O=system:nodes, CN=system:node:ec2-107-23-232-25.compute-1.amaz
onaws.com"}, "msg": "On host '54.88.146.77' the cert /etc/origin/generated-configs/node-ec2-107-23-232-25.compute-1.amazonaws.com/system:node:ec2-107-23-232-25.compute-1.amazonaws.com.crt with CommonName O=system:
nodes, CN=system:node:ec2-107-23-232-25.compute-1.amazonaws.com expires in 728 days (Jul 19 21:25:46 2018 GMT)"}
failed: [54.204.157.7] (item={'cert': u'/etc/origin/node/server.crt', 'expiry': u'Jul 19 21:25:52 2018 GMT', 'days_remaining': 728, 'subject': u'CN=107.23.232.25'}) => {"failed": true, "item": {"cert": "/etc/origi
n/node/server.crt", "days_remaining": 728, "expiry": "Jul 19 21:25:52 2018 GMT", "subject": "CN=107.23.232.25"}, "msg": "On host '54.204.157.7' the cert /etc/origin/node/server.crt with CommonName CN=107.23.232.25
 expires in 728 days (Jul 19 21:25:52 2018 GMT)"}
failed: [54.88.146.77] (item={'cert': u'/etc/origin/master/master.etcd-client.crt', 'expiry': u'Jul 19 21:06:09 2017 GMT', 'days_remaining': 363, 'subject': u'CN=ec2-54-209-71-248.compute-1.amazonaws.com'}) => {"f
ailed": true, "item": {"cert": "/etc/origin/master/master.etcd-client.crt", "days_remaining": 363, "expiry": "Jul 19 21:06:09 2017 GMT", "subject": "CN=ec2-54-209-71-248.compute-1.amazonaws.com"}, "msg": "On host 
'54.88.146.77' the cert /etc/origin/master/master.etcd-client.crt with CommonName CN=ec2-54-209-71-248.compute-1.amazonaws.com expires in 363 days (Jul 19 21:06:09 2017 GMT)"}
failed: [54.88.146.77] (item={'cert': u'/etc/origin/master/master.kubelet-client.crt', 'expiry': u'Jul 19 21:13:58 2018 GMT', 'days_remaining': 728, 'subject': u'O=system:node-admins, CN=system:openshift-node-admi
n'}) => {"failed": true, "item": {"cert": "/etc/origin/master/master.kubelet-client.crt", "days_remaining": 728, "expiry": "Jul 19 21:13:58 2018 GMT", "subject": "O=system:node-admins, CN=system:openshift-node-adm
in"}, "msg": "On host '54.88.146.77' the cert /etc/origin/master/master.kubelet-client.crt with CommonName O=system:node-admins, CN=system:openshift-node-admin expires in 728 days (Jul 19 21:13:58 2018 GMT)"}
failed: [54.88.146.77] (item={'cert': u'/etc/origin/generated-configs/node-ec2-107-23-232-25.compute-1.amazonaws.com/server.crt', 'expiry': u'Jul 19 21:25:52 2018 GMT', 'days_remaining': 728, 'subject': u'CN=107.2
3.232.25'}) => {"failed": true, "item": {"cert": "/etc/origin/generated-configs/node-ec2-107-23-232-25.compute-1.amazonaws.com/server.crt", "days_remaining": 728, "expiry": "Jul 19 21:25:52 2018 GMT", "subject": "
CN=107.23.232.25"}, "msg": "On host '54.88.146.77' the cert /etc/origin/generated-configs/node-ec2-107-23-232-25.compute-1.amazonaws.com/server.crt with CommonName CN=107.23.232.25 expires in 728 days (Jul 19 21:2
5:52 2018 GMT)"}

NO MORE HOSTS LEFT *************************************************************
        to retry, use: --limit @playbooks/adhoc/check-cert-expiry.retry

PLAY RECAP *********************************************************************
54.204.157.7               : ok=6    changed=0    unreachable=0    failed=1
54.88.146.77               : ok=5    changed=0    unreachable=0    failed=1
```
