### PR TITLE
Add role to manageiq to allow creation of projects

### DIFF
--- a/roles/openshift_manageiq/vars/main.yml
+++ b/roles/openshift_manageiq/vars/main.yml
@@ -30,6 +30,7 @@ manage_iq_tasks:
     - policy add-scc-to-user privileged system:serviceaccount:management-infra:management-admin
     - policy add-cluster-role-to-user system:image-puller system:serviceaccount:management-infra:inspector-admin
     - policy add-scc-to-user privileged system:serviceaccount:management-infra:inspector-admin
+    - policy add-cluster-role-to-user self-provisioner system:serviceaccount:management-infra:management-admin
 
 manage_iq_openshift_3_2_tasks:
     - policy add-cluster-role-to-user system:image-auditor system:serviceaccount:management-infra:management-admin


### PR DESCRIPTION
This should allow manageiq to:
  1. request a new project, become an admin in that project,
  2. instantiate a template in that project,
  3. bind a role in that project

@deads2k Please review.

@enoodle Thanks for the help
cc @simon3z @moolitayer @zakiva