### PR TITLE
Add an option var to change the hawkular hostname

### DIFF
--- a/roles/openshift_metrics/README.md
+++ b/roles/openshift_metrics/README.md
@@ -13,16 +13,16 @@ Role Variables
 
 From this role:
 
-| Name                                            | Default value         |                                                             |
-|-------------------------------------------------|-----------------------|-------------------------------------------------------------|
-| openshift_hosted_metrics_deploy                 | `False`               | If metrics should be deployed                               |
-| hawkular_metrics_hostname                       | `hawkular-metrics.<default_subdomain>` | Metrics hostanme                       |
-| openshift_hosted_metrics_storage_nfs_directory  | `/exports`            | Root export directory.                                      |
-| openshift_hosted_metrics_storage_volume_name    | `metrics`             | Metrics volume within openshift_hosted_metrics_volume_dir   |
-| openshift_hosted_metrics_storage_volume_size    | `10Gi`                | Metrics volume size                                         |
-| openshift_hosted_metrics_storage_nfs_options    | `*(rw,root_squash)`   | NFS options for configured exports.                         |
-| openshift_hosted_metrics_duration               | `7`                   | Metrics query duration                                      |
-| openshift_hosted_metrics_resolution             | `10s`                 | Metrics resolution                                          |
+| Name                                            | Default value                          |                                                             |
+|-------------------------------------------------|----------------------------------------|-------------------------------------------------------------|
+| openshift_hosted_metrics_deploy                 | `False`                                | If metrics should be deployed                               |
+| hawkular_metrics_hostname                       | `hawkular-metrics.<default_subdomain>` | Metrics hostanme                                            |
+| openshift_hosted_metrics_storage_nfs_directory  | `/exports`                             | Root export directory.                                      |
+| openshift_hosted_metrics_storage_volume_name    | `metrics`                              | Metrics volume within openshift_hosted_metrics_volume_dir   |
+| openshift_hosted_metrics_storage_volume_size    | `10Gi`                                 | Metrics volume size                                         |
+| openshift_hosted_metrics_storage_nfs_options    | `*(rw,root_squash)`                    | NFS options for configured exports.                         |
+| openshift_hosted_metrics_duration               | `7`                                    | Metrics query duration                                      |
+| openshift_hosted_metrics_resolution             | `10s`                                  | Metrics resolution                                          |
 
 
 From openshift_common:

--- a/roles/openshift_metrics/README.md
+++ b/roles/openshift_metrics/README.md
@@ -16,6 +16,7 @@ From this role:
 | Name                                            | Default value         |                                                             |
 |-------------------------------------------------|-----------------------|-------------------------------------------------------------|
 | openshift_hosted_metrics_deploy                 | `False`               | If metrics should be deployed                               |
+| hawkular_metrics_hostname                       | `hawkular-metrics.<default_subdomain>` | Metrics hostanme                       |
 | openshift_hosted_metrics_storage_nfs_directory  | `/exports`            | Root export directory.                                      |
 | openshift_hosted_metrics_storage_volume_name    | `metrics`             | Metrics volume within openshift_hosted_metrics_volume_dir   |
 | openshift_hosted_metrics_storage_volume_size    | `10Gi`                | Metrics volume size                                         |

--- a/roles/openshift_metrics/defaults/main.yaml
+++ b/roles/openshift_metrics/defaults/main.yaml
@@ -1,0 +1,1 @@
+hawkular_metrics_hostname: "hawkular-metrics.{{ openshift.master.default_subdomain }}"

--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -44,7 +44,7 @@
   shell: >
    {{ openshift.common.client_binary }} process -f \
    /usr/share/openshift/examples/infrastructure-templates/{{ hawkular_type }}/metrics-deployer.yaml -v \
-    HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.{{ openshift.master.default_subdomain }},USE_PERSISTENT_STORAGE={{ hawkular_persistence }},METRIC_DURATION={{ openshift.hosted.metrics.duration }},METRIC_RESOLUTION={{ openshift.hosted.metrics.resolution }} \
+    HAWKULAR_METRICS_HOSTNAME={{ hawkular_metrics_hostname }},USE_PERSISTENT_STORAGE={{ hawkular_persistence }},METRIC_DURATION={{ openshift.hosted.metrics.duration }},METRIC_RESOLUTION={{ openshift.hosted.metrics.resolution }} \
     | {{ openshift.common.client_binary }} create -n openshift-infra --config={{hawkular_tmp_conf}} -f -
   register: oex_heapster_services
   failed_when: "'already exists' not in oex_heapster_services.stderr and oex_heapster_services.rc != 0"


### PR DESCRIPTION
Add an optional variable to set the hawkular metrics hostname, defaults to current value.

the haawkular metrics hostname defaults to the current value: `hawkular-metrics.{{ openshift.master.default_subdomain }}`.

Issue:
https://github.com/openshift/openshift-ansible/issues/2208