### PR TITLE
Don't upgrade etcd on backup operations

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -57,7 +57,7 @@
     when: (embedded_etcd | bool) and (etcd_disk_usage.stdout|int > avail_disk.stdout|int)
 
   - name: Install etcd (for etcdctl)
-    action: "{{ ansible_pkg_mgr }} name=etcd state=latest"
+    action: "{{ ansible_pkg_mgr }} name=etcd state=installed"
     when: not openshift.common.is_atomic | bool
 
   - name: Generate etcd backup


### PR DESCRIPTION
We need to install etcd for etcdctl but if it's already installed we shouldn't upgrade it.

Fixes Bug 1393187
Fixes BZ1393187

We'll be providing a comprehensive etcd upgrade playbook in #2562 ASAP