### PR TITLE
Reverting commit 3257 and renaming master_url to openshift_logging_ma…

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -474,7 +474,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # pods are deleted
 #
 # Other Logging Options -- Common items you may wish to reconfigure, for the complete
-# list of options please see roles/openshift_hosted_logging/README.md
+# list of options please see roles/openshift_logging/README.md
 #
 # Configure loggingPublicURL in the master config for aggregate logging, defaults
 # to https://kibana.{{ openshift_master_default_subdomain }}

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -474,18 +474,18 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # pods are deleted
 #
 # Other Logging Options -- Common items you may wish to reconfigure, for the complete
-# list of options please see roles/openshift_logging/README.md
+# list of options please see roles/openshift_hosted_logging/README.md
 #
 # Configure loggingPublicURL in the master config for aggregate logging, defaults
 # to https://kibana.{{ openshift_master_default_subdomain }}
 #openshift_master_logging_public_url=https://kibana.example.com
 # Configure the number of elastic search nodes, unless you're using dynamic provisioning
 # this value must be 1
-#openshift_logging_es_cluster_size=1
-#openshift_logging_kibana_hostname=logging.apps.example.com
+#openshift_hosted_logging_elasticsearch_cluster_size=1
+#openshift_hosted_logging_hostname=logging.apps.example.com
 # Configure the prefix and version for the deployer image
-#openshift_logging_image_prefix=registry.example.com:8888/openshift3/
-#openshift_logging_image_version=3.3.0
+#openshift_hosted_logging_deployer_prefix=registry.example.com:8888/openshift3/
+#openshift_hosted_logging_deployer_version=3.3.0
 
 # Configure the multi-tenant SDN plugin (default is 'redhat/openshift-ovs-subnet')
 # os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -475,7 +475,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # pods are deleted
 #
 # Other Logging Options -- Common items you may wish to reconfigure, for the complete
-# list of options please see roles/openshift_hosted_logging/README.md
+# list of options please see roles/openshift_logging/README.md
 #
 # Configure loggingPublicURL in the master config for aggregate logging, defaults
 # to https://kibana.{{ openshift_master_default_subdomain }}

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -482,11 +482,11 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_master_logging_public_url=https://kibana.example.com
 # Configure the number of elastic search nodes, unless you're using dynamic provisioning
 # this value must be 1
-#openshift_logging_es_cluster_size=1
-#openshift_logging_kibana_hostname=logging.apps.example.com
+#openshift_hosted_logging_elasticsearch_cluster_size=1
+#openshift_hosted_logging_hostname=logging.apps.example.com
 # Configure the prefix and version for the deployer image
-#openshift_logging_image_prefix=registry.example.com:8888/openshift3/
-#openshift_logging_image_version=3.3.0
+#openshift_hosted_logging_deployer_prefix=registry.example.com:8888/openshift3/
+#openshift_hosted_logging_deployer_version=3.3.0
 
 # Configure the multi-tenant SDN plugin (default is 'redhat/openshift-ovs-subnet')
 # os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'

--- a/playbooks/adhoc/openshift_hosted_logging_efk.yaml
+++ b/playbooks/adhoc/openshift_hosted_logging_efk.yaml
@@ -1,16 +1,16 @@
 ---
 - hosts: masters[0]
   roles:
-  - role: openshift_hosted_logging
+  - role: openshift_logging
     openshift_hosted_logging_cleanup: no
 
 - name: Update master-config for publicLoggingURL
   hosts: masters:!masters[0]
   pre_tasks:
   - set_fact:
-      logging_hostname: "{{ openshift_hosted_logging_hostname | default('kibana.' ~ (openshift_master_default_subdomain | default('router.default.svc.cluster.local', true))) }}"
+      openshift_logging_kibana_hostname: "{{ openshift_hosted_logging_hostname | default('kibana.' ~ (openshift_master_default_subdomain | default('router.default.svc.cluster.local', true))) }}"
   tasks:
   - include_role:
-      name: openshift_hosted_logging
+      name: openshift_logging
       tasks_from: update_master_config
     when: openshift_hosted_logging_deploy | default(false) | bool

--- a/playbooks/adhoc/openshift_hosted_logging_efk.yaml
+++ b/playbooks/adhoc/openshift_hosted_logging_efk.yaml
@@ -1,7 +1,7 @@
 ---
 - hosts: masters[0]
   roles:
-  - role: openshift_logging
+  - role: openshift_hosted_logging
     openshift_hosted_logging_cleanup: no
 
 - name: Update master-config for publicLoggingURL
@@ -11,6 +11,6 @@
       logging_hostname: "{{ openshift_hosted_logging_hostname | default('kibana.' ~ (openshift_master_default_subdomain | default('router.default.svc.cluster.local', true))) }}"
   tasks:
   - include_role:
-      name: openshift_logging
+      name: openshift_hosted_logging
       tasks_from: update_master_config
     when: openshift_hosted_logging_deploy | default(false) | bool

--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -27,21 +27,21 @@
       logging_elasticsearch_ops_cluster_size: "{{ openshift_hosted_logging_elasticsearch_ops_cluster_size | default(1) }}"
   roles:
   - role: openshift_hosted
-  - role: openshift_metrics
+  - role: openshift_hosted_metrics
     when: openshift_hosted_metrics_deploy | default(false) | bool
-  - role: openshift_logging
+  - role: openshift_hosted_logging
     when: openshift_hosted_logging_deploy | default(false) | bool
-    openshift_logging_kibana_hostname: "{{ logging_hostname }}"
-    openshift_logging_kibana_ops_hostname: "{{ logging_ops_hostname }}"
-    openshift_logging_master_public_url: "{{ logging_master_public_url }}"
-    openshift_logging_es_cluster_size: "{{ logging_elasticsearch_cluster_size }}"
-    openshift_logging_es_pvc_dynamic: "{{ 'true' if openshift_hosted_logging_storage_kind | default(none) == 'dynamic' else '' }}"
-    openshift_logging_es_pvc_size: "{{ openshift.hosted.logging.storage.volume.size if openshift_hosted_logging_storage_kind | default(none) in ['dynamic','nfs'] else ''  }}"
-    openshift_logging_es_pvc_prefix: "{{ 'logging-es' if openshift_hosted_logging_storage_kind | default(none) == 'dynamic' else '' }}"
-    openshift_logging_es_ops_cluster_size: "{{ logging_elasticsearch_ops_cluster_size }}"
-    openshift_logging_es_ops_pvc_dynamic: "{{ 'true' if openshift_hosted_logging_storage_kind | default(none) == 'dynamic' else '' }}"
-    openshift_logging_es_ops_pvc_size: "{{ openshift.hosted.logging.storage.volume.size if openshift_hosted_logging_storage_kind | default(none) in ['dynamic','nfs' ] else ''  }}"
-    openshift_logging_es_ops_pvc_prefix: "{{ 'logging-es' if openshift_hosted_logging_storage_kind | default(none) =='dynamic' else '' }}"
+    openshift_hosted_logging_hostname: "{{ logging_hostname }}"
+    openshift_hosted_logging_ops_hostname: "{{ logging_ops_hostname }}"
+    openshift_hosted_logging_master_public_url: "{{ logging_master_public_url }}"
+    openshift_hosted_logging_elasticsearch_cluster_size: "{{ logging_elasticsearch_cluster_size }}"
+    openshift_hosted_logging_elasticsearch_pvc_dynamic: "{{ 'true' if openshift_hosted_logging_storage_kind | default(none) == 'dynamic' else '' }}"
+    openshift_hosted_logging_elasticsearch_pvc_size: "{{ openshift.hosted.logging.storage.volume.size if openshift_hosted_logging_storage_kind | default(none) in ['dynamic','nfs'] else ''  }}"
+    openshift_hosted_logging_elasticsearch_pvc_prefix: "{{ 'logging-es' if openshift_hosted_logging_storage_kind | default(none) == 'dynamic' else '' }}"
+    openshift_hosted_logging_elasticsearch_ops_cluster_size: "{{ logging_elasticsearch_ops_cluster_size }}"
+    openshift_hosted_logging_elasticsearch_ops_pvc_dynamic: "{{ 'true' if openshift_hosted_logging_storage_kind | default(none) == 'dynamic' else '' }}"
+    openshift_hosted_logging_elasticsearch_ops_pvc_size: "{{ openshift.hosted.logging.storage.volume.size if openshift_hosted_logging_storage_kind | default(none) in ['dynamic','nfs' ] else ''  }}"
+    openshift_hosted_logging_elasticsearch_ops_pvc_prefix: "{{ 'logging-es' if openshift_hosted_logging_storage_kind | default(none) =='dynamic' else '' }}"
 
   - role: cockpit-ui
     when: ( openshift.common.version_gte_3_3_or_1_3  | bool ) and ( openshift_hosted_manage_registry | default(true) | bool ) and not (openshift.docker.hosted_registry_insecure | default(false) | bool)

--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -27,9 +27,9 @@
       logging_elasticsearch_ops_cluster_size: "{{ openshift_hosted_logging_elasticsearch_ops_cluster_size | default(1) }}"
   roles:
   - role: openshift_hosted
-  - role: openshift_hosted_metrics
+  - role: openshift_metrics
     when: openshift_hosted_metrics_deploy | default(false) | bool
-  - role: openshift_hosted_logging
+  - role: openshift_logging
     when: openshift_hosted_logging_deploy | default(false) | bool
     openshift_hosted_logging_hostname: "{{ logging_hostname }}"
     openshift_hosted_logging_ops_hostname: "{{ logging_ops_hostname }}"
@@ -52,11 +52,11 @@
   - hosted
   pre_tasks:
   - set_fact:
-      logging_hostname: "{{ openshift_hosted_logging_hostname | default('kibana.' ~ (openshift_master_default_subdomain | default('router.default.svc.cluster.local', true))) }}"
+      openshift_logging_kibana_hostname: "{{ openshift_hosted_logging_hostname | default('kibana.' ~ (openshift_master_default_subdomain | default('router.default.svc.cluster.local', true))) }}"
   tasks:
 
   - block:
     - include_role:
-        name: openshift_hosted_logging
+        name: openshift_logging
         tasks_from: update_master_config
     when: openshift_hosted_logging_deploy | default(false) | bool

--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -24,8 +24,8 @@ When both `openshift_logging_install_logging` and `openshift_logging_upgrade_log
 - `openshift_logging_image_prefix`: The prefix for the logging images to use. Defaults to 'docker.io/openshift/origin-'.
 - `openshift_logging_image_version`: The image version for the logging images to use. Defaults to 'latest'.
 - `openshift_logging_use_ops`: If 'True', set up a second ES and Kibana cluster for infrastructure logs. Defaults to 'False'.
-- `master_url`: The URL for the Kubernetes master, this does not need to be public facing but should be accessible from within the cluster. Defaults to 'https://kubernetes.default.svc.cluster.local'.
-- `openshift_logging_master_public_url`: The public facing URL for the Kubernetes master, this is used for Authentication redirection. Defaults to 'https://localhost:8443'.
+- `openshift_logging_master_url`: The URL for the Kubernetes master, this does not need to be public facing but should be accessible from within the cluster. Defaults to 'https://kubernetes.default.svc.{{openshift.common.dns_domain}}'.
+- `openshift_logging_master_public_url`: The public facing URL for the Kubernetes master, this is used for Authentication redirection. Defaults to 'https://{{openshift.common.public_hostname}}:8443'.
 - `openshift_logging_namespace`: The namespace that Aggregated Logging will be installed in. Defaults to 'logging'.
 - `openshift_logging_curator_default_days`: The default minimum age (in days) Curator uses for deleting log records. Defaults to '30'.
 - `openshift_logging_curator_run_hour`: The hour of the day that Curator will run at. Defaults to '0'.

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
-openshift_logging_image_prefix: docker.io/openshift/origin-
-openshift_logging_image_version: latest
+openshift_logging_image_prefix: "{{ openshift_hosted_logging_deployer_prefix | default(docker.io/openshift/origin-) }}"
+openshift_logging_image_version: "{{ openshift_hosted_logging_deployer_version | default(latest) }}"
 openshift_logging_use_ops: False
 openshift_logging_master_url: "https://kubernetes.default.svc.{{ openshift.common.dns_domain }}"
-openshift_logging_master_public_url: "https://{{openshift.common.public_hostname}}:8443"
+openshift_logging_master_public_url: "{{ openshift_hosted_logging_master_public_url | default(https://{{openshift.common.public_hostname}}:8443) }}"
 openshift_logging_namespace: logging
 openshift_logging_install_logging: True
 
@@ -19,7 +19,7 @@ openshift_logging_curator_memory_limit: null
 openshift_logging_curator_ops_cpu_limit: 100m
 openshift_logging_curator_ops_memory_limit: null
 
-openshift_logging_kibana_hostname: "kibana.{{openshift.common.dns_domain}}"
+openshift_logging_kibana_hostname: "{{ openshift_hosted_logging_hostname | default(kibana.{{openshift.common.dns_domain}}) }}"
 openshift_logging_kibana_cpu_limit: null
 openshift_logging_kibana_memory_limit: null
 openshift_logging_kibana_proxy_debug: false
@@ -27,7 +27,7 @@ openshift_logging_kibana_proxy_cpu_limit: null
 openshift_logging_kibana_proxy_memory_limit: null
 openshift_logging_kibana_replica_count: 1
 
-openshift_logging_kibana_ops_hostname: "kibana-ops.{{openshift.common.dns_domain}}"
+openshift_logging_kibana_ops_hostname: "{{ openshift_hosted_logging_ops_hostname | default(kibana-ops.{{openshift.common.dns_domain}}) }}"
 openshift_logging_kibana_ops_cpu_limit: null
 openshift_logging_kibana_ops_memory_limit: null
 openshift_logging_kibana_ops_proxy_debug: false
@@ -48,13 +48,13 @@ openshift_logging_es_port: 9200
 openshift_logging_es_ca: /etc/fluent/keys/ca
 openshift_logging_es_client_cert: /etc/fluent/keys/cert
 openshift_logging_es_client_key: /etc/fluent/keys/key
-openshift_logging_es_cluster_size: 1
+openshift_logging_es_cluster_size: "{{ openshift_hosted_logging_elasticsearch_cluster_size | default(1) }}"
 openshift_logging_es_cpu_limit: null
 openshift_logging_es_memory_limit: 1024Mi
 openshift_logging_es_pv_selector: null
-openshift_logging_es_pvc_dynamic: False
-openshift_logging_es_pvc_size: ""
-openshift_logging_es_pvc_prefix: logging-es
+openshift_logging_es_pvc_dynamic: "{{ openshift_hosted_logging_elasticsearch_pvc_dynamic | default(False) }}"
+openshift_logging_es_pvc_size: "{{ openshift_hosted_logging_elasticsearch_pvc_size | default('') }}"
+openshift_logging_es_pvc_prefix: "{{ openshift_hosted_logging_elasticsearch_pvc_prefix | default(logging-es) }}"
 openshift_logging_es_recover_after_time: 5m
 openshift_logging_es_storage_group: 65534
 
@@ -66,13 +66,13 @@ openshift_logging_es_ops_port: 9200
 openshift_logging_es_ops_ca: /etc/fluent/keys/ca
 openshift_logging_es_ops_client_cert: /etc/fluent/keys/cert
 openshift_logging_es_ops_client_key: /etc/fluent/keys/key
-openshift_logging_es_ops_cluster_size: 1
+openshift_logging_es_ops_cluster_size: "{{ openshift_hosted_logging_elasticsearch_ops_cluster_size | default(1) }}"
 openshift_logging_es_ops_cpu_limit: null
 openshift_logging_es_ops_memory_limit: 1024Mi
 openshift_logging_es_ops_pv_selector: None
-openshift_logging_es_ops_pvc_dynamic: False
-openshift_logging_es_ops_pvc_size: ""
-openshift_logging_es_ops_pvc_prefix: logging-es-ops
+openshift_logging_es_ops_pvc_dynamic: "{{ openshift_hosted_logging_elasticsearch_ops_pvc_dynamic | default(False) }}"
+openshift_logging_es_ops_pvc_size: "{{ openshift_hosted_logging_elasticsearch_ops_pvc_size | default('') }}"
+openshift_logging_es_ops_pvc_prefix: "{{ openshift_hosted_logging_elasticsearch_ops_pvc_prefix | default(logging-es-ops) }}"
 openshift_logging_es_ops_recover_after_time: 5m
 openshift_logging_es_ops_storage_group: 65534
 

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -2,7 +2,7 @@
 openshift_logging_image_prefix: docker.io/openshift/origin-
 openshift_logging_image_version: latest
 openshift_logging_use_ops: False
-master_url: "https://kubernetes.default.svc.{{ openshift.common.dns_domain }}"
+openshift_logging_master_url: "https://kubernetes.default.svc.{{ openshift.common.dns_domain }}"
 openshift_logging_master_public_url: "https://{{openshift.common.public_hostname}}:8443"
 openshift_logging_namespace: logging
 openshift_logging_install_logging: True

--- a/roles/openshift_logging/templates/curator.j2
+++ b/roles/openshift_logging/templates/curator.j2
@@ -48,7 +48,7 @@ spec:
           env:
             -
               name: "K8S_HOST_URL"
-              value: "{{master_url}}"
+              value: "{{openshift_logging_master_url}}"
             -
               name: "ES_HOST"
               value: "{{es_host}}"

--- a/roles/openshift_logging/templates/fluentd.j2
+++ b/roles/openshift_logging/templates/fluentd.j2
@@ -61,7 +61,7 @@ spec:
           readOnly: true
         env:
         - name: "K8S_HOST_URL"
-          value: "{{master_url}}"
+          value: "{{openshift_logging_master_url}}"
         - name: "ES_HOST"
           value: "{{openshift_logging_es_host}}"
         - name: "ES_PORT"

--- a/roles/openshift_logging/templates/kibana.j2
+++ b/roles/openshift_logging/templates/kibana.j2
@@ -90,7 +90,7 @@ spec:
              value: kibana-proxy
             -
              name: "OAP_MASTER_URL"
-             value: {{master_url}}
+             value: {{openshift_logging_master_url}}
             -
              name: "OAP_PUBLIC_MASTER_URL"
              value: {{openshift_logging_master_public_url}}

--- a/roles/openshift_metrics/defaults/main.yaml
+++ b/roles/openshift_metrics/defaults/main.yaml
@@ -31,6 +31,8 @@ openshift_metrics_heapster_requests_memory: 0.9375G
 openshift_metrics_heapster_requests_cpu: null
 openshift_metrics_heapster_nodeselector: ""
 
+openshift_metrics_hostname: "hawkular-metrics.{{openshift_master_default_subdomain}}"
+
 openshift_metrics_duration: 7
 openshift_metrics_resolution: 15s
 


### PR DESCRIPTION
…ster_url

I believe the correct approach would be to introduce a way to run either the openshift_hosted_{logging,metrics} roles or the new openshift_{logging,metrics} roles instead of just replacing them outright