### PR TITLE
Add default ansible.cfg file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ gce.ini
 multi_ec2.yaml
 .vagrant
 .tags*
-/ansible.cfg
 *.retry
 .vscode/*
 .cache

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,15 +3,18 @@
 
 # This config file provides examples for running
 # the OpenShift playbooks with the provided
-# inventory scripts. Only global defaults are
-# left uncommented
+# inventory scripts.
 
 [defaults]
-# Add the roles directory to the roles path
-roles_path = roles/
-
 # Set the log_path
-log_path = /tmp/ansible.log
+#log_path = /tmp/ansible.log
+
+# Additional default options for OpenShift Ansible
+callback_plugins = callback_plugins/
+forks = 20
+host_key_checking = False
+retry_files_enabled = False
+nocows = True
 
 # Uncomment to use the provided BYO inventory
 #hostfile = inventory/byo/hosts
@@ -21,3 +24,7 @@ log_path = /tmp/ansible.log
 
 # Uncomment to use the provided AWS dynamic inventory script
 #hostfile = inventory/aws/ec2.py
+
+# Additional ssh options for OpenShift Ansible
+[ssh_connection]
+pipelining = True


### PR DESCRIPTION
By default the callback_plugins need to be run to ensure proper Ansible version