### PR TITLE
facts/main: Require Python 3 for Fedora, Python 2 everywhere else

### DIFF
--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -14,6 +14,18 @@
     l_is_master_system_container: "{{ (use_master_system_container | default(use_system_containers) | bool) }}"
     l_is_etcd_system_container: "{{ (use_etcd_system_container | default(use_system_containers) | bool) }}"
 
+- name: Validate python version
+  fail:
+    msg: |
+      openshift-ansible requires Python 3 for {{ ansible_distribution }};
+      For information on enabling Python 3 with Ansible, see https://docs.ansible.com/ansible/python_3_support.html
+  when: ansible_distribution == 'Fedora' and ansible_python['version']['major'] != 3
+
+- name: Validate python version
+  fail:
+    msg: "openshift-ansible requires Python 2 for {{ ansible_distribution }}"
+  when: ansible_distribution != 'Fedora' and ansible_python['version']['major'] != 2
+
 - name: Ensure various deps are installed
   package: name={{ item }} state=present
   with_items: "{{ required_packages }}"


### PR DESCRIPTION
For a few reasons; among them that we currently have a dependency on `PyYAML`
which on Fedora Atomic Host isn't installed for Python 2 by default. Further,
many dependencies are being ported in Fedora to be Python 3.

Conversely, ensure that we're using Python 2 everywhere else (which is really
CentOS/RHEL), since AFAIK we don't test that path at all, and we really don't
need *more* entries in the supported matrix.

Related: https://github.com/openshift/openshift-ansible/issues/3394