### PR TITLE
More fixes for reboot/wait for hosts.

### DIFF
--- a/playbooks/common/openshift-master/restart_hosts.yml
+++ b/playbooks/common/openshift-master/restart_hosts.yml
@@ -7,14 +7,26 @@
   ignore_errors: true
   become: yes
 
+# WARNING: This process is riddled with weird behavior.
+
+# Workaround for https://github.com/ansible/ansible/issues/21269
+- set_fact:
+    wait_for_host: "{{ ansible_host }}"
+
+# Ansible's blog documents this *without* the port, which appears to now
+# just wait until the timeout value and then proceed without checking anything.
+# port is now required.
+#
+# However neither ansible_ssh_port or ansible_port are reliably defined, likely
+# only if overridden. Assume a default of 22.
 - name: Wait for master to restart
   local_action:
     module: wait_for
-      host="{{ ansible_host }}"
+      host="{{ wait_for_host }}"
       state=started
       delay=10
       timeout=600
-      port="{{ ansible_ssh_port }}"
+      port="{{ ansible_port | default(ansible_ssh_port | default(22,boolean=True),boolean=True) }}"
   become: no
 
 # Now that ssh is back up we can wait for API on the remote system,


### PR DESCRIPTION
See comments in patch for why, this has been a bit messy lately but transitioning back to inventory_hostname is where we were at before and is by far the most tested path. It does technically work for ops needs, even though there is some concern it's not a guarantee. At this point I can't find anything else that will. (CC @mwoodson)

The ansible_ssh_port is not always defined, and has been moved to ansible_port now, so use that and add a default. I think it may only be defined in non-standard use cases, i.e. when the user sets it themselves.

@sdodson Requesting priority merge on this if you can, no build needed, we will carry the patch until the next build.