### PR TITLE
Merge admission plugin configs

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -619,6 +619,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # masterConfig.volumeConfig.dynamicProvisioningEnabled, configurable as of 1.2/3.2, enabled by default
 #openshift_master_dynamic_provisioning_enabled=False
 
+# Admission plugin config
+#openshift_master_admission_plugin_config={"ProjectRequestLimit":{"configuration":{"apiVersion":"v1","kind":"ProjectRequestLimitConfig","limits":[{"selector":{"admin":"true"}},{"maxProjects":"1"}]}},"PodNodeConstraints":{"configuration":{"apiVersion":"v1","kind":"PodNodeConstraintsConfig"}}}
+
 # Configure usage of openshift_clock role.
 #openshift_clock_enabled=true
 

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -619,6 +619,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # masterConfig.volumeConfig.dynamicProvisioningEnabled, configurable as of 1.2/3.2, enabled by default
 #openshift_master_dynamic_provisioning_enabled=False
 
+# Admission plugin config
+#openshift_master_admission_plugin_config={"ProjectRequestLimit":{"configuration":{"apiVersion":"v1","kind":"ProjectRequestLimitConfig","limits":[{"selector":{"admin":"true"}},{"maxProjects":"1"}]}},"PodNodeConstraints":{"configuration":{"apiVersion":"v1","kind":"PodNodeConstraintsConfig"}}}
+
 # Configure usage of openshift_clock role.
 #openshift_clock_enabled=true
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/master_config_upgrade.yml
@@ -48,3 +48,18 @@
     dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
     yaml_key: 'controllerConfig.servicesServingCert.signer.keyFile'
     yaml_value: service-signer.key
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'admissionConfig.pluginConfig'
+    yaml_value: "{{ openshift.master.admission_plugin_config }}"
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'admissionConfig.pluginOrderOverride'
+    yaml_value:
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'kubernetesMasterConfig.admissionConfig'
+    yaml_value:

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/master_config_upgrade.yml
@@ -1,0 +1,15 @@
+---
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'admissionConfig.pluginConfig'
+    yaml_value: "{{ openshift.master.admission_plugin_config }}"
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'admissionConfig.pluginOrderOverride'
+    yaml_value:
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'kubernetesMasterConfig.admissionConfig'
+    yaml_value:

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -1,7 +1,4 @@
 admissionConfig:
-{% if 'admission_plugin_order' in openshift.master %}
-  pluginOrderOverride:{{ openshift.master.admission_plugin_order | to_padded_yaml(level=2) }}
-{% endif %}
 {% if 'admission_plugin_config' in openshift.master %}
   pluginConfig:{{ openshift.master.admission_plugin_config | to_padded_yaml(level=2) }}
 {% endif %}
@@ -115,13 +112,6 @@ kubernetesMasterConfig:
   apiLevels:
   - v1beta3
   - v1
-{% endif %}
-  admissionConfig:
-{% if 'kube_admission_plugin_order' in openshift.master %}
-    pluginOrderOverride:{{ openshift.master.kube_admission_plugin_order | to_padded_yaml(level=3) }}
-{% endif %}
-{% if 'kube_admission_plugin_config' in openshift.master %}
-    pluginConfig:{{ openshift.master.kube_admission_plugin_config | to_padded_yaml(level=3) }}
 {% endif %}
   apiServerArguments: {{ openshift.master.api_server_args | default(None) | to_padded_yaml( level=2 ) }}
   controllerArguments: {{ openshift.master.controller_args | default(None) | to_padded_yaml( level=2 ) }}

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -66,10 +66,8 @@
       master_image: "{{ osm_image | default(None) }}"
       scheduler_predicates: "{{ openshift_master_scheduler_predicates | default(None) }}"
       scheduler_priorities: "{{ openshift_master_scheduler_priorities | default(None) }}"
-      admission_plugin_order: "{{openshift_master_admission_plugin_order | default(None) }}"
       admission_plugin_config: "{{openshift_master_admission_plugin_config | default(None) }}"
-      kube_admission_plugin_order: "{{openshift_master_kube_admission_plugin_order | default(None) }}"
-      kube_admission_plugin_config: "{{openshift_master_kube_admission_plugin_config | default(None) }}"
+      kube_admission_plugin_config: "{{openshift_master_kube_admission_plugin_config | default(None) }}" # deprecated, merged with admission_plugin_config
       oauth_template: "{{ openshift_master_oauth_template | default(None) }}" # deprecated in origin 1.2 / OSE 3.2
       oauth_templates: "{{ openshift_master_oauth_templates | default(None) }}"
       oauth_always_show_provider_selection: "{{ openshift_master_oauth_always_show_provider_selection | default(None) }}"


### PR DESCRIPTION
Fixes Bug 1393645
Fixes #2462
Supersedes #2782 

This change deprecates the following inventory variables:

```
openshift_master_admission_plugin_order
openshift_master_kube_admission_plugin_order
openshift_master_kube_admission_plugin_config
```

Based on the [documentation](https://docs.openshift.com/container-platform/latest/architecture/additional_concepts/admission_controllers.html), plugin order should no longer be set and all admission plugin configuration should be moved to `admissionConfig.pluginConfig` in `/etc/origin/master/master-config.yaml`. Admission plugin configuration set within `openshift_master_kube_admission_plugin_config` will be merged into configuration set within `openshift_master_admission_plugin_config`.

Since inventories may not be updated to reflect this change, it is still possible to set `openshift_master_kube_admission_plugin_config` which will always be merged into `openshift_master_admission_plugin_config`

https://bugzilla.redhat.com/show_bug.cgi?id=1393645