### PR TITLE
removing auto ansible_connection = local attr from ooinstaller

### DIFF
--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -202,7 +202,6 @@ def write_host(host, role, inventory, schedulable=None):
 
     installer_host = socket.gethostname()
     if installer_host in [host.connect_to, host.hostname, host.public_hostname]:
-        facts += ' ansible_connection=local'
         if os.geteuid() != 0:
             no_pwd_sudo = subprocess.call(['sudo', '-n', 'echo', 'openshift'])
             if no_pwd_sudo == 1:


### PR DESCRIPTION
@smunilla @sdodson 
suggested fix for:
https://github.com/openshift/openshift-ansible/issues/2262
We will loose the few optimizations because we connecting via ssh to the same machine, but if a user will specify it it will still work.