### PR TITLE
fixing openshift key error in case of node failure during run (ssh is…

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -39,7 +39,6 @@ class FilterModule(object):
             the value.
 
             If the key isn't present, None is returned.
-
             Ex: data = {'a': {'b': {'c': 5}}}
                 attribute = "a.b.c"
                 returns 5
@@ -56,6 +55,7 @@ class FilterModule(object):
                 break
 
         return ptr
+
 
     @staticmethod
     def oo_flatten(data):
@@ -146,6 +146,7 @@ class FilterModule(object):
             retval = [FilterModule.get_attr(d, attribute) for d in data]
 
         retval = [val for val in retval if val != None]
+
         return retval
 
     @staticmethod

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -43,7 +43,7 @@
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_become: "{{ g_sudo | default(omit) }}"
     with_items: "{{ groups.oo_nodes_to_config | default([]) }}"
-    when: hostvars[item].openshift.common.is_containerized | bool and (item in groups.oo_nodes_to_config and item in groups.oo_masters_to_config)
+    when: hostvars[item].openshift.common is defined and hostvars[item].openshift.common.is_containerized | bool and (item in groups.oo_nodes_to_config and item in groups.oo_masters_to_config)
 
 - name: Configure node instances
   hosts: oo_containerized_master_nodes

--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -13,10 +13,11 @@
     {{ openshift.common.admin_binary }} manage-node {{ item.openshift.common.hostname | lower }} --schedulable={{ 'true' if item.openshift.node.schedulable | bool else 'false' }}
   with_items:
     -  "{{ openshift_node_vars }}"
+  when: item.openshift.common.hostname is defined
 
 - name: Label nodes
   command: >
     {{ openshift.common.client_binary }} label --overwrite node {{ item.openshift.common.hostname | lower }} {{ item.openshift.node.labels | oo_combine_dict  }}
   with_items:
     -  "{{ openshift_node_vars }}"
-  when: "'labels' in item.openshift.node and item.openshift.node.labels != {}"
+  when: item.openshift.common.hostname is defined and 'labels' in item.openshift.node and item.openshift.node.labels != {}


### PR DESCRIPTION
the PR fixes   #2158 
When sshing a node is failing, ansible abort with a runtime error, leading to a situation where a failing node prevents the install of a whole cluster. This is a fix for it