### PR TITLE
Fixed issue where upgrade fails when using daemon sets (e.g. aggregated logging)

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -43,7 +43,7 @@
 
   - name: Drain Node for Kubelet upgrade
     command: >
-      {{ openshift.common.admin_binary }} drain {{ openshift.node.nodename }} --force --delete-local-data
+      {{ openshift.common.admin_binary }} drain {{ openshift.node.nodename }} --force --delete-local-data --ignore-daemonsets
     delegate_to: "{{ groups.oo_first_master.0 }}"
     when: l_docker_upgrade is defined and l_docker_upgrade | bool and inventory_hostname in groups.oo_nodes_to_upgrade
 

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -257,7 +257,7 @@
 
   - name: Drain Node for Kubelet upgrade
     command: >
-      {{ hostvars[groups.oo_first_master.0].openshift.common.admin_binary }} drain {{ openshift.node.nodename | lower }} --force --delete-local-data
+      {{ hostvars[groups.oo_first_master.0].openshift.common.admin_binary }} drain {{ openshift.node.nodename | lower }} --force --delete-local-data --ignore-daemonsets
     delegate_to: "{{ groups.oo_first_master.0 }}"
 
   roles:

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -26,7 +26,7 @@
 
   - name: Drain Node for Kubelet upgrade
     command: >
-      {{ hostvars[groups.oo_first_master.0].openshift.common.admin_binary }} drain {{ openshift.node.nodename | lower }} --force --delete-local-data
+      {{ hostvars[groups.oo_first_master.0].openshift.common.admin_binary }} drain {{ openshift.node.nodename | lower }} --force --delete-local-data --ignore-daemonsets
     delegate_to: "{{ groups.oo_first_master.0 }}"
 
   roles:

--- a/roles/openshift_node_upgrade/README.md
+++ b/roles/openshift_node_upgrade/README.md
@@ -82,7 +82,7 @@ Including an example of how to use your role (for instance, with variables passe
 
   - name: Drain Node for Kubelet upgrade
     command: >
-      {{ hostvars[groups.oo_first_master.0].openshift.common.admin_binary }} drain {{ openshift.node.nodename | lower }} --force --delete-local-data
+      {{ hostvars[groups.oo_first_master.0].openshift.common.admin_binary }} drain {{ openshift.node.nodename | lower }} --force --delete-local-data --ignore-daemonsets
     delegate_to: "{{ groups.oo_first_master.0 }}"
 
   roles:


### PR DESCRIPTION
The upgrade from origin version 1.3.1 to 1.4.1 fails when a node and/or master uses daemon sets. I'm betting this is true for any version upgrade since daemon sets were introduced.  

It fails as follows:

TASK [Drain Node for Kubelet upgrade] ******************************************
fatal: [master1.example.com -> master1.example.com]: FAILED! => {"changed": true, "cmd": ["oadm", "drain", "master1.example.com", "--force", "--delete-local-data"], "delta": "0:00:00.259678", "end": "2017-02-14 15:51:00.930817", "failed": true, "rc": 1, "start": "2017-02-14 15:51:00.671139", "stderr": "error: DaemonSet-managed pods (use --ignore-daemonsets to ignore): logging-fluentd-mjxkv", "stdout": "node \"master1.example.com\" already cordoned", "stdout_lines": ["node \"master1.example.com\" already cordoned"], "warnings": []}

Adding  --ignore-daemonsets to the task resolves the issue.