### PR TITLE
rename registered mktemp command

### DIFF
--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -20,17 +20,6 @@
         annotations: "{{ openshift_node_annotations | default(None) }}"
         schedulable: "{{ openshift_schedulable | default(openshift_scheduleable) | default(None) }}"
 
-- name: Create temp directory for syncing certs
-  hosts: localhost
-  connection: local
-  become: no
-  gather_facts: no
-  tasks:
-  - name: Create local temp directory for syncing certs
-    local_action: command mktemp -d /tmp/openshift-ansible-XXXXXXX
-    register: mktemp
-    changed_when: False
-
 - name: Evaluate node groups
   hosts: localhost
   become: no
@@ -101,13 +90,4 @@
   tasks:
   - name: Create group for deployment type
     group_by: key=oo_nodes_deployment_type_{{ openshift.common.deployment_type }}
-    changed_when: False
-
-- name: Delete temporary directory on localhost
-  hosts: localhost
-  connection: local
-  become: no
-  gather_facts: no
-  tasks:
-  - file: name={{ mktemp.stdout }} state=absent
     changed_when: False


### PR DESCRIPTION
When running `playbooks/byo/config.yml` playbook, I've encountered following error:
```
PLAY [Delete temporary directory on localhost] *********************************
TASK [file] ********************************************************************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'dict object' has no attribute 'stdout'\n\nThe error appears to have been in '/home/ec2-user/openshift-ansible/playbooks/common/openshift-node/config.yml': line 112, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  tasks:\n  - file: name={{ mktemp.stdout }} state=absent\n  ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes.  Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n - {{ foo }}\n\nShould be written as:\n\n    with_items:\n - \"{{ foo }}\"\n"}
```

Fixed by renaming the registered cmd name, since it look like it collides with the build-in commands... but not really sure, not a ansible expert (yet :P)

@abutcher PTAL
