### PR TITLE
a-o-i: Set roles on standalone storage

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -322,9 +322,7 @@ Note: Containerized storage hosts are not currently supported.
     else:
         host_props['connect_to'] = hostname_or_ip
         host_props['preconfigured'] = False
-        host_props['master'] = False
-        host_props['node'] = False
-        host_props['storage'] = True
+        host_props['roles'] = ['storage']
         storage = Host(**host_props)
         hosts.append(storage)
 


### PR DESCRIPTION
Sets the roles appropriately when using a standalone storage host.

Fixes BZ#1353152