### PR TITLE
Add nuage rest server port to haproxy firewall rules.

### DIFF
--- a/roles/openshift_loadbalancer/meta/main.yml
+++ b/roles/openshift_loadbalancer/meta/main.yml
@@ -17,4 +17,9 @@ dependencies:
     port: "9000/tcp"
   - service: haproxy balance
     port: "{{ openshift_master_api_port | default(8443) }}/tcp"
+- role: os_firewall
+  os_firewall_allow:
+  - service: nuage mon
+    port: "{{ nuage_mon_rest_server_port | default(9443) }}/tcp"
+  when: openshift_use_nuage | default(false) | bool
 - role: openshift_repos


### PR DESCRIPTION
Adds another dep of `os_firewall` to `openshift_loadbalancer` that is conditionally added when `openshift_use_nuage=true` has been set.

@vishpat Could you give this a try?

Fixes #2577.
