### PR TITLE
Support openshift_node_port_range for configuring service NodePorts

### DIFF
--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -83,6 +83,12 @@
     - service: OpenShift OVS sdn
       port: 4789/udp
       when: openshift.node.use_openshift_sdn | bool
+    - service: Kubernetes service NodePort TCP
+      port: "{{ openshift_node_port_range }}/tcp"
+      when: openshift_node_port_range | bool
+    - service: Kubernetes service NodePort UDP
+      port: "{{ openshift_node_port_range }}/udp"
+      when: openshift_node_port_range | bool
   - role: openshift_node
 
 - name: Configure nodes
@@ -122,6 +128,12 @@
     - service: OpenShift OVS sdn
       port: 4789/udp
       when: openshift.node.use_openshift_sdn | bool
+    - service: Kubernetes service NodePort TCP
+      port: "{{ openshift_node_port_range }}/tcp"
+      when: openshift_node_port_range | bool
+    - service: Kubernetes service NodePort UDP
+      port: "{{ openshift_node_port_range }}/udp"
+      when: openshift_node_port_range | bool
   - role: openshift_node
 
 - name: Additional node config

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -122,7 +122,7 @@ kubernetesMasterConfig:
     certFile: master.proxy-client.crt
     keyFile: master.proxy-client.key
   schedulerConfigFile: {{ openshift_master_scheduler_conf }}
-  servicesNodePortRange: ""
+  servicesNodePortRange: "{{ openshift_node_port_range | default("") }}"
   servicesSubnet: {{ openshift.common.portal_net }}
   staticNodeNames: {{ openshift_node_ips | default([], true) }}
 {% endif %}

--- a/roles/os_firewall/library/os_firewall_manage_iptables.py
+++ b/roles/os_firewall/library/os_firewall_manage_iptables.py
@@ -127,7 +127,7 @@ class IpTablesManager(object): # pylint: disable=too-many-instance-attributes
 
     def gen_rule(self, port, proto):
         return [self.chain, '-p', proto, '-m', 'state', '--state', 'NEW',
-                '-m', proto, '--dport', str(port), '-j', 'ACCEPT']
+                '-m', proto, '--dport', port_as_argument(port), '-j', 'ACCEPT']
 
     def create_jump(self):
         if self.check_mode:
@@ -221,6 +221,14 @@ class IpTablesManager(object): # pylint: disable=too-many-instance-attributes
         return ['/usr/libexec/iptables/iptables.init', 'save']
 
 
+def port_as_argument(port):
+    if isinstance(port, int):
+        return str(port)
+    if isinstance(port, basestring):
+        return port.replace('-', ":")
+    return port
+
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -231,7 +239,7 @@ def main():
             create_jump_rule=dict(required=False, type='bool', default=True),
             jump_rule_chain=dict(required=False, default='INPUT'),
             protocol=dict(required=False, choices=['tcp', 'udp']),
-            port=dict(required=False, type='int'),
+            port=dict(required=False, type='str'),
             ip_version=dict(required=False, default='ipv4',
                             choices=['ipv4', 'ipv6']),
         ),


### PR DESCRIPTION
Sets the appropriate config field if openshift_node_port_range is set
and also configures filewalls on each node.  firewalld already supports
port ranges like "30000-32000", while iptables needs that value
converted to the correct "30000:32000" form for use with `--dport`.

If not set, no node ports are opened.