### PR TITLE
Set cloudprovider kind with openshift_facts.

### DIFF
--- a/roles/openshift_cloud_provider/tasks/main.yml
+++ b/roles/openshift_cloud_provider/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Set cloud provider facts
+  openshift_facts:
+    role: cloudprovider
+    local_facts:
+      kind: "{{ openshift_cloudprovider_kind | default(None) }}"
+
 - name: Create cloudprovider config dir
   file:
     path: "{{ openshift.common.config_base }}/cloudprovider"


### PR DESCRIPTION
This allows openshift_facts to set default master and node cloud provider configuration snippets.

@sdodson PTAL

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1371006