### PR TITLE
Adding bool filter to ensure that we correctly set ops host for fluentd

### DIFF
--- a/roles/openshift_logging/tasks/install_fluentd.yaml
+++ b/roles/openshift_logging/tasks/install_fluentd.yaml
@@ -1,8 +1,8 @@
 ---
-- set_fact: fluentd_ops_host={{ (openshift_logging_use_ops) | ternary(openshift_logging_es_ops_host, openshift_logging_es_host) }}
+- set_fact: fluentd_ops_host={{ (openshift_logging_use_ops | bool) | ternary(openshift_logging_es_ops_host, openshift_logging_es_host) }}
   check_mode: no
 
-- set_fact: fluentd_ops_port={{ (openshift_logging_use_ops) | ternary(openshift_logging_es_ops_port, openshift_logging_es_port) }}
+- set_fact: fluentd_ops_port={{ (openshift_logging_use_ops | bool) | ternary(openshift_logging_es_ops_port, openshift_logging_es_port) }}
   check_mode: no
 
 - name: Generating Fluentd daemonset


### PR DESCRIPTION
If the openshift_logging_use_ops=false then it would evaluate incorrectly.
This resolves that issue.

@jcantrill @sdodson 