### PR TITLE
Ensure python-ruamel-yaml is installed

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -20,6 +20,7 @@ Requires:      tar
 Requires:      openshift-ansible-docs = %{version}-%{release}
 Requires:      java-1.8.0-openjdk-headless
 Requires:      httpd-tools
+Requires:      python-ruamel-yaml
 
 %description
 Openshift and Atomic Enterprise Ansible

--- a/roles/lib_openshift/tasks/main.yml
+++ b/roles/lib_openshift/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: lib_openshift ensure python-ruamel-yaml package is on target
+  package:
+    name: python-ruamel-yaml
+    state: present

--- a/roles/lib_utils/tasks/main.yml
+++ b/roles/lib_utils/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: lib_utils ensure python-ruamel-yaml package is on target
+  package:
+    name: python-ruamel-yaml
+    state: present

--- a/roles/openshift_logging/tasks/main.yaml
+++ b/roles/openshift_logging/tasks/main.yaml
@@ -12,10 +12,6 @@
 
 - debug: msg="Created temp dir {{mktemp.stdout}}"
 
-- name: Ensuring ruamel.yaml package is on target
-  command: yum install -y ruamel.yaml
-  check_mode: no
-
 - name: Copy the admin client config(s)
   command: >
     cp {{ openshift_master_config_dir }}/admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig


### PR DESCRIPTION
need to revisit this, currently python2-ruamel-yaml doesn't provide
'python-ruamel-yaml'. It probably should and that should be what we're
installing.

Fixes Bug 1418911