### PR TITLE
Install flannel RPM on containerized but not atomic

### DIFF
--- a/roles/flannel/tasks/main.yml
+++ b/roles/flannel/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Install flannel
   become: yes
   action: "{{ ansible_pkg_mgr }} name=flannel state=present"
-  when: not openshift.common.is_containerized | bool
+  when: not openshift.common.is_atomic | bool
 
 - name: Set flannel etcd options
   become: yes


### PR DESCRIPTION
Need to figure out if flannel is always installed on atomic host and if not what we should do there.