### PR TITLE
Correct consistency between upgrade playbooks

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
@@ -94,5 +94,7 @@
   - include: ../../../../common/openshift-cluster/upgrades/cleanup_unused_images.yml
 
 - include: ../../../../common/openshift-cluster/upgrades/upgrade_control_plane.yml
+  vars:
+    master_config_hook: "v3_4/master_config_upgrade.yml"
 
 - include: ../../../../common/openshift-cluster/upgrades/post_control_plane.yml


### PR DESCRIPTION
The control_plane only playbook should be consistent with the 'all' playbook as referenced below.

https://github.com/openshift/openshift-ansible/blob/78b948edb0c30e3ec876916a8bbe08db5f055ea7/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade.yml#L92-L93