### PR TITLE
make the improved log formatter work with ansible 2.1

### DIFF
--- a/callback_plugins/default.py
+++ b/callback_plugins/default.py
@@ -27,6 +27,12 @@ DEFAULT_MODULE = imp.load_source(
     DEFAULT_PATH
 )
 
+try:
+    from ansible.plugins.callback import CallbackBase
+    BASECLASS = CallbackBase
+except ImportError: # < ansible 2.1
+    BASECLASS = DEFAULT_MODULE.CallbackModule
+
 
 class CallbackModule(DEFAULT_MODULE.CallbackModule):  # pylint: disable=too-few-public-methods,no-init
     '''
@@ -48,7 +54,7 @@ class CallbackModule(DEFAULT_MODULE.CallbackModule):  # pylint: disable=too-few-
             if key in result:
                 save[key] = result.pop(key)
 
-        output = DEFAULT_MODULE.CallbackModule._dump_results(self, result)
+        output = BASECLASS._dump_results(self, result) # pylint: disable=protected-access
 
         for key in ['stdout', 'stderr', 'msg']:
             if key in save and save[key]:


### PR DESCRIPTION
Ansible 2.1 changed the base class used for log formatting.  Using
the old one with ansible 2.1 caused a "too much recursion" problem.
The fix is to call _dump_results in the new CallbackBase base class
when using ansible 2.1 or later.