### PR TITLE
update flannel_subnet_len default value

### DIFF
--- a/roles/flannel_register/README.md
+++ b/roles/flannel_register/README.md
@@ -16,7 +16,7 @@ Role Variables
 |---------------------|----------------------------------------------------|-------------------------------------------------|
 | flannel_network     | {{ openshift.common.portal_net }} or 172.16.1.1/16 | interface to use for inter-host communication   |
 | flannel_min_network | {{ min_network }} or 172.16.5.0                    | beginning of IP range for the subnet allocation |
-| flannel_subnet_len  | /openshift.com/network                             | size of the subnet allocated to each host       |
+| flannel_subnet_len  | 24                                                 | size of the subnet allocated to each host       |
 | flannel_etcd_key    | /openshift.com/network                             | etcd prefix                                     |
 | etcd_hosts          | etcd_urls                                          | a list of etcd endpoints                        |
 | etcd_conf_dir       | {{ openshift.common.config_base }}/master          | SSL certificates directory                      |


### PR DESCRIPTION
Default value for flannel_subnet_len should 24 as per defaults/main.yaml so updated the README.md file with correct data.