### PR TITLE
trouble creating service signer certificate while running upgrade dockerized

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/create_service_signer_cert.yml
+++ b/playbooks/common/openshift-cluster/upgrades/create_service_signer_cert.yml
@@ -23,10 +23,10 @@
   - name: Create service signer certificate
     command: >
       {{ openshift.common.client_binary }} adm ca create-signer-cert
-      --cert=service-signer.crt
-      --key=service-signer.key
-      --name=openshift-service-serving-signer
-      --serial=service-signer.serial.txt
+      --cert="{{ remote_cert_create_tmpdir.stdout }}/"service-signer.crt
+      --key="{{ remote_cert_create_tmpdir.stdout }}/"service-signer.key
+      --name="{{ remote_cert_create_tmpdir.stdout }}/"openshift-service-serving-signer
+      --serial="{{ remote_cert_create_tmpdir.stdout }}/"service-signer.serial.txt
     args:
       chdir: "{{ remote_cert_create_tmpdir.stdout }}/"
     when: not (hostvars[groups.oo_first_master.0].service_signer_cert_stat.stat.exists | bool)


### PR DESCRIPTION
When running update on dockerized instanses, it failed on the step retrieve service signer certificate as the files where not created in the right location when running oc as a dockerized application.