### PR TITLE
[openstack] updates documentation to show that you need to install shade

### DIFF
--- a/README_openstack.md
+++ b/README_openstack.md
@@ -25,6 +25,7 @@ On Fedora:
 On RHEL / CentOS:
 ```
   yum install -y ansible python-novaclient python-neutronclient python-heatclient
+  sudo pip install shade
 ```
 
 Configuration


### PR DESCRIPTION
Documentation fix to show that you need the shade module install in CentOS in order to continue when using the OpenStack method.

Error detailed in issue #2731 