### PR TITLE
[WIP] Add support for specifying registry-console version and bump on upgrade

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -462,6 +462,12 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_hosted_logging_deployer_prefix=registry.example.com:8888/openshift3/
 #openshift_hosted_logging_deployer_version=3.3.0
 
+# Registry console deployment
+#
+# Configure the prefix and version for the deployer image
+#openshift_cockpit_deployer_prefix=registry.example.com:8888/openshift3/
+#openshift_cockpit_deployer_version=3.3
+
 # Configure the multi-tenant SDN plugin (default is 'redhat/openshift-ovs-subnet')
 # os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
 

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -462,6 +462,12 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_hosted_logging_deployer_prefix=registry.example.com:8888/openshift3/
 #openshift_hosted_logging_deployer_version=3.3.0
 
+# Registry console deployment
+#
+# Configure the prefix and version for the deployer image
+#openshift_cockpit_deployer_prefix=registry.example.com:8888/openshift3/
+#openshift_cockpit_deployer_version=3.3
+
 # Configure the multi-tenant SDN plugin (default is 'redhat/openshift-ovs-subnet')
 # os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
 

--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -8,6 +8,7 @@
     openshift_deployment_type: "{{ deployment_type }}"
     registry_image: "{{  openshift.master.registry_url | replace( '${component}', 'docker-registry' )  | replace ( '${version}', openshift_image_tag ) }}"
     router_image: "{{ openshift.master.registry_url | replace( '${component}', 'haproxy-router' ) | replace ( '${version}', openshift_image_tag ) }}"
+    registry_console_image: "{{  openshift.master.registry_url | replace( '${component}', 'registry-console' )  | replace ( '${version}', openshift_image_tag ) }}"
     oc_cmd: "{{ openshift.common.client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig"
   roles:
   - openshift_manageiq
@@ -59,6 +60,20 @@
     command: >
       {{ oc_cmd }} patch dc/docker-registry -n default -p
       '{"spec":{"template":{"spec":{"containers":[{"name":"registry","image":"{{ registry_image }}"}]}}}}'
+      --api-version=v1
+
+  - name: Check for default registry-console
+    command: >
+      {{ oc_cmd }} get -n default dc/registry-console
+    register: _default_registry_console
+    failed_when: false
+    changed_when: false
+
+  - name: Update registry console image to current version
+    when: _default_registry_console.rc == 0
+    command: >
+      {{ oc_cmd }} patch dc/registry-console -n default -p
+      '{"spec":{"template":{"spec":{"containers":[{"name":"registry-console","image":"{{ registry_console_image }}"}]}}}}'
       --api-version=v1
 
 # Check for warnings to be printed at the end of the upgrade:

--- a/roles/cockpit-ui/tasks/main.yml
+++ b/roles/cockpit-ui/tasks/main.yml
@@ -67,6 +67,7 @@
   command: >
     {{ openshift.common.client_binary }} new-app --template=registry-console
     {% if openshift_cockpit_deployer_prefix is defined  %}-p IMAGE_PREFIX="{{ openshift_cockpit_deployer_prefix }}"{% endif %}
+    {% if openshift_cockpit_deployer_version is defined %}-p IMAGE_VERSION="{{ openshift_cockpit_deployer_version }}"{% endif %}
     -p OPENSHIFT_OAUTH_PROVIDER_URL="{{ openshift.master.public_api_url }}"
     -p REGISTRY_HOST="{{ docker_registry_route.stdout }}"
     -p COCKPIT_KUBE_URL="{{ registry_console_cockpit_kube_url.stdout }}"


### PR DESCRIPTION
```
# Registry console deployment
#
# Configure the prefix and version for the deployer image
#openshift_cockpit_deployer_prefix=registry.example.com:8888/openshift3/
#openshift_cockpit_deployer_version=3.3
```

@sdodson PTAL