### PR TITLE
Persist net.ipv4.ip_forward sysctl entry for openshift nodes

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -55,6 +55,12 @@
 - name: Install the systemd units
   include: systemd_units.yml
 
+# The atomic-openshift-node service will set this parameter on
+# startup, but if the network service is restarted this setting is
+# lost. Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1372388
+- name: Persist net.ipv4.ip_forward sysctl entry
+  sysctl: name="net.ipv4.ip_forward" value=1 sysctl_set=yes state=present reload=yes
+
 - name: Start and enable openvswitch docker service
   service: name=openvswitch.service enabled=yes state=started
   when: openshift.common.is_containerized | bool and openshift.common.use_openshift_sdn | bool


### PR DESCRIPTION
Reference:
https://bugzilla.redhat.com/show_bug.cgi?id=1372388