### PR TITLE
Add pvc=true and pv=true

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -324,6 +324,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # the storage_host. For example, the remote volume path using these
 # options would be "nfs.example.com:/exports/registry"
 #openshift_hosted_registry_storage_kind=nfs
+# In case the pv & pvc does not exists let openshift create it for you
+#openshift_hosted_registry_storage_create_pv=true
+#openshift_hosted_registry_storage_create_pvc=true
 #openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
 #openshift_hosted_registry_storage_host=nfs.example.com
 #openshift_hosted_registry_storage_nfs_directory=/exports
@@ -397,6 +400,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # the storage_host. For example, the remote volume path using these
 # options would be "nfs.example.com:/exports/metrics"
 #openshift_hosted_metrics_storage_kind=nfs
+# In case the pv & pvc does not exists let openshift create it for you
+#openshift_hosted_metrics_storage_create_pv=true
+#openshift_hosted_metrics_storage_create_pvc=true
 #openshift_hosted_metrics_storage_access_modes=['ReadWriteOnce']
 #openshift_hosted_metrics_storage_host=nfs.example.com
 #openshift_hosted_metrics_storage_nfs_directory=/exports
@@ -435,6 +441,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # the storage_host. For example, the remote volume path using these
 # options would be "nfs.example.com:/exports/logging"
 #openshift_hosted_logging_storage_kind=nfs
+# In case the pv & pvc does not exists let openshift create it for you
+#openshift_hosted_logging_storage_create_pv=true
+#openshift_hosted_logging_storage_create_pvc=true
 #openshift_hosted_logging_storage_access_modes=['ReadWriteOnce']
 #openshift_hosted_logging_storage_host=nfs.example.com
 #openshift_hosted_logging_storage_nfs_directory=/exports


### PR DESCRIPTION
In https://github.com/openshift/openshift-ansible/blob/master/playbooks/common/openshift-cluster/openshift_hosted.yml#L7-L8 checks openshift if any pv or pvc exists.

When you not add the  pvc=true and pv=true into the hosted sections the setup will fail because the pv's & pvc's are not created.

This can be verified in the code, as long as I have understood python right.

oo_persistent_volumes https://github.com/openshift/openshift-ansible/blob/master/filter_plugins/oo_filters.py#L669
create_pv https://github.com/openshift/openshift-ansible/blob/master/filter_plugins/oo_filters.py#L687

oo_persistent_volume_claims https://github.com/openshift/openshift-ansible/blob/master/filter_plugins/oo_filters.py#L733
create_pvc https://github.com/openshift/openshift-ansible/blob/master/filter_plugins/oo_filters.py#L750