### PR TITLE
Migrate from nose to pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,7 +12,7 @@ omit =
     *_tests.py
 
 [report]
-fail_under = 25
+fail_under = 28
 
 [html]
 directory = cover

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,18 @@
 [run]
-omit=
+branch = True
+omit =
     */lib/python*/site-packages/*
     */lib/python*/*
     /usr/*
+    setup.py
+    # TODO(rhcarvalho): this is used to ignore test files from coverage report.
+    # We can make this less generic when we stick with a single test pattern in
+    # the repo.
+    test_*.py
+    *_tests.py
+
+[report]
+fail_under = 25
+
+[html]
+directory = cover

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+"""pytest configuration"""
+
+
+def pytest_ignore_collect(path):
+    """Hook to ignore symlink files and directories."""
+    return path.islink()

--- a/roles/openshift_master_facts/test/conftest.py
+++ b/roles/openshift_master_facts/test/conftest.py
@@ -1,0 +1,54 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir, "lookup_plugins"))
+
+from openshift_master_facts_default_predicates import LookupModule as PredicatesLookupModule  # noqa: E402
+from openshift_master_facts_default_priorities import LookupModule as PrioritiesLookupModule  # noqa: E402
+
+
+@pytest.fixture()
+def predicates_lookup():
+    return PredicatesLookupModule()
+
+
+@pytest.fixture()
+def priorities_lookup():
+    return PrioritiesLookupModule()
+
+
+@pytest.fixture()
+def facts(request):
+    return {
+        'openshift': {
+            'common': {}
+        }
+    }
+
+
+@pytest.fixture(params=[True, False])
+def regions_enabled(request):
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def zones_enabled(request):
+    return request.param
+
+
+def v_prefix(release):
+    """Prefix a release number with 'v'."""
+    return "v" + release
+
+
+def minor(release):
+    """Add a suffix to release, making 'X.Y' become 'X.Y.Z'."""
+    return release + ".1"
+
+
+@pytest.fixture(params=[str, v_prefix, minor])
+def release_mod(request):
+    """Modifies a release string to alternative valid values."""
+    return request.param

--- a/roles/openshift_master_facts/test/openshift_master_facts_bad_input_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_bad_input_tests.py
@@ -1,0 +1,58 @@
+import copy
+import os
+import sys
+
+from ansible.errors import AnsibleError
+from nose.tools import raises
+
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir, "lookup_plugins"))
+
+from openshift_master_facts_default_predicates import LookupModule  # noqa: E402
+
+
+class TestOpenShiftMasterFactsBadInput(object):
+    def setUp(self):
+        self.lookup = LookupModule()
+        self.default_facts = {
+            'openshift': {
+                'common': {}
+            }
+        }
+
+    @raises(AnsibleError)
+    def test_missing_openshift_facts(self):
+        facts = {}
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
+    def test_missing_deployment_type(self):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['short_version'] = '10.10'
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
+    def test_missing_short_version_and_missing_openshift_release(self):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['deployment_type'] = 'origin'
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
+    def test_unknown_deployment_types(self):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['short_version'] = '1.1'
+        facts['openshift']['common']['deployment_type'] = 'bogus'
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
+    def test_unknown_origin_version(self):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['short_version'] = '0.1'
+        facts['openshift']['common']['deployment_type'] = 'origin'
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
+    def test_unknown_ocp_version(self):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['short_version'] = '0.1'
+        facts['openshift']['common']['deployment_type'] = 'openshift-enterprise'
+        self.lookup.run(None, variables=facts)

--- a/roles/openshift_master_facts/test/openshift_master_facts_bad_input_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_bad_input_tests.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 from ansible.errors import AnsibleError
-from nose.tools import raises
+import pytest
 
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir, "lookup_plugins"))
 
@@ -11,48 +11,47 @@ from openshift_master_facts_default_predicates import LookupModule  # noqa: E402
 
 
 class TestOpenShiftMasterFactsBadInput(object):
-    def setUp(self):
-        self.lookup = LookupModule()
-        self.default_facts = {
-            'openshift': {
-                'common': {}
-            }
+    lookup = LookupModule()
+    default_facts = {
+        'openshift': {
+            'common': {}
         }
+    }
 
-    @raises(AnsibleError)
     def test_missing_openshift_facts(self):
-        facts = {}
-        self.lookup.run(None, variables=facts)
+        with pytest.raises(AnsibleError):
+            facts = {}
+            self.lookup.run(None, variables=facts)
 
-    @raises(AnsibleError)
     def test_missing_deployment_type(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '10.10'
-        self.lookup.run(None, variables=facts)
+        with pytest.raises(AnsibleError):
+            facts = copy.deepcopy(self.default_facts)
+            facts['openshift']['common']['short_version'] = '10.10'
+            self.lookup.run(None, variables=facts)
 
-    @raises(AnsibleError)
     def test_missing_short_version_and_missing_openshift_release(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['deployment_type'] = 'origin'
-        self.lookup.run(None, variables=facts)
+        with pytest.raises(AnsibleError):
+            facts = copy.deepcopy(self.default_facts)
+            facts['openshift']['common']['deployment_type'] = 'origin'
+            self.lookup.run(None, variables=facts)
 
-    @raises(AnsibleError)
     def test_unknown_deployment_types(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '1.1'
-        facts['openshift']['common']['deployment_type'] = 'bogus'
-        self.lookup.run(None, variables=facts)
+        with pytest.raises(AnsibleError):
+            facts = copy.deepcopy(self.default_facts)
+            facts['openshift']['common']['short_version'] = '1.1'
+            facts['openshift']['common']['deployment_type'] = 'bogus'
+            self.lookup.run(None, variables=facts)
 
-    @raises(AnsibleError)
     def test_unknown_origin_version(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '0.1'
-        facts['openshift']['common']['deployment_type'] = 'origin'
-        self.lookup.run(None, variables=facts)
+        with pytest.raises(AnsibleError):
+            facts = copy.deepcopy(self.default_facts)
+            facts['openshift']['common']['short_version'] = '0.1'
+            facts['openshift']['common']['deployment_type'] = 'origin'
+            self.lookup.run(None, variables=facts)
 
-    @raises(AnsibleError)
     def test_unknown_ocp_version(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '0.1'
-        facts['openshift']['common']['deployment_type'] = 'openshift-enterprise'
-        self.lookup.run(None, variables=facts)
+        with pytest.raises(AnsibleError):
+            facts = copy.deepcopy(self.default_facts)
+            facts['openshift']['common']['short_version'] = '0.1'
+            facts['openshift']['common']['deployment_type'] = 'openshift-enterprise'
+            self.lookup.run(None, variables=facts)

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
@@ -98,9 +98,9 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
 
     def test_openshift_version(self):
         for regions_enabled in (True, False):
-            for release, deployment_type, default_predicates in TEST_VARS:
-                release = release + '.1'
-                yield self.check_defaults_version, release, deployment_type, default_predicates, regions_enabled
+            for version, deployment_type, default_predicates in TEST_VARS:
+                version = version + '.1'
+                yield self.check_defaults_version, version, deployment_type, default_predicates, regions_enabled
 
     def check_defaults_version(self, version, deployment_type, default_predicates,
                                regions_enabled):
@@ -143,8 +143,8 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
 
     def test_short_version_defaults(self):
         for regions_enabled in (True, False):
-            for release, deployment_type, default_predicates in TEST_VARS:
-                yield self.check_defaults_short_version, release, deployment_type, default_predicates, regions_enabled
+            for short_version, deployment_type, default_predicates in TEST_VARS:
+                yield self.check_defaults_short_version, short_version, deployment_type, default_predicates, regions_enabled
 
     def check_defaults_short_version(self, short_version, deployment_type, default_predicates,
                                      regions_enabled):
@@ -160,8 +160,8 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
 
     def test_short_version_kwarg(self):
         for regions_enabled in (True, False):
-            for release, deployment_type, default_predicates in TEST_VARS:
-                yield self.check_defaults_short_version_kwarg, release, deployment_type, default_predicates, regions_enabled
+            for short_version, deployment_type, default_predicates in TEST_VARS:
+                yield self.check_defaults_short_version_kwarg, short_version, deployment_type, default_predicates, regions_enabled
 
     def check_defaults_short_version_kwarg(self, short_version, deployment_type, default_predicates,
                                            regions_enabled):
@@ -177,8 +177,8 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
 
     def test_deployment_type_kwarg(self):
         for regions_enabled in (True, False):
-            for release, deployment_type, default_predicates in TEST_VARS:
-                yield self.check_defaults_deployment_type_kwarg, release, deployment_type, default_predicates, regions_enabled
+            for short_version, deployment_type, default_predicates in TEST_VARS:
+                yield self.check_defaults_deployment_type_kwarg, short_version, deployment_type, default_predicates, regions_enabled
 
     def check_defaults_deployment_type_kwarg(self, short_version, deployment_type,
                                              default_predicates, regions_enabled):
@@ -194,8 +194,8 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
 
     def test_only_kwargs(self):
         for regions_enabled in (True, False):
-            for release, deployment_type, default_predicates in TEST_VARS:
-                yield self.check_defaults_only_kwargs, release, deployment_type, default_predicates, regions_enabled
+            for short_version, deployment_type, default_predicates in TEST_VARS:
+                yield self.check_defaults_only_kwargs, short_version, deployment_type, default_predicates, regions_enabled
 
     def check_defaults_only_kwargs(self, short_version, deployment_type,
                                    default_predicates, regions_enabled):

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
@@ -1,10 +1,5 @@
-import copy
-import os
-import sys
+import pytest
 
-sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir, "lookup_plugins"))
-
-from openshift_master_facts_default_predicates import LookupModule  # noqa: E402
 
 # Predicates ordered according to OpenShift Origin source:
 # origin/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -85,123 +80,99 @@ TEST_VARS = [
 ]
 
 
-class TestOpenShiftMasterFactsDefaultPredicates(object):
-    lookup = LookupModule()
-    default_facts = {
-        'openshift': {
-            'common': {}
-        }
-    }
+def test_openshift_version(predicates_lookup, openshift_version_fixture, regions_enabled):
+    facts, default_predicates = openshift_version_fixture
+    results = predicates_lookup.run(None, variables=facts, regions_enabled=regions_enabled)
+    if regions_enabled:
+        assert results == default_predicates + [REGION_PREDICATE]
+    else:
+        assert results == default_predicates
 
-    def test_openshift_version(self):
-        for regions_enabled in (True, False):
-            for version, deployment_type, default_predicates in TEST_VARS:
-                version = version + '.1'
-                yield self.check_defaults_version, version, deployment_type, default_predicates, regions_enabled
 
-    def check_defaults_version(self, version, deployment_type, default_predicates,
-                               regions_enabled):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift_version'] = version
-        facts['openshift']['common']['deployment_type'] = deployment_type
-        results = self.lookup.run(None, variables=facts,
-                                  regions_enabled=regions_enabled)
-        if regions_enabled:
-            assert results == default_predicates + [REGION_PREDICATE]
-        else:
-            assert results == default_predicates
+@pytest.fixture(params=TEST_VARS)
+def openshift_version_fixture(request, facts):
+    version, deployment_type, default_predicates = request.param
+    version += '.1'
+    facts['openshift_version'] = version
+    facts['openshift']['common']['deployment_type'] = deployment_type
+    return facts, default_predicates
 
-    def test_release_defaults(self):
-        for regions_enabled in (True, False):
-            for release, deployment_type, default_predicates in TEST_VARS:
-                yield self.check_defaults_release, release, deployment_type, default_predicates, regions_enabled
 
-    def test_v_release_defaults(self):
-        for regions_enabled in (True, False):
-            for release, deployment_type, default_predicates in TEST_VARS:
-                yield self.check_defaults_release, 'v' + release, deployment_type, default_predicates, regions_enabled
+def test_openshift_release(predicates_lookup, openshift_release_fixture, regions_enabled):
+    facts, default_predicates = openshift_release_fixture
+    results = predicates_lookup.run(None, variables=facts, regions_enabled=regions_enabled)
+    if regions_enabled:
+        assert results == default_predicates + [REGION_PREDICATE]
+    else:
+        assert results == default_predicates
 
-    def test_trunc_openshift_release(self):
-        for release, deployment_type, default_predicates in TEST_VARS:
-            release = release + '.1'
-            yield self.check_defaults_release, release, deployment_type, default_predicates, False
 
-    def check_defaults_release(self, release, deployment_type, default_predicates,
-                               regions_enabled):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift_release'] = release
-        facts['openshift']['common']['deployment_type'] = deployment_type
-        results = self.lookup.run(None, variables=facts,
-                                  regions_enabled=regions_enabled)
-        if regions_enabled:
-            assert results == default_predicates + [REGION_PREDICATE]
-        else:
-            assert results == default_predicates
+@pytest.fixture(params=TEST_VARS)
+def openshift_release_fixture(request, facts, release_mod):
+    release, deployment_type, default_predicates = request.param
+    facts['openshift_release'] = release_mod(release)
+    facts['openshift']['common']['deployment_type'] = deployment_type
+    return facts, default_predicates
 
-    def test_short_version_defaults(self):
-        for regions_enabled in (True, False):
-            for short_version, deployment_type, default_predicates in TEST_VARS:
-                yield self.check_defaults_short_version, short_version, deployment_type, default_predicates, regions_enabled
 
-    def check_defaults_short_version(self, short_version, deployment_type, default_predicates,
-                                     regions_enabled):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = short_version
-        facts['openshift']['common']['deployment_type'] = deployment_type
-        results = self.lookup.run(None, variables=facts,
-                                  regions_enabled=regions_enabled)
-        if regions_enabled:
-            assert results == default_predicates + [REGION_PREDICATE]
-        else:
-            assert results == default_predicates
+def test_short_version(predicates_lookup, short_version_fixture, regions_enabled):
+    facts, default_predicates = short_version_fixture
+    results = predicates_lookup.run(None, variables=facts, regions_enabled=regions_enabled)
+    if regions_enabled:
+        assert results == default_predicates + [REGION_PREDICATE]
+    else:
+        assert results == default_predicates
 
-    def test_short_version_kwarg(self):
-        for regions_enabled in (True, False):
-            for short_version, deployment_type, default_predicates in TEST_VARS:
-                yield self.check_defaults_short_version_kwarg, short_version, deployment_type, default_predicates, regions_enabled
 
-    def check_defaults_short_version_kwarg(self, short_version, deployment_type, default_predicates,
-                                           regions_enabled):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['deployment_type'] = deployment_type
-        results = self.lookup.run(None, variables=facts,
-                                  regions_enabled=regions_enabled,
-                                  short_version=short_version)
-        if regions_enabled:
-            assert results == default_predicates + [REGION_PREDICATE]
-        else:
-            assert results == default_predicates
+@pytest.fixture(params=TEST_VARS)
+def short_version_fixture(request, facts):
+    short_version, deployment_type, default_predicates = request.param
+    facts['openshift']['common']['short_version'] = short_version
+    facts['openshift']['common']['deployment_type'] = deployment_type
+    return facts, default_predicates
 
-    def test_deployment_type_kwarg(self):
-        for regions_enabled in (True, False):
-            for short_version, deployment_type, default_predicates in TEST_VARS:
-                yield self.check_defaults_deployment_type_kwarg, short_version, deployment_type, default_predicates, regions_enabled
 
-    def check_defaults_deployment_type_kwarg(self, short_version, deployment_type,
-                                             default_predicates, regions_enabled):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = short_version
-        results = self.lookup.run(None, variables=facts,
-                                  regions_enabled=regions_enabled,
-                                  deployment_type=deployment_type)
-        if regions_enabled:
-            assert results == default_predicates + [REGION_PREDICATE]
-        else:
-            assert results == default_predicates
+def test_short_version_kwarg(predicates_lookup, short_version_kwarg_fixture, regions_enabled):
+    facts, short_version, default_predicates = short_version_kwarg_fixture
+    results = predicates_lookup.run(None, variables=facts, regions_enabled=regions_enabled, short_version=short_version)
+    if regions_enabled:
+        assert results == default_predicates + [REGION_PREDICATE]
+    else:
+        assert results == default_predicates
 
-    def test_only_kwargs(self):
-        for regions_enabled in (True, False):
-            for short_version, deployment_type, default_predicates in TEST_VARS:
-                yield self.check_defaults_only_kwargs, short_version, deployment_type, default_predicates, regions_enabled
 
-    def check_defaults_only_kwargs(self, short_version, deployment_type,
-                                   default_predicates, regions_enabled):
-        facts = copy.deepcopy(self.default_facts)
-        results = self.lookup.run(None, variables=facts,
-                                  regions_enabled=regions_enabled,
-                                  short_version=short_version,
-                                  deployment_type=deployment_type)
-        if regions_enabled:
-            assert results == default_predicates + [REGION_PREDICATE]
-        else:
-            assert results == default_predicates
+@pytest.fixture(params=TEST_VARS)
+def short_version_kwarg_fixture(request, facts):
+    short_version, deployment_type, default_predicates = request.param
+    facts['openshift']['common']['deployment_type'] = deployment_type
+    return facts, short_version, default_predicates
+
+
+def test_deployment_type_kwarg(predicates_lookup, deployment_type_kwarg_fixture, regions_enabled):
+    facts, deployment_type, default_predicates = deployment_type_kwarg_fixture
+    results = predicates_lookup.run(None, variables=facts, regions_enabled=regions_enabled, deployment_type=deployment_type)
+    if regions_enabled:
+        assert results == default_predicates + [REGION_PREDICATE]
+    else:
+        assert results == default_predicates
+
+
+@pytest.fixture(params=TEST_VARS)
+def deployment_type_kwarg_fixture(request, facts):
+    short_version, deployment_type, default_predicates = request.param
+    facts['openshift']['common']['short_version'] = short_version
+    return facts, deployment_type, default_predicates
+
+
+def test_short_version_deployment_type_kwargs(predicates_lookup, short_version_deployment_type_kwargs_fixture, regions_enabled):
+    short_version, deployment_type, default_predicates = short_version_deployment_type_kwargs_fixture
+    results = predicates_lookup.run(None, regions_enabled=regions_enabled, short_version=short_version, deployment_type=deployment_type)
+    if regions_enabled:
+        assert results == default_predicates + [REGION_PREDICATE]
+    else:
+        assert results == default_predicates
+
+
+@pytest.fixture(params=TEST_VARS)
+def short_version_deployment_type_kwargs_fixture(request):
+    return request.param

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
@@ -80,13 +80,17 @@ TEST_VARS = [
 ]
 
 
-def test_openshift_version(predicates_lookup, openshift_version_fixture, regions_enabled):
-    facts, default_predicates = openshift_version_fixture
-    results = predicates_lookup.run(None, variables=facts, regions_enabled=regions_enabled)
+def assert_ok(predicates_lookup, default_predicates, regions_enabled, **kwargs):
+    results = predicates_lookup.run(None, regions_enabled=regions_enabled, **kwargs)
     if regions_enabled:
         assert results == default_predicates + [REGION_PREDICATE]
     else:
         assert results == default_predicates
+
+
+def test_openshift_version(predicates_lookup, openshift_version_fixture, regions_enabled):
+    facts, default_predicates = openshift_version_fixture
+    assert_ok(predicates_lookup, default_predicates, variables=facts, regions_enabled=regions_enabled)
 
 
 @pytest.fixture(params=TEST_VARS)
@@ -100,11 +104,7 @@ def openshift_version_fixture(request, facts):
 
 def test_openshift_release(predicates_lookup, openshift_release_fixture, regions_enabled):
     facts, default_predicates = openshift_release_fixture
-    results = predicates_lookup.run(None, variables=facts, regions_enabled=regions_enabled)
-    if regions_enabled:
-        assert results == default_predicates + [REGION_PREDICATE]
-    else:
-        assert results == default_predicates
+    assert_ok(predicates_lookup, default_predicates, variables=facts, regions_enabled=regions_enabled)
 
 
 @pytest.fixture(params=TEST_VARS)
@@ -117,11 +117,7 @@ def openshift_release_fixture(request, facts, release_mod):
 
 def test_short_version(predicates_lookup, short_version_fixture, regions_enabled):
     facts, default_predicates = short_version_fixture
-    results = predicates_lookup.run(None, variables=facts, regions_enabled=regions_enabled)
-    if regions_enabled:
-        assert results == default_predicates + [REGION_PREDICATE]
-    else:
-        assert results == default_predicates
+    assert_ok(predicates_lookup, default_predicates, variables=facts, regions_enabled=regions_enabled)
 
 
 @pytest.fixture(params=TEST_VARS)
@@ -134,11 +130,7 @@ def short_version_fixture(request, facts):
 
 def test_short_version_kwarg(predicates_lookup, short_version_kwarg_fixture, regions_enabled):
     facts, short_version, default_predicates = short_version_kwarg_fixture
-    results = predicates_lookup.run(None, variables=facts, regions_enabled=regions_enabled, short_version=short_version)
-    if regions_enabled:
-        assert results == default_predicates + [REGION_PREDICATE]
-    else:
-        assert results == default_predicates
+    assert_ok(predicates_lookup, default_predicates, variables=facts, regions_enabled=regions_enabled, short_version=short_version)
 
 
 @pytest.fixture(params=TEST_VARS)
@@ -150,11 +142,7 @@ def short_version_kwarg_fixture(request, facts):
 
 def test_deployment_type_kwarg(predicates_lookup, deployment_type_kwarg_fixture, regions_enabled):
     facts, deployment_type, default_predicates = deployment_type_kwarg_fixture
-    results = predicates_lookup.run(None, variables=facts, regions_enabled=regions_enabled, deployment_type=deployment_type)
-    if regions_enabled:
-        assert results == default_predicates + [REGION_PREDICATE]
-    else:
-        assert results == default_predicates
+    assert_ok(predicates_lookup, default_predicates, variables=facts, regions_enabled=regions_enabled, deployment_type=deployment_type)
 
 
 @pytest.fixture(params=TEST_VARS)
@@ -166,11 +154,7 @@ def deployment_type_kwarg_fixture(request, facts):
 
 def test_short_version_deployment_type_kwargs(predicates_lookup, short_version_deployment_type_kwargs_fixture, regions_enabled):
     short_version, deployment_type, default_predicates = short_version_deployment_type_kwargs_fixture
-    results = predicates_lookup.run(None, regions_enabled=regions_enabled, short_version=short_version, deployment_type=deployment_type)
-    if regions_enabled:
-        assert results == default_predicates + [REGION_PREDICATE]
-    else:
-        assert results == default_predicates
+    assert_ok(predicates_lookup, default_predicates, regions_enabled=regions_enabled, short_version=short_version, deployment_type=deployment_type)
 
 
 @pytest.fixture(params=TEST_VARS)

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
@@ -244,6 +244,6 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         self.lookup.run(None, variables=facts)
 
     @raises(AnsibleError)
-    def testMissingOpenShiftFacts(self):
+    def test_missing_openshift_facts(self):
         facts = {}
         self.lookup.run(None, variables=facts)

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
@@ -5,7 +5,7 @@ import sys
 from ansible.errors import AnsibleError
 from nose.tools import raises, assert_equal
 
-sys.path = [os.path.abspath(os.path.dirname(__file__) + "/../lookup_plugins/")] + sys.path
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir, "lookup_plugins"))
 
 from openshift_master_facts_default_predicates import LookupModule  # noqa: E402
 

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
@@ -2,8 +2,6 @@ import copy
 import os
 import sys
 
-from nose.tools import assert_equal
-
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir, "lookup_plugins"))
 
 from openshift_master_facts_default_predicates import LookupModule  # noqa: E402
@@ -110,9 +108,9 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         results = self.lookup.run(None, variables=facts,
                                   regions_enabled=regions_enabled)
         if regions_enabled:
-            assert_equal(results, default_predicates + [REGION_PREDICATE])
+            assert results == default_predicates + [REGION_PREDICATE]
         else:
-            assert_equal(results, default_predicates)
+            assert results == default_predicates
 
     def test_release_defaults(self):
         for regions_enabled in (True, False):
@@ -137,9 +135,9 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         results = self.lookup.run(None, variables=facts,
                                   regions_enabled=regions_enabled)
         if regions_enabled:
-            assert_equal(results, default_predicates + [REGION_PREDICATE])
+            assert results == default_predicates + [REGION_PREDICATE]
         else:
-            assert_equal(results, default_predicates)
+            assert results == default_predicates
 
     def test_short_version_defaults(self):
         for regions_enabled in (True, False):
@@ -154,9 +152,9 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         results = self.lookup.run(None, variables=facts,
                                   regions_enabled=regions_enabled)
         if regions_enabled:
-            assert_equal(results, default_predicates + [REGION_PREDICATE])
+            assert results == default_predicates + [REGION_PREDICATE]
         else:
-            assert_equal(results, default_predicates)
+            assert results == default_predicates
 
     def test_short_version_kwarg(self):
         for regions_enabled in (True, False):
@@ -171,9 +169,9 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
                                   regions_enabled=regions_enabled,
                                   short_version=short_version)
         if regions_enabled:
-            assert_equal(results, default_predicates + [REGION_PREDICATE])
+            assert results == default_predicates + [REGION_PREDICATE]
         else:
-            assert_equal(results, default_predicates)
+            assert results == default_predicates
 
     def test_deployment_type_kwarg(self):
         for regions_enabled in (True, False):
@@ -188,9 +186,9 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
                                   regions_enabled=regions_enabled,
                                   deployment_type=deployment_type)
         if regions_enabled:
-            assert_equal(results, default_predicates + [REGION_PREDICATE])
+            assert results == default_predicates + [REGION_PREDICATE]
         else:
-            assert_equal(results, default_predicates)
+            assert results == default_predicates
 
     def test_only_kwargs(self):
         for regions_enabled in (True, False):
@@ -205,6 +203,6 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
                                   short_version=short_version,
                                   deployment_type=deployment_type)
         if regions_enabled:
-            assert_equal(results, default_predicates + [REGION_PREDICATE])
+            assert results == default_predicates + [REGION_PREDICATE]
         else:
-            assert_equal(results, default_predicates)
+            assert results == default_predicates

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
@@ -86,13 +86,12 @@ TEST_VARS = [
 
 
 class TestOpenShiftMasterFactsDefaultPredicates(object):
-    def setUp(self):
-        self.lookup = LookupModule()
-        self.default_facts = {
-            'openshift': {
-                'common': {}
-            }
+    lookup = LookupModule()
+    default_facts = {
+        'openshift': {
+            'common': {}
         }
+    }
 
     def test_openshift_version(self):
         for regions_enabled in (True, False):

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
@@ -96,65 +96,11 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
             }
         }
 
-    def check_defaults_short_version(self, short_version, deployment_type, default_predicates,
-                                     regions_enabled):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = short_version
-        facts['openshift']['common']['deployment_type'] = deployment_type
-        results = self.lookup.run(None, variables=facts,
-                                  regions_enabled=regions_enabled)
-        if regions_enabled:
-            assert_equal(results, default_predicates + [REGION_PREDICATE])
-        else:
-            assert_equal(results, default_predicates)
-
-    def check_defaults_short_version_kwarg(self, short_version, deployment_type, default_predicates,
-                                           regions_enabled):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['deployment_type'] = deployment_type
-        results = self.lookup.run(None, variables=facts,
-                                  regions_enabled=regions_enabled,
-                                  short_version=short_version)
-        if regions_enabled:
-            assert_equal(results, default_predicates + [REGION_PREDICATE])
-        else:
-            assert_equal(results, default_predicates)
-
-    def check_defaults_deployment_type_kwarg(self, short_version, deployment_type,
-                                             default_predicates, regions_enabled):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = short_version
-        results = self.lookup.run(None, variables=facts,
-                                  regions_enabled=regions_enabled,
-                                  deployment_type=deployment_type)
-        if regions_enabled:
-            assert_equal(results, default_predicates + [REGION_PREDICATE])
-        else:
-            assert_equal(results, default_predicates)
-
-    def check_defaults_only_kwargs(self, short_version, deployment_type,
-                                   default_predicates, regions_enabled):
-        facts = copy.deepcopy(self.default_facts)
-        results = self.lookup.run(None, variables=facts,
-                                  regions_enabled=regions_enabled,
-                                  short_version=short_version,
-                                  deployment_type=deployment_type)
-        if regions_enabled:
-            assert_equal(results, default_predicates + [REGION_PREDICATE])
-        else:
-            assert_equal(results, default_predicates)
-
-    def check_defaults_release(self, release, deployment_type, default_predicates,
-                               regions_enabled):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift_release'] = release
-        facts['openshift']['common']['deployment_type'] = deployment_type
-        results = self.lookup.run(None, variables=facts,
-                                  regions_enabled=regions_enabled)
-        if regions_enabled:
-            assert_equal(results, default_predicates + [REGION_PREDICATE])
-        else:
-            assert_equal(results, default_predicates)
+    def test_openshift_version(self):
+        for regions_enabled in (True, False):
+            for release, deployment_type, default_predicates in TEST_VARS:
+                release = release + '.1'
+                yield self.check_defaults_version, release, deployment_type, default_predicates, regions_enabled
 
     def check_defaults_version(self, version, deployment_type, default_predicates,
                                regions_enabled):
@@ -168,43 +114,97 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         else:
             assert_equal(results, default_predicates)
 
-    def test_openshift_version(self):
+    def test_release_defaults(self):
         for regions_enabled in (True, False):
             for release, deployment_type, default_predicates in TEST_VARS:
-                release = release + '.1'
-                yield self.check_defaults_version, release, deployment_type, default_predicates, regions_enabled
+                yield self.check_defaults_release, release, deployment_type, default_predicates, regions_enabled
 
     def test_v_release_defaults(self):
         for regions_enabled in (True, False):
             for release, deployment_type, default_predicates in TEST_VARS:
                 yield self.check_defaults_release, 'v' + release, deployment_type, default_predicates, regions_enabled
 
-    def test_release_defaults(self):
-        for regions_enabled in (True, False):
-            for release, deployment_type, default_predicates in TEST_VARS:
-                yield self.check_defaults_release, release, deployment_type, default_predicates, regions_enabled
+    def test_trunc_openshift_release(self):
+        for release, deployment_type, default_predicates in TEST_VARS:
+            release = release + '.1'
+            yield self.check_defaults_release, release, deployment_type, default_predicates, False
+
+    def check_defaults_release(self, release, deployment_type, default_predicates,
+                               regions_enabled):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift_release'] = release
+        facts['openshift']['common']['deployment_type'] = deployment_type
+        results = self.lookup.run(None, variables=facts,
+                                  regions_enabled=regions_enabled)
+        if regions_enabled:
+            assert_equal(results, default_predicates + [REGION_PREDICATE])
+        else:
+            assert_equal(results, default_predicates)
 
     def test_short_version_defaults(self):
         for regions_enabled in (True, False):
             for release, deployment_type, default_predicates in TEST_VARS:
                 yield self.check_defaults_short_version, release, deployment_type, default_predicates, regions_enabled
 
+    def check_defaults_short_version(self, short_version, deployment_type, default_predicates,
+                                     regions_enabled):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['short_version'] = short_version
+        facts['openshift']['common']['deployment_type'] = deployment_type
+        results = self.lookup.run(None, variables=facts,
+                                  regions_enabled=regions_enabled)
+        if regions_enabled:
+            assert_equal(results, default_predicates + [REGION_PREDICATE])
+        else:
+            assert_equal(results, default_predicates)
+
     def test_short_version_kwarg(self):
         for regions_enabled in (True, False):
             for release, deployment_type, default_predicates in TEST_VARS:
                 yield self.check_defaults_short_version_kwarg, release, deployment_type, default_predicates, regions_enabled
 
-    def test_only_kwargs(self):
-        for regions_enabled in (True, False):
-            for release, deployment_type, default_predicates in TEST_VARS:
-                yield self.check_defaults_only_kwargs, release, deployment_type, default_predicates, regions_enabled
+    def check_defaults_short_version_kwarg(self, short_version, deployment_type, default_predicates,
+                                           regions_enabled):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['deployment_type'] = deployment_type
+        results = self.lookup.run(None, variables=facts,
+                                  regions_enabled=regions_enabled,
+                                  short_version=short_version)
+        if regions_enabled:
+            assert_equal(results, default_predicates + [REGION_PREDICATE])
+        else:
+            assert_equal(results, default_predicates)
 
     def test_deployment_type_kwarg(self):
         for regions_enabled in (True, False):
             for release, deployment_type, default_predicates in TEST_VARS:
                 yield self.check_defaults_deployment_type_kwarg, release, deployment_type, default_predicates, regions_enabled
 
-    def test_trunc_openshift_release(self):
-        for release, deployment_type, default_predicates in TEST_VARS:
-            release = release + '.1'
-            yield self.check_defaults_release, release, deployment_type, default_predicates, False
+    def check_defaults_deployment_type_kwarg(self, short_version, deployment_type,
+                                             default_predicates, regions_enabled):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['short_version'] = short_version
+        results = self.lookup.run(None, variables=facts,
+                                  regions_enabled=regions_enabled,
+                                  deployment_type=deployment_type)
+        if regions_enabled:
+            assert_equal(results, default_predicates + [REGION_PREDICATE])
+        else:
+            assert_equal(results, default_predicates)
+
+    def test_only_kwargs(self):
+        for regions_enabled in (True, False):
+            for release, deployment_type, default_predicates in TEST_VARS:
+                yield self.check_defaults_only_kwargs, release, deployment_type, default_predicates, regions_enabled
+
+    def check_defaults_only_kwargs(self, short_version, deployment_type,
+                                   default_predicates, regions_enabled):
+        facts = copy.deepcopy(self.default_facts)
+        results = self.lookup.run(None, variables=facts,
+                                  regions_enabled=regions_enabled,
+                                  short_version=short_version,
+                                  deployment_type=deployment_type)
+        if regions_enabled:
+            assert_equal(results, default_predicates + [REGION_PREDICATE])
+        else:
+            assert_equal(results, default_predicates)

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
@@ -98,9 +98,41 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         }
 
     @raises(AnsibleError)
+    def test_missing_openshift_facts(self):
+        facts = {}
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
+    def test_missing_deployment_type(self):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['short_version'] = '10.10'
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
     def test_missing_short_version_and_missing_openshift_release(self):
         facts = copy.deepcopy(self.default_facts)
         facts['openshift']['common']['deployment_type'] = 'origin'
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
+    def test_unknown_deployment_types(self):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['short_version'] = '1.1'
+        facts['openshift']['common']['deployment_type'] = 'bogus'
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
+    def test_unknown_origin_version(self):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['short_version'] = '0.1'
+        facts['openshift']['common']['deployment_type'] = 'origin'
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
+    def test_unknown_ocp_version(self):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['short_version'] = '0.1'
+        facts['openshift']['common']['deployment_type'] = 'openshift-enterprise'
         self.lookup.run(None, variables=facts)
 
     def check_defaults_short_version(self, short_version, deployment_type, default_predicates,
@@ -215,35 +247,3 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         for release, deployment_type, default_predicates in TEST_VARS:
             release = release + '.1'
             yield self.check_defaults_release, release, deployment_type, default_predicates, False
-
-    @raises(AnsibleError)
-    def test_unknown_deployment_types(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '1.1'
-        facts['openshift']['common']['deployment_type'] = 'bogus'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_unknown_origin_version(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '0.1'
-        facts['openshift']['common']['deployment_type'] = 'origin'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_unknown_ocp_version(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '0.1'
-        facts['openshift']['common']['deployment_type'] = 'openshift-enterprise'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_missing_deployment_type(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '10.10'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_missing_openshift_facts(self):
-        facts = {}
-        self.lookup.run(None, variables=facts)

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
@@ -2,8 +2,7 @@ import copy
 import os
 import sys
 
-from ansible.errors import AnsibleError
-from nose.tools import raises, assert_equal
+from nose.tools import assert_equal
 
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir, "lookup_plugins"))
 
@@ -96,44 +95,6 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
                 'common': {}
             }
         }
-
-    @raises(AnsibleError)
-    def test_missing_openshift_facts(self):
-        facts = {}
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_missing_deployment_type(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '10.10'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_missing_short_version_and_missing_openshift_release(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['deployment_type'] = 'origin'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_unknown_deployment_types(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '1.1'
-        facts['openshift']['common']['deployment_type'] = 'bogus'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_unknown_origin_version(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '0.1'
-        facts['openshift']['common']['deployment_type'] = 'origin'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_unknown_ocp_version(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '0.1'
-        facts['openshift']['common']['deployment_type'] = 'openshift-enterprise'
-        self.lookup.run(None, variables=facts)
 
     def check_defaults_short_version(self, short_version, deployment_type, default_predicates,
                                      regions_enabled):

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
@@ -86,14 +86,14 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
 
     def test_openshift_version(self):
         for zones_enabled in (True, False):
-            for release, deployment_type, default_priorities in TEST_VARS:
-                release = release + '.1'
-                yield self.check_defaults_version, release, deployment_type, default_priorities, zones_enabled
+            for version, deployment_type, default_priorities in TEST_VARS:
+                version = version + '.1'
+                yield self.check_defaults_version, version, deployment_type, default_priorities, zones_enabled
 
-    def check_defaults_version(self, release, deployment_type, default_priorities,
+    def check_defaults_version(self, version, deployment_type, default_priorities,
                                zones_enabled):
         facts = copy.deepcopy(self.default_facts)
-        facts['openshift_version'] = release
+        facts['openshift_version'] = version
         facts['openshift']['common']['deployment_type'] = deployment_type
         results = self.lookup.run(None, variables=facts, zones_enabled=zones_enabled)
         if zones_enabled:
@@ -109,8 +109,7 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
     def test_v_release_defaults(self):
         for zones_enabled in (True, False):
             for release, deployment_type, default_priorities in TEST_VARS:
-                release = 'v' + release
-                yield self.check_defaults_release, release, deployment_type, default_priorities, zones_enabled
+                yield self.check_defaults_release, 'v' + release, deployment_type, default_priorities, zones_enabled
 
     def test_trunc_openshift_release(self):
         for release, deployment_type, default_priorities in TEST_VARS:
@@ -133,10 +132,10 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
             for short_version, deployment_type, default_priorities in TEST_VARS:
                 yield self.check_defaults_short_version, short_version, deployment_type, default_priorities, zones_enabled
 
-    def check_defaults_short_version(self, release, deployment_type,
+    def check_defaults_short_version(self, short_version, deployment_type,
                                      default_priorities, zones_enabled):
         facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = release
+        facts['openshift']['common']['short_version'] = short_version
         facts['openshift']['common']['deployment_type'] = deployment_type
         results = self.lookup.run(None, variables=facts, zones_enabled=zones_enabled)
         if zones_enabled:
@@ -144,18 +143,18 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         else:
             assert_equal(results, default_priorities)
 
-    def test_release_kwarg(self):
+    def test_short_version_kwarg(self):
         for zones_enabled in (True, False):
             for short_version, deployment_type, default_priorities in TEST_VARS:
                 yield self.check_defaults_short_version_kwarg, short_version, deployment_type, default_priorities, zones_enabled
 
-    def check_defaults_short_version_kwarg(self, release, deployment_type,
+    def check_defaults_short_version_kwarg(self, short_version, deployment_type,
                                            default_priorities, zones_enabled):
         facts = copy.deepcopy(self.default_facts)
         facts['openshift']['common']['deployment_type'] = deployment_type
         results = self.lookup.run(None, variables=facts,
                                   zones_enabled=zones_enabled,
-                                  short_version=release)
+                                  short_version=short_version)
         if zones_enabled:
             assert_equal(results, default_priorities + [ZONE_PRIORITY])
         else:
@@ -166,10 +165,10 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
             for short_version, deployment_type, default_priorities in TEST_VARS:
                 yield self.check_defaults_deployment_type_kwarg, short_version, deployment_type, default_priorities, zones_enabled
 
-    def check_defaults_deployment_type_kwarg(self, release, deployment_type,
+    def check_defaults_deployment_type_kwarg(self, short_version, deployment_type,
                                              default_priorities, zones_enabled):
         facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = release
+        facts['openshift']['common']['short_version'] = short_version
         results = self.lookup.run(None, variables=facts,
                                   zones_enabled=zones_enabled,
                                   deployment_type=deployment_type)
@@ -183,12 +182,12 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
             for short_version, deployment_type, default_priorities in TEST_VARS:
                 yield self.check_defaults_only_kwargs, short_version, deployment_type, default_priorities, zones_enabled
 
-    def check_defaults_only_kwargs(self, release, deployment_type,
+    def check_defaults_only_kwargs(self, short_version, deployment_type,
                                    default_priorities, zones_enabled):
         facts = copy.deepcopy(self.default_facts)
         results = self.lookup.run(None, variables=facts,
                                   zones_enabled=zones_enabled,
-                                  short_version=release,
+                                  short_version=short_version,
                                   deployment_type=deployment_type)
         if zones_enabled:
             assert_equal(results, default_priorities + [ZONE_PRIORITY])

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
@@ -2,8 +2,7 @@ import copy
 import os
 import sys
 
-from ansible.errors import AnsibleError
-from nose.tools import raises, assert_equal
+from nose.tools import assert_equal
 
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir, "lookup_plugins"))
 
@@ -84,44 +83,6 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
                 'common': {}
             }
         }
-
-    @raises(AnsibleError)
-    def test_missing_openshift_facts(self):
-        facts = {}
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_missing_deployment_type(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '10.10'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_missing_short_version_and_missing_openshift_release(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['deployment_type'] = 'origin'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_unknown_deployment_types(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '1.1'
-        facts['openshift']['common']['deployment_type'] = 'bogus'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_unknown_origin_version(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '0.1'
-        facts['openshift']['common']['deployment_type'] = 'origin'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_unknown_ocp_version(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '0.1'
-        facts['openshift']['common']['deployment_type'] = 'openshift-enterprise'
-        self.lookup.run(None, variables=facts)
 
     def check_defaults_short_version(self, release, deployment_type,
                                      default_priorities, zones_enabled):

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
@@ -74,13 +74,12 @@ TEST_VARS = [
 
 
 class TestOpenShiftMasterFactsDefaultPredicates(object):
-    def setUp(self):
-        self.lookup = LookupModule()
-        self.default_facts = {
-            'openshift': {
-                'common': {}
-            }
+    lookup = LookupModule()
+    default_facts = {
+        'openshift': {
+            'common': {}
         }
+    }
 
     def test_openshift_version(self):
         for zones_enabled in (True, False):

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
@@ -68,13 +68,17 @@ TEST_VARS = [
 ]
 
 
-def test_openshift_version(priorities_lookup, openshift_version_fixture, zones_enabled):
-    facts, default_priorities = openshift_version_fixture
-    results = priorities_lookup.run(None, variables=facts, zones_enabled=zones_enabled)
+def assert_ok(priorities_lookup, default_priorities, zones_enabled, **kwargs):
+    results = priorities_lookup.run(None, zones_enabled=zones_enabled, **kwargs)
     if zones_enabled:
         assert results == default_priorities + [ZONE_PRIORITY]
     else:
         assert results == default_priorities
+
+
+def test_openshift_version(priorities_lookup, openshift_version_fixture, zones_enabled):
+    facts, default_priorities = openshift_version_fixture
+    assert_ok(priorities_lookup, default_priorities, variables=facts, zones_enabled=zones_enabled)
 
 
 @pytest.fixture(params=TEST_VARS)
@@ -88,11 +92,7 @@ def openshift_version_fixture(request, facts):
 
 def test_openshift_release(priorities_lookup, openshift_release_fixture, zones_enabled):
     facts, default_priorities = openshift_release_fixture
-    results = priorities_lookup.run(None, variables=facts, zones_enabled=zones_enabled)
-    if zones_enabled:
-        assert results == default_priorities + [ZONE_PRIORITY]
-    else:
-        assert results == default_priorities
+    assert_ok(priorities_lookup, default_priorities, variables=facts, zones_enabled=zones_enabled)
 
 
 @pytest.fixture(params=TEST_VARS)
@@ -105,11 +105,7 @@ def openshift_release_fixture(request, facts, release_mod):
 
 def test_short_version(priorities_lookup, short_version_fixture, zones_enabled):
     facts, default_priorities = short_version_fixture
-    results = priorities_lookup.run(None, variables=facts, zones_enabled=zones_enabled)
-    if zones_enabled:
-        assert results == default_priorities + [ZONE_PRIORITY]
-    else:
-        assert results == default_priorities
+    assert_ok(priorities_lookup, default_priorities, variables=facts, zones_enabled=zones_enabled)
 
 
 @pytest.fixture(params=TEST_VARS)
@@ -122,11 +118,7 @@ def short_version_fixture(request, facts):
 
 def test_short_version_kwarg(priorities_lookup, short_version_kwarg_fixture, zones_enabled):
     facts, short_version, default_priorities = short_version_kwarg_fixture
-    results = priorities_lookup.run(None, variables=facts, zones_enabled=zones_enabled, short_version=short_version)
-    if zones_enabled:
-        assert results == default_priorities + [ZONE_PRIORITY]
-    else:
-        assert results == default_priorities
+    assert_ok(priorities_lookup, default_priorities, variables=facts, zones_enabled=zones_enabled, short_version=short_version)
 
 
 @pytest.fixture(params=TEST_VARS)
@@ -138,11 +130,7 @@ def short_version_kwarg_fixture(request, facts):
 
 def test_deployment_type_kwarg(priorities_lookup, deployment_type_kwarg_fixture, zones_enabled):
     facts, deployment_type, default_priorities = deployment_type_kwarg_fixture
-    results = priorities_lookup.run(None, variables=facts, zones_enabled=zones_enabled, deployment_type=deployment_type)
-    if zones_enabled:
-        assert results == default_priorities + [ZONE_PRIORITY]
-    else:
-        assert results == default_priorities
+    assert_ok(priorities_lookup, default_priorities, variables=facts, zones_enabled=zones_enabled, deployment_type=deployment_type)
 
 
 @pytest.fixture(params=TEST_VARS)
@@ -154,11 +142,7 @@ def deployment_type_kwarg_fixture(request, facts):
 
 def test_short_version_deployment_type_kwargs(priorities_lookup, short_version_deployment_type_kwargs_fixture, zones_enabled):
     short_version, deployment_type, default_priorities = short_version_deployment_type_kwargs_fixture
-    results = priorities_lookup.run(None, zones_enabled=zones_enabled, short_version=short_version, deployment_type=deployment_type)
-    if zones_enabled:
-        assert results == default_priorities + [ZONE_PRIORITY]
-    else:
-        assert results == default_priorities
+    assert_ok(priorities_lookup, default_priorities, zones_enabled=zones_enabled, short_version=short_version, deployment_type=deployment_type)
 
 
 @pytest.fixture(params=TEST_VARS)

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
@@ -86,9 +86,41 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         }
 
     @raises(AnsibleError)
+    def test_missing_openshift_facts(self):
+        facts = {}
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
+    def test_missing_deployment_type(self):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['short_version'] = '10.10'
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
     def test_missing_short_version_and_missing_openshift_release(self):
         facts = copy.deepcopy(self.default_facts)
         facts['openshift']['common']['deployment_type'] = 'origin'
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
+    def test_unknown_deployment_types(self):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['short_version'] = '1.1'
+        facts['openshift']['common']['deployment_type'] = 'bogus'
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
+    def test_unknown_origin_version(self):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['short_version'] = '0.1'
+        facts['openshift']['common']['deployment_type'] = 'origin'
+        self.lookup.run(None, variables=facts)
+
+    @raises(AnsibleError)
+    def test_unknown_ocp_version(self):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift']['common']['short_version'] = '0.1'
+        facts['openshift']['common']['deployment_type'] = 'openshift-enterprise'
         self.lookup.run(None, variables=facts)
 
     def check_defaults_short_version(self, release, deployment_type,
@@ -201,35 +233,3 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         for release, deployment_type, default_priorities in TEST_VARS:
             release = release + '.1'
             yield self.check_defaults_release, release, deployment_type, default_priorities, False
-
-    @raises(AnsibleError)
-    def test_unknown_origin_version(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '0.1'
-        facts['openshift']['common']['deployment_type'] = 'origin'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_unknown_ocp_version(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '0.1'
-        facts['openshift']['common']['deployment_type'] = 'openshift-enterprise'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_unknown_deployment_types(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '1.1'
-        facts['openshift']['common']['deployment_type'] = 'bogus'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_missing_deployment_type(self):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift']['common']['short_version'] = '10.10'
-        self.lookup.run(None, variables=facts)
-
-    @raises(AnsibleError)
-    def test_missing_openshift_facts(self):
-        facts = {}
-        self.lookup.run(None, variables=facts)

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
@@ -5,7 +5,7 @@ import sys
 from ansible.errors import AnsibleError
 from nose.tools import raises, assert_equal
 
-sys.path = [os.path.abspath(os.path.dirname(__file__) + "/../lookup_plugins/")] + sys.path
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir, "lookup_plugins"))
 
 from openshift_master_facts_default_priorities import LookupModule  # noqa: E402
 

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
@@ -2,8 +2,6 @@ import copy
 import os
 import sys
 
-from nose.tools import assert_equal
-
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir, "lookup_plugins"))
 
 from openshift_master_facts_default_priorities import LookupModule  # noqa: E402
@@ -97,9 +95,9 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         facts['openshift']['common']['deployment_type'] = deployment_type
         results = self.lookup.run(None, variables=facts, zones_enabled=zones_enabled)
         if zones_enabled:
-            assert_equal(results, default_priorities + [ZONE_PRIORITY])
+            assert results == default_priorities + [ZONE_PRIORITY]
         else:
-            assert_equal(results, default_priorities)
+            assert results == default_priorities
 
     def test_release_defaults(self):
         for zones_enabled in (True, False):
@@ -123,9 +121,9 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         facts['openshift']['common']['deployment_type'] = deployment_type
         results = self.lookup.run(None, variables=facts, zones_enabled=zones_enabled)
         if zones_enabled:
-            assert_equal(results, default_priorities + [ZONE_PRIORITY])
+            assert results == default_priorities + [ZONE_PRIORITY]
         else:
-            assert_equal(results, default_priorities)
+            assert results == default_priorities
 
     def test_short_version_defaults(self):
         for zones_enabled in (True, False):
@@ -139,9 +137,9 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         facts['openshift']['common']['deployment_type'] = deployment_type
         results = self.lookup.run(None, variables=facts, zones_enabled=zones_enabled)
         if zones_enabled:
-            assert_equal(results, default_priorities + [ZONE_PRIORITY])
+            assert results == default_priorities + [ZONE_PRIORITY]
         else:
-            assert_equal(results, default_priorities)
+            assert results == default_priorities
 
     def test_short_version_kwarg(self):
         for zones_enabled in (True, False):
@@ -156,9 +154,9 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
                                   zones_enabled=zones_enabled,
                                   short_version=short_version)
         if zones_enabled:
-            assert_equal(results, default_priorities + [ZONE_PRIORITY])
+            assert results == default_priorities + [ZONE_PRIORITY]
         else:
-            assert_equal(results, default_priorities)
+            assert results == default_priorities
 
     def test_deployment_type_kwarg(self):
         for zones_enabled in (True, False):
@@ -173,9 +171,9 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
                                   zones_enabled=zones_enabled,
                                   deployment_type=deployment_type)
         if zones_enabled:
-            assert_equal(results, default_priorities + [ZONE_PRIORITY])
+            assert results == default_priorities + [ZONE_PRIORITY]
         else:
-            assert_equal(results, default_priorities)
+            assert results == default_priorities
 
     def test_only_kwargs(self):
         for zones_enabled in (True, False):
@@ -190,6 +188,6 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
                                   short_version=short_version,
                                   deployment_type=deployment_type)
         if zones_enabled:
-            assert_equal(results, default_priorities + [ZONE_PRIORITY])
+            assert results == default_priorities + [ZONE_PRIORITY]
         else:
-            assert_equal(results, default_priorities)
+            assert results == default_priorities

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
@@ -84,6 +84,55 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
             }
         }
 
+    def test_openshift_version(self):
+        for zones_enabled in (True, False):
+            for release, deployment_type, default_priorities in TEST_VARS:
+                release = release + '.1'
+                yield self.check_defaults_version, release, deployment_type, default_priorities, zones_enabled
+
+    def check_defaults_version(self, release, deployment_type, default_priorities,
+                               zones_enabled):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift_version'] = release
+        facts['openshift']['common']['deployment_type'] = deployment_type
+        results = self.lookup.run(None, variables=facts, zones_enabled=zones_enabled)
+        if zones_enabled:
+            assert_equal(results, default_priorities + [ZONE_PRIORITY])
+        else:
+            assert_equal(results, default_priorities)
+
+    def test_release_defaults(self):
+        for zones_enabled in (True, False):
+            for release, deployment_type, default_priorities in TEST_VARS:
+                yield self.check_defaults_release, release, deployment_type, default_priorities, zones_enabled
+
+    def test_v_release_defaults(self):
+        for zones_enabled in (True, False):
+            for release, deployment_type, default_priorities in TEST_VARS:
+                release = 'v' + release
+                yield self.check_defaults_release, release, deployment_type, default_priorities, zones_enabled
+
+    def test_trunc_openshift_release(self):
+        for release, deployment_type, default_priorities in TEST_VARS:
+            release = release + '.1'
+            yield self.check_defaults_release, release, deployment_type, default_priorities, False
+
+    def check_defaults_release(self, release, deployment_type, default_priorities,
+                               zones_enabled):
+        facts = copy.deepcopy(self.default_facts)
+        facts['openshift_release'] = release
+        facts['openshift']['common']['deployment_type'] = deployment_type
+        results = self.lookup.run(None, variables=facts, zones_enabled=zones_enabled)
+        if zones_enabled:
+            assert_equal(results, default_priorities + [ZONE_PRIORITY])
+        else:
+            assert_equal(results, default_priorities)
+
+    def test_short_version_defaults(self):
+        for zones_enabled in (True, False):
+            for short_version, deployment_type, default_priorities in TEST_VARS:
+                yield self.check_defaults_short_version, short_version, deployment_type, default_priorities, zones_enabled
+
     def check_defaults_short_version(self, release, deployment_type,
                                      default_priorities, zones_enabled):
         facts = copy.deepcopy(self.default_facts)
@@ -94,6 +143,11 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
             assert_equal(results, default_priorities + [ZONE_PRIORITY])
         else:
             assert_equal(results, default_priorities)
+
+    def test_release_kwarg(self):
+        for zones_enabled in (True, False):
+            for short_version, deployment_type, default_priorities in TEST_VARS:
+                yield self.check_defaults_short_version_kwarg, short_version, deployment_type, default_priorities, zones_enabled
 
     def check_defaults_short_version_kwarg(self, release, deployment_type,
                                            default_priorities, zones_enabled):
@@ -107,6 +161,11 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         else:
             assert_equal(results, default_priorities)
 
+    def test_deployment_type_kwarg(self):
+        for zones_enabled in (True, False):
+            for short_version, deployment_type, default_priorities in TEST_VARS:
+                yield self.check_defaults_deployment_type_kwarg, short_version, deployment_type, default_priorities, zones_enabled
+
     def check_defaults_deployment_type_kwarg(self, release, deployment_type,
                                              default_priorities, zones_enabled):
         facts = copy.deepcopy(self.default_facts)
@@ -119,6 +178,11 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
         else:
             assert_equal(results, default_priorities)
 
+    def test_only_kwargs(self):
+        for zones_enabled in (True, False):
+            for short_version, deployment_type, default_priorities in TEST_VARS:
+                yield self.check_defaults_only_kwargs, short_version, deployment_type, default_priorities, zones_enabled
+
     def check_defaults_only_kwargs(self, release, deployment_type,
                                    default_priorities, zones_enabled):
         facts = copy.deepcopy(self.default_facts)
@@ -130,67 +194,3 @@ class TestOpenShiftMasterFactsDefaultPredicates(object):
             assert_equal(results, default_priorities + [ZONE_PRIORITY])
         else:
             assert_equal(results, default_priorities)
-
-    def check_defaults_release(self, release, deployment_type, default_priorities,
-                               zones_enabled):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift_release'] = release
-        facts['openshift']['common']['deployment_type'] = deployment_type
-        results = self.lookup.run(None, variables=facts, zones_enabled=zones_enabled)
-        if zones_enabled:
-            assert_equal(results, default_priorities + [ZONE_PRIORITY])
-        else:
-            assert_equal(results, default_priorities)
-
-    def check_defaults_version(self, release, deployment_type, default_priorities,
-                               zones_enabled):
-        facts = copy.deepcopy(self.default_facts)
-        facts['openshift_version'] = release
-        facts['openshift']['common']['deployment_type'] = deployment_type
-        results = self.lookup.run(None, variables=facts, zones_enabled=zones_enabled)
-        if zones_enabled:
-            assert_equal(results, default_priorities + [ZONE_PRIORITY])
-        else:
-            assert_equal(results, default_priorities)
-
-    def test_openshift_version(self):
-        for zones_enabled in (True, False):
-            for release, deployment_type, default_priorities in TEST_VARS:
-                release = release + '.1'
-                yield self.check_defaults_version, release, deployment_type, default_priorities, zones_enabled
-
-    def test_v_release_defaults(self):
-        for zones_enabled in (True, False):
-            for release, deployment_type, default_priorities in TEST_VARS:
-                release = 'v' + release
-                yield self.check_defaults_release, release, deployment_type, default_priorities, zones_enabled
-
-    def test_release_defaults(self):
-        for zones_enabled in (True, False):
-            for release, deployment_type, default_priorities in TEST_VARS:
-                yield self.check_defaults_release, release, deployment_type, default_priorities, zones_enabled
-
-    def test_short_version_defaults(self):
-        for zones_enabled in (True, False):
-            for short_version, deployment_type, default_priorities in TEST_VARS:
-                yield self.check_defaults_short_version, short_version, deployment_type, default_priorities, zones_enabled
-
-    def test_only_kwargs(self):
-        for zones_enabled in (True, False):
-            for short_version, deployment_type, default_priorities in TEST_VARS:
-                yield self.check_defaults_only_kwargs, short_version, deployment_type, default_priorities, zones_enabled
-
-    def test_deployment_type_kwarg(self):
-        for zones_enabled in (True, False):
-            for short_version, deployment_type, default_priorities in TEST_VARS:
-                yield self.check_defaults_deployment_type_kwarg, short_version, deployment_type, default_priorities, zones_enabled
-
-    def test_release_kwarg(self):
-        for zones_enabled in (True, False):
-            for short_version, deployment_type, default_priorities in TEST_VARS:
-                yield self.check_defaults_short_version_kwarg, short_version, deployment_type, default_priorities, zones_enabled
-
-    def test_trunc_openshift_release(self):
-        for release, deployment_type, default_priorities in TEST_VARS:
-            release = release + '.1'
-            yield self.check_defaults_release, release, deployment_type, default_priorities, False

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,20 +4,6 @@
 # will need to generate wheels for each Python version that you support.
 universal=1
 
-[nosetests]
-tests=roles/lib_openshift/src/test/unit,
-      roles/lib_utils/src/test/unit,
-      roles/openshift_master_facts/test,
-      test
-verbosity=2
-with-coverage=1
-cover-html=1
-cover-inclusive=1
-cover-min-percentage=25
-cover-erase=1
-detailed-errors=1
-cover-branches=1
-
 [yamllint]
 excludes=.tox,utils,files
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,22 @@ lint_disable=fixme,locally-disabled,file-ignored,duplicate-code
 exclude=.tox/*,utils/*,inventory/*
 max_line_length = 120
 ignore = E501,T003
+
+[tool:pytest]
+norecursedirs =
+    .*
+    __pycache__
+    cover
+    docs
+    # utils have its own config
+    utils
+python_files =
+    # TODO(rhcarvalho): rename test files to follow a single pattern. "test*.py"
+    # is Python unittest's default, while pytest discovers both "test_*.py" and
+    # "*_test.py" by default.
+    test_*.py
+    *_tests.py
+addopts =
+    --cov=.
+    --cov-report=term
+    --cov-report=html

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,3 +10,4 @@ yamllint
 nose
 coverage
 mock
+pytest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,6 @@ pylint
 setuptools-lint
 PyYAML
 yamllint
-nose
 coverage
 mock
 pytest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,3 +11,4 @@ nose
 coverage
 mock
 pytest
+pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ deps =
     ansible22: ansible~=2.2
 
 commands =
-    unit: pytest
-    flake8: flake8
+    unit: pytest {posargs}
+    flake8: flake8 {posargs}
     pylint: python setup.py lint
     yamllint: python setup.py yamllint
     generate_validation: python setup.py generate_validation

--- a/tox.ini
+++ b/tox.ini
@@ -17,3 +17,5 @@ commands =
     yamllint: python setup.py yamllint
     unit: nosetests
     generate_validation: python setup.py generate_validation
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -12,10 +12,10 @@ deps =
     ansible22: ansible~=2.2
 
 commands =
+    unit: pytest
     flake8: flake8
     pylint: python setup.py lint
     yamllint: python setup.py yamllint
-    unit: nosetests
     generate_validation: python setup.py generate_validation
 
 

--- a/utils/.coveragerc
+++ b/utils/.coveragerc
@@ -12,7 +12,7 @@ omit =
     *_tests.py
 
 [report]
-fail_under = 70
+fail_under = 73
 
 [html]
 directory = cover

--- a/utils/.coveragerc
+++ b/utils/.coveragerc
@@ -1,5 +1,18 @@
 [run]
-omit=
+branch = True
+omit =
     */lib/python*/site-packages/*
     */lib/python*/*
     /usr/*
+    setup.py
+    # TODO(rhcarvalho): this is used to ignore test files from coverage report.
+    # We can make this less generic when we stick with a single test pattern in
+    # the repo.
+    test_*.py
+    *_tests.py
+
+[report]
+fail_under = 70
+
+[html]
+directory = cover

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,55 +1,60 @@
-# Running Tests (NEW)
+# Running Tests
 
 Run the command:
 
     make ci
 
-to run an array of unittests locally.
+to run tests and linting tools.
 
 Underneath the covers, we use [tox](http://readthedocs.org/docs/tox/) to manage virtualenvs and run
 tests. Alternatively, tests can be run using [detox](https://pypi.python.org/pypi/detox/) which allows
-for running tests in parallel
-
+for running tests in parallel.
 
 ```
 pip install tox detox
 ```
 
 List the test environments available:
+
 ```
 tox -l
 ```
 
 Run all of the tests with:
+
 ```
 tox
 ```
 
 Run all of the tests in parallel with detox:
+
 ```
 detox
 ```
 
-Running a particular test environment (python 2.7 flake8 tests in this case):
+Run a particular test environment:
+
 ```
-tox -e py27-ansible22-flake8
+tox -e py27-flake8
 ```
 
-Running a particular test environment in a clean virtualenv (python 3.5 pylint
-tests in this case):
+Run a particular test environment in a clean virtualenv:
+
 ```
-tox -r -e py35-ansible22-pylint
+tox -r -e py35-pylint
 ```
 
 If you want to enter the virtualenv created by tox to do additional
-testing/debugging (py27-flake8 env in this case):
+testing/debugging:
+
 ```
-source .tox/py27-ansible22-flake8/bin/activate
+source .tox/py27-flake8/bin/activate
 ```
 
 You will get errors if the log files already exist and can not be
 written to by the current user (`/tmp/ansible.log` and
 `/tmp/installer.txt`). *We're working on it.*
+
 
 # Running From Source
 
@@ -66,17 +71,3 @@ The virtualenv `bin` directory should now be at the start of your
 You can exit the virtualenv with:
 
     $ deactivate
-
-# Testing (OLD)
-
-*This section is deprecated, but still works*
-
-First, run the **virtualenv setup steps** described above.
-
-Install some testing libraries: (we cannot do this via setuptools due to the version virtualenv bundles)
-
-$ pip install mock nose
-
-Then run the tests with:
-
-$ oo-install/bin/nosetests

--- a/utils/setup.cfg
+++ b/utils/setup.cfg
@@ -4,15 +4,8 @@
 # will need to generate wheels for each Python version that you support.
 universal=1
 
-[nosetests]
-verbosity=2
-with-coverage=1
-cover-html=1
-cover-inclusive=1
-cover-min-percentage=70
-cover-erase=1
-detailed-errors=1
-cover-branches=1
+[aliases]
+test=pytest
 
 [flake8]
 max-line-length=120
@@ -21,3 +14,19 @@ ignore=E501
 
 [lint]
 lint_disable=fixme,locally-disabled,file-ignored,duplicate-code
+
+[tool:pytest]
+testpaths = test
+norecursedirs =
+    .*
+    __pycache__
+python_files =
+    # TODO(rhcarvalho): rename test files to follow a single pattern. "test*.py"
+    # is Python unittest's default, while pytest discovers both "test_*.py" and
+    # "*_test.py" by default.
+    test_*.py
+    *_tests.py
+addopts =
+    --cov=.
+    --cov-report=term
+    --cov-report=html

--- a/utils/setup.py
+++ b/utils/setup.py
@@ -40,7 +40,7 @@ setup(
     # simple. Or you can use find_packages().
     #packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     packages=['ooinstall'],
-    package_dir={'ooinstall': 'src/ooinstall'},
+    package_dir={'': 'src'},
 
 
     # List run-time dependencies here.  These will be installed by pip when
@@ -65,9 +65,8 @@ setup(
         'ooinstall': ['ansible.cfg', 'ansible-quiet.cfg', 'ansible_plugins/*'],
     },
 
-    tests_require=['nose'],
-
-    test_suite='nose.collector',
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
 
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow

--- a/utils/src/ooinstall/oo_config.py
+++ b/utils/src/ooinstall/oo_config.py
@@ -176,7 +176,7 @@ class Deployment(object):
 class OOConfig(object):
     default_dir = os.path.normpath(
         os.environ.get('XDG_CONFIG_HOME',
-                       os.environ['HOME'] + '/.config/') + '/openshift/')
+                       os.environ.get('HOME', '') + '/.config/') + '/openshift/')
     default_file = '/installer.cfg.yml'
 
     def __init__(self, config_path):

--- a/utils/test-requirements.txt
+++ b/utils/test-requirements.txt
@@ -2,7 +2,6 @@ ansible
 # flake8 moved to before setuptools-lint to satisfy mccabe dependency issue
 flake8
 setuptools-lint
-nose
 coverage
 mock
 PyYAML
@@ -12,3 +11,5 @@ pyOpenSSL
 yamllint
 tox
 detox
+pytest
+pytest-cov

--- a/utils/tox.ini
+++ b/utils/tox.ini
@@ -14,6 +14,6 @@ commands =
     # Needed to make detox work, since it ignores usedevelop
     # https://github.com/tox-dev/tox/issues/180
     unit: pip install -e .
-    unit: pytest
+    unit: pytest {posargs}
     flake8: python setup.py flake8
     pylint: python setup.py lint

--- a/utils/tox.ini
+++ b/utils/tox.ini
@@ -11,6 +11,9 @@ deps =
     -rtest-requirements.txt
     py35-flake8: flake8-bugbear
 commands =
+    # Needed to make detox work, since it ignores usedevelop
+    # https://github.com/tox-dev/tox/issues/180
+    unit: pip install -e .
+    unit: pytest
     flake8: python setup.py flake8
-    unit: python setup.py nosetests
     pylint: python setup.py lint


### PR DESCRIPTION
#2998 is introducing a dependency on `pytest` because of the `molecule` framework for integration tests.
Instead of having both `nose` and `pytest`, it is an appropriate time to migrate to `pytest`.

Pytest is more actively maintained than nose, has a vibrant community, plugins, etc.

It also allows us to write more concise test code, and produces good reports on errors.

This PR removes code-level dependencies on nose, rewrite tests to use pytest fixtures, and switch test execution / CI to use pytest, eliminating the dependency on nose for both the top-level and installer wrapper (utils/).