### PR TITLE
default to multizone GCE config

### DIFF
--- a/roles/openshift_cloud_provider/tasks/gce.yml
+++ b/roles/openshift_cloud_provider/tasks/gce.yml
@@ -1,0 +1,16 @@
+# Work around ini_file create option in 2.2 which defaults to no
+- name: Create cloud config file
+  file:
+    dest: "{{ openshift.common.config_base }}/cloudprovider/gce.conf"
+    state: touch
+    mode: 0660
+    owner: root
+    group: root
+  changed_when: false
+
+- name: Configure GCE cloud provider
+  ini_file:
+    dest: "{{ openshift.common.config_base }}/cloudprovider/gce.conf"
+    section: Global
+    option: multizone
+    value: "true"

--- a/roles/openshift_cloud_provider/tasks/main.yml
+++ b/roles/openshift_cloud_provider/tasks/main.yml
@@ -16,3 +16,6 @@
 
 - include: aws.yml
   when: cloudprovider_is_aws | bool
+
+- include: gce.yml
+  when: cloudprovider_is_gce | bool

--- a/roles/openshift_cloud_provider/vars/main.yml
+++ b/roles/openshift_cloud_provider/vars/main.yml
@@ -2,3 +2,4 @@
 has_cloudprovider: "{{ openshift_cloudprovider_kind | default(None) != None }}"
 cloudprovider_is_aws: "{{ has_cloudprovider | bool and openshift_cloudprovider_kind == 'aws' }}"
 cloudprovider_is_openstack: "{{ has_cloudprovider | bool and openshift_cloudprovider_kind == 'openstack' }}"
+cloudprovider_is_gce: "{{ has_cloudprovider | bool and openshift_cloudprovider_kind == 'gce' }}"

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1060,6 +1060,7 @@ values provided as a list. Hence the gratuitous use of ['foo'] below.
                     kubelet_args['cloud-config'] = [cloud_cfg_path + '/openstack.conf']
                 if facts['cloudprovider']['kind'] == 'gce':
                     kubelet_args['cloud-provider'] = ['gce']
+                    kubelet_args['cloud-config'] = [cloud_cfg_path + '/gce.conf']
 
         # Automatically add node-labels to the kubeletArguments
         # parameter. See BZ1359848 for additional details.
@@ -1102,6 +1103,7 @@ def build_controller_args(facts):
                     controller_args['cloud-config'] = [cloud_cfg_path + '/openstack.conf']
                 if facts['cloudprovider']['kind'] == 'gce':
                     controller_args['cloud-provider'] = ['gce']
+                    kubelet_args['cloud-config'] = [cloud_cfg_path + '/gce.conf']
         if controller_args != {}:
             facts = merge_facts({'master': {'controller_args': controller_args}}, facts, [], [])
     return facts
@@ -1122,6 +1124,7 @@ def build_api_server_args(facts):
                     api_server_args['cloud-config'] = [cloud_cfg_path + '/openstack.conf']
                 if facts['cloudprovider']['kind'] == 'gce':
                     api_server_args['cloud-provider'] = ['gce']
+                    kubelet_args['cloud-config'] = [cloud_cfg_path + '/gce.conf']
         if api_server_args != {}:
             facts = merge_facts({'master': {'api_server_args': api_server_args}}, facts, [], [])
     return facts


### PR DESCRIPTION
Nodes created in zones other than the master are being deleted by the node controller because the master is not running in multizone mode when `openshift_cloudprovider_kind=gce`

This PR assumes we want to run in multizone for all configurations since there is no downside as far as I know of for doing so.

xref https://bugzilla.redhat.com/show_bug.cgi?id=1390160

@derekwaynecarr @detiber 