### PR TITLE
Optimize the cloud-specific list.yml playbooks

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -608,8 +608,8 @@ class FilterModule(object):
                           host_type=_get_tag_value(host['group_names'], 'host-type'),
                           sub_host_type=_get_tag_value(host['group_names'], 'sub-host-type'),
                           host={'name': host['inventory_hostname'],
-                                'public IP': host['ansible_ssh_host'],
-                                'private IP': host['ansible_default_ipv4']['address']})
+                                'public IP': host['oo_public_ipv4'],
+                                'private IP': host['oo_private_ipv4']})
             except KeyError:
                 pass
         return clusters

--- a/playbooks/aws/openshift-cluster/list.yml
+++ b/playbooks/aws/openshift-cluster/list.yml
@@ -16,11 +16,8 @@
       groups: oo_list_hosts
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_become: "{{ deployment_vars[deployment_type].become }}"
+      oo_public_ipv4: "{{ hostvars[item].ec2_ip_address }}"
+      oo_private_ipv4: "{{ hostvars[item].ec2_private_ip_address }}"
     with_items: "{{ groups[scratch_group] | default([]) | difference(['localhost']) }}"
-
-- name: List Hosts
-  hosts: oo_list_hosts
-  gather_facts: no
-  tasks:
   - debug:
-      msg: "public ip:{{ hostvars[inventory_hostname].ec2_ip_address }} private ip:{{ hostvars[inventory_hostname].ec2_private_ip_address }}"
+      msg: "{{ hostvars | oo_select_keys(groups[scratch_group] | default([])) | oo_pretty_print_cluster }}"

--- a/playbooks/gce/openshift-cluster/list.yml
+++ b/playbooks/gce/openshift-cluster/list.yml
@@ -16,18 +16,8 @@
       groups: oo_list_hosts
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_become: "{{ deployment_vars[deployment_type].become }}"
+      oo_public_ipv4: "{{ hostvars[item].gce_public_ip }}"
+      oo_private_ipv4: "{{ hostvars[item].gce_private_ip }}"
     with_items: "{{ groups[scratch_group] | default([], true) | difference(['localhost']) | difference(groups.status_terminated | default([], true)) }}"
-
-- name: List Hosts
-  hosts: oo_list_hosts
-
-- name: List Hosts
-  hosts: localhost
-  become: no
-  connection: local
-  gather_facts: no
-  vars_files:
-  - vars.yml
-  tasks:
   - debug:
       msg: "{{ hostvars | oo_select_keys(groups[scratch_group] | default([])) | oo_pretty_print_cluster }}"

--- a/playbooks/libvirt/openshift-cluster/list.yml
+++ b/playbooks/libvirt/openshift-cluster/list.yml
@@ -16,18 +16,8 @@
       groups: oo_list_hosts
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_become: "{{ deployment_vars[deployment_type].become }}"
+      oo_public_ipv4: ""
+      oo_private_ipv4: "{{ hostvars[item].libvirt_ip_address }}"
     with_items: "{{ groups[scratch_group] | default([]) | difference(['localhost']) }}"
-
-- name: List Hosts
-  hosts: oo_list_hosts
-
-- name: List Hosts
-  hosts: localhost
-  become: no
-  connection: local
-  gather_facts: no
-  vars_files:
-  - vars.yml
-  tasks:
   - debug:
       msg: "{{ hostvars | oo_select_keys(groups[scratch_group] | default([])) | oo_pretty_print_cluster }}"

--- a/playbooks/openstack/openshift-cluster/list.yml
+++ b/playbooks/openstack/openshift-cluster/list.yml
@@ -17,18 +17,8 @@
       ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
       ansible_ssh_host: "{{ hostvars[item].ansible_ssh_host | default(item) }}"
       ansible_become: "{{ deployment_vars[deployment_type].become }}"
+      oo_public_ipv4: "{{ hostvars[item].openstack.public_v4 }}"
+      oo_private_ipv4: "{{ hostvars[item].openstack.private_v4 }}"
     with_items: "{{ groups[scratch_group] | default([]) | difference(['localhost']) }}"
-
-- name: List Hosts
-  hosts: oo_list_hosts
-
-- name: List Hosts
-  hosts: localhost
-  become: no
-  connection: local
-  gather_facts: no
-  vars_files:
-  - vars.yml
-  tasks:
   - debug:
       msg: "{{ hostvars | oo_select_keys(groups[scratch_group] | default([])) | oo_pretty_print_cluster('meta-') }}"


### PR DESCRIPTION
by removing the need to gather facts on all VMs in order to list them.

And prettify the output of AWS list the same way it is done for other cloud providers.