### PR TITLE
Resume restarting node after upgrading node rpms.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
@@ -5,3 +5,7 @@
 - name: Ensure python-yaml present for config upgrade
   action: "{{ ansible_pkg_mgr }} name=PyYAML state=present"
   when: not openshift.common.is_atomic | bool
+
+- name: Restart node service
+  service: name="{{ openshift.common.service_type }}-node" state=restarted
+  when: component == "node"


### PR DESCRIPTION
Error in commit 245fef16573757b6e691c448075d8564f5d569f4.
As it turns out this is the only place a rpm based node can be restarted
in upgrade. Restoring the restart but making it conditional to avoid the
two issues reported with out of sync node restarts.