### PR TITLE
Apply openshift_node_dnsmasq after os_firewall in node deps

### DIFF
--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -17,8 +17,6 @@ dependencies:
 - role: openshift_docker
 - role: openshift_node_certificates
 - role: openshift_cloud_provider
-- role: openshift_node_dnsmasq
-  when: openshift.common.use_dnsmasq | bool
 - role: os_firewall
   os_firewall_allow:
   - service: Kubernetes kubelet
@@ -43,3 +41,5 @@ dependencies:
   - service: Kubernetes service NodePort UDP
     port: "{{ openshift_node_port_range | default('') }}/udp"
   when: openshift_node_port_range is defined
+- role: openshift_node_dnsmasq
+  when: openshift.common.use_dnsmasq | bool


### PR DESCRIPTION
Reorder node dnsmasq dependency s.t. networkmanager is restarted after firewall changes have been applied.
