### PR TITLE
node_dnsmasq -- Set dnsmasq as our only nameserver

### DIFF
--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -85,7 +85,10 @@ EOF
       systemctl restart dnsmasq
     fi
 
-    sed -i '0,/^nameserver/ s/^nameserver.*$/nameserver '"${def_route_ip}"'/g' /etc/resolv.conf
+    # Only if dnsmasq is running properly make it our only nameserver
+    if `systemctl -q is-active dnsmasq.service`; then
+      sed -i -e '/^nameserver.*$/d' -e 'a\nameserver '"${def_route_ip}"'\' /etc/resolv.conf
+    fi
 
     if ! grep -q '99-origin-dns.sh' /etc/resolv.conf; then
       echo "# nameserver updated by /etc/NetworkManager/dispatcher.d/99-origin-dns.sh" >> /etc/resolv.conf

--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -36,6 +36,7 @@ if [[ $2 =~ ^(up|dhcp4-change)$ ]]; then
   UPSTREAM_DNS_TMP=`mktemp`
   UPSTREAM_DNS_TMP_SORTED=`mktemp`
   CURRENT_UPSTREAM_DNS_SORTED=`mktemp`
+  NEW_RESOLV_CONF=`mktemp`
 
   ######################################################################
   # couldn't find an existing method to determine if the interface owns the
@@ -87,14 +88,15 @@ EOF
 
     # Only if dnsmasq is running properly make it our only nameserver
     if `systemctl -q is-active dnsmasq.service`; then
-      sed -i -e '/^nameserver.*$/d' -e 'a\nameserver '"${def_route_ip}"'\' /etc/resolv.conf
-    fi
-
-    if ! grep -q '99-origin-dns.sh' /etc/resolv.conf; then
-      echo "# nameserver updated by /etc/NetworkManager/dispatcher.d/99-origin-dns.sh" >> /etc/resolv.conf
+      sed -e '/^nameserver.*$/d' /etc/resolv.conf > ${NEW_RESOLV_CONF}
+      echo "nameserver "${def_route_ip}"" >> ${NEW_RESOLV_CONF}
+      if ! grep -q '99-origin-dns.sh' ${NEW_RESOLV_CONF}; then
+          echo "# nameserver updated by /etc/NetworkManager/dispatcher.d/99-origin-dns.sh" >> ${NEW_RESOLV_CONF}
+      fi
+      cp -Z ${NEW_RESOLV_CONF} /etc/resolv.conf
     fi
   fi
 
   # Clean up after yourself
-  rm -f $UPSTREAM_DNS_TMP $UPSTREAM_DNS_TMP_SORTED $CURRENT_UPSTREAM_DNS_SORTED
+  rm -f $UPSTREAM_DNS_TMP $UPSTREAM_DNS_TMP_SORTED $CURRENT_UPSTREAM_DNS_SORTED $NEW_RESOLV_CONF
 fi


### PR DESCRIPTION
The kubelet appends nameservers and search path from the host's /etc/resolv.conf inside the pods. If someone had PEERDNS=no and DNS1, DNS2 then the pod would get
```
nameserver $nodeip
nameserver $nodeip
nameserver $DNS1
nameserver $DNS2
```

Alpine linux based images, and others, don't iterate through the list in order so they'd attempt to resolve via any of the nameservers and they'd get different results. If we ensure that the host only has dnsmasq in /etc/resolv.conf we can avoid this problem.

Also, since we're making dnsmasq the only resolver, make sure it's running before switching things.