### PR TITLE
Where we use curl force it to use tlsv1.2

### DIFF
--- a/playbooks/common/openshift-master/scaleup.yml
+++ b/playbooks/common/openshift-master/scaleup.yml
@@ -33,7 +33,7 @@
     service: name={{ openshift.common.service_type }}-master-controllers state=restarted
   - name: verify api server
     command: >
-      curl --silent
+      curl --silent --tlsv1.2
       {% if openshift.common.version_gte_3_2_or_1_2 | bool %}
       --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
       {% else %}

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -165,7 +165,7 @@
     # Using curl here since the uri module requires python-httplib2 and
     # wait_for port doesn't provide health information.
     command: >
-      curl --silent
+      curl --silent --tlsv1.2
       {% if openshift.common.version_gte_3_2_or_1_2 | bool %}
       --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
       {% else %}

--- a/roles/openshift_master/handlers/main.yml
+++ b/roles/openshift_master/handlers/main.yml
@@ -17,7 +17,7 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent
+    curl --silent --tlsv1.2
     {% if openshift.common.version_gte_3_2_or_1_2 | bool %}
     --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
     {% else %}

--- a/roles/openshift_metrics/handlers/main.yml
+++ b/roles/openshift_metrics/handlers/main.yml
@@ -17,7 +17,7 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent
+    curl --silent --tlsv1.2
     {% if openshift.common.version_gte_3_2_or_1_2 | bool %}
     --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
     {% else %}


### PR DESCRIPTION
curl, prior to RHEL 7.2, did not properly negotiate up the TLS protocol, so
force it to use tlsv1.2 as origin 1.4 has bumped the TLS requirement to v1.2.

See https://bugzilla.redhat.com/show_bug.cgi?id=1170339 and https://github.com/openshift/origin/issues/11702
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1390869