### PR TITLE
should be libvirt. :-)

### DIFF
--- a/inventory/README.md
+++ b/inventory/README.md
@@ -5,5 +5,5 @@ You can install OpenShift on:
 * [Amazon Web Services](aws/hosts/)
 * [BYO](byo/) (Bring your own), use this inventory config file to install OpenShift on your bare metal servers
 * [GCE](gce/) (Google Compute Engine)
-* [libvirt](libviert/hosts/)
+* [libvirt](libvirt/hosts/)
 * [OpenStack](openstack/hosts/)


### PR DESCRIPTION
and the same typo in ocp-3.4 and ocp-3.4-GA branch.