### PR TITLE
Fix string substitution error in the to_padded_yaml filter

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -625,7 +625,7 @@ class FilterModule(object):
             padded = "\n".join([" " * level * indent + line for line in transformed.splitlines()])
             return to_unicode("\n{0}".format(padded))
         except Exception as my_e:
-            raise errors.AnsibleFilterError('Failed to convert: %s', my_e)
+            raise errors.AnsibleFilterError('Failed to convert: %s' % my_e)
 
     @staticmethod
     def oo_openshift_env(hostvars):


### PR DESCRIPTION
Discovered in issue **Deploy PersistentVolume definitions FAILS** #2401

Failed calls to the `to_padded_yaml` function will not print the actual exception message text. This is because the string substitution which would show the error is not actually happening.

Patch fixes call to `errors.AnsibleFilterError` so that the original exception text is properly substituted into the raised Ansible exception. 