### PR TITLE
allow 'latest' origin_image_tag

### DIFF
--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - set_fact:
     openshift_image_tag: "{{ 'v' + openshift_image_tag }}"
-  when: openshift_image_tag is defined and openshift_image_tag[0] != 'v'
+  when: openshift_image_tag is defined and openshift_image_tag[0] != 'v' and openshift_image_tag != 'latest'
 
 - set_fact:
     openshift_pkg_version: "{{ '-' + openshift_pkg_version }}"


### PR DESCRIPTION
Right now, we expose the `origin_image_tag` variable to users but normalize it, assuming it should begin with the letter 'v'.  However, in my use case, I'm wanting to pull the `latest` tag for the origin images.  This is currently not possible, even though the variable that should allow it is exposed.

This PR creates an exception for `latest` and doesn't prepend a 'v' to the tag in that case.

@dgoodwin @sdodson 