### PR TITLE
Do not hardcode openshift_image_tag

### DIFF
--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -127,8 +127,7 @@ def write_inventory_vars(base_inventory, lb):
             "openshift_master_cluster_public_hostname={}\n".format(lb.public_hostname))
 
     if CFG.settings.get('variant_version', None) == '3.1':
-        # base_inventory.write('openshift_image_tag=v{}\n'.format(CFG.settings.get('variant_version')))
-        base_inventory.write('openshift_image_tag=v{}\n'.format('3.1.1.6'))
+        base_inventory.write('openshift_image_tag=v{}\n'.format(CFG.settings.get('variant_version')))
 
     write_proxy_settings(base_inventory)
 


### PR DESCRIPTION
It is no longer necessary for us to hardcode openshift_image_tag to
'3.1.1.6' and we can now set it to 3.1.

Fixes Bug 1406713