### PR TITLE
Bug 1390064 - [quick install] a complete installed cluster was reported as a mix of installed and uninstalled env

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -739,17 +739,17 @@ def get_hosts_to_run_on(oo_cfg, callback_facts, unattended, force):
     installed_hosts, uninstalled_hosts = get_installed_hosts(oo_cfg.deployment.hosts,
                                                              callback_facts)
     nodes = [host for host in oo_cfg.deployment.hosts if host.is_node()]
-    not_balancers = [host for host in oo_cfg.deployment.hosts if not host.is_master_lb()]
+    masters_and_nodes = [host for host in oo_cfg.deployment.hosts if host.is_master() or host.is_node()]
 
     in_hosts = [str(h) for h in installed_hosts]
     un_hosts = [str(h) for h in uninstalled_hosts]
     all_hosts = [str(h) for h in oo_cfg.deployment.hosts]
-    no_bals = [str(h) for h in not_balancers]
+    m_and_n = [str(h) for h in masters_and_nodes]
 
     INSTALLER_LOG.debug("installed hosts: %s", ", ".join(in_hosts))
     INSTALLER_LOG.debug("uninstalled hosts: %s", ", ".join(un_hosts))
     INSTALLER_LOG.debug("deployment hosts: %s", ", ".join(all_hosts))
-    INSTALLER_LOG.debug("not balancers: %s", ", ".join(no_bals))
+    INSTALLER_LOG.debug("masters and nodes: %s", ", ".join(m_and_n))
 
     # Case (1): All uninstalled hosts
     if len(uninstalled_hosts) == len(nodes):
@@ -757,7 +757,7 @@ def get_hosts_to_run_on(oo_cfg, callback_facts, unattended, force):
         hosts_to_run_on = list(oo_cfg.deployment.hosts)
     else:
         # Case (2): All installed hosts
-        if len(installed_hosts) == len(not_balancers):
+        if len(installed_hosts) == len(masters_and_nodes):
             message = """
 All specified hosts in specified environment are installed.
 """


### PR DESCRIPTION
This is round 2 for https://github.com/openshift/openshift-ansible/pull/2697

We missed some edge cases in the original PR, this should catch what we missed. The prior fix attempted to fix the mixed env issue by comparing against all nodes **except load balancers**. This changes the comparison to only check masters and nodes. 

https://bugzilla.redhat.com/show_bug.cgi?id=1390064