### PR TITLE
Use tox and molecule for Ansible testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,11 +8,12 @@ omit =
     # TODO(rhcarvalho): this is used to ignore test files from coverage report.
     # We can make this less generic when we stick with a single test pattern in
     # the repo.
-    test_*.py
-    *_tests.py
+    */conftest.py
+    */test_*.py
+    */*_tests.py
 
 [report]
-fail_under = 28
+fail_under = 25
 
 [html]
 directory = cover

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ cover/
 .molecule/
 .cache
 pytestdebug.log
+htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ multi_ec2.yaml
 *.egg-info
 .eggs
 cover/
+.molecule/
+.cache
+pytestdebug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,26 @@
 ---
 sudo: false
 
-cache:
-  - pip
-
 language: python
+
 python:
   - "2.7"
   - "3.5"
 
+cache:
+  - pip
+
+before_cache:
+  - rm ~/.cache/pip/log/debug.log
+
+env:
+  - TEST_DIR=root TEST_TYPE=lint
+  - TEST_DIR=root TEST_TYPE=unit
+  - TEST_DIR=utils
+
 install:
-  - pip install -r requirements.txt
   - pip install tox-travis
 
 script:
-  # TODO(rhcarvalho): check syntax of other important entrypoint playbooks
-  - ansible-playbook --syntax-check playbooks/byo/config.yml
-  - tox
-  - cd utils && tox
+  - if [[ "${TEST_DIR}" == "root" ]]; then tox; fi
+  - if [[ "${TEST_DIR}" == "utils" ]]; then cd utils && tox; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 ---
-sudo: false
+sudo: required
+
+services:
+  - docker
 
 language: python
 
@@ -16,7 +19,13 @@ before_cache:
 env:
   - TEST_DIR=root TEST_TYPE=lint
   - TEST_DIR=root TEST_TYPE=unit
+  - TEST_DIR=root TEST_TYPE=functional
   - TEST_DIR=utils
+
+matrix:
+  exclude:
+    - python: "3.5"
+      env: TEST_DIR=root TEST_TYPE=functional
 
 install:
   - pip install tox-travis

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,21 +118,21 @@ Run all of the tests in parallel with detox:
 detox
 ```
 
-Running a particular test environment (python 2.7 flake8 tests in this case):
+Running a particular test environment (python 2.7 lint tests in this case):
 ```
-tox -e py27-ansible22-flake8
+tox -e py27-lint
 ```
 
-Running a particular test environment in a clean virtualenv (python 3.5 pylint
+Running a particular test environment in a clean virtualenv (python 3.5 unit
 tests in this case):
 ```
-tox -r -e py35-ansible22-pylint
+tox -r -e py35-unit
 ```
 
 If you want to enter the virtualenv created by tox to do additional
-testing/debugging (py27-flake8 env in this case):
+testing/debugging (py27-lint env in this case):
 ```
-source .tox/py27-ansible22-flake8/bin/activate
+source .tox/py27-lint/bin/activate
 ```
 
 ## Submitting contributions

--- a/molecule_common/base/Dockerfile
+++ b/molecule_common/base/Dockerfile
@@ -1,0 +1,6 @@
+FROM centos/systemd:latest
+
+RUN yum makecache fast && yum update -y && \
+    yum install -y sudo yum-plugin-ovl && \
+    sed -i 's/^plugins=0$/plugins=1/g' /etc/yum.conf && \
+    yum clean all

--- a/molecule_common/create.yml
+++ b/molecule_common/create.yml
@@ -1,0 +1,24 @@
+---
+# Ansible 2.2 required
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  vars:
+    l_config_subdir: "{{ molecule_docker_config_subdir | default('base') }}"
+    molecule_docker_image: "openshift-ansible-tests-{{ l_config_subdir }}:latest"
+    l_start_command: "{{ 'start master' if l_config_subdir.startswith('origin-') else 'sleep infinity'}}"
+  tasks:
+    - name: Build an Ansible compatible image
+      docker_image:
+        path: "{{ l_config_subdir }}"
+        name: "{{ molecule_docker_image }}"
+
+    - name: Create molecule instance(s)
+      docker_container:
+        name: "{{ item }}"
+        hostname: "{{ item }}"
+        image: "{{ molecule_docker_image }}"
+        state: started
+        recreate: no
+        command: "{{ l_start_command }}"
+      with_items: "{{ groups.test_group }}"

--- a/molecule_common/destroy.yml
+++ b/molecule_common/destroy.yml
@@ -1,0 +1,13 @@
+---
+# Ansible 2.2 required
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  vars:
+    molecule_scenario_basename: "{{ molecule_scenario_directory | basename }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      docker_container:
+        name: "{{ item }}"
+        state: absent
+      with_items: "{{ groups.test_group }}"

--- a/molecule_common/origin-latest/Dockerfile
+++ b/molecule_common/origin-latest/Dockerfile
@@ -1,0 +1,6 @@
+FROM openshift/origin:latest
+
+RUN yum makecache fast && yum update -y && \
+    yum install -y sudo yum-plugin-ovl && \
+    sed -i 's/^plugins=0$/plugins=1/g' /etc/yum.conf &&\
+    yum clean all

--- a/roles/lib_openshift/molecule/origin-latest/molecule.yml
+++ b/roles/lib_openshift/molecule/origin-latest/molecule.yml
@@ -1,0 +1,35 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+  options:
+    privileged: yes
+lint:
+  name: ansible-lint
+platforms:
+- name: oa-role-lib-openshift-test
+  groups:
+  - test_group
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: profile_tasks
+  group_vars:
+    test_group:
+      deployment_type: origin
+      openshift_deployment_type: "{{ deployment_type }}"
+  host_vars:
+    localhost:
+      molecule_docker_config_subdir: 'origin-latest'
+scenario:
+  name: origin-latest
+  setup: ../../../../molecule_common/create.yml
+  teardown: ../../../../molecule_common/destroy.yml
+verifier:
+  name: testinfra
+  env:
+    ANSIBLE_LIBRARY: ../../library
+  options:
+    n: 4

--- a/roles/lib_openshift/molecule/origin-latest/playbook.yml
+++ b/roles/lib_openshift/molecule/origin-latest/playbook.yml
@@ -1,0 +1,14 @@
+---
+- hosts: test_group
+  pre_tasks:
+  - name: Pre-install python2-ruamel-yaml
+    package:
+      name: http://cbs.centos.org/kojifiles/packages/python-ruamel-yaml/0.12.14/9.el7/x86_64/python2-ruamel-yaml-0.12.14-9.el7.x86_64.rpm
+      state: present
+  - name: symlink /var/lib/origin.local.config
+    file:
+      path: /etc/origin
+      src: /var/lib/origin/openshift.local.config
+      state: link
+  roles:
+  - lib_openshift

--- a/roles/lib_openshift/molecule/origin-latest/tests/test_oc_secret.py
+++ b/roles/lib_openshift/molecule/origin-latest/tests/test_oc_secret.py
@@ -1,0 +1,330 @@
+import base64
+import pytest
+import testinfra.utils.ansible_runner
+import uuid
+import yaml
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory.yml').get_hosts('test_group')
+
+
+@pytest.fixture()
+def namespace(Command, tmpdir):
+    namespace = 'test-' + str(uuid.uuid4())
+
+    Command.run_test("mkdir -p {}".format(tmpdir))
+    Command.run_test("cp /etc/origin/master/admin.kubeconfig {}/admin.kubeconfig".format(tmpdir))
+    Command.run_test("oc new-project {} --config {}/admin.kubeconfig".format(namespace, tmpdir))
+
+    yield namespace
+
+    Command.run_test("oc delete project {} --config {}/admin.kubeconfig".format(namespace, tmpdir))
+    Command.run_test("rm -rf {}".format(tmpdir))
+
+
+@pytest.fixture()
+def test_config_file():
+    return {
+        'name': 'config.yml',
+        'contents': yaml.dump({'value': True})
+    }
+
+
+@pytest.fixture()
+def test_passwd_file():
+    return {
+        'name': 'passwords',
+        'contents': "test1\ntest2\ntest3\ntest4"
+    }
+
+
+@pytest.fixture()
+def secret(namespace, tmpdir, Ansible, test_config_file, test_passwd_file):
+    secret_name = 'test-{}'.format(uuid.uuid4())
+
+    config_file = tmpdir.join(test_config_file['name'])
+    with config_file.open(mode='w') as f:
+        f.write(test_config_file['contents'])
+
+    passwd_file = tmpdir.join(test_passwd_file['name'])
+    with passwd_file.open(mode='w') as f:
+        f.write(test_passwd_file['contents'])
+
+    Ansible('file', {'dest': str(tmpdir), 'state': 'directory'}, check=False)
+    Ansible('copy', {'src': str(config_file), 'dest': str(config_file)}, check=False)
+    Ansible('copy', {'src': str(passwd_file), 'dest': str(passwd_file)}, check=False)
+
+    secret_create_params = {
+        'name': secret_name,
+        'namespace': namespace,
+        'state': 'present',
+        'files': [
+            {
+                'name': 'config.yml',
+                'path': str(config_file)
+            },
+            {
+                'name': 'passwords',
+                'path': str(passwd_file)
+            }
+        ]
+    }
+    secret_create = Ansible('oc_secret', secret_create_params, check=False)
+    assert secret_create['changed'] is True
+    assert secret_create['results']['returncode'] == 0
+
+    yield secret_create_params
+
+    secret_delete_params = {
+        'name': secret_name,
+        'namespace': namespace,
+        'state': 'absent'
+    }
+    secret_delete = Ansible('oc_secret', secret_delete_params, check=False)
+    assert secret_delete['changed'] is True
+    assert secret_delete['results']['returncode'] == 0
+
+    Ansible('file', {'dest': str(tmpdir), 'state': 'absent'}, check=False)
+
+
+def test_decode(secret, Ansible, test_config_file, test_passwd_file):
+    secret_list_params = {
+        'name': secret['name'],
+        'namespace': secret['namespace'],
+        'decode': 'yes',
+        'state': 'list'
+    }
+    secret_list = Ansible('oc_secret', secret_list_params)
+    assert secret_list['changed'] is False
+    assert secret_list['results']['exists'] is True
+    assert 'decoded' in secret_list['results']
+    assert test_config_file['name'] in secret_list['results']['decoded']
+    assert test_passwd_file['name'] in secret_list['results']['decoded']
+    assert len(secret_list['results']['decoded']) == 2
+    assert secret_list['results']['decoded'][test_config_file['name']] == test_config_file['contents']
+    assert secret_list['results']['decoded'][test_passwd_file['name']] == test_passwd_file['contents']
+
+
+def test_delete_after(tmpdir, namespace, Ansible, test_config_file, test_passwd_file, File):
+    secret_name = 'test-{}'.format(uuid.uuid4())
+
+    config_file = tmpdir.join(test_config_file['name'])
+    with config_file.open(mode='w') as f:
+        f.write(test_config_file['contents'])
+
+    passwd_file = tmpdir.join(test_passwd_file['name'])
+    with passwd_file.open(mode='w') as f:
+        f.write(test_passwd_file['contents'])
+
+    Ansible('file', {'dest': str(tmpdir), 'state': 'directory'}, check=False)
+    Ansible('copy', {'src': str(config_file), 'dest': str(config_file)}, check=False)
+    Ansible('copy', {'src': str(passwd_file), 'dest': str(passwd_file)}, check=False)
+
+    secret_create_params = {
+        'name': secret_name,
+        'namespace': namespace,
+        'state': 'present',
+        'delete_after': 'yes',
+        'files': [
+            {
+                'name': 'config.yml',
+                'path': str(config_file)
+            },
+            {
+                'name': 'passwords',
+                'path': str(passwd_file)
+            }
+        ]
+    }
+    secret_create = Ansible('oc_secret', secret_create_params, check=False)
+    assert secret_create['changed'] is True
+    assert secret_create['results']['returncode'] == 0
+    assert not File(str(config_file)).exists
+    assert not File(str(passwd_file)).exists
+
+
+@pytest.mark.skip(msg="Need to find a way to test force arg for oc_secret")
+def test_force():
+    assert False
+
+
+@pytest.mark.skip(msg="Need to find a way to test kubeconfig arg for oc_secret")
+def test_kubeconfig(tmpdir, Ansible, Command, namespace):
+    assert False
+
+
+def test_modify_secret(secret, Ansible, test_config_file, test_passwd_file, tmpdir):
+    secret_list_params = {
+        'name': secret['name'],
+        'namespace': secret['namespace'],
+        'state': 'list'
+    }
+    secret_list = Ansible('oc_secret', secret_list_params)
+    assert secret_list['changed'] is False
+    assert secret_list['results']['returncode'] == 0
+    assert secret_list['results']['exists'] is True
+    assert secret_list['results']['results'][0]['type'] == 'Opaque'
+    assert secret_list['results']['results'][0]['metadata']['name'] == secret_list_params['name']
+    assert secret_list['results']['results'][0]['metadata']['namespace'] == secret_list_params['namespace']
+    assert test_config_file['name'] in secret_list['results']['results'][0]['data']
+    assert test_passwd_file['name'] in secret_list['results']['results'][0]['data']
+    assert len(secret_list['results']['results'][0]['data']) == 2
+    assert secret_list['results']['results'][0]['data'][test_config_file['name']] == base64.encodestring(test_config_file['contents']).strip()
+    assert secret_list['results']['results'][0]['data'][test_passwd_file['name']] == base64.encodestring(test_passwd_file['contents']).strip()
+
+    config_file_update_params = {
+        'name': secret['name'],
+        'namespace': secret['namespace'],
+        'state': 'present',
+        'contents': [
+            {
+                'path': test_config_file['name'],
+                'data': yaml.dump({'value': False})
+            }
+        ]
+    }
+    config_file_update = Ansible('oc_secret', config_file_update_params, check=False)
+    assert config_file_update['changed'] is True
+    assert config_file_update['results']['returncode'] == 0
+
+    secret_list_params = {
+        'name': secret['name'],
+        'namespace': secret['namespace'],
+        'state': 'list'
+    }
+    secret_list = Ansible('oc_secret', secret_list_params)
+    print(yaml.dump(secret_list))
+    assert secret_list['changed'] is False
+    assert secret_list['results']['returncode'] == 0
+    assert secret_list['results']['exists'] is True
+    assert secret_list['results']['results'][0]['type'] == 'Opaque'
+    assert secret_list['results']['results'][0]['metadata']['name'] == config_file_update_params['name']
+    assert secret_list['results']['results'][0]['metadata']['namespace'] == config_file_update_params['namespace']
+    assert test_config_file['name'] in secret_list['results']['results'][0]['data']
+    assert test_passwd_file['name'] not in secret_list['results']['results'][0]['data']
+    assert len(secret_list['results']['results'][0]['data']) == 1
+    assert secret_list['results']['results'][0]['data'][test_config_file['name']] == base64.encodestring(config_file_update_params['contents'][0]['data']).strip()
+
+
+def test_secret_update_check(secret, Ansible, test_config_file, test_passwd_file):
+    config_file_update_params = {
+        'name': secret['name'],
+        'namespace': secret['namespace'],
+        'state': 'present',
+        'contents': [
+            {
+                'path': test_config_file['name'],
+                'data': yaml.dump({'value': False})
+            }
+        ]
+    }
+    config_file_update = Ansible('oc_secret', config_file_update_params)
+    assert config_file_update['changed'] is True
+
+    secret_list_params = {
+        'name': secret['name'],
+        'namespace': secret['namespace'],
+        'state': 'list'
+    }
+    secret_list = Ansible('oc_secret', secret_list_params)
+    assert secret_list['changed'] is False
+    assert secret_list['results']['returncode'] == 0
+    assert secret_list['results']['exists'] is True
+    assert secret_list['results']['results'][0]['type'] == 'Opaque'
+    assert secret_list['results']['results'][0]['metadata']['name'] == secret_list_params['name']
+    assert secret_list['results']['results'][0]['metadata']['namespace'] == secret_list_params['namespace']
+    assert test_config_file['name'] in secret_list['results']['results'][0]['data']
+    assert test_passwd_file['name'] in secret_list['results']['results'][0]['data']
+    assert len(secret_list['results']['results'][0]['data']) == 2
+    assert secret_list['results']['results'][0]['data'][test_config_file['name']] == base64.encodestring(test_config_file['contents']).strip()
+    assert secret_list['results']['results'][0]['data'][test_passwd_file['name']] == base64.encodestring(test_passwd_file['contents']).strip()
+
+
+def test_secret_create_check(namespace, Ansible):
+    secret_name = 'test-{}'.format(uuid.uuid4())
+    secret_create_params = {
+        'name': secret_name,
+        'namespace': namespace,
+        'state': 'present',
+        'files': [
+            {
+                'name': 'my_file',
+                'path': 'my/file/path'
+            }
+        ]
+    }
+    secret_create = Ansible('oc_secret', secret_create_params)
+    assert secret_create['changed'] is True
+
+    secret_list_params = {
+        'name': secret_name,
+        'namespace': namespace,
+        'state': 'list'
+    }
+    secret_list = Ansible('oc_secret', secret_list_params)
+    assert secret_list['changed'] is False
+    assert secret_list['results']['exists'] is False
+
+
+def test_secret_delete_check(secret, Ansible):
+    secret_delete_params = {
+        'name': secret['name'],
+        'namespace': secret['namespace'],
+        'state': 'absent'
+    }
+    secret_delete = Ansible('oc_secret', secret_delete_params)
+    assert secret_delete['changed'] is True
+    assert secret_delete['msg'] == 'Would have performed a delete.'
+
+    secret_list_params = {
+        'name': secret['name'],
+        'namespace': secret['namespace'],
+        'state': 'list'
+    }
+    secret_list = Ansible('oc_secret', secret_list_params)
+    assert secret_list['changed'] is False
+    assert secret_list['results']['returncode'] == 0
+    assert secret_list['results']['exists'] is True
+
+
+def test_secret_already_exists(secret, Ansible, test_config_file, test_passwd_file):
+    secret_list_params = {
+        'name': secret['name'],
+        'namespace': secret['namespace'],
+        'state': 'list'
+    }
+    secret_list = Ansible('oc_secret', secret_list_params)
+    assert secret_list['changed'] is False
+    assert secret_list['results']['returncode'] == 0
+    assert secret_list['results']['exists'] is True
+    assert secret_list['results']['results'][0]['type'] == 'Opaque'
+    assert secret_list['results']['results'][0]['metadata']['name'] == secret_list_params['name']
+    assert secret_list['results']['results'][0]['metadata']['namespace'] == secret_list_params['namespace']
+    assert test_config_file['name'] in secret_list['results']['results'][0]['data']
+    assert test_passwd_file['name'] in secret_list['results']['results'][0]['data']
+    assert len(secret_list['results']['results'][0]['data']) == 2
+    assert secret_list['results']['results'][0]['data'][test_config_file['name']] == base64.encodestring(test_config_file['contents']).strip()
+    assert secret_list['results']['results'][0]['data'][test_passwd_file['name']] == base64.encodestring(test_passwd_file['contents']).strip()
+
+    secret_create = Ansible('oc_secret', secret, check=False)
+    assert secret_create['changed'] is False
+
+
+def test_secret_exists_not(namespace, Ansible):
+    exists_not_name = "exists-not-{}".format(str(uuid.uuid4()))
+    secret_params = {
+        'name': exists_not_name,
+        'namespace': namespace,
+        'state': 'absent'
+    }
+    result = Ansible('oc_secret', secret_params)
+    assert result['changed'] is False
+
+    secret_list_params = {
+        'name': exists_not_name,
+        'namespace': namespace,
+        'state': 'list'
+    }
+    secret_list = Ansible('oc_secret', secret_list_params)
+    assert secret_list['changed'] is False
+    assert secret_list['results']['exists'] is False

--- a/roles/openshift_docker_facts/molecule/default/molecule.yml
+++ b/roles/openshift_docker_facts/molecule/default/molecule.yml
@@ -1,0 +1,25 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+  options:
+    privileged: yes
+lint:
+  name: ansible-lint
+platforms:
+- name: oa-role-openshift-docker-facts-test
+  groups:
+  - test_group
+provisioner:
+  name: ansible
+  group_vars:
+    test_group:
+      deployment_type: origin
+      openshift_deployment_type: origin
+scenario:
+  name: default
+  setup: ../../../../molecule_common/create.yml
+  teardown: ../../../../molecule_common/destroy.yml
+verifier:
+  name: testinfra

--- a/roles/openshift_docker_facts/molecule/default/playbook.yml
+++ b/roles/openshift_docker_facts/molecule/default/playbook.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  roles:
+  - role: openshift_docker_facts
+  post_tasks:
+  - name: verify expected results
+    assert:
+      that:
+      - openshift.docker | default(none) is not none

--- a/roles/openshift_facts/molecule/default/molecule.yml
+++ b/roles/openshift_facts/molecule/default/molecule.yml
@@ -1,0 +1,25 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+  options:
+    privileged: yes
+lint:
+  name: ansible-lint
+platforms:
+- name: oa-role-openshift-facts-test
+  groups:
+  - test_group
+provisioner:
+  name: ansible
+  group_vars:
+    test_group:
+      deployment_type: origin
+      openshift_deployment_type: "{{ deployment_type }}"
+scenario:
+  name: default
+  setup: ../../../../molecule_common/create.yml
+  teardown: ../../../../molecule_common/destroy.yml
+verifier:
+  name: testinfra

--- a/roles/openshift_facts/molecule/default/playbook.yml
+++ b/roles/openshift_facts/molecule/default/playbook.yml
@@ -1,0 +1,10 @@
+---
+- hosts: test_group
+  roles:
+  - role: openshift_facts
+  post_tasks:
+  - name: verify expected results
+    assert:
+      that:
+      - openshift | default(none) is not none
+      - openshift.common | default(none) is not none

--- a/roles/openshift_master_facts/molecule/default/molecule.yml
+++ b/roles/openshift_master_facts/molecule/default/molecule.yml
@@ -1,0 +1,26 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+  options:
+    privileged: yes
+lint:
+  name: ansible-lint
+platforms:
+- name: oa-role-openshift-master-facts-test
+  groups:
+  - test_group
+provisioner:
+  name: ansible
+  group_vars:
+    test_group:
+      deployment_type: origin
+      openshift_deployment_type: origin
+      openshift_release: '1.5'
+scenario:
+  name: default
+  setup: ../../../../molecule_common/create.yml
+  teardown: ../../../../molecule_common/destroy.yml
+verifier:
+  name: testinfra

--- a/roles/openshift_master_facts/molecule/default/playbook.yml
+++ b/roles/openshift_master_facts/molecule/default/playbook.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  roles:
+  - role: openshift_master_facts
+  post_tasks:
+  - name: verify expected results
+    assert:
+      that:
+      - openshift.master | default(none) is not none

--- a/setup-requirements.txt
+++ b/setup-requirements.txt
@@ -1,2 +1,0 @@
-setuptools-lint
-yamllint

--- a/setup-requirements.txt
+++ b/setup-requirements.txt
@@ -1,0 +1,2 @@
+setuptools-lint
+yamllint

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,8 @@ norecursedirs =
     docs
     # utils have its own config
     utils
+    # exclude molecule directories, since they are run by molecule
+    molecule
 python_files =
     # TODO(rhcarvalho): rename test files to follow a single pattern. "test*.py"
     # is Python unittest's default, while pytest discovers both "test_*.py" and

--- a/test-requirements-functional.txt
+++ b/test-requirements-functional.txt
@@ -1,0 +1,4 @@
+# Functional deps
+git+https://github.com/detiber/molecule@v2_tweaks
+pytest-xdist
+docker-py==1.10.6

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,12 +1,10 @@
-six
-pyOpenSSL
+# Linter Deps
 flake8
 flake8-mutable
 flake8-print
 pylint
-setuptools-lint
-PyYAML
-yamllint
+
+# Unit Deps
 coverage
 mock
 pytest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,8 @@ flake8
 flake8-mutable
 flake8-print
 pylint
+setuptools-lint
+yamllint
 
 # Unit Deps
 coverage

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ flake8-mutable
 flake8-print
 pylint
 setuptools-lint
+sh
 yamllint
 
 # Unit Deps

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,27 @@
 [tox]
 minversion=2.3.1
 envlist =
-    py{27,35}-ansible22-{pylint,unit,flake8,yamllint,generate_validation}
+    py{27,35}-{lint,unit}
 skipsdist=True
 skip_missing_interpreters=True
 
 [testenv]
 deps =
+    -rrequirements.txt
+    -rsetup-requirements.txt
     -rtest-requirements.txt
-    py35-flake8: flake8-bugbear
-    ansible22: ansible~=2.2
+    py35-lint: flake8-bugbear
 
 commands =
     unit: pytest {posargs}
-    flake8: flake8 {posargs}
-    pylint: python setup.py lint
-    yamllint: python setup.py yamllint
-    generate_validation: python setup.py generate_validation
+    lint: flake8 {posargs}
+    lint: python setup.py lint
+    lint: python setup.py yamllint
+    lint: python setup.py generate_validation
+    # TODO(rhcarvalho): check syntax of other important entrypoint playbooks
+    lint: ansible-playbook --syntax-check playbooks/byo/config.yml
 
-
+[travis:env]
+TEST_TYPE =
+    lint: lint
+    unit: unit

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 minversion=2.3.1
 envlist =
     py{27,35}-{lint,unit}
+    py27-ansible22-functional
 skipsdist=True
 skip_missing_interpreters=True
 
@@ -9,6 +10,7 @@ skip_missing_interpreters=True
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
+    functional: -rtest-requirements-functional.txt
     py35-lint: flake8-bugbear
 
 commands =
@@ -19,8 +21,11 @@ commands =
     lint: python setup.py generate_validation
     # TODO(rhcarvalho): check syntax of other important entrypoint playbooks
     lint: ansible-playbook --syntax-check playbooks/byo/config.yml
+    ansible22: pip install ansible==2.2.0.0
+    py27-functional: python setup.py molecule_tests
 
 [travis:env]
 TEST_TYPE =
     lint: lint
     unit: unit
+    functional: functional

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ skip_missing_interpreters=True
 [testenv]
 deps =
     -rrequirements.txt
-    -rsetup-requirements.txt
     -rtest-requirements.txt
     py35-lint: flake8-bugbear
 


### PR DESCRIPTION
To test an individual role (openshift_facts and openshift_master_facts currently have a molecule definition):
```
cd roles/<rolename>
molecule test
```

To test all roles that have a molecule definition:
```
cd <repo root>
python setup.py molecule_tests
```

To use tox to test all roles:
```
cd <repo root>
tox -e py27-ansible22-functional
```

As currently configured, the molecule tests defined using testinfra: https://testinfra.readthedocs.io

Molecule docs are: http://molecule.readthedocs.io/en/v2

Currently, molecule is being pulled from the v2_tweaks branch of my fork, since we are relying on the currently in development v2 version of molecule to enable Ansible-native provisioning support and support for running multiple scenarios.