### PR TITLE
Set metrics url even if metrics_deploy is false

### DIFF
--- a/roles/openshift_hosted_metrics/tasks/install.yml
+++ b/roles/openshift_hosted_metrics/tasks/install.yml
@@ -128,5 +128,5 @@
   modify_yaml:
     dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
     yaml_key: assetConfig.metricsPublicURL
-    yaml_value: "{{ openshift_hosted_metrics_public_url }}"
+    yaml_value: "{{ openshift_hosted_metrics_deploy_url }}"
   notify: restart master

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -15,8 +15,8 @@ assetConfig:
 {% if 'logging_public_url' in openshift.master %}
   loggingPublicURL: {{ openshift.master.logging_public_url }}
 {% endif %}
-{% if openshift_hosted_metrics_deploy | default(false) | bool %}
-  metricsPublicURL: {{ openshift_hosted_metrics_public_url }}
+{% if openshift_hosted_metrics_deploy_url is defined %}
+  metricsPublicURL: {{ openshift_hosted_metrics_deploy_url }}
 {% endif %}
 {% if 'extension_scripts' in openshift.master %}
   extensionScripts: {{ openshift.master.extension_scripts | to_padded_yaml(1, 2) }}

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -21,11 +21,10 @@
     g_metrics_hostname: "{{ openshift_hosted_metrics_public_url
                         | default('hawkular-metrics.' ~ (openshift_master_default_subdomain))
                         | oo_hostname_from_url }}"
-  when: openshift_hosted_metrics_deploy | default(false) | bool
 
 - set_fact:
-    openshift_hosted_metrics_public_url: "https://{{ g_metrics_hostname }}/hawkular/metrics"
-  when: openshift_hosted_metrics_deploy | default(false) | bool
+    openshift_hosted_metrics_deploy_url: "https://{{ g_metrics_hostname }}/hawkular/metrics"
+  when: (openshift_hosted_metrics_deploy | default(false) | bool) or (openshift_hosted_metrics_public_url is defined)
 
 - name: Set master facts
   openshift_facts:


### PR DESCRIPTION
Follow up of  #2938 

Allow to set the `metricsPublicUrl` in the master configuration without the need of deploying the metrics with Ansible.

@dgoodwin I've done it in the way you proposed, using an extra variable that is only set when `openshift_hosted_metrics_deploy`is `true` or when `openshift_hosted_metrics_public_url` is explicitly set in the inventory file. Could you verify?

Thanks!