### PR TITLE
ansible playbooks continue running after get error

### DIFF
--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -47,6 +47,7 @@
 
 - name: Configure containerized nodes
   hosts: oo_containerized_master_nodes
+  any_errors_fatal: true
   serial: 1
   vars:
     openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
@@ -87,6 +88,7 @@
 
 - name: Configure nodes
   hosts: oo_nodes_to_config:!oo_containerized_master_nodes
+  any_errors_fatal: true
   vars:
     openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
     openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"


### PR DESCRIPTION
Fail on any errors when configuring nodes.

Fixes:
- BZ1377619 - https://bugzilla.redhat.com/show_bug.cgi?id=1377619

Adds the `any_errors_fatal` key to the node configuration plays. This causes a complete abort of the installation if any task under those plays fails. This is in the spirit of the "fail fast" system of design.

Without this parameter set to a boolean true value then the installation continues until the master attempts to register the failed node. That results in a waste of time for the user.
