### PR TITLE
Fix the list done after cluster creation on libvirt and OpenStack

### DIFF
--- a/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
@@ -116,6 +116,7 @@
     ansible_become: "{{ deployment_vars[deployment_type].become }}"
     groups: "tag_environment-{{ cluster_env }}, tag_host-type-{{ type }}, tag_sub-host-type-{{ g_sub_host_type }}, tag_clusterid-{{ cluster_id }}"
     openshift_node_labels: "{{ node_label }}"
+    libvirt_ip_address: "{{ item.1 }}"
   with_together:
     - '{{ instances }}'
     - '{{ ips }}'

--- a/playbooks/openstack/openshift-cluster/launch.yml
+++ b/playbooks/openstack/openshift-cluster/launch.yml
@@ -107,6 +107,9 @@
       groups: 'meta-environment_{{ cluster_env }}, meta-host-type_etcd, meta-sub-host-type_default, meta-clusterid_{{ cluster_id }}'
       openshift_node_labels:
         type: "etcd"
+      openstack:
+        public_v4: '{{ item[2] }}'
+        private_v4: '{{ item[1] }}'
     with_together:
       - '{{ parsed_outputs.etcd_names }}'
       - '{{ parsed_outputs.etcd_ips }}'
@@ -121,6 +124,9 @@
       groups: 'meta-environment_{{ cluster_env }}, meta-host-type_master, meta-sub-host-type_default, meta-clusterid_{{ cluster_id }}'
       openshift_node_labels:
         type: "master"
+      openstack:
+        public_v4: '{{ item[2] }}'
+        private_v4: '{{ item[1] }}'
     with_together:
       - '{{ parsed_outputs.master_names }}'
       - '{{ parsed_outputs.master_ips }}'
@@ -135,6 +141,9 @@
       groups: 'meta-environment_{{ cluster_env }}, meta-host-type_node, meta-sub-host-type_compute, meta-clusterid_{{ cluster_id }}'
       openshift_node_labels:
         type: "compute"
+      openstack:
+        public_v4: '{{ item[2] }}'
+        private_v4: '{{ item[1] }}'
     with_together:
       - '{{ parsed_outputs.node_names }}'
       - '{{ parsed_outputs.node_ips }}'
@@ -149,6 +158,9 @@
       groups: 'meta-environment_{{ cluster_env }}, meta-host-type_node, meta-sub-host-type_infra, meta-clusterid_{{ cluster_id }}'
       openshift_node_labels:
         type: "infra"
+      openstack:
+        public_v4: '{{ item[2] }}'
+        private_v4: '{{ item[1] }}'
     with_together:
       - '{{ parsed_outputs.infra_names }}'
       - '{{ parsed_outputs.infra_ips }}'


### PR DESCRIPTION
The `list.yml` playbooks are using cloud provider specific variables to find
the IPs of the VMs since 82449c6.

Those “cloud provider specific” variables are the ones provided by the dynamic
inventories.

But there was a problem when the `list.yml` playbooks are invoked from the
`launch.yml` ones because, in that case, the inventory is not coming from the
dynamic inventory scripts, but from the `add_host` done inside
`launch_instances.yml`.

Whereas the GCE and AWS `launch_instances.yml` were correctly adding in the
`add_host` the variables used by `list.yml`, libvirt and OpenStack were missing
that.

Fixes #2856