### PR TITLE
Prevent useless master restart by reworking template for master service enf file

### DIFF
--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -127,15 +127,21 @@
 
 - name: Preserve Master Proxy Config options
   command: grep PROXY /etc/sysconfig/{{ openshift.common.service_type }}-master
-  register: master_proxy
+  register: master_proxy_result
   failed_when: false
   changed_when: false
 
+- set_fact:
+    master_proxy: "{{ master_proxy_result.stdout_lines | default([]) }}"
+
 - name: Preserve Master AWS options
   command: grep AWS_ /etc/sysconfig/{{ openshift.common.service_type }}-master
-  register: master_aws
+  register: master_aws_result
   failed_when: false
   changed_when: false
+
+- set_fact:
+    master_aws: "{{ master_aws_result.stdout_lines | default([]) }}"
 
 - name: Create the master service env file
   template:
@@ -144,17 +150,3 @@
     backup: true
   notify:
   - restart master
-
-- name: Restore Master Proxy Config Options
-  lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-master
-    line: "{{ item }}"
-  with_items: "{{ master_proxy.stdout_lines | default([]) }}"
-  when: master_proxy.rc == 0 and 'http_proxy' not in openshift.common and 'https_proxy' not in openshift.common
-
-- name: Restore Master AWS Options
-  lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-master
-    line: "{{ item }}"
-  with_items: "{{ master_aws.stdout_lines | default([]) }}"
-  when: master_aws.rc == 0 and not (openshift_cloudprovider_kind is defined and openshift_cloudprovider_kind == 'aws' and openshift_cloudprovider_aws_access_key is defined and openshift_cloudprovider_aws_secret_key is defined)

--- a/roles/openshift_master/templates/atomic-openshift-master.j2
+++ b/roles/openshift_master/templates/atomic-openshift-master.j2
@@ -8,6 +8,11 @@ IMAGE_VERSION={{ openshift_image_tag }}
 AWS_ACCESS_KEY_ID={{ openshift_cloudprovider_aws_access_key }}
 AWS_SECRET_ACCESS_KEY={{ openshift_cloudprovider_aws_secret_key }}
 {% endif %}
+{% if not (openshift_cloudprovider_kind is defined and openshift_cloudprovider_kind == 'aws' and openshift_cloudprovider_aws_access_key is defined and openshift_cloudprovider_aws_secret_key is defined) %}
+{% for item in master_aws %}
+{{ item }}
+{% endfor %}
+{% endif %}
 
 {% if 'api_env_vars' in openshift.master or 'controllers_env_vars' in openshift.master -%}
 {% for key, value in openshift.master.api_env_vars.items() | default([]) | union(openshift.master.controllers_env_vars.items() | default([])) -%}
@@ -25,4 +30,9 @@ HTTPS_PROXY={{ openshift.common.https_proxy | default('')}}
 {% endif %}
 {% if 'no_proxy' in openshift.common %}
 NO_PROXY={{ openshift.common.no_proxy | default('') | join(',') }},{{ openshift.common.portal_net }},{{ openshift.master.sdn_cluster_network_cidr }}
+{% endif %}
+{% if not ('https_proxy' in openshift.common or 'https_proxy' in openshift.common or 'no_proxy' in openshift.common) %}
+{% for item in master_proxy %}
+{{ item }}
+{% endfor %}
 {% endif %}


### PR DESCRIPTION
We are running openshift-ansible every x minutes(among the reasons detecting and running openshift ansible for new nodes joining the cluster ex: preemptible vms), and for every run, master is restarting because the master service env file is changing. this is because of the lineinfile statement added after creating the template of the file,
I think in general manner, it would be good to ensure that all changes are in the template, and hence the master will restart only if needed.