### PR TITLE
a-o-i: Fix nosetests after removing 3.2 from installer

### DIFF
--- a/utils/src/ooinstall/variants.py
+++ b/utils/src/ooinstall/variants.py
@@ -46,8 +46,16 @@ origin = Variant('origin', 'OpenShift Origin',
     ]
 )
 
+LEGACY = Variant('openshift-enterprise', 'OpenShift Container Platform',
+    [
+        Version('3.2', 'openshift-enterprise'),
+        Version('3.1', 'openshift-enterprise'),
+        Version('3.0', 'openshift-enterprise'),
+    ]
+)
+
 # Ordered list of variants we can install, first is the default.
-SUPPORTED_VARIANTS = (OSE, origin)
+SUPPORTED_VARIANTS = (OSE, origin, LEGACY)
 DISPLAY_VARIANTS = (OSE, )
 
 def find_variant(name, version=None):

--- a/utils/test/cli_installer_tests.py
+++ b/utils/test/cli_installer_tests.py
@@ -557,7 +557,7 @@ class UnattendedCliTests(OOCliFixture):
         self.assertEquals('openshift-enterprise', written_config['variant'])
         # We didn't specify a version so the latest should have been assumed,
         # and written to disk:
-        self.assertEquals('3.2', written_config['variant_version'])
+        self.assertEquals('3.3', written_config['variant_version'])
 
         # Make sure the correct value was passed to ansible:
         inventory = ConfigParser.ConfigParser(allow_no_value=True)
@@ -573,7 +573,7 @@ class UnattendedCliTests(OOCliFixture):
         run_playbook_mock.return_value = 0
 
         config = SAMPLE_CONFIG % 'openshift-enterprise'
-        config = '%s\n%s' % (config, 'variant_version: 3.2')
+        config = '%s\n%s' % (config, 'variant_version: 3.3')
         config_file = self.write_config(os.path.join(self.work_dir,
             'ooinstall.conf'), config)
 
@@ -586,7 +586,7 @@ class UnattendedCliTests(OOCliFixture):
         self.assertEquals('openshift-enterprise', written_config['variant'])
         # Make sure our older version was preserved:
         # and written to disk:
-        self.assertEquals('3.2', written_config['variant_version'])
+        self.assertEquals('3.3', written_config['variant_version'])
 
         inventory = ConfigParser.ConfigParser(allow_no_value=True)
         inventory.read(os.path.join(self.work_dir, 'hosts'))

--- a/utils/test/fixture.py
+++ b/utils/test/fixture.py
@@ -10,7 +10,7 @@ from click.testing import CliRunner
 # Substitute in a product name before use:
 SAMPLE_CONFIG = """
 variant: %s
-variant_version: 3.2
+variant_version: 3.3
 master_routingconfig_subdomain: example.com
 deployment:
     ansible_ssh_user: root

--- a/utils/test/oo_config_tests.py
+++ b/utils/test/oo_config_tests.py
@@ -12,7 +12,7 @@ from ooinstall.oo_config import OOConfig, Host, OOConfigInvalidHostError
 
 SAMPLE_CONFIG = """
 variant: openshift-enterprise
-variant_version: 3.2
+variant_version: 3.3
 deployment:
     ansible_ssh_user: root
     hosts:


### PR DESCRIPTION
Update the tests to match 3.3 being the only version.