### PR TITLE
Fix GCE Launch

### DIFF
--- a/playbooks/gce/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/gce/openshift-cluster/tasks/launch_instances.yml
@@ -1,7 +1,7 @@
 ---
 - name: Launch instance(s)
   gce:
-    instance_names: "{{ instances }}"
+    instance_names: "{{ instances|join(',') }}"
     machine_type: "{{ gce_machine_type | default(deployment_vars[deployment_type].machine_type, true) }}"
     image: "{{ gce_machine_image | default(deployment_vars[deployment_type].image, true) }}"
     service_account_email: "{{ lookup('env', 'gce_service_account_email_address') }}"


### PR DESCRIPTION
The Ansible GCE module (documentation here: http://docs.ansible.com/ansible/gce_module.html) requires a comma separated list when you pass an array here (even with a single element) the argument has square brackets around it and the instance doesn't get launched.  Testing shows that joining with ', ' (comma space) works with one instance but breaks with two so I used ',' (comma no space).