### PR TITLE
Fix standalone Docker upgrade missing symlink.

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/docker/nuke_images.sh
+++ b/playbooks/byo/openshift-cluster/upgrades/docker/nuke_images.sh
@@ -1,0 +1,1 @@
+../../../../common/openshift-cluster/upgrades/files/nuke_images.sh


### PR DESCRIPTION
Really straightforward missing symlink, might have happened during 3.3 upgrade refactor or via the Ansible 2.2 bump.