### PR TITLE
Pre-pull master/node/ovs images during upgrade.

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -29,13 +29,6 @@
     state: present
   when: not openshift.common.is_containerized | bool
 
-- name: Pull master image
-  command: >
-    docker pull {{ openshift.master.master_image }}:{{ openshift_image_tag }}
-  register: pull_result
-  changed_when: "'Downloaded newer image' in pull_result.stdout"
-  when: openshift.common.is_containerized | bool
-
 - name: Create openshift.common.data_dir
   file:
     path: "{{ openshift.common.data_dir }}"

--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -13,6 +13,14 @@
     ha_svc_template_path: "docker-cluster"
   when: openshift.common.is_containerized | bool
 
+# This is the image used for both HA and non-HA clusters:
+- name: Pre-pull master image
+  command: >
+    docker pull {{ openshift.master.master_image }}:{{ openshift_image_tag }}
+  register: pull_result
+  changed_when: "'Downloaded newer image' in pull_result.stdout"
+  when: openshift.common.is_containerized | bool
+
 # workaround for missing systemd unit files
 - name: Create the systemd unit files
   template:

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -58,20 +58,6 @@
     state: present
   when: openshift.common.use_openshift_sdn and not openshift.common.is_containerized | bool
 
-- name: Pull node image
-  command: >
-    docker pull {{ openshift.node.node_image }}:{{ openshift_image_tag }}
-  register: pull_result
-  changed_when: "'Downloaded newer image' in pull_result.stdout"
-  when: openshift.common.is_containerized | bool
-
-- name: Pull OpenVSwitch image
-  command: >
-    docker pull {{ openshift.node.ovs_image }}:{{ openshift_image_tag }}
-  register: pull_result
-  changed_when: "'Downloaded newer image' in pull_result.stdout"
-  when: openshift.common.is_containerized | bool and openshift.common.use_openshift_sdn | bool
-
 - name: Install the systemd units
   include: systemd_units.yml
 

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -1,6 +1,20 @@
 # This file is included both in the openshift_master role and in the upgrade
 # playbooks.
 
+- name: Pre-pull node image
+  command: >
+    docker pull {{ openshift.node.node_image }}:{{ openshift_image_tag }}
+  register: pull_result
+  changed_when: "'Downloaded newer image' in pull_result.stdout"
+  when: openshift.common.is_containerized | bool
+
+- name: Pre-pull openvswitch image
+  command: >
+    docker pull {{ openshift.node.ovs_image }}:{{ openshift_image_tag }}
+  register: pull_result
+  changed_when: "'Downloaded newer image' in pull_result.stdout"
+  when: openshift.common.is_containerized | bool and openshift.common.use_openshift_sdn | bool
+
 - name: Install Node dependencies docker service file
   template:
     dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node-dep.service"


### PR DESCRIPTION
We did this for install but not upgrade, leading to situations where the
service restarts after upgrade could take much longer than expected as
docker pulls down the new image. Now the images are present when we
restart services and should allow them to come back online much more
quickly, equivalent to rpm service restarts.