### PR TITLE
Bug 1364160 - facts collection for openshift.common.admin_binary does not seem to work in mixed environments

### DIFF
--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -87,7 +87,7 @@
 # This should NOT replace the CA due to --overwrite=false when a CA already exists.
 - name: Create the master certificates if they do not already exist
   command: >
-    {{ openshift.common.client_binary }} adm create-master-certs
+    {{ hostvars[openshift_ca_host].openshift.common.client_binary }} adm create-master-certs
     {% for named_ca_certificate in openshift.master.named_certificates | default([]) | oo_collect('cafile') %}
     --certificate-authority {{ named_ca_certificate }}
     {% endfor %}


### PR DESCRIPTION
A lot of the binary locations for master delegations were updated in #2671. This is the last one I think. Tested with mixed containerized masters and nodes.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1364160