### PR TITLE
Standardize add_host: with name and changed_when

### DIFF
--- a/playbooks/byo/openshift-cluster/config.yml
+++ b/playbooks/byo/openshift-cluster/config.yml
@@ -8,7 +8,8 @@
   - always
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
-  - add_host:
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
     with_items: "{{ g_all_hosts | default([]) }}"

--- a/playbooks/byo/openshift-cluster/enable_dnsmasq.yml
+++ b/playbooks/byo/openshift-cluster/enable_dnsmasq.yml
@@ -5,10 +5,12 @@
   gather_facts: no
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
-  - add_host:
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
     with_items: "{{ g_all_hosts | default([]) }}"
+    changed_when: False
 
 - hosts: l_oo_all_hosts
   gather_facts: no

--- a/playbooks/byo/openshift-cluster/openshift-logging.yml
+++ b/playbooks/byo/openshift-cluster/openshift-logging.yml
@@ -15,10 +15,12 @@
   - always
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
-  - add_host:
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
     with_items: "{{ g_all_hosts | default([]) }}"
+    changed_when: False
 
 - name: Create initial host groups for all hosts
   hosts: l_oo_all_hosts

--- a/playbooks/byo/openshift-cluster/redeploy-certificates.yml
+++ b/playbooks/byo/openshift-cluster/redeploy-certificates.yml
@@ -5,10 +5,12 @@
   gather_facts: no
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
-  - add_host:
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
     with_items: "{{ g_all_hosts | default([]) }}"
+    changed_when: False
 
 - hosts: l_oo_all_hosts
   gather_facts: no

--- a/playbooks/byo/openshift-cluster/upgrades/docker/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/docker/upgrade.yml
@@ -6,11 +6,12 @@
   gather_facts: no
   tasks:
   - include_vars: ../../cluster_hosts.yml
-  - add_host:
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
     with_items: "{{ g_all_hosts | default([]) }}"
-    changed_when: false
+    changed_when: False
 
 - hosts: l_oo_all_hosts
   gather_facts: no

--- a/playbooks/byo/openshift-cluster/upgrades/upgrade_etcd.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/upgrade_etcd.yml
@@ -8,10 +8,12 @@
   - always
   tasks:
   - include_vars: ../cluster_hosts.yml
-  - add_host:
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
     with_items: "{{ g_all_hosts | default([]) }}"
+    changed_when: False
 
 - name: Create initial host groups for all hosts
   hosts: l_oo_all_hosts

--- a/playbooks/byo/openshift-master/restart.yml
+++ b/playbooks/byo/openshift-master/restart.yml
@@ -5,10 +5,12 @@
   gather_facts: no
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
-  - add_host:
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
-    with_items: "{{ g_all_hosts }}"
+    with_items: "{{ g_all_hosts | default([]) }}"
+    changed_when: False
 
 - hosts: l_oo_all_hosts
   gather_facts: no

--- a/playbooks/byo/openshift-master/scaleup.yml
+++ b/playbooks/byo/openshift-master/scaleup.yml
@@ -5,10 +5,12 @@
   gather_facts: no
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
-  - add_host:
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
-    with_items: "{{ g_all_hosts }}"
+    with_items: "{{ g_all_hosts | default([]) }}"
+    changed_when: False
 
 - hosts: l_oo_all_hosts
   gather_facts: no

--- a/playbooks/byo/openshift-node/network_manager.yml
+++ b/playbooks/byo/openshift-node/network_manager.yml
@@ -5,10 +5,12 @@
   gather_facts: no
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
-  - add_host:
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
-    with_items: "{{ g_all_hosts }}"
+    with_items: "{{ g_all_hosts | default([]) }}"
+    changed_when: False
 
 - hosts: l_oo_all_hosts
   become: yes

--- a/playbooks/byo/openshift-node/scaleup.yml
+++ b/playbooks/byo/openshift-node/scaleup.yml
@@ -5,10 +5,12 @@
   gather_facts: no
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
-  - add_host:
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
-    with_items: "{{ g_all_hosts }}"
+    with_items: "{{ g_all_hosts | default([]) }}"
+    changed_when: False
 
 - hosts: l_oo_all_hosts
   gather_facts: no

--- a/playbooks/byo/openshift_facts.yml
+++ b/playbooks/byo/openshift_facts.yml
@@ -5,10 +5,12 @@
   gather_facts: no
   tasks:
   - include_vars: openshift-cluster/cluster_hosts.yml
-  - add_host:
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
-    with_items: "{{ g_all_hosts }}"
+    with_items: "{{ g_all_hosts | default([]) }}"
+    changed_when: False
 
 - hosts: l_oo_all_hosts
   gather_facts: no

--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -5,10 +5,12 @@
   gather_facts: no
   tasks:
   - include_vars: openshift-cluster/cluster_hosts.yml
-  - add_host:
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
-    with_items: "{{ g_all_hosts }}"
+    with_items: "{{ g_all_hosts | default([]) }}"
+    changed_when: False
 
 - hosts: l_oo_all_hosts
   gather_facts: no

--- a/playbooks/common/openshift-cluster/upgrades/etcd/main.yml
+++ b/playbooks/common/openshift-cluster/upgrades/etcd/main.yml
@@ -22,11 +22,14 @@
       name: "{{ item }}"
       groups: etcd_hosts_to_upgrade
     with_items: "{{ groups.oo_etcd_to_config if groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config | length > 0 else [] }}"
+    changed_when: False
+
   - name: Evaluate etcd_hosts_to_backup
     add_host:
       name: "{{ item }}"
       groups: etcd_hosts_to_backup
     with_items: "{{ groups.oo_etcd_to_config if groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config | length > 0 else groups.oo_first_master }}"
+    changed_when: False
 
 - name: Backup etcd before upgrading anything
   include: backup.yml

--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -6,10 +6,12 @@
   gather_facts: no
   tasks:
   - include_vars: ../../../byo/openshift-cluster/cluster_hosts.yml
-  - add_host:
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
       name: "{{ item }}"
       groups: l_oo_all_hosts
     with_items: "{{ g_all_hosts | default([]) }}"
+    changed_when: False
 
 - name: Include g_*_hosts vars for hosts in group l_oo_all_hosts
   hosts: l_oo_all_hosts

--- a/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
@@ -38,3 +38,4 @@
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_become: "{{ g_sudo | default(omit) }}"
     with_items: "{{ groups['temp_nodes_to_upgrade'] | default(groups['oo_nodes_to_config']) }}"
+    changed_when: False

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -12,6 +12,7 @@
       name: "{{ item }}"
       groups: etcd_hosts_to_backup
     with_items: "{{ groups.oo_etcd_to_config if groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config | length > 0 else groups.oo_first_master }}"
+    changed_when: False
 
 # If facts cache were for some reason deleted, this fact may not be set, and if not set
 # it will always default to true. This causes problems for the etcd data dir fact detection

--- a/playbooks/common/openshift-etcd/service.yml
+++ b/playbooks/common/openshift-etcd/service.yml
@@ -9,8 +9,11 @@
     when: new_cluster_state is not defined
 
   - name: Evaluate g_service_etcd
-    add_host: name={{ item }} groups=g_service_etcd
+    add_host:
+      name: "{{ item }}"
+      groups: g_service_etcd
     with_items: "{{ oo_host_group_exp | default([]) }}"
+    changed_when: False
 
 - name: Change etcd state on etcd instance(s)
   hosts: g_service_etcd

--- a/playbooks/common/openshift-loadbalancer/service.yml
+++ b/playbooks/common/openshift-loadbalancer/service.yml
@@ -9,8 +9,11 @@
     when: new_cluster_state is not defined
 
   - name: Evaluate g_service_lb
-    add_host: name={{ item }} groups=g_service_lb
+    add_host:
+      name: "{{ item }}"
+      groups: g_service_lb
     with_items: "{{ oo_host_group_exp | default([]) }}"
+    changed_when: False
 
 - name: Change state on lb instance(s)
   hosts: g_service_lb

--- a/playbooks/common/openshift-master/service.yml
+++ b/playbooks/common/openshift-master/service.yml
@@ -9,8 +9,11 @@
     when: new_cluster_state is not defined
 
   - name: Evaluate g_service_masters
-    add_host: name={{ item }} groups=g_service_masters
+    add_host:
+      name: "{{ item }}"
+      groups: g_service_masters
     with_items: "{{ oo_host_group_exp | default([]) }}"
+    changed_when: False
 
 - name: Change state on master instance(s)
   hosts: g_service_masters

--- a/playbooks/common/openshift-nfs/service.yml
+++ b/playbooks/common/openshift-nfs/service.yml
@@ -7,8 +7,11 @@
     when: new_cluster_state is not defined
 
   - name: Evaluate g_service_nfs
-    add_host: name={{ item }} groups=g_service_nfs
+    add_host:
+      name: "{{ item }}"
+      groups: g_service_nfs
     with_items: "{{ oo_host_group_exp | default([]) }}"
+    changed_when: False
 
 - name: Change state on nfs instance(s)
   hosts: g_service_nfs

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -44,6 +44,7 @@
       ansible_become: "{{ g_sudo | default(omit) }}"
     with_items: "{{ groups.oo_nodes_to_config | default([]) }}"
     when: hostvars[item].openshift.common is defined and hostvars[item].openshift.common.is_containerized | bool and (item in groups.oo_nodes_to_config and item in groups.oo_masters_to_config)
+    changed_when: False
 
 - name: Configure containerized nodes
   hosts: oo_containerized_master_nodes

--- a/playbooks/common/openshift-node/service.yml
+++ b/playbooks/common/openshift-node/service.yml
@@ -9,12 +9,18 @@
     when: new_cluster_state is not defined
 
   - name: Evaluate g_service_nodes
-    add_host: name={{ item }} groups=g_service_nodes
+    add_host:
+      name: "{{ item }}"
+      groups: g_service_nodes
     with_items: "{{ oo_host_group_exp | default([]) }}"
+    changed_when: False
 
 - name: Change state on node instance(s)
   hosts: g_service_nodes
   connection: ssh
   gather_facts: no
   tasks:
-  - service: name={{ service_type }}-node state="{{ new_cluster_state }}"
+  - name: Change state on node instance(s)
+    service:
+      name: "{{ service_type }}-node"
+      state: "{{ new_cluster_state }}"


### PR DESCRIPTION
The add_host: task does not change any data on the host and as practice
has been configured to changed_when: False.  This commit standardizes
that usage in the byo and common playbooks.  Additionally, task names
are added to each task to improve troubleshooting.