### PR TITLE
g_master_mktemp in openshift-master conflicts with openshift_master_c…

### DIFF
--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -105,7 +105,7 @@
 
 - name: Create local temp directory for syncing certs
   local_action: command mktemp -d /tmp/openshift-ansible-XXXXXXX
-  register: g_master_mktemp
+  register: g_master_certs_mktemp
   changed_when: False
   when: master_certs_missing | bool
   delegate_to: localhost
@@ -123,7 +123,7 @@
 - name: Retrieve the master cert tarball from the master
   fetch:
     src: "{{ openshift_master_generated_config_dir }}.tgz"
-    dest: "{{ g_master_mktemp.stdout }}/"
+    dest: "{{ g_master_certs_mktemp.stdout }}/"
     flat: yes
     fail_on_missing: yes
     validate_checksum: yes
@@ -138,11 +138,11 @@
 
 - name: Unarchive the tarball on the master
   unarchive:
-    src: "{{ g_master_mktemp.stdout }}/{{ openshift_master_cert_subdir }}.tgz"
+    src: "{{ g_master_certs_mktemp.stdout }}/{{ openshift_master_cert_subdir }}.tgz"
     dest: "{{ openshift_master_config_dir }}"
   when: master_certs_missing | bool and inventory_hostname != openshift_ca_host
 
-- file: name={{ g_master_mktemp.stdout }} state=absent
+- file: name={{ g_master_certs_mktemp.stdout }} state=absent
   changed_when: False
   when: master_certs_missing | bool
   delegate_to: localhost


### PR DESCRIPTION
…ertificates

(cherry picked from commit 92d0897ff898822772106b6e8edf9a32afb9f4ca)