### PR TITLE
Added tar as a requirement per BZ1388445

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -16,6 +16,7 @@ BuildArch:      noarch
 Requires:      ansible >= 2.2.0.0-1
 Requires:      python2
 Requires:      python-six
+Requires:      tar
 Requires:      openshift-ansible-docs = %{version}-%{release}
 
 %description


### PR DESCRIPTION
```
$ rpmlint --version
rpmlint version 1.9 Copyright (C) 1999-2007 Frederic Lepied, Mandriva
$ sha1sum openshift-ansible.spec 
cc6a220819818c55bd90acb0c30b87aac0464aec  openshift-ansible.spec
$ rpmlint openshift-ansible.spec
openshift-ansible.spec:1: W: macro-in-comment %commit
openshift-ansible.spec: W: invalid-url Source0: https://github.com/openshift/openshift-ansible/archive/c64d09e528ca433832c6b6e6f5c7734a9cc8ee6f/openshift-ansible-3.5.1.tar.gz HTTP Error 404: Not Found
0 packages and 1 specfiles checked; 0 errors, 2 warnings.
```