### PR TITLE
Fix yaml representer error seen with ansible-2.2.1.0

### DIFF
--- a/filter_plugins/openshift_master.py
+++ b/filter_plugins/openshift_master.py
@@ -10,6 +10,7 @@ import sys
 from distutils.version import LooseVersion  # pylint: disable=no-name-in-module,import-error
 
 from ansible import errors
+from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.plugins.filter.core import to_bool as ansible_bool
 from six import string_types
 
@@ -485,7 +486,10 @@ class FilterModule(object):
             idp_list.append(idp_inst)
 
         IdentityProviderBase.validate_idp_list(idp_list, openshift_version, deployment_type)
-        return yaml.safe_dump([idp.to_dict() for idp in idp_list], default_flow_style=False)
+        return yaml.dump([idp.to_dict() for idp in idp_list],
+                         allow_unicode=True,
+                         default_flow_style=False,
+                         Dumper=AnsibleDumper)
 
     @staticmethod
     def validate_pcs_cluster(data, masters=None):


### PR DESCRIPTION
Make use of `AnsibleDumper` in `openshift_master` filters s.t. we can represent `AnsibleUnsafeText` when dumping yaml.

Fixes #3111

Requires https://github.com/ansible/ansible/commit/ec14572a60bd901bb52f80c2f0dbdaf1ada0eb8a