### PR TITLE
Add 'MaxGCEPDVolumeCount' to default scheduler predicates.

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1731,6 +1731,7 @@ class OpenShiftFacts(object):
                 {"name": "NoDiskConflict"},
                 {"name": "NoVolumeZoneConflict"},
                 {"name": "MaxEBSVolumeCount"},
+                {"name": "MaxGCEPDVolumeCount"},
                 {"name": "Region", "argument": {"serviceAffinity" : {"labels" : ["region"]}}}
             ]
             scheduler_priorities = [


### PR DESCRIPTION
Fixes: Bug 1370707

https://bugzilla.redhat.com/show_bug.cgi?id=1370707