### PR TITLE
Correct usage of draining nodes

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -31,7 +31,7 @@
 
   - name: Drain Node for Kubelet upgrade
     command: >
-      {{ openshift.common.client_binary }} adm manage-node {{ openshift.node.nodename }} {{ openshift.common.evacuate_or_drain }} --force
+      {{ openshift.common.admin_binary }} drain {{ openshift.node.nodename }} --force --delete-local-data
     delegate_to: "{{ groups.oo_first_master.0 }}"
     when: l_docker_upgrade is defined and l_docker_upgrade | bool and inventory_hostname in groups.oo_nodes_to_upgrade
 

--- a/playbooks/common/openshift-cluster/redeploy-certificates.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates.yml
@@ -228,9 +228,8 @@
 
   - name: Drain node
     command: >
-      {{ openshift.common.client_binary }} adm --config={{ hostvars[groups.oo_first_master.0].mktemp.stdout }}/admin.kubeconfig
-      manage-node {{ openshift.node.nodename }}
-      {{ openshift.common.evacuate_or_drain }} --force
+      {{ openshift.common.admin_binary }} --config={{ hostvars[groups.oo_first_master.0].mktemp.stdout }}/admin.kubeconfig
+      drain {{ openshift.node.nodename }} --force --delete-local-data
     delegate_to: "{{ groups.oo_first_master.0 }}"
     when: openshift_certificates_redeploy_ca | default(false) | bool and was_schedulable | bool
 

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -41,7 +41,7 @@
 
   - name: Drain Node for Kubelet upgrade
     command: >
-      {{ hostvars[groups.oo_first_master.0].openshift.common.client_binary }} adm manage-node {{ openshift.node.nodename | lower }} {{ openshift.common.evacuate_or_drain }} --force
+      {{ hostvars[groups.oo_first_master.0].openshift.common.admin_binary }} drain {{ openshift.node.nodename | lower }} --force --delete-local-data
     delegate_to: "{{ groups.oo_first_master.0 }}"
     when: inventory_hostname in groups.oo_nodes_to_upgrade
 

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -867,20 +867,6 @@ def set_deployment_facts_if_unset(facts):
     return facts
 
 
-def set_evacuate_or_drain_option(facts):
-    """OCP before 1.5/3.5 used '--evacuate'. As of 1.5/3.5 OCP uses
-'--drain'. Let's make that a fact for easy reference later.
-    """
-    if facts['common']['version_gte_3_5_or_1_5']:
-        # New-style
-        facts['common']['evacuate_or_drain'] = '--drain'
-    else:
-        # Old-style
-        facts['common']['evacuate_or_drain'] = '--evacuate'
-
-    return facts
-
-
 def set_version_facts_if_unset(facts):
     """ Set version facts. This currently includes common.version and
         common.version_gte_3_1_or_1_1.
@@ -1969,7 +1955,6 @@ class OpenShiftFacts(object):
         facts = build_controller_args(facts)
         facts = build_api_server_args(facts)
         facts = set_version_facts_if_unset(facts)
-        facts = set_evacuate_or_drain_option(facts)
         facts = set_dnsmasq_facts_if_unset(facts)
         facts = set_manageiq_facts_if_unset(facts)
         facts = set_aggregate_facts(facts)


### PR DESCRIPTION
Verified `oadm drain NODE` applies to 1.3, 1.4 and 1.5.
Verified upgrade from 3.4 to 3.5.