### PR TITLE
Standardize entry-point playbooks with named plays

### DIFF
--- a/playbooks/byo/openshift-cluster/enable_dnsmasq.yml
+++ b/playbooks/byo/openshift-cluster/enable_dnsmasq.yml
@@ -1,8 +1,11 @@
 ---
-- hosts: localhost
+- name: Create initial host groups for localhost
+  hosts: localhost
   connection: local
   become: no
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
   - name: Evaluate group l_oo_all_hosts
@@ -12,8 +15,11 @@
     with_items: "{{ g_all_hosts | default([]) }}"
     changed_when: False
 
-- hosts: l_oo_all_hosts
+- name: Create initial host groups for all hosts
+  hosts: l_oo_all_hosts
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
 

--- a/playbooks/byo/openshift-cluster/openshift-logging.yml
+++ b/playbooks/byo/openshift-cluster/openshift-logging.yml
@@ -4,8 +4,6 @@
 # Hosted logging on.  See inventory/byo/hosts.*.example for the
 # currently supported method.
 #
-- include: ../../common/openshift-cluster/verify_ansible_version.yml
-
 - name: Create initial host groups for localhost
   hosts: localhost
   connection: local

--- a/playbooks/byo/openshift-cluster/redeploy-certificates.yml
+++ b/playbooks/byo/openshift-cluster/redeploy-certificates.yml
@@ -1,8 +1,11 @@
 ---
-- hosts: localhost
+- name: Create initial host groups for localhost
+  hosts: localhost
   connection: local
   become: no
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
   - name: Evaluate group l_oo_all_hosts
@@ -12,8 +15,11 @@
     with_items: "{{ g_all_hosts | default([]) }}"
     changed_when: False
 
-- hosts: l_oo_all_hosts
+- name: Create initial host groups for all hosts
+  hosts: l_oo_all_hosts
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
 

--- a/playbooks/byo/openshift-cluster/upgrades/docker/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/docker/upgrade.yml
@@ -1,9 +1,12 @@
 ---
 # Playbook to upgrade Docker to the max allowable version for an OpenShift cluster.
-- hosts: localhost
+- name: Create initial host groups for localhost
+  hosts: localhost
   connection: local
   become: no
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../cluster_hosts.yml
   - name: Evaluate group l_oo_all_hosts
@@ -13,8 +16,11 @@
     with_items: "{{ g_all_hosts | default([]) }}"
     changed_when: False
 
-- hosts: l_oo_all_hosts
+- name: Create initial host groups for all hosts
+  hosts: l_oo_all_hosts
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../cluster_hosts.yml
 

--- a/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade.yml
@@ -6,8 +6,8 @@
   tags:
   - pre_upgrade
 
-# Configure the upgrade target for the common upgrade tasks:
-- hosts: l_oo_all_hosts
+- name: Configure the upgrade target for the common upgrade tasks
+  hosts: l_oo_all_hosts
   tags:
   - pre_upgrade
   tasks:

--- a/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
@@ -15,8 +15,8 @@
   tags:
   - pre_upgrade
 
-# Configure the upgrade target for the common upgrade tasks:
-- hosts: l_oo_all_hosts
+- name: Configure the upgrade target for the common upgrade tasks
+  hosts: l_oo_all_hosts
   tags:
   - pre_upgrade
   tasks:

--- a/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade_nodes.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade_nodes.yml
@@ -8,8 +8,8 @@
   tags:
   - pre_upgrade
 
-# Configure the upgrade target for the common upgrade tasks:
-- hosts: l_oo_all_hosts
+- name: Configure the upgrade target for the common upgrade tasks
+  hosts: l_oo_all_hosts
   tags:
   - pre_upgrade
   tasks:

--- a/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
@@ -15,8 +15,8 @@
   tags:
   - pre_upgrade
 
-# Configure the upgrade target for the common upgrade tasks:
-- hosts: l_oo_all_hosts
+- name: Configure the upgrade target for the common upgrade tasks
+  hosts: l_oo_all_hosts
   tags:
   - pre_upgrade
   tasks:

--- a/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade_nodes.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade_nodes.yml
@@ -8,8 +8,8 @@
   tags:
   - pre_upgrade
 
-# Configure the upgrade target for the common upgrade tasks:
-- hosts: l_oo_all_hosts
+- name: Configure the upgrade target for the common upgrade tasks
+  hosts: l_oo_all_hosts
   tags:
   - pre_upgrade
   tasks:

--- a/playbooks/byo/openshift-master/restart.yml
+++ b/playbooks/byo/openshift-master/restart.yml
@@ -1,8 +1,11 @@
 ---
-- hosts: localhost
+- name: Create initial host groups for localhost
+  hosts: localhost
   connection: local
   become: no
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
   - name: Evaluate group l_oo_all_hosts
@@ -12,8 +15,11 @@
     with_items: "{{ g_all_hosts | default([]) }}"
     changed_when: False
 
-- hosts: l_oo_all_hosts
+- name: Create initial host groups for all hosts
+  hosts: l_oo_all_hosts
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
 

--- a/playbooks/byo/openshift-master/scaleup.yml
+++ b/playbooks/byo/openshift-master/scaleup.yml
@@ -1,8 +1,11 @@
 ---
-- hosts: localhost
+- name: Create initial host groups for localhost
+  hosts: localhost
   connection: local
   become: no
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
   - name: Evaluate group l_oo_all_hosts
@@ -12,8 +15,11 @@
     with_items: "{{ g_all_hosts | default([]) }}"
     changed_when: False
 
-- hosts: l_oo_all_hosts
+- name: Create initial host groups for all hosts
+  hosts: l_oo_all_hosts
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
 

--- a/playbooks/byo/openshift-node/network_manager.yml
+++ b/playbooks/byo/openshift-node/network_manager.yml
@@ -1,8 +1,11 @@
 ---
-- hosts: localhost
+- name: Create initial host groups for localhost
+  hosts: localhost
   connection: local
   become: no
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
   - name: Evaluate group l_oo_all_hosts
@@ -12,7 +15,8 @@
     with_items: "{{ g_all_hosts | default([]) }}"
     changed_when: False
 
-- hosts: l_oo_all_hosts
+- name: Install and configure NetworkManager
+  hosts: l_oo_all_hosts
   become: yes
   tasks:
   - name: install NetworkManager

--- a/playbooks/byo/openshift-node/scaleup.yml
+++ b/playbooks/byo/openshift-node/scaleup.yml
@@ -1,8 +1,11 @@
 ---
-- hosts: localhost
+- name: Create initial host groups for localhost
+  hosts: localhost
   connection: local
   become: no
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
   - name: Evaluate group l_oo_all_hosts
@@ -12,8 +15,11 @@
     with_items: "{{ g_all_hosts | default([]) }}"
     changed_when: False
 
-- hosts: l_oo_all_hosts
+- name: Create initial host groups for all hosts
+  hosts: l_oo_all_hosts
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
 

--- a/playbooks/byo/openshift_facts.yml
+++ b/playbooks/byo/openshift_facts.yml
@@ -1,10 +1,13 @@
 ---
-- hosts: localhost
+- name: Create initial host groups for localhost
+  hosts: localhost
   connection: local
   become: no
   gather_facts: no
+  tags:
+  - always
   tasks:
-  - include_vars: openshift-cluster/cluster_hosts.yml
+  - include_vars: ../byo/openshift-cluster/cluster_hosts.yml
   - name: Evaluate group l_oo_all_hosts
     add_host:
       name: "{{ item }}"
@@ -12,10 +15,13 @@
     with_items: "{{ g_all_hosts | default([]) }}"
     changed_when: False
 
-- hosts: l_oo_all_hosts
+- name: Create initial host groups for all hosts
+  hosts: l_oo_all_hosts
   gather_facts: no
+  tags:
+  - always
   tasks:
-  - include_vars: openshift-cluster/cluster_hosts.yml
+  - include_vars: ../byo/openshift-cluster/cluster_hosts.yml
 
 - include: ../common/openshift-cluster/evaluate_groups.yml
 

--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -1,8 +1,11 @@
 ---
-- hosts: localhost
+- name: Create initial host groups for localhost
+  hosts: localhost
   connection: local
   become: no
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: openshift-cluster/cluster_hosts.yml
   - name: Evaluate group l_oo_all_hosts
@@ -12,14 +15,18 @@
     with_items: "{{ g_all_hosts | default([]) }}"
     changed_when: False
 
-- hosts: l_oo_all_hosts
+- name: Create initial host groups for all hosts
+  hosts: l_oo_all_hosts
   gather_facts: no
+  tags:
+  - always
   tasks:
-  - include_vars: openshift-cluster/cluster_hosts.yml
+  - include_vars: ../byo/openshift-cluster/cluster_hosts.yml
 
 - include: ../common/openshift-cluster/evaluate_groups.yml
 
-- hosts: l_oo_all_hosts
+- name: Subscribe hosts, update repos and update OS packages
+  hosts: l_oo_all_hosts
   vars:
     openshift_deployment_type: "{{ deployment_type }}"
   roles:

--- a/playbooks/common/openshift-cluster/initialize_openshift_version.yml
+++ b/playbooks/common/openshift-cluster/initialize_openshift_version.yml
@@ -1,6 +1,7 @@
 ---
 # NOTE: requires openshift_facts be run
-- hosts: l_oo_all_hosts
+- name: Verify compatible yum/subscription-manager combination
+  hosts: l_oo_all_hosts
   gather_facts: no
   tasks:
   # See:

--- a/playbooks/common/openshift-cluster/update_repos_and_packages.yml
+++ b/playbooks/common/openshift-cluster/update_repos_and_packages.yml
@@ -1,7 +1,8 @@
 ---
 - include: evaluate_groups.yml
 
-- hosts: oo_hosts_to_update
+- name: Subscribe hosts, update repos and update OS packages
+  hosts: oo_hosts_to_update
   vars:
     openshift_deployment_type: "{{ deployment_type }}"
   roles:

--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -1,9 +1,11 @@
 ---
-- name: Create l_oo_all_hosts group
+- name: Create initial host groups for localhost
   hosts: localhost
   connection: local
   become: no
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../../byo/openshift-cluster/cluster_hosts.yml
   - name: Evaluate group l_oo_all_hosts
@@ -13,9 +15,11 @@
     with_items: "{{ g_all_hosts | default([]) }}"
     changed_when: False
 
-- name: Include g_*_hosts vars for hosts in group l_oo_all_hosts
+- name: Create initial host groups for all hosts
   hosts: l_oo_all_hosts
   gather_facts: no
+  tags:
+  - always
   tasks:
   - include_vars: ../../../byo/openshift-cluster/cluster_hosts.yml
 


### PR DESCRIPTION
Standardized the use of `name:` for playbook entry-points to improve troubleshooting and consistency.