### PR TITLE
upgrades: fix path to disable_excluder.yml

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade_nodes.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade_nodes.yml
@@ -47,7 +47,7 @@
   tags:
   - pre_upgrade
 
-- include: ../disable_excluder.yml
+- include: ../../../../common/openshift-cluster/disable_excluder.yml
   tags:
   - pre_upgrade
 


### PR DESCRIPTION
With #3261 PR merged, I can no longer run nodes upgrade playbook to 3.4 due to incorrect path to ``disable_excluder.yml`` playbook. This PR fixes the path to the file.