### PR TITLE
[WIP] Forward requests for PTR records to kube as well

### DIFF
--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -51,7 +51,7 @@ if [[ $2 =~ ^(up|dhcp4-change|dhcp6-change)$ ]]; then
 no-resolv
 domain-needed
 server=/cluster.local/172.30.0.1
-server=/30.172.in-addr.arpa/172.30.0.1
+server=/in-addr.arpa/172.30.0.1
 EOF
       # New config file, must restart
       NEEDS_RESTART=1
@@ -62,6 +62,7 @@ EOF
     for ns in ${IP4_NAMESERVERS}; do
       if [[ ! -z $ns ]]; then
         echo "server=${ns}"
+        echo "server=/in-addr.arpa/${ns}"
       fi
     done > $UPSTREAM_DNS_TMP
 

--- a/roles/openshift_node_dnsmasq/templates/origin-dns.conf.j2
+++ b/roles/openshift_node_dnsmasq/templates/origin-dns.conf.j2
@@ -1,3 +1,4 @@
 no-resolv
 domain-needed
 server=/{{ openshift.common.dns_domain }}/{{ openshift.common.kube_svc_ip }}
+server=/in-addr.arpa/{{ openshift.common.kube_svc_ip }}


### PR DESCRIPTION
SkyDNS returns SERVFAIL for non existant records and dnsmasq forwards the
requests on to the remaining servers so this should be safe.

Fixes #3017 