### PR TITLE
Added dependency of os_firewall to docker role

### DIFF
--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -17,7 +17,7 @@ docker_udev_workaround: raises udevd timeout to 5 minutes (https://bugzilla.redh
 Dependencies
 ------------
 
-None
+Depends on the os_firewall role.
 
 Example Playbook
 ----------------

--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -9,4 +9,6 @@ galaxy_info:
   - name: EL
     versions:
     - 7
-dependencies: []
+dependencies:
+  - role: os_firewall
+    os_firewall_use_firewalld: False

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-- stat: path=/etc/sysconfig/docker-storage
-  register: docker_storage_check
-
 - name: Get current installed Docker version
   command: "{{ repoquery_cmd }} --installed --qf '%{version}' docker"
   when: not openshift.common.is_atomic | bool

--- a/roles/os_firewall/README.md
+++ b/roles/os_firewall/README.md
@@ -14,7 +14,7 @@ Role Variables
 
 | Name                      | Default |                                        |
 |---------------------------|---------|----------------------------------------|
-| os_firewall_use_firewalld | True    | If false, use iptables                 |
+| os_firewall_use_firewalld | False   | If false, use iptables                 |
 | os_firewall_allow         | []      | List of service,port mappings to allow |
 | os_firewall_deny          | []      | List of service, port mappings to deny |
 

--- a/roles/os_firewall/meta/main.yml
+++ b/roles/os_firewall/meta/main.yml
@@ -11,5 +11,6 @@ galaxy_info:
     - 7
   categories:
   - system
+allow_duplicates: yes
 dependencies:
 - { role: openshift_facts }


### PR DESCRIPTION
The docker role requires iptables-services to be installed. Added
dependency on so_firewall role to ensure the iptables service is
installed first. Currently this will only work with iptables and
not with firewalld.

* Added allow_duplicates to os_firewall role meta
* Removed unused task from docker/tasks
* Corrected os_firewall Defaults in README