### PR TITLE
Add etcd scaleup playbook

### DIFF
--- a/playbooks/aws/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/aws/openshift-cluster/cluster_hosts.yml
@@ -4,6 +4,8 @@ g_all_hosts: "{{ groups['tag_clusterid_' ~ cluster_id] | default([])
 
 g_etcd_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type_etcd'] | default([])) }}"
 
+g_new_etcd_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type_new_etcd'] | default([])) }}"
+
 g_lb_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type_lb'] | default([])) }}"
 
 g_nfs_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type_nfs'] | default([])) }}"

--- a/playbooks/byo/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/byo/openshift-cluster/cluster_hosts.yml
@@ -1,6 +1,8 @@
 ---
 g_etcd_hosts: "{{ groups.etcd | default([]) }}"
 
+g_new_etcd_hosts: "{{ groups.new_etcd | default([]) }}"
+
 g_lb_hosts: "{{ groups.lb | default([]) }}"
 
 g_master_hosts: "{{ groups.masters | default([]) }}"
@@ -18,6 +20,6 @@ g_glusterfs_hosts: "{{ groups.glusterfs | default([]) }}"
 g_glusterfs_registry_hosts: "{{ groups.glusterfs_registry | default(g_glusterfs_hosts) }}"
 
 g_all_hosts: "{{ g_master_hosts | union(g_node_hosts) | union(g_etcd_hosts)
-                 | union(g_lb_hosts) | union(g_nfs_hosts)
+                 | union(g_new_etcd_hosts) | union(g_lb_hosts) | union(g_nfs_hosts)
                  | union(g_new_node_hosts)| union(g_new_master_hosts)
                  | default([]) }}"

--- a/playbooks/byo/openshift-etcd/scaleup.yml
+++ b/playbooks/byo/openshift-etcd/scaleup.yml
@@ -1,0 +1,22 @@
+---
+- hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+  - add_host:
+      name: "{{ item }}"
+      groups: l_oo_all_hosts
+    with_items: "{{ g_all_hosts }}"
+
+- hosts: l_oo_all_hosts
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+
+- include: ../../common/openshift-cluster/evaluate_groups.yml
+- include: ../../common/openshift-etcd/scaleup.yml
+  vars:
+    openshift_cluster_id: "{{ cluster_id | default('default') }}"
+    openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/common/openshift-cluster/evaluate_groups.yml
+++ b/playbooks/common/openshift-cluster/evaluate_groups.yml
@@ -5,10 +5,10 @@
   become: no
   gather_facts: no
   tasks:
-  - name: Evaluate groups - g_etcd_hosts required
+  - name: Evaluate groups - g_etcd_hosts or g_new_etcd_hosts required
     fail:
-      msg: This playbook requires g_etcd_hosts to be set
-    when: g_etcd_hosts is not defined
+      msg: This playbook requires g_etcd_hosts or g_new_etcd_hosts to be set
+    when: "{{ g_etcd_hosts is not defined and g_new_etcd_hosts is not defined}}"
 
   - name: Evaluate groups - g_master_hosts or g_new_master_hosts required
     fail:
@@ -65,6 +65,15 @@
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_become: "{{ g_sudo | default(omit) }}"
     when: g_master_hosts|length > 0
+    changed_when: no
+
+  - name: Evaluate oo_new_etcd_to_config
+    add_host:
+      name: "{{ item }}"
+      groups: oo_new_etcd_to_config
+      ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
+      ansible_become: "{{ g_sudo | default(omit) }}"
+    with_items: "{{ g_new_etcd_hosts | default([]) }}"
     changed_when: no
 
   - name: Evaluate oo_masters_to_config

--- a/playbooks/common/openshift-etcd/scaleup.yml
+++ b/playbooks/common/openshift-etcd/scaleup.yml
@@ -1,0 +1,30 @@
+---
+- name: Configure etcd
+  hosts: oo_new_etcd_to_config
+  serial: 1
+  any_errors_fatal: true
+  vars:
+    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
+  pre_tasks:
+  - name: Add new etcd members to cluster
+    command: >
+      /usr/bin/etcdctl  --cert-file {{ etcd_peer_cert_file }}
+                        --key-file {{ etcd_peer_key_file }}
+                        --ca-file {{ etcd_peer_ca_file }}
+                        -C {{ etcd_peer_url_scheme }}://{{ etcd_ca_host }}:{{ etcd_client_port }}
+                        member add {{ inventory_hostname }} {{ etcd_peer_url_scheme }}://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ etcd_peer_port }}
+    delegate_to: "{{ etcd_ca_host }}"
+    register: etcd_add_check
+  roles:
+  - role: openshift_etcd
+    when: etcd_add_check.rc == 0
+    etcd_peers: "{{ groups.oo_etcd_to_config | union(groups.oo_new_etcd_to_config)| default([], true) }}"
+    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
+    etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"
+    etcd_initial_cluster_state: "existing"
+    initial_etcd_cluster: "{{ etcd_add_check.stdout_lines[3] | regex_replace('ETCD_INITIAL_CLUSTER=','') }}"
+    etcd_hostname: "{{ inventory_hostname }}"
+    etcd_ca_setup: False
+    r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
+  - role: nickhammond.logrotate
+    when: etcd_add_check.rc == 0

--- a/playbooks/gce/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/gce/openshift-cluster/cluster_hosts.yml
@@ -4,6 +4,8 @@ g_all_hosts: "{{ groups['tag_clusterid-' ~ cluster_id] | default([])
 
 g_etcd_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-etcd'] | default([])) }}"
 
+g_new_etcd_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-new_etcd'] | default([])) }}"
+
 g_lb_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-lb'] | default([])) }}"
 
 g_nfs_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-nfs'] | default([])) }}"

--- a/playbooks/libvirt/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/libvirt/openshift-cluster/cluster_hosts.yml
@@ -4,6 +4,8 @@ g_all_hosts: "{{ groups['tag_clusterid-' ~ cluster_id] | default([])
 
 g_etcd_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-etcd'] | default([])) }}"
 
+g_new_etcd_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-new_etcd'] | default([])) }}"
+
 g_lb_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-lb'] | default([])) }}"
 
 g_nfs_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-nfs'] | default([])) }}"

--- a/playbooks/openstack/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/openstack/openshift-cluster/cluster_hosts.yml
@@ -4,6 +4,8 @@ g_all_hosts: "{{ groups['meta-clusterid_' ~ cluster_id] | default([])
 
 g_etcd_hosts: "{{ g_all_hosts | intersect(groups['meta-host-type_etcd'] | default([])) }}"
 
+g_new_etcd_hosts: "{{ g_all_hosts | intersect(groups['meta-host-type_new_etcd'] | default([])) }}"
+
 g_lb_hosts: "{{ g_all_hosts | intersect(groups['meta-host-type_lb'] | default([])) }}"
 
 g_nfs_hosts: "{{ g_all_hosts | intersect(groups['meta-host-type_nfs'] | default([])) }}"

--- a/roles/etcd/templates/etcd.conf.j2
+++ b/roles/etcd/templates/etcd.conf.j2
@@ -8,12 +8,8 @@
 {% endfor -%}
 {% endmacro -%}
 
-{% if (etcd_peers | default([]) | length > 1) or (etcd_is_thirdparty) %}
 ETCD_NAME={{ etcd_hostname }}
 ETCD_LISTEN_PEER_URLS={{ etcd_listen_peer_urls }}
-{% else %}
-ETCD_NAME=default
-{% endif %}
 ETCD_DATA_DIR={{ etcd_data_dir }}
 #ETCD_SNAPSHOT_COUNTER=10000
 ETCD_HEARTBEAT_INTERVAL=500
@@ -23,20 +19,20 @@ ETCD_LISTEN_CLIENT_URLS={{ etcd_listen_client_urls }}
 #ETCD_MAX_WALS=5
 #ETCD_CORS=
 
-{% if etcd_is_thirdparty %}
+
 #[cluster]
 ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_initial_advertise_peer_urls }}
-
+{% if etcd_is_thirdparty %}
 # TODO: This needs to be altered to support the correct etcd instances
 ETCD_INITIAL_CLUSTER={{ etcd_hostname}}={{ etcd_initial_advertise_peer_urls }}
 ETCD_INITIAL_CLUSTER_STATE={{ etcd_initial_cluster_state }}
 ETCD_INITIAL_CLUSTER_TOKEN=thirdparty-etcd-cluster-1
-{% endif %}
-
-{% if etcd_peers | default([]) | length > 1 %}
-#[cluster]
-ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_initial_advertise_peer_urls }}
+{% else %}
+{% if initial_etcd_cluster is defined and initial_etcd_cluster %}
+ETCD_INITIAL_CLUSTER={{ initial_etcd_cluster }}
+{% else %}
 ETCD_INITIAL_CLUSTER={{ initial_cluster() }}
+{% endif %}
 ETCD_INITIAL_CLUSTER_STATE={{ etcd_initial_cluster_state }}
 ETCD_INITIAL_CLUSTER_TOKEN={{ etcd_initial_cluster_token }}
 #ETCD_DISCOVERY=

--- a/roles/etcd_server_certificates/meta/main.yml
+++ b/roles/etcd_server_certificates/meta/main.yml
@@ -14,3 +14,4 @@ galaxy_info:
   - system
 dependencies:
 - role: etcd_ca
+  when: (etcd_ca_setup | default(True) | bool)

--- a/roles/openshift_etcd_ca/meta/main.yml
+++ b/roles/openshift_etcd_ca/meta/main.yml
@@ -15,3 +15,4 @@ galaxy_info:
 dependencies:
 - role: openshift_etcd_facts
 - role: etcd_ca
+  when: (etcd_ca_setup | default(True) | bool)


### PR DESCRIPTION
An etcd scaleup playbook is needed for these reasons:
- master scaleup playbook does not scaleup etcd
- if we broke a master vm and we loose it, the master recovery does not recover the etcd cluster size, each master rebuild results on decreasing etcd cluster size, this is particularly troubelsome for upgrades whenever someone wants to upgrades master nodes by destroying/recreating each one progressively