### PR TITLE
flake8 mccabe dependency fix

### DIFF
--- a/utils/test-requirements.txt
+++ b/utils/test-requirements.txt
@@ -1,11 +1,10 @@
 ansible
-configparser
-pylint
+# flake8 moved to before setuptools-lint to satisfy mccabe dependency issue
+flake8
 setuptools-lint
 nose
 coverage
 mock
-flake8
 PyYAML
 click
 backports.functools_lru_cache
@@ -13,5 +12,3 @@ pyOpenSSL
 yamllint
 tox
 detox
-# Temporary work-around for flake8 vs maccabe version conflict
-mccabe==0.5.3


### PR DESCRIPTION
flake8 has a more restrictive mccabe dependency than setuptools-lint.  This PR moves flake8 before setuptools-lint to ensure a supported version of mccabe is installed.

```
> $ pipdeptree
coverage==4.3.4
detox==0.10.0
  - eventlet [required: >=0.15.0, installed: 0.20.1]
    - enum-compat [required: Any, installed: 0.0.2]
      - enum34 [required: Any, installed: 1.1.6]
    - greenlet [required: >=0.3, installed: 0.4.11]
  - py [required: >=1.4.27, installed: 1.4.32]
  - tox [required: <3.0.0,>=2.0.0, installed: 2.5.0]
    - pluggy [required: <1.0,>=0.3.0, installed: 0.4.0]
    - py [required: >=1.4.17, installed: 1.4.32]
    - virtualenv [required: >=1.11.2, installed: 15.1.0]
flake8==3.2.1
  - configparser [required: Any, installed: 3.5.0]
  - enum34 [required: Any, installed: 1.1.6]
  - mccabe [required: >=0.5.0,<0.6.0, installed: 0.5.3]
  - pycodestyle [required: >=2.0.0,<2.3.0, installed: 2.2.0]
  - pyflakes [required: !=1.2.1,!=1.2.2,>=0.8.1,<1.4.0,!=1.2.0, installed: 1.3.0]
mock==2.0.0
  - funcsigs [required: >=1, installed: 1.0.2]
  - pbr [required: >=0.11, installed: 1.10.0]
  - six [required: >=1.9, installed: 1.10.0]
nose==1.3.7
ooinstall==3.0.0
  - ansible [required: Any, installed: 2.2.1.0]
    - jinja2 [required: <2.9, installed: 2.8.1]
      - MarkupSafe [required: Any, installed: 0.23]
    - paramiko [required: Any, installed: 2.1.1]
      - cryptography [required: >=1.1, installed: 1.7.1]
        - cffi [required: >=1.4.1, installed: 1.9.1]
          - pycparser [required: Any, installed: 2.17]
        - enum34 [required: Any, installed: 1.1.6]
        - idna [required: >=2.0, installed: 2.2]
        - ipaddress [required: Any, installed: 1.0.18]
        - pyasn1 [required: >=0.1.8, installed: 0.1.9]
        - setuptools [required: >=11.3, installed: 34.0.2]
          - appdirs [required: >=1.4.0, installed: 1.4.0]
          - packaging [required: >=16.8, installed: 16.8]
            - pyparsing [required: Any, installed: 2.1.10]
            - six [required: Any, installed: 1.10.0]
          - six [required: >=1.10.0, installed: 1.10.0]
        - six [required: >=1.4.1, installed: 1.10.0]
      - pyasn1 [required: >=0.1.7, installed: 0.1.9]
    - pycrypto [required: >=2.6, installed: 2.6.1]
    - PyYAML [required: Any, installed: 3.12]
    - setuptools [required: Any, installed: 34.0.2]
      - appdirs [required: >=1.4.0, installed: 1.4.0]
      - packaging [required: >=16.8, installed: 16.8]
        - pyparsing [required: Any, installed: 2.1.10]
        - six [required: Any, installed: 1.10.0]
      - six [required: >=1.10.0, installed: 1.10.0]
  - click [required: Any, installed: 6.7]
  - PyYAML [required: Any, installed: 3.12]
pyOpenSSL==16.2.0
  - cryptography [required: >=1.3.4, installed: 1.7.1]
    - cffi [required: >=1.4.1, installed: 1.9.1]
      - pycparser [required: Any, installed: 2.17]
    - enum34 [required: Any, installed: 1.1.6]
    - idna [required: >=2.0, installed: 2.2]
    - ipaddress [required: Any, installed: 1.0.18]
    - pyasn1 [required: >=0.1.8, installed: 0.1.9]
    - setuptools [required: >=11.3, installed: 34.0.2]
      - appdirs [required: >=1.4.0, installed: 1.4.0]
      - packaging [required: >=16.8, installed: 16.8]
        - pyparsing [required: Any, installed: 2.1.10]
        - six [required: Any, installed: 1.10.0]
      - six [required: >=1.10.0, installed: 1.10.0]
    - six [required: >=1.4.1, installed: 1.10.0]
  - six [required: >=1.5.2, installed: 1.10.0]
setuptools-lint==0.5.2
  - pylint [required: Any, installed: 1.6.5]
    - astroid [required: <1.5.0,>=1.4.5, installed: 1.4.9]
      - lazy-object-proxy [required: Any, installed: 1.2.2]
      - six [required: Any, installed: 1.10.0]
      - wrapt [required: Any, installed: 1.10.8]
    - backports.functools-lru-cache [required: Any, installed: 1.3]
    - configparser [required: Any, installed: 3.5.0]
    - isort [required: >=4.2.5, installed: 4.2.5]
    - mccabe [required: Any, installed: 0.5.3]
    - six [required: Any, installed: 1.10.0]
wheel==0.29.0
yamllint==1.6.0
  - pyyaml [required: Any, installed: 3.12]
```