### PR TITLE
etcd_upgrade: Simplify package installation

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/etcd/rhel_tasks.yml
+++ b/playbooks/common/openshift-cluster/upgrades/etcd/rhel_tasks.yml
@@ -2,13 +2,10 @@
 - name: Verify cluster is healthy pre-upgrade
   command: "etcdctl --cert-file /etc/etcd/peer.crt --key-file /etc/etcd/peer.key --ca-file /etc/etcd/ca.crt -C https://{{ openshift.common.hostname }}:2379 cluster-health"
 
-- name: Update etcd package but exclude etcd3
-  command: "{{ ansible_pkg_mgr }} install -y etcd-{{ upgrade_version }}\\* --exclude etcd3"
-  when: upgrade_version | version_compare('3.0','<')
-
-- name: Update etcd package not excluding etcd3
-  command: "{{ ansible_pkg_mgr }} install -y etcd3-{{ upgrade_version }}\\*"
-  when: not upgrade_version | version_compare('3.0','<')
+- name: Update etcd RPM
+  package:
+    name: etcd-{{ upgrade_version }}*
+    state: latest
 
 - name: Restart etcd
   service:


### PR DESCRIPTION
Further simplification, requires rhel 7.3.2 or fedora packaging of etcd-3.x rather than RHEL 7.3.0-7.3.1 packaging as etcd3-3.x