### PR TITLE
a-o-i: Do not display version number in quick installer

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -483,8 +483,7 @@ def get_variant_and_version(multi_master=False):
     i = 1
     combos = get_variant_version_combos()
     for (variant, version) in combos:
-        message = "%s\n(%s) %s %s" % (message, i, variant.description,
-                                      version.name)
+        message = "%s\n(%s) %s" % (message, i, variant.description)
         i = i + 1
     message = "%s\n" % message
 


### PR DESCRIPTION
As we now require the version of the installer to match what will be installed in
the target environment and to avoid any potential confusion, remove the version
number from the variant choice question.