### PR TITLE
Bug 1347650 - New master isn't added to haproxy.cfg file of LB when scaling masters

### DIFF
--- a/playbooks/common/openshift-master/scaleup.yml
+++ b/playbooks/common/openshift-master/scaleup.yml
@@ -58,4 +58,6 @@
 
 - include: ../openshift-master/config.yml
 
+- include: ../openshift-loadbalancer/config.yml
+
 - include: ../openshift-node/config.yml


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1347650