### PR TITLE
Fix role openshift_storage_nfs_lvm keys should be lowercase in the pv spec template

### DIFF
--- a/roles/openshift_storage_nfs_lvm/templates/nfs.json.j2
+++ b/roles/openshift_storage_nfs_lvm/templates/nfs.json.j2
@@ -14,8 +14,8 @@
     "accessModes": [ "ReadWriteOnce", "ReadWriteMany" ],
     "persistentVolumeReclaimPolicy": "{{ osnl_volume_reclaim_policy }}",
     "nfs": {
-      "Server": "{{ inventory_hostname }}",
-      "Path": "{{ osnl_mount_dir }}/{{ item }}"
+      "server": "{{ inventory_hostname }}",
+      "path": "{{ osnl_mount_dir }}/{{ item }}"
     }
   }
 }


### PR DESCRIPTION
According to the spec, the server and path keys should be lower case.

```
The PersistentVolume "pv-192-168-173-18-os-pv1g0001" is invalid.

* spec.nfs.server: Required value
* spec.nfs.path: Required value
* spec.nfs.path: Invalid value: "": must be an absolute path
```