### PR TITLE
openshift_logging link pull secret to serviceaccounts

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -36,6 +36,7 @@ When both `openshift_logging_install_logging` and `openshift_logging_upgrade_log
 - `openshift_logging_curator_cpu_limit`: The amount of CPU to allocate to Curator. Default is '100m'.
 - `openshift_logging_curator_memory_limit`: The amount of memory to allocate to Curator. Unset if not specified.
 - `openshift_logging_curator_nodeselector`: A map of labels (e.g. {"node":"infra","region":"west"} to select the nodes where the curator pod will land.
+- `openshift_logging_image_pull_secret`: The name of an existing pull secret to link to the logging service accounts
 
 - `openshift_logging_kibana_hostname`: The Kibana hostname. Defaults to 'kibana.example.com'.
 - `openshift_logging_kibana_cpu_limit`: The amount of CPU to allocate to Kibana or unset if not specified.

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -57,6 +57,28 @@
     loop_var: file
   when: ansible_check_mode
 
+  # TODO replace task with oc_secret module that supports
+  # linking when available
+- name: Link Pull Secrets With Service Accounts
+  include: oc_secret.yaml
+  vars:
+    kubeconfig: "{{ mktemp.stdout }}/admin.kubeconfig"
+    subcommand: link
+    service_account: "{{sa_account}}"
+    secret_name: "{{openshift_logging_image_pull_secret}}"
+    add_args: "--for=pull"
+  with_items:
+    - default
+    - aggregated-logging-elasticsearch
+    - aggregated-logging-kibana
+    - aggregated-logging-fluentd
+    - aggregated-logging-curator
+  register: link_pull_secret
+  loop_control:
+    loop_var: sa_account
+  when: openshift_logging_image_pull_secret is defined
+  failed_when: link_pull_secret.rc != 0
+
 - name: Scaling up cluster
   include: start_cluster.yaml
   when: start_cluster | default(true) | bool

--- a/roles/openshift_logging/tasks/oc_secret.yaml
+++ b/roles/openshift_logging/tasks/oc_secret.yaml
@@ -1,0 +1,7 @@
+---
+- command: >
+    {{ openshift.common.client_binary }}
+    --config={{ kubeconfig }}
+    secret {{subcommand}} {{service_account}} {{secret_name}}
+    {{add_args}}
+    -n {{openshift_logging_namespace}}


### PR DESCRIPTION
This PR:

* Allows a user to provide a pull-secret to link to the logging service accounts
* fixes an error when undeploying logging

cc @ewolinetz @sdodson 

aos-ci-test