### PR TITLE
Generate wildcard router certificate

### DIFF
--- a/roles/openshift_hosted/tasks/router/router.yml
+++ b/roles/openshift_hosted/tasks/router/router.yml
@@ -20,12 +20,39 @@
   - "{{ (openshift_hosted_router_certificate | default({'cafile':none})).cafile }}"
   when: openshift_hosted_router_certificate is defined
 
+- name: Generate wildcard router certificate
+  command: >
+    {{ openshift.common.client_binary }} adm ca create-server-cert
+    --config={{ openshift_hosted_kubeconfig }}
+    --signer-cert={{ openshift_master_config_dir }}/ca.crt
+    --signer-key={{ openshift_master_config_dir }}/ca.key
+    --signer-serial={{ openshift_master_config_dir }}/ca.serial.txt
+    --hostnames='*.{{ openshift_master_default_subdomain }}'
+    --cert='{{ openshift_master_config_dir }}/openshift-router.crt'
+    --key='{{ openshift_master_config_dir }}/openshift-router.key'
+  when: (openshift_hosted_router_create_certificate | default(false)) and (not '{{ openshift_master_config_dir }}/openshift-router.key' | exists)
+
+- name: Read generated certificate and key
+  slurp:
+    src: "{{ item }}"
+  register: openshift_router_certificate_output
+  # Defaulting dictionary keys to none to avoid deprecation warnings
+  # (future fatal errors) during template evaluation. Dictionary keys
+  # won't be accessed unless openshift_hosted_router_certificate is
+  # defined and has all keys (certfile, keyfile, cafile) which we
+  # check above.
+  with_items:
+  - "{{ openshift_master_config_dir }}/openshift-router.crt"
+  - "{{ openshift_master_config_dir }}/openshift-router.key"
+  - "{{ openshift_master_config_dir }}/ca.crt"
+  when: openshift_hosted_router_create_certificate | default(false)
+
 - name: Persist certificate contents
   openshift_facts:
     role: hosted
     openshift_env:
       openshift_hosted_router_certificate_contents: "{% for certificate in openshift_router_certificate_output.results -%}{{ certificate.content | b64decode }}{% endfor -%}"
-  when: openshift_hosted_router_certificate is defined
+  when: openshift_hosted_router_certificate is defined or (openshift_hosted_router_create_certificate | default(false))
 
 - name: Create PEM certificate
   copy:


### PR DESCRIPTION
Proof of concept for generating default router cert valid for 
`*.{{openshift_master_default_subdomain}}`.

Motivation: make it effortless to rely on openshift-signer (trusting just its root cert) for master API, hosted services (I'm particularly intersted in hawkular metrics) and other app routes.
Currently hawkular-metrics route by default doesn't define `certificate`, falls back on router default cert which by default only issued by openshift-service-serving-signer for `router.default.svc`, `router.default.svc.cluster.local` domains — useless from outside.
It's already possible to pass externally generated hosted metrics and/or router certs.  But doing so requires users to generate their own CA root and the needed certs themselves, and then to trust both their root and openshift-signer — or go to even more trouble rooting all certs at their CA.  (That makes sense if you already have an organization CA, but should not be required for I-just-want-a-demo-openshift scenarios.)

I see hosted registry & logging already have code to generate a cert.
(As does openshift_metrics role.  What's the difference between openshift_metrics and openshift_hosted_metrics?)
So another option would be to add similar code to openshift_hosted_metrics.  But this approach has a major benefit of covering app routes!

- Worked for me, with byo playbook and this inventory: https://gist.github.com/cben/5396f531b17115db94ccc380997ac785
  `curl --cacert OPENSHIFT_SIGNER_ROOT.ca.crt` happily connects to both hawkular-metrics.10.35.48.131.xip.io and an example app nodejs-ex-red-dragon.10.35.48.131.xip.io (internal ips, don't promise to keep them up).

  - TODO: The chain I'm seeing the router present has openshift-signer self-signed root twice at the end.

  - New cert isn't valid for `router.default.svc`, `router.default.svc.cluster.local`.  Should I include them?   Can this (or the fact it's not signed by openshift-service-serving-signer) break something for internal connections to router?

- Conditioned on openshift_hosted_router_create_certificate=true.  The way I did the conditions is probably wrong.  I hope this could (eventually) become the default behavior when router cert is not explicitly specified.

- No idea how this behaves wrt. caching & re-deploying certs...

cc @jcantrill @bbguimaraes @simon3z 