### PR TITLE
don't set virt_sandbox_use_nfs on Fedora, it was replaced by virt_use_nfs

### DIFF
--- a/roles/openshift_node/tasks/storage_plugins/nfs.yml
+++ b/roles/openshift_node/tasks/storage_plugins/nfs.yml
@@ -17,16 +17,16 @@
     persistent: yes
   when: ansible_selinux and ansible_selinux.status == "enabled" and virt_use_nfs_output.rc == 0
 
-- name: Check for existence of virt_sandbox_use_nfs seboolean
+- name: Check for existence of virt_sandbox_use_nfs seboolean (RHEL)
   command: getsebool virt_sandbox_use_nfs
   register: virt_sandbox_use_nfs_output
-  when: ansible_selinux and ansible_selinux.status == "enabled"
+  when: ansible_distribution != "Fedora" and ansible_selinux and ansible_selinux.status == "enabled"
   failed_when: false
   changed_when: false
 
-- name: Set seboolean to allow nfs storage plugin access from containers(sandbox)
+- name: Set seboolean to allow nfs storage plugin access from containers(sandbox) (RHEL)
   seboolean:
     name: virt_sandbox_use_nfs
     state: yes
     persistent: yes
-  when: ansible_selinux and ansible_selinux.status == "enabled" and virt_sandbox_use_nfs_output.rc == 0
+  when: ansible_distribution != "Fedora" and ansible_selinux and ansible_selinux.status == "enabled" and virt_sandbox_use_nfs_output.rc == 0


### PR DESCRIPTION
Note that virt_use_nfs is already set in a previous play in the role's tasks

Signed-off-by: Adam Miller <maxamillion@fedoraproject.org>