### PR TITLE
Update service presence checks to work with systemd in RHEL 7.3

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -28,20 +28,21 @@
     state: directory
     mode: 0700
 
+- name: Check for etcd service presence
+  command: systemctl show etcd.service
+  register: etcd_show
+  changed_when: false
+  failed_when: false
+
 - name: Disable system etcd when containerized
-  when: etcd_is_containerized | bool
+  when: etcd_is_containerized | bool and etcd_show.rc == 0 and 'LoadState=not-found' not in etcd_show.stdout
   service:
     name: etcd
     state: stopped
     enabled: no
 
-- name: Check for etcd service presence
-  command: systemctl show etcd.service
-  register: etcd_show
-  changed_when: false
-
 - name: Mask system etcd when containerized
-  when: etcd_is_containerized | bool and 'LoadState=not-found' not in etcd_show.stdout
+  when: etcd_is_containerized | bool and etcd_show.rc == 0 and 'LoadState=not-found' not in etcd_show.stdout
   command: systemctl mask etcd
 
 - name: Reload systemd units

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -164,9 +164,15 @@
   register: start_result
   notify: Verify API Server
 
+- name: Check for non-HA master service presence
+  command: systemctl show {{ openshift.common.service_type }}-master.service
+  register: master_svc_show
+  changed_when: false
+  failed_when: false
+
 - name: Stop and disable non HA master when running HA
   service: name={{ openshift.common.service_type }}-master enabled=no state=stopped
-  when: openshift_master_ha | bool
+  when: openshift_master_ha | bool and master_svc_show.rc == 0 and 'LoadState=not-found' not in master_svc_show.stdout
 
 - set_fact:
     master_service_status_changed: "{{ start_result | changed }}"


### PR DESCRIPTION
Backport https://github.com/openshift/openshift-ansible/pull/2502

This adds a check on the master non ha service that didn't exist in the
release-1.1 branch but I figured it made sense to add it when backporting these
changes.