### PR TITLE
fix openshift_logging where defaults filter needs quoting

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
-openshift_logging_image_prefix: "{{ openshift_hosted_logging_deployer_prefix | default(docker.io/openshift/origin-) }}"
-openshift_logging_image_version: "{{ openshift_hosted_logging_deployer_version | default(latest) }}"
+openshift_logging_image_prefix: "{{ openshift_hosted_logging_deployer_prefix | default('docker.io/openshift/origin-') }}"
+openshift_logging_image_version: "{{ openshift_hosted_logging_deployer_version | default('latest') }}"
 openshift_logging_use_ops: False
 openshift_logging_master_url: "https://kubernetes.default.svc.{{ openshift.common.dns_domain }}"
-openshift_logging_master_public_url: "{{ openshift_hosted_logging_master_public_url | default(https://{{openshift.common.public_hostname}}:8443) }}"
+openshift_logging_master_public_url: "{{ openshift_hosted_logging_master_public_url | default('https://{{openshift.common.public_hostname}}:8443') }}"
 openshift_logging_namespace: logging
 openshift_logging_install_logging: True
 
@@ -39,7 +39,7 @@ openshift_logging_kibana_key: ""
 #for the public facing kibana certs
 openshift_logging_kibana_ca: ""
 
-openshift_logging_kibana_ops_hostname: "{{ openshift_hosted_logging_ops_hostname | default(kibana-ops.{{openshift.common.dns_domain}}) }}"
+openshift_logging_kibana_ops_hostname: "{{ openshift_hosted_logging_ops_hostname | default('kibana-ops.{{openshift.common.dns_domain}}') }}"
 openshift_logging_kibana_ops_cpu_limit: null
 openshift_logging_kibana_ops_memory_limit: null
 openshift_logging_kibana_ops_proxy_debug: false
@@ -66,7 +66,7 @@ openshift_logging_es_memory_limit: 1024Mi
 openshift_logging_es_pv_selector: null
 openshift_logging_es_pvc_dynamic: "{{ openshift_hosted_logging_elasticsearch_pvc_dynamic | default(False) }}"
 openshift_logging_es_pvc_size: "{{ openshift_hosted_logging_elasticsearch_pvc_size | default('') }}"
-openshift_logging_es_pvc_prefix: "{{ openshift_hosted_logging_elasticsearch_pvc_prefix | default(logging-es) }}"
+openshift_logging_es_pvc_prefix: "{{ openshift_hosted_logging_elasticsearch_pvc_prefix | default('logging-es') }}"
 openshift_logging_es_recover_after_time: 5m
 openshift_logging_es_storage_group: 65534
 
@@ -84,7 +84,7 @@ openshift_logging_es_ops_memory_limit: 1024Mi
 openshift_logging_es_ops_pv_selector: None
 openshift_logging_es_ops_pvc_dynamic: "{{ openshift_hosted_logging_elasticsearch_ops_pvc_dynamic | default(False) }}"
 openshift_logging_es_ops_pvc_size: "{{ openshift_hosted_logging_elasticsearch_ops_pvc_size | default('') }}"
-openshift_logging_es_ops_pvc_prefix: "{{ openshift_hosted_logging_elasticsearch_ops_pvc_prefix | default(logging-es-ops) }}"
+openshift_logging_es_ops_pvc_prefix: "{{ openshift_hosted_logging_elasticsearch_ops_pvc_prefix | default('logging-es-ops') }}"
 openshift_logging_es_ops_recover_after_time: 5m
 openshift_logging_es_ops_storage_group: 65534
 


### PR DESCRIPTION
Various tasks were failing because the defaults filter needed quotes around string values.