### PR TITLE
Fix the “node on master” feature

### DIFF
--- a/playbooks/common/openshift-cluster/evaluate_groups.yml
+++ b/playbooks/common/openshift-cluster/evaluate_groups.yml
@@ -77,7 +77,7 @@
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_become: "{{ g_sudo | default(omit) }}"
     with_items: "{{ g_master_hosts | default([]) }}"
-    when: g_nodeonmaster | default(false) == true and g_new_node_hosts is not defined
+    when: g_nodeonmaster | default(false) | bool and not g_new_node_hosts | default(false) | bool
 
   - name: Evaluate oo_first_etcd
     add_host:


### PR DESCRIPTION
What we want to do is to add the master as a node if:
* `g_nodeonmaster` is set to true, and
* we are not in the case where we want to add new nodes.

The second test was done by only checking whether `g_new_node_hosts` was defined.
This was wrong because, in all cloud-provider setups, this variable was set
with the default value of “empty list” (`[]`).
The test has been changed to use the `bool` filter so that it correctly evaluates
to false (and hence, effectively add the master as a node) when `g_new_node_hosts`
is the empty list.