### PR TITLE
Pause after restarting openvswitch in containerized upgrade.

### DIFF
--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -2,6 +2,12 @@
 - name: restart openvswitch
   service: name=openvswitch state=restarted
   when: not (ovs_service_status_changed | default(false) | bool)
+  notify:
+  - restart openvswitch pause
+
+- name: restart openvswitch pause
+  pause: seconds=15
+  when: openshift.common.is_containerized | bool
 
 - name: restart node
   service: name={{ openshift.common.service_type }}-node state=restarted


### PR DESCRIPTION
The openvswitch restart appears to hang the node container running
briefly, if you try to restart node too quickly it will fail complaining
that the node container name is still in use. Pausing after openvswitch
restart allows the existing node container to catch up and then shutdown
cleanly.