### PR TITLE
Fix containerized haproxy config

### DIFF
--- a/roles/openshift_loadbalancer/tasks/main.yml
+++ b/roles/openshift_loadbalancer/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Create the systemd unit files
   template:
     src: "haproxy.docker.service.j2"
-    dest: "{{ containerized_svc_dir }}/haproxy.service"
+    dest: "/etc/systemd/system/haproxy.service"
   when: openshift.common.is_containerized | bool
   notify: restart haproxy
 

--- a/roles/openshift_loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/openshift_loadbalancer/templates/haproxy.cfg.j2
@@ -1,16 +1,20 @@
 # Global settings
 #---------------------------------------------------------------------
 global
+    maxconn     {{ openshift_loadbalancer_global_maxconn | default(20000) }}
+    log         /dev/log local0 info
+{% if openshift.common.is_containerized | bool %}
+    stats socket /var/lib/haproxy/run/haproxy.sock mode 600 level admin
+{% else %}
     chroot      /var/lib/haproxy
     pidfile     /var/run/haproxy.pid
-    maxconn     {{ openshift_loadbalancer_global_maxconn | default(20000) }}
     user        haproxy
     group       haproxy
     daemon
-    log         /dev/log local0 info
 
     # turn on stats unix socket
     stats socket /var/lib/haproxy/stats
+{% endif %}
 
 #---------------------------------------------------------------------
 # common defaults that all the 'listen' and 'backend' sections will

--- a/roles/openshift_loadbalancer/templates/haproxy.docker.service.j2
+++ b/roles/openshift_loadbalancer/templates/haproxy.docker.service.j2
@@ -5,7 +5,7 @@ PartOf=docker.service
 
 [Service]
 ExecStartPre=-/usr/bin/docker rm -f openshift_loadbalancer
-ExecStart=/usr/bin/docker run --rm --name openshift_loadbalancer -p {{ openshift_master_api_port | default(8443) }}:{{ openshift_master_api_port | default(8443) }} -v /etc/haproxy/haproxy.cfg:/etc/haproxy/haproxy.cfg:ro --entrypoint="haproxy -f /etc/haproxy/haproxy.cfg" {{ openshift.common.router_image }}:{{ openshift_image_tag }}
+ExecStart=/usr/bin/docker run --rm --name openshift_loadbalancer -p {{ openshift_master_api_port | default(8443) }}:{{ openshift_master_api_port | default(8443) }} -v /etc/haproxy/haproxy.cfg:/etc/haproxy/haproxy.cfg:ro --entrypoint=haproxy {{ openshift.common.router_image }}:{{ openshift_image_tag }} -f /etc/haproxy/haproxy.cfg
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop openshift_loadbalancer
 LimitNOFILE={{ openshift_loadbalancer_limit_nofile | default(100000) }}


### PR DESCRIPTION
Follow up for #3106 

- Fixes haproxy config when using the router image
- Properly passes the config file as a parameter