### PR TITLE
In AWS where the master node was not part of the nodes and unschedulable

### DIFF
--- a/playbooks/aws/openshift-cluster/config.yml
+++ b/playbooks/aws/openshift-cluster/config.yml
@@ -30,7 +30,7 @@
     openshift_hosted_router_selector: 'type=infra'
     openshift_node_labels:
       region: "{{ deployment_vars[deployment_type].region }}"
-      type: "{{ hostvars[inventory_hostname]['ec2_tag_sub-host-type'] if inventory_hostname in groups['tag_host-type_node'] else hostvars[inventory_hostname]['ec2_tag_host-type'] }}"
+      type: "{{ hostvars[inventory_hostname]['ec2_tag_sub-host-type'] }}"
     openshift_master_cluster_method: 'native'
     openshift_use_openshift_sdn: "{{ lookup('oo_option', 'use_openshift_sdn') }}"
     os_sdn_network_plugin_name: "{{ lookup('oo_option', 'sdn_network_plugin_name') }}"


### PR DESCRIPTION
Before this change the master was missing (those nodes are compute and infra only)

[root@ip-172-31-20-21 ~]# oc get nodes
NAME                                         STATUS                     AGE
ip-172-31-20-41.us-west-2.compute.internal   Ready                      5m
ip-172-31-20-42.us-west-2.compute.internal   Ready                      5m
ip-172-31-20-81.us-west-2.compute.internal   Ready                      5m

After the change the master is in the ndoes list and is disabled for scheduling

[root@ip-172-31-20-21 ~]# oc get nodes
NAME                                         STATUS                     AGE
ip-172-31-20-21.us-west-2.compute.internal   Ready,SchedulingDisabled   5m
ip-172-31-20-41.us-west-2.compute.internal   Ready                      5m
ip-172-31-20-42.us-west-2.compute.internal   Ready                      5m
ip-172-31-20-81.us-west-2.compute.internal   Ready                      5m