### PR TITLE
Fix HA etcd upgrade when facts cache has been deleted.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -13,10 +13,23 @@
       groups: etcd_hosts_to_backup
     with_items: "{{ groups.oo_etcd_to_config if groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config | length > 0 else groups.oo_first_master }}"
 
+# If facts cache were for some reason deleted, this fact may not be set, and if not set
+# it will always default to true. This causes problems for the etcd data dir fact detection
+# so we must first make sure this is set correctly before attempting the backup.
+- name: Set master embedded_etcd fact
+  hosts: oo_masters_to_config
+  roles:
+  - openshift_facts
+  tasks:
+  - openshift_facts:
+      role: master
+      local_facts:
+        embedded_etcd: "{{ groups.oo_etcd_to_config | length == 0 }}"
+
 - name: Backup etcd
   hosts: etcd_hosts_to_backup
   vars:
-    embedded_etcd: "{{ hostvars[groups.oo_first_master.0].openshift.master.embedded_etcd }}"
+    embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
     timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
   roles:
   - openshift_facts


### PR DESCRIPTION
Upgrade will fail if you do not have a
/etc/ansible/facts.d/openshift.fact cache on the system, usually from
running original config.yml for installation.

To fix we check if running embedded etcd more logically, however the
fact for etcd_data_dir still needs to be populated, and this is not
possible without running the openshift_master_facts role, which involves
a huge number of variables and thus we need to include this common
config.yml to get them all populated.

@abutcher or @detiber could really use your feedback on whether or not this include is safe. It works, but it brings in quite a bit of yaml. Here is the link to what's included: https://github.com/openshift/openshift-ansible/blob/master/playbooks/common/openshift-master/config.yml