### PR TITLE
Fix issues with Hawkular Metrics certificates

### DIFF
--- a/roles/openshift_metrics/tasks/generate_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_certificates.yaml
@@ -6,6 +6,6 @@
     --key='{{ mktemp.stdout }}/ca.key'
     --cert='{{ mktemp.stdout }}/ca.crt'
     --serial='{{ mktemp.stdout }}/ca.serial.txt'
-    --name="metrics-signer@$(date +%s)"
+    --name="metrics-signer@{{lookup('pipe','date +%s')}}"
 
 - include: generate_hawkular_certificates.yaml

--- a/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
@@ -3,7 +3,7 @@
   include: setup_certificate.yaml
   vars:
     component: hawkular-metrics
-    hostnames: "hawkular-metrics,{{ openshift_metrics_hawkular_hostname }}"
+    hostnames: "hawkular-metrics,hawkular-metrics.{{ openshift_metrics_project }}.svc.cluster.local,{{ openshift_metrics_hawkular_hostname }}"
   changed_when: no
 
 - name: generate hawkular-cassandra certificates


### PR DESCRIPTION
Add missing full hostname for the Hawkular Metrics certificate (BZ1421060)

Fix issue where the signer certificate's name is static, preventing redeployments from being acceptable.