### PR TITLE
Add node redeploy playbook for (re)provisioning on top of gold images

### DIFF
--- a/playbooks/byo/openshift-node/redeploy.yml
+++ b/playbooks/byo/openshift-node/redeploy.yml
@@ -1,0 +1,18 @@
+---
+- hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+  - add_host:
+      name: "{{ item }}"
+      groups: l_oo_all_hosts
+    with_items: "{{ g_all_hosts }}"
+
+- hosts: l_oo_all_hosts
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+
+- include: ../../common/openshift-node/redeploy.yml

--- a/playbooks/common/openshift-node/redeploy.yml
+++ b/playbooks/common/openshift-node/redeploy.yml
@@ -1,0 +1,83 @@
+---
+- include: ../openshift-cluster/evaluate_groups.yml
+
+- name: Gather and set facts for first master
+  hosts: oo_first_master
+  vars:
+    openshift_master_count: "{{ groups.oo_masters | length }}"
+  pre_tasks:
+  - set_fact:
+      openshift_master_default_subdomain: "{{ lookup('oo_option', 'openshift_master_default_subdomain') | default(None, true) }}"
+    when: openshift_master_default_subdomain is not defined
+  roles:
+  - openshift_master_facts
+
+# ../openshift-node/config.yml without packages
+
+- name: Create temp directory for syncing certs
+  hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tasks:
+  - name: Create local temp directory for syncing certs
+    local_action: command mktemp -d /tmp/openshift-ansible-XXXXXXX
+    register: mktemp
+    changed_when: False
+
+- name: Gather and set facts for node hosts
+  hosts: oo_nodes_to_config
+  roles:
+  - role: openshift_facts
+  - role: openshift_node_certificates
+    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+  tasks:
+  # Since the master is generating the node certificates before they are
+  # configured, we need to make sure to set the node properties beforehand if
+  # we do not want the defaults
+  - openshift_facts:
+      role: node
+      local_facts:
+        annotations: "{{ openshift_node_annotations | default(none) }}"
+        debug_level: "{{ openshift_node_debug_level | default(openshift.common.debug_level) }}"
+        iptables_sync_period: "{{ openshift_node_iptables_sync_period | default(None) }}"
+        kubelet_args: "{{ openshift_node_kubelet_args | default(None) }}"
+        labels: "{{ lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true) }}"
+        registry_url: "{{ oreg_url | default(none) }}"
+        schedulable: "{{ openshift_schedulable | default(openshift_scheduleable) | default(None) }}"
+        sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
+        storage_plugin_deps: "{{ osn_storage_plugin_deps | default(None) }}"
+        set_node_ip: "{{ openshift_set_node_ip | default(None) }}"
+        node_image: "{{ osn_image | default(None) }}"
+        ovs_image: "{{ osn_ovs_image | default(None) }}"
+        proxy_mode: "{{ openshift_node_proxy_mode | default('iptables') }}"
+        local_quota_per_fsgroup: "{{ openshift_node_local_quota_per_fsgroup | default(None) }}"
+        dns_ip: "{{ openshift_dns_ip | default(none) | get_dns_ip(hostvars[inventory_hostname])}}"
+        env_vars: "{{ openshift_node_env_vars | default(None) }}"
+  - name: Create the Node config
+    template:
+      dest: "{{ openshift.common.config_base }}/node/node-config.yaml"
+      src: ../openshift-node/roles/openshift_node/templates/node.yaml.v1.j2
+      backup: true
+      owner: root
+      group: root
+      mode: 0600
+    notify:
+    - restart node
+    - restart openvswitch
+  handlers:
+    - name: restart node
+      become: yes
+      service: name={{ openshift.common.service_type }}-node state=restarted
+    - name: restart openvswitch
+      become: yes
+      service: name=openvswitch state=restarted
+
+- name: Delete temporary directory on localhost
+  hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tasks:
+  - file: name={{ mktemp.stdout }} state=absent
+    changed_when: False


### PR DESCRIPTION
Deploying with gold images cuts the install process significantly. 

This playbook removes a lot of the installation processes/checks from the scaleup playbook so new nodes can be added in about 1 minute compared to 5-15 minutes with the scaleup playbook.

This has worked in my test setup, but not sure if I missed anything.
