### PR TITLE
fix selinux issues with etcd container

### DIFF
--- a/roles/etcd/templates/etcd.docker.service
+++ b/roles/etcd/templates/etcd.docker.service
@@ -7,7 +7,7 @@ PartOf=docker.service
 [Service]
 EnvironmentFile=/etc/etcd/etcd.conf
 ExecStartPre=-/usr/bin/docker rm -f {{ etcd_service }}
-ExecStart=/usr/bin/docker run --name {{ etcd_service }} --rm -v /var/lib/etcd:/var/lib/etcd:z -v /etc/etcd:/etc/etcd:z --env-file=/etc/etcd/etcd.conf --net=host --entrypoint=/usr/bin/etcd {{ openshift.etcd.etcd_image }}
+ExecStart=/usr/bin/docker run --name {{ etcd_service }} --rm -v /var/lib/etcd:/var/lib/etcd:z -v /etc/etcd:/etc/etcd:ro --env-file=/etc/etcd/etcd.conf --net=host --entrypoint=/usr/bin/etcd {{ openshift.etcd.etcd_image }}
 ExecStop=/usr/bin/docker stop {{ etcd_service }}
 SyslogIdentifier=etcd_container
 Restart=always


### PR DESCRIPTION
Make it so that we don't relabel /etc/etcd/ (via `:z`) on every run.
Doing this causes systemd to fail accessing /etc/etcd/etcd.conf when
trying to run the systemd unit file on the next run. Convert it from
`:z` to `:ro` since we only need read-only access to the files.

Fixes #2811