### PR TITLE
ensure/enable dependencies needed for FC24

### DIFF
--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -10,12 +10,19 @@
 - set_fact:
     l_is_containerized: "{{ (l_is_atomic | bool) or (containerized | default(false) | bool) }}"
 
-- name: Ensure PyYaml is installed
-  action: "{{ ansible_pkg_mgr }} name=PyYAML state=present"
+- name: Ensure required packages are installed
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=present"
+  with_items:
+    - PyYAML
+    - yum-utils
+    - dbus-python
+    - libselinux-python
+    - libsemanage-python
+    - NetworkManager
   when: not l_is_atomic | bool
 
-- name: Ensure yum-utils is installed
-  action: "{{ ansible_pkg_mgr }} name=yum-utils state=present"
+- name: Enable NetworkManager
+  service: name=NetworkManager enabled=yes state=started
   when: not l_is_atomic | bool
 
 - name: Gather Cluster facts and set is_containerized if needed


### PR DESCRIPTION
These packages are required in order to install on Fedora Cloud 24 -- as well, NetworkManager needs to be enabled and running.  
