### PR TITLE
fixes jks generation, node labeling, and rerunning for oauth secrets

### DIFF
--- a/roles/openshift_logging/tasks/generate_certs.yaml
+++ b/roles/openshift_logging/tasks/generate_certs.yaml
@@ -88,56 +88,12 @@
 - name: Creating necessary JKS certs
   include: generate_jks.yaml
 
-# check for secret/logging-kibana-proxy
-- command: >
-    {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig get secret/logging-kibana-proxy -n {{openshift_logging_namespace}} -o jsonpath='{.data.oauth-secret}'
-  register: kibana_secret_oauth_check
-  ignore_errors: yes
-  changed_when: no
-  check_mode: no
-
-- command: >
-    {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig get secret/logging-kibana-proxy -n {{openshift_logging_namespace}} -o jsonpath='{.data.session-secret}'
-  register: kibana_secret_session_check
-  ignore_errors: yes
-  changed_when: no
-  check_mode: no
-
-# check for oauthclient secret
-- command: >
-    {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig get oauthclient/kibana-proxy -n {{openshift_logging_namespace}} -o jsonpath='{.secret}'
-  register: oauth_secret_check
-  ignore_errors: yes
-  changed_when: no
-  check_mode: no
-
-# set or generate as needed
+# TODO: make idempotent
 - name: Generate proxy session
   set_fact: session_secret={{'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'|random_word(200)}}
   check_mode: no
-  when:
-    - kibana_secret_session_check.stdout is not defined or kibana_secret_session_check.stdout == ''
 
-- name: Generate proxy session
-  set_fact: session_secret={{kibana_secret_session_check.stdout | b64decode }}
-  check_mode: no
-  when:
-    - kibana_secret_session_check.stdout is defined
-    - kibana_secret_session_check.stdout != ''
-
+# TODO: make idempotent
 - name: Generate oauth client secret
   set_fact: oauth_secret={{'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'|random_word(64)}}
   check_mode: no
-  when: kibana_secret_oauth_check.stdout is not defined or kibana_secret_oauth_check.stdout == ''
-    or oauth_secret_check.stdout is not defined or oauth_secret_check.stdout == ''
-    or kibana_secret_oauth_check.stdout | b64decode != oauth_secret_check.stdout
-
-- name: Generate oauth client secret
-  set_fact: oauth_secret={{kibana_secret_oauth_check.stdout | b64decode}}
-  check_mode: no
-  when:
-    - kibana_secret_oauth_check is defined
-    - kibana_secret_oauth_check.stdout != ''
-    - oauth_secret_check.stdout is defined
-    - oauth_secret_check.stdout != ''
-    - kibana_secret_oauth_check.stdout | b64decode == oauth_secret_check.stdout

--- a/roles/openshift_logging/tasks/generate_jks.yaml
+++ b/roles/openshift_logging/tasks/generate_jks.yaml
@@ -27,34 +27,22 @@
   check_mode: no
 
 - name: Create placeholder for previously created JKS certs to prevent recreating...
-  file:
-    path: "{{local_tmp.stdout}}/elasticsearch.jks"
-    state: touch
-    mode: "u=rw,g=r,o=r"
+  local_action: file path="{{local_tmp.stdout}}/elasticsearch.jks" state=touch mode="u=rw,g=r,o=r"
   when: elasticsearch_jks.stat.exists
   changed_when: False
 
 - name: Create placeholder for previously created JKS certs to prevent recreating...
-  file:
-    path: "{{local_tmp.stdout}}/logging-es.jks"
-    state: touch
-    mode: "u=rw,g=r,o=r"
+  local_action: file path="{{local_tmp.stdout}}/logging-es.jks" state=touch mode="u=rw,g=r,o=r"
   when: logging_es_jks.stat.exists
   changed_when: False
 
 - name: Create placeholder for previously created JKS certs to prevent recreating...
-  file:
-    path: "{{local_tmp.stdout}}/system.admin.jks"
-    state: touch
-    mode: "u=rw,g=r,o=r"
+  local_action: file path="{{local_tmp.stdout}}/system.admin.jks" state=touch mode="u=rw,g=r,o=r"
   when: system_admin_jks.stat.exists
   changed_when: False
 
 - name: Create placeholder for previously created JKS certs to prevent recreating...
-  file:
-    path: "{{local_tmp.stdout}}/truststore.jks"
-    state: touch
-    mode: "u=rw,g=r,o=r"
+  local_action: file path="{{local_tmp.stdout}}/truststore.jks" state=touch mode="u=rw,g=r,o=r"
   when: truststore_jks.stat.exists
   changed_when: False
 
@@ -69,15 +57,16 @@
     - ca.serial.txt
     - ca.crl.srl
     - ca.db
+  when: not elasticsearch_jks.stat.exists or not logging_es_jks.stat.exists or not system_admin_jks.stat.exists or not truststore_jks.stat.exists
 
 - local_action: template src=signing.conf.j2 dest={{local_tmp.stdout}}/signing.conf
   vars:
     - top_dir: "{{local_tmp.stdout}}"
+  when: not elasticsearch_jks.stat.exists or not logging_es_jks.stat.exists or not system_admin_jks.stat.exists or not truststore_jks.stat.exists
 
 - name: Run JKS generation script
   local_action: script generate-jks.sh {{local_tmp.stdout}} {{openshift_logging_namespace}}
   check_mode: no
-  become: yes
   when: not elasticsearch_jks.stat.exists or not logging_es_jks.stat.exists or not system_admin_jks.stat.exists or not truststore_jks.stat.exists
 
 - name: Pushing locally generated JKS certs to remote host...
@@ -105,7 +94,5 @@
   when: not truststore_jks.stat.exists
 
 - name: Cleaning up temp dir
-  file:
-    path: "{{local_tmp.stdout}}"
-    state: absent
+  local_action: file path="{{local_tmp.stdout}}" state=absent
   changed_when: False

--- a/roles/openshift_logging/tasks/label_node.yaml
+++ b/roles/openshift_logging/tasks/label_node.yaml
@@ -1,11 +1,34 @@
 ---
 - command: >
     {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig get node {{host}}
-    -o jsonpath='{.metadata.labels.{{ label }}}'
-  register: label_value
-  failed_when: label_value.rc == 1 and 'exists' not in label_value.stderr
+    -o jsonpath='{.metadata.labels}'
+  register: node_labels
   when: not ansible_check_mode
   changed_when: no
+
+- command: >
+    {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig label node {{host}} {{label}}={{value}}
+  register: label_result
+  failed_when: label_result.rc == 1 and 'exists' not in label_result.stderr
+  when:
+  - value is defined
+  - node_labels.stdout is defined
+  - label not in node_labels.stdout
+  - unlabel is not defined or not unlabel
+  - not ansible_check_mode
+
+- command: >
+    {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig get node {{host}}
+    -o jsonpath='{.metadata.labels.{{ label }}}'
+  register: label_value
+  ignore_errors: yes
+  changed_when: no
+  when:
+  - value is defined
+  - node_labels.stdout is defined
+  - label in node_labels.stdout
+  - unlabel is not defined or not unlabel
+  - not ansible_check_mode
 
 - command: >
     {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig label node {{host}} {{label}}={{value}} --overwrite


### PR DESCRIPTION
@sdodson 
@jcantrill 

Will address the idempotency of the oauth secret at a later time.. it was breaking rerunning the playbook