### PR TITLE
allow openshift_logging role to specify nodeSelectors

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -35,6 +35,7 @@ When both `openshift_logging_install_logging` and `openshift_logging_upgrade_log
 - `openshift_logging_curator_log_level`: The log level for the Curator process. Defaults to 'ERROR'.
 - `openshift_logging_curator_cpu_limit`: The amount of CPU to allocate to Curator. Default is '100m'.
 - `openshift_logging_curator_memory_limit`: The amount of memory to allocate to Curator. Unset if not specified.
+- `openshift_logging_curator_nodeselector`: A map of labels (e.g. {"node":"infra","region":"west"} to select the nodes where the curator pod will land.
 
 - `openshift_logging_kibana_hostname`: The Kibana hostname. Defaults to 'kibana.example.com'.
 - `openshift_logging_kibana_cpu_limit`: The amount of CPU to allocate to Kibana or unset if not specified.
@@ -43,6 +44,7 @@ When both `openshift_logging_install_logging` and `openshift_logging_upgrade_log
 - `openshift_logging_kibana_proxy_cpu_limit`: The amount of CPU to allocate to Kibana proxy or unset if not specified.
 - `openshift_logging_kibana_proxy_memory_limit`: The amount of memory to allocate to Kibana proxy or unset if not specified.
 - `openshift_logging_kibana_replica_count`: The number of replicas Kibana should be scaled up to. Defaults to 1.
+- `openshift_logging_kibana_nodeselector`: A map of labels (e.g. {"node":"infra","region":"west"} to select the nodes where the pod will land.
 
 - `openshift_logging_fluentd_nodeselector`: The node selector that the Fluentd daemonset uses to determine where to deploy to. Defaults to '"logging-infra-fluentd": "true"'.
 - `openshift_logging_fluentd_cpu_limit`: The CPU limit for Fluentd pods. Defaults to '100m'.
@@ -67,6 +69,7 @@ When both `openshift_logging_install_logging` and `openshift_logging_upgrade_log
 - `openshift_logging_es_pvc_prefix`: The prefix for the generated PVCs. Defaults to 'logging-es'.
 - `openshift_logging_es_recover_after_time`: The amount of time ES will wait before it tries to recover. Defaults to '5m'.
 - `openshift_logging_es_storage_group`: The storage group used for ES. Defaults to '65534'.
+- `openshift_logging_es_nodeselector`: A map of labels (e.g. {"node":"infra","region":"west"} to select the nodes where the pod will land.
 
 When `openshift_logging_use_ops` is `True`, there are some additional vars. These work the
 same as above for their non-ops counterparts, but apply to the OPS cluster instance:

--- a/roles/openshift_logging/tasks/install_curator.yaml
+++ b/roles/openshift_logging/tasks/install_curator.yaml
@@ -31,6 +31,7 @@
     curator_cpu_limit: "{{openshift_logging_curator_cpu_limit }}"
     curator_memory_limit: "{{openshift_logging_curator_memory_limit }}"
     replicas: "{{curator_replica_count.stdout | default (0)}}"
+    curator_node_selector: "{{openshift_logging_curator_nodeselector | default({}) }}"
   check_mode: no
   changed_when: no
 
@@ -46,6 +47,7 @@
     curator_cpu_limit: "{{openshift_logging_curator_ops_cpu_limit }}"
     curator_memory_limit: "{{openshift_logging_curator_ops_memory_limit }}"
     replicas: "{{curator_ops_replica_count.stdout | default (0)}}"
+    curator_node_selector: "{{openshift_logging_curator_ops_nodeselector | default({}) }}"
   when: openshift_logging_use_ops
   check_mode: no
   changed_when: no

--- a/roles/openshift_logging/tasks/install_elasticsearch.yaml
+++ b/roles/openshift_logging/tasks/install_elasticsearch.yaml
@@ -33,6 +33,7 @@
     volume_names: "{{es_pvc_pool | default([])}}"
     pvc_claim: "{{(volume_names | length > item.0) | ternary(volume_names[item.0], None)}}"
     deploy_name: "{{item.1}}"
+    es_node_selector: "{{openshift_logging_es_nodeselector | default({})}}"
   with_indexed_items:
     - "{{es_dc_pool | default([])}}"
   check_mode: no
@@ -98,6 +99,7 @@
     es_recover_after_nodes: "{{es_ops_recover_after_nodes}}"
     es_recover_expected_nodes: "{{es_ops_recover_expected_nodes}}"
     openshift_logging_es_recover_after_time: "{{openshift_logging_es_ops_recover_after_time}}"
+    es_node_selector: "{{openshift_logging_es_ops_nodeselector | default({})}}"
   with_indexed_items:
     - "{{es_dc_pool_ops | default([])}}"
   when:

--- a/roles/openshift_logging/tasks/install_kibana.yaml
+++ b/roles/openshift_logging/tasks/install_kibana.yaml
@@ -35,6 +35,7 @@
     kibana_proxy_cpu_limit: "{{openshift_logging_kibana_proxy_cpu_limit }}"
     kibana_proxy_memory_limit: "{{openshift_logging_kibana_proxy_memory_limit }}"
     replicas: "{{kibana_replica_count.stdout | default (0)}}"
+    kibana_node_selector: "{{openshift_logging_kibana_nodeselector | default({}) }}"
   check_mode: no
   changed_when: no
 
@@ -53,6 +54,7 @@
     kibana_proxy_cpu_limit: "{{openshift_logging_kibana_ops_proxy_cpu_limit }}"
     kibana_proxy_memory_limit: "{{openshift_logging_kibana_ops_proxy_memory_limit }}"
     replicas: "{{kibana_ops_replica_count.stdout | default (0)}}"
+    kibana_node_selector: "{{openshift_logging_kibana_ops_nodeselector | default({}) }}"
   when: openshift_logging_use_ops
   check_mode: no
   changed_when: no

--- a/roles/openshift_logging/templates/curator.j2
+++ b/roles/openshift_logging/templates/curator.j2
@@ -28,6 +28,12 @@ spec:
     spec:
       terminationGracePeriod: 600
       serviceAccountName: aggregated-logging-curator
+{% if curator_node_selector is iterable and curator_node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in curator_node_selector.iteritems() %}
+        {{key}}: {{value}}
+{% endfor %}
+{% endif %}
       containers:
         -
           name: "curator"

--- a/roles/openshift_logging/templates/es.j2
+++ b/roles/openshift_logging/templates/es.j2
@@ -30,6 +30,12 @@ spec:
       securityContext:
         supplementalGroups:
         - {{openshift_logging_es_storage_group}}
+{% if es_node_selector is iterable and es_node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in es_node_selector.iteritems() %}
+        {{key}}: {{value}}
+{% endfor %}
+{% endif %}
       containers:
         -
           name: "elasticsearch"

--- a/roles/openshift_logging/templates/kibana.j2
+++ b/roles/openshift_logging/templates/kibana.j2
@@ -27,6 +27,12 @@ spec:
         component: "{{component}}"
     spec:
       serviceAccountName: aggregated-logging-kibana
+{% if kibana_node_selector is iterable and kibana_node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in kibana_node_selector.iteritems() %}
+        {{key}}: {{value}}
+{% endfor %}
+{% endif %}
       containers:
         -
           name: "kibana"


### PR DESCRIPTION
This PR allows you to specify nodeSelectors for the logging pods in the openshift_logging role

cc @ewolinetz @sdodson 