### PR TITLE
Open OpenStack security group for the service node port range

### DIFF
--- a/README_openstack.md
+++ b/README_openstack.md
@@ -43,6 +43,7 @@ The following options are used only by `heat_stack.yaml`. They are so used only 
 * `external_net` (default to `external`): Name of the external network to connect to
 * `floating_ip_pool` (default to `external`): comma separated list of floating IP pools
 * `ssh_from` (default to `0.0.0.0/0`): IPs authorized to connect to the VMs via ssh
+* `node_port_from` (default to `0.0.0.0/0`): IPs authorized to connect to the services exposed via nodePort
 
 
 Creating a cluster

--- a/playbooks/openstack/openshift-cluster/files/heat_stack.yaml
+++ b/playbooks/openstack/openshift-cluster/files/heat_stack.yaml
@@ -42,6 +42,12 @@ parameters:
     description: Source of legitimate ssh connections
     default: 0.0.0.0/0
 
+  node_port_incoming:
+    type: string
+    label: Source of node port connections
+    description: Authorized sources targetting node ports
+    default: 0.0.0.0/0
+
   num_etcd:
     type: number
     label: Number of etcd nodes
@@ -393,6 +399,11 @@ resources:
           port_range_min: 4789
           port_range_max: 4789
           remote_mode: remote_group_id
+        - direction: ingress
+          protocol: tcp
+          port_range_min: 30000
+          port_range_max: 32767
+          remote_ip_prefix: { get_param: node_port_incoming }
 
   infra-secgrp:
     type: OS::Neutron::SecurityGroup

--- a/playbooks/openstack/openshift-cluster/launch.yml
+++ b/playbooks/openstack/openshift-cluster/launch.yml
@@ -33,6 +33,7 @@
              -P external_net={{ openstack_network_external_net }}
              -P ssh_public_key="{{ openstack_ssh_public_key }}"
              -P ssh_incoming={{ openstack_ssh_access_from }}
+             -P node_port_incoming={{ openstack_node_port_access_from }}
              -P num_etcd={{ num_etcd }}
              -P num_masters={{ num_masters }}
              -P num_nodes={{ num_nodes }}

--- a/playbooks/openstack/openshift-cluster/vars.yml
+++ b/playbooks/openstack/openshift-cluster/vars.yml
@@ -12,6 +12,8 @@ openstack_ssh_public_key:       "{{ lookup('file', lookup('oo_option', 'public_k
                                     default('~/.ssh/id_rsa.pub',             True)) }}"
 openstack_ssh_access_from:      "{{ lookup('oo_option', 'ssh_from')          |
                                     default('0.0.0.0/0',                     True) }}"
+openstack_node_port_access_from: "{{ lookup('oo_option', 'node_port_from')   |
+                                    default('0.0.0.0/0',                     True) }}"
 openstack_flavor:
   dns:    "{{ lookup('oo_option', 'dns_flavor'       ) | default('m1.small',  True) }}"
   etcd:   "{{ lookup('oo_option', 'etcd_flavor'      ) | default('m1.small',  True) }}"


### PR DESCRIPTION
With OpenShift 3.2, creating a service accessible from the outside of the
cluster thanks to `nodePort` automatically opens the “local” `iptables`
firewall to allow incoming connection on the `nodePort` of the service.

In order to benefit from this improvement, the OpenStack security group
shouldn’t block those incoming connections.

This change opens, on the OS nodes, the port range dedicated to service
node ports.