### PR TITLE
Do not default registry storage kind to 'nfs' when 'nfs' host group exists.

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -74,11 +74,6 @@
         public_console_url: "{{ openshift_master_public_console_url | default(None) }}"
         ha: "{{ openshift_master_ha | default(groups.oo_masters | length > 1) }}"
         master_count: "{{ openshift_master_count | default(groups.oo_masters | length) }}"
-  - openshift_facts:
-      role: hosted
-      openshift_env:
-        openshift_hosted_registry_storage_kind: 'nfs'
-    when: openshift_hosted_registry_storage_kind is not defined and groups.oo_nfs_to_config is defined and groups.oo_nfs_to_config | length > 0
 
 - name: Create temp directory for syncing certs
   hosts: localhost


### PR DESCRIPTION
This makes it possible to use openshift-ansible configured nfs for
hosted components other than the registry while also configuring
empty-dir registry storage (no `openshift_hosted_registry_storage_kind`
set).

Fixes #3063

@thoraxe