### PR TITLE
Build full node config path in systemd_units tasks.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
@@ -5,3 +5,7 @@
 - name: Ensure python-yaml present for config upgrade
   action: "{{ ansible_pkg_mgr }} name=PyYAML state=present"
   when: not openshift.common.is_atomic | bool
+
+- name: Restart node service
+  service: name="{{ openshift.common.service_type }}-node" state=restarted
+  when: component == "node"

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -76,7 +76,7 @@
 # TODO: add the validate parameter when there is a validation command to run
 - name: Create the Node config
   template:
-    dest: "{{ openshift_node_config_file }}"
+    dest: "{{ openshift.common.config_base }}/node/node-config.yaml"
     src: node.yaml.v1.j2
     backup: true
     owner: root

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -42,7 +42,7 @@
     - regex: '^OPTIONS='
       line: "OPTIONS=--loglevel={{ openshift.node.debug_level | default(2) }}"
     - regex: '^CONFIG_FILE='
-      line: "CONFIG_FILE={{ openshift_node_config_file }}"
+      line: "CONFIG_FILE={{ openshift.common.config_base }}/node/node-config.yaml }}"
     - regex: '^IMAGE_VERSION='
       line: "IMAGE_VERSION={{ openshift_image_tag }}"
   notify:

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -42,7 +42,7 @@
     - regex: '^OPTIONS='
       line: "OPTIONS=--loglevel={{ openshift.node.debug_level | default(2) }}"
     - regex: '^CONFIG_FILE='
-      line: "CONFIG_FILE={{ openshift.common.config_base }}/node/node-config.yaml }}"
+      line: "CONFIG_FILE={{ openshift.common.config_base }}/node/node-config.yaml"
     - regex: '^IMAGE_VERSION='
       line: "IMAGE_VERSION={{ openshift_image_tag }}"
   notify:

--- a/roles/openshift_node/vars/main.yml
+++ b/roles/openshift_node/vars/main.yml
@@ -1,3 +1,0 @@
----
-openshift_node_config_dir: "{{ openshift.common.config_base }}/node"
-openshift_node_config_file: "{{ openshift_node_config_dir }}/node-config.yaml"


### PR DESCRIPTION
The `openshift_node_config_file` var isn't available from `openshift_node` role vars when included in upgrade playbooks with ansible 2.2 rc1.

@sdodson ptal