### PR TITLE
a-o-i: Move inventory vars to the correct location

### DIFF
--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -49,23 +49,7 @@ def generate_inventory(hosts):
 
     write_inventory_vars(base_inventory, multiple_masters, proxy)
 
-    # Find the correct deployment type for ansible:
-    ver = find_variant(CFG.settings['variant'],
-        version=CFG.settings.get('variant_version', None))[1]
-    base_inventory.write('deployment_type={}\n'.format(ver.ansible_key))
 
-    if 'OO_INSTALL_ADDITIONAL_REGISTRIES' in os.environ:
-        base_inventory.write('openshift_docker_additional_registries={}\n'
-          .format(os.environ['OO_INSTALL_ADDITIONAL_REGISTRIES']))
-    if 'OO_INSTALL_INSECURE_REGISTRIES' in os.environ:
-        base_inventory.write('openshift_docker_insecure_registries={}\n'
-          .format(os.environ['OO_INSTALL_INSECURE_REGISTRIES']))
-    if 'OO_INSTALL_PUDDLE_REPO' in os.environ:
-        # We have to double the '{' here for literals
-        base_inventory.write("openshift_additional_repos=[{{'id': 'ose-devel', "
-            "'name': 'ose-devel', "
-            "'baseurl': '{}', "
-            "'enabled': 1, 'gpgcheck': 0}}]\n".format(os.environ['OO_INSTALL_PUDDLE_REPO']))
 
     base_inventory.write('\n[masters]\n')
     for master in masters:
@@ -161,6 +145,24 @@ def write_inventory_vars(base_inventory, multiple_masters, proxy):
         base_inventory.write('openshift_image_tag=v{}\n'.format('3.1.1.6'))
 
     write_proxy_settings(base_inventory)
+
+    # Find the correct deployment type for ansible:
+    ver = find_variant(CFG.settings['variant'],
+        version=CFG.settings.get('variant_version', None))[1]
+    base_inventory.write('deployment_type={}\n'.format(ver.ansible_key))
+
+    if 'OO_INSTALL_ADDITIONAL_REGISTRIES' in os.environ:
+        base_inventory.write('openshift_docker_additional_registries={}\n'
+          .format(os.environ['OO_INSTALL_ADDITIONAL_REGISTRIES']))
+    if 'OO_INSTALL_INSECURE_REGISTRIES' in os.environ:
+        base_inventory.write('openshift_docker_insecure_registries={}\n'
+          .format(os.environ['OO_INSTALL_INSECURE_REGISTRIES']))
+    if 'OO_INSTALL_PUDDLE_REPO' in os.environ:
+        # We have to double the '{' here for literals
+        base_inventory.write("openshift_additional_repos=[{{'id': 'ose-devel', "
+            "'name': 'ose-devel', "
+            "'baseurl': '{}', "
+            "'enabled': 1, 'gpgcheck': 0}}]\n".format(os.environ['OO_INSTALL_PUDDLE_REPO']))
 
     for name, role_obj in CFG.deployment.roles.iteritems():
         if role_obj.variables:


### PR DESCRIPTION
Several variables such as 'deployment_type' and 'ansible_config' were
being set under a variable group for the last defined role instead of
under OSEv3:vars.