### PR TITLE
WIP - Use hostvars.localhost.g_master_mktemp

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -151,5 +151,7 @@
   become: no
   gather_facts: no
   tasks:
-  - file: name={{ g_master_mktemp.stdout }} state=absent
+  - file:
+      path: "{{ hostvars.localhost.g_master_mktemp.stdout }}"
+      state: absent
     changed_when: False


### PR DESCRIPTION
Fixes an error when users have specified a host named localhost.

```
PLAY [Delete temporary directory on localhost] *********************************
 
TASK [file] ********************************************************************
fatal: [localhost]: FAILED! => {
    "failed": true
}
 
MSG:
 
the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'dict object' has no attribute 'stdout'
 
The error appears to have been in '/usr/share/ansible/openshift-ansible/playbooks/common/openshift-master/config.yml': line 195, column 5, but may
be elsewhere in the file depending on the exact syntax problem.
 
The offending line appears to be:
 
  tasks:
  - file: name={{ g_master_mktemp.stdout }} state=absent
    ^ here
We could be wrong, but this one looks like it might be an issue with
missing quotes.  Always quote template expression brackets when they
start a value. For instance:
 
    with_items:
      - {{ foo }}
 
Should be written as:
 
    with_items:
      - "{{ foo }}"
 
 
        to retry, use: --limit @/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/config.retry
 
PLAY RECAP *********************************************************************
localhost                  : ok=301  changed=78   unreachable=0    failed=1
```