### PR TITLE
Systemd `systemctl show` workaround

### DIFF
--- a/roles/os_firewall/tasks/firewall/firewalld.yml
+++ b/roles/os_firewall/tasks/firewall/firewalld.yml
@@ -13,7 +13,7 @@
     - iptables
     - ip6tables
   register: task_result
-  failed_when: "task_result|failed and 'Could not find' not in task_result.msg"
+  failed_when: "task_result|failed and 'could not' not in task_result.msg|lower"
 
 - name: Start and enable firewalld service
   systemd:

--- a/roles/os_firewall/tasks/firewall/iptables.yml
+++ b/roles/os_firewall/tasks/firewall/iptables.yml
@@ -7,7 +7,7 @@
     enabled: no
     masked: yes
   register: task_result
-  failed_when: "task_result|failed and 'Could not find' not in task_result.msg"
+  failed_when: "task_result|failed and 'could not' not in task_result.msg|lower"
 
 - name: Install iptables packages
   package: name={{ item }} state=present


### PR DESCRIPTION
`systemctl show` would exit with RC=1 for non-existent services in v231.
This caused the Ansible systemd module to exit with a failure of running the
`systemctl show` command instead of exiting stating the service was not found.

This change catches both failures on either older or newer versions of systemd.

The change in systemd exit status could be resolved in systemd v232.
https://github.com/systemd/systemd/commit/3dced37b7c2c9a5c733817569d2bbbaa397adaf7

Testing:
```
---
- name: Test Playbook
  hosts: all
  gather_facts: false

  tasks:
    - name: Test systemd
      systemd:
        name: foo.service
        state: started
      register: task_result
      failed_when: "task_result|failed and 'could not' not in task_result.msg|lower"

    - debug: var=task_result
```

```
# Output
> $ ansible-playbook test.yml -i hosts                                                                  

PLAY [Test Playbook] ***********************************************************

TASK [Test systemd] ************************************************************
ok: [localhost]
ok: [rhel-atomic-7.3.0]
ok: [fedora-atomic-25]

TASK [debug] *******************************************************************
ok: [localhost] => {
    "task_result": {
        "changed": false, 
        "failed": false, 
        "failed_when_result": false, 
        "msg": "failure 1 running systemctl show for 'foo.service': Unit foo.service could not be found.\n"
    }
}
ok: [fedora-atomic-25] => {
    "task_result": {
        "changed": false, 
        "failed": false, 
        "failed_when_result": false, 
        "msg": "failure 1 running systemctl show for 'foo.service': Unit foo.service could not be found.\n"
    }
}
ok: [rhel-atomic-7.3.0] => {
    "task_result": {
        "changed": false, 
        "failed": false, 
        "failed_when_result": false, 
        "msg": "Could not find the requested service \"'foo.service'\": "
    }
}

PLAY RECAP *********************************************************************
fedora-atomic-25           : ok=2    changed=0    unreachable=0    failed=0   
localhost                  : ok=2    changed=0    unreachable=0    failed=0   
rhel-atomic-7.3.0          : ok=2    changed=0    unreachable=0    failed=0   
```

References:
https://github.com/ansible/ansible-modules-core/issues/5710
https://github.com/openshift/openshift-ansible/pull/2817