### PR TITLE
Bug 1366595 - installer failed at task "Validate permissions on certificate files"

### DIFF
--- a/roles/etcd_server_certificates/tasks/main.yml
+++ b/roles/etcd_server_certificates/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Install etcd
+  action: "{{ ansible_pkg_mgr }} name=etcd state=present"
+  when: not etcd_is_containerized | bool
+
 - name: Check status of etcd certificates
   stat:
     path: "{{ etcd_cert_config_dir }}/{{ item }}"


### PR DESCRIPTION
Ensure etcd user exists in etcd_server_certificates by installing etcd.

@sdodson PTAL

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1366595