### PR TITLE
[redeploy-certificates] Correct etcd service name for containerized.

### DIFF
--- a/playbooks/common/openshift-cluster/redeploy-certificates.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates.yml
@@ -52,6 +52,14 @@
     openshift_ca_host: "{{ groups.oo_first_master.0 }}"
     openshift_master_count: "{{ openshift.master.master_count | default(groups.oo_masters | length) }}"
   pre_tasks:
+  # set_fact task copied from playbooks/common/openshift-master/config.yml
+  # so that openshift_master_default_subdomain has a default value of ""
+  # (emptry string). openshift_master_default_subdomain must have a default
+  # value for openshift_master_facts to set metrics_public_url.
+  # TODO: clean this up.
+  - set_fact:
+      openshift_master_default_subdomain: "{{ lookup('oo_option', 'openshift_master_default_subdomain') | default(None, true) }}"
+    when: openshift_master_default_subdomain is not defined
   - stat:
       path: "{{ openshift_generated_configs_dir }}"
     register: openshift_generated_configs_dir_stat

--- a/playbooks/common/openshift-cluster/redeploy-certificates.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates.yml
@@ -133,7 +133,9 @@
   hosts: oo_etcd_to_config
   tasks:
   - name: restart etcd
-    service: name=etcd state=restarted
+    service:
+      name: "{{ 'etcd' if not openshift.common.is_containerized | bool else 'etcd_container' }}"
+      state: restarted
 
 - name: Stop master services
   hosts: oo_masters_to_config


### PR DESCRIPTION
Template etcd service name in cert redeploy playbook.

I'm also setting `openshift_master_default_subdomain` similarly to [playbooks/common/openshift-master/config.yml#L39-L41](https://github.com/openshift/openshift-ansible/blob/872aafbe7a65388c473d125095ae60fc9ae915a4/playbooks/common/openshift-master/config.yml#L39-L41) to work around an issue I encountered with master facts in the redeploy playbook.

```
TASK [openshift_master_facts : Set master facts] *******************************
Wednesday 14 September 2016  12:05:16 -0400 (0:00:00.068)       0:01:44.888 ***
fatal: [master4.example.com]: FAILED! => {
    "failed": true
}

MSG:

the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: {{ openshift_hosted_metrics_public_url | default('hawkular-metrics.' ~ (openshift.master.default_subdomain | default(openshift_master_default_subdomain ))) | oo_hostname_from_url }}: 'openshift_master_default_subdomain' is undefined

The error appears to have been in '/home/abutcher/rhat/openshift-ansible/roles/openshift_master_facts/tasks/main.yml': line 2, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
- name: Set master facts
  ^ here
```

Setting the `metrics_public_url` in master facts only seems to work because `openshift_master_default_subdomain` has a value of `""` and can be used as a default. Copying it here mirrors how the byo playbooks function. Will follow up / create issue to fix.

Fixes #2448.
@sdodson PTAL