### PR TITLE
Corrected mistake in container resources

### DIFF
--- a/roles/openshift_examples/files/examples/v1.4/cfme-templates/cfme-template.yaml
+++ b/roles/openshift_examples/files/examples/v1.4/cfme-templates/cfme-template.yaml
@@ -143,7 +143,7 @@ objects:
               name: "POSTGRESQL_SHARED_BUFFERS"
               value: "${POSTGRESQL_SHARED_BUFFERS}"
           resources:
-            requests:
+            limits:
               memory: "${MEMORY_APPLICATION_MIN}"
           lifecycle:
             preStop:

--- a/roles/openshift_examples/files/examples/v1.5/cfme-templates/cfme-template.yaml
+++ b/roles/openshift_examples/files/examples/v1.5/cfme-templates/cfme-template.yaml
@@ -143,7 +143,7 @@ objects:
               name: "POSTGRESQL_SHARED_BUFFERS"
               value: "${POSTGRESQL_SHARED_BUFFERS}"
           resources:
-            requests:
+            limits:
               memory: "${MEMORY_APPLICATION_MIN}"
           lifecycle:
             preStop:


### PR DESCRIPTION
This is `limits` in both the memcached and postgresql deployment configs,
using `requests` causes an error during deployment.