### PR TITLE
Remove is_containerized check for firewalld installs

### DIFF
--- a/roles/os_firewall/tasks/firewall/firewalld.yml
+++ b/roles/os_firewall/tasks/firewall/firewalld.yml
@@ -1,7 +1,8 @@
 ---
 - name: Install firewalld packages
-  package: name=firewalld state=present
-  when: not openshift.common.is_containerized | bool
+  package:
+    name: firewalld
+    state: present
 
 - name: Ensure iptables services are not enabled
   systemd:


### PR DESCRIPTION
Need to install firewalld on containerized deployments.