### PR TITLE
Fix some bugs in OpenShift Hosted Logging role

### DIFF
--- a/roles/openshift_hosted_logging/defaults/main.yml
+++ b/roles/openshift_hosted_logging/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+examples_base: "{{ openshift.common.config_base if openshift.common.is_containerized | bool else '/usr/share/openshift' }}/examples"

--- a/roles/openshift_hosted_logging/tasks/deploy_logging.yaml
+++ b/roles/openshift_hosted_logging/tasks/deploy_logging.yaml
@@ -40,7 +40,7 @@
 
   - name: "Create templates for logging accounts and the deployer"
     command: >
-      {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig create -f /usr/share/openshift/examples/infrastructure-templates/enterprise/logging-deployer.yaml
+      {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig create -f {{ examples_base }}/infrastructure-templates/{{ openshift_deployment_type }}/logging-deployer.yaml
     register: template_output
     failed_when: "template_output.rc == 1 and 'exists' not in template_output.stderr"
 
@@ -138,7 +138,7 @@
     delay: 10
 
   - name: "Deploy fluentd by labeling the node"
-    shell:  "{{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig label node {{ openshift_hostname }} {{ openshift_hosted_logging_fluentd_nodeselector if openshift_hosted_logging_fluentd_nodeselector is defined else 'logging-infra-fluentd=true' }}"
+    shell:  "{{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig label node {{ openshift_hosted_logging_fluentd_nodeselector if openshift_hosted_logging_fluentd_nodeselector is defined else '--all' }} logging-infra-fluentd=true --overwrite"
 
   - name: "Wait for fluentd to be running"
     shell:  "{{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig get pods -l component=fluentd | grep Running"


### PR DESCRIPTION
- Fix bug: now create templates for logging accounts and the deployer use {{ examples_base }} variable
- Fix bug: syntax error in deploy fluentd by labeling the node
