### PR TITLE
Only run tuned-adm if tuned exists.

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -38,9 +38,15 @@
   action: "{{ ansible_pkg_mgr }} name={{ openshift.common.service_type }}-node{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }},tuned-profiles-{{ openshift.common.service_type }}-node{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }} state=present"
   when: not openshift.common.is_containerized | bool
 
+- name: Check for tuned package
+  command: rpm -q tuned
+  register: tuned_installed
+  changed_when: false
+  failed_when: false
+
 - name: Set atomic-guest tuned profile
   command: "tuned-adm profile atomic-guest"
-  when: openshift.common.is_atomic | bool
+  when: tuned_installed.rc == 0 and openshift.common.is_atomic | bool
 
 - name: Install sdn-ovs package
   action: "{{ ansible_pkg_mgr }} name={{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version | oo_image_tag_to_rpm_version(include_dash=True) }} state=present"


### PR DESCRIPTION
Fedora Atomic Host does not have tuned installed.