### PR TITLE
Replace has_key in new modules

### DIFF
--- a/roles/lib_openshift/library/oc_secret.py
+++ b/roles/lib_openshift/library/oc_secret.py
@@ -1429,7 +1429,7 @@ class Secret(Yedit):
     def update_secret(self, key, value):
         ''' update a secret'''
         # pylint: disable=no-member
-        if self.secrets.has_key(key):
+        if key in self.secrets:
             self.secrets[key] = value
         else:
             self.add_secret(key, value)
@@ -1467,7 +1467,7 @@ class OCSecret(OpenShiftCLI):
         if results['returncode'] == 0 and results['results'][0]:
             results['exists'] = True
             if self.decode:
-                if results['results'][0].has_key('data'):
+                if 'data' in results['results'][0]:
                     for sname, value in results['results'][0]['data'].items():
                         results['decoded'][sname] = base64.b64decode(value)
 

--- a/roles/lib_openshift/src/class/oc_secret.py
+++ b/roles/lib_openshift/src/class/oc_secret.py
@@ -29,7 +29,7 @@ class OCSecret(OpenShiftCLI):
         if results['returncode'] == 0 and results['results'][0]:
             results['exists'] = True
             if self.decode:
-                if results['results'][0].has_key('data'):
+                if 'data' in results['results'][0]:
                     for sname, value in results['results'][0]['data'].items():
                         results['decoded'][sname] = base64.b64decode(value)
 

--- a/roles/lib_openshift/src/lib/secret.py
+++ b/roles/lib_openshift/src/lib/secret.py
@@ -91,7 +91,7 @@ class Secret(Yedit):
     def update_secret(self, key, value):
         ''' update a secret'''
         # pylint: disable=no-member
-        if self.secrets.has_key(key):
+        if key in self.secrets:
             self.secrets[key] = value
         else:
             self.add_secret(key, value)


### PR DESCRIPTION
The dict.has_key has been removed in Python 3. However, both Python 2
and 3 support:

    if needle in dict

See: #3396