### PR TITLE
Bug 1367284 - rootdirectory configuration is hardcode when installer is using s3 as registry storage

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -318,6 +318,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_hosted_registry_storage_s3_bucket=bucket_name
 #openshift_hosted_registry_storage_s3_region=bucket_region
 #openshift_hosted_registry_storage_s3_chunksize=26214400
+#openshift_hosted_registry_storage_s3_rootdirectory=/registry
 #openshift_hosted_registry_pullthrough=true
 
 # Metrics deployment

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -317,6 +317,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_hosted_registry_storage_s3_bucket=bucket_name
 #openshift_hosted_registry_storage_s3_region=bucket_region
 #openshift_hosted_registry_storage_s3_chunksize=26214400
+#openshift_hosted_registry_storage_s3_rootdirectory=/registry
 #openshift_hosted_registry_pullthrough=true
 
 # Metrics deployment

--- a/roles/openshift_hosted/templates/registry_config.j2
+++ b/roles/openshift_hosted/templates/registry_config.j2
@@ -15,7 +15,7 @@ storage:
     encrypt: false
     secure: true
     v4auth: true
-    rootdirectory: /registry
+    rootdirectory: {{ openshift.hosted.registry.storage.s3.rootdirectory | default('/registry') }}
     chunksize: "{{ openshift.hosted.registry.storage.s3.chunksize | default(26214400) }}"
 {% elif openshift.hosted.registry.storage.provider == 'azure_blob' %}
   azure:


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1367284
Bug 1367284