### PR TITLE
Add a configurable 30 second pause after draining a node to allow for rescheduling

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -106,6 +106,10 @@ openshift_release=v1.4
 #
 # Tasks to run after each master is upgraded and system/services have been restarted.
 # openshift_master_upgrade_post_hook=/usr/share/custom/post_master.yml
+#
+# Pause this number of seconds after draining each node to wait for rescheduling, this
+# may be too low for your environment, adjust accordingly
+# openshift_node_upgrade_pause=30
 
 
 # Alternate image format string, useful if you've got your own registry mirror

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -106,6 +106,10 @@ openshift_release=v3.4
 #
 # Tasks to run after each master is upgraded and system/services have been restarted.
 # openshift_master_upgrade_post_hook=/usr/share/custom/post_master.yml
+#
+# Pause this number of seconds after draining each node to wait for rescheduling, this
+# may be too low for your environment, adjust accordingly
+# openshift_node_upgrade_pause=30
 
 
 # Alternate image format string, useful if you've got your own registry mirror

--- a/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -47,6 +47,10 @@
     delegate_to: "{{ groups.oo_first_master.0 }}"
     when: l_docker_upgrade is defined and l_docker_upgrade | bool and inventory_hostname in groups.oo_nodes_to_upgrade
 
+  - name: Pause for pod rescheduling during docker upgrade
+    pause:
+      seconds: "{{ openshift_node_upgrade_pause | default(30) | int }}"
+
   - include: ../../../../common/openshift-cluster/upgrades/docker/upgrade.yml
     when: l_docker_upgrade is defined and l_docker_upgrade | bool
 

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -260,6 +260,10 @@
       {{ hostvars[groups.oo_first_master.0].openshift.common.admin_binary }} drain {{ openshift.node.nodename | lower }} --force --delete-local-data
     delegate_to: "{{ groups.oo_first_master.0 }}"
 
+  - name: Pause for pod rescheduling during control plane
+    pause:
+      seconds: "{{ openshift_node_upgrade_pause | default(30) | int }}"
+
   roles:
   - lib_openshift
   - openshift_facts

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -29,6 +29,10 @@
       {{ hostvars[groups.oo_first_master.0].openshift.common.admin_binary }} drain {{ openshift.node.nodename | lower }} --force --delete-local-data
     delegate_to: "{{ groups.oo_first_master.0 }}"
 
+  - name: Pause for pod rescheduling during node ugprade
+    pause:
+      seconds: "{{ openshift_node_upgrade_pause | default(30) | int }}"
+
   roles:
   - lib_openshift
   - openshift_facts


### PR DESCRIPTION
This is a quick hack to provide marginal improvement and will require tuning per your environment's needs. 30 seconds may be too low for your environment.

In the future we should replace this with logic that actually evaluates whether or not pods have been rescheduled and are running on their new nodes.

I did some testing today on 3.2. What I found is that on the node being evacuated the pods immediately go terminating. On the nodes where they've been rescheduled how fast they come up depends entirely on how long it takes to pull the images. If the image was already there it was instantaneous. When the image had to be pulled my 400mb nodejs image was ready in a few seconds.