### PR TITLE
Fix node label / schedulability when inventory_hostname != openshift.common.hostname

### DIFF
--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -156,9 +156,7 @@
 - name: Set schedulability
   hosts: oo_first_master
   vars:
-    openshift_nodes: "{{ hostvars
-                         | oo_select_keys(groups['oo_nodes_to_config'])
-                         | oo_collect('openshift.common.hostname') }}"
+    openshift_nodes: "{{ groups.oo_nodes_to_config | default([]) }}"
   pre_tasks:
   # Necessary because when you're on a node that's also a master the master will be
   # restarted after the node restarts docker and it will take up to 60 seconds for

--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Wait for Node Registration
   command: >
-    {{ openshift.common.client_binary }} get node {{ item | lower }}
+    {{ openshift.common.client_binary }} get node {{ hostvars[item].openshift.common.hostname | lower }}
     --config={{ openshift_manage_node_kubeconfig }}
     -n default
   register: omd_get_node
@@ -29,8 +29,7 @@
     {{ openshift.common.admin_binary }} manage-node {{ hostvars[item].openshift.common.hostname | lower }} --schedulable={{ 'true' if hostvars[item].openshift.node.schedulable | bool else 'false' }}
     --config={{ openshift_manage_node_kubeconfig }}
     -n default
-  with_items:
-    -  "{{ openshift_nodes }}"
+  with_items: "{{ openshift_nodes }}"
   when: hostvars[item].openshift.common.hostname is defined
 
 - name: Label nodes
@@ -38,8 +37,7 @@
     {{ openshift.common.client_binary }} label --overwrite node {{ hostvars[item].openshift.common.hostname | lower }} {{ hostvars[item].openshift.node.labels | oo_combine_dict  }}
     --config={{ openshift_manage_node_kubeconfig }}
     -n default
-  with_items:
-    -  "{{ openshift_nodes }}"
+  with_items: "{{ openshift_nodes }}"
   when: hostvars[item].openshift.common.hostname is defined and 'labels' in hostvars[item].openshift.node and hostvars[item].openshift.node.labels != {}
 
 - name: Delete temp directory


### PR DESCRIPTION
Fixes problem introduced by 75d4f13ad39a770a8954aef9507e5d136ecb3306 in which node labels / schedulability would not be applied when node `inventory_hostname` differed from `openshift.common.hostname`.

Previously, tasks in the `openshift_manage_node` role looped over `openshift.common.hostname` for all nodes but will now loop over `inventory_hostname` for all nodes s.t. `item == inventory_hostname` and can be used to access `hostvars` within each task.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1374474

