### PR TITLE
Make os_firewall_manage_iptables run on python3

### DIFF
--- a/roles/os_firewall/library/os_firewall_manage_iptables.py
+++ b/roles/os_firewall/library/os_firewall_manage_iptables.py
@@ -139,7 +139,7 @@ class IpTablesManager(object): # pylint: disable=too-many-instance-attributes
                 output = check_output(cmd, stderr=subprocess.STDOUT)
 
                 # break the input rules into rows and columns
-                input_rules = [s.split() for s in output.split('\n')]
+                input_rules = [s.split() for s in to_native(output).split('\n')]
 
                 # Find the last numbered rule
                 last_rule_num = None
@@ -269,5 +269,6 @@ def main():
 # pylint: disable=redefined-builtin, unused-wildcard-import, wildcard-import
 # import module snippets
 from ansible.module_utils.basic import *
+from ansible.module_utils._text import to_native
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
It fail with that traceback:

    Traceback (most recent call last):
      File \"/tmp/ansible_ib5gpbsp/ansible_module_os_firewall_manage_iptables.py\", line 273, in <module>
        main()
      File \"/tmp/ansible_ib5gpbsp/ansible_module_os_firewall_manage_iptables.py\", line 257, in main
        iptables_manager.add_rule(port, protocol)
      File \"/tmp/ansible_ib5gpbsp/ansible_module_os_firewall_manage_iptables.py\", line 87, in add_rule
        self.verify_chain()
      File \"/tmp/ansible_ib5gpbsp/ansible_module_os_firewall_manage_iptables.py\", line 82, in verify_chain
        self.create_jump()
      File \"/tmp/ansible_ib5gpbsp/ansible_module_os_firewall_manage_iptables.py\", line 142, in create_jump
        input_rules = [s.split() for s in output.split('\\n')]