### PR TITLE
Fix etcd upgrades to etcd 3.x

### DIFF
--- a/README_CONTAINERIZED_INSTALLATION.md
+++ b/README_CONTAINERIZED_INSTALLATION.md
@@ -48,17 +48,17 @@ before attempting to pull any of the following images.
         openshift/origin
         openshift/node (node + openshift-sdn + openvswitch rpm for client tools)
         openshift/openvswitch (centos7 + openvswitch rpm, runs ovsdb ovsctl processes)
-        registry.access.redhat.com/rhel7/etcd3
+        registry.access.redhat.com/rhel7/etcd
     OpenShift Enterprise
         openshift3/ose
         openshift3/node
         openshift3/openvswitch
-        registry.access.redhat.com/rhel7/etcd3
+        registry.access.redhat.com/rhel7/etcd
     Atomic Enterprise Platform
         aep3/aep
         aep3/node
         aep3/openvswitch
-        registry.access.redhat.com/rhel7/etcd3
+        registry.access.redhat.com/rhel7/etcd
 
   * note openshift3/* and aep3/* images come from registry.access.redhat.com and
 rely on the --additional-repository flag being set appropriately.

--- a/playbooks/common/openshift-cluster/upgrades/etcd/backup.yml
+++ b/playbooks/common/openshift-cluster/upgrades/etcd/backup.yml
@@ -41,9 +41,11 @@
         {{ avail_disk.stdout }} Kb available.
     when: (embedded_etcd | bool) and (etcd_disk_usage.stdout|int > avail_disk.stdout|int)
 
-  - name: Install etcd (for etcdctl)
-    package: name=etcd state=present
-    when: not openshift.common.is_atomic | bool
+  # for non containerized etcd is already installed, don't touch it, but for containerized
+  # but not atomic always get the latest
+  - name: Install latest text for containerized but not atomic
+    package: name=etcd state=latest
+    when: not openshift.common.is_atomic | bool and openshift.common.is_containerized
 
   - name: Generate etcd backup
     command: >

--- a/playbooks/common/openshift-cluster/upgrades/etcd/main.yml
+++ b/playbooks/common/openshift-cluster/upgrades/etcd/main.yml
@@ -38,12 +38,12 @@
   tasks:
   - name: Record RPM based etcd version
     command: rpm -qa --qf '%{version}' etcd\*
-    register: etcd_installed_version
+    register: etcd_rpm_version
     failed_when: false
     when: not openshift.common.is_containerized | bool
   - name: Record containerized etcd version
     command: docker exec etcd_container rpm -qa --qf '%{version}' etcd\*
-    register: etcd_installed_version
+    register: etcd_container_version
     failed_when: false
     when: openshift.common.is_containerized | bool
 
@@ -56,7 +56,7 @@
     upgrade_version: '2.1'
   tasks:
   - include: rhel_tasks.yml
-    when: etcd_installed_version.stdout | default('99') | version_compare('2.1','<') and ansible_distribution == 'RedHat' and not openshift.common.is_containerized | bool
+    when: etcd_rpm_version.stdout | default('99') | version_compare('2.1','<') and ansible_distribution == 'RedHat' and not openshift.common.is_containerized | bool
 
 - name: Upgrade RPM hosts to 2.2
   hosts: etcd_hosts_to_upgrade
@@ -65,7 +65,7 @@
     upgrade_version: '2.2'
   tasks:
   - include: rhel_tasks.yml
-    when: etcd_installed_version.stdout | default('99') | version_compare('2.2','<') and ansible_distribution == 'RedHat' and not openshift.common.is_containerized | bool
+    when: etcd_rpm_version.stdout | default('99') | version_compare('2.2','<') and ansible_distribution == 'RedHat' and not openshift.common.is_containerized | bool
 
 - name: Upgrade containerized hosts to 2.2.5
   hosts: etcd_hosts_to_upgrade
@@ -74,7 +74,7 @@
     upgrade_version: 2.2.5
   tasks:
   - include: containerized_tasks.yml
-    when: etcd_installed_version.stdout | default('99') | version_compare('2.2','<') and openshift.common.is_containerized | bool
+    when: etcd_container_version.stdout | default('99') | version_compare('2.2','<') and openshift.common.is_containerized | bool
 
 - name: Upgrade RPM hosts to 2.3
   hosts: etcd_hosts_to_upgrade
@@ -83,7 +83,7 @@
     upgrade_version: '2.3'
   tasks:
   - include: rhel_tasks.yml
-    when: etcd_installed_version.stdout | default('99') | version_compare('2.3','<') and ansible_distribution == 'RedHat' and not openshift.common.is_containerized | bool
+    when: etcd_rpm_version.stdout | default('99') | version_compare('2.3','<') and ansible_distribution == 'RedHat' and not openshift.common.is_containerized | bool
 
 - name: Upgrade containerized hosts to 2.3.7
   hosts: etcd_hosts_to_upgrade
@@ -92,7 +92,7 @@
     upgrade_version: 2.3.7
   tasks:
   - include: containerized_tasks.yml
-    when: etcd_installed_version.stdout | default('99') | version_compare('2.3','<') and openshift.common.is_containerized | bool
+    when: etcd_container_version.stdout | default('99') | version_compare('2.3','<') and openshift.common.is_containerized | bool
 
 - name: Upgrade RPM hosts to 3.0
   hosts: etcd_hosts_to_upgrade
@@ -101,16 +101,16 @@
     upgrade_version: '3.0'
   tasks:
   - include: rhel_tasks.yml
-    when: etcd_installed_version.stdout | default('99') | version_compare('3.0','<') and ansible_distribution == 'RedHat' and not openshift.common.is_containerized | bool
+    when: etcd_rpm_version.stdout | default('99') | version_compare('3.0','<') and ansible_distribution == 'RedHat' and not openshift.common.is_containerized | bool
 
 - name: Upgrade containerized hosts to etcd3 image
   hosts: etcd_hosts_to_upgrade
   serial: 1
   vars:
-    upgrade_version: 3.0.3
+    upgrade_version: 3.0.14
   tasks:
   - include: containerized_tasks.yml
-    when: etcd_installed_version.stdout | default('99') | version_compare('3.0','<') and openshift.common.is_containerized | bool
+    when: etcd_container_version.stdout | default('99') | version_compare('3.0','<') and openshift.common.is_containerized | bool
 
 - name: Upgrade fedora to latest
   hosts: etcd_hosts_to_upgrade

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1673,7 +1673,7 @@ def set_container_facts_if_unset(facts):
         cli_image = master_image
         node_image = 'openshift3/node'
         ovs_image = 'openshift3/openvswitch'
-        etcd_image = 'registry.access.redhat.com/rhel7/etcd3'
+        etcd_image = 'registry.access.redhat.com/rhel7/etcd'
         pod_image = 'openshift3/ose-pod'
         router_image = 'openshift3/ose-haproxy-router'
         registry_image = 'openshift3/ose-docker-registry'
@@ -1683,7 +1683,7 @@ def set_container_facts_if_unset(facts):
         cli_image = master_image
         node_image = 'aep3_beta/node'
         ovs_image = 'aep3_beta/openvswitch'
-        etcd_image = 'registry.access.redhat.com/rhel7/etcd3'
+        etcd_image = 'registry.access.redhat.com/rhel7/etcd'
         pod_image = 'aep3_beta/aep-pod'
         router_image = 'aep3_beta/aep-haproxy-router'
         registry_image = 'aep3_beta/aep-docker-registry'
@@ -1693,7 +1693,7 @@ def set_container_facts_if_unset(facts):
         cli_image = master_image
         node_image = 'openshift/node'
         ovs_image = 'openshift/openvswitch'
-        etcd_image = 'registry.access.redhat.com/rhel7/etcd3'
+        etcd_image = 'registry.access.redhat.com/rhel7/etcd'
         pod_image = 'openshift/origin-pod'
         router_image = 'openshift/origin-haproxy-router'
         registry_image = 'openshift/origin-docker-registry'


### PR DESCRIPTION
 - Fix variable trampling between containerized and rpm based upgrades
 - Switch back to using etcd image, a future update will push etcd 3.x into registry.access.redhat.com/rhel7/etcd