### PR TITLE
Set openshift_clock_enabled=True by default

### DIFF
--- a/inventory/byo/hosts.aep.example
+++ b/inventory/byo/hosts.aep.example
@@ -442,8 +442,8 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # masterConfig.volumeConfig.dynamicProvisioningEnabled, configurable as of 1.2/3.2, enabled by default
 #openshift_master_dynamic_provisioning_enabled=False
 
-# Configure usage of openshift_clock role.
-#openshift_clock_enabled=true
+# Configure usage of openshift_clock role, on by default.
+#openshift_clock_enabled=false
 
 # OpenShift Per-Service Environment Variables
 # Environment variables are added to /etc/sysconfig files for

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -477,8 +477,8 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # masterConfig.volumeConfig.dynamicProvisioningEnabled, configurable as of 1.2/3.2, enabled by default
 #openshift_master_dynamic_provisioning_enabled=False
 
-# Configure usage of openshift_clock role.
-#openshift_clock_enabled=true
+# Configure usage of openshift_clock role, on by default.
+#openshift_clock_enabled=false
 
 # OpenShift Per-Service Environment Variables
 # Environment variables are added to /etc/sysconfig files for

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -476,8 +476,8 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # masterConfig.volumeConfig.dynamicProvisioningEnabled, configurable as of 1.2/3.2, enabled by default
 #openshift_master_dynamic_provisioning_enabled=False
 
-# Configure usage of openshift_clock role.
-#openshift_clock_enabled=true
+# Configure usage of openshift_clock role, on by default.
+#openshift_clock_enabled=false
 
 # OpenShift Per-Service Environment Variables
 # Environment variables are added to /etc/sysconfig files for

--- a/roles/openshift_clock/tasks/main.yaml
+++ b/roles/openshift_clock/tasks/main.yaml
@@ -3,7 +3,7 @@
   openshift_facts:
     role: clock
     local_facts:
-      enabled: "{{ openshift_clock_enabled | default(None) }}"
+      enabled: "{{ openshift_clock_enabled | default(True) }}"
 
 - name: Install ntp package
   action: "{{ ansible_pkg_mgr }} name=ntp state=present"


### PR DESCRIPTION
Remove openshift_facts dep too, we don't depend on any facts that we're not
setting within the role tasks.

FYI -- I think we should hold this until post 3.3.