### PR TITLE
Comma separate no_proxy host list in openshift_facts

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -85,7 +85,7 @@
   - reg_conf_var: HTTPS_PROXY
     reg_fact_val: "{{ docker_https_proxy | default('') }}"
   - reg_conf_var: NO_PROXY
-    reg_fact_val: "{{ docker_no_proxy | default('') | join(',') }}"
+    reg_fact_val: "{{ docker_no_proxy | default('') }}"
   notify:
   - restart docker
   when:

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1641,7 +1641,7 @@ def set_proxy_facts(facts):
             # We always add local dns domain and ourselves no matter what
             common['no_proxy'].append('.' + common['dns_domain'])
             common['no_proxy'].append(common['hostname'])
-            common['no_proxy'] = sort_unique(common['no_proxy'])
+            common['no_proxy'] = ','.join(sort_unique(common['no_proxy']))
         facts['common'] = common
     return facts
 

--- a/roles/openshift_master/templates/atomic-openshift-master.j2
+++ b/roles/openshift_master/templates/atomic-openshift-master.j2
@@ -29,7 +29,7 @@ HTTP_PROXY={{ openshift.common.http_proxy | default('') }}
 HTTPS_PROXY={{ openshift.common.https_proxy | default('')}}
 {% endif %}
 {% if 'no_proxy' in openshift.common %}
-NO_PROXY={{ openshift.common.no_proxy | default('') | join(',') }},{{ openshift.common.portal_net }},{{ openshift.master.sdn_cluster_network_cidr }}
+NO_PROXY={{ openshift.common.no_proxy | default('') }},{{ openshift.common.portal_net }},{{ openshift.master.sdn_cluster_network_cidr }}
 {% endif %}
 {% if not ('https_proxy' in openshift.common or 'https_proxy' in openshift.common or 'no_proxy' in openshift.common) %}
 {% for item in master_proxy %}

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
@@ -24,5 +24,5 @@ HTTP_PROXY={{ openshift.common.http_proxy | default('') }}
 HTTPS_PROXY={{ openshift.common.https_proxy | default('')}}
 {% endif %}
 {% if 'no_proxy' in openshift.common %}
-NO_PROXY={{ openshift.common.no_proxy | default('') | join(',') }},{{ openshift.common.portal_net }},{{ openshift.master.sdn_cluster_network_cidr }}
+NO_PROXY={{ openshift.common.no_proxy | default('') }},{{ openshift.common.portal_net }},{{ openshift.master.sdn_cluster_network_cidr }}
 {% endif %}

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.j2
@@ -24,5 +24,5 @@ HTTP_PROXY={{ openshift.common.http_proxy | default('') }}
 HTTPS_PROXY={{ openshift.common.https_proxy | default('')}}
 {% endif %}
 {% if 'no_proxy' in openshift.common %}
-NO_PROXY={{ openshift.common.no_proxy | default('') | join(',') }},{{ openshift.common.portal_net }},{{ openshift.master.sdn_cluster_network_cidr }}
+NO_PROXY={{ openshift.common.no_proxy | default('') }},{{ openshift.common.portal_net }},{{ openshift.master.sdn_cluster_network_cidr }}
 {% endif %}

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -90,7 +90,7 @@
   - regex: '^HTTPS_PROXY='
     line: "HTTPS_PROXY={{ openshift.common.https_proxy | default('') }}"
   - regex: '^NO_PROXY='
-    line: "NO_PROXY={{ openshift.common.no_proxy | default([]) | join(',') }},{{ openshift.common.portal_net }},{{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }}"
+    line: "NO_PROXY={{ openshift.common.no_proxy | default([]) }},{{ openshift.common.portal_net }},{{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }}"
   when: ('http_proxy' in openshift.common and openshift.common.http_proxy != '')
   notify:
   - restart node


### PR DESCRIPTION
Proposed change comma separates the `no_proxy` host list upstream in `openshift_facts` so that it appears as a string everywhere it is used. Note that `set_proxy_facts()` converts the `no_proxy` host list to a list and then back to a string.

Fixes #3180.

@sdodson @bparees PTAL