### PR TITLE
[openstack] allows timeout option for heat create stack

### DIFF
--- a/README_openstack.md
+++ b/README_openstack.md
@@ -49,6 +49,7 @@ The following options are used only by `heat_stack.yaml`. They are so used only 
 * `floating_ip_pool` (default to `external`): comma separated list of floating IP pools
 * `ssh_from` (default to `0.0.0.0/0`): IPs authorized to connect to the VMs via ssh
 * `node_port_from` (default to `0.0.0.0/0`): IPs authorized to connect to the services exposed via nodePort
+* `heat_timeout` (default to `3`): Timeout (in minutes) passed to heat for create or update stack.
 
 
 Creating a cluster

--- a/playbooks/openstack/openshift-cluster/launch.yml
+++ b/playbooks/openstack/openshift-cluster/launch.yml
@@ -25,7 +25,7 @@
 
   - name: Create or Update OpenStack Stack
     command: 'heat {{ heat_stack_action }} -f {{ openstack_infra_heat_stack }}
-             --timeout 3
+             --timeout {{ openstack_heat_timeout }}
              -P cluster_env={{ cluster_env }}
              -P cluster_id={{ cluster_id }}
              -P subnet_24_prefix={{ openstack_subnet_24_prefix }}

--- a/playbooks/openstack/openshift-cluster/vars.yml
+++ b/playbooks/openstack/openshift-cluster/vars.yml
@@ -14,6 +14,8 @@ openstack_ssh_access_from:      "{{ lookup('oo_option', 'ssh_from')          |
                                     default('0.0.0.0/0',                     True) }}"
 openstack_node_port_access_from: "{{ lookup('oo_option', 'node_port_from')   |
                                     default('0.0.0.0/0',                     True) }}"
+openstack_heat_timeout:         "{{ lookup('oo_option', 'heat_timeout')   |
+                                    default('3',                             True) }}"
 openstack_flavor:
   etcd:   "{{ lookup('oo_option', 'etcd_flavor'      ) | default('m1.small',  True) }}"
   master: "{{ lookup('oo_option', 'master_flavor'    ) | default('m1.small',  True) }}"


### PR DESCRIPTION
Proposes adding a `heat_timeout` option to the openstack method to allow overriding how long is given for the heat stack to be created, so that it is not hardcoded at 3 minutes maximum. Especially useful for slower environments (i.e. virtual machines).

Proposed fix for issue #2733 