### PR TITLE
Bug 1415800 - Installer fails to add/check iptables rule due to lock on xtables.

### DIFF
--- a/roles/os_firewall/library/os_firewall_manage_iptables.py
+++ b/roles/os_firewall/library/os_firewall_manage_iptables.py
@@ -223,7 +223,9 @@ class IpTablesManager(object):  # pylint: disable=too-many-instance-attributes
 
     def gen_cmd(self):
         cmd = 'iptables' if self.ip_version == 'ipv4' else 'ip6tables'
-        return ["/usr/sbin/%s" % cmd]
+        # Include -w (wait for xtables lock) in default arguments.
+        default_args = '-w'
+        return ["/usr/sbin/%s %s" % (cmd, default_args)]
 
     def gen_save_cmd(self):  # pylint: disable=no-self-use
         return ['/usr/libexec/iptables/iptables.init', 'save']


### PR DESCRIPTION
Add `-w` to `os_firewall` iptables invocations to wait for the xtables lock.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1415800