### PR TITLE
Fix role openshift_storage_nfs_lvm

### DIFF
--- a/roles/openshift_storage_nfs_lvm/meta/main.yml
+++ b/roles/openshift_storage_nfs_lvm/meta/main.yml
@@ -14,4 +14,5 @@ galaxy_info:
     - all
   categories:
   - openshift
-dependencies: []
+dependencies:
+- role: openshift_facts

--- a/roles/openshift_storage_nfs_lvm/tasks/main.yml
+++ b/roles/openshift_storage_nfs_lvm/tasks/main.yml
@@ -2,7 +2,7 @@
 # TODO -- this may actually work on atomic hosts
 - fail:
     msg: "openshift_storage_nfs_lvm is not compatible with atomic host"
-    when: openshift.common.is_atomic | true
+  when: openshift.common.is_atomic | bool
 
 - name: Create lvm volumes
   lvol: vg={{osnl_volume_group}} lv={{ item }} size={{osnl_volume_size}}G


### PR DESCRIPTION
This role would always fail at the first task when testing whether we're running atomic even when applied to a non-atomic host.

- Fixed the 'when' statement that was wrongly indented at the task options level
- Added openshift_facts as a dependency in order to ensure the openshift.common.is_atomic is set prior to running this role

