### PR TITLE
GCE deployment fails due to invalid lookup

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1019,7 +1019,7 @@ def set_nodename(facts):
         if 'cloudprovider' in facts and facts['cloudprovider']['kind'] == 'openstack':
             facts['node']['nodename'] = facts['provider']['metadata']['hostname'].replace('.novalocal', '')
         elif 'cloudprovider' in facts and facts['cloudprovider']['kind'] == 'gce':
-            facts['node']['nodename'] = '.'.split(facts['provider']['metadata']['hostname'])[0]
+            facts['node']['nodename'] = facts['provider']['metadata']['instance']['hostname'].split('.')[0]
         else:
             facts['node']['nodename'] = facts['common']['hostname'].lower()
     return facts


### PR DESCRIPTION
Data is only available under ['instance'] and split was in the wrong
order.  This deploys against GCE for me.

Change in #3172 did not work for me