### PR TITLE
Change HA master controller service to restart always.

### DIFF
--- a/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-controllers.service.j2
+++ b/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-controllers.service.j2
@@ -18,7 +18,7 @@ LimitNOFILE=131072
 LimitCORE=infinity
 WorkingDirectory={{ openshift.common.data_dir }}
 SyslogIdentifier={{ openshift.common.service_type }}-master-controllers
-Restart=on-failure
+Restart=always
 RestartSec=5s
 
 [Install]

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.service.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.service.j2
@@ -19,7 +19,7 @@ LimitNOFILE=131072
 LimitCORE=infinity
 WorkingDirectory={{ openshift.common.data_dir }}
 SyslogIdentifier={{ openshift.common.service_type }}-master-controllers
-Restart=on-failure
+Restart=always
 RestartSec=5s
 
 [Install]


### PR DESCRIPTION
Restarts of systemd-journald can cause the master controllers service to
die in HA environments, due to a SIGPIPE and how it's handled.
(seemingly by default in golang)

on-failure does not trigger in this situation, instead we set to
Restart=always in the systemd unit, which matches the non-HA service
definitions as well.

See https://bugzilla.redhat.com/show_bug.cgi?id=1378929 for more info.