### PR TITLE
During node upgrade upgrade openvswitch rpms

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -81,6 +81,21 @@
     failed_when: false
     when: openshift.common.is_containerized | bool
 
+  - name: Upgrade openvswitch
+    package:
+      name: openvswitch
+      state: latest
+    register: ovs_pkg
+    when: inventory_hostname in groups.oo_nodes_to_upgrade and not openshift.common.is_containerized | bool
+
+  - name: Restart openvswitch
+    systemd:
+      name: openvswitch
+      state: restarted
+    when:
+    - inventory_hostname in groups.oo_nodes_to_upgrade and not openshift.common.is_containerized | bool
+    - ovs_pkg | changed
+
   # Mandatory Docker restart, ensure all containerized services are running:
   - include: docker/restart.yml
 


### PR DESCRIPTION
Containerized upgrades of openvswitch are already handled by updating
the container image which will have the requisite version of openvswitch already.