### PR TITLE
Begin requiring Docker 1.12.

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -84,7 +84,7 @@ openshift_release=v1.4
 
 # Specify exact version of Docker to configure or upgrade to.
 # Downgrades are not supported and will error out. Be careful when upgrading docker from < 1.10 to > 1.10.
-# docker_version="1.10.3"
+# docker_version="1.12.1"
 
 # Skip upgrading Docker during an OpenShift upgrade, leaves the current Docker version alone.
 # docker_upgrade=False

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -84,7 +84,7 @@ openshift_release=v3.4
 
 # Specify exact version of Docker to configure or upgrade to.
 # Downgrades are not supported and will error out. Be careful when upgrading docker from < 1.10 to > 1.10.
-# docker_version="1.10.3"
+# docker_version="1.12.1"
 
 # Skip upgrading Docker during an OpenShift upgrade, leaves the current Docker version alone.
 # docker_upgrade=False

--- a/playbooks/byo/openshift-cluster/upgrades/docker/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/docker/upgrade.yml
@@ -1,6 +1,4 @@
 # Playbook to upgrade Docker to the max allowable version for an OpenShift cluster.
-#
-# Currently only supports upgrading 1.9.x to >= 1.10.x.
 - hosts: localhost
   connection: local
   become: no

--- a/playbooks/common/openshift-cluster/upgrades/docker/upgrade_check.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/upgrade_check.yml
@@ -28,9 +28,9 @@
   changed_when: false
 
 - fail:
-    msg: This playbook requires access to Docker 1.10 or later
-  # Disable the 1.10 requirement if the user set a specific Docker version
-  when: docker_version is not defined and (docker_upgrade is not defined or docker_upgrade | bool == True) and (pkg_check.rc == 0 and (avail_docker_version.stdout == "" or avail_docker_version.stdout | version_compare('1.10','<')))
+    msg: This playbook requires access to Docker 1.12 or later
+  # Disable the 1.12 requirement if the user set a specific Docker version
+  when: docker_version is not defined and (docker_upgrade is not defined or docker_upgrade | bool == True) and (pkg_check.rc == 0 and (avail_docker_version.stdout == "" or avail_docker_version.stdout | version_compare('1.12','<')))
 
 # Default l_docker_upgrade to False, we'll set to True if an upgrade is required:
 - set_fact:
@@ -50,4 +50,3 @@
   set_fact:
       docker_upgrade_nuke_images: True
   when: l_docker_upgrade | bool and docker_upgrade_nuke_images is not defined and curr_docker_version.stdout | version_compare('1.10','<') and docker_version | version_compare('1.10','>=')
-

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_docker_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_docker_upgrade_targets.yml
@@ -19,5 +19,5 @@
     when: openshift.common.is_atomic | bool
 
   - fail:
-      msg: This playbook requires access to Docker 1.10 or later
-    when: openshift.common.is_atomic | bool and l_docker_version.avail_version | default(l_docker_version.curr_version, true) | version_compare('1.10','<')
+      msg: This playbook requires access to Docker 1.12 or later
+    when: openshift.common.is_atomic | bool and l_docker_version.avail_version | default(l_docker_version.curr_version, true) | version_compare('1.12','<')


### PR DESCRIPTION
Building off the work done for Docker 1.10, we now require Docker 1.12
by default.

The upgrade process was already set to ensure you are running the latest
docker during upgrade, and the standalone docker upgrade playbook can
also be used if desired.

As before, you can override this Docker 1.12 requirement by setting a
docker_version=1.10.3 (or similar), or you can skip upgrading docker entirely with docker_upgrade=false.