### PR TITLE
upgrade: Don't check avail docker version if not already installed.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/docker/upgrade_check.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/upgrade_check.yml
@@ -22,13 +22,15 @@
   command: >
     {{ repoquery_cmd }} --qf '%{version}' "docker"
   register: avail_docker_version
+  # Don't expect docker rpm to be available on hosts that don't already have it installed:
+  when: pkg_check.rc == 0
   failed_when: false
   changed_when: false
 
 - fail:
     msg: This playbook requires access to Docker 1.10 or later
   # Disable the 1.10 requirement if the user set a specific Docker version
-  when: avail_docker_version.stdout | version_compare('1.10','<') and docker_version is not defined
+  when: pkg_check.rc == 0 and avail_docker_version.stdout | version_compare('1.10','<') and docker_version is not defined
 
 # Default l_docker_upgrade to False, we'll set to True if an upgrade is required:
 - set_fact:
@@ -37,7 +39,7 @@
 # Make sure a docker_verison is set if none was requested:
 - set_fact:
     docker_version: "{{ avail_docker_version.stdout }}"
-  when: docker_version is not defined
+  when: pkg_check.rc == 0 and docker_version is not defined
 
 - name: Flag for Docker upgrade if necessary
   set_fact:


### PR DESCRIPTION
This PR is for x.2 backport.