### PR TITLE
Error out if containerized=true for lb host.

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -596,8 +596,10 @@ ose3-master[1:3]-ansible.test.example.com
 [etcd]
 ose3-etcd[1:3]-ansible.test.example.com
 
+# NOTE: Containerized load balancer hosts are not yet supported, if using a global
+# containerized=true host variable we must set to false.
 [lb]
-ose3-lb-ansible.test.example.com
+ose3-lb-ansible.test.example.com containerized=false
 
 # NOTE: Currently we require that masters be part of the SDN which requires that they also be nodes
 # However, in order to ensure that your masters are not burdened with running pods you should

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -596,8 +596,10 @@ ose3-master[1:3]-ansible.test.example.com
 [etcd]
 ose3-etcd[1:3]-ansible.test.example.com
 
+# NOTE: Containerized load balancer hosts are not yet supported, if using a global
+# containerized=true host variable we must set to false.
 [lb]
-ose3-lb-ansible.test.example.com
+ose3-lb-ansible.test.example.com containerized=false
 
 # NOTE: Currently we require that masters be part of the SDN which requires that they also be nodes
 # However, in order to ensure that your masters are not burdened with running pods you should

--- a/roles/openshift_loadbalancer/tasks/main.yml
+++ b/roles/openshift_loadbalancer/tasks/main.yml
@@ -1,7 +1,9 @@
 ---
+- fail: msg="Cannot use containerized=true for load balancer hosts."
+  when: openshift.common.is_containerized | bool
+
 - name: Install haproxy
   action: "{{ ansible_pkg_mgr }} name=haproxy state=present"
-  when: not openshift.common.is_containerized | bool
 
 - name: Configure systemd service directory for haproxy
   file:


### PR DESCRIPTION
Fixes #1980.

It's not early in the process as we don't have a great place for cross-playbook pre-flight checks right now, so if a user hits this they will need to just correct the problem in inventory with containerized=false on that host, and then re-run.