### PR TITLE
fix 1406057. Allow openshift_metrics nodeselectors for components

### DIFF
--- a/roles/openshift_metrics/defaults/main.yaml
+++ b/roles/openshift_metrics/defaults/main.yaml
@@ -13,6 +13,7 @@ openshift_metrics_hawkular_requests_cpu: null
 openshift_metrics_hawkular_cert: ""
 openshift_metrics_hawkular_key: ""
 openshift_metrics_hawkular_ca: ""
+openshift_metrics_hawkular_nodeselector: ""
 
 openshift_metrics_cassandra_replicas: 1
 openshift_metrics_cassandra_storage_type: emptydir
@@ -21,12 +22,14 @@ openshift_metrics_cassandra_limits_memory: 2G
 openshift_metrics_cassandra_limits_cpu: null
 openshift_metrics_cassandra_requests_memory: 1G
 openshift_metrics_cassandra_requests_cpu: null
+openshift_metrics_cassandra_nodeselector: ""
 
 openshift_metrics_heapster_standalone: False
 openshift_metrics_heapster_limits_memory: 3.75G
 openshift_metrics_heapster_limits_cpu: null
 openshift_metrics_heapster_requests_memory: 0.9375G
 openshift_metrics_heapster_requests_cpu: null
+openshift_metrics_heapster_nodeselector: ""
 
 openshift_metrics_duration: 7
 openshift_metrics_resolution: 15s

--- a/roles/openshift_metrics/tasks/install_cassandra.yaml
+++ b/roles/openshift_metrics/tasks/install_cassandra.yaml
@@ -18,6 +18,7 @@
     node: "{{ item }}"
     master: "{{ (item == '1')|string|lower }}"
     replica_count: "{{cassandra_replica_count.results[item|int - 1].stdout}}"
+    node_selector: "{{openshift_metrics_cassandra_nodeselector | default('') }}"
   with_sequence: count={{ openshift_metrics_cassandra_replicas }}
   changed_when: false
 

--- a/roles/openshift_metrics/tasks/install_hawkular.yaml
+++ b/roles/openshift_metrics/tasks/install_hawkular.yaml
@@ -13,6 +13,7 @@
     dest: "{{ mktemp.stdout }}/templates/hawkular_metrics_rc.yaml"
   vars:
     replica_count: "{{hawkular_metrics_replica_count.stdout | default(0)}}"
+    node_selector: "{{openshift_metrics_hawkular_nodeselector | default('') }}"
   changed_when: false
 
 - name: read hawkular-metrics route destination ca certificate

--- a/roles/openshift_metrics/tasks/install_heapster.yaml
+++ b/roles/openshift_metrics/tasks/install_heapster.yaml
@@ -11,4 +11,5 @@
   template: src=heapster.j2 dest={{mktemp.stdout}}/templates/metrics-heapster-rc.yaml
   vars:
     replica_count: "{{heapster_replica_count.stdout | default(0)}}"
+    node_selector: "{{openshift_metrics_heapster_nodeselector | default('') }}"
   changed_when: no

--- a/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
@@ -19,6 +19,12 @@ spec:
         type: hawkular-cassandra
     spec:
       serviceAccount: cassandra
+{% if node_selector is iterable and node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in node_selector.iteritems() %}
+        {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
       containers:
       - image: "{{ openshift_metrics_image_prefix }}metrics-cassandra:{{ openshift_metrics_image_version }}"
         name: hawkular-cassandra-{{ node }}

--- a/roles/openshift_metrics/templates/hawkular_metrics_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_metrics_rc.j2
@@ -17,6 +17,12 @@ spec:
         name: hawkular-metrics
     spec:
       serviceAccount: hawkular
+{% if node_selector is iterable and node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in node_selector.iteritems() %}
+        {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
       containers:
       - image: {{openshift_metrics_image_prefix}}metrics-hawkular-metrics:{{openshift_metrics_image_version}}
         name: hawkular-metrics

--- a/roles/openshift_metrics/templates/heapster.j2
+++ b/roles/openshift_metrics/templates/heapster.j2
@@ -18,6 +18,12 @@ spec:
         name: heapster
     spec:
       serviceAccountName: heapster
+{% if node_selector is iterable and node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in node_selector.iteritems() %}
+        {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
       containers:
       - name: heapster
         image: {{openshift_metrics_image_prefix}}metrics-heapster:{{openshift_metrics_image_version}}


### PR DESCRIPTION
This would also partially fix #2800. In regards to https://github.com/openshift/openshift-ansible/issues/2800#issuecomment-268399097  I believe this is resolvable using  affinity/anti-affinity rules.