### PR TITLE
a-o-i: Fix broken uninstall

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -828,21 +828,25 @@ def uninstall(ctx):
     oo_cfg = ctx.obj['oo_cfg']
     verbose = ctx.obj['verbose']
 
-    if len(oo_cfg.deployment.hosts) == 0:
+    if hasattr(oo_cfg, 'deployment'):
+        hosts = oo_cfg.deployment.hosts
+    elif hasattr(oo_cfg, 'hosts'):
+        hosts = oo_cfg.hosts
+    else:
         click.echo("No hosts defined in: %s" % oo_cfg.config_path)
         sys.exit(1)
 
     click.echo("OpenShift will be uninstalled from the following hosts:\n")
     if not ctx.obj['unattended']:
         # Prompt interactively to confirm:
-        for host in oo_cfg.deployment.hosts:
+        for host in hosts:
             click.echo("  * %s" % host.connect_to)
         proceed = click.confirm("\nDo you wish to proceed?")
         if not proceed:
             click.echo("Uninstall cancelled.")
             sys.exit(0)
 
-    openshift_ansible.run_uninstall_playbook(verbose)
+    openshift_ansible.run_uninstall_playbook(hosts, verbose)
 
 
 @click.command()

--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -279,10 +279,10 @@ def run_ansible(playbook, inventory, env_vars, verbose=False):
     return subprocess.call(args, env=env_vars)
 
 
-def run_uninstall_playbook(verbose=False):
+def run_uninstall_playbook(hosts, verbose=False):
     playbook = os.path.join(CFG.settings['ansible_playbook_directory'],
         'playbooks/adhoc/uninstall.yml')
-    inventory_file = generate_inventory(CFG.hosts)
+    inventory_file = generate_inventory(hosts)
     facts_env = os.environ.copy()
     if 'ansible_log_path' in CFG.settings:
         facts_env['ANSIBLE_LOG_PATH'] = CFG.settings['ansible_log_path']


### PR DESCRIPTION
The uninstall method was looking for the host list according to the
old quick-installer config file format. Updated to match the new
arbitrary yaml config format.

Fixes BZ#1359427