### PR TITLE
Update flannel etcd vars for 0.5.5

### DIFF
--- a/roles/flannel/tasks/main.yml
+++ b/roles/flannel/tasks/main.yml
@@ -4,21 +4,18 @@
   action: "{{ ansible_pkg_mgr }} name=flannel state=present"
   when: not openshift.common.is_containerized | bool
 
-- name: Set flannel etcd url
+- name: Set flannel etcd options
   become: yes
   lineinfile:
     dest: /etc/sysconfig/flanneld
     backrefs: yes
-    regexp: "^(FLANNEL_ETCD=)"
-    line: '\1{{ etcd_hosts|join(",") }}'
-
-- name: Set flannel etcd key
-  become: yes
-  lineinfile:
-    dest: /etc/sysconfig/flanneld
-    backrefs: yes
-    regexp: "^(FLANNEL_ETCD_KEY=)"
-    line: '\1{{ flannel_etcd_key }}'
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+    with_items:
+      - { regexp: "^(FLANNEL_ETCD=)", line: '\1{{ etcd_hosts|join(",") }}' }
+      - { regexp: "^(FLANNEL_ETCD_ENDPOINTS=)", line: '\1{{ etcd_hosts|join(",") }}' }
+      - { regexp: "^(FLANNEL_ETCD_KEY=)", line: '\1{{ flannel_etcd_key }}' }
+      - { regexp: "^(FLANNEL_ETCD_KEY_PREFIX=)", line: '\1{{ flannel_etcd_key }}' }
 
 - name: Set flannel options
   become: yes

--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -306,6 +306,7 @@ hostname.
     else:
         return None
 
+
 def set_cluster_hostname(oo_cfg):
     message = """
 You have chosen to install a single master cluster (non-HA).
@@ -320,6 +321,7 @@ If you want to override the cluster host name now to something other than the de
     cluster_hostname = click.prompt('Enter hostname or IP address',
                                     default='')
     oo_cfg.deployment.variables['openshift_master_cluster_hostname'] = cluster_hostname
+
 
 def collect_storage_host(hosts):
     """


### PR DESCRIPTION
flannel-0.5.5 uses different variable names in /etc/sysconfig/flannel.
This writes both the old and next variable name to the file for
quick compatibility.

Fixes #2635
Fixes Bug 1391515