### PR TITLE
Escape LOGNAME variable according to GCE rules #2736

### DIFF
--- a/playbooks/gce/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/gce/openshift-cluster/tasks/launch_instances.yml
@@ -13,7 +13,7 @@
 # unsupported in 1.9.+
     #service_account_permissions: "datastore,logging-write"
     tags:
-      - created-by-{{ lookup('env', 'LOGNAME') |default(cluster, true) }}
+      - created-by-{{ lookup('env', 'LOGNAME') | regex_replace('[^a-z0-9]+', '') | default(cluster, true) }}
       - environment-{{ cluster_env }}
       - clusterid-{{ cluster_id }}
       - host-type-{{ type }}


### PR DESCRIPTION
Machine tags are restricted to only alpha numeric values, so when your logname contains a dot you are not able to properly create machine

This should solve a problem submitted by me in #2736 