### PR TITLE
a-o-i: Support for arbitrary host-level variables

### DIFF
--- a/utils/src/ooinstall/oo_config.py
+++ b/utils/src/ooinstall/oo_config.py
@@ -56,6 +56,8 @@ class Host(object):
         # allowable roles: master, node, etcd, storage, master_lb, new
         self.roles = kwargs.get('roles', [])
 
+        self.other_variables = kwargs.get('other_variables', {})
+
         if self.connect_to is None:
             raise OOConfigInvalidHostError(
                 "You must specify either an ip or hostname as 'connect_to'")
@@ -71,7 +73,8 @@ class Host(object):
         d = {}
 
         for prop in ['ip', 'hostname', 'public_ip', 'public_hostname', 'connect_to',
-                     'preconfigured', 'containerized', 'schedulable', 'roles', 'node_labels']:
+                     'preconfigured', 'containerized', 'schedulable', 'roles', 'node_labels',
+                     'other_variables']:
             # If the property is defined (not None or False), export it:
             if getattr(self, prop):
                 d[prop] = getattr(self, prop)

--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -191,6 +191,7 @@ def write_proxy_settings(base_inventory):
         pass
 
 
+# pylint: disable=too-many-branches
 def write_host(host, inventory, schedulable=None):
     global CFG
 
@@ -205,6 +206,9 @@ def write_host(host, inventory, schedulable=None):
         facts += ' openshift_public_hostname={}'.format(host.public_hostname)
     if host.containerized:
         facts += ' containerized={}'.format(host.containerized)
+    if host.other_variables:
+        for variable, value in host.other_variables.iteritems():
+            facts += " {}={}".format(variable, value)
 
     # Distinguish between three states, no schedulability specified (use default),
     # explicitly set to True, or explicitly set to False:


### PR DESCRIPTION
This allows the user to set a block containing any variables they want to set per-host
instead of per-role.