### PR TITLE
Add missing nuke_images.sh symlink.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/nuke_images.sh
+++ b/playbooks/common/openshift-cluster/upgrades/v3_1_to_v3_2/nuke_images.sh
@@ -1,0 +1,1 @@
+../files/nuke_images.sh


### PR DESCRIPTION
Fixes a containerized upgrade error for 3.2 upgrades when using Ansible 2.1.