### PR TITLE
a-o-i: flexible to set openshift_hostname and openshift_public_hostname

### DIFF
--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import os
 import yaml
+import re
 from ooinstall.variants import find_variant
 
 CFG = None
@@ -172,6 +173,10 @@ def write_host(host, role, inventory, schedulable=None):
 
     if host.preconfigured:
         return
+    
+    # Assuming host.connect_to is a hostname if it's not all-numeric
+    if not re.match(r"[\d.]+$", host.connect_to):
+        host.public_hostname = host.hostname = host.connect_to
 
     facts = ''
     if host.ip:


### PR DESCRIPTION
In my previous testing on OpenStack (Neutron deployment), we're bothered that 'openshift_hostname' and 'openshift_public_hostname' is set to [instance_name].novalocal by quick-installer, this hostname can't be resloved in Neutron deployment (only host-192-168-2-xx can be resloved by internal dns). Thus we have to modify installer.cfg.yml manually, this is really not convenient. 

(Note: in nova-network deployment, [instance_name].novalocal can be resloved successfully, but nova-network has been deprecated in recent OpenStack releases)

So if users input a hostname instead of ip address, it's better to apply the hostname to the values of "openshift_hostname" and "openshift_public_hostname" directly.