### PR TITLE
added --ignore-daemonsets to drain nodes

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -43,7 +43,7 @@
 
   - name: Drain Node for Kubelet upgrade
     command: >
-      {{ openshift.common.admin_binary }} drain {{ openshift.node.nodename }} --force --delete-local-data
+      {{ openshift.common.admin_binary }} drain {{ openshift.node.nodename }} --force --delete-local-data --ignore-daemonsets
     delegate_to: "{{ groups.oo_first_master.0 }}"
     when: l_docker_upgrade is defined and l_docker_upgrade | bool and inventory_hostname in groups.oo_nodes_to_upgrade
 

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -26,7 +26,7 @@
 
   - name: Drain Node for Kubelet upgrade
     command: >
-      {{ hostvars[groups.oo_first_master.0].openshift.common.admin_binary }} drain {{ openshift.node.nodename | lower }} --force --delete-local-data
+      {{ hostvars[groups.oo_first_master.0].openshift.common.admin_binary }} drain {{ openshift.node.nodename | lower }} --force --delete-local-data --ignore-daemonsets
     delegate_to: "{{ groups.oo_first_master.0 }}"
 
   roles:


### PR DESCRIPTION
adding option "--ignore-daemonsets" on drain node.  This helps get by this error in upgrade:

```
TASK [Drain Node for Kubelet upgrade] ******************************************
fatal: [xxxxx -> None]: FAILED! => {"changed": true, "cmd": ["oadm", "drain", "ip-172-31-6-214.ec2.internal", "--force", "--delete-local-data"], "delta": "0:00:01.922891", "end": "2017-02-16 21:30:49.688601", "failed": true, "rc": 1, "start": "2017-02-16 21:30:47.765710", "stderr": "error: DaemonSet-managed pods (use --ignore-daemonsets to ignore): logging-fluentd-oujwf", "stdout": "node \"ip-172-31-6-214.ec2.internal\" already cordoned", "stdout_lines": ["node \"ip-172-31-6-214.ec2.internal\" already cordoned"], "warnings": []}

```