### PR TITLE
Enable support for image pruning

### DIFF
--- a/roles/openshift_hosted/templates/registry_config.j2
+++ b/roles/openshift_hosted/templates/registry_config.j2
@@ -4,6 +4,8 @@ log:
 http:
   addr: :5000
 storage:
+  delete:
+    enabled: true
   cache:
     blobdescriptor: inmemory
 {% if openshift.hosted.registry.storage.provider == 's3' %}


### PR DESCRIPTION
This is required for image pruning to work, there doesn't seem to be any documentation on downsides for enabling this?
https://docs.openshift.org/latest/install_config/registry/extended_registry_configuration.html#docker-registry-configuration-reference-storage