### PR TITLE
Don't set a networkPluginName in 3.3 installs

### DIFF
--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -13,14 +13,14 @@ imageConfig:
 kind: NodeConfig
 kubeletArguments: {{ openshift.node.kubelet_args | default(None) | to_padded_yaml(level=1) }}
 masterKubeConfig: system:node:{{ openshift.common.hostname }}.kubeconfig
-{% if openshift.common.use_openshift_sdn %}
+{% if openshift.common.use_openshift_sdn | bool and not openshift.common.version_gte_3_3_or_1_3 | bool %}
 networkPluginName: {{ openshift.common.sdn_network_plugin_name }}
 {% endif %}
 # networkConfig struct introduced in origin 1.0.6 and OSE 3.0.2 which
 # deprecates networkPluginName above. The two should match.
 networkConfig:
    mtu: {{ openshift.node.sdn_mtu }}
-{% if openshift.common.use_openshift_sdn or openshift.common.use_nuage %}
+{% if ( openshift.common.use_openshift_sdn | bool or openshift.common.use_nuage | bool ) and not openshift.common.version_gte_3_3_or_1_3 | bool%}
    networkPluginName: {{ openshift.common.sdn_network_plugin_name }}
 {% endif %}
 {% if openshift.node.set_node_ip | bool %}


### PR DESCRIPTION
Fixes #2066 

For now, conditionalize it, remove it entirely in the near future.