### PR TITLE
Resolve docker and iptables service dependencies

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -46,11 +46,23 @@
   action: "{{ ansible_pkg_mgr }} name=docker{{ '-' + docker_version if docker_version is defined else '' }} state=present"
   when: not openshift.common.is_atomic | bool
 
+- name: Ensure docker.service.d directory exists
+  file:
+    path: "{{ docker_systemd_dir }}"
+    state: directory
+
+# Extend the default Docker service unit file
+- name: Configure Docker service unit file
+  template:
+    dest: "{{ docker_systemd_dir }}/custom.conf"
+    src: custom.conf.j2
+
 - name: Start the Docker service
-  service:
+  systemd:
     name: docker
     enabled: yes
     state: started
+    daemon_reload: yes
   register: start_result
 
 - set_fact:

--- a/roles/docker/templates/custom.conf.j2
+++ b/roles/docker/templates/custom.conf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+[Unit]
+Requires=iptables.service
+After=iptables.service

--- a/roles/docker/vars/main.yml
+++ b/roles/docker/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 udevw_udevd_dir: /etc/systemd/system/systemd-udevd.service.d
+docker_systemd_dir: /etc/systemd/system/docker.service.d


### PR DESCRIPTION
The docker service adds rules to the iptables configuration to support proper
network functionality for running containers. If the service is started prior
to iptables, these rules are not properly created.

* Ensure iptables is started prior to docker

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1390835