### PR TITLE
a-i-o: Relocate the variables related ansible

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -490,7 +490,7 @@ def error_if_missing_info(oo_cfg):
                    'command line or in the config file: %s' % oo_cfg.config_path)
         sys.exit(1)
 
-    if 'ansible_ssh_user' not in oo_cfg.settings:
+    if 'ansible_ssh_user' not in oo_cfg.deployment.variables:
         click.echo("Must specify ansible_ssh_user in configuration file.")
         sys.exit(1)
 
@@ -586,7 +586,8 @@ https://docs.openshift.com/enterprise/latest/admin_guide/install/prerequisites.h
     click.clear()
 
     if not oo_cfg.settings.get('ansible_ssh_user', ''):
-        oo_cfg.settings['ansible_ssh_user'] = get_ansible_ssh_user()
+        oo_cfg.deployment.variables['ansible_ssh_user'] = \
+                                                            get_ansible_ssh_user()
         click.clear()
 
     if not oo_cfg.settings.get('variant', ''):

--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -19,8 +19,6 @@ ROLES_TO_GROUPS_MAP = {
 
 VARIABLES_MAP = {
     'ansible_ssh_user': 'ansible_ssh_user',
-    'ansible_config': 'ansible_config',
-    'ansible_log_path': 'ansible_log_path',
     'deployment_type': 'deployment_type',
     'master_routingconfig_subdomain':'openshift_master_default_subdomain',
     'proxy_http':'openshift_http_proxy',
@@ -106,7 +104,7 @@ def write_inventory_vars(base_inventory, multiple_masters, lb):
         if value:
             base_inventory.write('{}={}\n'.format(inventory_var, value))
 
-    if CFG.settings['ansible_ssh_user'] != 'root':
+    if CFG.deployment.variables['ansible_ssh_user'] != 'root':
         base_inventory.write('ansible_become=yes\n')
 
     if multiple_masters and lb is not None:


### PR DESCRIPTION
ansible_log_path and ansible_config should be the env variables used by ansible, they needn't to be written to inventory hosts. 
ansible_ssh_user is a variable under [OSEv3:vars] in inventory hosts, it's better to be moved to development in installer.cfg.yml.