### PR TITLE
Bug 1367323 - the "OpenShift Container Platform 3.2" variant is still listed when quick install ose-3.3

### DIFF
--- a/utils/src/ooinstall/variants.py
+++ b/utils/src/ooinstall/variants.py
@@ -37,7 +37,6 @@ class Variant(object):
 OSE = Variant('openshift-enterprise', 'OpenShift Container Platform',
     [
         Version('3.3', 'openshift-enterprise'),
-        Version('3.2', 'openshift-enterprise'),
     ]
 )
 


### PR DESCRIPTION
Remove 3.2 from the install options in 3.3 installer.