### PR TITLE
Remove duplicate flannel registration

### DIFF
--- a/playbooks/common/openshift-cluster/additional_config.yml
+++ b/playbooks/common/openshift-cluster/additional_config.yml
@@ -24,7 +24,3 @@
   - role: cockpit
     when: not openshift.common.is_atomic and ( deployment_type in ['atomic-enterprise','openshift-enterprise'] ) and
       (osm_use_cockpit | bool or osm_use_cockpit is undefined )
-  - role: flannel_register
-    when: openshift.common.use_flannel | bool
-
-

--- a/playbooks/common/openshift-cluster/additional_config.yml
+++ b/playbooks/common/openshift-cluster/additional_config.yml
@@ -1,11 +1,3 @@
-- name: Configure flannel
-  hosts: oo_first_master
-  vars:
-    etcd_urls: "{{ openshift.master.etcd_urls }}"
-  roles:
-  - role: flannel_register
-    when: openshift.common.use_flannel | bool
-
 - name: Additional master configuration
   hosts: oo_first_master
   vars:
@@ -24,3 +16,5 @@
   - role: cockpit
     when: not openshift.common.is_atomic and ( deployment_type in ['atomic-enterprise','openshift-enterprise'] ) and
       (osm_use_cockpit | bool or osm_use_cockpit is undefined )
+  - role: flannel_register
+    when: openshift.common.use_flannel | bool


### PR DESCRIPTION
In playbooks/common/openshift-cluster/additional_config.yml, flannel_register role is called twice. So remove one entry which is not really required.