### PR TITLE
Conditionally include metrics start/stop

### DIFF
--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -7,6 +7,7 @@
 - name: Create temp directory for all our templates
   file: path={{mktemp.stdout}}/templates state=directory mode=0755
   changed_when: False
+  when: "{{ openshift_metrics_install_metrics | bool }}"
 
 - name: Copy the admin client config(s)
   command: >
@@ -15,8 +16,4 @@
   check_mode: no
   tags: metrics_init
 
-- include: install_metrics.yaml
-  when: openshift_metrics_install_metrics | default(false) | bool
-
-- include: uninstall_metrics.yaml
-  when: not openshift_metrics_install_metrics | default(false) | bool
+- include: "{{ (openshift_metrics_install_metrics | bool) | ternary('install_metrics.yaml','uninstall_metrics.yaml') }}"


### PR DESCRIPTION
fix to BZ-1415447 stop heaster.  This PR:

* Modify main to conditionally include start/stop task based on install/uninstall of metrics.

Not really certain how the bug was generated other then I can guess ansible somehow did not properly evaluate the variable to a boolean.

cc @bbguimaraes @sdodson @detiber 