### PR TITLE
Fix coverage not appending new data

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -78,7 +78,7 @@ ci-unittests:
 	@echo "#############################################"
 	@echo "# Running Unit Tests in virtualenv"
 	@echo "#############################################"
-	. $(NAME)env/bin/activate && python setup.py nosetests
+	. $(NAME)env/bin/activate && python setup.py nosetests --cover-erase
 	@echo "VIEW CODE COVERAGE REPORT WITH 'xdg-open cover/index.html' or run 'make viewcover'"
 
 ci-pylint:


### PR DESCRIPTION
* Adds '--cover-erase' flag to the 'ci-unittests' target

Fixes bug introduced in d7b4265f329591817bac381e2772ae14ac337cea:
"Can't add arcs to existing line data" error message