### PR TITLE
initialize oo_nodes_to_upgrade group when running control plane upgrade only

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
@@ -25,6 +25,9 @@
       openshift_upgrade_min: "{{ '1.2' if deployment_type == 'origin' else '3.2' }}"
 
 # Pre-upgrade
+- include: ../../../../common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+  tags:
+  - pre_upgrade
 
 - name: Update repos on control plane hosts
   hosts: oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config

--- a/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
@@ -25,6 +25,9 @@
       openshift_upgrade_min: "{{ '1.3' if deployment_type == 'origin' else '3.3' }}"
 
 # Pre-upgrade
+- include: ../../../../common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+  tags:
+  - pre_upgrade
 
 - name: Update repos on control plane hosts
   hosts: oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config

--- a/playbooks/byo/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
@@ -25,6 +25,9 @@
       openshift_upgrade_min: "{{ '1.4' if deployment_type == 'origin' else '3.4' }}"
 
 # Pre-upgrade
+- include: ../../../../common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+  tags:
+  - pre_upgrade
 
 - name: Update repos on control plane hosts
   hosts: oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config


### PR DESCRIPTION
The missing piece to initialize ``oo_nodes_up_upgrade`` group in order to upgrade nodes that are masters at the same time.

Before, control plane upgrade was responsible for upgrading master nodes. Recently, node upgrade play was integrated into the control plane upgrade. Unfortunately, as the control plane upgrade did not manage node upgrades, only some groups of hosts were initialized. The ``oo_nodes_up_upgrade`` group was not among them. Which cause the integrated node upgrade to be skipped.