### PR TITLE
a-o-i: Add support for Atomic Registry Installs

### DIFF
--- a/playbooks/byo/openshift-cluster/config.yml
+++ b/playbooks/byo/openshift-cluster/config.yml
@@ -26,4 +26,4 @@
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
     openshift_debug_level: "{{ debug_level | default(2) }}"
     openshift_deployment_type: "{{ deployment_type }}"
-    openshift_deployment_subtype: "{{ deployment_subtype }}"
+    openshift_deployment_subtype: "{{ deployment_subtype | default(none) }}"

--- a/playbooks/byo/openshift-cluster/config.yml
+++ b/playbooks/byo/openshift-cluster/config.yml
@@ -26,3 +26,4 @@
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
     openshift_debug_level: "{{ debug_level | default(2) }}"
     openshift_deployment_type: "{{ deployment_type }}"
+    openshift_deployment_subtype: "{{ deployment_subtype }}"

--- a/playbooks/common/openshift-cluster/additional_config.yml
+++ b/playbooks/common/openshift-cluster/additional_config.yml
@@ -15,6 +15,8 @@
     when: openshift.common.use_manageiq | bool
   - role: cockpit
     when: not openshift.common.is_atomic and ( deployment_type in ['atomic-enterprise','openshift-enterprise'] ) and
-      (osm_use_cockpit | bool or osm_use_cockpit is undefined )
+      (osm_use_cockpit | bool or osm_use_cockpit is undefined ) and ( deployment_subtype != 'registry' )
+  - role: cockpit-ui
+    when: not openshift.common.is_atomic and ( deployment_subtype == 'registry' )
   - role: flannel_register
     when: openshift.common.use_flannel | bool

--- a/playbooks/common/openshift-cluster/additional_config.yml
+++ b/playbooks/common/openshift-cluster/additional_config.yml
@@ -15,6 +15,6 @@
     when: openshift.common.use_manageiq | bool
   - role: cockpit
     when: not openshift.common.is_atomic and ( deployment_type in ['atomic-enterprise','openshift-enterprise'] ) and
-      (osm_use_cockpit | bool or osm_use_cockpit is undefined ) and ( deployment_subtype != 'registry' )
+      (osm_use_cockpit | bool or osm_use_cockpit is undefined ) and ( openshift.common.deployment_subtype != 'registry' )
   - role: flannel_register
     when: openshift.common.use_flannel | bool

--- a/playbooks/common/openshift-cluster/additional_config.yml
+++ b/playbooks/common/openshift-cluster/additional_config.yml
@@ -16,7 +16,5 @@
   - role: cockpit
     when: not openshift.common.is_atomic and ( deployment_type in ['atomic-enterprise','openshift-enterprise'] ) and
       (osm_use_cockpit | bool or osm_use_cockpit is undefined ) and ( deployment_subtype != 'registry' )
-  - role: cockpit-ui
-    when: not openshift.common.is_atomic and ( deployment_subtype == 'registry' )
   - role: flannel_register
     when: openshift.common.use_flannel | bool

--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -45,4 +45,4 @@
   - role: openshift_metrics
     when: openshift.hosted.metrics.deploy | bool
   - role: cockpit-ui
-    when: not openshift.common.is_atomic and ( deployment_subtype == 'registry' )
+    when: ( openshift.common.deployment_subtype == 'registry' )

--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -1,3 +1,4 @@
+---
 - name: Create persistent volumes
   hosts: oo_first_master
   tags:
@@ -43,3 +44,5 @@
   - role: openshift_hosted
   - role: openshift_metrics
     when: openshift.hosted.metrics.deploy | bool
+  - role: cockpit-ui
+    when: not openshift.common.is_atomic and ( deployment_subtype == 'registry' )

--- a/roles/cockpit-ui/meta/main.yml
+++ b/roles/cockpit-ui/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  author: Samuel Munilla
+  description: Deploy and Enable cockpit-ui
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 2.1
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud

--- a/roles/cockpit-ui/tasks/main.yml
+++ b/roles/cockpit-ui/tasks/main.yml
@@ -1,15 +1,47 @@
 ---
-- name: Expose registry with route
-  command: oc expose service docker-registry
+- name: Expose docker-registry
+  command: >
+    {{ openshift.common.client_binary }} expose service docker-registry -n default
+  register: expose_docker_registry
+  changed_when: "'already exists' not in expose_docker_registry.stderr"
+  failed_when: "'already exists' not in expose_docker_registry.stderr and expose_docker_registry.rc != 0"
 
-- name: Install Cockpit template
-  command: oc create -f registry-console.yaml -n default
+- name: Create passthrough route for registry-console
+  command: >
+    {{ openshift.common.client_binary }} create route passthrough
+    --service registry-console
+    --port registry-console
+    -n default
+  register: create_registry_console_route
+  changed_when: "'already exists' not in create_registry_console_route.stderr"
+  failed_when: "'already exists' not in create_registry_console_route.stderr and create_registry_console_route.rc != 0"
 
-- name: Create passthrough route for Registry
-  command: oc create route passthrough --service registry-console --port registry-console -n default
+- name: Retrieve docker-registry route
+  command: "{{ openshift.common.client_binary }} get route docker-registry -n default --template='{{ '{{' }} .spec.host {{ '}}' }}'"
+  register: docker_registry_route
+  failed_when: false
+  changed_when: false
 
-- name: Deploy Registry
-  command: oc new-app -n default --template=registry-console -p OPENSHIFT_OAUTH_PROVIDER_URL="{{ openshift_https_proxy }}:8443",REGISTRY_HOST=$(oc get route docker-registry -n default --template='{{ .spec.host }}'),COCKPIT_KUBE_URL=$(oc get route registry-console -n default --template='https://{{ .spec.host }}')
+- name: Retrieve cockpit kube url
+  command: "{{ openshift.common.client_binary }} get route registry-console -n default --template='https://{{ '{{' }} .spec.host {{ '}}' }}'"
+  register: registry_console_cockpit_kube_url
+  failed_when: false
+  changed_when: false
+
+- set_fact:
+    cockpit_image_prefix: "{{ '-p IMAGE_PREFIX=' ~ openshift_cockpit_deployer_prefix | default('') }}"
+
+- name: Deploy registry-console
+  command: >
+    {{ openshift.common.client_binary }} new-app --template=registry-console
+    {{ cockpit_image_prefix }}
+    -p OPENSHIFT_OAUTH_PROVIDER_URL="{{ openshift.master.public_api_url }}"
+    -p REGISTRY_HOST="{{ docker_registry_route.stdout }}"
+    -p COCKPIT_KUBE_URL="{{ registry_console_cockpit_kube_url.stdout }}"
+    -n default
+  register: deploy_registry_console
+  changed_when: "'already exists' not in deploy_registry_console.stderr"
+  failed_when: "'already exists' not in deploy_registry_console.stderr and deploy_registry_console.rc != 0"
 
 - name: Enable cockpit-ui
   service:

--- a/roles/cockpit-ui/tasks/main.yml
+++ b/roles/cockpit-ui/tasks/main.yml
@@ -42,10 +42,3 @@
   register: deploy_registry_console
   changed_when: "'already exists' not in deploy_registry_console.stderr"
   failed_when: "'already exists' not in deploy_registry_console.stderr and deploy_registry_console.rc != 0"
-
-- name: Enable cockpit-ui
-  service:
-    name: cockpit.socket
-    enabled: true
-    state: started
-  when: not openshift.common.is_containerized | bool

--- a/roles/cockpit-ui/tasks/main.yml
+++ b/roles/cockpit-ui/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Expose registry with route
+  command: oc expose service docker-registry
+
+- name: Install Cockpit template
+  command: oc create -f registry-console.yaml -n default
+
+- name: Create passthrough route for Registry
+  command: oc create route passthrough --service registry-console --port registry-console -n default
+
+- name: Deploy Registry
+  command: oc new-app -n default --template=registry-console -p OPENSHIFT_OAUTH_PROVIDER_URL="{{ openshift_https_proxy }}:8443",REGISTRY_HOST=$(oc get route docker-registry -n default --template='{{ .spec.host }}'),COCKPIT_KUBE_URL=$(oc get route registry-console -n default --template='https://{{ .spec.host }}')
+
+- name: Enable cockpit-ui
+  service:
+    name: cockpit.socket
+    enabled: true
+    state: started
+  when: not openshift.common.is_containerized | bool

--- a/roles/openshift_examples/defaults/main.yml
+++ b/roles/openshift_examples/defaults/main.yml
@@ -20,6 +20,8 @@ xpaas_templates_base: "{{ examples_base }}/xpaas-templates"
 quickstarts_base: "{{ examples_base }}/quickstart-templates"
 infrastructure_origin_base: "{{ examples_base }}/infrastructure-templates/origin"
 infrastructure_enterprise_base: "{{ examples_base }}/infrastructure-templates/enterprise"
+cockpit_ui_base: "{{ examples_base }}/infrastructure-templates/enterprise"
+
 
 openshift_examples_import_command: "create"
 registry_url: ""

--- a/roles/openshift_examples/files/examples/v1.3/infrastructure-templates/enterprise/registry-console.yaml
+++ b/roles/openshift_examples/files/examples/v1.3/infrastructure-templates/enterprise/registry-console.yaml
@@ -1,0 +1,124 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: "registry-console"
+  annotations:
+    description: "Template for deploying registry web console. Requires cluster-admin."
+    tags: infrastructure
+labels:
+  createdBy: "registry-console-template"
+objects:
+  - kind: DeploymentConfig
+    apiVersion: v1
+    metadata:
+      name: "registry-console"
+      labels:
+        name: "registry-console"
+    spec:
+      triggers:
+      - type: ConfigChange
+      replicas: 1
+      selector:
+        name: "registry-console"
+      template:
+        metadata:
+          labels:
+            name: "registry-console"
+        spec:
+          containers:
+            - name: registry-console
+              image: ${IMAGE_PREFIX}registry-console:${IMAGE_VERSION}
+              ports:
+                - containerPort: 9090
+                  protocol: TCP
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /ping
+                  port: 9090
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /ping
+                  port: 9090
+                  scheme: HTTP
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              env:
+                - name: OPENSHIFT_OAUTH_PROVIDER_URL
+                  value: "${OPENSHIFT_OAUTH_PROVIDER_URL}"
+                - name: OPENSHIFT_OAUTH_CLIENT_ID
+                  value: "${OPENSHIFT_OAUTH_CLIENT_ID}"
+                - name: KUBERNETES_INSECURE
+                  value: "false"
+                - name: COCKPIT_KUBE_INSECURE
+                  value: "false"
+                - name: REGISTRY_ONLY
+                  value: "true"
+                - name: REGISTRY_HOST
+                  value: "${REGISTRY_HOST}"
+  - kind: Service
+    apiVersion: v1
+    metadata:
+     name: "registry-console"
+     labels:
+       name: "registry-console"
+    spec:
+      type: ClusterIP
+      ports:
+        - name: registry-console
+          protocol: TCP
+          port: 9000
+          targetPort: 9090
+      selector:
+        name: "registry-console"
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: registry-console
+      annotations:
+        description: Atomic Registry console
+    spec:
+      tags:
+        - annotations: null
+          from:
+            kind: DockerImage
+            name: ${IMAGE_PREFIX}registry-console
+          name: ${IMAGE_VERSION}
+  - kind: OAuthClient
+    apiVersion: v1
+    metadata:
+      name: "${OPENSHIFT_OAUTH_CLIENT_ID}"
+      respondWithChallenges: false
+    secret: "${OPENSHIFT_OAUTH_CLIENT_SECRET}"
+    redirectURIs:
+      - "${COCKPIT_KUBE_URL}"
+parameters:
+  - description: 'Specify "registry/repository" prefix for container image; e.g. for "registry.access.redhat.com/openshift3/registry-console:latest", set prefix "registry.access.redhat.com/openshift3/"'
+    name: IMAGE_PREFIX
+    value: "registry.access.redhat.com/openshift3/"
+  - description: 'Specify image version; e.g. for "registry.access.redhat.com/openshift3/registry-console:3.3", set version "3.3"'
+    name: IMAGE_VERSION
+    value: "3.3"
+  - description: "The public URL for the Openshift OAuth Provider, e.g. https://openshift.example.com:8443"
+    name: OPENSHIFT_OAUTH_PROVIDER_URL
+    required: true
+  - description: "The registry console URL. This should be created beforehand using 'oc create route passthrough --service registry-console --port registry-console -n default', e.g. https://registry-console-default.example.com"
+    name: COCKPIT_KUBE_URL
+    required: true
+  - description: "Oauth client secret"
+    name: OPENSHIFT_OAUTH_CLIENT_SECRET
+    from: "user[a-zA-Z0-9]{64}"
+    generate: expression
+  - description: "Oauth client id"
+    name: OPENSHIFT_OAUTH_CLIENT_ID
+    value: "cockpit-oauth-client"
+  - description: "The integrated registry hostname exposed via route, e.g. registry.example.com"
+    name: REGISTRY_HOST
+    required: true

--- a/roles/openshift_examples/files/examples/v1.3/infrastructure-templates/origin/registry-console.yaml
+++ b/roles/openshift_examples/files/examples/v1.3/infrastructure-templates/origin/registry-console.yaml
@@ -1,0 +1,124 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: "registry-console"
+  annotations:
+    description: "Template for deploying registry web console. Requires cluster-admin."
+    tags: infrastructure
+labels:
+  createdBy: "registry-console-template"
+objects:
+  - kind: DeploymentConfig
+    apiVersion: v1
+    metadata:
+      name: "registry-console"
+      labels:
+        name: "registry-console"
+    spec:
+      triggers:
+      - type: ConfigChange
+      replicas: 1
+      selector:
+        name: "registry-console"
+      template:
+        metadata:
+          labels:
+            name: "registry-console"
+        spec:
+          containers:
+            - name: registry-console
+              image: ${IMAGE_NAME}:${IMAGE_VERSION}
+              ports:
+                - containerPort: 9090
+                  protocol: TCP
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /ping
+                  port: 9090
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /ping
+                  port: 9090
+                  scheme: HTTP
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              env:
+                - name: OPENSHIFT_OAUTH_PROVIDER_URL
+                  value: "${OPENSHIFT_OAUTH_PROVIDER_URL}"
+                - name: OPENSHIFT_OAUTH_CLIENT_ID
+                  value: "${OPENSHIFT_OAUTH_CLIENT_ID}"
+                - name: KUBERNETES_INSECURE
+                  value: "false"
+                - name: COCKPIT_KUBE_INSECURE
+                  value: "false"
+                - name: REGISTRY_ONLY
+                  value: "true"
+                - name: REGISTRY_HOST
+                  value: "${REGISTRY_HOST}"
+  - kind: Service
+    apiVersion: v1
+    metadata:
+     name: "registry-console"
+     labels:
+       name: "registry-console"
+    spec:
+      type: ClusterIP
+      ports:
+        - name: registry-console
+          protocol: TCP
+          port: 9000
+          targetPort: 9090
+      selector:
+        name: "registry-console"
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: registry-console
+      annotations:
+        description: Atomic Registry console
+    spec:
+      tags:
+        - annotations: null
+          from:
+            kind: DockerImage
+            name: ${IMAGE_NAME}
+          name: ${IMAGE_VERSION}
+  - kind: OAuthClient
+    apiVersion: v1
+    metadata:
+      name: "${OPENSHIFT_OAUTH_CLIENT_ID}"
+      respondWithChallenges: false
+    secret: "${OPENSHIFT_OAUTH_CLIENT_SECRET}"
+    redirectURIs:
+      - "${COCKPIT_KUBE_URL}"
+parameters:
+  - description: "Container image name"
+    name: IMAGE_NAME
+    value: "cockpit/kubernetes"
+  - description: 'Specify image version; e.g. for "cockpit/kubernetes:latest", set version "latest"'
+    name: IMAGE_VERSION
+    value: latest
+  - description: "The public URL for the Openshift OAuth Provider, e.g. https://openshift.example.com:8443"
+    name: OPENSHIFT_OAUTH_PROVIDER_URL
+    required: true
+  - description: "The registry console URL. This should be created beforehand using 'oc create route passthrough --service registry-console --port registry-console -n default', e.g. https://registry-console-default.example.com"
+    name: COCKPIT_KUBE_URL
+    required: true
+  - description: "Oauth client secret"
+    name: OPENSHIFT_OAUTH_CLIENT_SECRET
+    from: "user[a-zA-Z0-9]{64}"
+    generate: expression
+  - description: "Oauth client id"
+    name: OPENSHIFT_OAUTH_CLIENT_ID
+    value: "cockpit-oauth-client"
+  - description: "The integrated registry hostname exposed via route, e.g. registry.example.com"
+    name: REGISTRY_HOST
+    required: true

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -797,7 +797,7 @@ def set_deployment_facts_if_unset(facts):
                 curr_disabled_features = set(facts['master']['disabled_features'])
                 facts['master']['disabled_features'] = list(curr_disabled_features.union(openshift_features))
         else:
-            if deployment_type == 'atomic-enterprise':
+            if facts['common']['deployment_subtype'] == 'registry':
                 facts['master']['disabled_features'] = openshift_features
 
     if 'node' in facts:

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1657,7 +1657,12 @@ class OpenShiftFacts(object):
         else:
             deployment_type = 'origin'
 
-        defaults = self.get_defaults(roles, deployment_type)
+        if 'common' in local_facts and 'deployment_subtype' in local_facts['common']:
+            deployment_subtype = local_facts['common']['deployment_subtype']
+        else:
+            deployment_subtype = 'basic'
+
+        defaults = self.get_defaults(roles, deployment_type, deployment_subtype)
         provider_facts = self.init_provider_facts()
         facts = apply_provider_facts(defaults, provider_facts)
         facts = merge_facts(facts,
@@ -1689,7 +1694,7 @@ class OpenShiftFacts(object):
             facts = set_installed_variant_rpm_facts(facts)
         return dict(openshift=facts)
 
-    def get_defaults(self, roles, deployment_type):
+    def get_defaults(self, roles, deployment_type, deployment_subtype):
         """ Get default fact values
 
             Args:
@@ -1709,6 +1714,7 @@ class OpenShiftFacts(object):
         defaults['common'] = dict(use_openshift_sdn=True, ip=ip_addr,
                                   public_ip=ip_addr,
                                   deployment_type=deployment_type,
+                                  deployment_subtype=deployment_subtype,
                                   hostname=hostname,
                                   public_hostname=hostname,
                                   portal_net='172.30.0.0/16',

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -24,6 +24,7 @@
     local_facts:
       # TODO: Deprecate deployment_type in favor of openshift_deployment_type
       deployment_type: "{{ openshift_deployment_type | default(deployment_type) }}"
+      deployment_subtype: "{{ openshift_deployment_subtype | default(deployment_subtype) }}"
       cluster_id: "{{ openshift_cluster_id | default('default') }}"
       hostname: "{{ openshift_hostname | default(None) }}"
       ip: "{{ openshift_ip | default(None) }}"
@@ -40,4 +41,3 @@
 - name: Set repoquery command
   set_fact:
     repoquery_cmd: "{{ 'dnf repoquery --latest-limit 1 -d 0' if ansible_pkg_mgr == 'dnf' else 'repoquery --plugins' }}"
-

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -24,7 +24,7 @@
     local_facts:
       # TODO: Deprecate deployment_type in favor of openshift_deployment_type
       deployment_type: "{{ openshift_deployment_type | default(deployment_type) }}"
-      deployment_subtype: "{{ openshift_deployment_subtype | default(deployment_subtype) }}"
+      deployment_subtype: "{{ openshift_deployment_subtype | default(None) }}"
       cluster_id: "{{ openshift_cluster_id | default('default') }}"
       hostname: "{{ openshift_hostname | default(None) }}"
       ip: "{{ openshift_ip | default(None) }}"

--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -638,6 +638,7 @@ https://docs.openshift.com/enterprise/latest/admin_guide/install/prerequisites.h
         variant, version = get_variant_and_version()
         oo_cfg.settings['variant'] = variant.name
         oo_cfg.settings['variant_version'] = version.name
+        oo_cfg.settings['variant_subtype'] = version.subtype
         click.clear()
 
     if not oo_cfg.deployment.hosts:

--- a/utils/src/ooinstall/oo_config.py
+++ b/utils/src/ooinstall/oo_config.py
@@ -17,6 +17,7 @@ CONFIG_PERSIST_SETTINGS = [
     'deployment',
     'version',
     'variant',
+    'variant_subtype',
     'variant_version',
 ]
 

--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -22,8 +22,12 @@ ROLES_TO_GROUPS_MAP = {
 VARIABLES_MAP = {
     'ansible_ssh_user': 'ansible_ssh_user',
     'deployment_type': 'deployment_type',
+    'variant_subtype': 'deployment_subtype',
     'master_routingconfig_subdomain': 'openshift_master_default_subdomain',
     'proxy_http': 'openshift_http_proxy',
+    'variant_subtype': 'deployment_subtype',
+    'master_routingconfig_subdomain':'openshift_master_default_subdomain',
+    'proxy_http':'openshift_http_proxy',
     'proxy_https': 'openshift_https_proxy',
     'proxy_exclude_hosts': 'openshift_no_proxy',
 }
@@ -128,6 +132,8 @@ def write_inventory_vars(base_inventory, multiple_masters, lb):
     ver = find_variant(CFG.settings['variant'],
                        version=CFG.settings.get('variant_version', None))[1]
     base_inventory.write('deployment_type={}\n'.format(ver.ansible_key))
+    if getattr(ver, 'variant_subtype', False):
+        base_inventory.write('deployment_subtype={}\n'.format(ver.deployment_subtype))
 
     if 'OO_INSTALL_ADDITIONAL_REGISTRIES' in os.environ:
         base_inventory.write('openshift_docker_additional_registries={}\n'.format(

--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -25,9 +25,6 @@ VARIABLES_MAP = {
     'variant_subtype': 'deployment_subtype',
     'master_routingconfig_subdomain': 'openshift_master_default_subdomain',
     'proxy_http': 'openshift_http_proxy',
-    'variant_subtype': 'deployment_subtype',
-    'master_routingconfig_subdomain':'openshift_master_default_subdomain',
-    'proxy_http':'openshift_http_proxy',
     'proxy_https': 'openshift_https_proxy',
     'proxy_exclude_hosts': 'openshift_no_proxy',
 }

--- a/utils/src/ooinstall/variants.py
+++ b/utils/src/ooinstall/variants.py
@@ -16,10 +16,11 @@ installer_log = logging.getLogger('installer')
 
 
 class Version(object):
-    def __init__(self, name, ansible_key):
+    def __init__(self, name, ansible_key, subtype=''):
         self.name = name  # i.e. 3.0, 3.1
 
         self.ansible_key = ansible_key
+        self.subtype = subtype
 
 
 class Variant(object):
@@ -43,6 +44,12 @@ OSE = Variant('openshift-enterprise', 'OpenShift Container Platform',
               ]
 )
 
+REG = Variant('openshift-enterprise', 'Registry',
+    [
+        Version('3.2', 'openshift-enterprise', 'registry'),
+    ]
+)
+
 origin = Variant('origin', 'OpenShift Origin',
                  [
                      Version('1.2', 'origin'),
@@ -58,8 +65,8 @@ LEGACY = Variant('openshift-enterprise', 'OpenShift Container Platform',
 )
 
 # Ordered list of variants we can install, first is the default.
-SUPPORTED_VARIANTS = (OSE, origin, LEGACY)
-DISPLAY_VARIANTS = (OSE, )
+SUPPORTED_VARIANTS = (OSE, REG, origin, LEGACY)
+DISPLAY_VARIANTS = (OSE, REG,)
 
 
 def find_variant(name, version=None):

--- a/utils/src/ooinstall/variants.py
+++ b/utils/src/ooinstall/variants.py
@@ -45,9 +45,9 @@ OSE = Variant('openshift-enterprise', 'OpenShift Container Platform',
 )
 
 REG = Variant('openshift-enterprise', 'Registry',
-    [
-        Version('3.2', 'openshift-enterprise', 'registry'),
-    ]
+              [
+                  Version('3.2', 'openshift-enterprise', 'registry'),
+              ]
 )
 
 origin = Variant('origin', 'OpenShift Origin',


### PR DESCRIPTION
Add the Registry deployment type as an option in the quick installer.

Supersedes #2318 