### PR TITLE
Add requirements, fix a small formatting issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,16 @@ not practical to start over at 1.0.
 
 ##Setup
 - Install base dependencies:
+  - Requirements:
+    - Ansible >= 2.1.0 though 2.2 is preferred for performance reasons.
+    - Jinja >= 2.7
+
   - Fedora:
   ```
     dnf install -y ansible-2.1.0.0 pyOpenSSL python-cryptography
   ```
-   - OSX:
+
+  - OSX:
   ```
     # Install ansible 2.1.0.0 and python 2
     brew install ansible python


### PR DESCRIPTION
Ansible can be run with jinja <= 2.7 but jinja 2,7 is required for some of the iptables modules (at least), specifically the map filter: http://jinja.pocoo.org/docs/dev/changelog/#version-2-7