### PR TITLE
Skip firewalld commands when is_containerized

### DIFF
--- a/roles/os_firewall/tasks/firewall/firewalld.yml
+++ b/roles/os_firewall/tasks/firewall/firewalld.yml
@@ -23,6 +23,7 @@
     masked: no
     daemon_reload: yes
   register: result
+  when: not openshift.common.is_containerized | bool
 
 - name: need to pause here, otherwise the firewalld service starting can sometimes cause ssh to fail
   pause: seconds=10
@@ -35,6 +36,7 @@
     immediate: true
     state: enabled
   with_items: "{{ os_firewall_allow }}"
+  when: not openshift.common.is_containerized | bool
 
 - name: Remove firewalld allow rules
   firewalld:
@@ -43,3 +45,4 @@
     immediate: true
     state: disabled
   with_items: "{{ os_firewall_deny }}"
+  when: not openshift.common.is_containerized | bool


### PR DESCRIPTION
When the system is setup for is_containerized to a value of true, then the deployment will fail due to missing firewalld dependency.