### PR TITLE
Don't set IMAGE_PREFIX if openshift_cockpit_deployer_prefix is empty

### DIFF
--- a/roles/cockpit-ui/tasks/main.yml
+++ b/roles/cockpit-ui/tasks/main.yml
@@ -50,13 +50,10 @@
   register: registry_console_cockpit_kube_url
   changed_when: false
 
-- set_fact:
-    cockpit_image_prefix: "{{ '-p IMAGE_PREFIX=' ~ openshift_cockpit_deployer_prefix | default('') }}"
-
 - name: Deploy registry-console
   command: >
     {{ openshift.common.client_binary }} new-app --template=registry-console
-    {{ cockpit_image_prefix }}
+    {% if openshift_cockpit_deployer_prefix is defined  %}-p IMAGE_PREFIX="{{ openshift_cockpit_deployer_prefix }}"{% endif %}
     -p OPENSHIFT_OAUTH_PROVIDER_URL="{{ openshift.master.public_api_url }}"
     -p REGISTRY_HOST="{{ docker_registry_route.stdout }}"
     -p COCKPIT_KUBE_URL="{{ registry_console_cockpit_kube_url.stdout }}"


### PR DESCRIPTION
If openshift_cockpit_deployer_prefix was empty then they called
"-p IMAGE_PREFIX=" and this overwrite the template default. For example:
```
grep -A1 -B1 'name: IMAGE_PREFIX' examples/infrastructure-templates/enterprise/registry-console.yaml
  - description: 'Specify "registry/repository" prefix for container image; e.g. for "registry.access.redhat.com/openshift3/registry-console:latest", set prefix "registry.access.redhat.com/openshift3/"'
    name: IMAGE_PREFIX
    value: "registry.access.redhat.com/openshift3/"
```