### PR TITLE
Support openshift_node_port_range for configuring service NodePorts

### DIFF
--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -123,7 +123,7 @@ kubernetesMasterConfig:
     keyFile: master.proxy-client.key
   schedulerArguments: {{ openshift_master_scheduler_args | default(None) | to_padded_yaml( level=3 ) }}
   schedulerConfigFile: {{ openshift_master_scheduler_conf }}
-  servicesNodePortRange: ""
+  servicesNodePortRange: "{{ openshift_node_port_range | default("") }}"
   servicesSubnet: {{ openshift.common.portal_net }}
   staticNodeNames: {{ openshift_node_ips | default([], true) }}
 {% endif %}

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -31,6 +31,15 @@ dependencies:
     port: 10255/tcp
   - service: Openshift kubelet ReadOnlyPort udp
     port: 10255/udp
+- role: os_firewall
+  os_firewall_allow:
   - service: OpenShift OVS sdn
     port: 4789/udp
-    when: openshift.node.use_openshift_sdn | bool
+  when: openshift.common.use_openshift_sdn | bool
+- role: os_firewall
+  os_firewall_allow:
+  - service: Kubernetes service NodePort TCP
+    port: "{{ openshift_node_port_range | default('') }}/tcp"
+  - service: Kubernetes service NodePort UDP
+    port: "{{ openshift_node_port_range | default('') }}/udp"
+  when: openshift_node_port_range is defined

--- a/roles/os_firewall/library/os_firewall_manage_iptables.py
+++ b/roles/os_firewall/library/os_firewall_manage_iptables.py
@@ -127,9 +127,17 @@ class IpTablesManager(object):  # pylint: disable=too-many-instance-attributes
         check_cmd = self.cmd + ['-C'] + rule
         return True if subprocess.call(check_cmd) == 0 else False
 
+    @staticmethod
+    def port_as_argument(port):
+        if isinstance(port, int):
+            return str(port)
+        if isinstance(port, basestring):  # noqa: F405
+            return port.replace('-', ":")
+        return port
+
     def gen_rule(self, port, proto):
         return [self.chain, '-p', proto, '-m', 'state', '--state', 'NEW',
-                '-m', proto, '--dport', str(port), '-j', 'ACCEPT']
+                '-m', proto, '--dport', IpTablesManager.port_as_argument(port), '-j', 'ACCEPT']
 
     def create_jump(self):
         if self.check_mode:
@@ -231,7 +239,7 @@ def main():
             create_jump_rule=dict(required=False, type='bool', default=True),
             jump_rule_chain=dict(required=False, default='INPUT'),
             protocol=dict(required=False, choices=['tcp', 'udp']),
-            port=dict(required=False, type='int'),
+            port=dict(required=False, type='str'),
             ip_version=dict(required=False, default='ipv4',
                             choices=['ipv4', 'ipv6']),
         ),


### PR DESCRIPTION
Sets the appropriate config field if openshift_node_port_range is set
and also configures filewalls on each node.  firewalld already supports
port ranges like "30000-32000", while iptables needs that value
converted to the correct "30000:32000" form for use with `--dport`.

If not set, no node ports are opened.

Supersedes #3018