### PR TITLE
Reduce warning output

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -17,8 +17,16 @@ import re
 import json
 import yaml
 from ansible.parsing.yaml.dumper import AnsibleDumper
-from ansible.utils.unicode import to_unicode
 from urlparse import urlparse
+
+try:
+    # ansible-2.2
+    # ansible.utils.unicode.to_unicode is deprecated in ansible-2.2,
+    # ansible.module_utils._text.to_text should be used instead.
+    from ansible.module_utils._text import to_text
+except ImportError:
+    # ansible-2.1
+    from ansible.utils.unicode import to_unicode as to_text
 
 # Disabling too-many-public-methods, since filter methods are necessarily
 # public
@@ -626,7 +634,7 @@ class FilterModule(object):
                                     default_flow_style=False,
                                     Dumper=AnsibleDumper, **kw)
             padded = "\n".join([" " * level * indent + line for line in transformed.splitlines()])
-            return to_unicode("\n{0}".format(padded))
+            return to_text("\n{0}".format(padded))
         except Exception as my_e:
             raise errors.AnsibleFilterError('Failed to convert: %s' % my_e)
 

--- a/playbooks/common/openshift-master/scaleup.yml
+++ b/playbooks/common/openshift-master/scaleup.yml
@@ -40,6 +40,10 @@
       --cacert {{ openshift.common.config_base }}/master/ca.crt
       {% endif %}
       {{ openshift.master.api_url }}/healthz/ready
+    args:
+      # Disables the following warning:
+      # Consider using get_url or uri module rather than running curl
+      warn: no
     register: api_available_output
     until: api_available_output.stdout == 'ok'
     retries: 120

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -172,6 +172,10 @@
       --cacert {{ openshift.common.config_base }}/master/ca.crt
       {% endif %}
       {{ openshift.master.api_url }}/healthz/ready
+    args:
+      # Disables the following warning:
+      # Consider using get_url or uri module rather than running curl
+      warn: no
     register: api_available_output
     until: api_available_output.stdout == 'ok'
     retries: 120

--- a/roles/etcd_client_certificates/tasks/main.yml
+++ b/roles/etcd_client_certificates/tasks/main.yml
@@ -93,6 +93,9 @@
       -C {{ etcd_generated_certs_dir }}/{{ etcd_cert_subdir }} .
   args:
     creates: "{{ etcd_generated_certs_dir }}/{{ etcd_cert_subdir }}.tgz"
+    # Disables the following warning:
+    # Consider using unarchive module rather than running tar
+    warn: no
   when: etcd_client_certs_missing | bool
   delegate_to: "{{ etcd_ca_host }}"
 

--- a/roles/etcd_server_certificates/tasks/main.yml
+++ b/roles/etcd_server_certificates/tasks/main.yml
@@ -114,6 +114,9 @@
       -C {{ etcd_generated_certs_dir }}/{{ etcd_cert_subdir }} .
   args:
     creates: "{{ etcd_generated_certs_dir }}/{{ etcd_cert_subdir }}.tgz"
+    # Disables the following warning:
+    # Consider using unarchive module rather than running tar
+    warn: no
   when: etcd_server_certs_missing | bool
   delegate_to: "{{ etcd_ca_host }}"
 

--- a/roles/openshift_examples/tasks/main.yml
+++ b/roles/openshift_examples/tasks/main.yml
@@ -19,6 +19,10 @@
 
 - name: Create tar of OpenShift examples
   local_action: command tar -C "{{ role_path }}/files/examples/{{ content_version }}/" -cvf "{{ copy_examples_mktemp.stdout }}/openshift-examples.tar" .
+  args:
+    # Disables the following warning:
+    # Consider using unarchive module rather than running tar
+    warn: no
   become: False
   register: copy_examples_tar
 

--- a/roles/openshift_master/handlers/main.yml
+++ b/roles/openshift_master/handlers/main.yml
@@ -24,6 +24,10 @@
     --cacert {{ openshift.common.config_base }}/master/ca.crt
     {% endif %}
     {{ openshift.master.api_url }}/healthz/ready
+  args:
+    # Disables the following warning:
+    # Consider using get_url or uri module rather than running curl
+    warn: no
   register: api_available_output
   until: api_available_output.stdout == 'ok'
   retries: 120

--- a/roles/openshift_metrics/handlers/main.yml
+++ b/roles/openshift_metrics/handlers/main.yml
@@ -24,6 +24,10 @@
     --cacert {{ openshift.common.config_base }}/master/ca.crt
     {% endif %}
     {{ openshift.master.api_url }}/healthz/ready
+  args:
+    # Disables the following warning:
+    # Consider using get_url or uri module rather than running curl
+    warn: no
   register: api_available_output
   until: api_available_output.stdout == 'ok'
   retries: 120

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -93,9 +93,9 @@
     create: true
   with_items:
     - regex: '^AWS_ACCESS_KEY_ID='
-      line: "AWS_ACCESS_KEY_ID={{ openshift_cloudprovider_aws_access_key }}"
+      line: "AWS_ACCESS_KEY_ID={{ openshift_cloudprovider_aws_access_key | default('') }}"
     - regex: '^AWS_SECRET_ACCESS_KEY='
-      line: "AWS_SECRET_ACCESS_KEY={{ openshift_cloudprovider_aws_secret_key }}"
+      line: "AWS_SECRET_ACCESS_KEY={{ openshift_cloudprovider_aws_secret_key | default('') }}"
   when: "openshift_cloudprovider_kind is defined and openshift_cloudprovider_kind == 'aws' and openshift_cloudprovider_aws_access_key is defined and openshift_cloudprovider_aws_secret_key is defined"
   notify:
   - restart node
@@ -134,6 +134,10 @@
   command: >
     curl --silent --cacert {{ openshift.common.config_base }}/node/ca.crt
     {{ openshift_node_master_api_url }}/healthz/ready
+  args:
+    # Disables the following warning:
+    # Consider using get_url or uri module rather than running curl
+    warn: no
   register: api_available_output
   until: api_available_output.stdout == 'ok'
   retries: 120

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -56,12 +56,12 @@
     create: true
   with_items:
     - regex: '^HTTP_PROXY='
-      line: "HTTP_PROXY={{ openshift.common.http_proxy }}"
+      line: "HTTP_PROXY={{ openshift.common.http_proxy | default('') }}"
     - regex: '^HTTPS_PROXY='
-      line: "HTTPS_PROXY={{ openshift.common.https_proxy }}"
+      line: "HTTPS_PROXY={{ openshift.common.https_proxy | default('') }}"
     - regex: '^NO_PROXY='
-      line: "NO_PROXY={{ openshift.common.no_proxy | join(',') }},{{ openshift.common.portal_net }},{{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }}"
-  when: "{{ openshift.common.http_proxy is defined and openshift.common.http_proxy != '' }}"
+      line: "NO_PROXY={{ openshift.common.no_proxy | default([]) | join(',') }},{{ openshift.common.portal_net }},{{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }}"
+  when: ('http_proxy' in openshift.common and openshift.common.http_proxy != '')
   notify:
   - restart node
 

--- a/roles/openshift_node_certificates/tasks/main.yml
+++ b/roles/openshift_node_certificates/tasks/main.yml
@@ -91,6 +91,9 @@
     -C {{ openshift_node_generated_config_dir }} .
   args:
     creates: "{{ openshift_node_generated_config_dir }}.tgz"
+    # Disables the following warning:
+    # Consider using unarchive module rather than running tar
+    warn: no
   when: node_certs_missing | bool
   delegate_to: "{{ openshift_ca_host }}"
 

--- a/roles/openshift_repos/handlers/main.yml
+++ b/roles/openshift_repos/handlers/main.yml
@@ -1,3 +1,7 @@
 ---
 - name: refresh cache
   command: "{{ ansible_pkg_mgr }} clean all"
+  args:
+    # Disables the following warning:
+    # Consider using yum module rather than running yum
+    warn: no

--- a/roles/os_firewall/tasks/firewall/iptables.yml
+++ b/roles/os_firewall/tasks/firewall/iptables.yml
@@ -1,6 +1,10 @@
 ---
 - name: Check if firewalld is installed
   command: rpm -q firewalld
+  args:
+    # Disables the following warning:
+    # Consider using yum, dnf or zypper module rather than running rpm
+    warn: no
   register: pkg_check
   failed_when: pkg_check.rc > 1
   changed_when: no


### PR DESCRIPTION
Especially from the command module since we are using the command module rather than the alternative for a reason in most (if not all) cases.

There are a few warnings not covered here such as from the standalone registry deployment tasks in `openshift_hosted` that are removed in https://github.com/openshift/openshift-ansible/pull/2475.