### PR TITLE
Touch all ini_file files before using them

### DIFF
--- a/roles/openshift_cloud_provider/tasks/aws.yml
+++ b/roles/openshift_cloud_provider/tasks/aws.yml
@@ -1,4 +1,14 @@
-- name: Create cloud config
+# Work around ini_file create option in 2.2 which defaults to no
+- name: Create cloud config file
+  file:
+    dest: "{{ openshift.common.config_base }}/cloudprovider/aws.conf"
+    state: touch
+    mode: 0660
+    owner: root
+    group: root
+    changed_when: false
+
+- name: Configure AWS cloud provider
   ini_file:
     dest: "{{ openshift.common.config_base }}/cloudprovider/aws.conf"
     section: Global

--- a/roles/openshift_loadbalancer/tasks/main.yml
+++ b/roles/openshift_loadbalancer/tasks/main.yml
@@ -10,6 +10,16 @@
     path: /etc/systemd/system/haproxy.service.d
     state: directory
 
+# Work around ini_file create option in 2.2 which defaults to no
+- name: Create limits.conf file
+  file:
+    dest: /etc/systemd/system/haproxy.service.d/limits.conf
+    state: touch
+    mode: 0660
+    owner: root
+    group: root
+    changed_when: false
+
 - name: Configure the nofile limits for haproxy
   ini_file:
     dest: /etc/systemd/system/haproxy.service.d/limits.conf


### PR DESCRIPTION
Ansible 2.2 adds 'create' flag, however we'd like to preserve backwards
compatability.

Fixes bug 1390169
Fixes BZ1390169
Fixes #2668