### PR TITLE
Wrap openshift_hosted_logging include_role within a block.

### DIFF
--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -47,12 +47,15 @@
     when: ( openshift.common.version_gte_3_3_or_1_3  | bool ) and ( openshift_hosted_manage_registry | default(true) | bool ) and not (openshift.docker.hosted_registry_insecure | default(false) | bool)
 
 - name: Update master-config for publicLoggingURL
-  hosts: masters:!oo_first_master
+  hosts: oo_masters_to_config:!oo_first_master
+  tags:
+  - hosted
   pre_tasks:
   - set_fact:
       logging_hostname: "{{ openshift_hosted_logging_hostname | default('kibana.' ~ (openshift_master_default_subdomain | default('router.default.svc.cluster.local', true))) }}"
   tasks:
-  - include_role:
-      name: openshift_hosted_logging
-      tasks_from: update_master_config
+  - block:
+    - include_role:
+        name: openshift_hosted_logging
+        tasks_from: update_master_config
     when: openshift_hosted_logging_deploy | default(false) | bool


### PR DESCRIPTION
Encountered the following error during an HA install and found a thread [1] indicating that using `when` with `include_role` may be broken. Wrapping the `include_role` within a block seems to workaround the issue.

```
PLAY [Update master-config for publicLoggingURL] *******************************
 
TASK [setup] *******************************************************************
ok: [master3.abutcher.com]
ok: [master2.abutcher.com]
 
TASK [set_fact] ****************************************************************
ok: [master2.abutcher.com]
ok: [master3.abutcher.com]
 
TASK [openshift_facts : Detecting Operating System] ****************************
fatal: [master2.abutcher.com]: FAILED! => {"failed": true, "msg": "The conditional check 'o' failed. The error was: error while evaluating conditional (o): 'o' is undefined\n\nThe error appears to have been in '
/home/abutcher/rhat/openshift-ansible/playbooks/common/openshift-cluster/openshift_hosted.yml': line 55, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line a
ppears to be:\n\n  tasks:\n  - include_role:\n    ^ here\n"}
fatal: [master3.abutcher.com]: FAILED! => {"failed": true, "msg": "The conditional check 'o' failed. The error was: error while evaluating conditional (o): 'o' is undefined\n\nThe error appears to have been in '
/home/abutcher/rhat/openshift-ansible/playbooks/common/openshift-cluster/openshift_hosted.yml': line 55, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line a
ppears to be:\n\n  tasks:\n  - include_role:\n    ^ here\n"}
```

[1] https://groups.google.com/forum/#!topic/ansible-project/JFF-5wxjM70

cc @ewolinetz @detiber 
