### PR TITLE
Add support for the write access option of hawkular mrtrics

### DIFF
--- a/roles/openshift_metrics/README.md
+++ b/roles/openshift_metrics/README.md
@@ -17,6 +17,7 @@ From this role:
 |-------------------------------------------------|-----------------------|-------------------------------------------------------------|
 | openshift_hosted_metrics_deploy                 | `False`               | If metrics should be deployed                               |
 | openshift_hosted_metrics_public_url             | null                  | Hawkular metrics public url                                 |
+| openshift_hosted_metrics_write_access           | `False`               | Hawkular metrics public url allow write access              |
 | openshift_hosted_metrics_storage_nfs_directory  | `/exports`            | Root export directory.                                      |
 | openshift_hosted_metrics_storage_volume_name    | `metrics`             | Metrics volume within openshift_hosted_metrics_volume_dir   |
 | openshift_hosted_metrics_storage_volume_size    | `10Gi`                | Metrics volume size                                         |

--- a/roles/openshift_metrics/tasks/install.yml
+++ b/roles/openshift_metrics/tasks/install.yml
@@ -71,7 +71,7 @@
   set_fact:
     deployer_cmd: "{{ openshift.common.client_binary }} process -f \
       {{ metrics_template_dir }}/metrics-deployer.yaml -v \
-      HAWKULAR_METRICS_HOSTNAME={{ metrics_hostname }},USE_PERSISTENT_STORAGE={{metrics_persistence | string | lower }},DYNAMICALLY_PROVISION_STORAGE={{metrics_dynamic_vol | string | lower }},METRIC_DURATION={{ openshift.hosted.metrics.duration }},METRIC_RESOLUTION={{ openshift.hosted.metrics.resolution }}{{ image_prefix }}{{ image_version }},MODE={{ deployment_mode }} \
+      HAWKULAR_METRICS_HOSTNAME={{ metrics_hostname }},USER_WRITE_ACCESS={{ metrics_write_access | string | lower }},USE_PERSISTENT_STORAGE={{metrics_persistence | string | lower }},DYNAMICALLY_PROVISION_STORAGE={{metrics_dynamic_vol | string | lower }},METRIC_DURATION={{ openshift.hosted.metrics.duration }},METRIC_RESOLUTION={{ openshift.hosted.metrics.resolution }}{{ image_prefix }}{{ image_version }},MODE={{ deployment_mode }} \
         | {{ openshift.common.client_binary }} --namespace openshift-infra \
         --config={{ openshift_metrics_kubeconfig }} \
         create -o name -f -"

--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -33,6 +33,7 @@
                           | default('hawkular-metrics.' ~ (openshift.master.default_subdomain
                           | default(openshift_master_default_subdomain )))
                           | oo_hostname_from_url }}"
+    metrics_write_access: "{{ openshift_hosted_metrics_write_access | default('False') }}"
     metrics_persistence: "{{ openshift.hosted.metrics.storage_kind | default(none) is not none }}"
     metrics_dynamic_vol: "{{ openshift.hosted.metrics.storage_kind | default(none) == 'dynamic' }}"
     metrics_template_dir: "{{ openshift.common.config_base if openshift.common.is_containerized | bool else '/usr/share/openshift' }}/examples/infrastructure-templates/{{ 'origin' if deployment_type == 'origin' else 'enterprise' }}"


### PR DESCRIPTION
CFME use openshift-metrics for metrics collection and for storing of the openshift-ops team add-hock system metrics. We use hawkular-metrics write access option to allow writing metrics into hawkular using the it's restful api.

This PR adds the option to set the write access option of hawkular-metrics, using the ansible inventory file.