### PR TITLE
Ansible version check update

### DIFF
--- a/playbooks/common/openshift-cluster/verify_ansible_version.yml
+++ b/playbooks/common/openshift-cluster/verify_ansible_version.yml
@@ -1,11 +1,11 @@
 ---
-- name: Verify Ansible version is greater than or equal to 2.1.0.0
+- name: Verify Ansible version is greater than or equal to 2.2.0
   hosts: localhost
   connection: local
   become: no
   gather_facts: no
   tasks:
-  - name: Verify Ansible version is greater than or equal to 2.1.0.0
+  - name: Verify Ansible version is greater than or equal to 2.2.0
     fail:
       msg: "Unsupported ansible version: {{ ansible_version.full }} found"
-    when: not ansible_version.full | version_compare('2.1.0.0', 'ge')
+    when: not ansible_version.full | version_compare('2.2.0', 'ge')


### PR DESCRIPTION
We require ansible >= 2.2.0 now. Updating version checking playbook to reflect this change.