### PR TITLE
Flush handlers before marking a node schedulable after upgrade.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade.yml
@@ -211,6 +211,8 @@
   - include: containerized_node_upgrade.yml
     when: inventory_hostname in groups.oo_nodes_to_config and openshift.common.is_containerized | bool
 
+  - meta: flush_handlers
+
   - name: Set node schedulability
     command: >
       {{ openshift.common.admin_binary }} manage-node {{ openshift.common.hostname | lower }} --schedulable=true


### PR DESCRIPTION
Handlers normally only trigger at the end of the play, but in this case
we just set our node schedulable again resulting in it immediately
getting taken down again.