### PR TITLE
Revert temporary hack to skip router/registry upgrade.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -14,9 +14,6 @@
   - name: Load lib_openshift modules
     include_role:
       name: lib_openshift
-  # TODO: remove temp_skip_router_registry_upgrade variable. This is a short term hack
-  # to allow ops to use this control plane upgrade, without triggering router/registry
-  # upgrade which has not yet been synced with their process.
   - name: Collect all routers
     oc_obj:
       state: list
@@ -24,22 +21,18 @@
       all_namespaces: True
       selector: 'router'
     register: all_routers
-    when: temp_skip_router_registry_upgrade is not defined
 
   - set_fact: haproxy_routers="{{ (all_routers.reults.results[0]['items'] | oo_pods_match_component(openshift_deployment_type, 'haproxy-router') | oo_select_keys_from_list(['metadata']) }}"
     when:
     - all_routers.results.returncode == 0
-    - temp_skip_router_registry_upgrade is not defined
 
   - set_fact: haproxy_routers=[]
     when:
     - all_routers.results.returncode != 0
-    - temp_skip_router_registry_upgrade is not defined
 
   - name: Update router image to current version
     when:
     - all_routers.results.returncode == 0
-    - temp_skip_router_registry_upgrade is not defined
     command: >
       {{ oc_cmd }} patch dc/{{ item['labels']['deploymentconfig'] }} -n {{ item['namespace'] }} -p
       '{"spec":{"template":{"spec":{"containers":[{"name":"router","image":"{{ router_image }}","livenessProbe":{"tcpSocket":null,"httpGet":{"path": "/healthz", "port": 1936, "host": "localhost", "scheme": "HTTP"},"initialDelaySeconds":10,"timeoutSeconds":1}}]}}}}'
@@ -55,12 +48,10 @@
       kind: dc
       name: docker-registry
     register: _default_registry
-    when: temp_skip_router_registry_upgrade is not defined
 
   - name: Update registry image to current version
     when:
     - _default_registry.results.results[0] != {}
-    - temp_skip_router_registry_upgrade is not defined
     command: >
       {{ oc_cmd }} patch dc/docker-registry -n default -p
       '{"spec":{"template":{"spec":{"containers":[{"name":"registry","image":"{{ registry_image }}"}]}}}}'


### PR DESCRIPTION
Ops ended up using openshift-ansible for this anyhow.