### PR TITLE
Fix 3.2 HA upgrade when no master debug_level fact is set.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre.yml
@@ -232,10 +232,24 @@
 ###############################################################################
 # Backup etcd
 ###############################################################################
+# If facts cache were for some reason deleted, this fact may not be set, and if not set
+# it will always default to true. This causes problems for the etcd data dir fact detection
+# so we must first make sure this is set correctly before attempting the backup.
+- name: Set master embedded_etcd fact
+  hosts: oo_masters_to_config
+  roles:
+  - openshift_facts
+  tasks:
+  - openshift_facts:
+      role: master
+      local_facts:
+        embedded_etcd: "{{ groups.oo_etcd_to_config | length == 0 }}"
+        debug_level: "{{ openshift_master_debug_level | default(openshift.common.debug_level | default(2)) }}"
+
 - name: Backup etcd
   hosts: etcd_hosts_to_backup
   vars:
-    embedded_etcd: "{{ hostvars[groups.oo_first_master.0].openshift.master.embedded_etcd }}"
+    embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
     timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
   roles:
   - openshift_facts


### PR DESCRIPTION
This is related to #2584 but covers HA environment templates as well. 

Suspected fix for bug (still waiting to hear back): https://bugzilla.redhat.com/show_bug.cgi?id=1396295

