### PR TITLE
allow networkConfig.ingressIPNetworkCIDRs to be configured

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -441,6 +441,13 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # your nodes, pods, or service CIDRs for security reasons.
 #openshift_master_external_ip_network_cidrs=['0.0.0.0/0']
 
+# IngressIPNetworkCIDR controls the range to assign ingress IPs from for
+# services of type LoadBalancer on bare metal. If empty, ingress IPs will not
+# be assigned. It may contain a single CIDR that will be allocated from. For
+# security reasons, you should ensure that this range does not overlap with
+# the CIDRs reserved for external IPs, nodes, pods, or services.
+#openshift_master_ingress_ip_network_cidrs=['0.0.0.0/0']
+
 # Configure number of bits to allocate to each host’s subnet e.g. 8
 # would mean a /24 network on the host.
 #osm_host_subnet_length=8

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -440,6 +440,13 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # your nodes, pods, or service CIDRs for security reasons.
 #openshift_master_external_ip_network_cidrs=['0.0.0.0/0']
 
+# IngressIPNetworkCIDR controls the range to assign ingress IPs from for
+# services of type LoadBalancer on bare metal. If empty, ingress IPs will not
+# be assigned. It may contain a single CIDR that will be allocated from. For
+# security reasons, you should ensure that this range does not overlap with
+# the CIDRs reserved for external IPs, nodes, pods, or services.
+#openshift_master_ingress_ip_network_cidrs=['0.0.0.0/0']
+
 # Configure number of bits to allocate to each host’s subnet e.g. 8
 # would mean a /24 network on the host.
 #osm_host_subnet_length=8

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -164,6 +164,9 @@ networkConfig:
 # serviceNetworkCIDR must match kubernetesMasterConfig.servicesSubnet
   serviceNetworkCIDR: {{ openshift.common.portal_net }}
   externalIPNetworkCIDRs: {{ openshift_master_external_ip_network_cidrs | default(["0.0.0.0/0"]) | to_padded_yaml(1,2) }}
+{% if openshift_master_ingress_ip_network_cidrs %}
+  ingressIPNetworkCIDR: {{ openshift_master_ingress_ip_network_cidrs | to_padded_yaml(1,2) }}
+{% endif %}
 oauthConfig:
 {% if 'oauth_always_show_provider_selection' in openshift.master %}
   alwaysShowProviderSelection: {{ openshift.master.oauth_always_show_provider_selection }}


### PR DESCRIPTION
Make networkConfig.ingressIPNetworkCIDRs configurable via na inventory variable. This is currently untested. I'm going to test it now and update this PR if everything's fine.