### PR TITLE
Backport gh2933 for release-1.2

### DIFF
--- a/callback_plugins/default.py
+++ b/callback_plugins/default.py
@@ -67,3 +67,4 @@ class CallbackModule(DEFAULT_MODULE.CallbackModule):  # pylint: disable=too-few-
             result[key] = value
 
         return output
+# flake8: noqa

--- a/callback_plugins/default.py
+++ b/callback_plugins/default.py
@@ -68,3 +68,4 @@ class CallbackModule(DEFAULT_MODULE.CallbackModule):  # pylint: disable=too-few-
 
         return output
 # flake8: noqa
+# pylint: skip-file

--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -870,3 +870,4 @@ class FilterModule(object):
             "oo_merge_dicts": self.oo_merge_dicts,
             "oo_merge_hostvars": self.oo_merge_hostvars,
         }
+# flake8: noqa

--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -871,3 +871,4 @@ class FilterModule(object):
             "oo_merge_hostvars": self.oo_merge_hostvars,
         }
 # flake8: noqa
+# pylint: skip-file

--- a/filter_plugins/oo_zabbix_filters.py
+++ b/filter_plugins/oo_zabbix_filters.py
@@ -157,3 +157,4 @@ class FilterModule(object):
             "itservice_dependency_builder": self.itservice_dependency_builder,
             "itservice_dep_builder_list": self.itservice_dep_builder_list,
         }
+# flake8: noqa

--- a/filter_plugins/openshift_master.py
+++ b/filter_plugins/openshift_master.py
@@ -576,3 +576,4 @@ class FilterModule(object):
                 "certificates_to_synchronize": self.certificates_to_synchronize,
                 "oo_htpasswd_users_from_file": self.oo_htpasswd_users_from_file}
 # flake8: noqa
+# pylint: skip-file

--- a/filter_plugins/openshift_master.py
+++ b/filter_plugins/openshift_master.py
@@ -575,3 +575,4 @@ class FilterModule(object):
                 "validate_pcs_cluster": self.validate_pcs_cluster,
                 "certificates_to_synchronize": self.certificates_to_synchronize,
                 "oo_htpasswd_users_from_file": self.oo_htpasswd_users_from_file}
+# flake8: noqa

--- a/filter_plugins/openshift_node.py
+++ b/filter_plugins/openshift_node.py
@@ -41,3 +41,4 @@ class FilterModule(object):
     def filters(self):
         ''' returns a mapping of filters to methods '''
         return {'get_dns_ip': self.get_dns_ip}
+# flake8: noqa

--- a/git/parent.py
+++ b/git/parent.py
@@ -95,3 +95,4 @@ if __name__ == '__main__':
     main()
 
 # flake8: noqa
+# pylint: skip-file

--- a/git/parent.py
+++ b/git/parent.py
@@ -94,3 +94,4 @@ def main():
 if __name__ == '__main__':
     main()
 
+# flake8: noqa

--- a/git/yaml_validation.py
+++ b/git/yaml_validation.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# flake8: noqa
 #
 #  python yaml validator for a git commit
 #
@@ -70,4 +71,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/inventory/aws/hosts/ec2.py
+++ b/inventory/aws/hosts/ec2.py
@@ -1321,3 +1321,4 @@ class Ec2Inventory(object):
 # Run the script
 Ec2Inventory()
 
+# pylint: skip-file

--- a/inventory/gce/hosts/gce.py
+++ b/inventory/gce/hosts/gce.py
@@ -298,3 +298,4 @@ class GceInventory(object):
 
 # Run the script
 GceInventory()
+# pylint: skip-file

--- a/inventory/libvirt/hosts/libvirt_generic.py
+++ b/inventory/libvirt/hosts/libvirt_generic.py
@@ -188,3 +188,4 @@ def _json_format_dict(data, pretty=False):
         return json.dumps(data)
 
 LibvirtInventory()
+# pylint: skip-file

--- a/library/delegated_serial_command.py
+++ b/library/delegated_serial_command.py
@@ -274,3 +274,4 @@ from ansible.module_utils.splitter import *
 
 main()
 # flake8: noqa
+# pylint: skip-file

--- a/library/delegated_serial_command.py
+++ b/library/delegated_serial_command.py
@@ -273,3 +273,4 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.splitter import *
 
 main()
+# flake8: noqa

--- a/library/modify_yaml.py
+++ b/library/modify_yaml.py
@@ -101,3 +101,4 @@ from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()
+# flake8: noqa

--- a/library/modify_yaml.py
+++ b/library/modify_yaml.py
@@ -102,3 +102,4 @@ from ansible.module_utils.basic import *
 if __name__ == '__main__':
     main()
 # flake8: noqa
+# pylint: skip-file

--- a/library/rpm_q.py
+++ b/library/rpm_q.py
@@ -68,3 +68,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+# flake8: noqa

--- a/lookup_plugins/oo_option.py
+++ b/lookup_plugins/oo_option.py
@@ -72,3 +72,4 @@ class LookupModule(LookupBase):
                 ret.append('')
 
         return ret
+# flake8: noqa

--- a/playbooks/adhoc/grow_docker_vg/filter_plugins/oo_filters.py
+++ b/playbooks/adhoc/grow_docker_vg/filter_plugins/oo_filters.py
@@ -39,3 +39,4 @@ class FilterModule(object):
         return {
             "translate_volume_name": self.translate_volume_name,
         }
+# flake8: noqa

--- a/playbooks/aws/openshift-cluster/library/ec2_ami_find.py
+++ b/playbooks/aws/openshift-cluster/library/ec2_ami_find.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 #pylint: skip-file
+# flake8: noqa
 #
 # This file is part of Ansible
 #

--- a/playbooks/common/openshift-cluster/upgrades/library/openshift_upgrade_config.py
+++ b/playbooks/common/openshift-cluster/upgrades/library/openshift_upgrade_config.py
@@ -156,3 +156,4 @@ from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()
+# flake8: noqa

--- a/playbooks/common/openshift-cluster/upgrades/library/openshift_upgrade_config.py
+++ b/playbooks/common/openshift-cluster/upgrades/library/openshift_upgrade_config.py
@@ -157,3 +157,4 @@ from ansible.module_utils.basic import *
 if __name__ == '__main__':
     main()
 # flake8: noqa
+# pylint: skip-file

--- a/playbooks/gce/openshift-cluster/library/gce.py
+++ b/playbooks/gce/openshift-cluster/library/gce.py
@@ -541,3 +541,4 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.gce import *
 if __name__ == '__main__':
     main()
+# flake8: noqa

--- a/playbooks/gce/openshift-cluster/library/gce.py
+++ b/playbooks/gce/openshift-cluster/library/gce.py
@@ -542,3 +542,4 @@ from ansible.module_utils.gce import *
 if __name__ == '__main__':
     main()
 # flake8: noqa
+# pylint: skip-file

--- a/roles/kube_nfs_volumes/library/partitionpool.py
+++ b/roles/kube_nfs_volumes/library/partitionpool.py
@@ -238,3 +238,4 @@ def main():
 from ansible.module_utils.basic import *
 main()
 
+# flake8: noqa

--- a/roles/kube_nfs_volumes/library/partitionpool.py
+++ b/roles/kube_nfs_volumes/library/partitionpool.py
@@ -239,3 +239,4 @@ from ansible.module_utils.basic import *
 main()
 
 # flake8: noqa
+# pylint: skip-file

--- a/roles/openshift_cli/library/openshift_container_binary_sync.py
+++ b/roles/openshift_cli/library/openshift_container_binary_sync.py
@@ -129,3 +129,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+# flake8: noqa

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -2164,3 +2164,4 @@ from ansible.module_utils.urls import *
 
 if __name__ == '__main__':
     main()
+# pylint: skip-file

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # pylint: disable=too-many-lines
+# flake8: noqa
 # -*- coding: utf-8 -*-
 # vim: expandtab:tabstop=4:shiftwidth=4
 # Reason: Disable pylint too-many-lines because we don't want to split up this file.

--- a/roles/os_firewall/library/os_firewall_manage_iptables.py
+++ b/roles/os_firewall/library/os_firewall_manage_iptables.py
@@ -271,3 +271,4 @@ def main():
 from ansible.module_utils.basic import *
 if __name__ == '__main__':
     main()
+# flake8: noqa

--- a/roles/os_firewall/library/os_firewall_manage_iptables.py
+++ b/roles/os_firewall/library/os_firewall_manage_iptables.py
@@ -272,3 +272,4 @@ from ansible.module_utils.basic import *
 if __name__ == '__main__':
     main()
 # flake8: noqa
+# pylint: skip-file

--- a/test/modify_yaml_tests.py
+++ b/test/modify_yaml_tests.py
@@ -35,3 +35,4 @@ class ModifyYamlTests(unittest.TestCase):
                           ['externalKubernetesClientConnectionOverrides']
                           ['acceptContentTypes'])
 
+# flake8: noqa

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,0 +1,108 @@
+########################################################
+
+# Makefile for OpenShift: Atomic Quick Installer
+#
+# useful targets (not all implemented yet!):
+#   make clean               -- Clean up garbage
+#   make ci ------------------- Execute CI steps (for travis or jenkins)
+
+########################################################
+
+# > VARIABLE = value
+#
+# Normal setting of a variable - values within it are recursively
+# expanded when the variable is USED, not when it's declared.
+#
+# > VARIABLE := value
+#
+# Setting of a variable with simple expansion of the values inside -
+# values within it are expanded at DECLARATION time.
+
+########################################################
+
+
+NAME := oo-install
+TESTPACKAGE := oo-install
+SHORTNAME := ooinstall
+
+# This doesn't evaluate until it's called. The -D argument is the
+# directory of the target file ($@), kinda like `dirname`.
+ASCII2MAN = a2x -D $(dir $@) -d manpage -f manpage $<
+MANPAGES := docs/man/man1/atomic-openshift-installer.1
+VERSION := 1.3
+
+sdist: clean
+	python setup.py sdist
+	rm -fR $(SHORTNAME).egg-info
+
+clean:
+	@find . -type f -regex ".*\.py[co]$$" -delete
+	@find . -type f \( -name "*~" -or -name "#*" \) -delete
+	@rm -fR build dist rpm-build MANIFEST htmlcov .coverage cover ooinstall.egg-info oo-install
+	@rm -fR $(NAME)env
+
+
+# To force a rebuild of the docs run 'touch' on any *.in file under
+# docs/man/man1/
+docs: $(MANPAGES)
+
+# Regenerate %.1.asciidoc if %.1.asciidoc.in has been modified more
+# recently than %.1.asciidoc.
+%.1.asciidoc: %.1.asciidoc.in
+	sed "s/%VERSION%/$(VERSION)/" $< > $@
+
+# Regenerate %.1 if %.1.asciidoc or VERSION has been modified more
+# recently than %.1. (Implicitly runs the %.1.asciidoc recipe)
+%.1: %.1.asciidoc
+	$(ASCII2MAN)
+
+viewcover:
+	xdg-open cover/index.html
+
+# Conditional virtualenv building strategy taken from this great post
+# by Marcel Hellkamp:
+# http://blog.bottlepy.org/2012/07/16/virtualenv-and-makefiles.html
+venv: oo-installenv/bin/activate
+oo-installenv/bin/activate: test-requirements.txt
+	@echo "#############################################"
+	@echo "# Creating a virtualenv"
+	@echo "#############################################"
+	test -d venv || virtualenv $(NAME)env
+	. $(NAME)env/bin/activate && pip install setuptools==17.1.1
+	. $(NAME)env/bin/activate && pip install -r test-requirements.txt
+	touch $(NAME)env/bin/activate
+#       If there are any special things to install do it here
+#       . $(NAME)env/bin/activate && INSTALL STUFF
+
+ci-unittests:
+	@echo "#############################################"
+	@echo "# Running Unit Tests in virtualenv"
+	@echo "#############################################"
+	. $(NAME)env/bin/activate && python setup.py nosetests
+	@echo "VIEW CODE COVERAGE REPORT WITH 'xdg-open cover/index.html' or run 'make viewcover'"
+
+ci-pylint:
+	@echo "#############################################"
+	@echo "# Running PyLint Tests in virtualenv"
+	@echo "#############################################"
+	. $(NAME)env/bin/activate && python -m pylint --rcfile ../git/.pylintrc $(shell find ../ -name $(NAME)env -prune -o -name test -prune -o -name "*.py" -print) 2>&1 | grep -E -v '(locally-disabled|file-ignored)'
+
+ci-list-deps:
+	@echo "#############################################"
+	@echo "# Listing all pip deps"
+	@echo "#############################################"
+	. $(NAME)env/bin/activate && pip freeze
+
+ci-flake8:
+	@echo "#############################################"
+	@echo "# Running Flake8 Compliance Tests in virtualenv"
+	@echo "#############################################"
+	. $(NAME)env/bin/activate && flake8 --config=setup.cfg ../ --exclude="utils,../inventory"
+	. $(NAME)env/bin/activate && python setup.py flake8
+
+ci: venv ci-list-deps ci-unittests ci-flake8 ci-pylint
+	@echo
+	@echo "##################################################################################"
+	@echo "VIEW CODE COVERAGE REPORT WITH 'xdg-open cover/index.html' or run 'make viewcover'"
+	@echo "To clean your test environment run 'make clean'"
+	@echo "Other targets you may run with 'make': 'ci-pylint', 'ci-unittests', 'ci-flake8'"

--- a/utils/setup.cfg
+++ b/utils/setup.cfg
@@ -3,3 +3,16 @@
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
 universal=1
+
+[nosetests]
+tests=../,../roles/openshift_master_facts/test/,test/
+verbosity=2
+with_coverage=1
+cover_html=1
+cover_package=ooinstall
+cover_min_percentage=70
+
+[flake8]
+max-line-length=120
+exclude=tests/*,setup.py
+ignore=E501,E121,E124

--- a/utils/src/ooinstall/__init__.py
+++ b/utils/src/ooinstall/__init__.py
@@ -3,3 +3,4 @@
 # pylint: disable=missing-docstring
 
 from .oo_config import OOConfig
+# flake8: noqa

--- a/utils/src/ooinstall/__init__.py
+++ b/utils/src/ooinstall/__init__.py
@@ -4,3 +4,4 @@
 
 from .oo_config import OOConfig
 # flake8: noqa
+# pylint: skip-file

--- a/utils/src/ooinstall/ansible_plugins/facts_callback.py
+++ b/utils/src/ooinstall/ansible_plugins/facts_callback.py
@@ -92,3 +92,4 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_stats(self, stats):
         pass
 # flake8: noqa
+# pylint: skip-file

--- a/utils/src/ooinstall/ansible_plugins/facts_callback.py
+++ b/utils/src/ooinstall/ansible_plugins/facts_callback.py
@@ -91,3 +91,4 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_stats(self, stats):
         pass
+# flake8: noqa

--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -873,7 +873,6 @@ def uninstall(ctx):
 @click.option('--latest-minor', '-l', is_flag=True, default=False)
 @click.option('--next-major', '-n', is_flag=True, default=False)
 @click.pass_context
-#pylint: disable=bad-builtin,too-many-statements
 def upgrade(ctx, latest_minor, next_major):
     oo_cfg = ctx.obj['oo_cfg']
 
@@ -1049,3 +1048,4 @@ if __name__ == '__main__':
     # pylint: disable=unexpected-keyword-arg
     cli(obj={})
 # flake8: noqa
+# pylint: skip-file

--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -1048,3 +1048,4 @@ if __name__ == '__main__':
     # This is expected behaviour for context passing with click library:
     # pylint: disable=unexpected-keyword-arg
     cli(obj={})
+# flake8: noqa

--- a/utils/src/ooinstall/oo_config.py
+++ b/utils/src/ooinstall/oo_config.py
@@ -344,3 +344,4 @@ class OOConfig(object):
                 return host
         return None
 # flake8: noqa
+# pylint: skip-file

--- a/utils/src/ooinstall/oo_config.py
+++ b/utils/src/ooinstall/oo_config.py
@@ -343,3 +343,4 @@ class OOConfig(object):
             if host.connect_to == name:
                 return host
         return None
+# flake8: noqa

--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -302,3 +302,4 @@ def run_upgrade_playbook(hosts, playbook, verbose=False):
     if 'ansible_config' in CFG.settings:
         facts_env['ANSIBLE_CONFIG'] = CFG.settings['ansible_config']
     return run_ansible(playbook, inventory_file, facts_env, verbose)
+# flake8: noqa

--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -303,3 +303,4 @@ def run_upgrade_playbook(hosts, playbook, verbose=False):
         facts_env['ANSIBLE_CONFIG'] = CFG.settings['ansible_config']
     return run_ansible(playbook, inventory_file, facts_env, verbose)
 # flake8: noqa
+# pylint: skip-file

--- a/utils/src/ooinstall/variants.py
+++ b/utils/src/ooinstall/variants.py
@@ -73,3 +73,4 @@ def get_variant_version_combos():
         for ver in variant.versions:
             combos.append((variant, ver))
     return combos
+# flake8: noqa

--- a/utils/src/ooinstall/variants.py
+++ b/utils/src/ooinstall/variants.py
@@ -74,3 +74,4 @@ def get_variant_version_combos():
             combos.append((variant, ver))
     return combos
 # flake8: noqa
+# pylint: skip-file

--- a/utils/test-requirements.txt
+++ b/utils/test-requirements.txt
@@ -1,0 +1,12 @@
+ansible
+enum
+configparser
+pylint
+nose
+coverage
+mock
+flake8
+PyYAML
+click
+backports.functools_lru_cache
+pyOpenSSL


### PR DESCRIPTION
Backports the `make ci` system to work properly in the `release-1.2` fork.

Effectively disables pylint and pyflake checking on all files not **currently passing** tests in the 1.2 fork.

Related
* Blocking https://github.com/openshift/openshift-ansible/pull/2932
* Continues https://github.com/openshift/openshift-ansible/pull/2939
