### PR TITLE
openshift-master/restart : use openshift.common.hostname instead of inventory_hostname

### DIFF
--- a/playbooks/common/openshift-master/restart_hosts.yml
+++ b/playbooks/common/openshift-master/restart_hosts.yml
@@ -11,7 +11,7 @@
   become: no
   local_action:
     module: wait_for
-      host="{{ inventory_hostname }}"
+      host="{{ openshift.common.hostname }}"
       state=started
       delay=10
       port="{{ openshift.master.api_port }}"

--- a/playbooks/common/openshift-master/restart_services.yml
+++ b/playbooks/common/openshift-master/restart_services.yml
@@ -12,7 +12,7 @@
   become: no
   local_action:
     module: wait_for
-      host="{{ inventory_hostname }}"
+      host="{{ openshift.common.hostname }}"
       state=started
       delay=10
       port="{{ openshift.master.api_port }}"


### PR DESCRIPTION
When using a dynamic inventory inventory_hostname isn't guaranteed to be usable.  We should use openshift.common.hostname which already copes with this