### PR TITLE
Fix HA upgrade when fact cache deleted.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -25,6 +25,7 @@
       role: master
       local_facts:
         embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
+        debug_level: "{{ openshift_master_debug_level | default(openshift.common.debug_level | default(2)) }}"
 
 - name: Backup etcd
   hosts: etcd_hosts_to_backup


### PR DESCRIPTION
This variable is referenced in the systemd unit templates, this seems
like the easiest and most consistent fix.