### PR TITLE
Fix standalone docker upgrade playbook skipping nodes.

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/docker/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/docker/upgrade.yml
@@ -26,4 +26,6 @@
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
     openshift_deployment_type: "{{ deployment_type }}"
 
+- include: ../../../../common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+
 - include: docker_upgrade.yml


### PR DESCRIPTION
Transition to being able to specify nodes to upgrade caused standalone
nodes to get skipped in this playbook.