### PR TITLE
Change how we set master's metricsPublicURL

### DIFF
--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -80,3 +80,4 @@
       api_env_vars: "{{ openshift_master_api_env_vars | default(None) }}"
       controllers_env_vars: "{{ openshift_master_controllers_env_vars | default(None) }}"
       audit_config: "{{ openshift_master_audit_config | default(None) }}"
+      metrics_public_url: "{% if openshift_hosted_metrics_deploy | default(false) %}https://{{ metrics_hostname }}/hawkular/metrics{% endif %}"

--- a/roles/openshift_master_facts/vars/main.yml
+++ b/roles/openshift_master_facts/vars/main.yml
@@ -18,3 +18,8 @@ builddefaults_yaml:
         value: "{{ openshift.master.builddefaults_https_proxy | default(omit, true) }}"
       - name: no_proxy
         value: "{{ openshift.master.builddefaults_no_proxy | default(omit, true) | join(',') }}"
+
+metrics_hostname: "{{ openshift.hosted.metrics.public_url
+                    | default('hawkular-metrics.' ~ (openshift.master.default_subdomain
+                    | default(openshift_master_default_subdomain )))
+                    | oo_hostname_from_url }}"

--- a/roles/openshift_metrics/tasks/install.yml
+++ b/roles/openshift_metrics/tasks/install.yml
@@ -95,7 +95,7 @@
     get {{ deploy_metrics.stdout }}
   register: deploy_result
   until: "{{ 'Completed' in deploy_result.stdout }}"
-  failed_when: "{{ 'Completed' not in deploy_result.stdout }}"
+  failed_when: False
   retries: 60
   delay: 10
 


### PR DESCRIPTION
 - If we're deploying metrics configure master during master role execution for metrics rather than only in openshift_metrics role
 - Ignore failed metrics deployers -- there's not much we can do to recover from this and the admin will need to debug what went wrong.

Fixes BZ1371179
Fixes BZ1371103 