### PR TITLE
Document playbook directories

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,6 @@
+# The `bin/cluster` tool
+
+This tool was meant to be the entry point for managing OpenShift clusters,
+running against different "providers" (`aws`, `gce`, `libvirt`, `openstack`),
+though its use is now deprecated in favor of the [`byo`](../playbooks/byo)
+playbooks.

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -1,0 +1,19 @@
+# openshift-ansible playbooks
+
+In summary:
+
+- [`byo`](byo) (_Bring Your Own_ hosts) has the most actively maintained
+  playbooks for installing, upgrading and performing others tasks on OpenShift
+  clusters.
+- [`common`](common) has a set of playbooks that are included by playbooks in
+  `byo` and others.
+
+And:
+
+- [`adhoc`](adhoc) is a generic home for playbooks and tasks that are community
+  supported and not officially maintained.
+- [`aws`](aws), [`gce`](gce), [`libvirt`](libvirt) and [`openstack`](openstack)
+  are related to the [`bin/cluster`](../bin) tool and its usage is deprecated.
+
+Refer to the `README.md` file in each playbook directory for more information
+about them.

--- a/playbooks/adhoc/README.md
+++ b/playbooks/adhoc/README.md
@@ -1,0 +1,5 @@
+# _Ad hoc_ playbooks
+
+This directory holds playbooks and tasks that really don't have a better home.
+Existing playbooks living here are community supported and not officially
+maintained.

--- a/playbooks/aws/README.md
+++ b/playbooks/aws/README.md
@@ -1,0 +1,4 @@
+# AWS playbooks
+
+This playbook directory is meant to be driven by [`bin/cluster`](../../bin),
+which is community supported and most use is considered deprecated.

--- a/playbooks/byo/README.md
+++ b/playbooks/byo/README.md
@@ -1,0 +1,11 @@
+# Bring Your Own hosts playbooks
+
+This directory has the most actively used, maintained and supported set of
+playbooks for installing, upgrading and performing others tasks on OpenShift
+clusters.
+
+Usage is documented in the official OpenShift documentation pages, under the
+Advanced Installation topic:
+
+- [OpenShift Origin: Advanced Installation](https://docs.openshift.org/latest/install_config/install/advanced_install.html)
+- [OpenShift Container Platform: Advanced Installation](https://docs.openshift.com/container-platform/latest/install_config/install/advanced_install.html)

--- a/playbooks/common/README.md
+++ b/playbooks/common/README.md
@@ -1,0 +1,9 @@
+# Common playbooks
+
+This directory has a generic set of playbooks that are included by playbooks in
+[`byo`](../byo), as well as other playbooks related to the
+[`bin/cluster`](../../bin) tool.
+
+Note: playbooks in this directory use generic group names that do not line up
+with the groups used by the `byo` playbooks or `bin/cluster` derived playbooks,
+requiring an explicit remapping of groups.

--- a/playbooks/gce/README.md
+++ b/playbooks/gce/README.md
@@ -1,0 +1,4 @@
+# GCE playbooks
+
+This playbook directory is meant to be driven by [`bin/cluster`](../../bin),
+which is community supported and most use is considered deprecated.

--- a/playbooks/libvirt/README.md
+++ b/playbooks/libvirt/README.md
@@ -1,0 +1,4 @@
+# libvirt playbooks
+
+This playbook directory is meant to be driven by [`bin/cluster`](../../bin),
+which is community supported and most use is considered deprecated.

--- a/playbooks/openstack/README.md
+++ b/playbooks/openstack/README.md
@@ -1,0 +1,4 @@
+# OpenStack playbooks
+
+This playbook directory is meant to be driven by [`bin/cluster`](../../bin),
+which is community supported and most use is considered deprecated.


### PR DESCRIPTION
Add `README.md` files to explain the multiple playbook directories, and the `bin/cluster` tool.

From https://github.com/openshift/openshift-ansible/pull/2993#discussion_r95385014 / https://github.com/openshift/openshift-ansible/pull/2993#discussion_r95396763.