### PR TITLE
Add osnl_volume_reclaim_policy variable to nfs_lvm role

### DIFF
--- a/roles/openshift_storage_nfs_lvm/README.md
+++ b/roles/openshift_storage_nfs_lvm/README.md
@@ -48,6 +48,13 @@ osnl_volume_num_start: 3
 # How many volumes/partitions to build, with the size we stated.
 osnl_number_of_volumes: 2
 
+# osnl_volume_reclaim_policy
+# Volume reclaim policy of a PersistentVolume tells the cluster
+# what to do with the volume after it is released.
+#
+# Valid values are "Retain" or "Recycle" (default).
+osnl_volume_reclaim_policy: "Recycle"
+
 ```
 
 ## Dependencies
@@ -71,6 +78,7 @@ exported via NFS.  json files are created in /root.
           osnl_volume_size: 5
           osnl_volume_num_start: 3
           osnl_number_of_volumes: 2
+          osnl_volume_reclaim_policy: "Recycle"
 
 
 ## Full example
@@ -96,6 +104,7 @@ exported via NFS.  json files are created in /root.
           osnl_volume_size: 5
           osnl_volume_num_start: 3
           osnl_number_of_volumes: 2
+          osnl_volume_reclaim_policy: "Recycle"
 
 * Run the playbook:
     ```

--- a/roles/openshift_storage_nfs_lvm/defaults/main.yml
+++ b/roles/openshift_storage_nfs_lvm/defaults/main.yml
@@ -8,3 +8,10 @@ osnl_mount_dir: /exports/openshift
 
 # Volume Group to use.
 osnl_volume_group: openshiftvg
+
+# Volume reclaim policy of a PersistentVolume tells the cluster
+# what to do with the volume after it is released.
+#
+# Valid values are "Retain" or "Recycle".
+# See https://docs.openshift.com/enterprise/3.0/architecture/additional_concepts/storage.html#pv-recycling-policy
+osnl_volume_reclaim_policy: "Recycle"

--- a/roles/openshift_storage_nfs_lvm/templates/nfs.json.j2
+++ b/roles/openshift_storage_nfs_lvm/templates/nfs.json.j2
@@ -12,7 +12,7 @@
       "storage": "{{ osnl_volume_size }}Gi"
     },
     "accessModes": [ "ReadWriteOnce", "ReadWriteMany" ],
-    "persistentVolumeReclaimPolicy": "Recycle",
+    "persistentVolumeReclaimPolicy": "{{ osnl_volume_reclaim_policy }}",
     "nfs": {
       "Server": "{{ inventory_hostname }}",
       "Path": "{{ osnl_mount_dir }}/{{ item }}"


### PR DESCRIPTION
This allows to choose which volume reclamation policy to use when provisioning storage with `openshift_storage_nfs_lvm`.