### PR TITLE
Fix missing play assignment in a-o-i callback plugin

### DIFF
--- a/callback_plugins/openshift_quick_installer.py
+++ b/callback_plugins/openshift_quick_installer.py
@@ -1,4 +1,4 @@
-# pylint: disable=invalid-name,protected-access,import-error,line-too-long
+# pylint: disable=invalid-name,protected-access,import-error,line-too-long,attribute-defined-outside-init
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -111,6 +111,8 @@ role. Only the tasks directly assigned to a play are exposed in the
             msg = "PLAY"
         else:
             msg = "PLAY [%s]" % name
+
+        self._play = play
 
         self.banner(msg)
 


### PR DESCRIPTION
If a task fails in the quick installer it calls the `v2_runner_on_failed` method in the callback plugin. I missed setting `self._play` in the first iteration of the callback plugin, which it turns out is critical for the `on_failed` method to work. This fixes that by adding back in the assignment in the `play_start` method.