### PR TITLE
nfs: Handle seboolean aliases not just in Fedora

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -112,6 +112,8 @@
 
 - name: NFS storage plugin configuration
   include: storage_plugins/nfs.yml
+  tags:
+    - nfs
 
 - name: GlusterFS storage plugin configuration
   include: storage_plugins/glusterfs.yml

--- a/roles/openshift_node/tasks/storage_plugins/nfs.yml
+++ b/roles/openshift_node/tasks/storage_plugins/nfs.yml
@@ -3,30 +3,24 @@
   action: "{{ ansible_pkg_mgr }} name=nfs-utils state=present"
   when: not openshift.common.is_atomic | bool
 
-- name: Check for existence of virt_use_nfs seboolean
-  command: getsebool virt_use_nfs
-  register: virt_use_nfs_output
+- name: Check for existence of seboolean
+  command: getsebool {{ item }}
+  register: getsebool_status
   when: ansible_selinux and ansible_selinux.status == "enabled"
   failed_when: false
   changed_when: false
+  with_items:
+    - virt_use_nfs
+    - virt_sandbox_use_nfs
 
 - name: Set seboolean to allow nfs storage plugin access from containers
   seboolean:
-    name: virt_use_nfs
+    name: "{{ item.item }}"
     state: yes
     persistent: yes
-  when: ansible_selinux and ansible_selinux.status == "enabled" and virt_use_nfs_output.rc == 0
-
-- name: Check for existence of virt_sandbox_use_nfs seboolean (RHEL)
-  command: getsebool virt_sandbox_use_nfs
-  register: virt_sandbox_use_nfs_output
-  when: ansible_distribution != "Fedora" and ansible_selinux and ansible_selinux.status == "enabled"
-  failed_when: false
-  changed_when: false
-
-- name: Set seboolean to allow nfs storage plugin access from containers(sandbox) (RHEL)
-  seboolean:
-    name: virt_sandbox_use_nfs
-    state: yes
-    persistent: yes
-  when: ansible_distribution != "Fedora" and ansible_selinux and ansible_selinux.status == "enabled" and virt_sandbox_use_nfs_output.rc == 0
+  # We need to detect whether or not the boolean is an alias, since `seboolean`
+  # will error if it is an alias.  We do this by inspecting stdout for the boolean name,
+  # since getsebool prints the resolved name.  (At some point Ansible's seboolean module
+  # should learn to deal with aliases)
+  when: ansible_selinux and ansible_selinux.status == "enabled" and item.rc == 0 and item.stdout.find(item.item) != -1
+  with_items: "{{ getsebool_status.results }}"


### PR DESCRIPTION
I'm testing with a bleeding edge RHEL Atomic Host, and it looks
like we pulled in a new version of selinux-policy that has
`virt_sandbox_use_nfs` aliased to `virt_use_nfs`.

In https://github.com/openshift/openshift-ansible/pull/2356
Adam changed this to check for Fedora.  This changes things
to drop the distribution check, and instead parse the `getsebool`
output to determine whether or not the boolean is an alias,
and should hence work on all distributions/versions.