### PR TITLE
Bug 1327409 - scaleup playbook uses current oc login which may not have enough permissions

### DIFF
--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -159,7 +159,6 @@
     openshift_nodes: "{{ hostvars
                          | oo_select_keys(groups['oo_nodes_to_config'])
                          | oo_collect('openshift.common.hostname') }}"
-    openshift_node_vars: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']) }}"
   pre_tasks:
   # Necessary because when you're on a node that's also a master the master will be
   # restarted after the node restarts docker and it will take up to 60 seconds for

--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -1,6 +1,22 @@
+---
+- name: Create temp directory for kubeconfig
+  command: mktemp -d /tmp/openshift-ansible-XXXXXX
+  register: mktemp
+  changed_when: False
+
+- set_fact:
+    openshift_manage_node_kubeconfig: "{{ mktemp.stdout }}/admin.kubeconfig"
+
+- name: Copy the admin client config(s)
+  command: >
+    cp {{ openshift.common.config_base }}/master/admin.kubeconfig {{ openshift_manage_node_kubeconfig }}
+  changed_when: False
+
 - name: Wait for Node Registration
   command: >
-      {{ openshift.common.client_binary }} get node {{ item | lower }}
+    {{ openshift.common.client_binary }} get node {{ item | lower }}
+    --config={{ openshift_manage_node_kubeconfig }}
+    -n default
   register: omd_get_node
   until: omd_get_node.rc == 0
   retries: 50
@@ -11,6 +27,8 @@
 - name: Set node schedulability
   command: >
     {{ openshift.common.admin_binary }} manage-node {{ item.openshift.common.hostname | lower }} --schedulable={{ 'true' if item.openshift.node.schedulable | bool else 'false' }}
+    --config={{ openshift_manage_node_kubeconfig }}
+    -n default
   with_items:
     -  "{{ openshift_node_vars }}"
   when: item.openshift.common.hostname is defined
@@ -18,6 +36,14 @@
 - name: Label nodes
   command: >
     {{ openshift.common.client_binary }} label --overwrite node {{ item.openshift.common.hostname | lower }} {{ item.openshift.node.labels | oo_combine_dict  }}
+    --config={{ openshift_manage_node_kubeconfig }}
+    -n default
   with_items:
     -  "{{ openshift_node_vars }}"
   when: item.openshift.common.hostname is defined and 'labels' in item.openshift.node and item.openshift.node.labels != {}
+
+- name: Delete temp directory
+  file:
+    name: "{{ mktemp.stdout }}"
+    state: absent
+  changed_when: False

--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -26,21 +26,21 @@
 
 - name: Set node schedulability
   command: >
-    {{ openshift.common.admin_binary }} manage-node {{ item.openshift.common.hostname | lower }} --schedulable={{ 'true' if item.openshift.node.schedulable | bool else 'false' }}
+    {{ openshift.common.admin_binary }} manage-node {{ hostvars[item].openshift.common.hostname | lower }} --schedulable={{ 'true' if hostvars[item].openshift.node.schedulable | bool else 'false' }}
     --config={{ openshift_manage_node_kubeconfig }}
     -n default
   with_items:
-    -  "{{ openshift_node_vars }}"
-  when: item.openshift.common.hostname is defined
+    -  "{{ openshift_nodes }}"
+  when: hostvars[item].openshift.common.hostname is defined
 
 - name: Label nodes
   command: >
-    {{ openshift.common.client_binary }} label --overwrite node {{ item.openshift.common.hostname | lower }} {{ item.openshift.node.labels | oo_combine_dict  }}
+    {{ openshift.common.client_binary }} label --overwrite node {{ hostvars[item].openshift.common.hostname | lower }} {{ hostvars[item].openshift.node.labels | oo_combine_dict  }}
     --config={{ openshift_manage_node_kubeconfig }}
     -n default
   with_items:
-    -  "{{ openshift_node_vars }}"
-  when: item.openshift.common.hostname is defined and 'labels' in item.openshift.node and item.openshift.node.labels != {}
+    -  "{{ openshift_nodes }}"
+  when: hostvars[item].openshift.common.hostname is defined and 'labels' in hostvars[item].openshift.node and hostvars[item].openshift.node.labels != {}
 
 - name: Delete temp directory
   file:


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1327409

Added an extra commit to avoid looping over entire hostvar blocks when setting node schedulability.