### PR TITLE
Fix hosted_logging

### DIFF
--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -20,7 +20,7 @@
   - role: openshift_projects
     # TODO: Move standard project definitions to openshift_hosted/vars/main.yml
     # Vars are not accessible in meta/main.yml in ansible-1.9.x
-    openshift_projects: "{{ openshift_additional_projects | default({}) | oo_merge_dicts({'default':{'default_node_selector':''},'openshift-infra':{'default_node_selector':''},'logging':{'default_node_selector':''}}) }}"
+    openshift_projects: "{{ openshift_additional_projects | default({}) | oo_merge_dicts({'default':{'default_node_selector':''},'openshift-infra':{'default_node_selector':''}}) }}"
   - role: openshift_serviceaccounts
     openshift_serviceaccounts_names:
     - router
@@ -39,3 +39,6 @@
   - role: openshift_metrics
     when: openshift.hosted.metrics.deploy | bool
   - role: openshift_hosted
+  - role: openshift_hosted_logging
+    openshift_hosted_logging_cleanup: no
+    when: openshift.hosted.logging.deploy

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -48,6 +48,11 @@
   - set_fact:
       openshift_hosted_metrics_resolution: "{{ lookup('oo_option', 'openshift_hosted_metrics_resolution') | default('10s', true) }}"
     when: openshift_hosted_metrics_resolution is not defined
+
+  - set_fact:
+      openshift_hosted_logging_deploy: "{{ lookup('oo_option', 'openshift_hosted_logging_deploy') | default(false, true) }}"
+    when: openshift_hosted_logging_deploy is not defined
+
   roles:
   - openshift_facts
   post_tasks:

--- a/roles/openshift_hosted_logging/tasks/deploy_logging.yaml
+++ b/roles/openshift_hosted_logging/tasks/deploy_logging.yaml
@@ -40,9 +40,17 @@
     register: deployer_output
     failed_when: "deployer_output.rc == 1 and 'exists' not in deployer_output.stderr"
 
+  - name: "Create supporting Service Accounts"
+    command: >
+      {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig new-app logging-deployer-account-template
+    register: sa_deployer_output
+    failed_when: "sa_deployer_output.rc == 1 and 'exists' not in sa_deployer_output.stderr"
+
   - name: "Set permissions for logging-deployer service account"
     command: >
       {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig policy add-role-to-user edit system:serviceaccount:logging:logging-deployer
+    command: >
+      {{ openshift.common.admin_binary }} policy add-cluster-role-to-user oauth-editor system:serviceaccount:logging:logging-deployer
     register: permiss_output
     failed_when: "permiss_output.rc == 1 and 'exists' not in permiss_output.stderr"
 
@@ -71,11 +79,11 @@
     shell:  "{{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig get pods | grep logging-deployer.*Completed"
     register: result
     until: result.rc == 0
-    retries: 15
+    retries: 20
     delay: 10
 
-  - name: "Process support template"
-    shell:  "{{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig process logging-support-template |  {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig create -f -"
+  - name: "Process imagestream template"
+    shell:  "{{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig process logging-imagestream-template |  {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig create -f -"
 
   - name: "Set insecured registry"
     command:  "{{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig annotate is --all  openshift.io/image.insecureRepository=true --overwrite"
@@ -90,18 +98,12 @@
     delay: 10
 
   - name: "Wait for replication controllers to become available"
-    shell:  "{{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig get rc | grep logging-fluentd-1"
+    shell:  "{{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig get rc | grep logging-kibana-1"
     register: result
     until: result.rc == 0
     failed_when: result.rc == 1 and 'not found' not in result.stderr
     retries: 20
     delay: 10
-
-
-  - name: "Scale fluentd deployment config"
-    command: >
-      {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig scale dc/logging-fluentd --replicas={{ fluentd_replicas | default('1') }}
-
 
   - debug:
       msg: "Logging components deployed. Note persistant volume for elasticsearch must be setup manually"


### PR DESCRIPTION
This is fixing some problems with the hosted logging role, probably the logging deployment project has changed and this role didn't keep up:
- using ```logging-deployer-account-template``` to create the service accounts
- processing the ```imagestream``` template instead of ```support```
- ```fluentd``` is deployed using daemon set so there are no replication controllers for it
- ```loggging-deployer``` SA need the oauth-editor role too

I also added a fact to allow the user to deploy the hosted logging from the inventory file.

[1] https://github.com/openshift/origin-aggregated-logging/tree/master/deployer