### PR TITLE
[upgrades] Use etcd3 to backup embedded etcd if possible

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/embedded_etcdctl.yml
+++ b/playbooks/common/openshift-cluster/upgrades/embedded_etcdctl.yml
@@ -1,0 +1,30 @@
+- name: Install etcd for etcdctl on non RHEL
+  action: "{{ ansible_pkg_mgr }} name=etcd state=latest"
+  when: not openshift.common.is_atomic | bool and ansible_distribution != 'RedHat'
+
+# etcd3 in RHEL 7.3.0 does not Obsolstes: etcd, however etcd3-3.0.12 or later will
+# so until that ships we need to carefully install etcd 3.0 to ensure we get fixes
+# for backing up embedded etcd in 2.3
+# see https://github.com/coreos/etcd/pull/4952 and https://bugzilla.redhat.com/show_bug.cgi?id=1382634
+- name: Check for etcd package
+  rpm_q:
+    name: etcd
+    state: present
+  failed_when: false
+  register: etcd_rpmq
+  when: ansible_distribution == 'RedHat'
+
+- name: Determine if we need to yum swap etcd3 etcd
+  set_fact:
+    etcd2_installed: "{{ etcd_rpmq.installed_versions | default('99') | version_compare('3.0','<') }}"
+  when: ansible_distribution == 'RedHat'
+
+- name: Install etcd3 (for etcdctl)
+  action: "{{ ansible_pkg_mgr }} name=etcd3 state=latest"
+  when: not openshift.common.is_atomic | bool and ansible_distribution == 'RedHat' and not etcd2_installed | bool
+
+- name: Swap etcd3 for etcd
+  command: "yum swap etcd etcd3 -y"
+  args:
+    warn: no
+  when: not openshift.common.is_atomic | bool and ansible_distribution == 'RedHat' and etcd2_installed | bool

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -56,9 +56,9 @@
         {{ avail_disk.stdout }} Kb available.
     when: (embedded_etcd | bool) and (etcd_disk_usage.stdout|int > avail_disk.stdout|int)
 
-  - name: Install etcd (for etcdctl)
-    action: "{{ ansible_pkg_mgr }} name=etcd state=latest"
-    when: not openshift.common.is_atomic | bool
+  - name: Install etcdctl for embedded environments
+    include: embedded_etcdctl.yml
+    when: embedded_etcd
 
   - name: Generate etcd backup
     command: >


### PR DESCRIPTION
If RHEL, detect if etcd is installed and is < 3.0. If so then swap etcd3 for
etcd.

If Fedora, install latest etcd and attempt to backup. If it fails advise the
user they may need to download etcd from github to attempt a backup.

Fixes Bug 1382634
Fixes BZ1382634