### PR TITLE
Fix warnings in OpenStack provider with ansible 2.1

### DIFF
--- a/playbooks/openstack/openshift-cluster/launch.yml
+++ b/playbooks/openstack/openshift-cluster/launch.yml
@@ -48,6 +48,8 @@
              -P infra_flavor={{ openstack_flavor["infra"] }}
              -P dns_flavor={{ openstack_flavor["dns"] }}
              openshift-ansible-{{ cluster_id }}-stack'
+    args:
+      chdir: '{{ playbook_dir }}'
 
   - name: Wait for OpenStack Stack readiness
     shell: 'heat stack-show openshift-ansible-{{ cluster_id }}-stack | awk ''$2 == "stack_status" {print $4}'''
@@ -107,9 +109,9 @@
       openshift_node_labels:
         type: "etcd"
     with_together:
-      - parsed_outputs.etcd_names
-      - parsed_outputs.etcd_ips
-      - parsed_outputs.etcd_floating_ips
+      - '{{ parsed_outputs.etcd_names }}'
+      - '{{ parsed_outputs.etcd_ips }}'
+      - '{{ parsed_outputs.etcd_floating_ips }}'
 
   - name: Add new master instances groups and variables
     add_host:
@@ -121,9 +123,9 @@
       openshift_node_labels:
         type: "master"
     with_together:
-      - parsed_outputs.master_names
-      - parsed_outputs.master_ips
-      - parsed_outputs.master_floating_ips
+      - '{{ parsed_outputs.master_names }}'
+      - '{{ parsed_outputs.master_ips }}'
+      - '{{ parsed_outputs.master_floating_ips }}'
 
   - name: Add new node instances groups and variables
     add_host:
@@ -135,9 +137,9 @@
       openshift_node_labels:
         type: "compute"
     with_together:
-      - parsed_outputs.node_names
-      - parsed_outputs.node_ips
-      - parsed_outputs.node_floating_ips
+      - '{{ parsed_outputs.node_names }}'
+      - '{{ parsed_outputs.node_ips }}'
+      - '{{ parsed_outputs.node_floating_ips }}'
 
   - name: Add new infra instances groups and variables
     add_host:
@@ -149,9 +151,9 @@
       openshift_node_labels:
         type: "infra"
     with_together:
-      - parsed_outputs.infra_names
-      - parsed_outputs.infra_ips
-      - parsed_outputs.infra_floating_ips
+      - '{{ parsed_outputs.infra_names }}'
+      - '{{ parsed_outputs.infra_ips }}'
+      - '{{ parsed_outputs.infra_floating_ips }}'
 
   - name: Add DNS groups and variables
     add_host:
@@ -166,10 +168,10 @@
       host: '{{ item }}'
       port: 22
     with_flattened:
-      - parsed_outputs.master_floating_ips
-      - parsed_outputs.node_floating_ips
-      - parsed_outputs.infra_floating_ips
-      - parsed_outputs.dns_floating_ip
+      - '{{ parsed_outputs.master_floating_ips }}'
+      - '{{ parsed_outputs.node_floating_ips }}'
+      - '{{ parsed_outputs.infra_floating_ips }}'
+      - '{{ parsed_outputs.dns_floating_ip }}'
 
   - name: Wait for user setup
     command: 'ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null {{ deployment_vars[deployment_type].ssh_user }}@{{ item }} echo {{ deployment_vars[deployment_type].ssh_user }} user is setup'
@@ -178,10 +180,10 @@
     retries: 30
     delay: 1
     with_flattened:
-      - parsed_outputs.master_floating_ips
-      - parsed_outputs.node_floating_ips
-      - parsed_outputs.infra_floating_ips
-      - parsed_outputs.dns_floating_ip
+      - '{{ parsed_outputs.master_floating_ips }}'
+      - '{{ parsed_outputs.node_floating_ips }}'
+      - '{{ parsed_outputs.infra_floating_ips }}'
+      - '{{ parsed_outputs.dns_floating_ip }}'
 
 - include: update.yml
 

--- a/playbooks/openstack/openshift-cluster/list.yml
+++ b/playbooks/openstack/openshift-cluster/list.yml
@@ -17,7 +17,7 @@
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_ssh_host: "{{ hostvars[item].ansible_ssh_host | default(item) }}"
       ansible_become: "{{ deployment_vars[deployment_type].become }}"
-    with_items: groups[scratch_group] | default([]) | difference(['localhost'])
+    with_items: "{{ groups[scratch_group] | default([]) | difference(['localhost']) }}"
 
 - name: List Hosts
   hosts: oo_list_hosts

--- a/playbooks/openstack/openshift-cluster/terminate.yml
+++ b/playbooks/openstack/openshift-cluster/terminate.yml
@@ -11,7 +11,7 @@
       groups: oo_hosts_to_terminate
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_become: "{{ deployment_vars[deployment_type].become }}"
-    with_items: (groups['tag_environment_' ~ cluster_env]|default([])) | intersect(groups['tag_clusterid_' ~ cluster_id ]|default([]))
+    with_items: "{{ (groups['tag_environment_' ~ cluster_env]|default([])) | intersect(groups['tag_clusterid_' ~ cluster_id ]|default([])) }}"
 
 - name: Unsubscribe VMs
   hosts: oo_hosts_to_terminate

--- a/roles/openshift_serviceaccounts/tasks/legacy_add_scc_to_user.yml
+++ b/roles/openshift_serviceaccounts/tasks/legacy_add_scc_to_user.yml
@@ -15,7 +15,7 @@
   template:
     src: serviceaccount.j2
     dest: "/tmp/openshift/{{ item }}-serviceaccount.yaml"
-  with_items: openshift_serviceaccounts_names
+  with_items: '{{ openshift_serviceaccounts_names }}'
 
 - name: Get current security context constraints
   shell: >
@@ -30,8 +30,8 @@
     insertafter: "^users:$"
   when: "item.1.rc == 0 and 'system:serviceaccount:{{ openshift_serviceaccounts_namespace }}:{{ item.0 }}' not in {{ (item.1.stdout | from_yaml).users }}"
   with_nested:
-  - openshift_serviceaccounts_names
-  - scc_test.results
+  - '{{ openshift_serviceaccounts_names }}'
+  - '{{ scc_test.results }}'
 
 - name: Apply new scc rules for service accounts
   command: "{{ openshift.common.client_binary }} update -f /tmp/openshift/scc.yaml --api-version=v1"


### PR DESCRIPTION
Some expressions now need to be enclosed inside `{{…}}`.