### PR TITLE
openshift_node_dnsmasq - Remove strict-order option from dnsmasq

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -590,7 +590,8 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # be used with 1.0 and 3.0.
 #openshift_use_dnsmasq=False
 # Define an additional dnsmasq.conf file to deploy to /etc/dnsmasq.d/openshift-ansible.conf
-# This is useful for POC environments where DNS may not actually be available yet.
+# This is useful for POC environments where DNS may not actually be available yet or to set
+# options like 'strict-order' to alter dnsmasq configuration.
 #openshift_node_dnsmasq_additional_config_file=/home/bob/ose-dnsmasq.conf
 
 # Global Proxy Configuration

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -588,7 +588,8 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # be used with 1.0 and 3.0.
 #openshift_use_dnsmasq=False
 # Define an additional dnsmasq.conf file to deploy to /etc/dnsmasq.d/openshift-ansible.conf
-# This is useful for POC environments where DNS may not actually be available yet.
+# This is useful for POC environments where DNS may not actually be available yet or to set
+# options like 'strict-order' to alter dnsmasq configuration.
 #openshift_node_dnsmasq_additional_config_file=/home/bob/ose-dnsmasq.conf
 
 # Global Proxy Configuration

--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -48,7 +48,6 @@ if [[ $2 =~ ^(up|dhcp4-change)$ ]]; then
        -n "${IP4_NAMESERVERS}" ]]; then
     if [ ! -f /etc/dnsmasq.d/origin-dns.conf ]; then
       cat << EOF > /etc/dnsmasq.d/origin-dns.conf
-strict-order
 no-resolv
 domain-needed
 server=/cluster.local/172.30.0.1

--- a/roles/openshift_node_dnsmasq/templates/origin-dns.conf.j2
+++ b/roles/openshift_node_dnsmasq/templates/origin-dns.conf.j2
@@ -1,4 +1,3 @@
-strict-order
 no-resolv
 domain-needed
 server=/{{ openshift.common.dns_domain }}/{{ openshift.common.kube_svc_ip }}


### PR DESCRIPTION
strict-order forces dnsmasq to iterate through nameservers in order. If one of
the nameservers is down this will slow things down while dnsmasq waits for a
timeout. Also, this option prevents dnsmasq from querying other nameservers if
the first one returns a negative result. While I think it's odd to have a
nameserver that returns negative results for a query that another returns
positive results for this does seem to fix the issue in testing.

Fixes Bug 1399577