### PR TITLE
Fixed ansible module unit and integration tests and added runners.

### DIFF
--- a/roles/lib_openshift/library/oc_label.py
+++ b/roles/lib_openshift/library/oc_label.py
@@ -1552,7 +1552,7 @@ def main():
             state=dict(default='present', type='str',
                        choices=['present', 'absent', 'list', 'add']),
             debug=dict(default=False, type='bool'),
-            kind=dict(default='node', type='str', required=True,
+            kind=dict(default='node', type='str',
                       choices=['node', 'pod', 'namespace']),
             name=dict(default=None, type='str'),
             namespace=dict(default=None, type='str'),

--- a/roles/lib_openshift/src/ansible/oc_label.py
+++ b/roles/lib_openshift/src/ansible/oc_label.py
@@ -10,7 +10,7 @@ def main():
             state=dict(default='present', type='str',
                        choices=['present', 'absent', 'list', 'add']),
             debug=dict(default=False, type='bool'),
-            kind=dict(default='node', type='str', required=True,
+            kind=dict(default='node', type='str',
                       choices=['node', 'pod', 'namespace']),
             name=dict(default=None, type='str'),
             namespace=dict(default=None, type='str'),

--- a/roles/lib_openshift/src/test/generate-and-run-tests.sh
+++ b/roles/lib_openshift/src/test/generate-and-run-tests.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -e
+
+
+if [ $# -ne 1 ] ; then
+    echo "Usage: $(basename $0) <master name>"
+    exit 1
+fi
+
+MASTER=$1
+
+
+
+# Put us in the same dir as the script.
+cd $(dirname $0)
+
+
+echo
+echo "Running lib_utils generate-and-run-tests.sh"
+echo "-------------------------------------------"
+../../../lib_utils/src/test/generate-and-run-tests.sh
+
+
+echo
+echo "Running lib_openshift generate"
+echo "------------------------------"
+../generate.py
+
+
+echo
+echo "Running lib_openshift Unit Tests"
+echo "----------------------------"
+cd unit
+
+for test in *.py; do
+    echo
+    echo "--------------------------------------------------------------------------------"
+    echo
+    echo "Running $test..."
+    ./$test
+done
+
+
+echo
+echo "Running lib_openshift Integration Tests"
+echo "-----------------------------------"
+cd ../integration
+
+for test in *.yml; do
+    echo
+    echo "--------------------------------------------------------------------------------"
+    echo
+    echo "Running $test..."
+    ./$test -vvv -e cli_master_test="$MASTER"
+done

--- a/roles/lib_openshift/src/test/integration/oadm_manage_node.yml
+++ b/roles/lib_openshift/src/test/integration/oadm_manage_node.yml
@@ -1,40 +1,51 @@
 #!/usr/bin/ansible-playbook --module-path=../../../library/
-# ./oadm_manage_node.yml -M ../../../library -e "cli_master_test=$OPENSHIFT_MASTER cli_node_test=$OPENSHIFT_NODE
+#
+# ./oadm_manage_node.yml -e "cli_master_test=$OPENSHIFT_MASTER
 ---
 - hosts: "{{ cli_master_test }}"
   gather_facts: no
   user: root
   tasks:
+  - name: get list of nodes
+    oc_obj:
+      state: list
+      kind: node
+    register: obj_out
+
+  - name: Set the node to work with
+    set_fact:
+      node_to_test: "{{ obj_out['results']['results'][0]['items'][0]['metadata']['name'] }}"
+
   - name: list pods from a node
     oadm_manage_node:
       list_pods: True
       node:
-      - "{{ cli_node_test }}"
+      - "{{ node_to_test }}"
     register: podout
   - debug: var=podout
 
   - assert:
-      that: "'{{ cli_node_test }}' in podout.results.nodes"
+      that: "'{{ node_to_test }}' in podout.results.nodes"
       msg: Pod data was not returned
 
   - name: set node to unschedulable
     oadm_manage_node:
       schedulable: False
       node:
-      - "{{ cli_node_test }}"
+      - "{{ node_to_test }}"
     register: nodeout
   - debug: var=nodeout
 
   - name: assert that schedulable=False
     assert:
       that: nodeout.results.nodes[0]['schedulable'] == False
-      msg: "{{ cli_node_test }} schedulable set to True"
+      msg: "{{ node_to_test }} schedulable set to True"
 
   - name: get node scheduable
     oc_obj:
       kind: node
       state: list
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       namespace: None
     register: nodeout
 
@@ -48,11 +59,11 @@
     oadm_manage_node:
       schedulable: True
       node:
-      - "{{ cli_node_test }}"
+      - "{{ node_to_test }}"
     register: nodeout
   - debug: var=nodeout
 
   - name: assert that schedulable=False
     assert:
       that: nodeout.results.nodes[0]['schedulable']
-      msg: "{{ cli_node_test }} schedulable set to False"
+      msg: "{{ node_to_test }} schedulable set to False"

--- a/roles/lib_openshift/src/test/integration/oc_label.yml
+++ b/roles/lib_openshift/src/test/integration/oc_label.yml
@@ -1,5 +1,7 @@
 #!/usr/bin/ansible-playbook --module-path=../../../library/
-# ./oc_label.yml -e "cli_master_test=$OPENSHIFT_MASTER -e "cli_node_test=ip-172-0-31-1.ec2"
+#
+# ./oc_label.yml -e "cli_master_test=$OPENSHIFT_MASTER
+#
 ---
 - hosts: "{{ cli_master_test }}"
   gather_facts: no
@@ -15,16 +17,25 @@
       msg: "{{ item }} not defined"
     when: "{{ item }} is not defined"
     with_items:
-    - cli_node_test  # openshift node to be used to add/remove labels to
     - cli_master_test  # ansible inventory instance to run playbook against
 
   tasks:
+  - name: get list of nodes
+    oc_obj:
+      state: list
+      kind: node
+    register: obj_out
+
+  - name: Set the node to work with
+    set_fact:
+      node_to_test: "{{ obj_out['results']['results'][0]['items'][0]['metadata']['name'] }}"
+
   - name: delete test labels (start from known starting position)
     oc_label:
       state: absent
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       labels:
       - key: testlabel2
       - key: testlabel3
@@ -34,7 +45,7 @@
       state: list
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
     register: original_labels
   - name: assert that testlabel2 and testlabel3 test labels don't exist
     assert:
@@ -47,7 +58,7 @@
       state: add
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       labels:
       - key: testlabel2
         value: "yes"
@@ -62,7 +73,7 @@
       state: list
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
     register: label_out
   - name: assert that testlabel2 label actually added
     assert:
@@ -75,7 +86,7 @@
       state: add
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       labels:
       - key: testlabel2
         value: "yes"
@@ -90,7 +101,7 @@
       state: add
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       labels:
       - key: testlabel2
         value: "different"
@@ -105,7 +116,7 @@
       state: list
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
     register: label_out
   - name: assert that testlabel2 label actually modified
     assert:
@@ -118,7 +129,7 @@
       state: absent
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       labels:
       - key: testlabelnone
     register: label_out
@@ -132,7 +143,7 @@
       state: absent
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       labels:
       - key: testlabel2
     register: label_out
@@ -146,7 +157,7 @@
       state: absent
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       labels:
       - key: testlabel2
     register: label_out
@@ -160,7 +171,7 @@
       state: list
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
     register: label_out
   - name: assert label actually deleted
     assert:
@@ -172,7 +183,7 @@
       state: add
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       labels:
       - key: testlabel2
         value: "yes"
@@ -189,7 +200,7 @@
       state: list
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
     register: label_out
   - name: assert that both labels actually exist
     assert:
@@ -204,7 +215,7 @@
       state: absent
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       labels:
       - key: testlabel2
       - key: testlabel3
@@ -219,7 +230,7 @@
       state: absent
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       labels:
       - key: testlabel2
       - key: testlabel3
@@ -237,7 +248,7 @@
       state: present
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       labels: "{{ original_labels_as_key_value_list }}"
     register: label_out
   - name: assert that no changes are made when current list matches existing list
@@ -250,7 +261,7 @@
       state: present
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       labels: "{{ original_labels_as_key_value_list + [{'key': 'testlabel2', 'value': 'yes'}] }}"
     register: label_out
   - name: assert that changes were made
@@ -263,7 +274,7 @@
       state: list
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
     register: label_out
   - name: asssert that new label was actually added
     assert:
@@ -276,7 +287,7 @@
       state: present
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       labels: "{{ original_labels_as_key_value_list + [{'key': 'testlabel2', 'value': 'different'}]}}"
     register: label_out
   - name: assert that changes were made when existing key's value is changed
@@ -289,7 +300,7 @@
       state: list
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
     register: label_out
   - name: asssert that changed label was actually changed
     assert:
@@ -302,7 +313,7 @@
       state: present
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
       labels: "{{ original_labels_as_key_value_list }}"
     register: label_out
   - name: assert that changes were made
@@ -315,7 +326,7 @@
       state: list
       namespace: "{{ def_namespace }}"
       kind: "{{ def_kind }}"
-      name: "{{ cli_node_test }}"
+      name: "{{ node_to_test }}"
     register: label_out
   - name: asssert that present-removed actually removed
     assert:

--- a/roles/lib_openshift/src/test/integration/oc_service.yml
+++ b/roles/lib_openshift/src/test/integration/oc_service.yml
@@ -123,6 +123,6 @@
   - assert:
       that:
       - svc_out.changed == False
-      - svc_out.results.returncode == 1
+      - svc_out.results.returncode == 0
       - "'not found' in svc_out.results.stderr"
       msg: service get failed

--- a/roles/lib_utils/src/test/generate-and-run-tests.sh
+++ b/roles/lib_utils/src/test/generate-and-run-tests.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -e
+
+
+# Put us in the same dir as the script.
+cd $(dirname $0)
+
+echo
+echo "Running lib_openshift generate"
+echo "------------------------------"
+../generate.py
+
+
+echo
+echo "Running lib_utils Unit Tests"
+echo "----------------------------"
+cd unit
+
+for test in *.py; do
+    echo
+    echo "--------------------------------------------------------------------------------"
+    echo
+    echo "Running $test..."
+    ./$test
+done
+
+
+echo
+echo "Running lib_utils Integration Tests"
+echo "-----------------------------------"
+cd ../integration
+
+for test in *.yml; do
+    echo
+    echo "--------------------------------------------------------------------------------"
+    echo
+    echo "Running $test..."
+    ./$test -vvv
+done
+
+# Clean up this damn file
+# TODO: figure out why this is being written and clean it up.
+rm kube-manager-test.yaml

--- a/roles/lib_utils/src/test/integration/yedit.yml
+++ b/roles/lib_utils/src/test/integration/yedit.yml
@@ -1,8 +1,9 @@
-#!/usr/bin/ansible-playbook
+#!/usr/bin/ansible-playbook --module-path=../../../library/
+#
 # Yedit test so that we can quickly determine if features are working
 # Ensure that the kube-manager.yaml file exists
 #
-# ./yedit_test.yml -M ../../library
+# ./yedit_test.yml
 #
 ---
 - hosts: localhost


### PR DESCRIPTION
Specifically:
* Added `generate-and-run-tests.sh` scripts in lib_utils and lib_openshift. These make it easy to run the ansible module unit and integration tests in those roles.
   * Note that the lib_openshift `generate-and-run-tests.sh` script also runs the `generate-and-run-tests.sh` from lib_utils. This ensures that lib_utils has been generated and is up to date as well as making it so we can run all tests with a single script.

* Fixed the `oadm_manage_node` itegration test and changed it to only require a master to run. It uses that master and picks the first node returned by oc_obj.

* Fixed the `oc_label` integration test. Also made it run without requiring a node.

* Fixed the `oc_service` integration test.

* Updated the `yedit` integration test to be in line with our new integration testing patterns.