### PR TITLE
System containers

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -164,9 +164,12 @@
     - atomic-enterprise
     - origin
 
-  - shell: atomic uninstall openvswitch
+  - shell: atomic uninstall "{{ item }}"
     changed_when: False
     failed_when: False
+    with_items:
+    - etcd
+    - openvswitch
 
   - shell: find /var/lib/origin/openshift.local.volumes -type d -exec umount {} \; 2>/dev/null || true
     changed_when: False

--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -148,6 +148,26 @@
       - vovsbr
     when: "{{ openshift_remove_all | default(true) | bool }}"
 
+  - shell: atomic uninstall "{{ item }}"-master
+    changed_when: False
+    failed_when: False
+    with_items:
+    - openshift-enterprise
+    - atomic-enterprise
+    - origin
+
+  - shell: atomic uninstall "{{ item }}"-node
+    changed_when: False
+    failed_when: False
+    with_items:
+    - openshift-enterprise
+    - atomic-enterprise
+    - origin
+
+  - shell: atomic uninstall openvswitch
+    changed_when: False
+    failed_when: False
+
   - shell: find /var/lib/origin/openshift.local.volumes -type d -exec umount {} \; 2>/dev/null || true
     changed_when: False
 
@@ -262,6 +282,9 @@
     - /etc/systemd/system/origin-node.service.wants
     - /var/lib/atomic-enterprise
     - /var/lib/openshift
+
+  - shell: systemctl daemon-reload
+    changed_when: False
 
   - name: restart docker
     service: name=docker state=restarted

--- a/playbooks/common/openshift-cluster/upgrades/etcd/backup.yml
+++ b/playbooks/common/openshift-cluster/upgrades/etcd/backup.yml
@@ -4,7 +4,7 @@
   vars:
     embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
     timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
-    etcdctl_command: "{{ 'etcdctl' if not openshift.common.is_containerized or embedded_etcd else 'docker exec etcd_container etcdctl' }}"
+    etcdctl_command: "{{ 'etcdctl' if not openshift.common.is_containerized or embedded_etcd else 'docker exec etcd_container etcdctl' if not openshift.common.is_etcd_system_container else 'runc exec etcd etcdctl' }}"
   roles:
   - openshift_facts
   tasks:

--- a/playbooks/common/openshift-cluster/upgrades/etcd/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/etcd/upgrade.yml
@@ -14,6 +14,16 @@
     register: etcd_container_version
     failed_when: false
     when: openshift.common.is_containerized | bool
+  - name: Record containerized etcd version
+    command: docker exec etcd_container rpm -qa --qf '%{version}' etcd\*
+    register: etcd_container_version
+    failed_when: false
+    when: openshift.common.is_containerized | bool and not openshift.common.is_etcd_system_container | bool
+  - name: Record containerized etcd version
+    command: runc exec etcd_container rpm -qa --qf '%{version}' etcd\*
+    register: etcd_container_version
+    failed_when: false
+    when: openshift.common.is_containerized | bool and openshift.common.is_etcd_system_container | bool
 
 # I really dislike this copy/pasta but I wasn't able to find a way to get it to loop
 # through hosts, then loop through tasks only when appropriate

--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-etcd_service: "{{ 'etcd' if not etcd_is_containerized | bool else 'etcd_container' }}"
+etcd_service: "{{ 'etcd' if openshift.common.is_etcd_system_container | bool or not etcd_is_containerized | bool else 'etcd_container' }}"
 etcd_client_port: 2379
 etcd_peer_port: 2380
 etcd_url_scheme: http

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -14,13 +14,17 @@
   command: docker pull {{ openshift.etcd.etcd_image }}
   register: pull_result
   changed_when: "'Downloaded newer image' in pull_result.stdout"
-  when: etcd_is_containerized | bool
+  when:
+  - etcd_is_containerized | bool
+  - not openshift.common.is_etcd_system_container | bool
 
 - name: Install etcd container service file
   template:
     dest: "/etc/systemd/system/etcd_container.service"
     src: etcd.docker.service
-  when: etcd_is_containerized | bool
+  when:
+  - etcd_is_containerized | bool
+  - not openshift.common.is_etcd_system_container | bool
 
 - name: Ensure etcd datadir exists when containerized
   file:
@@ -36,9 +40,21 @@
     enabled: no
     masked: yes
     daemon_reload: yes
-  when: etcd_is_containerized | bool
+  when:
+  - etcd_is_containerized | bool
+  - not openshift.common.is_etcd_system_container | bool
   register: task_result
   failed_when: "task_result|failed and 'could not' not in task_result.msg|lower"
+
+- name: Install etcd container service file
+  template:
+    dest: "/etc/systemd/system/etcd_container.service"
+    src: etcd.docker.service
+  when: etcd_is_containerized | bool and not openshift.common.is_etcd_system_container | bool
+
+- name: Install Etcd system container
+  include: system_container.yml
+  when: etcd_is_containerized | bool and openshift.common.is_etcd_system_container | bool
 
 - name: Validate permissions on the config dir
   file:
@@ -54,7 +70,7 @@
     dest: /etc/etcd/etcd.conf
     backup: true
   notify:
-    - restart etcd
+  - restart etcd
 
 - name: Enable etcd
   systemd:

--- a/roles/etcd/tasks/system_container.yml
+++ b/roles/etcd/tasks/system_container.yml
@@ -1,0 +1,63 @@
+---
+- name: Pull etcd system container
+  command: atomic pull --storage=ostree {{ openshift.etcd.etcd_image }}
+  register: pull_result
+  changed_when: "'Pulling layer' in pull_result.stdout"
+
+- name: Check etcd system container package
+  command: >
+    atomic containers list --no-trunc -a -f container=etcd
+  register: result
+
+- name: Set initial Etcd cluster
+  set_fact:
+    etcd_initial_cluster: >
+      {% for host in etcd_peers | default([]) -%}
+      {% if loop.last -%}
+      {{ hostvars[host].etcd_hostname }}={{ etcd_peer_url_scheme }}://{{ hostvars[host].etcd_ip }}:{{ etcd_peer_port }}
+      {%- else -%}
+      {{ hostvars[host].etcd_hostname }}={{ etcd_peer_url_scheme }}://{{ hostvars[host].etcd_ip }}:{{ etcd_peer_port }},
+      {%- endif -%}
+      {% endfor -%}
+
+- name: Update Etcd system container package
+  command: >
+    atomic containers update
+    --set ETCD_LISTEN_PEER_URLS={{ etcd_listen_peer_urls }}
+    --set ETCD_NAME={{ etcd_hostname }}
+    --set ETCD_INITIAL_CLUSTER={{ etcd_initial_cluster | replace('\n', '') }}
+    --set ETCD_LISTEN_CLIENT_URLS={{ etcd_listen_client_urls }}
+    --set ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_initial_advertise_peer_urls }}
+    --set ETCD_INITIAL_CLUSTER_STATE={{ etcd_initial_cluster_state }}
+    --set ETCD_INITIAL_CLUSTER_TOKEN={{ etcd_initial_cluster_token }}
+    --set ETCD_ADVERTISE_CLIENT_URLS={{ etcd_advertise_client_urls }}
+    --set ETCD_CA_FILE={{ etcd_system_container_conf_dir }}/ca.crt
+    --set ETCD_CERT_FILE={{ etcd_system_container_conf_dir }}/server.crt
+    --set ETCD_KEY_FILE={{ etcd_system_container_conf_dir }}/server.key
+    --set ETCD_PEER_CA_FILE={{ etcd_system_container_conf_dir }}/ca.crt
+    --set ETCD_PEER_CERT_FILE={{ etcd_system_container_conf_dir }}/peer.crt
+    --set ETCD_PEER_KEY_FILE={{ etcd_system_container_conf_dir }}/peer.key
+    etcd
+  when:
+  - ("etcd" in result.stdout)
+
+- name: Install Etcd system container package
+  command: >
+    atomic install --system --name=etcd
+    --set ETCD_LISTEN_PEER_URLS={{ etcd_listen_peer_urls }}
+    --set ETCD_NAME={{ etcd_hostname }}
+    --set ETCD_INITIAL_CLUSTER={{ etcd_initial_cluster | replace('\n', '') }}
+    --set ETCD_LISTEN_CLIENT_URLS={{ etcd_listen_client_urls }}
+    --set ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_initial_advertise_peer_urls }}
+    --set ETCD_INITIAL_CLUSTER_STATE={{ etcd_initial_cluster_state }}
+    --set ETCD_INITIAL_CLUSTER_TOKEN={{ etcd_initial_cluster_token }}
+    --set ETCD_ADVERTISE_CLIENT_URLS={{ etcd_advertise_client_urls }}
+    --set ETCD_CA_FILE={{ etcd_system_container_conf_dir }}/ca.crt
+    --set ETCD_CERT_FILE={{ etcd_system_container_conf_dir }}/server.crt
+    --set ETCD_KEY_FILE={{ etcd_system_container_conf_dir }}/server.key
+    --set ETCD_PEER_CA_FILE={{ etcd_system_container_conf_dir }}/ca.crt
+    --set ETCD_PEER_CERT_FILE={{ etcd_system_container_conf_dir }}/peer.crt
+    --set ETCD_PEER_KEY_FILE={{ etcd_system_container_conf_dir }}/peer.key
+    {{ openshift.etcd.etcd_image }}
+  when:
+  - ("etcd" not in result.stdout)

--- a/roles/etcd_common/defaults/main.yml
+++ b/roles/etcd_common/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # etcd server vars
-etcd_conf_dir: /etc/etcd
+etcd_conf_dir: "{{ '/etc/etcd' if not openshift.common.is_etcd_system_container else '/var/lib/etcd/etcd.etcd/etc'  }}"
+etcd_system_container_conf_dir: /var/lib/etcd/etc
 etcd_ca_file: "{{ etcd_conf_dir }}/ca.crt"
 etcd_cert_file: "{{ etcd_conf_dir }}/server.crt"
 etcd_key_file: "{{ etcd_conf_dir }}/server.key"

--- a/roles/openshift_etcd_facts/vars/main.yml
+++ b/roles/openshift_etcd_facts/vars/main.yml
@@ -5,6 +5,6 @@ etcd_hostname: "{{ openshift.common.hostname }}"
 etcd_ip: "{{ openshift.common.ip }}"
 etcd_cert_subdir: "etcd-{{ openshift.common.hostname }}"
 etcd_cert_prefix:
-etcd_cert_config_dir: /etc/etcd
+etcd_cert_config_dir: "{{ '/etc/etcd' if not openshift.common.is_etcd_system_container | bool else '/var/lib/etcd/etcd.etcd/etc' }}"
 etcd_peer_url_scheme: https
 etcd_url_scheme: https

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+use_system_containers: false

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1785,11 +1785,14 @@ def set_container_facts_if_unset(facts):
         facts['etcd']['etcd_image'] = etcd_image
     if 'master' in facts and 'master_image' not in facts['master']:
         facts['master']['master_image'] = master_image
+        facts['master']['master_system_image'] = master_image
     if 'node' in facts:
         if 'node_image' not in facts['node']:
             facts['node']['node_image'] = node_image
+            facts['node']['node_system_image'] = node_image
         if 'ovs_image' not in facts['node']:
             facts['node']['ovs_image'] = ovs_image
+            facts['node']['ovs_system_image'] = ovs_image
 
     if safe_get_bool(facts['common']['is_containerized']):
         facts['common']['admin_binary'] = '/usr/local/bin/oadm'

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -9,6 +9,9 @@
     l_is_atomic: "{{ ostree_booted.stat.exists }}"
 - set_fact:
     l_is_containerized: "{{ (l_is_atomic | bool) or (containerized | default(false) | bool) }}"
+    l_is_openvswitch_system_container: "{{ (use_openvswitch_system_container | default(use_system_containers) | bool) }}"
+    l_is_node_system_container: "{{ (use_node_system_container | default(use_system_containers) | bool) }}"
+    l_is_master_system_container: "{{ (use_master_system_container | default(use_system_containers) | bool) }}"
 
 - name: Ensure various deps are installed
   package: name={{ item }} state=present
@@ -27,6 +30,10 @@
       hostname: "{{ openshift_hostname | default(None) }}"
       ip: "{{ openshift_ip | default(None) }}"
       is_containerized: "{{ l_is_containerized | default(None) }}"
+      is_openvswitch_system_container: "{{ l_is_openvswitch_system_container | default(false) }}"
+      is_node_system_container: "{{ l_is_node_system_container | default(false) }}"
+      is_master_system_container: "{{ l_is_master_system_container | default(false) }}"
+      system_images_registry: "{{ system_images_registry | default('') }}"
       public_hostname: "{{ openshift_public_hostname | default(None) }}"
       public_ip: "{{ openshift_public_ip | default(None) }}"
       portal_net: "{{ openshift_portal_net | default(openshift_master_portal_net) | default(None) }}"

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -12,6 +12,7 @@
     l_is_openvswitch_system_container: "{{ (use_openvswitch_system_container | default(use_system_containers) | bool) }}"
     l_is_node_system_container: "{{ (use_node_system_container | default(use_system_containers) | bool) }}"
     l_is_master_system_container: "{{ (use_master_system_container | default(use_system_containers) | bool) }}"
+    l_is_etcd_system_container: "{{ (use_etcd_system_container | default(use_system_containers) | bool) }}"
 
 - name: Ensure various deps are installed
   package: name={{ item }} state=present
@@ -33,6 +34,7 @@
       is_openvswitch_system_container: "{{ l_is_openvswitch_system_container | default(false) }}"
       is_node_system_container: "{{ l_is_node_system_container | default(false) }}"
       is_master_system_container: "{{ l_is_master_system_container | default(false) }}"
+      is_etcd_system_container: "{{ l_is_etcd_system_container | default(false) }}"
       system_images_registry: "{{ system_images_registry | default('') }}"
       public_hostname: "{{ openshift_public_hostname | default(None) }}"
       public_ip: "{{ openshift_public_ip | default(None) }}"

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -131,6 +131,10 @@
 - name: Install the systemd units
   include: systemd_units.yml
 
+- name: Install Master system container
+  include: system_container.yml
+  when: openshift.common.is_containerized | bool and openshift.common.is_master_system_container | bool
+
 - name: Create session secrets file
   template:
     dest: "{{ openshift.master.session_secrets_file }}"

--- a/roles/openshift_master/tasks/system_container.yml
+++ b/roles/openshift_master/tasks/system_container.yml
@@ -5,13 +5,32 @@
   register: pull_result
   changed_when: "'Pulling layer' in pull_result.stdout"
 
+- name: Check Master system container package
+  command: >
+    atomic containers list --no-trunc -a -f container={{ openshift.common.service_type }}-master
+  register: result
+
+- name: Update Master system container package
+  command: >
+    atomic containers update {{ openshift.common.service_type }}-master
+  register: update_result
+  changed_when: "'Extracting' in update_result.stdout"
+  when:
+    - ("master" in result.stdout)
+    - (openshift.common.version is defined) and (openshift.common.version == openshift_version) | bool
+
 - name: Uninstall Master system container package
   command: >
     atomic uninstall {{ openshift.common.service_type }}-master
   failed_when: False
-  when: openshift.common.version != openshift_version
+  when:
+    - ("master" in result.stdout)
+    - (openshift.common.version is not defined) or (openshift.common.version != openshift_version) | bool
 
 - name: Install Master system container package
   command: >
     atomic install --system --name={{ openshift.common.service_type }}-master {{ openshift.common.system_images_registry }}/{{ openshift.master.master_system_image }}:{{ openshift_image_tag }}
-  when: openshift.common.version != openshift_version
+  when:
+    - (openshift.common.version is not defined) or (openshift.common.version != openshift_version) or ("master" not in result.stdout) | bool
+  notify:
+    - restart master

--- a/roles/openshift_master/tasks/system_container.yml
+++ b/roles/openshift_master/tasks/system_container.yml
@@ -1,0 +1,17 @@
+---
+- name: Pre-pull master system container image
+  command: >
+    atomic pull --storage=ostree {{ openshift.common.system_images_registry }}/{{ openshift.master.master_system_image }}:{{ openshift_image_tag }}
+  register: pull_result
+  changed_when: "'Pulling layer' in pull_result.stdout"
+
+- name: Uninstall Master system container package
+  command: >
+    atomic uninstall {{ openshift.common.service_type }}-master
+  failed_when: False
+  when: openshift.common.version != openshift_version
+
+- name: Install Master system container package
+  command: >
+    atomic install --system --name={{ openshift.common.service_type }}-master {{ openshift.common.system_images_registry }}/{{ openshift.master.master_system_image }}:{{ openshift_image_tag }}
+  when: openshift.common.version != openshift_version

--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -20,14 +20,14 @@
     docker pull {{ openshift.master.master_image }}:{{ openshift_image_tag }}
   register: pull_result
   changed_when: "'Downloaded newer image' in pull_result.stdout"
-  when: openshift.common.is_containerized | bool
+  when: openshift.common.is_containerized | bool and not openshift.common.is_master_system_container | bool
 
 # workaround for missing systemd unit files
 - name: Create the systemd unit files
   template:
     src: "master_docker/master.docker.service.j2"
     dest: "{{ containerized_svc_dir }}/{{ openshift.common.service_type }}-master.service"
-  when: openshift.common.is_containerized | bool and (openshift.master.ha is not defined or not openshift.master.ha | bool)
+  when: openshift.common.is_containerized | bool and (openshift.master.ha is not defined or not openshift.master.ha | bool and not openshift.common.is_master_system_container | bool)
   register: create_master_unit_file
 
 - command: systemctl daemon-reload
@@ -132,7 +132,7 @@
     dest: "/etc/systemd/system/{{ openshift.common.service_type }}-master.service"
     src: master_docker/master.docker.service.j2
   register: install_result
-  when: openshift.common.is_containerized | bool and openshift.master.ha is defined and not openshift.master.ha | bool
+  when: openshift.common.is_containerized | bool and openshift.master.ha is defined and not openshift.master.ha | bool and not openshift.common.is_master_system_container | bool
 
 - name: Preserve Master Proxy Config options
   command: grep PROXY /etc/sysconfig/{{ openshift.common.service_type }}-master

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -69,7 +69,7 @@
 - name: Persist net.ipv4.ip_forward sysctl entry
   sysctl: name="net.ipv4.ip_forward" value=1 sysctl_set=yes state=present reload=yes
 
-- name: Start and enable openvswitch docker service
+- name: Start and enable openvswitch service
   systemd:
     name: openvswitch.service
     enabled: yes

--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -1,0 +1,19 @@
+---
+- name: Pre-pull node system container image
+  command: >
+    atomic pull --storage=ostree {{ openshift.common.system_images_registry }}/{{ openshift.node.node_system_image }}:{{ openshift_image_tag }}
+  register: pull_result
+  changed_when: "'Pulling layer' in pull_result.stdout"
+
+- name: Uninstall Node system container package
+  command: >
+    atomic uninstall {{ openshift.common.service_type }}-node
+  failed_when: False
+  when: openshift.common.version != openshift_version | bool
+
+- name: Install Node system container package
+  command: >
+    atomic install --system --name={{ openshift.common.service_type }}-node {{ openshift.common.system_images_registry }}/{{ openshift.node.node_system_image }}:{{ openshift_image_tag }}
+  register: install_node_result
+  changed_when: "'Extracting' in pull_result.stdout"
+  when: openshift.common.version != openshift_version | bool

--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -5,15 +5,30 @@
   register: pull_result
   changed_when: "'Pulling layer' in pull_result.stdout"
 
+- name: Check Node system container package
+  command: >
+    atomic containers list --no-trunc -a -f container={{ openshift.common.service_type }}-node
+  register: result
+
+- name: Update Node system container package
+  command: >
+    atomic containers update {{ openshift.common.service_type }}-node
+  register: update_result
+  changed_when: "'Extracting' in update_result.stdout"
+  when:
+  - (openshift.common.version is defined) and (openshift.common.version == openshift_version) and ("node" in result.stdout) | bool
+
 - name: Uninstall Node system container package
   command: >
     atomic uninstall {{ openshift.common.service_type }}-node
   failed_when: False
-  when: openshift.common.version != openshift_version | bool
+  when:
+  - (openshift.common.version is not defined) or (openshift.common.version != openshift_version) and ("node" in result.stdout) | bool
 
 - name: Install Node system container package
   command: >
     atomic install --system --name={{ openshift.common.service_type }}-node {{ openshift.common.system_images_registry }}/{{ openshift.node.node_system_image }}:{{ openshift_image_tag }}
   register: install_node_result
   changed_when: "'Extracting' in pull_result.stdout"
-  when: openshift.common.version != openshift_version | bool
+  when:
+  - (openshift.common.version is not defined) or (openshift.common.version != openshift_version) or ("node" not in result.stdout) | bool

--- a/roles/openshift_node/tasks/openvswitch_system_container.yml
+++ b/roles/openshift_node/tasks/openvswitch_system_container.yml
@@ -5,15 +5,32 @@
   register: pull_result
   changed_when: "'Pulling layer' in pull_result.stdout"
 
+- name: Check OpenvSwitch system container package
+  command: >
+    atomic containers list --no-trunc -a -f container=openvswitch
+  register: result
+  when:
+  - openshift.common.is_openvswitch_system_container | bool
+
+- name: Update OpenvSwitch system container package
+  command: >
+    atomic containers update openvswitch
+  register: update_result
+  changed_when: "'Extracting' in update_result.stdout"
+  when:
+  - (openshift.common.version is defined) and (openshift.common.version == openshift_version) and ("openvswitch" in result.stdout) | bool
+
 - name: Uninstall OpenvSwitch system container package
   command: >
     atomic uninstall openvswitch
   failed_when: False
-  when: openshift.common.version != openshift_version | bool
+  when:
+  - (openshift.common.version is not defined) or (openshift.common.version != openshift_version) and ("openvswitch" in result.stdout) | bool
 
 - name: Install OpenvSwitch system container package
   command: >
     atomic install --system --name=openvswitch {{ openshift.common.system_images_registry }}/{{ openshift.node.ovs_system_image }}:{{ openshift_image_tag }}
-  when: openshift.common.version != openshift_version | bool
+  when:
+  - (openshift.common.version is not defined) or (openshift.common.version != openshift_version) or ("openvswitch" not in result.stdout) | bool
   notify:
-    - restart docker
+  - restart docker

--- a/roles/openshift_node/tasks/openvswitch_system_container.yml
+++ b/roles/openshift_node/tasks/openvswitch_system_container.yml
@@ -1,0 +1,19 @@
+---
+- name: Pre-pull OpenVSwitch system container image
+  command: >
+    atomic pull --storage=ostree {{ openshift.common.system_images_registry }}/{{ openshift.node.ovs_system_image }}:{{ openshift_image_tag }}
+  register: pull_result
+  changed_when: "'Pulling layer' in pull_result.stdout"
+
+- name: Uninstall OpenvSwitch system container package
+  command: >
+    atomic uninstall openvswitch
+  failed_when: False
+  when: openshift.common.version != openshift_version | bool
+
+- name: Install OpenvSwitch system container package
+  command: >
+    atomic install --system --name=openvswitch {{ openshift.common.system_images_registry }}/{{ openshift.node.ovs_system_image }}:{{ openshift_image_tag }}
+  when: openshift.common.version != openshift_version | bool
+  notify:
+    - restart docker

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -2,20 +2,6 @@
 # This file is included both in the openshift_master role and in the upgrade
 # playbooks.
 
-- name: Pre-pull node image
-  command: >
-    docker pull {{ openshift.node.node_image }}:{{ openshift_image_tag }}
-  register: pull_result
-  changed_when: "'Downloaded newer image' in pull_result.stdout"
-  when: openshift.common.is_containerized | bool and not openshift.common.is_node_system_container | bool
-
-- name: Pre-pull openvswitch image
-  command: >
-    docker pull {{ openshift.node.ovs_image }}:{{ openshift_image_tag }}
-  register: pull_result
-  changed_when: "'Downloaded newer image' in pull_result.stdout"
-  when: openshift.common.is_containerized | bool and openshift.common.use_openshift_sdn | bool and not openshift.common.is_node_system_container | bool
-
 - name: Install Node dependencies docker service file
   template:
     dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node-dep.service"
@@ -23,11 +9,18 @@
   register: install_node_dep_result
   when: openshift.common.is_containerized | bool
 
-- name: Install Node docker service file
-  template:
-    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
-    src: openshift.docker.node.service
-  register: install_node_result
+- block:
+  - name: Pre-pull node image
+    command: >
+      docker pull {{ openshift.node.node_image }}:{{ openshift_image_tag }}
+    register: pull_result
+    changed_when: "'Downloaded newer image' in pull_result.stdout"
+
+  - name: Install Node docker service file
+    template:
+      dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
+      src: openshift.docker.node.service
+    register: install_node_result
   when:
   - openshift.common.is_containerized | bool
   - not openshift.common.is_node_system_container | bool
@@ -69,16 +62,23 @@
   notify:
   - restart openvswitch
 
-- name: Install OpenvSwitch docker service file
-  template:
-    dest: "/etc/systemd/system/openvswitch.service"
-    src: openvswitch.docker.service
+- block:
+  - name: Pre-pull openvswitch image
+    command: >
+      docker pull {{ openshift.node.ovs_image }}:{{ openshift_image_tag }}
+    register: pull_result
+    changed_when: "'Downloaded newer image' in pull_result.stdout"
+
+  - name: Install OpenvSwitch docker service file
+    template:
+      dest: "/etc/systemd/system/openvswitch.service"
+      src: openvswitch.docker.service
+    notify:
+    - restart openvswitch
   when:
   - openshift.common.is_containerized | bool
   - openshift.common.use_openshift_sdn | default(true) | bool
   - not openshift.common.is_openvswitch_system_container | bool
-  notify:
-  - restart openvswitch
 
 - name: Configure Node settings
   lineinfile:

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -7,14 +7,14 @@
     docker pull {{ openshift.node.node_image }}:{{ openshift_image_tag }}
   register: pull_result
   changed_when: "'Downloaded newer image' in pull_result.stdout"
-  when: openshift.common.is_containerized | bool
+  when: openshift.common.is_containerized | bool and not openshift.common.is_node_system_container | bool
 
 - name: Pre-pull openvswitch image
   command: >
     docker pull {{ openshift.node.ovs_image }}:{{ openshift_image_tag }}
   register: pull_result
   changed_when: "'Downloaded newer image' in pull_result.stdout"
-  when: openshift.common.is_containerized | bool and openshift.common.use_openshift_sdn | bool
+  when: openshift.common.is_containerized | bool and openshift.common.use_openshift_sdn | bool and not openshift.common.is_node_system_container | bool
 
 - name: Install Node dependencies docker service file
   template:
@@ -28,7 +28,9 @@
     dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
     src: openshift.docker.node.service
   register: install_node_result
-  when: openshift.common.is_containerized | bool
+  when:
+  - openshift.common.is_containerized | bool
+  - not openshift.common.is_node_system_container | bool
 
 - name: Create the openvswitch service env file
   template:
@@ -38,6 +40,19 @@
   register: install_ovs_sysconfig
   notify:
   - restart openvswitch
+
+- name: Install Node system container
+  include: node_system_container.yml
+  when:
+  - openshift.common.is_containerized | bool
+  - openshift.common.is_node_system_container | bool
+
+- name: Install OpenvSwitch system containers
+  include: openvswitch_system_container.yml
+  when:
+  - openshift.common.use_openshift_sdn | default(true) | bool
+  - openshift.common.is_containerized | bool
+  - openshift.common.is_openvswitch_system_container | bool
 
 # May be a temporary workaround.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1331590
@@ -58,7 +73,10 @@
   template:
     dest: "/etc/systemd/system/openvswitch.service"
     src: openvswitch.docker.service
-  when: openshift.common.is_containerized | bool and openshift.common.use_openshift_sdn | default(true) | bool
+  when:
+  - openshift.common.is_containerized | bool
+  - openshift.common.use_openshift_sdn | default(true) | bool
+  - not openshift.common.is_openvswitch_system_container | bool
   notify:
   - restart openvswitch
 


### PR DESCRIPTION
I am submitting these patches just to get some early feedbacks.

First of all, some custom images must be created to install OpenShift as system container:

https://github.com/giuseppe/atomic-openshift-system-containers

This is the command I am using for creating these images, where `localhost:5000` is a Docker registry running on my machine.

`$ SRC_REGISTRY=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888 sudo -E ./generate_images.sh localhost:5000`

Once these images are built, which are just the original images for ose, node and openvswitch, I add the system container configuration files for running in a runc container.
Once these files get into the official builds, we don't need this step anymore (which is quite annoying).

For installing the system containers I am using this inventory file:
```
[OSEv3:children]
masters
nodes
etcd

[OSEv3:vars]

ansible_ssh_user=cloud-user
ansible_become=yes
deployment_type=openshift-enterprise

#openshift_docker_additional_registries=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888
#openshift_docker_insecure_registries=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888
openshift_use_dnsmasq=False

deployment_type=openshift-enterprise
#deployment_subtype=registry
#deployment_type=origin

openshift_router_selector='router=true'
openshift_registry_selector='registry=true'

openshift_image_tag=v3.3.0.26

openshift_master_default_subdomain=localorigin.io

openshift_docker_additional_registries=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888
openshift_docker_insecure_registries=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888

######SYSTEM CONTAINERS#######################################
system_images_registry=192.168.125.1:5000  # Docker registry with the custom images
use_system_containers=True
#use_openvswitch_system_container=True
#use_node_system_container=True
#use_master_system_container=True
##########################################################

registry_url=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888

containerized=True
openshift_uninstall_images=False

# enable htpasswd auth
openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
openshift_master_htpasswd_users={'admin': '$apr1$zgSjCrLt$1KSuj66CggeWSv.D.BXOA1', 'user': '$apr1$.gw8w9i1$ln9bfTRiD6OwuNTG5LvW50'}

# host group for masters
[masters]
192.168.125.89 openshift_schedulable=true 

[etcd]
192.168.125.89

# host group for nodes
[nodes]
192.168.125.89  openshift_schedulable=true openshift_node_labels="{'router':'true','registry':'true'}"
```

Is it possible to switch single components to be system containers.  `use_system_containers=True` will use system containers for any component supported.

The idempotent update is left to "atomic update --containers (atomic containers update in the upstream version)" that reinstall the container only when a different IMAGE ID is available, so if a container is rebuilt this will trigger the update.

An uninstall/install is done when the version is different or the container is not installed.