### PR TITLE
post_control_plane.yml: don't fail on grep

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -87,6 +87,7 @@
     register: grep_plugin_order_override
     when: openshift.common.version_gte_3_3_or_1_3 | bool
     changed_when: false
+    failed_when: false
 
   - name: Warn if pluginOrderOverride is in use in master-config.yaml
     debug:


### PR DESCRIPTION
grep returns rc != 0 if the text is not found, the next rule assumes
that.  Do not fail on the check when the line is not found.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>