### PR TITLE
Fix host when waiting for a master system restart.

### DIFF
--- a/playbooks/common/openshift-master/restart_hosts.yml
+++ b/playbooks/common/openshift-master/restart_hosts.yml
@@ -10,9 +10,10 @@
 - name: Wait for master to restart
   local_action:
     module: wait_for
-      host="{{ inventory_hostname }}"
+      host="{{ ansible_host }}"
       state=started
       delay=10
+      timeout=600
   become: no
 
 # Now that ssh is back up we can wait for API on the remote system,


### PR DESCRIPTION
Discovered situations where the inventory hostname may not be resolvable
with ops clusters. Switching to the ssh host (an IP) should always be
correct.

Ops was also using a 10 minute timeout to make sure the host has enough time to come back, 5 minutes is the default. Open to discussion if this is overkill or not but we thought we'd include it anyhow.

CC @mwoodson 