### PR TITLE
docker-registry's middleware stanza should contain 'registry' and 'storage' by default

### DIFF
--- a/roles/openshift_hosted/templates/registry_config.j2
+++ b/roles/openshift_hosted/templates/registry_config.j2
@@ -58,6 +58,8 @@ auth:
   openshift:
     realm: openshift
 middleware:
+  registry:
+  - name: openshift
   repository:
   - name: openshift
     options:
@@ -69,4 +71,7 @@ middleware:
       baseurl: {{ openshift.hosted.registry.storage.s3.cloudfront.baseurl }}
       privatekey: {{ openshift.hosted.registry.storage.s3.cloudfront.privatekeyfile }}
       keypairid: {{ openshift.hosted.registry.storage.s3.cloudfront.keypairid }}
+{% else %}
+  storage:
+  - name: openshift
 {% endif -%}

--- a/roles/openshift_hosted/templates/registry_config.j2
+++ b/roles/openshift_hosted/templates/registry_config.j2
@@ -58,8 +58,10 @@ auth:
   openshift:
     realm: openshift
 middleware:
+{% if openshift.common.version_gte_3_3_or_1_3 | bool %}
   registry:
   - name: openshift
+{% endif -%}
   repository:
   - name: openshift
     options:
@@ -71,7 +73,7 @@ middleware:
       baseurl: {{ openshift.hosted.registry.storage.s3.cloudfront.baseurl }}
       privatekey: {{ openshift.hosted.registry.storage.s3.cloudfront.privatekeyfile }}
       keypairid: {{ openshift.hosted.registry.storage.s3.cloudfront.keypairid }}
-{% else %}
+{% elif openshift.common.version_gte_3_3_or_1_3 | bool %}
   storage:
   - name: openshift
 {% endif -%}


### PR DESCRIPTION
Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1356823