### PR TITLE
Stop restarting node after upgrading master rpms.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
@@ -5,6 +5,3 @@
 - name: Ensure python-yaml present for config upgrade
   action: "{{ ansible_pkg_mgr }} name=PyYAML state=present"
   when: not openshift.common.is_atomic | bool
-
-- name: Restart node service
-  service: name="{{ openshift.common.service_type }}-node" state=restarted


### PR DESCRIPTION
This sucks a bit but I cannot reproduce the original issue, however several users and customers have hit a problem where node restart causes upgrade to fail. I have one log from such an install and found this, a node restart immediately following a master package upgrade. (note: not a master service restart, which comes later after we setup systemd configs)

In this case the node attempts to use an EgressNetworkPolicy API which does not yet exist because master services are not yet restarted, and the upgrade fails.

The node restart here appears out of place and unnecessary.

This is likely the cause behind #2523. If this does not fix all instances of the problem, there are still workarounds available.