### PR TITLE
Set node-labels in kubeletArguments

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -234,7 +234,7 @@ class FilterModule(object):
            arrange them as a string 'key=value key=value'
         """
         if not isinstance(data, dict):
-            raise errors.AnsibleFilterError("|failed expects first param is a dict")
+            raise errors.AnsibleFilterError("|failed expects first param is a dict [oo_combine_dict]. Got %s. Type: %s" % (str(data), str(type(data))))
 
         return out_joiner.join([in_joiner.join([k, str(v)]) for k, v in data.items()])
 
@@ -286,7 +286,7 @@ class FilterModule(object):
                 }
         """
         if not isinstance(data, dict):
-            raise errors.AnsibleFilterError("|failed expects first param is a dict")
+            raise errors.AnsibleFilterError("|failed expects first param is a dict [oo_ec2_volume_def]. Got %s. Type: %s" % (str(data), str(type(data))))
         if host_type not in ['master', 'node', 'etcd']:
             raise errors.AnsibleFilterError("|failed expects etcd, master or node"
                                             " as the host type")

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -9,6 +9,10 @@
     role: "{{ item.role }}"
     local_facts: "{{ item.local_facts }}"
   with_items:
+  # Reset node labels to an empty dictionary.
+  - role: node
+    local_facts:
+      labels: {}
   - role: node
     local_facts:
       annotations: "{{ openshift_node_annotations | default(none) }}"


### PR DESCRIPTION
This takes `openshift_node_labels` from your inventory and adds them to the `node-config.yaml` file as array items under the `kubeletArguments.node-labels` subkey.

Given an inventory with a host like this:

`hostname .... openshift_node_labels="{'region': 'infra', 'foo': 'bar'}" .....`

This will produce output in your `node-config.yaml` file as such:

```yaml
kubeletArguments:
  node-labels:
  - region=infra
  - foo=bar
```

**CURRENT BUG**
* If `openshift_node_labels` changes (items added/removed) only **additions** are reflected in the `node-config.yaml` file
* Removing labels from the inventory does not result in the labels being removed from the `node-config.yaml` file


Feature requests comes from the Ops team

* https://bugzilla.redhat.com/show_bug.cgi?id=1359848
