### PR TITLE
Add master config hook for 3.4 upgrade and fix facts ordering

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade.yml
@@ -89,6 +89,8 @@
   - include: ../../../../common/openshift-cluster/upgrades/cleanup_unused_images.yml
 
 - include: ../../../../common/openshift-cluster/upgrades/upgrade_control_plane.yml
+  vars:
+    master_config_hook: "v3_4/master_config_upgrade.yml"
 
 - include: ../../../../common/openshift-cluster/upgrades/upgrade_nodes.yml
 

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -51,6 +51,14 @@
 
 - include: create_service_signer_cert.yml
 
+# Set openshift_master_facts separately. In order to reconcile
+# admission_config's, we currently must run openshift_master_facts and
+# then run openshift_facts.
+- name: Set OpenShift master facts
+  hosts: oo_masters_to_config
+  roles:
+  - openshift_master_facts
+
 - name: Upgrade master config and systemd units
   hosts: oo_masters_to_config
   handlers:
@@ -58,8 +66,9 @@
     static: yes
   roles:
   - openshift_facts
-  - openshift_master_facts
-  tasks:
+  post_tasks:
+  - include_vars: ../../../../roles/openshift_master_facts/vars/main.yml
+
   - include: upgrade_scheduler.yml
 
   - include: "{{ master_config_hook }}"


### PR DESCRIPTION
When the `openshift_master_facts` role runs, it reads in `openshift_master_admission_plugin_config` and `openshift_master_kube_admission_plugin_config`. A subsequent run of `openshift_facts` merges these two dictionaries by [migrating local facts](https://github.com/openshift/openshift-ansible/blob/8fc936578f9cf2462148043ef3ff0470764d6cfd/roles/openshift_facts/library/openshift_facts.py#L149-L162).

So, when the `openshift_master_facts` role was added to the control plane upgrade right before we update the master config, these two facts were getting reset and weren't merged (because `openshift_facts` wasn't ran afterwards). This is extremely brittle but re-ordering roles around upgrade resolves the issue. Also, a `master_config_hook` wasn't getting set for the 3.4 upgrade. This has been added.