### PR TITLE
Fix metrics deployment in 3.4

### DIFF
--- a/roles/openshift_metrics/tasks/install.yml
+++ b/roles/openshift_metrics/tasks/install.yml
@@ -71,7 +71,14 @@
   set_fact:
     deployer_cmd: "{{ openshift.common.client_binary }} process -f \
       {{ hosted_base }}/metrics-deployer.yaml -v \
-      HAWKULAR_METRICS_HOSTNAME={{ metrics_hostname }},USE_PERSISTENT_STORAGE={{metrics_persistence | string | lower }},DYNAMICALLY_PROVISION_STORAGE={{metrics_dynamic_vol | string | lower }},METRIC_DURATION={{ openshift.hosted.metrics.duration }},METRIC_RESOLUTION={{ openshift.hosted.metrics.resolution }}{{ image_prefix }}{{ image_version }},MODE={{ deployment_mode }} \
+      HAWKULAR_METRICS_HOSTNAME={{ metrics_hostname }} \
+      -v USE_PERSISTENT_STORAGE={{metrics_persistence | string | lower }} \
+      -v DYNAMICALLY_PROVISION_STORAGE={{metrics_dynamic_vol | string | lower }} \
+      -v METRIC_DURATION={{ openshift.hosted.metrics.duration }} \
+      -v METRIC_RESOLUTION={{ openshift.hosted.metrics.resolution }}
+      {{ image_prefix }} \
+      {{ image_version }} \
+      -v MODE={{ deployment_mode }} \
         | {{ openshift.common.client_binary }} --namespace openshift-infra \
         --config={{ openshift_metrics_kubeconfig }} \
         create -o name -f -"

--- a/roles/openshift_metrics/tasks/install.yml
+++ b/roles/openshift_metrics/tasks/install.yml
@@ -37,6 +37,24 @@
     system:serviceaccount:openshift-infra:metrics-deployer
   when: "'system:serviceaccount:openshift-infra:metrics-deployer' not in edit_rolebindings.stdout"
 
+- name: Test hawkular view permissions
+  command: >
+    {{ openshift.common.client_binary }}
+    --config={{ openshift_metrics_kubeconfig }}
+    --namespace openshift-infra
+    get rolebindings -o jsonpath='{.items[?(@.metadata.name == "view")].userNames}'
+  register: view_rolebindings
+  changed_when: false
+
+- name: Add view permissions to hawkular SA
+  command: >
+      {{ openshift.common.client_binary }} adm
+      --config={{ openshift_metrics_kubeconfig }}
+      --namespace openshift-infra
+      policy add-role-to-user view
+      system:serviceaccount:openshift-infra:hawkular
+  when: "'system:serviceaccount:openshift-infra:hawkular' not in view_rolebindings"
+
 - name: Test cluster-reader permissions
   command: >
     {{ openshift.common.client_binary }}

--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -36,10 +36,8 @@
     metrics_persistence: "{{ openshift.hosted.metrics.storage_kind | default(none) is not none }}"
     metrics_dynamic_vol: "{{ openshift.hosted.metrics.storage_kind | default(none) == 'dynamic' }}"
     metrics_template_dir: "{{ openshift.common.config_base if openshift.common.is_containerized | bool else '/usr/share/openshift' }}/examples/infrastructure-templates/{{ 'origin' if deployment_type == 'origin' else 'enterprise' }}"
-    cassandra_nodes: "{{ ',CASSANDRA_NODES=' ~ openshift.hosted.metrics.cassandra_nodes if 'cassandra' in openshift.hosted.metrics else '' }}"
-    cassandra_pv_size: "{{ ',CASSANDRA_PV_SIZE=' ~ openshift.hosted.metrics.storage_volume_size if openshift.hosted.metrics.storage_volume_size | default(none) is not none else '' }}"
-    image_prefix: "{{ ',IMAGE_PREFIX=' ~ openshift.hosted.metrics.deployer_prefix if 'deployer_prefix' in openshift.hosted.metrics else '' }}"
-    image_version: "{{ ',IMAGE_VERSION=' ~ openshift.hosted.metrics.deployer_version if 'deployer_version' in openshift.hosted.metrics else '' }}"
+    image_prefix: "{{ '-v IMAGE_PREFIX=' ~ openshift.hosted.metrics.deployer.prefix if 'prefix' in openshift.hosted.metrics.deployer else '' }}"
+    image_version: "{{ '-v IMAGE_VERSION=' ~ openshift.hosted.metrics.deployer.version if 'version' in openshift.hosted.metrics.deployer else '' }}"
 
 
 - name: Check for existing metrics pods


### PR DESCRIPTION
Initial commit fixes PART of the issue with deploying the metrics component of OCP in 3.4. Specifically the first commit fixes an error caused by deprecation of providing multiple parameters as a comma-separated list to the 'oc process' command.

https://bugzilla.redhat.com/show_bug.cgi?id=1390849