### PR TITLE
Fix typo, s/ensure/state/

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/etcd/containerized_tasks.yml
+++ b/playbooks/common/openshift-cluster/upgrades/etcd/containerized_tasks.yml
@@ -30,7 +30,7 @@
 ## will fail on atomic host. We need to revisit how to do etcd backups there as
 ## the container may be newer than etcdctl on the host. Assumes etcd3 obsoletes etcd (7.3.1)
 - name: Upgrade etcd for etcdctl when not atomic
-  action: "{{ ansible_pkg_mgr }} name=etcd ensure=latest"
+  action: "{{ ansible_pkg_mgr }} name=etcd state=latest"
   when: not openshift.common.is_atomic | bool
 
 - name: Verify cluster is healthy


### PR DESCRIPTION
Fixes Bug 1400027

Already fixed on master by refactoring to use package module instead.