### PR TITLE
Bug 1367199 - iptablesSyncPeriod should default to 30s OOTB

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1747,7 +1747,7 @@ class OpenShiftFacts(object):
 
         if 'node' in roles:
             defaults['node'] = dict(labels={}, annotations={},
-                                    iptables_sync_period='5s',
+                                    iptables_sync_period='30s',
                                     local_quota_per_fsgroup="",
                                     set_node_ip=False)
 


### PR DESCRIPTION
Update the default to thirty seconds.