### PR TITLE
Update os_firewall_manage_iptables.py

### DIFF
--- a/roles/os_firewall/library/os_firewall_manage_iptables.py
+++ b/roles/os_firewall/library/os_firewall_manage_iptables.py
@@ -218,7 +218,7 @@ class IpTablesManager(object):  # pylint: disable=too-many-instance-attributes
         return ["/usr/sbin/%s" % cmd]
 
     def gen_save_cmd(self):  # pylint: disable=no-self-use
-        return ['/usr/libexec/iptables/iptables.init', 'save']
+        return ['cd /etc/sysconfig/iptables.d/; /sbin/iptables-save', '/etc/sysconfig/iptables.d/origin']
 
 
 def main():


### PR DESCRIPTION
changing from /usr/libexec/iptables/iptables.init to /sbin/iptables-save allows saving to somewhere other than /etc/sysconfig/iptables which could be under outside source control and using iptables.d/ is a better location for rules that need to persist over reboots in such situations.