### PR TITLE
Bug 1365379 - Need to have 'NoVolumeZoneConflict' scheduler policy enabled by installer

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1708,6 +1708,7 @@ class OpenShiftFacts(object):
                 {"name": "PodFitsResources"},
                 {"name": "PodFitsPorts"},
                 {"name": "NoDiskConflict"},
+                {"name": "NoVolumeZoneConflict"},
                 {"name": "Region", "argument": {"serviceAffinity" : {"labels" : ["region"]}}}
             ]
             scheduler_priorities = [


### PR DESCRIPTION
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1365379