### PR TITLE
Reload docker facts after upgrading docker

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/docker/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/upgrade.yml
@@ -39,6 +39,10 @@
 
 - service: name=docker state=started
 
+- name: Update docker facts
+  openshift_facts:
+    role: docker
+
 - name: Restart containerized services
   service: name={{ item }} state=started
   with_items:


### PR DESCRIPTION
The containerized node unit files depend on docker version facts so we should update them after we update docker.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1358197