### PR TITLE
Correct tox to run on Travis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 minversion=2.3.1
 envlist =
-    py{27,35}-ansible22-{pylint,unit,flake8}
-    yamllint
+    py{27,35}-ansible22-{pylint,unit,flake8,yamllint}
 skipsdist=True
 skip_missing_interpreters=True
 


### PR DESCRIPTION
tox-travis needs a python env descriptor in envlist