### PR TITLE
upgrades - Fix logic error about when to backup etcd

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -29,7 +29,7 @@
 
 - name: Backup etcd
   include: ./etcd/backup.yml
-  when: openshift_upgrade_skip_etcd_backup | default(false) | bool
+  when: not openshift_upgrade_skip_etcd_backup | default(false) | bool
 
 - name: Upgrade master packages
   hosts: oo_masters_to_config


### PR DESCRIPTION
We want backups on by default. When we add etcd upgrade to the default upgrade playbooks we'll want to reconsider this.