### PR TITLE
rpm_upgrade.yml: Restart the service that was upgraded

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
@@ -7,4 +7,4 @@
   when: "{{ not openshift.common.is_atomic | bool }}"
 
 - name: Restart node service
-  service: name="{{ openshift.common.service_type }}-node" state=restarted
+  service: name="{{ openshift.common.service_type }}-{{ component }}" state=restarted

--- a/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
@@ -6,5 +6,5 @@
   action: "{{ ansible_pkg_mgr }} name=PyYAML state=present"
   when: "{{ not openshift.common.is_atomic | bool }}"
 
-- name: Restart node service
+- name: Restart service
   service: name="{{ openshift.common.service_type }}-{{ component }}" state=restarted


### PR DESCRIPTION
Instead of only restarting the `...-node` service

While running through a cluster upgrade, from `3.1` to `3.2`, this section is failing on every attempted run against the master hosts as the `origin-node` service is not installed on them.