### PR TITLE
Update override cluster_hostname

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -318,6 +318,7 @@ hostname.
 
 
 def set_cluster_hostname(oo_cfg):
+    first_master = next((host for host in oo_cfg.deployment.hosts if host.is_master()), None)
     message = """
 You have chosen to install a single master cluster (non-HA).
 
@@ -329,8 +330,9 @@ If you want to override the cluster host name now to something other than the de
 """
     click.echo(message)
     cluster_hostname = click.prompt('Enter hostname or IP address',
-                                    default='')
+                                    default=str(first_master))
     oo_cfg.deployment.variables['openshift_master_cluster_hostname'] = cluster_hostname
+    oo_cfg.deployment.variables['openshift_master_cluster_public_hostname'] = cluster_hostname
 
 
 def collect_storage_host(hosts):


### PR DESCRIPTION
Update the default for the override prompt and set both
openshift_master_cluster_hostname and
openshift_master_cluster_public_hostname