### PR TITLE
Bug 1366522 - The value of "debug_level" isn't applied to /etc/sysconfig/atomic-openshift-master

### DIFF
--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -19,7 +19,6 @@
   openshift_facts:
     role: common
     local_facts:
-      debug_level: "{{ openshift_debug_level | default(2) }}"
       install_examples: "{{ openshift_install_examples | default(True) }}"
       use_openshift_sdn: "{{ openshift_use_openshift_sdn | default(None) }}"
       sdn_network_plugin_name: "{{ os_sdn_network_plugin_name | default(None) }}"

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -22,6 +22,7 @@
   openshift_facts:
     role: common
     local_facts:
+      debug_level: "{{ openshift_debug_level | default(2) }}"
       # TODO: Deprecate deployment_type in favor of openshift_deployment_type
       deployment_type: "{{ openshift_deployment_type | default(deployment_type) }}"
       deployment_subtype: "{{ openshift_deployment_subtype | default(None) }}"


### PR DESCRIPTION
Fixes BZ 1366522
https://bugzilla.redhat.com/show_bug.cgi?id=1366522

The `openshift_master_facts` role sets debug level as `openshift_master_debug_level` and defaults to `openshift.common.debug_level`. Since most users will be configuring the master debug level via `debug_level` which gets set as `openshift.common.debug_level` in `openshift_common` today, the `openshift_common` role would need to be applied to the master hosts before `openshift_master_facts` OR we could move `openshift.common.debug_level` to `openshift_facts` (which I've done here) to ensure that `openshift.common.debug_level` is set and `openshift.master.debug_level` can use it as a default.