### PR TITLE
Remove duplicate when key

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -42,6 +42,5 @@
     command: >
       {{ openshift.common.client_binary }} adm manage-node {{ openshift.node.nodename }} --schedulable=true
     delegate_to: "{{ groups.oo_first_master.0 }}"
-    when: openshift.node.schedulable | bool
     when: l_docker_upgrade is defined and l_docker_upgrade | bool and inventory_hostname in groups.oo_nodes_to_upgrade and openshift.node.schedulable | bool
 


### PR DESCRIPTION
Minor fix to remove a duplcate `when` key in the docker_upgrade.yml playbook.

cc: @dgoodwin 