### PR TITLE
Simplify OpenShift service debug levels.

### DIFF
--- a/inventory/byo/hosts.openstack
+++ b/inventory/byo/hosts.openstack
@@ -13,7 +13,7 @@ ansible_ssh_user=cloud-user
 ansible_become=yes
 
 # Debug level for all OpenShift components (Defaults to 2)
-debug_level=2
+openshift_debug_level=2
 
 deployment_type=openshift-enterprise
 

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -19,8 +19,14 @@ ansible_ssh_user=root
 # user must be configured for passwordless sudo
 #ansible_become=yes
 
-# Debug level for all OpenShift components (Defaults to 2)
-debug_level=2
+# Debug level for all OpenShift components (defaults to 2)
+openshift_debug_level=2
+
+# Specific debug level for master services if desired (defaults to openshift_debug_level)
+openshift_master_debug_level=2
+
+# Specific debug level for node services if desired (defaults to openshift_debug_level)
+openshift_master_node_level=2
 
 # deployment type valid values are origin, online, atomic-enterprise and openshift-enterprise
 deployment_type=origin

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -19,8 +19,14 @@ ansible_ssh_user=root
 # user must be configured for passwordless sudo
 #ansible_become=yes
 
-# Debug level for all OpenShift components (Defaults to 2)
-debug_level=2
+# Debug level for all OpenShift components (defaults to 2)
+openshift_debug_level=2
+
+# Specific debug level for master services if desired (defaults to openshift_debug_level)
+openshift_master_debug_level=2
+
+# Specific debug level for node services if desired (defaults to openshift_debug_level)
+openshift_master_node_level=2
 
 # deployment type valid values are origin, online, atomic-enterprise, and openshift-enterprise
 deployment_type=openshift-enterprise

--- a/playbooks/aws/openshift-cluster/config.yml
+++ b/playbooks/aws/openshift-cluster/config.yml
@@ -23,7 +23,6 @@
     g_sudo:         "{{ deployment_vars[deployment_type].become }}"
     g_nodeonmaster: true
     openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: "{{ debug_level }}"
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_public_hostname: "{{ ec2_ip_address }}"
     openshift_hosted_registry_selector: 'type=infra'

--- a/playbooks/aws/openshift-cluster/scaleup.yml
+++ b/playbooks/aws/openshift-cluster/scaleup.yml
@@ -27,6 +27,5 @@
     g_sudo: "{{ deployment_vars[deployment_type].become }}"
     g_nodeonmaster: true
     openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: "{{ debug_level }}"
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_public_hostname: "{{ ec2_ip_address }}"

--- a/playbooks/aws/openshift-cluster/vars.yml
+++ b/playbooks/aws/openshift-cluster/vars.yml
@@ -1,6 +1,4 @@
 ---
-debug_level: 2
-
 deployment_rhel7_ent_base:
   # rhel-7.1, requires cloud access subscription
   image: "{{ lookup('oo_option', 'ec2_image') | default('ami-10251c7a', True) }}"

--- a/playbooks/byo/openshift-cluster/config.yml
+++ b/playbooks/byo/openshift-cluster/config.yml
@@ -26,6 +26,5 @@
 - include: ../../common/openshift-cluster/config.yml
   vars:
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
-    openshift_debug_level: "{{ debug_level | default(2) }}"
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_deployment_subtype: "{{ deployment_subtype | default(none) }}"

--- a/playbooks/byo/openshift-master/scaleup.yml
+++ b/playbooks/byo/openshift-master/scaleup.yml
@@ -18,5 +18,4 @@
 - include: ../../common/openshift-master/scaleup.yml
   vars:
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
-    openshift_debug_level: "{{ debug_level | default(2) }}"
     openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/byo/openshift-node/scaleup.yml
+++ b/playbooks/byo/openshift-node/scaleup.yml
@@ -18,5 +18,4 @@
 - include: ../../common/openshift-node/scaleup.yml
   vars:
     openshift_cluster_id: "{{ cluster_id | default('default') }}"
-    openshift_debug_level: "{{ debug_level | default(2) }}"
     openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -25,7 +25,6 @@
       role: master
       local_facts:
         embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
-        debug_level: "{{ openshift_master_debug_level | default(openshift.common.debug_level | default(2)) }}"
 
 - name: Backup etcd
   include: ./etcd/backup.yml

--- a/playbooks/gce/openshift-cluster/config.yml
+++ b/playbooks/gce/openshift-cluster/config.yml
@@ -23,7 +23,6 @@
     g_sudo: "{{ deployment_vars[deployment_type].become }}"
     g_nodeonmaster: true
     openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: "{{ debug_level }}"
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_hostname: "{{ gce_private_ip }}"
     openshift_hosted_registry_selector: 'type=infra'

--- a/playbooks/gce/openshift-cluster/vars.yml
+++ b/playbooks/gce/openshift-cluster/vars.yml
@@ -1,6 +1,4 @@
 ---
-debug_level: 2
-
 deployment_rhel7_ent_base:
   image: "{{ lookup('oo_option', 'image_name') | default('rhel-7', True) }}"
   machine_type: "{{ lookup('oo_option', 'machine_type') | default('n1-standard-1', True) }}"

--- a/playbooks/libvirt/openshift-cluster/config.yml
+++ b/playbooks/libvirt/openshift-cluster/config.yml
@@ -27,7 +27,6 @@
     g_sudo: "{{ deployment_vars[deployment_type].become }}"
     g_nodeonmaster: true
     openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: "{{ debug_level }}"
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_hosted_registry_selector: 'type=infra'
     openshift_hosted_router_selector: 'type=infra'

--- a/playbooks/libvirt/openshift-cluster/vars.yml
+++ b/playbooks/libvirt/openshift-cluster/vars.yml
@@ -6,7 +6,6 @@ libvirt_network: "{{ lookup('oo_option', 'libvirt_network') | default('openshift
 libvirt_instance_memory_mib: "{{ lookup('oo_option', 'libvirt_instance_memory_mib') | default(1024, True) }}"
 libvirt_instance_vcpu: "{{ lookup('oo_option', 'libvirt_instance_vcpu') | default(2, True) }}"
 libvirt_uri: "{{ lookup('oo_option', 'libvirt_uri') | default('qemu:///system', True) }}"
-debug_level: 2
 
 # Automatic download of the qcow2 image for RHEL cannot be done directly from the RedHat portal because it requires authentication.
 # The default value of image_url for enterprise and openshift-enterprise deployment types below won't work.

--- a/playbooks/openstack/openshift-cluster/config.yml
+++ b/playbooks/openstack/openshift-cluster/config.yml
@@ -23,7 +23,6 @@
     g_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
     g_sudo: "{{ deployment_vars[deployment_type].become }}"
     openshift_cluster_id: "{{ cluster_id }}"
-    openshift_debug_level: "{{ debug_level }}"
     openshift_deployment_type: "{{ deployment_type }}"
     openshift_hosted_registry_selector: 'type=infra'
     openshift_hosted_router_selector: 'type=infra'

--- a/playbooks/openstack/openshift-cluster/vars.yml
+++ b/playbooks/openstack/openshift-cluster/vars.yml
@@ -1,5 +1,4 @@
 ---
-debug_level: 2
 openstack_infra_heat_stack:     "{{ lookup('oo_option', 'infra_heat_stack' ) |
                                     default('files/heat_stack.yaml',         True) }}"
 openstack_subnet_24_prefix:     "{{ lookup('oo_option', 'subnet_24_prefix'         ) |

--- a/roles/openshift_common/README.md
+++ b/roles/openshift_common/README.md
@@ -15,7 +15,6 @@ Role Variables
 | Name                      | Default value     |                                             |
 |---------------------------|-------------------|---------------------------------------------|
 | openshift_cluster_id      | default           | Cluster name if multiple OpenShift clusters |
-| openshift_debug_level     | 2                 | Global openshift debug log verbosity        |
 | openshift_hostname        | UNDEF             | Internal hostname to use for this host (this value will set the hostname on the system) |
 | openshift_ip              | UNDEF             | Internal IP address to use for this host    |
 | openshift_public_hostname | UNDEF             | Public hostname to use for this host        |

--- a/roles/openshift_common/defaults/main.yml
+++ b/roles/openshift_common/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
 openshift_cluster_id: 'default'
-openshift_debug_level: 2

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1848,8 +1848,7 @@ class OpenShiftFacts(object):
                                   portal_net='172.30.0.0/16',
                                   client_binary='oc', admin_binary='oadm',
                                   dns_domain='cluster.local',
-                                  install_examples=True,
-                                  debug_level=2)
+                                  install_examples=True)
 
         if 'master' in roles:
             scheduler_predicates = [

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -22,7 +22,6 @@
   openshift_facts:
     role: common
     local_facts:
-      debug_level: "{{ openshift_debug_level | default(2) }}"
       # TODO: Deprecate deployment_type in favor of openshift_deployment_type
       deployment_type: "{{ openshift_deployment_type | default(deployment_type) }}"
       deployment_subtype: "{{ openshift_deployment_subtype | default(None) }}"

--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -2,6 +2,16 @@
 # playbooks.  For that reason the ha_svc variables are use set_fact instead of
 # the vars directory on the role.
 
+- name: Ensure openshift_debug_level is set
+  set_fact:
+    openshift_debug_level: "{{ debug_level | default(2) }}"
+  when: openshift_debug_level is not defined
+
+- name: Ensure openshift_master_debug_level is set
+  set_fact:
+    openshift_master_debug_level: "{{ openshift_debug_level | default(2) }}"
+  when: openshift_master_debug_level is not defined
+
 - name: Init HA Service Info
   set_fact:
     containerized_svc_dir: "/usr/lib/systemd/system"

--- a/roles/openshift_master/templates/atomic-openshift-master.j2
+++ b/roles/openshift_master/templates/atomic-openshift-master.j2
@@ -1,4 +1,4 @@
-OPTIONS=--loglevel={{ openshift.master.debug_level | default(2) }}
+OPTIONS=--loglevel={{ openshift_master_debug_level }}
 CONFIG_FILE={{ openshift_master_config_file }}
 {% if openshift.common.is_containerized | bool %}
 IMAGE_VERSION={{ openshift_image_tag }}

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
@@ -1,4 +1,4 @@
-OPTIONS=--loglevel={{ openshift.master.debug_level }} --listen={{ 'https' if openshift.master.api_use_ssl else 'http' }}://{{ openshift.master.bind_addr }}:{{ openshift.master.api_port }} --master={{ openshift.master.loopback_api_url }}
+OPTIONS=--loglevel={{ openshift_master_debug_level }} --listen={{ 'https' if openshift.master.api_use_ssl else 'http' }}://{{ openshift.master.bind_addr }}:{{ openshift.master.api_port }} --master={{ openshift.master.loopback_api_url }}
 CONFIG_FILE={{ openshift_master_config_file }}
 {% if openshift.common.is_containerized | bool %}
 IMAGE_VERSION={{ openshift_image_tag }}

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.j2
@@ -1,4 +1,4 @@
-OPTIONS=--loglevel={{ openshift.master.debug_level }} --listen={{ 'https' if openshift.master.api_use_ssl else 'http' }}://{{ openshift.master.bind_addr }}:{{ openshift.master.controllers_port }}
+OPTIONS=--loglevel={{ openshift_master_debug_level }} --listen={{ 'https' if openshift.master.api_use_ssl else 'http' }}://{{ openshift.master.bind_addr }}:{{ openshift.master.controllers_port }}
 CONFIG_FILE={{ openshift_master_config_file }}
 {% if openshift.common.is_containerized | bool %}
 IMAGE_VERSION={{ openshift_image_tag }}

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -6,7 +6,6 @@
       cluster_method: "{{ openshift_master_cluster_method | default(None) }}"
       cluster_hostname: "{{ openshift_master_cluster_hostname | default(None) }}"
       cluster_public_hostname: "{{ openshift_master_cluster_public_hostname | default(None) }}"
-      debug_level: "{{ openshift_master_debug_level | default(openshift.common.debug_level) }}"
       api_port: "{{ openshift_master_api_port | default(None) }}"
       api_url: "{{ openshift_master_api_url | default(None) }}"
       api_use_ssl: "{{ openshift_master_api_use_ssl | default(None) }}"

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -16,7 +16,6 @@
   - role: node
     local_facts:
       annotations: "{{ openshift_node_annotations | default(none) }}"
-      debug_level: "{{ openshift_node_debug_level | default(openshift.common.debug_level) }}"
       iptables_sync_period: "{{ openshift_node_iptables_sync_period | default(None) }}"
       kubelet_args: "{{ openshift_node_kubelet_args | default(None) }}"
       labels: "{{ lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true) }}"

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -1,6 +1,16 @@
 # This file is included both in the openshift_master role and in the upgrade
 # playbooks.
 
+- name: Ensure openshift_debug_level is set
+  set_fact:
+    openshift_debug_level: "{{ debug_level | default(2) }}"
+  when: openshift_debug_level is not defined
+
+- name: Ensure openshift_node_debug_level is set
+  set_fact:
+    openshift_node_debug_level: "{{ openshift_debug_level | default(2) }}"
+  when: openshift_node_debug_level is not defined
+
 - name: Install Node dependencies docker service file
   template:
     dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node-dep.service"
@@ -55,7 +65,7 @@
     create: true
   with_items:
     - regex: '^OPTIONS='
-      line: "OPTIONS=--loglevel={{ openshift.node.debug_level | default(2) }}"
+      line: "OPTIONS=--loglevel={{ openshift_node_debug_level }}"
     - regex: '^CONFIG_FILE='
       line: "CONFIG_FILE={{ openshift.common.config_base }}/node/node-config.yaml"
     - regex: '^IMAGE_VERSION='

--- a/roles/openshift_persistent_volumes/README.md
+++ b/roles/openshift_persistent_volumes/README.md
@@ -17,13 +17,6 @@ From this role:
 | persistent_volume_claims | []            | List of persistent volume claim dictionaries, keys: name, capacity, access_modes    |
 
 
-From openshift_common:
-
-| Name                          | Default Value  |                                        |
-|-------------------------------|----------------|----------------------------------------|
-| openshift_debug_level         | 2              | Global openshift debug log verbosity   |
-
-
 Dependencies
 ------------
 


### PR DESCRIPTION
Stop using openshift_facts for debug levels entirely as this is not a fact about
the system, rather a configuration parameter of the playbooks/inventory.

Deprecate debug_level and rename to openshift_debug_level. Default is
2 if undefined, and can be specified separately for master/node if
desired.

Moved all definitions/defaulting straight to systemd_units.yml for
master/node where the values are actually used. Here we check if
openshift_debug_level is set and default it if not, and then set the
master/node variant if they are not set.

NOTE: Vars can't be used in the roles here as the systemd_units.yml
files are used separtely during upgrade.

@detiber @abutcher @sdodson could use one of your reviews here if possible.

@sdodson this is not explicitly for 3.4, I'm not sure it should be included at all. Based on end result it probably looks safe but it could be disruptive.