### PR TITLE
[POC] Cert redeploy 3.1

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -8,16 +8,6 @@
   register: curr_docker_version
   changed_when: false
 
-- name: Error out if Docker pre-installed but too old
-  fail:
-    msg: "Docker {{ curr_docker_version.stdout }} is installed, but >= 1.9.1 is required."
-  when: not curr_docker_version | skipped and curr_docker_version.stdout != '' and curr_docker_version.stdout | version_compare('1.9.1', '<') and not docker_version is defined and not docker_protect_installed_version | bool
-
-- name: Error out if requested Docker is too old
-  fail:
-    msg: "Docker {{ docker_version }} requested, but >= 1.9.1 is required."
-  when: docker_version is defined and docker_version | version_compare('1.9.1', '<')
-
 - name: Get latest available version of Docker
   command: >
     {{ repoquery_cmd }} --qf '%{version}' "docker"


### PR DESCRIPTION
Hacks to get release-1.2 cert-redeploy working in 3.1 installations.

Just a note, these playbooks require Ansible 2.x and the existing 3.1 playbooks require Ansible 1.9 so you'll need to upgrade or downgrade depending on which playbooks you're running.
I've tested only that the playbooks run i have not validated the function/fitness of the cluster after having run them.
