### PR TITLE
Add logic for deploying or not infrastructure templates

### DIFF
--- a/roles/openshift_examples/README.md
+++ b/roles/openshift_examples/README.md
@@ -21,13 +21,14 @@ Facts
 Role Variables
 --------------
 
-| Name                                | Default value                                       |                                          |
-|-------------------------------------|-----------------------------------------------------|------------------------------------------|
-| openshift_examples_load_centos      | true when openshift_deployment_typenot 'enterprise' | Load centos image streams                |
-| openshift_examples_load_rhel        | true if openshift_deployment_type is 'enterprise'   | Load rhel image streams                  |
-| openshift_examples_load_db_templates| true                                                | Loads database templates                 |
-| openshift_examples_load_quickstarts | true                                                | Loads quickstarts ie: nodejs, rails, etc |
-| openshift_examples_load_xpaas       | false                                               | Loads xpass streams and templates        |
+| Name                                    | Default value                                       |                                          |
+|-----------------------------------------|-----------------------------------------------------|------------------------------------------|
+| openshift_examples_load_centos          | true when openshift_deployment_typenot 'enterprise' | Load centos image streams                |
+| openshift_examples_load_rhel            | true if openshift_deployment_type is 'enterprise'   | Load rhel image streams                  |
+| openshift_examples_load_infra_templates | true                                                | Loads infrastructure templates           |
+| openshift_examples_load_db_templates	  | true                                                | Loads database templates                 |
+| openshift_examples_load_quickstarts 	  | true                                                | Loads quickstarts ie: nodejs, rails, etc |
+| openshift_examples_load_xpaas       	  | false                                               | Loads xpass streams and templates        |
 
 
 Dependencies

--- a/roles/openshift_examples/defaults/main.yml
+++ b/roles/openshift_examples/defaults/main.yml
@@ -3,6 +3,7 @@
 openshift_examples_load_centos: "{{ openshift_deployment_type == 'origin' }}"
 openshift_examples_load_rhel: "{{ openshift_deployment_type != 'origin' }}"
 openshift_examples_load_db_templates: true
+openshift_examples_load_infra_templates: true
 openshift_examples_load_xpaas: "{{ openshift_deployment_type != 'origin' }}"
 openshift_examples_load_quickstarts: true
 

--- a/roles/openshift_examples/tasks/main.yml
+++ b/roles/openshift_examples/tasks/main.yml
@@ -117,7 +117,7 @@
 - name: Import enterprise infrastructure-templates
   command: >
     {{ openshift.common.client_binary }} {{ openshift_examples_import_command }} -n openshift -f {{ infrastructure_enterprise_base }}
-  when: openshift_examples_load_rhel | bool
+  when: openshift_examples_load_infra_templates | bool
   register: oex_import_infrastructure
   failed_when: "'already exists' not in oex_import_infrastructure.stderr and oex_import_infrastructure.rc != 0"
   changed_when: false


### PR DESCRIPTION
Give the opportunity to users not to use the rhel/centos IS but still deploying infrastructure templates.
Before the "when" criteria was mapped to the same value "openshift_examples_load_rhel".
Having a dedicated one for infrastructure templates solves that issue. 