### PR TITLE
Fixes to 'make ci'

### DIFF
--- a/git/.pylintrc
+++ b/git/.pylintrc
@@ -71,7 +71,7 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 # w0511 - fixme - disabled because TODOs are acceptable
-disable=E1608,W1627,E1601,E1603,E1602,E1605,E1604,E1607,E1606,W1621,W1620,W1623,W1622,W1625,W1624,W1609,W1608,W1607,W1606,W1605,W1604,W1603,W1602,W1601,W1639,W1640,I0021,W1638,I0020,W1618,W1619,W1630,W1626,W1637,W1634,W1635,W1610,W1611,W1612,W1613,W1614,W1615,W1616,W1617,W1632,W1633,W0704,W1628,W1629,W1636,W0511,R0801
+disable=E1608,W1627,E1601,E1603,E1602,E1605,E1604,E1607,E1606,W1621,W1620,W1623,W1622,W1625,W1624,W1609,W1608,W1607,W1606,W1605,W1604,W1603,W1602,W1601,W1639,W1640,I0021,W1638,I0020,W1618,W1619,W1630,W1626,W1637,W1634,W1635,W1610,W1611,W1612,W1613,W1614,W1615,W1616,W1617,W1632,W1633,W0704,W1628,W1629,W1636,W0511,R0801,locally-disabled,file-ignored
 
 
 [REPORTS]
@@ -79,7 +79,7 @@ disable=E1608,W1627,E1601,E1603,E1602,E1605,E1604,E1607,E1606,W1621,W1620,W1623,
 # Set the output format. Available formats are text, parseable, colorized, msvs
 # (visual studio) and html. You can also give a reporter class, eg
 # mypackage.mymodule.MyReporterClass.
-output-format=text
+output-format=parseable
 
 # Put messages in a separate file for each module / package specified on the
 # command line instead of printing them on stdout. Reports (if any) will be
@@ -113,9 +113,6 @@ logging-modules=logging
 
 
 [BASIC]
-
-# Required attributes for module, separated by a comma
-required-attributes=
 
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter,input
@@ -347,10 +344,6 @@ max-public-methods=20
 
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -22,6 +22,7 @@
 
 
 NAME := oo-install
+VENV := $(NAME)env
 TESTPACKAGE := oo-install
 SHORTNAME := ooinstall
 
@@ -39,7 +40,7 @@ clean:
 	@find . -type f -regex ".*\.py[co]$$" -delete
 	@find . -type f \( -name "*~" -or -name "#*" \) -delete
 	@rm -fR build dist rpm-build MANIFEST htmlcov .coverage cover ooinstall.egg-info oo-install
-	@rm -fR $(NAME)env
+	@rm -fR $(VENV)
 
 
 # To force a rebuild of the docs run 'touch' on any *.in file under
@@ -62,45 +63,45 @@ viewcover:
 # Conditional virtualenv building strategy taken from this great post
 # by Marcel Hellkamp:
 # http://blog.bottlepy.org/2012/07/16/virtualenv-and-makefiles.html
-venv: oo-installenv/bin/activate
-oo-installenv/bin/activate: test-requirements.txt
+$(VENV): $(VENV)/bin/activate
+$(VENV)/bin/activate: test-requirements.txt
 	@echo "#############################################"
 	@echo "# Creating a virtualenv"
 	@echo "#############################################"
-	test -d venv || virtualenv $(NAME)env
-	. $(NAME)env/bin/activate && pip install setuptools==17.1.1
-	. $(NAME)env/bin/activate && pip install -r test-requirements.txt
-	touch $(NAME)env/bin/activate
+	test -d $(VENV) || virtualenv $(VENV)
+	. $(VENV)/bin/activate && pip install setuptools==17.1.1
+	. $(VENV)/bin/activate && pip install -r test-requirements.txt
+	touch $(VENV)/bin/activate
 #       If there are any special things to install do it here
-#       . $(NAME)env/bin/activate && INSTALL STUFF
+#       . $(VENV)/bin/activate && INSTALL STUFF
 
 ci-unittests:
 	@echo "#############################################"
 	@echo "# Running Unit Tests in virtualenv"
 	@echo "#############################################"
-	. $(NAME)env/bin/activate && python setup.py nosetests --cover-erase
+	. $(VENV)/bin/activate && python setup.py nosetests --cover-erase
 	@echo "VIEW CODE COVERAGE REPORT WITH 'xdg-open cover/index.html' or run 'make viewcover'"
 
 ci-pylint:
 	@echo "#############################################"
 	@echo "# Running PyLint Tests in virtualenv"
 	@echo "#############################################"
-	. $(NAME)env/bin/activate && python -m pylint --rcfile ../git/.pylintrc $(shell find ../ -name $(NAME)env -prune -o -name test -prune -o -name "*.py" -print) 2>&1 | grep -E -v '(locally-disabled|file-ignored)'
+	. $(VENV)/bin/activate && python -m pylint --rcfile ../git/.pylintrc $(shell find ../ -name $(VENV) -prune -o -name ooinstall.egg-info -prune -o -name test -prune -o -name "*.py" -print)
 
 ci-list-deps:
 	@echo "#############################################"
 	@echo "# Listing all pip deps"
 	@echo "#############################################"
-	. $(NAME)env/bin/activate && pip freeze
+	. $(VENV)/bin/activate && pip freeze
 
 ci-flake8:
 	@echo "#############################################"
 	@echo "# Running Flake8 Compliance Tests in virtualenv"
 	@echo "#############################################"
-	. $(NAME)env/bin/activate && flake8 --config=setup.cfg ../ --exclude="utils,../inventory"
-	. $(NAME)env/bin/activate && python setup.py flake8
+	. $(VENV)/bin/activate && flake8 --config=setup.cfg ../ --exclude="utils,../inventory"
+	. $(VENV)/bin/activate && python setup.py flake8
 
-ci: venv ci-list-deps ci-unittests ci-flake8 ci-pylint
+ci: $(VENV) ci-list-deps ci-unittests ci-flake8 ci-pylint
 	@echo
 	@echo "##################################################################################"
 	@echo "VIEW CODE COVERAGE REPORT WITH 'xdg-open cover/index.html' or run 'make viewcover'"

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -75,33 +75,33 @@ $(VENV)/bin/activate: test-requirements.txt
 #       If there are any special things to install do it here
 #       . $(VENV)/bin/activate && INSTALL STUFF
 
-ci-unittests:
+ci-unittests: $(VENV)
 	@echo "#############################################"
 	@echo "# Running Unit Tests in virtualenv"
 	@echo "#############################################"
-	. $(VENV)/bin/activate && python setup.py nosetests --cover-erase
+	. $(VENV)/bin/activate && python setup.py nosetests
 	@echo "VIEW CODE COVERAGE REPORT WITH 'xdg-open cover/index.html' or run 'make viewcover'"
 
-ci-pylint:
+ci-pylint: $(VENV)
 	@echo "#############################################"
 	@echo "# Running PyLint Tests in virtualenv"
 	@echo "#############################################"
 	. $(VENV)/bin/activate && python -m pylint --rcfile ../git/.pylintrc $(shell find ../ -name $(VENV) -prune -o -name ooinstall.egg-info -prune -o -name test -prune -o -name "*.py" -print)
 
-ci-list-deps:
+ci-list-deps: $(VENV)
 	@echo "#############################################"
 	@echo "# Listing all pip deps"
 	@echo "#############################################"
 	. $(VENV)/bin/activate && pip freeze
 
-ci-flake8:
+ci-flake8: $(VENV)
 	@echo "#############################################"
 	@echo "# Running Flake8 Compliance Tests in virtualenv"
 	@echo "#############################################"
 	. $(VENV)/bin/activate && flake8 --config=setup.cfg ../ --exclude="utils,../inventory"
 	. $(VENV)/bin/activate && python setup.py flake8
 
-ci: $(VENV) ci-list-deps ci-unittests ci-flake8 ci-pylint
+ci: ci-list-deps ci-unittests ci-flake8 ci-pylint
 	@echo
 	@echo "##################################################################################"
 	@echo "VIEW CODE COVERAGE REPORT WITH 'xdg-open cover/index.html' or run 'make viewcover'"

--- a/utils/setup.cfg
+++ b/utils/setup.cfg
@@ -11,6 +11,7 @@ with-coverage=1
 cover-html=1
 cover-inclusive=1
 cover-min-percentage=70
+cover-erase=1
 detailed-errors=1
 cover-branches=1
 


### PR DESCRIPTION
* Fixed: A grep filter was capturing the actual pylint check rc's

* Changed: pylint used to print out messages for locally-disabled and
  file-ignored items

* Changed: pylint output format is now 'parseable'

* Cleaned up: Pylint was emitting deprecation messages for
  'required-attributes' and 'ignore-iface-methods'. They have been
  removed from the pylintrc file