### PR TITLE
logging: fix enterprise deployer template

### DIFF
--- a/roles/openshift_examples/files/examples/v1.3/infrastructure-templates/enterprise/logging-deployer.yaml
+++ b/roles/openshift_examples/files/examples/v1.3/infrastructure-templates/enterprise/logging-deployer.yaml
@@ -202,11 +202,11 @@ items:
   -
     description: 'Specify prefix for logging components; e.g. for "registry.access.redhat.com/openshift3/logging-deployer:3.3.0", set prefix "registry.access.redhat.com/openshift3/"'
     name: IMAGE_PREFIX
-    value: "docker.io/openshift/origin-"
+    value: "registry.access.redhat.com/openshift3/"
   -
     description: 'Specify version for logging components; e.g. for "registry.access.redhat.com/openshift3/logging-deployer:3.3.0", set version "3.3.0"'
     name: IMAGE_VERSION
-    value: "latest"
+    value: "3.3.0"
   -
     description: "(Deprecated) Specify the name of an existing pull secret to be used for pulling component images from an authenticated registry."
     name: IMAGE_PULL_SECRET
@@ -323,4 +323,3 @@ items:
     description: "(Deprecated) Node selector operations Curator (label=value)."
     name: CURATOR_OPS_NODESELECTOR
     value: ""
-


### PR DESCRIPTION
It should refer to registry.access, not dockerhub, as the default.