### PR TITLE
Implement simple hooks pre/post master upgrade.

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -89,6 +89,21 @@ openshift_release=v1.4
 # Skip upgrading Docker during an OpenShift upgrade, leaves the current Docker version alone.
 # docker_upgrade=False
 
+
+# Upgrade Hooks
+#
+# Hooks are available to run custom tasks at various points during a cluster
+# upgrade. Each hook should point to a file with Ansible tasks defined. Suggest using
+# absolute paths, if not the path will be treated as relative to the file where the
+# hook is actually used.
+#
+# Tasks to run before each master is upgraded:
+# openshift_upgrade_pre_master_hook=/usr/share/custom/pre_master.yml
+#
+# Tasks to run after each master is upgraded:
+# openshift_upgrade_post_master_hook=/usr/share/custom/post_master.yml
+
+
 # Alternate image format string, useful if you've got your own registry mirror
 #oreg_url=example.com/openshift3/ose-${component}:${version}
 # If oreg_url points to a registry other than registry.access.redhat.com we can

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -97,11 +97,15 @@ openshift_release=v1.4
 # absolute paths, if not the path will be treated as relative to the file where the
 # hook is actually used.
 #
-# Tasks to run before each master is upgraded:
-# openshift_upgrade_pre_master_hook=/usr/share/custom/pre_master.yml
+# Tasks to run before each master is upgraded.
+# openshift_master_upgrade_pre_hook=/usr/share/custom/pre_master.yml
 #
-# Tasks to run after each master is upgraded:
-# openshift_upgrade_post_master_hook=/usr/share/custom/post_master.yml
+# Tasks to run to upgrade the master. These tasks run after the main openshift-ansible
+# upgrade steps, but before we restart system/services.
+# openshift_master_upgrade_hook=/usr/share/custom/master.yml
+#
+# Tasks to run after each master is upgraded and system/services have been restarted.
+# openshift_master_upgrade_post_hook=/usr/share/custom/post_master.yml
 
 
 # Alternate image format string, useful if you've got your own registry mirror

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -89,6 +89,21 @@ openshift_release=v3.4
 # Skip upgrading Docker during an OpenShift upgrade, leaves the current Docker version alone.
 # docker_upgrade=False
 
+
+# Upgrade Hooks
+#
+# Hooks are available to run custom tasks at various points during a cluster
+# upgrade. Each hook should point to a file with Ansible tasks defined. Suggest using
+# absolute paths, if not the path will be treated as relative to the file where the
+# hook is actually used.
+#
+# Tasks to run before each master is upgraded:
+# openshift_upgrade_pre_master_hook=/usr/share/custom/pre_master.yml
+#
+# Tasks to run after each master is upgraded:
+# openshift_upgrade_post_master_hook=/usr/share/custom/post_master.yml
+
+
 # Alternate image format string, useful if you've got your own registry mirror
 #oreg_url=example.com/openshift3/ose-${component}:${version}
 # If oreg_url points to a registry other than registry.access.redhat.com we can

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -97,11 +97,15 @@ openshift_release=v3.4
 # absolute paths, if not the path will be treated as relative to the file where the
 # hook is actually used.
 #
-# Tasks to run before each master is upgraded:
-# openshift_upgrade_pre_master_hook=/usr/share/custom/pre_master.yml
+# Tasks to run before each master is upgraded.
+# openshift_master_upgrade_pre_hook=/usr/share/custom/pre_master.yml
 #
-# Tasks to run after each master is upgraded:
-# openshift_upgrade_post_master_hook=/usr/share/custom/post_master.yml
+# Tasks to run to upgrade the master. These tasks run after the main openshift-ansible
+# upgrade steps, but before we restart system/services.
+# openshift_master_upgrade_hook=/usr/share/custom/master.yml
+#
+# Tasks to run after each master is upgraded and system/services have been restarted.
+# openshift_master_upgrade_post_hook=/usr/share/custom/post_master.yml
 
 
 # Alternate image format string, useful if you've got your own registry mirror

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -108,14 +108,15 @@
       state: link
     when: ca_crt_stat.stat.isreg and not ca_bundle_stat.stat.exists
 
+  # NOTE: We run user provided hooks prior to restarting the system or services.
+  - include: "{{ openshift_upgrade_post_master_hook }}"
+    when: openshift_upgrade_post_master_hook is defined
+
   - include: ../../openshift-master/restart_hosts.yml
     when: openshift.common.rolling_restart_mode == 'system'
 
   - include: ../../openshift-master/restart_services.yml
     when: openshift.common.rolling_restart_mode == 'services'
-
-  - include: "{{ openshift_upgrade_post_master_hook }}"
-    when: openshift_upgrade_post_master_hook is defined
 
   - set_fact:
       master_update_complete: True

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -51,6 +51,8 @@
   roles:
   - openshift_master_facts
 
+# The main master upgrade play. Should handle all changes to the system in one pass, with
+# support for optional hooks to be defined.
 - name: Upgrade master
   hosts: oo_masters_to_config
   vars:
@@ -62,6 +64,10 @@
   roles:
   - openshift_facts
   post_tasks:
+
+  - include: "{{ openshift_upgrade_pre_master_hook }}"
+    when: openshift_upgrade_pre_master_hook is defined
+
   - include: rpm_upgrade.yml component=master
     when: not openshift.common.is_containerized | bool
 
@@ -107,6 +113,9 @@
 
   - include: ../../openshift-master/restart_services.yml
     when: openshift.common.rolling_restart_mode == 'services'
+
+  - include: "{{ openshift_upgrade_post_master_hook }}"
+    when: openshift_upgrade_post_master_hook is defined
 
   - set_fact:
       master_update_complete: True

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -65,6 +65,9 @@
   - openshift_facts
   post_tasks:
 
+  - debug: msg="Running pre-master upgrade hook {{ openshift_upgrade_pre_master_hook }}"
+    when: openshift_upgrade_pre_master_hook is defined
+
   - include: "{{ openshift_upgrade_pre_master_hook }}"
     when: openshift_upgrade_pre_master_hook is defined
 
@@ -109,6 +112,9 @@
     when: ca_crt_stat.stat.isreg and not ca_bundle_stat.stat.exists
 
   # NOTE: We run user provided hooks prior to restarting the system or services.
+  - debug: msg="Running post-master upgrade hook {{ openshift_upgrade_post_master_hook }}"
+    when: openshift_upgrade_post_master_hook is defined
+
   - include: "{{ openshift_upgrade_post_master_hook }}"
     when: openshift_upgrade_post_master_hook is defined
 

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -65,11 +65,12 @@
   - openshift_facts
   post_tasks:
 
-  - debug: msg="Running pre-master upgrade hook {{ openshift_upgrade_pre_master_hook }}"
-    when: openshift_upgrade_pre_master_hook is defined
+  # Run the pre-upgrade hook if defined:
+  - debug: msg="Running master pre-upgrade hook {{ openshift_master_upgrade_pre_hook }}"
+    when: openshift_master_upgrade_pre_hook is defined
 
-  - include: "{{ openshift_upgrade_pre_master_hook }}"
-    when: openshift_upgrade_pre_master_hook is defined
+  - include: "{{ openshift_master_upgrade_pre_hook }}"
+    when: openshift_master_upgrade_pre_hook is defined
 
   - include: rpm_upgrade.yml component=master
     when: not openshift.common.is_containerized | bool
@@ -111,18 +112,25 @@
       state: link
     when: ca_crt_stat.stat.isreg and not ca_bundle_stat.stat.exists
 
-  # NOTE: We run user provided hooks prior to restarting the system or services.
-  - debug: msg="Running post-master upgrade hook {{ openshift_upgrade_post_master_hook }}"
-    when: openshift_upgrade_post_master_hook is defined
+  # Run the upgrade hook prior to restarting services/system if defined:
+  - debug: msg="Running master upgrade hook {{ openshift_master_upgrade_hook }}"
+    when: openshift_master_upgrade_hook is defined
 
-  - include: "{{ openshift_upgrade_post_master_hook }}"
-    when: openshift_upgrade_post_master_hook is defined
+  - include: "{{ openshift_master_upgrade_hook }}"
+    when: openshift_master_upgrade_hook is defined
 
   - include: ../../openshift-master/restart_hosts.yml
     when: openshift.common.rolling_restart_mode == 'system'
 
   - include: ../../openshift-master/restart_services.yml
     when: openshift.common.rolling_restart_mode == 'services'
+
+  # Run the post-upgrade hook if defined:
+  - debug: msg="Running master post-upgrade hook {{ openshift_master_upgrade_post_hook }}"
+    when: openshift_master_upgrade_post_hook is defined
+
+  - include: "{{ openshift_master_upgrade_post_hook }}"
+    when: openshift_master_upgrade_post_hook is defined
 
   - set_fact:
       master_update_complete: True


### PR DESCRIPTION
Implement simple hook variables for pre-post master upgrade, if defined we'll include the referenced file. Absolute paths seems best, otherwise it needs to be relative to where the include is actually used. 

This will allow users/ops to do things like pull masters out of load balancers and put them back in, perform system updates, etc.