### PR TITLE
Updating docs for Ansible 2.2 requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ not practical to start over at 1.0.
     ***
 
     Requirements:
-    - Ansible >= 2.1.0 (>= 2.2 is preferred for performance reasons)
+    - Ansible >= 2.2.0
     - Jinja >= 2.7
     - pyOpenSSL
     - python-lxml

--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -6,7 +6,7 @@ Ensures docker package is installed, and optionally raises timeout for systemd-u
 Requirements
 ------------
 
-None
+Ansible 2.2
 
 Role Variables
 --------------

--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: docker package install
   company: Red Hat, Inc
   license: ASL 2.0
-  min_ansible_version: 1.2
+  min_ansible_version: 2.2
   platforms:
   - name: EL
     versions:

--- a/roles/os_firewall/README.md
+++ b/roles/os_firewall/README.md
@@ -7,7 +7,7 @@ case (Adding/Removing rules based on protocol and port number).
 Requirements
 ------------
 
-None.
+Ansible 2.2
 
 Role Variables
 --------------

--- a/roles/os_firewall/meta/main.yml
+++ b/roles/os_firewall/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: os_firewall
   company: Red Hat, Inc.
   license: Apache License, Version 2.0
-  min_ansible_version: 1.7
+  min_ansible_version: 2.2
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Ansible 2.2 is required due to the use of the Ansible `systemd` module.

#2860