### PR TITLE
Bug 1393000: Install etcd for containerized environments as well as embedded.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -70,9 +70,9 @@
         {{ avail_disk.stdout }} Kb available.
     when: (embedded_etcd | bool) and (etcd_disk_usage.stdout|int > avail_disk.stdout|int)
 
-  - name: Install etcdctl for embedded environments
+  - name: Install etcdctl for for containerized or embedded environments
     include: embedded_etcdctl.yml
-    when: embedded_etcd
+    when: (embedded_etcd or openshift.common.is_containerized)
 
   - name: Generate etcd backup
     command: >
@@ -128,6 +128,10 @@
   handlers:
   - include: ../../../../roles/openshift_master/handlers/main.yml
     static: yes
+  pre_tasks:
+  - set_fact:
+      openshift_master_default_subdomain: "{{ lookup('oo_option', 'openshift_master_default_subdomain') | default(None, true) }}"
+    when: openshift_master_default_subdomain is not defined
   roles:
   - openshift_facts
   - openshift_master_facts


### PR DESCRIPTION
Also ensure that `openshift_master_default_subdomain` has been defaulted
as per the master config playbook so that the `openshift_master_facts`
role can be applied during control plane upgrade.

This is a targeted fix for 1.2-1.3 containerized (non embedded etcd) upgrades.

Fixes Bug 1393000

https://bugzilla.redhat.com/show_bug.cgi?id=1393000

```
TASK [Generate etcd backup] ****************************************************
fatal: [master1.abutcher.com]: FAILED! => {"changed": false, "cmd": "etcdctl backup --data-dir=/var/lib/etcd/ --backup-dir=/var/lib/origin/etcd-backup-20170209150256", "failed": true, "msg": "[Errno 2] No such file or directory", "rc": 2}
        to retry, use: --limit @/home/abutcher/rhat/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade.retry
```

```
TASK [openshift_master_facts : Set master facts] *******************************
fatal: [master1.abutcher.com]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: {{ openshift_hosted_metrics_public_url | default('hawkular-metrics.' ~ (openshift.master.default_subdomain | default(openshift_master_default_subdomain ))) | oo_hostname_from_url }}: 'openshift_master_default_subdomain' is undefined\n\nThe error appears to have been in '/home/abutcher/rhat/openshift-ansible/roles/openshift_master_facts/tasks/main.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Set master facts\n  ^ here\n"}
        to retry, use: --limit @/home/abutcher/rhat/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade.retry
```
