### PR TITLE
Verify the presence of dbus python binding

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -22,9 +22,14 @@ from distutils.util import strtobool
 from distutils.version import LooseVersion
 import struct
 import socket
-from dbus import SystemBus, Interface
-from dbus.exceptions import DBusException
 
+HAVE_DBUS=False
+try:
+    from dbus import SystemBus, Interface
+    from dbus.exceptions import DBusException
+    HAVE_DBUS=True
+except ImportError:
+    pass
 
 DOCUMENTATION = '''
 ---
@@ -2276,6 +2281,9 @@ def main():
         supports_check_mode=True,
         add_file_common_args=True,
     )
+
+    if not HAVE_DBUS:
+        module.fail_json(msg="This module requires dbus python bindings")
 
     module.params['gather_subset'] = ['hardware', 'network', 'virtual', 'facter']
     module.params['gather_timeout'] = 10


### PR DESCRIPTION
While the proper fix is to have it installed by default, this commit
will also permit to have a better error message in the case the module
is not present (as running on python 3)