### PR TITLE
Install repos on containerized hosts for python dependencies

### DIFF
--- a/roles/lib_openshift/meta/main.yml
+++ b/roles/lib_openshift/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: OpenShift Team
+  description: OpenShift Repositories
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 1.7
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+dependencies:
+- { role: openshift_repos }

--- a/roles/lib_utils/meta/main.yml
+++ b/roles/lib_utils/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: TODO
+  description: OpenShift Repositories
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 1.7
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+dependencies:
+- { role: openshift_repos }

--- a/roles/openshift_repos/files/origin/repos/openshift-ansible-centos-paas-sig.repo
+++ b/roles/openshift_repos/files/origin/repos/openshift-ansible-centos-paas-sig.repo
@@ -5,6 +5,13 @@ enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/openshift-ansible-CentOS-SIG-PaaS
 
+[centos-openshift-origin-common]
+name=CentOS OpenShift Origin Common
+baseurl=http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/common/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/openshift-ansible-CentOS-SIG-PaaS
+
 [centos-openshift-origin-testing]
 name=CentOS OpenShift Origin Testing
 baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin/

--- a/roles/openshift_repos/meta/main.yml
+++ b/roles/openshift_repos/meta/main.yml
@@ -11,5 +11,4 @@ galaxy_info:
     - 7
   categories:
   - cloud
-dependencies:
-- { role: openshift_facts }
+dependencies: []

--- a/roles/openshift_repos/tasks/main.yaml
+++ b/roles/openshift_repos/tasks/main.yaml
@@ -1,50 +1,47 @@
 ---
-# TODO: Add flag for enabling EPEL repo, default to false
-
-# TODO: Add subscription-management config, with parameters
-#       for username, password, poolid(name), and official repos to
-#       enable/disable. Might need to make a module that extends the
-#       subscription management module to take a poolid and enable/disable the
-#       proper repos correctly.
+- name: openshift_repos detect ostree
+  stat:
+    path: /run/ostree-booted
+  register: ostree_booted
 
 - assert:
     that: openshift_deployment_type in known_openshift_deployment_types
-  when: not openshift.common.is_containerized | bool
+    msg: "openshift_deployment_type must be one of {{ known_openshift_deployment_types }}"
 
-- name: Ensure libselinux-python is installed
-  package: name=libselinux-python state=present
-  when: not openshift.common.is_containerized | bool
+- block:
+  - name: Ensure libselinux-python is installed
+    package: name=libselinux-python state=present
 
-- name: Create any additional repos that are defined
-  template:
-    src: yum_repo.j2
-    dest: /etc/yum.repos.d/openshift_additional.repo
-  when: openshift_additional_repos | length > 0 and not openshift.common.is_containerized | bool
-  notify: refresh cache
+  - name: Create any additional repos that are defined
+    template:
+      src: yum_repo.j2
+      dest: /etc/yum.repos.d/openshift_additional.repo
+    when:
+    - openshift_additional_repos | length > 0
+    notify: refresh cache
 
-- name: Remove the additional repos if no longer defined
-  file:
-    dest: /etc/yum.repos.d/openshift_additional.repo
-    state: absent
-  when: openshift_additional_repos | length == 0 and not openshift.common.is_containerized | bool
-  notify: refresh cache
+  - name: Remove the additional repos if no longer defined
+    file:
+      dest: /etc/yum.repos.d/openshift_additional.repo
+      state: absent
+    when:
+    - openshift_additional_repos | length == 0
+    notify: refresh cache
 
-- name: Configure origin gpg keys if needed
-  copy:
-    src: origin/gpg_keys/openshift-ansible-CentOS-SIG-PaaS
-    dest: /etc/pki/rpm-gpg/
-  notify: refresh cache
-  when: ansible_os_family == "RedHat" and ansible_distribution != "Fedora"
-        and openshift_deployment_type == 'origin'
-        and not openshift.common.is_containerized | bool
-        and openshift_enable_origin_repo | default(true) | bool
+  - name: Configure origin gpg keys if needed
+    copy:
+      src: "{{ item.src }}"
+      dest: "{{ item.dest }}"
+    with_items:
+    - src: origin/gpg_keys/openshift-ansible-CentOS-SIG-PaaS
+      dest: /etc/pki/rpm-gpg/
+    - src: origin/repos/openshift-ansible-centos-paas-sig.repo
+      dest: /etc/yum.repos.d/
+    notify: refresh cache
+    when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution != "Fedora"
+    - openshift_deployment_type == 'origin'
+    - openshift_enable_origin_repo | default(true) | bool
 
-- name: Configure origin yum repositories RHEL/CentOS
-  copy:
-    src: origin/repos/openshift-ansible-centos-paas-sig.repo
-    dest: /etc/yum.repos.d/
-  notify: refresh cache
-  when: ansible_os_family == "RedHat" and ansible_distribution != "Fedora"
-        and openshift_deployment_type == 'origin'
-        and not openshift.common.is_containerized | bool
-        and openshift_enable_origin_repo | default(true) | bool
+  when: not ostree_booted.stat.exists


### PR DESCRIPTION
 - Removes dependency on openshift_facts
 - Adds Centos PaaS SIG common repo which is where origin users would get python2-ruamel-yaml
 - Makes lib_openshift and lib_utils depend on openshift_repos
 - Installs repos on containerized hosts for easier puddle testing