### PR TITLE
Reload units after node container service modified.

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -55,12 +55,6 @@
 - name: Install the systemd units
   include: systemd_units.yml
 
-- name: Reload systemd units
-  command: systemctl daemon-reload
-  when: openshift.common.is_containerized | bool and (install_node_result | changed or install_ovs_sysconfig | changed or install_node_dep_result | changed)
-  notify:
-  - restart node
-
 - name: Start and enable openvswitch docker service
   service: name=openvswitch.service enabled=yes state=started
   when: openshift.common.is_containerized | bool and openshift.common.use_openshift_sdn | bool

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -47,3 +47,9 @@
       line: "IMAGE_VERSION={{ openshift_image_tag }}"
   notify:
   - restart node
+
+- name: Reload systemd units
+  command: systemctl daemon-reload
+  when: openshift.common.is_containerized | bool and (install_node_result | changed or install_ovs_sysconfig | changed or install_node_dep_result | changed)
+  notify:
+  - restart node


### PR DESCRIPTION
@sdodson this should do it, the reload makes sense here as we want it in both upgrade and config playbook, it also matches what we're doing for the master systemd_units.yml.

Node container was restarting but no service changes were taking effect due to missing reload.