### PR TITLE
Backport 1.2: Adjust to_padded_yaml transformation to use the AnsibleDumper

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -16,6 +16,7 @@ import pkg_resources
 import re
 import json
 import yaml
+from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.utils.unicode import to_unicode
 from urlparse import urlparse
 
@@ -629,7 +630,9 @@ class FilterModule(object):
             return ""
 
         try:
-            transformed = yaml.safe_dump(data, indent=indent, allow_unicode=True, default_flow_style=False, **kw)
+            transformed = yaml.dump(data, indent=indent, allow_unicode=True,
+                                    default_flow_style=False,
+                                    Dumper=AnsibleDumper, **kw)
             padded = "\n".join([" " * level * indent + line for line in transformed.splitlines()])
             return to_text("\n{0}".format(padded))
         except Exception as my_e:


### PR DESCRIPTION
* Previously we used yaml.safe_dump
* Now we use yamp.dump with the `Dumper` parameter set to the
  AnsibleDumper class.
* AnsibleDumper subclasses yaml.SafeDumper, so we aren't losing any
  safety nets

Fixes 1419533

https://bugzilla.redhat.com/show_bug.cgi?id=1419533