### PR TITLE
Allow ansible to continue when a node is unaccessible or fails.

### DIFF
--- a/playbooks/common/openshift-cluster/initialize_facts.yml
+++ b/playbooks/common/openshift-cluster/initialize_facts.yml
@@ -1,7 +1,11 @@
 ---
+- name: Ensure that all non-node hosts are accessible
+  hosts: oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_nfs_to_config
+  any_errors_fatal: true
+  tasks:
+
 - name: Initialize host facts
   hosts: oo_all_hosts
-  any_errors_fatal: true
   roles:
   - openshift_facts
   tasks:

--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -23,6 +23,7 @@
   delay: 5
   changed_when: false
   with_items: "{{ openshift_nodes }}"
+  when: hostvars[item].openshift.node.nodename is defined
 
 - name: Set node schedulability
   command: >


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1377619
Supersedes #2666
