### PR TITLE
Clarify openshift_hosted_metrics_public_url

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -364,6 +364,8 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #
 # Override metricsPublicURL in the master config for cluster metrics
 # Defaults to https://hawkular-metrics.{{openshift_master_default_subdomain}}/hawkular/metrics
+# Currently, you may only alter the hostname portion of the url, alterting the
+# `/hawkular/metrics` path will break installation of metrics.
 #openshift_hosted_metrics_public_url=https://hawkular-metrics.example.com/hawkular/metrics
 
 # Configure the multi-tenant SDN plugin (default is 'redhat/openshift-ovs-subnet')

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -363,6 +363,8 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #
 # Override metricsPublicURL in the master config for cluster metrics
 # Defaults to https://hawkular-metrics.{{openshift_master_default_subdomain}}/hawkular/metrics
+# Currently, you may only alter the hostname portion of the url, alterting the
+# `/hawkular/metrics` path will break installation of metrics.
 #openshift_hosted_metrics_public_url=https://hawkular-metrics.example.com/hawkular/metrics
 
 


### PR DESCRIPTION
Currently, metrics only works at /hawkular/metrics so if you alter the path
portion of the variable then the master will direct traffic at an endpoint that
won't work.