### PR TITLE
Add containzerized haproxy option

### DIFF
--- a/roles/openshift_loadbalancer/defaults/main.yml
+++ b/roles/openshift_loadbalancer/defaults/main.yml
@@ -2,7 +2,7 @@
 haproxy_frontends:
 - name: main
   binds:
-  - "*:8443"
+  - "*:{{ openshift_master_api_port | default(8443) }}"
   default_backend: default
 
 haproxy_backends:

--- a/roles/openshift_loadbalancer/tasks/main.yml
+++ b/roles/openshift_loadbalancer/tasks/main.yml
@@ -1,14 +1,31 @@
 ---
-- fail: msg="Cannot use containerized=true for load balancer hosts."
-  when: openshift.common.is_containerized | bool
-
 - name: Install haproxy
   package: name=haproxy state=present
+  when: not openshift.common.is_containerized | bool
+
+- name: Pull haproxy image
+  command: >
+    docker pull {{ openshift.common.router_image }}:{{ openshift_image_tag }}
+  when: openshift.common.is_containerized | bool
+
+- name: Create config directory for haproxy
+  file:
+    path: /etc/haproxy
+    state: directory
+  when: openshift.common.is_containerized | bool
+
+- name: Create the systemd unit files
+  template:
+    src: "haproxy.docker.service.j2"
+    dest: "{{ containerized_svc_dir }}/haproxy.service"
+  when: openshift.common.is_containerized | bool
+  notify: restart haproxy
 
 - name: Configure systemd service directory for haproxy
   file:
     path: /etc/systemd/system/haproxy.service.d
     state: directory
+  when: not openshift.common.is_containerized | bool
 
 # Work around ini_file create option in 2.2 which defaults to no
 - name: Create limits.conf file
@@ -19,6 +36,7 @@
     owner: root
     group: root
   changed_when: false
+  when: not openshift.common.is_containerized | bool
 
 - name: Configure the nofile limits for haproxy
   ini_file:
@@ -27,6 +45,7 @@
     option: LimitNOFILE
     value: "{{ openshift_loadbalancer_limit_nofile | default(100000) }}"
   notify: restart haproxy
+  when: not openshift.common.is_containerized | bool
 
 - name: Configure haproxy
   template:

--- a/roles/openshift_loadbalancer/templates/haproxy.docker.service.j2
+++ b/roles/openshift_loadbalancer/templates/haproxy.docker.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+After=docker.service
+Requires=docker.service
+PartOf=docker.service
+
+[Service]
+ExecStartPre=-/usr/bin/docker rm -f openshift_loadbalancer
+ExecStart=/usr/bin/docker run --rm --name openshift_loadbalancer -p {{ openshift_master_api_port | default(8443) }}:{{ openshift_master_api_port | default(8443) }} -v /etc/haproxy/haproxy.cfg:/etc/haproxy/haproxy.cfg:ro --entrypoint="haproxy -f /etc/haproxy/haproxy.cfg" {{ openshift.common.router_image }}:{{ openshift_image_tag }}
+ExecStartPost=/usr/bin/sleep 10
+ExecStop=/usr/bin/docker stop openshift_loadbalancer
+LimitNOFILE={{ openshift_loadbalancer_limit_nofile | default(100000) }}
+LimitCORE=infinity
+Restart=always
+RestartSec=5s
+
+[Install]
+WantedBy=docker.service


### PR DESCRIPTION
Add containerised option for the openshift_loadbalancer

Simply uses the official Docker haproxy image and passes the same config file to the container `-v /etc/haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro`