### PR TITLE
bug 1420217. Default ES memory to be compariable to 3.4 deployer

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -62,7 +62,7 @@ openshift_logging_es_client_cert: /etc/fluent/keys/cert
 openshift_logging_es_client_key: /etc/fluent/keys/key
 openshift_logging_es_cluster_size: "{{ openshift_hosted_logging_elasticsearch_cluster_size | default(1) }}"
 openshift_logging_es_cpu_limit: null
-openshift_logging_es_memory_limit: 1024Mi
+openshift_logging_es_memory_limit: 8Gi
 openshift_logging_es_pv_selector: null
 openshift_logging_es_pvc_dynamic: "{{ openshift_hosted_logging_elasticsearch_pvc_dynamic | default(False) }}"
 openshift_logging_es_pvc_size: "{{ openshift_hosted_logging_elasticsearch_pvc_size | default('') }}"
@@ -80,7 +80,7 @@ openshift_logging_es_ops_client_cert: /etc/fluent/keys/cert
 openshift_logging_es_ops_client_key: /etc/fluent/keys/key
 openshift_logging_es_ops_cluster_size: "{{ openshift_hosted_logging_elasticsearch_ops_cluster_size | default(1) }}"
 openshift_logging_es_ops_cpu_limit: null
-openshift_logging_es_ops_memory_limit: 1024Mi
+openshift_logging_es_ops_memory_limit: 8Gi
 openshift_logging_es_ops_pv_selector: None
 openshift_logging_es_ops_pvc_dynamic: "{{ openshift_hosted_logging_elasticsearch_ops_pvc_dynamic | default(False) }}"
 openshift_logging_es_ops_pvc_size: "{{ openshift_hosted_logging_elasticsearch_ops_pvc_size | default('') }}"


### PR DESCRIPTION
Defaulting memory to be comparible to 3.4