### PR TITLE
a-o-i: Write missing openshift_node_labels

### DIFF
--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -205,6 +205,8 @@ def write_host(host, inventory, schedulable=None):
         facts += ' openshift_public_hostname={}'.format(host.public_hostname)
     if host.containerized:
         facts += ' containerized={}'.format(host.containerized)
+    if host.node_labels:
+        facts += ' openshift_node_labels="{}"'.format(host.node_labels)
 
     # Distinguish between three states, no schedulability specified (use default),
     # explicitly set to True, or explicitly set to False:


### PR DESCRIPTION
Currently, the node_labels aren't written to the inventory, which affects different features including the router (requires node label `"{'region': 'infra'}"`).