### PR TITLE
Make the role work on F25 Cloud

### DIFF
--- a/roles/openshift_node_dnsmasq/tasks/main.yml
+++ b/roles/openshift_node_dnsmasq/tasks/main.yml
@@ -4,6 +4,7 @@
     systemctl show NetworkManager
   register: nm_show
   changed_when: false
+  ignore_errors: True
 
 - name: Set fact using_network_manager
   set_fact:


### PR DESCRIPTION
On F24 and earlier, systemctl show always returned 0. On F25, it
return 1 when a service do not exist, and thus the role fail
on Fedora 25 cloud edition.