### PR TITLE
Limit node certificate SANs to node hostnames/ips.

### DIFF
--- a/roles/openshift_node_certificates/tasks/main.yml
+++ b/roles/openshift_node_certificates/tasks/main.yml
@@ -64,13 +64,13 @@
 - name: Generate the node server certificate
   command: >
     {{ hostvars[openshift_ca_host].openshift.common.client_binary }} adm ca create-server-cert
-      --cert={{ openshift_node_generated_config_dir }}/server.crt
-      --key={{ openshift_generated_configs_dir }}/node-{{ openshift.common.hostname }}/server.key
-      --overwrite=true
-      --hostnames={{ openshift.common.all_hostnames |join(",") }}
-      --signer-cert={{ openshift_ca_cert }}
-      --signer-key={{ openshift_ca_key }}
-      --signer-serial={{ openshift_ca_serial }}
+    --cert={{ openshift_node_generated_config_dir }}/server.crt
+    --key={{ openshift_generated_configs_dir }}/node-{{ openshift.common.hostname }}/server.key
+    --overwrite=true
+    --hostnames={{ openshift.common.hostname }},{{ openshift.common.public_hostname }},{{ openshift.common.ip }},{{ openshift.common.public_ip }}
+    --signer-cert={{ openshift_ca_cert }}
+    --signer-key={{ openshift_ca_key }}
+    --signer-serial={{ openshift_ca_serial }}
   args:
     creates: "{{ openshift_node_generated_config_dir }}/server.crt"
   when: node_certs_missing | bool


### PR DESCRIPTION
Node serving certificate hostnames are currently pulled from `openshift.common.all_hostnames` which [can include many names if the node is also a master](https://github.com/openshift/openshift-ansible/blob/ce39c9084bc20df242bbbef3a2a5b1c8060cbe9d/roles/openshift_facts/library/openshift_facts.py#L721-L732). This change limits those hostnames to node hostnames and IP addresses.