### PR TITLE
Fix rare failure to deploy new registry/router after upgrade.

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade.yml
@@ -92,9 +92,9 @@
   vars:
     master_config_hook: "v3_3/master_config_upgrade.yml"
 
-- include: ../../../../common/openshift-cluster/upgrades/post_control_plane.yml
-
 - include: ../../../../common/openshift-cluster/upgrades/upgrade_nodes.yml
   vars:
     node_config_hook: "v3_3/node_config_upgrade.yml"
+
+- include: ../../../../common/openshift-cluster/upgrades/post_control_plane.yml
 

--- a/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade.yml
@@ -90,7 +90,7 @@
 
 - include: ../../../../common/openshift-cluster/upgrades/upgrade_control_plane.yml
 
-- include: ../../../../common/openshift-cluster/upgrades/post_control_plane.yml
-
 - include: ../../../../common/openshift-cluster/upgrades/upgrade_nodes.yml
+
+- include: ../../../../common/openshift-cluster/upgrades/post_control_plane.yml
 


### PR DESCRIPTION
Router/registry update and re-deploy was recently reordered to
immediately follow control plane upgrade, right before we proceed to
node upgrade.

In some situations (small or single host clusters) it appears possible
that the deployer pods are running when the node in question is
evacuated for upgrade. When the deployer pod dies the deployment is
failed and the router/registry continue running the old version, despite
the deployment config being updated correctly.

This change re-orderes the router/registry upgrade to follow node
upgrade. However for separate control plane upgrade, the router/registry
still occurs at the end. This is because router/registry seems like they
should logically be included in a control plane upgrade, and presumably
the user will not manually launch node upgrade so quickly as to trigger
an evac on the node in question.

Workaround for this problem when it does occur is simply to:

oc deploy docker-registry --latest

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1395081