### PR TITLE
Use openshift.common.hostname when verifying API port available.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/docker/restart.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/restart.yml
@@ -19,11 +19,9 @@
   when: openshift.common.is_containerized | bool
 
 - name: Wait for master API to come back online
-  become: no
-  local_action:
-    module: wait_for
-      host="{{ inventory_hostname }}"
-      state=started
-      delay=10
-      port="{{ openshift.master.api_port }}"
+  wait_for:
+    host: "{{ openshift.common.hostname }}"
+    state: started
+    delay: 10
+    port: "{{ openshift.master.api_port }}"
   when: inventory_hostname in groups.oo_masters_to_config

--- a/playbooks/common/openshift-master/restart_services.yml
+++ b/playbooks/common/openshift-master/restart_services.yml
@@ -10,13 +10,11 @@
     state: restarted
   when: openshift_master_ha | bool and openshift.master.cluster_method != 'pacemaker'
 - name: Wait for master API to come back online
-  become: no
-  local_action:
-    module: wait_for
-      host="{{ openshift.common.hostname }}"
-      state=started
-      delay=10
-      port="{{ openshift.master.api_port }}"
+  wait_for:
+    host: "{{ openshift.common.hostname }}"
+    state: started
+    delay: 10
+    port: "{{ openshift.master.api_port }}"
   when: openshift_master_ha | bool and openshift.master.cluster_method != 'pacemaker'
 - name: Restart master controllers
   service:


### PR DESCRIPTION
$SSIA - inventory_hostname isn't guaranteed to be usable