### PR TITLE
a-o-i: Remove AEP, OSE 3.0, and OSE 3.2 choices

### DIFF
--- a/utils/src/ooinstall/variants.py
+++ b/utils/src/ooinstall/variants.py
@@ -37,15 +37,6 @@ class Variant(object):
 OSE = Variant('openshift-enterprise', 'OpenShift Enterprise',
     [
         Version('3.2', 'openshift-enterprise'),
-        Version('3.1', 'openshift-enterprise'),
-        Version('3.0', 'enterprise')
-    ]
-)
-
-AEP = Variant('atomic-enterprise', 'Atomic Enterprise Platform',
-    [
-        Version('3.2', 'atomic-enterprise'),
-        Version('3.1', 'atomic-enterprise')
     ]
 )
 
@@ -56,8 +47,8 @@ origin = Variant('origin', 'OpenShift Origin',
 )
 
 # Ordered list of variants we can install, first is the default.
-SUPPORTED_VARIANTS = (OSE, AEP, origin)
-DISPLAY_VARIANTS = (OSE, AEP)
+SUPPORTED_VARIANTS = (OSE, origin)
+DISPLAY_VARIANTS = (OSE, )
 
 def find_variant(name, version=None):
     """

--- a/utils/test/cli_installer_tests.py
+++ b/utils/test/cli_installer_tests.py
@@ -573,7 +573,7 @@ class UnattendedCliTests(OOCliFixture):
         run_playbook_mock.return_value = 0
 
         config = SAMPLE_CONFIG % 'openshift-enterprise'
-        config = '%s\n%s' % (config, 'variant_version: 3.0')
+        config = '%s\n%s' % (config, 'variant_version: 3.2')
         config_file = self.write_config(os.path.join(self.work_dir,
             'ooinstall.conf'), config)
 
@@ -586,11 +586,11 @@ class UnattendedCliTests(OOCliFixture):
         self.assertEquals('openshift-enterprise', written_config['variant'])
         # Make sure our older version was preserved:
         # and written to disk:
-        self.assertEquals('3.0', written_config['variant_version'])
+        self.assertEquals('3.2', written_config['variant_version'])
 
         inventory = ConfigParser.ConfigParser(allow_no_value=True)
         inventory.read(os.path.join(self.work_dir, 'hosts'))
-        self.assertEquals('enterprise',
+        self.assertEquals('openshift-enterprise',
             inventory.get('OSEv3:vars', 'deployment_type'))
 
     @patch('ooinstall.openshift_ansible.run_ansible')
@@ -1068,26 +1068,6 @@ class AttendedCliTests(OOCliFixture):
         self.assert_inventory_host_var(inventory, 'nodes', '10.0.0.1',
                                        'openshift_schedulable=True')
 
-    #interactive 3.0 install confirm no HA hints
-    @patch('ooinstall.openshift_ansible.run_main_playbook')
-    @patch('ooinstall.openshift_ansible.load_system_facts')
-    def test_ha_hint(self, load_facts_mock, run_playbook_mock):
-        load_facts_mock.return_value = (MOCK_FACTS, 0)
-        run_playbook_mock.return_value = 0
-
-        cli_input = build_input(hosts=[
-            ('10.0.0.1', True, False)],
-                                      ssh_user='root',
-                                      variant_num=3,
-                                      confirm_facts='y',
-                                      storage='10.1.0.1',)
-        self.cli_args.append("install")
-        result = self.runner.invoke(cli.cli, self.cli_args,
-            input=cli_input)
-        self.assert_result(result, 0)
-        print result.output
-        self.assertTrue("NOTE: Add a total of 3 or more Masters to perform an HA installation."
-            not in result.output)
 
     @patch('ooinstall.openshift_ansible.run_main_playbook')
     @patch('ooinstall.openshift_ansible.load_system_facts')


### PR DESCRIPTION
Remove the option to select unsupported versions in the quick installer.

Fixes BZ#1358101