### PR TITLE
Fix backport errors for 3.2 release.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/containerized_node_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/containerized_node_upgrade.yml
@@ -1,5 +1,3 @@
-- include_vars: ../../../../roles/openshift_node/vars/main.yml
-
 - name: Update systemd units
   include: ../../../../roles/openshift_node/tasks/systemd_units.yml openshift_version={{ openshift_image_tag }}
 

--- a/playbooks/common/openshift-cluster/upgrades/openvswitch-avoid-oom.conf
+++ b/playbooks/common/openshift-cluster/upgrades/openvswitch-avoid-oom.conf
@@ -1,0 +1,1 @@
+../../../../roles/openshift_node/templates/openvswitch-avoid-oom.conf


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1393662 (the file no longer exists)

Also backports the oom symlink fix from a few days ago, which would have been hit after this error above. With both of these I was able to complete a 3.2 containerized upgrade.