### PR TITLE
Add documentation about the openshift_hosted_metrics_public_url option

### DIFF
--- a/roles/openshift_metrics/README.md
+++ b/roles/openshift_metrics/README.md
@@ -16,6 +16,7 @@ From this role:
 | Name                                            | Default value         |                                                             |
 |-------------------------------------------------|-----------------------|-------------------------------------------------------------|
 | openshift_hosted_metrics_deploy                 | `False`               | If metrics should be deployed                               |
+| openshift_hosted_metrics_public_url             | null                  | Hawkular metrics public url                                 |
 | openshift_hosted_metrics_storage_nfs_directory  | `/exports`            | Root export directory.                                      |
 | openshift_hosted_metrics_storage_volume_name    | `metrics`             | Metrics volume within openshift_hosted_metrics_volume_dir   |
 | openshift_hosted_metrics_storage_volume_size    | `10Gi`                | Metrics volume size                                         |


### PR DESCRIPTION
We now have an option in the `openshift_metrics` role to set the metrics public hostname

This PR adds the missing documentaion.