### PR TITLE
Switch to origin-1.x branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,18 @@ that it installs currently require a package that provides `docker`. Currently
 the RPMs provided from dockerproject.org do not provide this requirement, though
 they may in the future.
 
-##Branches
+##Branches and tags
+
 The master branch tracks our current work and should be compatible with both
-Origin master branch and the current Origin stable release, currently that's
-v1.3 and v1.2. Enterprise branches exist where we coordinate with internal Red
-Hat Quality Assurance teams. Fixes and backwards compatible feature improvements
-are often backported to the more current enterprise branches.  The enterprise
-branches should also be compatible with the corresponding Origin release for
-users who are looking for more conservative rate of change.
+Origin master branch and the most recent Origin stable release. Currently that's
+v1.3 and v1.2.x. In addition to the master branch we maintain stable branches
+corresponding to upstream Origin releases, ie: release-1.2. The most recent of
+branch will often receive minor feature backports and fixes. Older branches will
+receive only critical fixes.
+
+Releases are tagged periodically from active branches and are versioned 3.x
+corresponding to Origin releases 1.x. We unfortunately started with 3.0 and it's
+not practical to start over at 1.0.
 
 ##Setup
 - Install base dependencies:


### PR DESCRIPTION
Prepare to switch from `enterprise-3.x` to `origin-1.x` branch names.