### PR TITLE
Bug 1420234 - illegal_argument_exception in Kibana UI.

### DIFF
--- a/roles/openshift_logging/files/fluent.conf
+++ b/roles/openshift_logging/files/fluent.conf
@@ -22,6 +22,7 @@
   @include configs.d/openshift/filter-k8s-flatten-hash.conf
   @include configs.d/openshift/filter-k8s-record-transform.conf
   @include configs.d/openshift/filter-syslog-record-transform.conf
+  @include configs.d/openshift/filter-common-data-model.conf
   @include configs.d/openshift/filter-post-*.conf
 ##
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1420234
The problem is that the fluent.conf is missing the common data model
filter which renames the "time" field to the "@timestamp" field.

@jcantrill @ewolinetz PTAL
[test]
aos-ci-test