### PR TITLE
Use openshift.common.hostname rather than inventory_hostname during upgrades

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/docker/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/upgrade.yml
@@ -56,11 +56,9 @@
   when: openshift.common.is_containerized | bool
 
 - name: Wait for master API to come back online
-  become: no
-  local_action:
-    module: wait_for
-      host="{{ inventory_hostname }}"
-      state=started
-      delay=10
-      port="{{ openshift.master.api_port }}"
+  wait_for:
+    host: "{{ openshift.common.hostname }}"
+    state: started
+    delay: 10
+    port:  "{{ openshift.master.api_port }}"
   when: inventory_hostname in groups.oo_masters_to_config


### PR DESCRIPTION
See also #3137

If a dynamic inventory is in use there's no guarantee that inventory_hostname is usable