### PR TITLE
Check for bad versions of yum and subscription-manager.

### DIFF
--- a/playbooks/common/openshift-cluster/initialize_openshift_version.yml
+++ b/playbooks/common/openshift-cluster/initialize_openshift_version.yml
@@ -1,5 +1,21 @@
 ---
 # NOTE: requires openshift_facts be run
+- hosts: l_oo_all_hosts
+  gather_facts: no
+  tasks:
+  # See:
+  #   https://bugzilla.redhat.com/show_bug.cgi?id=1395047
+  #   https://bugzilla.redhat.com/show_bug.cgi?id=1282961
+  #   https://github.com/openshift/openshift-ansible/issues/1138
+  - name: Check for bad combinations of yum and subscription-manager
+    command: >
+      {{ repoquery_cmd }} --installed --qf '%{version}' "yum"
+    register: yum_ver_test
+    changed_when: false
+  - fail:
+      msg: Incompatible versions of yum and subscription-manager found. You may need to update yum and yum-utils.
+    when: "'Plugin \"search-disabled-repos\" requires API 2.7. Supported API is 2.6.' in yum_ver_test.stdout"
+
 - name: Determine openshift_version to configure on first master
   hosts: oo_first_master
   roles:


### PR DESCRIPTION
Use of yum and repoquery will output the given additional warning when
using newer versions of subscription-manager, with older versions of
yum. (RHEL 7.1) Installing/upgrading newer docker can pull this
subscription-manager in resulting in problems with older versions of
ansible and it's yum module, as well as any use of repoquery/yum
commands in our playbooks.

This change explicitly checks for the problem by using repoquery and
fails early if found. This is run early in both config and upgrade.

Note that "yum update -y yum yum-utils" fixes the problem.


This is an altered version of #1507, but does not require rpm db checking during every openshift_facts run, rather only once early in our main playbooks.

There *may* be lingering problems if we attempted to repoquery *after* installing/upgrading docker and this pulling in newer subscription-manager. However it does not appear we do this, upgrade is successful with this change, and this is not something we can easily pre-emptively check for. We'll have to handle this via documentation/kbase/known issues if it arises.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1395047