### PR TITLE
Fix jsonpath expected output when checking registry volume secrets

### DIFF
--- a/roles/openshift_hosted/tasks/registry/secure.yml
+++ b/roles/openshift_hosted/tasks/registry/secure.yml
@@ -34,13 +34,12 @@
 - name: Create registry certificates if they do not exist
   command: >
     {{ openshift.common.client_binary }} adm ca create-server-cert
-    --signer-cert=/etc/origin/master/ca.crt
-    --signer-key=/etc/origin/master/ca.key
-    --signer-serial=/etc/origin/master/ca.serial.txt
+    --signer-cert={{ openshift_master_config_dir }}/ca.crt
+    --signer-key={{ openshift_master_config_dir }}/ca.key
+    --signer-serial={{ openshift_master_config_dir }}/ca.serial.txt
     --hostnames="{{ docker_registry_service_ip.stdout }},docker-registry.default.svc.cluster.local,{{ docker_registry_route_hostname }}"
     --cert={{ openshift_master_config_dir }}/registry.crt
     --key={{ openshift_master_config_dir }}/registry.key
-  when: False in (docker_registry_certificates_stat_result.results | default([]) | oo_collect(attribute='stat.exists') | list)
 
 - name: Create the secret for the registry certificates
   command: >
@@ -65,12 +64,12 @@
 - name: Determine if registry-certificates secret volume attached
   command: >
     {{ openshift.common.client_binary }} get dc/docker-registry
-    -o jsonpath='{.spec.template.spec.volumes[*].secret.secretName}'
+    -o jsonpath='{.spec.template.spec.volumes[?(@.secret)].secret.secretName}'
     --config={{ openshift_hosted_kubeconfig }}
     -n default
   register: docker_registry_volumes
   changed_when: false
-  failed_when: "'secretName is not found' not in docker_registry_volumes.stdout and docker_registry_volumes.rc != 0"
+  failed_when: "docker_registry_volumes.stdout != '' and 'secretName is not found' not in docker_registry_volumes.stdout and docker_registry_volumes.rc != 0"
 
 - name: Attach registry-certificates secret volume
   command: >


### PR DESCRIPTION
In k8s 1.5 (see rebase PR: origin 12143) jsonpath output is slightly different than previously. Causing this line to fail. We need to pick `secret` or `secretName` when checking this task failure condition.

@dgoodwin mind checking if this is the right approach, this is needed for the rebase PR https://github.com/openshift/origin/pull/12143

@ncdc @smarterclayton fyi
