### PR TITLE
Do not error on node labels set too non-string values.

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -236,7 +236,7 @@ class FilterModule(object):
         if not isinstance(data, dict):
             raise errors.AnsibleFilterError("|failed expects first param is a dict")
 
-        return out_joiner.join([in_joiner.join([k, v]) for k, v in data.items()])
+        return out_joiner.join([in_joiner.join([k, str(v)]) for k, v in data.items()])
 
     @staticmethod
     def oo_ami_selector(data, image_name):


### PR DESCRIPTION
When setting node_labels that evaluate to non-strings, ansible fails:

    [nodes]
    node1.example.com openshift_hostname='node1.example.com' openshift_ip='192.168.1.120' openshift_node_labels="{'region':'xyz','registry':'true'}"

this may fix #2602