### PR TITLE
Remove dead code in installer

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -72,12 +72,6 @@ You might want to override the default subdomain used for exposed routes. If you
     return click.prompt('New default subdomain (ENTER for none)', default='')
 
 
-def list_hosts(hosts):
-    hosts_idx = range(len(hosts))
-    for idx in hosts_idx:
-        click.echo('   {}: {}'.format(idx, hosts[idx]))
-
-
 def collect_hosts(oo_cfg, existing_env=False, masters_set=False, print_summary=True):
     """
         Collect host information from user. This will later be filled in using
@@ -654,20 +648,6 @@ https://docs.openshift.com/enterprise/latest/admin_guide/install/prerequisites.h
         click.clear()
 
     return oo_cfg
-
-
-def get_role_variable(oo_cfg, role_name, variable_name):
-    try:
-        target_role = next(role for role in oo_cfg.deployment.roles if role.name is role_name)
-        target_variable = target_role.variables[variable_name]
-        return target_variable
-    except (StopIteration, KeyError):
-        return None
-
-
-def set_role_variable(oo_cfg, role_name, variable_name, variable_value):
-    target_role = next(role for role in oo_cfg.deployment.roles if role.name is role_name)
-    target_role[variable_name] = variable_value
 
 
 def collect_new_nodes(oo_cfg):

--- a/utils/src/ooinstall/oo_config.py
+++ b/utils/src/ooinstall/oo_config.py
@@ -126,15 +126,6 @@ class Host(object):
         """ Does this host have the etcd role """
         return 'etcd' in self.roles
 
-    def is_etcd_member(self, all_hosts):
-        """ Will this host be a member of a standalone etcd cluster. """
-        if not self.is_master():
-            return False
-        masters = [host for host in all_hosts if host.is_master()]
-        if len(masters) > 1:
-            return True
-        return False
-
     def is_dedicated_node(self):
         """ Will this host be a dedicated node. (not a master) """
         return self.is_node() and not self.is_master()
@@ -435,12 +426,6 @@ class OOConfig(object):
 
     def __str__(self):
         return self.yaml()
-
-    def get_host(self, name):
-        for host in self.deployment.hosts:
-            if host.connect_to == name:
-                return host
-        return None
 
     def get_host_roles_set(self):
         roles_set = set()


### PR DESCRIPTION
Found using `vulture`, confirmed that code that was once used became
unused in later commits after its introduction.