### PR TITLE
Fix errors in docker role

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -67,7 +67,7 @@
     dest: /etc/sysconfig/docker
     regexp: '^{{ item.reg_conf_var }}=.*$'
     line: "{{ item.reg_conf_var }}='{{ item.reg_fact_val | oo_prepend_strings_in_list(item.reg_flag ~ ' ') | join(' ') }}'"
-  when: item.reg_fact_val != '' and  docker_check.stat.isreg
+  when: item.reg_fact_val != '' and  (docker_check.stat.isreg is define and docker_check.stat.isreg)
   with_items:
   - reg_conf_var: ADD_REGISTRY
     reg_fact_val: "{{ docker_additional_registries | default(None, true)}}"
@@ -96,7 +96,8 @@
       reg_fact_val: "{{ docker_no_proxy | default('') | join(',') }}"
   notify:
     - restart docker
-  when: "{{ 'http_proxy' in openshift.common or 'https_proxy' in openshift.common and docker_check.stat.isreg }}"
+  when:
+    - (docker_check.stat.isreg is define and docker_check.stat.isreg) and "{{ 'http_proxy' in openshift.common or 'https_proxy' in openshift.common }}"
 
 - name: Set various Docker options
   lineinfile:
@@ -108,7 +109,7 @@
       {% if docker_log_options is defined %} {{ docker_log_options |  oo_split() | oo_prepend_strings_in_list('--log-opt ') | join(' ')}}{% endif %}\
       {% if docker_options is defined %} {{ docker_options }}{% endif %}\
       {% if docker_disable_push_dockerhub is defined %} --confirm-def-push={{ docker_disable_push_dockerhub | bool }}{% endif %}'"
-  when: docker_check.stat.isreg
+  when: docker_check.stat.isreg is define and docker_check.stat.isreg
   notify:
     - restart docker
 

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -67,7 +67,7 @@
     dest: /etc/sysconfig/docker
     regexp: '^{{ item.reg_conf_var }}=.*$'
     line: "{{ item.reg_conf_var }}='{{ item.reg_fact_val | oo_prepend_strings_in_list(item.reg_flag ~ ' ') | join(' ') }}'"
-  when: item.reg_fact_val != '' and  (docker_check.stat.isreg is define and docker_check.stat.isreg)
+  when: item.reg_fact_val != '' and  (docker_check.stat.isreg is defined and docker_check.stat.isreg)
   with_items:
   - reg_conf_var: ADD_REGISTRY
     reg_fact_val: "{{ docker_additional_registries | default(None, true)}}"
@@ -97,7 +97,7 @@
   notify:
     - restart docker
   when:
-    - (docker_check.stat.isreg is define and docker_check.stat.isreg) and "{{ 'http_proxy' in openshift.common or 'https_proxy' in openshift.common }}"
+    - (docker_check.stat.isreg is defined and docker_check.stat.isreg) and "{{ 'http_proxy' in openshift.common or 'https_proxy' in openshift.common }}"
 
 - name: Set various Docker options
   lineinfile:
@@ -109,7 +109,7 @@
       {% if docker_log_options is defined %} {{ docker_log_options |  oo_split() | oo_prepend_strings_in_list('--log-opt ') | join(' ')}}{% endif %}\
       {% if docker_options is defined %} {{ docker_options }}{% endif %}\
       {% if docker_disable_push_dockerhub is defined %} --confirm-def-push={{ docker_disable_push_dockerhub | bool }}{% endif %}'"
-  when: docker_check.stat.isreg is define and docker_check.stat.isreg
+  when: docker_check.stat.isreg is defined and docker_check.stat.isreg
   notify:
     - restart docker
 

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -67,7 +67,7 @@
     dest: /etc/sysconfig/docker
     regexp: '^{{ item.reg_conf_var }}=.*$'
     line: "{{ item.reg_conf_var }}='{{ item.reg_fact_val | oo_prepend_strings_in_list(item.reg_flag ~ ' ') | join(' ') }}'"
-  when: item.reg_fact_val != '' and  (docker_check.stat.isreg is defined and docker_check.stat.isreg)
+  when: item.reg_fact_val != '' and docker_check.stat.isreg is defined and docker_check.stat.isreg
   with_items:
   - reg_conf_var: ADD_REGISTRY
     reg_fact_val: "{{ docker_additional_registries | default(None, true)}}"
@@ -97,7 +97,7 @@
   notify:
     - restart docker
   when:
-    - (docker_check.stat.isreg is defined and docker_check.stat.isreg) and "{{ 'http_proxy' in openshift.common or 'https_proxy' in openshift.common }}"
+    - docker_check.stat.isreg is defined and docker_check.stat.isreg and '"http_proxy" in openshift.common or "https_proxy" in openshift.common'
 
 - name: Set various Docker options
   lineinfile:


### PR DESCRIPTION
In https://github.com/openshift/openshift-ansible/blob/master/roles/docker/tasks/main.yml#L111 and many places in the file docker_check.stat.isreg variable has been referred directly without check it whether variable got value or not.

In latest docker release like 1.11 and 1.12, I don't see /etc/sysconfig/docker present in docker package, because of this test scripts will message like - 

The error was: error while evaluating conditional (docker_check.stat.isreg): 'dict object' has no attribute 'is_reg'