### PR TITLE
Fix etcd version check for embedded installs

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/embedded_etcdctl.yml
+++ b/playbooks/common/openshift-cluster/upgrades/embedded_etcdctl.yml
@@ -6,17 +6,15 @@
 # so until that ships we need to carefully install etcd 3.0 to ensure we get fixes
 # for backing up embedded etcd in 2.3
 # see https://github.com/coreos/etcd/pull/4952 and https://bugzilla.redhat.com/show_bug.cgi?id=1382634
-- name: Check for etcd package
-  rpm_q:
-    name: etcd
-    state: present
+- name: Record RPM based etcd version
+  command: rpm -q --qf '%{version}' etcd
+  register: etcd_installed_version
   failed_when: false
-  register: etcd_rpmq
   when: ansible_distribution == 'RedHat'
 
 - name: Determine if we need to yum swap etcd3 etcd
   set_fact:
-    etcd2_installed: "{{ etcd_rpmq.installed_versions | default('99') | version_compare('3.0','<') }}"
+    etcd2_installed: "{{ etcd_installed_version.stdout | version_compare('3.0','<') and etcd_installed_version.rc == 0 }}"
   when: ansible_distribution == 'RedHat'
 
 - name: Install etcd3 (for etcdctl)


### PR DESCRIPTION
rpmq returns something like 'etcd-2.3.7-4.el7.x86_64' which apparently loose_version sometimes interprets correctly, other times not, or maybe we just completely failed to test this. Just use the same method that's used in master for etcd upgrade playbooks