### PR TITLE
Merge kube_admission_plugin_config with admission_plugin_config

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -619,6 +619,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # masterConfig.volumeConfig.dynamicProvisioningEnabled, configurable as of 1.2/3.2, enabled by default
 #openshift_master_dynamic_provisioning_enabled=False
 
+# Admission plugin config
+#openshift_master_admission_plugin_config={"ProjectRequestLimit":{"configuration":{"apiVersion":"v1","kind":"ProjectRequestLimitConfig","limits":[{"selector":{"admin":"true"}},{"maxProjects":"1"}]}},"PodNodeConstraints":{"configuration":{"apiVersion":"v1","kind":"PodNodeConstraintsConfig"}}}
+
 # Configure usage of openshift_clock role.
 #openshift_clock_enabled=true
 

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -619,6 +619,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # masterConfig.volumeConfig.dynamicProvisioningEnabled, configurable as of 1.2/3.2, enabled by default
 #openshift_master_dynamic_provisioning_enabled=False
 
+# Admission plugin config
+#openshift_master_admission_plugin_config={"ProjectRequestLimit":{"configuration":{"apiVersion":"v1","kind":"ProjectRequestLimitConfig","limits":[{"selector":{"admin":"true"}},{"maxProjects":"1"}]}},"PodNodeConstraints":{"configuration":{"apiVersion":"v1","kind":"PodNodeConstraintsConfig"}}}
+
 # Configure usage of openshift_clock role.
 #openshift_clock_enabled=true
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/master_config_upgrade.yml
@@ -48,3 +48,18 @@
     dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
     yaml_key: 'controllerConfig.servicesServingCert.signer.keyFile'
     yaml_value: service-signer.key
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'admissionConfig.pluginConfig'
+    yaml_value: "{{ openshift.master.admission_plugin_config }}"
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'admissionConfig.pluginOrderOverride'
+    yaml_value:
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'kubernetesMasterConfig.admissionConfig'
+    yaml_value:

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/master_config_upgrade.yml
@@ -1,0 +1,15 @@
+---
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'admissionConfig.pluginConfig'
+    yaml_value: "{{ openshift.master.admission_plugin_config }}"
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'admissionConfig.pluginOrderOverride'
+    yaml_value:
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'kubernetesMasterConfig.admissionConfig'
+    yaml_value:

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -102,14 +102,6 @@ def migrate_node_facts(facts):
                     facts['node'][param] = facts[role].pop(param)
     return facts
 
-def migrate_local_facts(facts):
-    """ Apply migrations of local facts """
-    migrated_facts = copy.deepcopy(facts)
-    migrated_facts = migrate_docker_facts(migrated_facts)
-    migrated_facts = migrate_common_facts(migrated_facts)
-    migrated_facts = migrate_node_facts(migrated_facts)
-    migrated_facts = migrate_hosted_facts(migrated_facts)
-    return migrated_facts
 
 def migrate_hosted_facts(facts):
     """ Apply migrations for master facts """
@@ -127,6 +119,30 @@ def migrate_hosted_facts(facts):
                 facts['hosted']['registry'] = {}
             facts['hosted']['registry']['selector'] = facts['master'].pop('registry_selector')
     return facts
+
+def migrate_admission_plugin_facts(facts):
+    if 'master' in facts:
+        if 'kube_admission_plugin_config' in facts['master']:
+            if 'admission_plugin_config' not in facts['master']:
+                facts['master']['admission_plugin_config'] = dict()
+            # Merge existing kube_admission_plugin_config with admission_plugin_config.
+            facts['master']['admission_plugin_config'] = merge_facts(facts['master']['admission_plugin_config'],
+                                                                     facts['master']['kube_admission_plugin_config'],
+                                                                     additive_facts_to_overwrite=[],
+                                                                     protected_facts_to_overwrite=[])
+            # Remove kube_admission_plugin_config fact
+            facts['master'].pop('kube_admission_plugin_config', None)
+    return facts
+
+def migrate_local_facts(facts):
+    """ Apply migrations of local facts """
+    migrated_facts = copy.deepcopy(facts)
+    migrated_facts = migrate_docker_facts(migrated_facts)
+    migrated_facts = migrate_common_facts(migrated_facts)
+    migrated_facts = migrate_node_facts(migrated_facts)
+    migrated_facts = migrate_hosted_facts(migrated_facts)
+    migrated_facts = migrate_admission_plugin_facts(migrated_facts)
+    return migrated_facts
 
 def first_ip(network):
     """ Return the first IPv4 address in network
@@ -1555,14 +1571,14 @@ def set_proxy_facts(facts):
             builddefaults['git_http_proxy'] = builddefaults['http_proxy']
         if 'git_https_proxy' not in builddefaults and 'https_proxy' in builddefaults:
             builddefaults['git_https_proxy'] = builddefaults['https_proxy']
-        # If we're actually defining a proxy config then create kube_admission_plugin_config
+        # If we're actually defining a proxy config then create admission_plugin_config
         # if it doesn't exist, then merge builddefaults[config] structure
-        # into kube_admission_plugin_config
-        if 'kube_admission_plugin_config' not in facts['master']:
-            facts['master']['kube_admission_plugin_config'] = dict()
+        # into admission_plugin_config
+        if 'admission_plugin_config' not in facts['master']:
+            facts['master']['admission_plugin_config'] = dict()
         if 'config' in builddefaults and ('http_proxy' in builddefaults or \
                 'https_proxy' in builddefaults):
-            facts['master']['kube_admission_plugin_config'].update(builddefaults['config'])
+            facts['master']['admission_plugin_config'].update(builddefaults['config'])
         facts['builddefaults'] = builddefaults
 
     return facts

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -1,7 +1,4 @@
 admissionConfig:
-{% if 'admission_plugin_order' in openshift.master %}
-  pluginOrderOverride:{{ openshift.master.admission_plugin_order | to_padded_yaml(level=2) }}
-{% endif %}
 {% if 'admission_plugin_config' in openshift.master %}
   pluginConfig:{{ openshift.master.admission_plugin_config | to_padded_yaml(level=2) }}
 {% endif %}
@@ -115,13 +112,6 @@ kubernetesMasterConfig:
   apiLevels:
   - v1beta3
   - v1
-{% endif %}
-  admissionConfig:
-{% if 'kube_admission_plugin_order' in openshift.master %}
-    pluginOrderOverride:{{ openshift.master.kube_admission_plugin_order | to_padded_yaml(level=3) }}
-{% endif %}
-{% if 'kube_admission_plugin_config' in openshift.master %}
-    pluginConfig:{{ openshift.master.kube_admission_plugin_config | to_padded_yaml(level=3) }}
 {% endif %}
   apiServerArguments: {{ openshift.master.api_server_args | default(None) | to_padded_yaml( level=2 ) }}
   controllerArguments: {{ openshift.master.controller_args | default(None) | to_padded_yaml( level=2 ) }}

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -66,10 +66,8 @@
       master_image: "{{ osm_image | default(None) }}"
       scheduler_predicates: "{{ openshift_master_scheduler_predicates | default(None) }}"
       scheduler_priorities: "{{ openshift_master_scheduler_priorities | default(None) }}"
-      admission_plugin_order: "{{openshift_master_admission_plugin_order | default(None) }}"
       admission_plugin_config: "{{openshift_master_admission_plugin_config | default(None) }}"
-      kube_admission_plugin_order: "{{openshift_master_kube_admission_plugin_order | default(None) }}"
-      kube_admission_plugin_config: "{{openshift_master_kube_admission_plugin_config | default(None) }}"
+      kube_admission_plugin_config: "{{openshift_master_kube_admission_plugin_config | default(None) }}" # deprecated, merged with admission_plugin_config
       oauth_template: "{{ openshift_master_oauth_template | default(None) }}" # deprecated in origin 1.2 / OSE 3.2
       oauth_templates: "{{ openshift_master_oauth_templates | default(None) }}"
       oauth_always_show_provider_selection: "{{ openshift_master_oauth_always_show_provider_selection | default(None) }}"


### PR DESCRIPTION
Move the values in kube_admission_plugin_config up one level per
the new format from 1.3:

"The kubernetesMasterConfig.admissionConfig.pluginConfig should be moved
and merged into admissionConfig.pluginConfig."