### PR TITLE
Remove uneeded import of ansible.module_utils.splitter

### DIFF
--- a/roles/etcd_common/library/delegated_serial_command.py
+++ b/roles/etcd_common/library/delegated_serial_command.py
@@ -270,6 +270,5 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-from ansible.module_utils.splitter import *
 
 main()


### PR DESCRIPTION
This go with https://github.com/ansible/ansible/pull/18100 
