### PR TITLE
Bump ansible requirement to 2.2.0.0-1 (GA)

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -13,7 +13,7 @@ URL:            https://github.com/openshift/openshift-ansible
 Source0:        https://github.com/openshift/openshift-ansible/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-Requires:      ansible >= 2.1.0.0
+Requires:      ansible >= 2.2.0.0-1
 Requires:      python2
 Requires:      openshift-ansible-docs = %{version}-%{release}
 


### PR DESCRIPTION
Ansible 2.2.0.0 is now in F24, RHEL7 EPEL, and soon F23. Bump ansible requirement to 2.2.0.0. Ansible 2.2.0.0 will also ship via OCP channels.

2.2.0.0-1 in order to ensure we upgrade from pre-release versions that were made available previously.