### PR TITLE
TEMPORARY work-around for flake8 vs maccabe version conflict

### DIFF
--- a/utils/test-requirements.txt
+++ b/utils/test-requirements.txt
@@ -13,3 +13,5 @@ pyOpenSSL
 yamllint
 tox
 detox
+# Temporary work-around for flake8 vs maccabe version conflict
+mccabe==0.5.3


### PR DESCRIPTION
Should allow (at least) #3142 and #3141 to get moving again