### PR TITLE
Add warning at end of 3.3 upgrade if pluginOrderOverride is found.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/post.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post.yml
@@ -56,3 +56,16 @@
       {{ oc_cmd }} patch dc/docker-registry -n default -p
       '{"spec":{"template":{"spec":{"containers":[{"name":"registry","image":"{{ registry_image }}"}]}}}}'
       --api-version=v1
+
+# Check for warnings to be printed at the end of the upgrade:
+- name: Check for warnings
+  hosts: oo_masters_to_config
+  tasks:
+  # Check if any masters are using pluginOrderOverride and warn if so, only for 1.3/3.3 and beyond:
+  - command: >
+      grep pluginOrderOverride {{ openshift.common.config_base }}/master/master-config.yaml
+    register: grep_plugin_order_override
+    when: openshift.common.version_gte_3_3_or_1_3 | bool
+  - name: Warn if pluginOrderOverride is in use in master-config.yaml
+    debug: msg="WARNING pluginOrderOverride is being deprecated in master-config.yaml, please see https://docs.openshift.com/enterprise/latest/architecture/additional_concepts/admission_controllers.html for more information."
+    when: not grep_plugin_order_override | skipped and grep_plugin_order_override.rc == 0


### PR DESCRIPTION
Fixes #2335 but I still need a URL for the docs, @deads2k any idea what that would be yet?

Output looks like:

```
TASK [command] *****************************************************************
changed: [m1.aos.example.com]

TASK [Warn if pluginOrderOverride is in use in master-config.yaml] *************
ok: [m1.aos.example.com] => {
    "msg": "WARNING pluginOrderOverride is being deprecated in master-config.yaml, please see URLHERE for more information."
}

PLAY RECAP *********************************************************************
localhost                  : ok=17   changed=9    unreachable=0    failed=0   
m1.aos.example.com         : ok=167  changed=16   unreachable=0    failed=0   
n1.aos.example.com         : ok=77   changed=1    unreachable=0    failed=0   

ansible-playbook -i ./hosts   30.93s user 11.32s system 21% cpu 3:15.42 total
```