### PR TITLE
Added setup.py to flake8 tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,6 @@ excludes=.tox,utils,files
 lint_disable=fixme,locally-disabled,file-ignored,duplicate-code
 
 [flake8]
-exclude=.tox/*,setup.py,utils/*,inventory/*
+exclude=.tox/*,utils/*,inventory/*
 max_line_length = 120
 ignore = E501,T003

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ from yamllint.config import YamlLintConfig
 from yamllint.cli import Format
 from yamllint import linter
 
+
 def find_files(base_dir, exclude_dirs, include_dirs, file_regex):
     ''' find files matching file_regex '''
     found = []
@@ -111,7 +112,8 @@ class OpenShiftAnsibleYamlLint(Command):
 
         if has_errors or has_warnings:
             print('yammlint issues found')
-            exit(1)
+            raise SystemExit(1)
+
 
 class OpenShiftAnsiblePylint(PylintCommand):
     ''' Class to override the default behavior of PylintCommand '''


### PR DESCRIPTION
Added setup.py to ``flake8`` tests since it is code. Also minor updates to
slightly modernize.

Note: In the future ``{#}`` should probably be ported to ``{}`` as numbering is
no longer needed (and disliked by many).