### PR TITLE
Retry starting master and node services once

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -213,6 +213,9 @@
     state: started
   when: openshift_master_ha | bool and openshift.master.cluster_method == 'native' and inventory_hostname == openshift_master_hosts[0]
   register: start_result
+  until: not start_result | failed
+  retries: 1
+  delay: 60
 
 - set_fact:
     master_api_service_status_changed: "{{ start_result | changed }}"
@@ -229,6 +232,9 @@
     state: started
   when: openshift_master_ha | bool and openshift.master.cluster_method == 'native' and inventory_hostname != openshift_master_hosts[0]
   register: start_result
+  until: not start_result | failed
+  retries: 1
+  delay: 60
 
 - set_fact:
     master_api_service_status_changed: "{{ start_result | changed }}"
@@ -262,6 +268,9 @@
     state: started
   when: openshift_master_ha | bool and openshift.master.cluster_method == 'native' and inventory_hostname == openshift_master_hosts[0]
   register: start_result
+  until: not start_result | failed
+  retries: 1
+  delay: 60
 
 - pause:
     seconds: 15
@@ -274,6 +283,9 @@
     state: started
   when: openshift_master_ha | bool and openshift.master.cluster_method == 'native' and inventory_hostname != openshift_master_hosts[0]
   register: start_result
+  until: not start_result | failed
+  retries: 1
+  delay: 60
 
 - set_fact:
     master_controllers_service_status_changed: "{{ start_result | changed }}"

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -152,17 +152,9 @@
 - name: Start and enable node
   service: name={{ openshift.common.service_type }}-node enabled=yes state=started
   register: node_start_result
-  ignore_errors: yes
-
-- name: Wait 30 seconds for docker initialization whenever node has failed
-  pause:
-    seconds: 30
-  when: node_start_result | failed
-
-- name: Start and enable node again
-  service: name={{ openshift.common.service_type }}-node enabled=yes state=started
-  register: node_start_result
-  when: node_start_result | failed
+  until: not node_start_result | failed
+  retries: 1
+  delay: 30
 
 - set_fact:
     node_service_status_changed: "{{ node_start_result | changed }}"


### PR DESCRIPTION
Especially for containerized environments the services will fail the first time they're started. We should retry starting them once in order to ensure a higher rate of success. 