### PR TITLE
Cleaning repo cache earlier when upgrading

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade.yml
@@ -6,8 +6,8 @@
   tags:
   - pre_upgrade
 
-# Configure the upgrade target for the common upgrade tasks:
-- hosts: l_oo_all_hosts
+- name: Configure the upgrade target for the common upgrade tasks
+  hosts: l_oo_all_hosts
   tags:
   - pre_upgrade
   tasks:

--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Create l_oo_all_hosts group
+  hosts: localhost
   connection: local
   become: no
   gather_facts: no
@@ -10,7 +11,8 @@
       groups: l_oo_all_hosts
     with_items: "{{ g_all_hosts | default([]) }}"
 
-- hosts: l_oo_all_hosts
+- name: Include g_*_hosts vars for hosts in group l_oo_all_hosts
+  hosts: l_oo_all_hosts
   gather_facts: no
   tasks:
   - include_vars: ../../../byo/openshift-cluster/cluster_hosts.yml
@@ -46,3 +48,14 @@
     when: openshift_docker_log_options is not defined
 
 - include: ../initialize_facts.yml
+
+- name: Ensure clean repo cache in the event repos have been changed manually
+  hosts: oo_all_hosts
+  tags:
+  - pre_upgrade
+  tasks:
+  - name: Clean package cache
+    command: "{{ ansible_pkg_mgr }} clean all"
+    when: not openshift.common.is_atomic | bool
+    args:
+      warn: no

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -12,10 +12,6 @@
       msg: Verify the correct version was found
     when: verify_upgrade_version is defined and openshift_version != verify_upgrade_version
 
-  - name: Clean package cache
-    command: "{{ ansible_pkg_mgr }} clean all"
-    when: not openshift.common.is_atomic | bool
-
   - set_fact:
       g_new_service_name: "{{ 'origin' if deployment_type =='origin' else 'atomic-openshift' }}"
     when: not openshift.common.is_containerized | bool


### PR DESCRIPTION
When performing an upgrade, facts are set for the currently available version of OpenShift through repoquery.  However, if the repos have been changed manually, for instance to switch from 3.3 to 3.4 repos, and the repo cache was not manually cleaned, the fact would be set based on the repo cache.  A step was introduced previously to ensure all repo cache was clean, however the task was being run after the openshift_version fact was set.

This PR moves the task to clean repo cache early in execution to ensure the openshift_version fact is set according to what is actually available.  This PR was tested on a 3.3 to 3.4 upgrade.

Original Error:
```
TASK [openshift_version : fail] ************************************************
fatal: [ec2-54-208-186-136.compute-1.amazonaws.com]: FAILED! => {"changed": false, "failed": true, "msg": "Detected OpenShift version 3.3.1.9 does not match requested openshift_release 3.4. You may need to adjust your yum repositories, inventory, or run the appropriate OpenShift upgrade playbook."}
```
cc: @dgoodwin 