### PR TITLE
a-o-i: Allow better setting of host level variables

### DIFF
--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -31,6 +31,15 @@ VARIABLES_MAP = {
     'proxy_exclude_hosts': 'openshift_no_proxy',
 }
 
+HOST_VARIABLES_MAP = {
+    'ip': 'openshift_ip',
+    'public_ip': 'openshift_public_ip',
+    'hostname': 'openshift_hostname',
+    'public_hostname': 'openshift_public_hostname',
+    'node_labels': 'openshift_node_labels',
+    'containerized': 'containerized',
+}
+
 
 def set_config(cfg):
     global CFG
@@ -176,7 +185,6 @@ def write_proxy_settings(base_inventory):
         pass
 
 
-# pylint: disable=too-many-branches
 def write_host(host, role, inventory, schedulable=None):
     global CFG
 
@@ -184,22 +192,13 @@ def write_host(host, role, inventory, schedulable=None):
         return
 
     facts = ''
-    if host.ip:
-        facts += ' openshift_ip={}'.format(host.ip)
-    if host.public_ip:
-        facts += ' openshift_public_ip={}'.format(host.public_ip)
-    if host.hostname:
-        facts += ' openshift_hostname={}'.format(host.hostname)
-    if host.public_hostname:
-        facts += ' openshift_public_hostname={}'.format(host.public_hostname)
-    if host.containerized:
-        facts += ' containerized={}'.format(host.containerized)
+    for prop in HOST_VARIABLES_MAP:
+        if getattr(host, prop):
+            facts += ' {}={}'.format(HOST_VARIABLES_MAP.get(prop), getattr(host, prop))
+
     if host.other_variables:
         for variable, value in host.other_variables.iteritems():
             facts += " {}={}".format(variable, value)
-    if host.node_labels:
-        if role == 'node':
-            facts += ' openshift_node_labels="{}"'.format(host.node_labels)
 
     # Distinguish between three states, no schedulability specified (use default),
     # explicitly set to True, or explicitly set to False:


### PR DESCRIPTION
Allow the user to set arbitrary variables directly under the host item instead of
in under an 'other_variables' item.