### PR TITLE
a-o-i: Move oo_config objects out

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -7,7 +7,8 @@ import sys
 import click
 from pkg_resources import parse_version
 from ooinstall import openshift_ansible, utils
-from ooinstall.oo_config import Host, OOConfig, OOConfigInvalidHostError, Role
+from ooinstall.oo_config import OOConfig
+from ooinstall.models import Host, Role, InvalidHostError
 from ooinstall.variants import find_variant, get_variant_version_combos
 
 INSTALLER_LOG = logging.getLogger('installer')
@@ -870,8 +871,8 @@ def cli(ctx, unattended, configuration, ansible_playbook_directory, ansible_log_
 
     try:
         oo_cfg = OOConfig(ctx.obj['configuration'])
-    except OOConfigInvalidHostError as err:
-        click.echo(err)
+    except InvalidHostError as error:
+        click.echo(error)
         sys.exit(1)
 
     # If no playbook dir on the CLI, check the config:

--- a/utils/src/ooinstall/models.py
+++ b/utils/src/ooinstall/models.py
@@ -1,0 +1,127 @@
+# pylint: disable=too-few-public-methods,missing-docstring
+"""
+Models for the oo_config in memory object
+"""
+
+
+class Role(object):
+    """ A role that will be applied to a host. """
+    def __init__(self, name, variables):
+        self.name = name
+        self.variables = variables
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return self.name
+
+    def to_dict(self):
+        """ Used when exporting to yaml. """
+        dictionary = {}
+        for prop in ['name', 'variables']:
+            # If the property is defined (not None or False), export it:
+            if getattr(self, prop):
+                dictionary[prop] = getattr(self, prop)
+        return dictionary
+
+
+class InvalidHostError(Exception):
+    """ Host in config is missing both ip and hostname. """
+    pass
+
+
+class Host(object):
+    """ A system we will or have installed OpenShift on. """
+    # pylint: disable=invalid-name,too-many-instance-attributes
+    def __init__(self, **kwargs):
+        self.ip = kwargs.get('ip', None)
+        self.hostname = kwargs.get('hostname', None)
+        self.public_ip = kwargs.get('public_ip', None)
+        self.public_hostname = kwargs.get('public_hostname', None)
+        self.connect_to = kwargs.get('connect_to', None)
+
+        self.preconfigured = kwargs.get('preconfigured', None)
+        self.schedulable = kwargs.get('schedulable', None)
+        self.new_host = kwargs.get('new_host', None)
+        self.containerized = kwargs.get('containerized', False)
+        self.node_labels = kwargs.get('node_labels', '')
+
+        # allowable roles: master, node, etcd, storage, master_lb
+        self.roles = kwargs.get('roles', [])
+
+        self.other_variables = kwargs.get('other_variables', {})
+
+        if self.connect_to is None:
+            raise InvalidHostError(
+                "You must specify either an ip or hostname as 'connect_to'")
+
+    def __str__(self):
+        return self.connect_to
+
+    def __repr__(self):
+        return self.connect_to
+
+    def to_dict(self):
+        """ Used when exporting to yaml. """
+        dictionary = {}
+
+        for prop in ['ip', 'hostname', 'public_ip', 'public_hostname', 'connect_to',
+                     'preconfigured', 'containerized', 'schedulable', 'roles', 'node_labels', ]:
+            # If the property is defined (not None or False), export it:
+            if getattr(self, prop):
+                dictionary[prop] = getattr(self, prop)
+        for variable, value in self.other_variables.iteritems():
+            dictionary[variable] = value
+
+        return dictionary
+
+    def is_master(self):
+        return 'master' in self.roles
+
+    def is_node(self):
+        return 'node' in self.roles
+
+    def is_master_lb(self):
+        return 'master_lb' in self.roles
+
+    def is_storage(self):
+        return 'storage' in self.roles
+
+    def is_etcd_member(self, all_hosts):
+        """ Will this host be a member of a standalone etcd cluster. """
+        if not self.is_master():
+            return False
+        masters = [host for host in all_hosts if host.is_master()]
+        if len(masters) > 1:
+            return True
+        return False
+
+    def is_dedicated_node(self):
+        """ Will this host be a dedicated node. (not a master) """
+        return self.is_node() and not self.is_master()
+
+    def is_schedulable_node(self, all_hosts):
+        """ Will this host be a node marked as schedulable. """
+        if not self.is_node():
+            return False
+        if not self.is_master():
+            return True
+
+        masters = [host for host in all_hosts if host.is_master()]
+        nodes = [host for host in all_hosts if host.is_node()]
+        if len(masters) == len(nodes):
+            return True
+        return False
+
+
+class Deployment(object):
+    def __init__(self, **kwargs):
+        self.hosts = kwargs.get('hosts', [])
+        self.roles = kwargs.get('roles', {})
+        self.variables = kwargs.get('variables', {})
+
+    # pylint: disable=no-self-use
+    def to_dict(self):
+        # TODO: write to_dict for Deployment
+        return {}

--- a/utils/src/ooinstall/variants.py
+++ b/utils/src/ooinstall/variants.py
@@ -1,7 +1,3 @@
-# TODO: Temporarily disabled due to importing old code into openshift-ansible
-# repo. We will work on these over time.
-# pylint: disable=bad-continuation,missing-docstring,no-self-use,invalid-name,too-few-public-methods
-
 """
 Defines the supported variants and versions the installer supports, and metadata
 required to run Ansible correctly.
@@ -11,29 +7,47 @@ to be specified by the user, and to point the generic variants to the latest
 version.
 """
 
-import logging
-installer_log = logging.getLogger('installer')
 
-
+# pylint: disable=too-few-public-methods
 class Version(object):
+    """
+    Defines a deploy_type for use by the ansible playbooks.
+
+    Attributes:
+        name (str): The major and minor version for the deployment type.mro
+                    e.g. 3.0, 3.1
+        ansible_key (str): What will become deployment_type in the ansible inventory
+        subtype (str): A marker for disabling features or running additional
+                       configuration for a deployment.
+    """
     def __init__(self, name, ansible_key, subtype=''):
-        self.name = name  # i.e. 3.0, 3.1
+        self.name = name
 
         self.ansible_key = ansible_key
         self.subtype = subtype
 
 
 class Variant(object):
+    """
+    A wrapper for similar Versions
+
+    Attributes:
+        name (str): Supported variant name.
+        description (str): A friendly name for the variant.
+        versions (list): A collection of Versions. In order for this to
+                         function correctly, the Versions must be ordered
+                         from newest to oldest.
+    """
     def __init__(self, name, description, versions):
-        # Supported variant name:
         self.name = name
-
-        # Friendly name for the variant:
         self.description = description
-
         self.versions = versions
 
     def latest_version(self):
+        """
+        Returns the first entry in the versions collection, which
+        if it is properly ordered, should be the newest.
+        """
         return self.versions[0]
 
 
@@ -42,19 +56,19 @@ OSE = Variant('openshift-enterprise', 'OpenShift Container Platform',
               [
                   Version('3.4', 'openshift-enterprise'),
               ]
-)
+             )
 
 REG = Variant('openshift-enterprise', 'Registry',
               [
                   Version('3.4', 'openshift-enterprise', 'registry'),
               ]
-)
+             )
 
-origin = Variant('origin', 'OpenShift Origin',
+ORIGIN = Variant('origin', 'OpenShift Origin',
                  [
                      Version('1.4', 'origin'),
                  ]
-)
+                )
 
 LEGACY = Variant('openshift-enterprise', 'OpenShift Container Platform',
                  [
@@ -63,10 +77,10 @@ LEGACY = Variant('openshift-enterprise', 'OpenShift Container Platform',
                      Version('3.1', 'openshift-enterprise'),
                      Version('3.0', 'openshift-enterprise'),
                  ]
-)
+                )
 
 # Ordered list of variants we can install, first is the default.
-SUPPORTED_VARIANTS = (OSE, REG, origin, LEGACY)
+SUPPORTED_VARIANTS = (OSE, REG, ORIGIN, LEGACY)
 DISPLAY_VARIANTS = (OSE, REG,)
 
 
@@ -81,14 +95,18 @@ def find_variant(name, version=None):
         if prod.name == name:
             if version is None:
                 return (prod, prod.latest_version())
-            for v in prod.versions:
-                if v.name == version:
-                    return (prod, v)
+            for ver in prod.versions:
+                if ver.name == version:
+                    return (prod, ver)
 
     return (None, None)
 
 
 def get_variant_version_combos():
+    """
+    Returns a list of Variants to display to the user in
+    interactive mode.
+    """
     combos = []
     for variant in DISPLAY_VARIANTS:
         for ver in variant.versions:


### PR DESCRIPTION
Move the model objects used in oo_config out to their own models
file for readablity and future expansion.
