### PR TITLE
Copies CloudFront pem file to registry hosts

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -386,6 +386,12 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_hosted_registry_pullthrough=true
 #openshift_hosted_registry_acceptschema2=true
 #openshift_hosted_registry_enforcequota=true
+#
+# Additional CloudFront Options. When using CloudFront all three
+# of the followingg variables must be defined.
+#openshift_hosted_registry_storage_s3_cloudfront_baseurl=https://myendpoint.cloudfront.net/
+#openshift_hosted_registry_storage_s3_cloudfront_privatekeyfile=/full/path/to/secret.pem
+#openshift_hosted_registry_storage_s3_cloudfront_keypairid=yourpairid
 
 # Metrics deployment
 # See: https://docs.openshift.com/enterprise/latest/install_config/cluster_metrics.html

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -358,6 +358,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_hosted_registry_storage_volume_size=10Gi
 #
 # AWS S3
+#
 # S3 bucket must already exist.
 #openshift_hosted_registry_storage_kind=object
 #openshift_hosted_registry_storage_provider=s3
@@ -386,6 +387,12 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_hosted_registry_pullthrough=true
 #openshift_hosted_registry_acceptschema2=true
 #openshift_hosted_registry_enforcequota=true
+#
+# Additional CloudFront Options. When using CloudFront all three
+# of the followingg variables must be defined.
+#openshift_hosted_registry_storage_s3_cloudfront_baseurl=https://myendpoint.cloudfront.net/
+#openshift_hosted_registry_storage_s3_cloudfront_privatekeyfile=/full/path/to/secret.pem
+#openshift_hosted_registry_storage_s3_cloudfront_keypairid=yourpairid
 
 # Metrics deployment
 # See: https://docs.openshift.com/enterprise/latest/install_config/cluster_metrics.html

--- a/roles/openshift_hosted/tasks/registry/storage/s3.yml
+++ b/roles/openshift_hosted/tasks/registry/storage/s3.yml
@@ -10,3 +10,24 @@
       openshift_hosted_registry_storage_s3_bucket and
       openshift_hosted_registry_storage_s3_region are required
   when: openshift.hosted.registry.storage.s3.bucket | default(none) is none or openshift.hosted.registry.storage.s3.region | default(none) is none
+
+# If cloudfront is being used, fail if we don't have all the required variables
+- assert:
+    that:
+      - "openshift_hosted_registry_storage_s3_cloudfront_baseurl is not defined or openshift_hosted_registry_storage_s3_cloudfront_privatekeyfile | default(none) is not none"
+      - "openshift_hosted_registry_storage_s3_cloudfront_baseurl is not defined or openshift_hosted_registry_storage_s3_cloudfront_keypairid | default(none) is not none"
+    msg: >
+      When openshift_hosted_registry_storage_s3_cloudfront_baseurl is provided
+      openshift_hosted_registry_storage_s3_cloudfront_keypairid and
+      openshift_hosted_registry_storage_s3_cloudfront_privatekeyfile are required
+
+# Copy the cloudfront.pem to the host if the baseurl is given
+- name: Copy cloudfront.pem to the registry
+  copy:
+    src: "{{ openshift_hosted_registry_storage_s3_cloudfront_privatekeyfile }}"
+    dest: /etc/s3-cloudfront/cloudfront.pem
+    backup: true
+    owner: root
+    group: root
+    mode: 0600
+  when: openshift_hosted_registry_storage_s3_cloudfront_baseurl | default(none) is not none


### PR DESCRIPTION
This change copies the CloudFront private key to registry hosts when
the provider is set to s3 and CloudFront baseurl, privatekey, and
keyparid are all provided. It also adds the following variable
examples in the host inventory files:

- openshift_hosted_registry_storage_s3_cloudfront_baseurl
- openshift_hosted_registry_storage_s3_cloudfront_privatekeyfile
- openshift_hosted_registry_storage_s3_cloudfront_keypairid

See https://bugzilla.redhat.com/show_bug.cgi?id=1395168