### PR TITLE
Default to port 80 when deploying cockpit-ui

### DIFF
--- a/roles/cockpit-ui/tasks/main.yml
+++ b/roles/cockpit-ui/tasks/main.yml
@@ -36,7 +36,7 @@
     {{ openshift.common.client_binary }} new-app --template=registry-console
     {{ cockpit_image_prefix }}
     -p OPENSHIFT_OAUTH_PROVIDER_URL="{{ openshift.master.public_api_url }}"
-    -p REGISTRY_HOST="{{ docker_registry_route.stdout }}"
+    -p REGISTRY_HOST="{{ docker_registry_route.stdout }}:80"
     -p COCKPIT_KUBE_URL="{{ registry_console_cockpit_kube_url.stdout }}"
     -n default
   register: deploy_registry_console


### PR DESCRIPTION
This should save first-time users some pain.

Fixes BZ#1371031