### PR TITLE
Fix validation of generated code

### DIFF
--- a/roles/lib_utils/src/class/repoquery.py
+++ b/roles/lib_utils/src/class/repoquery.py
@@ -60,7 +60,7 @@ class Repoquery(RepoqueryCLI):
         ''' Gather and present the versions of each package '''
 
         versions_dict = {}
-        versions_dict['available_versions_full'] = formatted_versions.keys()
+        versions_dict['available_versions_full'] = list(formatted_versions.keys())
 
         # set the match version, if called
         if self.match_version:

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ import yaml
 from setuptools import setup, Command
 from setuptools_lint.setuptools_command import PylintCommand
 from six import string_types
+from six.moves import reload_module
 from yamllint.config import YamlLintConfig
 from yamllint.cli import Format
 from yamllint import linter
@@ -185,6 +186,7 @@ class OpenShiftAnsibleGenerateValidation(Command):
                 # the python path.
                 # pylint: disable=import-error
                 import generate
+                reload_module(generate)
                 generate.verify()
             except generate.GenerateAnsibleException as gae:
                 print(gae.args)


### PR DESCRIPTION
Importing modules with the same name will not reload an already imported
module. Explicitly reloading the module is the quickest fix.