### PR TITLE
Fix commit-offsets in version detection for containerized installs

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -889,11 +889,32 @@ class FilterModule(object):
                                           'servers': FilterModule.oo_haproxy_backend_masters(servers_hostvars, nuage_rest_port)})
         return loadbalancer_backends
 
+    @staticmethod
+    def oo_chomp_commit_offset(version):
+        """Chomp any "+git.foo" commit offset string from the given `version`
+        and return the modified version string.
+
+    Ex:
+    - chomp_commit_offset(None)                 => None
+    - chomp_commit_offset(1337)                 => "1337"
+    - chomp_commit_offset("v3.4.0.15+git.derp") => "v3.4.0.15"
+    - chomp_commit_offset("v3.4.0.15")          => "v3.4.0.15"
+    - chomp_commit_offset("v1.3.0+52492b4")     => "v1.3.0"
+        """
+        if version is None:
+            return version
+        else:
+            # Stringify, just in case it's a Number type. Split by '+' and
+            # return the first split. No concerns about strings without a
+            # '+', .split() returns an array of the original string.
+            return str(version).split('+')[0]
+
     def filters(self):
         """ returns a mapping of filters to methods """
         return {
             "oo_select_keys": self.oo_select_keys,
             "oo_select_keys_from_list": self.oo_select_keys_from_list,
+            "oo_chomp_commit_offset": self.oo_chomp_commit_offset,
             "oo_collect": self.oo_collect,
             "oo_flatten": self.oo_flatten,
             "oo_pdb": self.oo_pdb,

--- a/roles/openshift_version/tasks/set_version_containerized.yml
+++ b/roles/openshift_version/tasks/set_version_containerized.yml
@@ -37,3 +37,8 @@
     openshift_version: "{{ cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0:2][1:] | join('-') if openshift.common.deployment_type == 'origin' else cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0][1:] }}"
   when: openshift_version is defined and openshift_version.split('.') | length == 2
 
+# We finally have the specific version. Now we clean up any strange
+# dangly +c0mm1t-offset tags in the version. See also,
+# openshift_facts.py
+- set_fact:
+    openshift_version: "{{ openshift_version | oo_chomp_commit_offset }}"


### PR DESCRIPTION
* Applies the chomp_commit_offset logic to container version detection

https://bugzilla.redhat.com/show_bug.cgi?id=1389137