### PR TITLE
Backport 1.4: Support openshift_node_port_range for configuring service NodePorts

### DIFF
--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -26,27 +26,6 @@
       logging_elasticsearch_cluster_size: "{{ openshift_hosted_logging_elasticsearch_cluster_size | default(1) }}"
       logging_elasticsearch_ops_cluster_size: "{{ openshift_hosted_logging_elasticsearch_ops_cluster_size | default(1) }}"
   roles:
-  - role: openshift_cli
-  - role: openshift_hosted_facts
-  - role: openshift_projects
-    # TODO: Move standard project definitions to openshift_hosted/vars/main.yml
-    # Vars are not accessible in meta/main.yml in ansible-1.9.x
-    openshift_projects: "{{ openshift_additional_projects | default({}) | oo_merge_dicts({'default':{'default_node_selector':''},'openshift-infra':{'default_node_selector':''},'logging':{'default_node_selector':''}}) }}"
-  - role: openshift_serviceaccounts
-    openshift_serviceaccounts_names:
-    - router
-    openshift_serviceaccounts_namespace: default
-    openshift_serviceaccounts_sccs:
-    - hostnetwork
-    when: openshift.common.version_gte_3_2_or_1_2
-  - role: openshift_serviceaccounts
-    openshift_serviceaccounts_names:
-    - router
-    - registry
-    openshift_serviceaccounts_namespace: default
-    openshift_serviceaccounts_sccs:
-    - privileged
-    when: not openshift.common.version_gte_3_2_or_1_2
   - role: openshift_hosted
   - role: openshift_metrics
     when: openshift_hosted_metrics_deploy | default(false) | bool

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -133,9 +133,7 @@
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
   roles:
-  - role: openshift_master_facts
-  - role: openshift_hosted_facts
-  - role: openshift_master_certificates
+  - role: openshift_master
     openshift_ca_host: "{{ groups.oo_first_master.0 }}"
     openshift_master_etcd_hosts: "{{ hostvars
                                      | oo_select_keys(groups['oo_etcd_to_config'] | default([]))
@@ -145,35 +143,12 @@
                                     | oo_select_keys(groups['oo_masters_to_config'] | default([]))
                                     | oo_collect('openshift.common.all_hostnames')
                                     | oo_flatten | unique }}"
-  - role: openshift_etcd_client_certificates
+    openshift_master_hosts: "{{ groups.oo_masters_to_config }}"
     etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
     etcd_cert_subdir: "openshift-master-{{ openshift.common.hostname }}"
     etcd_cert_config_dir: "{{ openshift.common.config_base }}/master"
     etcd_cert_prefix: "master.etcd-"
-    when: groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config
-  - role: openshift_clock
-  - role: openshift_cloud_provider
-  - role: openshift_builddefaults
-  - role: os_firewall
-    os_firewall_allow:
-    - service: api server https
-      port: "{{ openshift.master.api_port }}/tcp"
-    - service: api controllers https
-      port: "{{ openshift.master.controllers_port }}/tcp"
-    - service: skydns tcp
-      port: "{{ openshift.master.dns_port }}/tcp"
-    - service: skydns udp
-      port: "{{ openshift.master.dns_port }}/udp"
-  - role: os_firewall
-    os_firewall_allow:
-    - service: etcd embedded
-      port: 4001/tcp
-    when: groups.oo_etcd_to_config | default([]) | length == 0
-  - role: openshift_master
-    openshift_master_hosts: "{{ groups.oo_masters_to_config }}"
-  - role: nickhammond.logrotate
-  - role: nuage_master
-    when: openshift.common.use_nuage | bool
+
   post_tasks:
   - name: Create group for deployment type
     group_by: key=oo_masters_deployment_type_{{ openshift.common.deployment_type }}

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -60,30 +60,8 @@
     when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
             openshift_generate_no_proxy_hosts | default(True) | bool }}"
   roles:
-  - role: openshift_common
-  - role: openshift_clock
-  - role: openshift_docker
-  - role: openshift_node_certificates
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
-  - role: openshift_cloud_provider
-  - role: openshift_node_dnsmasq
-    when: openshift.common.use_dnsmasq | bool
-  - role: os_firewall
-    os_firewall_allow:
-    - service: Kubernetes kubelet
-      port: 10250/tcp
-    - service: http
-      port: 80/tcp
-    - service: https
-      port: 443/tcp
-    - service: Openshift kubelet ReadOnlyPort
-      port: 10255/tcp
-    - service: Openshift kubelet ReadOnlyPort udp
-      port: 10255/udp
-    - service: OpenShift OVS sdn
-      port: 4789/udp
-      when: openshift.node.use_openshift_sdn | bool
   - role: openshift_node
+    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
 
 - name: Configure nodes
   hosts: oo_nodes_to_config:!oo_containerized_master_nodes
@@ -99,30 +77,8 @@
     when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
             openshift_generate_no_proxy_hosts | default(True) | bool }}"
   roles:
-  - role: openshift_common
-  - role: openshift_clock
-  - role: openshift_docker
-  - role: openshift_node_certificates
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
-  - role: openshift_cloud_provider
-  - role: openshift_node_dnsmasq
-    when: openshift.common.use_dnsmasq | bool
-  - role: os_firewall
-    os_firewall_allow:
-    - service: Kubernetes kubelet
-      port: 10250/tcp
-    - service: http
-      port: 80/tcp
-    - service: https
-      port: 443/tcp
-    - service: Openshift kubelet ReadOnlyPort
-      port: 10255/tcp
-    - service: Openshift kubelet ReadOnlyPort udp
-      port: 10255/udp
-    - service: OpenShift OVS sdn
-      port: 4789/udp
-      when: openshift.node.use_openshift_sdn | bool
   - role: openshift_node
+    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
 
 - name: Additional node config
   hosts: oo_nodes_to_config

--- a/roles/openshift_hosted/meta/main.yml
+++ b/roles/openshift_hosted/meta/main.yml
@@ -11,4 +11,23 @@ galaxy_info:
     - 7
   categories:
   - cloud
-dependencies: []
+dependencies:
+- role: openshift_cli
+- role: openshift_hosted_facts
+- role: openshift_projects
+  openshift_projects: "{{ openshift_additional_projects | default({}) | oo_merge_dicts({'default':{'default_node_selector':''},'openshift-infra':{'default_node_selector':''},'logging':{'default_node_selector':''}}) }}"
+- role: openshift_serviceaccounts
+  openshift_serviceaccounts_names:
+  - router
+  openshift_serviceaccounts_namespace: default
+  openshift_serviceaccounts_sccs:
+  - hostnetwork
+  when: openshift.common.version_gte_3_2_or_1_2
+- role: openshift_serviceaccounts
+  openshift_serviceaccounts_names:
+  - router
+  - registry
+  openshift_serviceaccounts_namespace: default
+  openshift_serviceaccounts_sccs:
+  - privileged
+  when: not openshift.common.version_gte_3_2_or_1_2

--- a/roles/openshift_master/meta/main.yml
+++ b/roles/openshift_master/meta/main.yml
@@ -11,4 +11,33 @@ galaxy_info:
     - 7
   categories:
   - cloud
-dependencies: []
+dependencies:
+- role: openshift_master_facts
+- role: openshift_hosted_facts
+- role: openshift_master_certificates
+- role: openshift_etcd_client_certificates
+  etcd_cert_subdir: "openshift-master-{{ openshift.common.hostname }}"
+  etcd_cert_config_dir: "{{ openshift.common.config_base }}/master"
+  etcd_cert_prefix: "master.etcd-"
+  when: groups.oo_etcd_to_config | default([]) | length != 0
+- role: openshift_clock
+- role: openshift_cloud_provider
+- role: openshift_builddefaults
+- role: os_firewall
+  os_firewall_allow:
+  - service: api server https
+    port: "{{ openshift.master.api_port }}/tcp"
+  - service: api controllers https
+    port: "{{ openshift.master.controllers_port }}/tcp"
+  - service: skydns tcp
+    port: "{{ openshift.master.dns_port }}/tcp"
+  - service: skydns udp
+    port: "{{ openshift.master.dns_port }}/udp"
+- role: os_firewall
+  os_firewall_allow:
+  - service: etcd embedded
+    port: 4001/tcp
+  when: groups.oo_etcd_to_config | default([]) | length == 0
+- role: nickhammond.logrotate
+- role: nuage_master
+  when: openshift.common.use_nuage | bool

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -123,7 +123,7 @@ kubernetesMasterConfig:
     keyFile: master.proxy-client.key
   schedulerArguments: {{ openshift_master_scheduler_args | default(None) | to_padded_yaml( level=3 ) }}
   schedulerConfigFile: {{ openshift_master_scheduler_conf }}
-  servicesNodePortRange: ""
+  servicesNodePortRange: "{{ openshift_node_port_range | default("") }}"
   servicesSubnet: {{ openshift.common.portal_net }}
   staticNodeNames: {{ openshift_node_ips | default([], true) }}
 {% endif %}

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -31,6 +31,15 @@ dependencies:
     port: 10255/tcp
   - service: Openshift kubelet ReadOnlyPort udp
     port: 10255/udp
+- role: os_firewall
+  os_firewall_allow:
   - service: OpenShift OVS sdn
     port: 4789/udp
-    when: openshift.node.use_openshift_sdn | bool
+  when: openshift.common.use_openshift_sdn | bool
+- role: os_firewall
+  os_firewall_allow:
+  - service: Kubernetes service NodePort TCP
+    port: "{{ openshift_node_port_range | default('') }}/tcp"
+  - service: Kubernetes service NodePort UDP
+    port: "{{ openshift_node_port_range | default('') }}/udp"
+  when: openshift_node_port_range is defined

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -11,4 +11,26 @@ galaxy_info:
     - 7
   categories:
   - cloud
-dependencies: []
+dependencies:
+- role: openshift_common
+- role: openshift_clock
+- role: openshift_docker
+- role: openshift_node_certificates
+- role: openshift_cloud_provider
+- role: openshift_node_dnsmasq
+  when: openshift.common.use_dnsmasq | bool
+- role: os_firewall
+  os_firewall_allow:
+  - service: Kubernetes kubelet
+    port: 10250/tcp
+  - service: http
+    port: 80/tcp
+  - service: https
+    port: 443/tcp
+  - service: Openshift kubelet ReadOnlyPort
+    port: 10255/tcp
+  - service: Openshift kubelet ReadOnlyPort udp
+    port: 10255/udp
+  - service: OpenShift OVS sdn
+    port: 4789/udp
+    when: openshift.node.use_openshift_sdn | bool

--- a/roles/os_firewall/library/os_firewall_manage_iptables.py
+++ b/roles/os_firewall/library/os_firewall_manage_iptables.py
@@ -127,9 +127,17 @@ class IpTablesManager(object):  # pylint: disable=too-many-instance-attributes
         check_cmd = self.cmd + ['-C'] + rule
         return True if subprocess.call(check_cmd) == 0 else False
 
+    @staticmethod
+    def port_as_argument(port):
+        if isinstance(port, int):
+            return str(port)
+        if isinstance(port, basestring):  # noqa: F405
+            return port.replace('-', ":")
+        return port
+
     def gen_rule(self, port, proto):
         return [self.chain, '-p', proto, '-m', 'state', '--state', 'NEW',
-                '-m', proto, '--dport', str(port), '-j', 'ACCEPT']
+                '-m', proto, '--dport', IpTablesManager.port_as_argument(port), '-j', 'ACCEPT']
 
     def create_jump(self):
         if self.check_mode:
@@ -231,7 +239,7 @@ def main():
             create_jump_rule=dict(required=False, type='bool', default=True),
             jump_rule_chain=dict(required=False, default='INPUT'),
             protocol=dict(required=False, choices=['tcp', 'udp']),
-            port=dict(required=False, type='int'),
+            port=dict(required=False, type='str'),
             ip_version=dict(required=False, default='ipv4',
                             choices=['ipv4', 'ipv6']),
         ),


### PR DESCRIPTION
Sets the appropriate config field if openshift_node_port_range is set
and also configures filewalls on each node.  firewalld already supports
port ranges like "30000-32000", while iptables needs that value
converted to the correct "30000:32000" form for use with `--dport`.

If not set, no node ports are opened.

Backports #3096, #3060