### PR TITLE
Restart API service always as well.

### DIFF
--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.service.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.service.j2
@@ -15,6 +15,7 @@ LimitNOFILE=131072
 LimitCORE=infinity
 WorkingDirectory={{ openshift.common.data_dir }}
 SyslogIdentifier=atomic-openshift-master-api
+Restart=always
 RestartSec=5s
 
 [Install]


### PR DESCRIPTION
Recently applied this fix for controllers due to the systemd-journald
restart issue, it sounds as is this one is also sometimes affected.
Containerized already uses this, so we will apply the same restart
strategy here.