### PR TITLE
Remove and document how to find dead Python code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,3 +152,17 @@ are run on a different Jenkins host that is not publicly accessible, however the
 test results are posted to S3 buckets when complete.
 
 The test output of each job is also posted to the Pull Request as comments.
+
+---
+
+## Appendix
+
+### Finding unused Python code
+
+If you are contributing with Python code, you can use the tool
+[`vulture`](https://pypi.python.org/pypi/vulture) to verify that you are not
+introducing unused code by accident.
+
+This tool is not used in an automated form in CI nor otherwise because it may
+produce both false positives and false negatives. Still, it can be helpful to
+detect dead code that escapes our eyes.

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
@@ -175,23 +175,6 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         else:
             assert_equal(results, default_predicates)
 
-    def check_defaults_override_vars(self, release, deployment_type,
-                                     default_predicates, regions_enabled,
-                                     extra_facts=None):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = release
-        facts['openshift']['common']['deployment_type'] = deployment_type
-        if extra_facts is not None:
-            for fact in extra_facts:
-                facts[fact] = extra_facts[fact]
-        results = self.lookup.run(None, variables=facts,
-                                  regions_enabled=regions_enabled,
-                                  return_set_vars=False)
-        if regions_enabled:
-            assert_equal(results, default_predicates + [REGION_PREDICATE])
-        else:
-            assert_equal(results, default_predicates)
-
     def test_openshift_version(self):
         for regions_enabled in (True, False):
             for release, deployment_type, default_predicates in TEST_VARS:

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
@@ -160,23 +160,6 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         else:
             assert_equal(results, default_priorities)
 
-    def check_defaults_override_vars(self, release, deployment_type,
-                                     default_priorities, zones_enabled,
-                                     extra_facts=None):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = release
-        facts['openshift']['common']['deployment_type'] = deployment_type
-        if extra_facts is not None:
-            for fact in extra_facts:
-                facts[fact] = extra_facts[fact]
-        results = self.lookup.run(None, variables=facts,
-                                  zones_enabled=zones_enabled,
-                                  return_set_vars=False)
-        if zones_enabled:
-            assert_equal(results, default_priorities + [ZONE_PRIORITY])
-        else:
-            assert_equal(results, default_priorities)
-
     def test_openshift_version(self):
         for zones_enabled in (True, False):
             for release, deployment_type, default_priorities in TEST_VARS:


### PR DESCRIPTION
I've used `vulture` some years ago, and it doesn't seem to have evolved much since then.
It does produce false positives and negatives, and, thus, is not suitable for use in CI. Still, it can be useful sometimes during development, so it might be worth sharing its existence as documentation.

The dead test code was spotted manually while rewriting those files to use pytest instead of nose...