### PR TITLE
Bug 1388191 - Default docker log driver should be journald

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -79,7 +79,7 @@ openshift_release=v1.4
 # Disable pushing to dockerhub
 #openshift_docker_disable_push_dockerhub=True
 # Items added, as is, to end of /etc/sysconfig/docker OPTIONS
-# Default value: "--log-driver=json-file --log-opt max-size=50m"
+# Default value: "--log-driver=journald"
 #openshift_docker_options="-l warn --ipv6=false"
 
 # Specify exact version of Docker to configure or upgrade to.

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -79,7 +79,7 @@ openshift_release=v3.4
 # Disable pushing to dockerhub
 #openshift_docker_disable_push_dockerhub=True
 # Items added, as is, to end of /etc/sysconfig/docker OPTIONS
-# Default value: "--log-driver=json-file --log-opt max-size=50m"
+# Default value: "--log-driver=journald"
 #openshift_docker_options="-l warn --ipv6=false"
 
 # Specify exact version of Docker to configure or upgrade to.

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -2027,7 +2027,7 @@ class OpenShiftFacts(object):
 
         if 'docker' in roles:
             docker = dict(disable_push_dockerhub=False,
-                          options='--log-driver=json-file --log-opt max-size=50m')
+                          options='--log-driver=journald')
             # NOTE: This is a workaround for a dnf output racecondition that can occur in
             # some situations. See https://bugzilla.redhat.com/show_bug.cgi?id=918184
             if self.system_facts['ansible_pkg_mgr'] == 'dnf':


### PR DESCRIPTION
Fixes Bug 1388191
https://bugzilla.redhat.com/show_bug.cgi?id=1388191
