### PR TITLE
Support 3rd party scheduler

### DIFF
--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -131,6 +131,7 @@ kubernetesMasterConfig:
   proxyClientInfo:
     certFile: master.proxy-client.crt
     keyFile: master.proxy-client.key
+  schedulerArguments: {{ openshift_master_scheduler_args | default(None) | to_padded_yaml( level=3 ) }}
   schedulerConfigFile: {{ openshift_master_scheduler_conf }}
   servicesNodePortRange: ""
   servicesSubnet: {{ openshift.common.portal_net }}

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -80,3 +80,4 @@
       controllers_env_vars: "{{ openshift_master_controllers_env_vars | default(None) }}"
       audit_config: "{{ openshift_master_audit_config | default(None) }}"
       metrics_public_url: "{% if openshift_hosted_metrics_deploy | default(false) %}https://{{ metrics_hostname }}/hawkular/metrics{% endif %}"
+      scheduler_args: "{{ openshift_master_scheduler_args | default(None) }}"

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -73,6 +73,11 @@
 - set_fact:
     ovs_service_status_changed: "{{ ovs_start_result | changed }}"
 
+- file:
+    dest: "{{ (openshift_node_kubelet_args|default({'config':None})).config}}"
+    state: directory
+  when: openshift_node_kubelet_args is defined and 'config' in openshift_node_kubelet_args
+
 # TODO: add the validate parameter when there is a validation command to run
 - name: Create the Node config
   template:


### PR DESCRIPTION
This work is mainly done by Andrew Butcher, during AnsibleFest when I described to him what the problem is and he pulled out the laptop and helped. You Rock Buddy!

I tested the code with the following in my hosts file:
openshift_node_kubelet_args={'config' : ['/etc/kubernetes/manifest']}

openshift_master_scheduler_args={'scheduler-name' : ['foo']}

The scheduler no longer runs, pods stay at pending state. 3rd party scheduler can be put in the config dir, and start as a mirror pod, which is specified as the first parameter for kubelet config.
