### PR TITLE
add origin 1.3 version

### DIFF
--- a/utils/src/ooinstall/variants.py
+++ b/utils/src/ooinstall/variants.py
@@ -52,6 +52,7 @@ REG = Variant('openshift-enterprise', 'Registry',
 
 origin = Variant('origin', 'OpenShift Origin',
                  [
+                     Version('1.3', 'origin'),
                      Version('1.2', 'origin'),
                  ]
 )


### PR DESCRIPTION
Was installing origin via byo playbook and found out it was installing 1.2 - I'm not sure this is the right fix or if there's already a PR which does this though.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>