### PR TITLE
Sync etcd ca certs from etcd_ca_host to other etcd hosts

### DIFF
--- a/roles/etcd_server_certificates/tasks/main.yml
+++ b/roles/etcd_server_certificates/tasks/main.yml
@@ -142,6 +142,38 @@
     dest: "{{ etcd_cert_config_dir }}"
   when: etcd_server_certs_missing | bool
 
+- name: Create a tarball of the etcd ca certs
+  command: >
+    tar -czvf {{ etcd_generated_certs_dir }}/{{ etcd_ca_name }}.tgz
+      -C {{ etcd_ca_dir }} .
+  args:
+    creates: "{{ etcd_generated_certs_dir }}/{{ etcd_ca_name }}.tgz"
+    warn: no
+  when: etcd_server_certs_missing | bool
+  delegate_to: "{{ etcd_ca_host }}"
+
+- name: Retrieve etcd ca cert tarball
+  fetch:
+    src: "{{ etcd_generated_certs_dir }}/{{ etcd_ca_name }}.tgz"
+    dest: "{{ g_etcd_server_mktemp.stdout }}/"
+    flat: yes
+    fail_on_missing: yes
+    validate_checksum: yes
+  when: etcd_server_certs_missing | bool
+  delegate_to: "{{ etcd_ca_host }}"
+
+- name: Ensure ca directory exists
+  file:
+    path: "{{ etcd_ca_dir }}"
+    state: directory
+  when: etcd_server_certs_missing | bool
+
+- name: Unarchive etcd ca cert tarballs
+  unarchive:
+    src: "{{ g_etcd_server_mktemp.stdout }}/{{ etcd_ca_name }}.tgz"
+    dest: "{{ etcd_ca_dir }}"
+  when: etcd_server_certs_missing | bool
+
 - name: Delete temporary directory
   file: name={{ g_etcd_server_mktemp.stdout }} state=absent
   become: no


### PR DESCRIPTION
When the etcd_ca_host (In most cases this is the first master) is broken, we can not use scaleup playbook, it exits with this error 
TASK [etcd_client_certificates : fail] *****************************************
fatal: [ose3-int-a-master-3.node.xxxx]: FAILED! => {"changed": false, "failed": true, "msg": "CA certificate /etc/etcd/ca/ca.crt doesn't exist on CA host ose3-int-a-master-2.node.xxxx. Apply 'etcd_ca' role to ose3-int-a-master-2.node.xxxx.\n"}
This is also true for node scaleup playbook
This is troublesome  and, we should ensure etcd ca certs are replicated to other etcd hosts
related to https://github.com/openshift/openshift-ansible/issues/3026