### PR TITLE
fixes 1417261. Points playbooks to the correct 3.5 roles for logging …

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -468,18 +468,18 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # pods are deleted
 #
 # Other Logging Options -- Common items you may wish to reconfigure, for the complete
-# list of options please see roles/openshift_hosted_logging/README.md
+# list of options please see roles/openshift_logging/README.md
 #
 # Configure loggingPublicURL in the master config for aggregate logging, defaults
 # to https://kibana.{{ openshift_master_default_subdomain }}
 #openshift_master_logging_public_url=https://kibana.example.com
 # Configure the number of elastic search nodes, unless you're using dynamic provisioning
 # this value must be 1
-#openshift_hosted_logging_elasticsearch_cluster_size=1
-#openshift_hosted_logging_hostname=logging.apps.example.com
+#openshift_logging_es_cluster_size=1
+#openshift_logging_kibana_hostname=logging.apps.example.com
 # Configure the prefix and version for the deployer image
-#openshift_hosted_logging_deployer_prefix=registry.example.com:8888/openshift3/
-#openshift_hosted_logging_deployer_version=3.3.0
+#openshift_logging_image_prefix=registry.example.com:8888/openshift3/
+#openshift_logging_image_version=3.3.0
 
 # Configure the multi-tenant SDN plugin (default is 'redhat/openshift-ovs-subnet')
 # os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -475,11 +475,11 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_master_logging_public_url=https://kibana.example.com
 # Configure the number of elastic search nodes, unless you're using dynamic provisioning
 # this value must be 1
-#openshift_hosted_logging_elasticsearch_cluster_size=1
-#openshift_hosted_logging_hostname=logging.apps.example.com
+#openshift_logging_es_cluster_size=1
+#openshift_logging_kibana_hostname=logging.apps.example.com
 # Configure the prefix and version for the deployer image
-#openshift_hosted_logging_deployer_prefix=registry.example.com:8888/openshift3/
-#openshift_hosted_logging_deployer_version=3.3.0
+#openshift_logging_image_prefix=registry.example.com:8888/openshift3/
+#openshift_logging_image_version=3.3.0
 
 # Configure the multi-tenant SDN plugin (default is 'redhat/openshift-ovs-subnet')
 # os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'

--- a/playbooks/adhoc/openshift_hosted_logging_efk.yaml
+++ b/playbooks/adhoc/openshift_hosted_logging_efk.yaml
@@ -1,7 +1,7 @@
 ---
 - hosts: masters[0]
   roles:
-  - role: openshift_hosted_logging
+  - role: openshift_logging
     openshift_hosted_logging_cleanup: no
 
 - name: Update master-config for publicLoggingURL
@@ -11,6 +11,6 @@
       logging_hostname: "{{ openshift_hosted_logging_hostname | default('kibana.' ~ (openshift_master_default_subdomain | default('router.default.svc.cluster.local', true))) }}"
   tasks:
   - include_role:
-      name: openshift_hosted_logging
+      name: openshift_logging
       tasks_from: update_master_config
     when: openshift_hosted_logging_deploy | default(false) | bool

--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -27,21 +27,21 @@
       logging_elasticsearch_ops_cluster_size: "{{ openshift_hosted_logging_elasticsearch_ops_cluster_size | default(1) }}"
   roles:
   - role: openshift_hosted
-  - role: openshift_hosted_metrics
+  - role: openshift_metrics
     when: openshift_hosted_metrics_deploy | default(false) | bool
-  - role: openshift_hosted_logging
+  - role: openshift_logging
     when: openshift_hosted_logging_deploy | default(false) | bool
-    openshift_hosted_logging_hostname: "{{ logging_hostname }}"
-    openshift_hosted_logging_ops_hostname: "{{ logging_ops_hostname }}"
-    openshift_hosted_logging_master_public_url: "{{ logging_master_public_url }}"
-    openshift_hosted_logging_elasticsearch_cluster_size: "{{ logging_elasticsearch_cluster_size }}"
-    openshift_hosted_logging_elasticsearch_pvc_dynamic: "{{ 'true' if openshift_hosted_logging_storage_kind | default(none) == 'dynamic' else '' }}"
-    openshift_hosted_logging_elasticsearch_pvc_size: "{{ openshift.hosted.logging.storage.volume.size if openshift_hosted_logging_storage_kind | default(none) in ['dynamic','nfs'] else ''  }}"
-    openshift_hosted_logging_elasticsearch_pvc_prefix: "{{ 'logging-es' if openshift_hosted_logging_storage_kind | default(none) == 'dynamic' else '' }}"
-    openshift_hosted_logging_elasticsearch_ops_cluster_size: "{{ logging_elasticsearch_ops_cluster_size }}"
-    openshift_hosted_logging_elasticsearch_ops_pvc_dynamic: "{{ 'true' if openshift_hosted_logging_storage_kind | default(none) == 'dynamic' else '' }}"
-    openshift_hosted_logging_elasticsearch_ops_pvc_size: "{{ openshift.hosted.logging.storage.volume.size if openshift_hosted_logging_storage_kind | default(none) in ['dynamic','nfs' ] else ''  }}"
-    openshift_hosted_logging_elasticsearch_ops_pvc_prefix: "{{ 'logging-es' if openshift_hosted_logging_storage_kind | default(none) =='dynamic' else '' }}"
+    openshift_logging_kibana_hostname: "{{ logging_hostname }}"
+    openshift_logging_kibana_ops_hostname: "{{ logging_ops_hostname }}"
+    openshift_logging_master_public_url: "{{ logging_master_public_url }}"
+    openshift_logging_es_cluster_size: "{{ logging_elasticsearch_cluster_size }}"
+    openshift_logging_es_pvc_dynamic: "{{ 'true' if openshift_hosted_logging_storage_kind | default(none) == 'dynamic' else '' }}"
+    openshift_logging_es_pvc_size: "{{ openshift.hosted.logging.storage.volume.size if openshift_hosted_logging_storage_kind | default(none) in ['dynamic','nfs'] else ''  }}"
+    openshift_logging_es_pvc_prefix: "{{ 'logging-es' if openshift_hosted_logging_storage_kind | default(none) == 'dynamic' else '' }}"
+    openshift_logging_es_ops_cluster_size: "{{ logging_elasticsearch_ops_cluster_size }}"
+    openshift_logging_es_ops_pvc_dynamic: "{{ 'true' if openshift_hosted_logging_storage_kind | default(none) == 'dynamic' else '' }}"
+    openshift_logging_es_ops_pvc_size: "{{ openshift.hosted.logging.storage.volume.size if openshift_hosted_logging_storage_kind | default(none) in ['dynamic','nfs' ] else ''  }}"
+    openshift_logging_es_ops_pvc_prefix: "{{ 'logging-es' if openshift_hosted_logging_storage_kind | default(none) =='dynamic' else '' }}"
 
   - role: cockpit-ui
     when: ( openshift.common.version_gte_3_3_or_1_3  | bool ) and ( openshift_hosted_manage_registry | default(true) | bool ) and not (openshift.docker.hosted_registry_insecure | default(false) | bool)

--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -25,7 +25,7 @@ When both `openshift_logging_install_logging` and `openshift_logging_upgrade_log
 - `openshift_logging_image_version`: The image version for the logging images to use. Defaults to 'latest'.
 - `openshift_logging_use_ops`: If 'True', set up a second ES and Kibana cluster for infrastructure logs. Defaults to 'False'.
 - `master_url`: The URL for the Kubernetes master, this does not need to be public facing but should be accessible from within the cluster. Defaults to 'https://kubernetes.default.svc.cluster.local'.
-- `public_master_url`: The public facing URL for the Kubernetes master, this is used for Authentication redirection. Defaults to 'https://localhost:8443'.
+- `openshift_logging_master_public_url`: The public facing URL for the Kubernetes master, this is used for Authentication redirection. Defaults to 'https://localhost:8443'.
 - `openshift_logging_namespace`: The namespace that Aggregated Logging will be installed in. Defaults to 'logging'.
 - `openshift_logging_curator_default_days`: The default minimum age (in days) Curator uses for deleting log records. Defaults to '30'.
 - `openshift_logging_curator_run_hour`: The hour of the day that Curator will run at. Defaults to '0'.

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -3,7 +3,7 @@ openshift_logging_image_prefix: docker.io/openshift/origin-
 openshift_logging_image_version: latest
 openshift_logging_use_ops: False
 master_url: "https://kubernetes.default.svc.{{ openshift.common.dns_domain }}"
-public_master_url: "https://{{openshift.common.public_hostname}}:8443"
+openshift_logging_master_public_url: "https://{{openshift.common.public_hostname}}:8443"
 openshift_logging_namespace: logging
 openshift_logging_install_logging: True
 

--- a/roles/openshift_logging/templates/kibana.j2
+++ b/roles/openshift_logging/templates/kibana.j2
@@ -93,10 +93,10 @@ spec:
              value: {{master_url}}
             -
              name: "OAP_PUBLIC_MASTER_URL"
-             value: {{public_master_url}}
+             value: {{openshift_logging_master_public_url}}
             -
              name: "OAP_LOGOUT_REDIRECT"
-             value: {{public_master_url}}/console/logout
+             value: {{openshift_logging_master_public_url}}/console/logout
             -
              name: "OAP_MASTER_CA_FILE"
              value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"


### PR DESCRIPTION
fixes 1417261. Points playbooks to the correct 3.5 roles for logging and metrics

@sdodson This addresses the initial bug I believe but Im having issues testing since the ansible 2.2.2.0 version dependency check.  Also I'm not sure if I should be additionally updating the 'hosted_storage' variable.  I will defer to you recommendation