### PR TITLE
node_dnsmasq - restart dnsmasq if it's not currently running

### DIFF
--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -80,6 +80,10 @@ EOF
       NEEDS_RESTART=1
     fi
 
+    if ! `systemctl -q is-active dnsmasq.service`; then
+      NEEDS_RESTART=1
+    fi
+
     ######################################################################
     if [ "${NEEDS_RESTART}" -eq "1" ]; then
       systemctl restart dnsmasq


### PR DESCRIPTION
Make sure that if our dispatcher script runs before dnsmasq has started that we start it otherwise we'll fail to update /etc/resolv.conf because we check for dnsmasq to have started.