### PR TITLE
[WIP] Correct return code compairison for yamllint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,14 +104,14 @@ class OpenShiftAnsibleYamlLint(Command):
                         first = False
 
                     print(format_method(problem, yaml_file))
-                    if problem.level == linter.PROBLEM_LEVELS['error']:
+                    if problem.level == linter.PROBLEM_LEVELS[2]:
                         has_errors = True
-                    elif problem.level == linter.PROBLEM_LEVELS['warning']:
+                    elif problem.level == linter.PROBLEM_LEVELS[1]:
                         has_warnings = True
 
-        assert not has_errors, 'yamllint errors found'
-        assert not has_warnings, 'yamllint warnings found'
-
+        if has_errors or has_warnings:
+            print('yammlint issues found')
+            exit(1)
 
 class OpenShiftAnsiblePylint(PylintCommand):
     ''' Class to override the default behavior of PylintCommand '''


### PR DESCRIPTION
This PR corrects a problem where yamllint check failures were not being reported as failed by tox.

The problem.level is text based and was being compared against integer based values, therefore never raising an exception on issues.

Additionally, the use of `assert` on the results felt wrong with the resulting traceback.  The code is not failing, we are just wanting to report that something bad happened.  However, there are probably better ways to do this than what I have here.