### PR TITLE
More reliable wait for master after full host reboot.

### DIFF
--- a/playbooks/common/openshift-master/restart_hosts.yml
+++ b/playbooks/common/openshift-master/restart_hosts.yml
@@ -7,12 +7,19 @@
   ignore_errors: true
   become: yes
 
-# Ensure the api_port is available.
-- name: Wait for master API to come back online
-  become: no
+- name: Wait for master to restart
   local_action:
     module: wait_for
-      host="{{ openshift.common.hostname }}"
+      host="{{ inventory_hostname }}"
       state=started
       delay=10
-      port="{{ openshift.master.api_port }}"
+  become: no
+
+# Now that ssh is back up we can wait for API on the remote system,
+# avoiding some potential connection issues from local system:
+- name: Wait for master API to come back online
+  wait_for:
+    host: "{{ openshift.common.hostname }}"
+    state: started
+    delay: 10
+    port: "{{ openshift.master.api_port }}"


### PR DESCRIPTION
This would fail in some environments where openshift.common.hostname was
not reachable from the local system running ansible. Additionally it is
also possible the API port would not be available even if the host were.

Instead we wait for master ssh connection to come back up, then wait for
the master API on the remote host just as we do for the "service" style
restart.