### PR TITLE
Add a fact to select --evacuate or --drain based on your OCP version

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -31,7 +31,7 @@
 
   - name: Drain Node for Kubelet upgrade
     command: >
-      {{ openshift.common.client_binary }} adm manage-node {{ openshift.node.nodename }} --drain --force
+      {{ openshift.common.client_binary }} adm manage-node {{ openshift.node.nodename }} {{ openshift.common.evacuate_or_drain }} --force
     delegate_to: "{{ groups.oo_first_master.0 }}"
     when: l_docker_upgrade is defined and l_docker_upgrade | bool and inventory_hostname in groups.oo_nodes_to_upgrade
 

--- a/playbooks/common/openshift-cluster/redeploy-certificates.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates.yml
@@ -234,7 +234,7 @@
     command: >
       {{ openshift.common.client_binary }} adm --config={{ hostvars[groups.oo_first_master.0].mktemp.stdout }}/admin.kubeconfig
       manage-node {{ openshift.node.nodename }}
-      --drain --force
+      {{ openshift.common.evacuate_or_drain }} --force
     delegate_to: "{{ groups.oo_first_master.0 }}"
     when: openshift_certificates_redeploy_ca | default(false) | bool and was_schedulable | bool
 

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -41,7 +41,7 @@
 
   - name: Drain Node for Kubelet upgrade
     command: >
-      {{ hostvars[groups.oo_first_master.0].openshift.common.client_binary }} adm manage-node {{ openshift.node.nodename | lower }} --drain --force
+      {{ hostvars[groups.oo_first_master.0].openshift.common.client_binary }} adm manage-node {{ openshift.node.nodename | lower }} {{ openshift.common.evacuate_or_drain }} --force
     delegate_to: "{{ groups.oo_first_master.0 }}"
     when: inventory_hostname in groups.oo_nodes_to_upgrade
 

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -867,6 +867,20 @@ def set_deployment_facts_if_unset(facts):
     return facts
 
 
+def set_evacuate_or_drain_option(facts):
+    """OCP before 1.5/3.5 used '--evacuate'. As of 1.5/3.5 OCP uses
+'--drain'. Let's make that a fact for easy reference later.
+    """
+    if facts['common']['version_gte_3_5_or_1_5']:
+        # New-style
+        facts['common']['evacuate_or_drain'] = '--drain'
+    else:
+        # Old-style
+        facts['common']['evacuate_or_drain'] = '--evacuate'
+
+    return facts
+
+
 def set_version_facts_if_unset(facts):
     """ Set version facts. This currently includes common.version and
         common.version_gte_3_1_or_1_1.
@@ -1898,6 +1912,7 @@ class OpenShiftFacts(object):
         facts = build_controller_args(facts)
         facts = build_api_server_args(facts)
         facts = set_version_facts_if_unset(facts)
+        facts = set_evacuate_or_drain_option(facts)
         facts = set_dnsmasq_facts_if_unset(facts)
         facts = set_manageiq_facts_if_unset(facts)
         facts = set_aggregate_facts(facts)

--- a/roles/openshift_node/README.md
+++ b/roles/openshift_node/README.md
@@ -47,6 +47,8 @@ oadm manage-node --drain ${NODE}
 oadm manage-node --schedulable=true ${NODE}
 ````
 
+> If you are using version less than 1.5/3.5 you must replace `--drain` with `--evacuate`.
+
 
 TODO
 


### PR DESCRIPTION
OCP < 1.5/3.5 uses '--evacuate', newer OCP uses '--drain'.

Closes #3070 
