### PR TITLE
Define master config dir in metrics role vars.

### DIFF
--- a/roles/openshift_metrics/vars/main.yaml
+++ b/roles/openshift_metrics/vars/main.yaml
@@ -18,3 +18,4 @@ hawkular_persistence: "{% if openshift.hosted.metrics.storage.kind != None %}tru
 hawkular_type: "{{ 'origin' if deployment_type == 'origin' else 'enterprise' }}"
 
 metrics_upgrade: openshift.hosted.metrics.upgrade | default(False)
+openshift_master_config_dir: "{{ openshift.common.config_base }}/master"


### PR DESCRIPTION
Reported as a problem in github issue #2588. Ensure the common var is
defined, the metrics role has a dependency on openshift_facts so this
should be safe and correct the problem.