### PR TITLE
Check that OpenStack hostnames are resolvable

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -364,12 +364,15 @@ def normalize_openstack_facts(metadata, facts):
     facts['network']['ip'] = local_ipv4
     facts['network']['public_ip'] = metadata['ec2_compat']['public-ipv4']
 
-    # TODO: verify local hostname makes sense and is resolvable
-    facts['network']['hostname'] = metadata['hostname']
-
-    # TODO: verify that public hostname makes sense and is resolvable
-    pub_h = metadata['ec2_compat']['public-hostname']
-    facts['network']['public_hostname'] = pub_h
+    for f_var, h_var, ip_var in [('hostname',        'hostname',        'local-ipv4'),
+                                 ('public_hostname', 'public-hostname', 'public-ipv4')]:
+        try:
+            if socket.gethostbyname(metadata['ec2_compat'][h_var]) == metadata['ec2_compat'][ip_var]:
+                facts['network'][f_var] = metadata['ec2_compat'][h_var]
+            else:
+                facts['network'][f_var] = metadata['ec2_compat'][ip_var]
+        except socket.gaierror:
+            facts['network'][f_var] = metadata['ec2_compat'][ip_var]
 
     return facts
 


### PR DESCRIPTION
On OpenStack, VMs have names which are not necessarily resolvable by DNS.
Those VM names are reported as “hostnames” in facts, even though they’re not valid.

This causes malfunction in [`openshift_facts.py:apply_provider_facts()`](https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_facts/library/openshift_facts.py#L1224):
```python
    common_vars = [('hostname', 'ip'), ('public_hostname', 'public_ip')]
    for h_var, ip_var in common_vars:
        ip_value = provider_facts['network'].get(ip_var)
        if ip_value:
            facts['common'][ip_var] = ip_value

        facts['common'][h_var] = choose_hostname(
            [provider_facts['network'].get(h_var)],
            facts['common'][h_var]
        )
```

Because the provider’s hostname (`provider_facts['network']['public_hostname']`) is not valid, it is filtered out by `choose_hostname()` and `facts['common'][h_var]` defaults to the non-provider hostname which is the private IP. (Only the provider’s facts can contain the public IP because the public IP is not known by the VM itself !)

This patch implements the `TODO`s that were in [`openshift_facts.py:normalize_openstack_facts()`](https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_facts/library/openshift_facts.py#L367) and checks that the hostnames are resolvable. If they’re not, we use IP instead.
The side effect is that if the provider’s public-hostname is not valid, it will be replaced by the public-ip and this will not be filtered out later by the `choose_hostname()` function.

Here is an example to make things clearer.
It shows the openshift_facts computed for an OpenStack VM named `lenaic-master-0`, which has the private IP `192.168.76.2` and the public IP `10.64.178.179`.

The diff below shows that this patch is not only fixing the `public_hostname` fields, but also the `public_api_url` and the `public_console_url`.

```bash
ansible -i inventory/openstack/hosts/openstack.py lenaic-master-0 -u openshift -b --module-path=roles/openshift_facts/library -m openshift_facts | tee /tmp/openshift_facts_master.before.txt

# Apply this patch

ansible -i inventory/openstack/hosts/openstack.py lenaic-master-0 -u openshift -b --module-path=roles/openshift_facts/library -m openshift_facts | tee /tmp/openshift_facts_master.after.txt

diff -u -F '^            ".*": {$' /tmp/openshift_facts_master.before.txt /tmp/openshift_facts_master.after.txt
```
```diff
--- /tmp/openshift_facts_master.before.txt      2016-10-06 14:43:42.517435617 +0200
+++ /tmp/openshift_facts_master.after.txt       2016-10-06 14:41:56.470768751 +0200
@@ -99,7 +99,7 @@ "common": {
                 "kube_svc_ip": "172.30.0.1", 
                 "pod_image": "openshift3/ose-pod", 
                 "portal_net": "172.30.0.0/16", 
-                "public_hostname": "192.168.76.2", 
+                "public_hostname": "10.64.178.179", 
                 "public_ip": "10.64.178.179", 
                 "registry_image": "openshift3/ose-docker-registry", 
                 "router_image": "openshift3/ose-haproxy-router", 
@@ -345,8 +345,8 @@ "master": {
                 "portal_net": "172.30.0.0/16", 
                 "project_request_message": "", 
                 "project_request_template": "", 
-                "public_api_url": "https://192.168.76.2:8443", 
-                "public_console_url": "https://192.168.76.2:8443/console", 
+                "public_api_url": "https://10.64.178.179:8443", 
+                "public_console_url": "https://10.64.178.179:8443/console", 
                 "registry_url": "openshift3/ose-${component}:${version}", 
                 "scheduler_predicates": [
                     {
@@ -494,11 +494,11 @@ "provider": {
                 }, 
                 "name": "openstack", 
                 "network": {
-                    "hostname": "lenaic-master-0", 
+                    "hostname": "192.168.76.2", 
                     "interfaces": [], 
                     "ip": "192.168.76.2", 
                     "ipv6_enabled": false, 
-                    "public_hostname": "lenaic-master-0", 
+                    "public_hostname": "10.64.178.179", 
                     "public_ip": "10.64.178.179"
                 }, 
                 "zone": "novb"
```