### PR TITLE
Bug 1419843 - Installation with ansible-2.2.1.0-2 may fail when set_fact for openshift_master

### DIFF
--- a/filter_plugins/openshift_master.py
+++ b/filter_plugins/openshift_master.py
@@ -162,7 +162,7 @@ class LDAPPasswordIdentityProvider(IdentityProviderBase):
             AnsibleFilterError:
     """
     def __init__(self, api_version, idp):
-        super(self.__class__, self).__init__(api_version, idp)
+        super(LDAPPasswordIdentityProvider, self).__init__(api_version, idp)
         self._allow_additional = False
         self._required += [['attributes'], ['url'], ['insecure']]
         self._optional += [['ca'],
@@ -206,7 +206,7 @@ class KeystonePasswordIdentityProvider(IdentityProviderBase):
             AnsibleFilterError:
     """
     def __init__(self, api_version, idp):
-        super(self.__class__, self).__init__(api_version, idp)
+        super(KeystonePasswordIdentityProvider, self).__init__(api_version, idp)
         self._allow_additional = False
         self._required += [['url'], ['domainName', 'domain_name']]
         self._optional += [['ca'], ['certFile', 'cert_file'], ['keyFile', 'key_file']]
@@ -225,7 +225,7 @@ class RequestHeaderIdentityProvider(IdentityProviderBase):
             AnsibleFilterError:
     """
     def __init__(self, api_version, idp):
-        super(self.__class__, self).__init__(api_version, idp)
+        super(RequestHeaderIdentityProvider, self).__init__(api_version, idp)
         self._allow_additional = False
         self._required += [['headers']]
         self._optional += [['challengeURL', 'challenge_url'],
@@ -256,7 +256,7 @@ class AllowAllPasswordIdentityProvider(IdentityProviderBase):
             AnsibleFilterError:
     """
     def __init__(self, api_version, idp):
-        super(self.__class__, self).__init__(api_version, idp)
+        super(AllowAllPasswordIdentityProvider, self).__init__(api_version, idp)
         self._allow_additional = False
 
 
@@ -273,7 +273,7 @@ class DenyAllPasswordIdentityProvider(IdentityProviderBase):
             AnsibleFilterError:
     """
     def __init__(self, api_version, idp):
-        super(self.__class__, self).__init__(api_version, idp)
+        super(DenyAllPasswordIdentityProvider, self).__init__(api_version, idp)
         self._allow_additional = False
 
 
@@ -290,7 +290,7 @@ class HTPasswdPasswordIdentityProvider(IdentityProviderBase):
             AnsibleFilterError:
     """
     def __init__(self, api_version, idp):
-        super(self.__class__, self).__init__(api_version, idp)
+        super(HTPasswdPasswordIdentityProvider, self).__init__(api_version, idp)
         self._allow_additional = False
         self._required += [['file', 'filename', 'fileName', 'file_name']]
 
@@ -315,7 +315,7 @@ class BasicAuthPasswordIdentityProvider(IdentityProviderBase):
             AnsibleFilterError:
     """
     def __init__(self, api_version, idp):
-        super(self.__class__, self).__init__(api_version, idp)
+        super(BasicAuthPasswordIdentityProvider, self).__init__(api_version, idp)
         self._allow_additional = False
         self._required += [['url']]
         self._optional += [['ca'], ['certFile', 'cert_file'], ['keyFile', 'key_file']]
@@ -334,7 +334,7 @@ class IdentityProviderOauthBase(IdentityProviderBase):
             AnsibleFilterError:
     """
     def __init__(self, api_version, idp):
-        super(self.__class__, self).__init__(api_version, idp)
+        super(IdentityProviderOauthBase, self).__init__(api_version, idp)
         self._allow_additional = False
         self._required += [['clientID', 'client_id'], ['clientSecret', 'client_secret']]
 


### PR DESCRIPTION
Reference class instead of `self.__class__` within super constructor to avoid calling self forever.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1419843

```
TASK [openshift_master : set_fact] *********************************************
task path: /root/openshift-ansible/roles/openshift_master/tasks/main.yml:146
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/ansible/executor/task_executor.py", line 126, in run
    res = self._execute()
  File "/usr/lib/python2.7/site-packages/ansible/executor/task_executor.py", line 443, in _execute
    self._task.post_validate(templar=templar)
  File "/usr/lib/python2.7/site-packages/ansible/playbook/task.py", line 248, in post_validate
    super(Task, self).post_validate(templar)
  File "/usr/lib/python2.7/site-packages/ansible/playbook/base.py", line 373, in post_validate
    value = templar.template(getattr(self, name))
  File "/usr/lib/python2.7/site-packages/ansible/template/__init__.py", line 427, in template
    disable_lookups=disable_lookups,
  File "/usr/lib/python2.7/site-packages/ansible/template/__init__.py", line 383, in template
    disable_lookups=disable_lookups,
  File "/usr/lib/python2.7/site-packages/ansible/template/__init__.py", line 583, in do_template
    res = j2_concat(rf)
  File "<template>", line 9, in root
  File "/root/openshift-ansible/filter_plugins/openshift_master.py", line 484, in translate_idps
    idp_inst = idp_class(api_version, idp) if idp_class is not None else IdentityProviderBase(api_version, idp)
  File "/root/openshift-ansible/filter_plugins/openshift_master.py", line 464, in __init__
    IdentityProviderOauthBase.__init__(self, api_version, idp)
  File "/root/openshift-ansible/filter_plugins/openshift_master.py", line 337, in __init__
    super(self.__class__, self).__init__(api_version, idp)
...
RuntimeError: maximum recursion depth exceeded while calling a Python object

fatal: [master1.abutcher.com]: FAILED! => {
    "failed": true
}

MSG:

Unexpected failure during module execution.
```