### PR TITLE
Removing the /usr/bin/ansible-playbook dependency in in the spec file

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -3,6 +3,10 @@
 %{!?commit:
 %global commit c64d09e528ca433832c6b6e6f5c7734a9cc8ee6f
 }
+# This is inserted to prevent RPM from requiring "/usr/bin/ansible-playbook"
+# The ansible-playbook requirement will be ansibled by the explicit
+#  "Requires: ansible" directive
+%global __requires_exclude ^/usr/bin/ansible-playbook$
 
 Name:           openshift-ansible
 Version:        3.5.3


### PR DESCRIPTION
When openshift-ansible-roles is created, the requirement of "/usr/bin/ansible-playbook" is inserted into the RPM.  This is specifying the binary, not the RPM package.  This is auto-generated by RPM looking at the file types.

This dependency is already handled by the explicit:

 Requires:      ansible

I followed this guide to attempt to remove that line.

https://fedoraproject.org/wiki/Packaging:AutoProvidesAndRequiresFiltering