### PR TITLE
Add localhost, 127.0.0.1 to certificate SANs.

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -647,6 +647,8 @@ def set_aggregate_facts(facts):
 
         internal_hostnames.add(facts['common']['hostname'])
         internal_hostnames.add(facts['common']['ip'])
+        internal_hostnames.add('localhost')
+        internal_hostnames.add('127.0.0.1')
 
         cluster_domain = facts['common']['dns_domain']
 

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -639,32 +639,29 @@ def set_aggregate_facts(facts):
     internal_hostnames = set()
     kube_svc_ip = first_ip(facts['common']['portal_net'])
     if 'common' in facts:
-        all_hostnames.add(facts['common']['hostname'])
-        all_hostnames.add(facts['common']['public_hostname'])
-        all_hostnames.add(facts['common']['ip'])
-        all_hostnames.add(facts['common']['public_ip'])
-        facts['common']['kube_svc_ip'] = kube_svc_ip
-
         internal_hostnames.add(facts['common']['hostname'])
         internal_hostnames.add(facts['common']['ip'])
         internal_hostnames.add('localhost')
         internal_hostnames.add('127.0.0.1')
 
+        all_hostnames.add(facts['common']['public_hostname'])
+        all_hostnames.add(facts['common']['public_ip'])
+        facts['common']['kube_svc_ip'] = kube_svc_ip
+
         cluster_domain = facts['common']['dns_domain']
 
         if 'master' in facts:
             if 'cluster_hostname' in facts['master']:
-                all_hostnames.add(facts['master']['cluster_hostname'])
+                internal_hostnames.add(facts['master']['cluster_hostname'])
             if 'cluster_public_hostname' in facts['master']:
                 all_hostnames.add(facts['master']['cluster_public_hostname'])
             svc_names = ['openshift', 'openshift.default', 'openshift.default.svc',
                          'openshift.default.svc.' + cluster_domain, 'kubernetes', 'kubernetes.default',
                          'kubernetes.default.svc', 'kubernetes.default.svc.' + cluster_domain]
-            all_hostnames.update(svc_names)
             internal_hostnames.update(svc_names)
-            all_hostnames.add(kube_svc_ip)
             internal_hostnames.add(kube_svc_ip)
 
+        all_hostnames.update(internal_hostnames)
         facts['common']['all_hostnames'] = list(all_hostnames)
         facts['common']['internal_hostnames'] = list(internal_hostnames)
 


### PR DESCRIPTION
When building a BYO/Origin/CentOS either Containerized or not during task "TASK [openshift_examples : Import Centos Image streams]" fails like:
fatal: [ose32-master-c1b-01.osdev.gce.example.com]: FAILED! => {"changed": false, "cmd": ["/usr/local/bin/oc", "create", "-n", "openshift", "-f", "/etc/origin/examples/image-streams/image-streams-centos7.json"], "delta": "0:00:00.083557", "end": "2016-08-16 23:58:46.590282", "failed": true, "failed_when_result": true, "rc": 1, "start": "2016-08-16 23:58:46.506725", "stderr": "unable to connect to a server to handle \"imagestreamlists\": Get https://localhost:8443/oapi: x509: certificate is valid for console.osdev.gce.example.com, kubernetes, kubernetes.default, kubernetes.default.svc, kubernetes.default.svc.cluster.local, master.osdev.gce.example.com, openshift, openshift.default, openshift.default.svc, openshift.default.svc.cluster.local, ose32-master-c1b-01.c.openshift-dev-00-1252.internal, ose32-master-c1c-01.c.openshift-dev-00-1252.internal, ose32-master-e1d-01.c.openshift-dev-00-1252.internal --master=https://master.osdev.gce.example.com:8443 --public-master=https://console.osdev.gce.example.com:8443, 10.128.0.2, 10.128.0.3, 10.142.0.2, 104.154.241.109, 104.196.3.249, 104.197.195.195, 172.8.0.1, not localhost", "stdout": "", "stdout_lines": [], "warnings": []}
