### PR TITLE
a-o-i: Rename OSE in Install Menu

### DIFF
--- a/utils/src/ooinstall/variants.py
+++ b/utils/src/ooinstall/variants.py
@@ -34,7 +34,7 @@ class Variant(object):
 
 
 # WARNING: Keep the versions ordered, most recent first:
-OSE = Variant('openshift-enterprise', 'OpenShift Enterprise',
+OSE = Variant('openshift-enterprise', 'OpenShift Container Platform',
     [
         Version('3.2', 'openshift-enterprise'),
     ]


### PR DESCRIPTION
Rename 'OpenShift Enterprise' to 'OpenShift Container Platform' in the quick installer menu.