### PR TITLE
Fix indenting/ordering in router cert redeploy

### DIFF
--- a/playbooks/common/openshift-cluster/redeploy-certificates/router.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/router.yml
@@ -2,14 +2,13 @@
 - name: Update router certificates
   hosts: oo_first_master
   vars:
+  roles:
+  - lib_openshift
   tasks:
   - name: Create temp directory for kubeconfig
     command: mktemp -d /tmp/openshift-ansible-XXXXXX
     register: mktemp
     changed_when: false
-  roles:
-  - lib_openshift
-
   - name: Copy admin client config(s)
     command: >
       cp {{ openshift.common.config_base }}/master//admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig


### PR DESCRIPTION
Fixes Bug 1423430

```
[root@jenkins-slave-1 201702]# ansible-playbook -v -i host /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/redeploy-router-certificates.yml 
Using /etc/ansible/ansible.cfg as config file
ERROR! the role 'Copy admin client config(s)' was not found in /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/../../common/openshift-cluster/redeploy-certificates/roles:/etc/ansible/roles:/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/../../common/openshift-cluster/redeploy-certificates

The error appears to have been in '/usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/redeploy-certificates/router.yml': line 13, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


  - name: Copy admin client config(s)
    ^ here
```