### PR TITLE
Set nameservers on DHCPv6 event

### DIFF
--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -28,7 +28,7 @@ cd /etc/sysconfig/network-scripts
 
 [ -f ../network ] && . ../network
 
-if [[ $2 =~ ^(up|dhcp4-change)$ ]]; then
+if [[ $2 =~ ^(up|dhcp4-change|dhcp6-change)$ ]]; then
   # If the origin-upstream-dns config file changed we need to restart
   NEEDS_RESTART=0
   UPSTREAM_DNS='/etc/dnsmasq.d/origin-upstream-dns.conf'


### PR DESCRIPTION
A dhcp6-change event may happen on nodes running dual stack
IPv4/IPv6 and DHCP, even if Openshift itself doesn't use IPv6.
/etc/resolv.conf needs be adjusted as well in this case.