### PR TITLE
Add VolumeZonePredicate to scheduler predicates

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1751,6 +1751,7 @@ class OpenShiftFacts(object):
                 {"name": "PodFitsPorts"},
                 {"name": "NoDiskConflict"},
                 {"name": "NoVolumeZoneConflict"},
+                {"name": "VolumeZonePredicate"},
                 {"name": "MaxEBSVolumeCount"},
                 {"name": "MaxGCEPDVolumeCount"},
                 {"name": "Region", "argument": {"serviceAffinity" : {"labels" : ["region"]}}}


### PR DESCRIPTION
VolumeZonePredicate ensures pods are placed in the same zone as their corresponding PVC.