### PR TITLE
qps typo

### DIFF
--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -136,7 +136,7 @@ masterClients:
     acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
     contentType: application/vnd.kubernetes.protobuf
     burst: 400
-    ops: 200
+    qps: 200
 {% endif %}
   externalKubernetesKubeConfig: ""
 {% if openshift.common.version_gte_3_3_or_1_3 | bool %}
@@ -144,7 +144,7 @@ masterClients:
     acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
     contentType: application/vnd.kubernetes.protobuf
     burst: 600
-    ops: 300
+    qps: 300
 {% endif %}
   openshiftLoopbackKubeConfig: openshift-master.kubeconfig
 masterPublicURL: {{ openshift.master.public_api_url }}

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -16,8 +16,8 @@ kubeletArguments: {{ openshift.node.kubelet_args | default(None) | to_padded_yam
 masterClientConnectionOverrides:
   acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
   contentType: application/vnd.kubernetes.protobuf
-  burst: 40
-  ops: 20
+  burst: 200
+  qps: 100
 {% endif %}
 masterKubeConfig: system:node:{{ openshift.common.hostname }}.kubeconfig
 {% if openshift.common.use_openshift_sdn | bool and not openshift.common.version_gte_3_3_or_1_3 | bool %}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1364431

This typo causes all of our core controllers to share a QPS of the default: 5 (not a typo).  Shockingly, our system mostly runs, but verrrrry poorly.

@sdodson ptal