### PR TITLE
Always add local dns domain to no_proxy

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1527,8 +1527,8 @@ def set_proxy_facts(facts):
                 safe_get_bool(common['generate_no_proxy_hosts']):
                 if 'no_proxy_internal_hostnames' in common:
                     common['no_proxy'].extend(common['no_proxy_internal_hostnames'].split(','))
-                common['no_proxy'].append('.' + common['dns_domain'])
-            # We always add ourselves no matter what
+            # We always add local dns domain and ourselves no matter what
+            common['no_proxy'].append('.' + common['dns_domain'])
             common['no_proxy'].append(common['hostname'])
             common['no_proxy'] = sort_unique(common['no_proxy'])
         facts['common'] = common


### PR DESCRIPTION
Even if we set generate_no_proxy_hosts to false, we want to have .cluster.local in the no_proxy by default