### PR TITLE
openshift_facts: handle 'latest' version

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -864,7 +864,7 @@ def set_version_facts_if_unset(facts):
     if 'common' in facts:
         deployment_type = facts['common']['deployment_type']
         openshift_version = get_openshift_version(facts)
-        if openshift_version:
+        if openshift_version and openshift_version != "latest":
             version = LooseVersion(openshift_version)
             facts['common']['version'] = openshift_version
             facts['common']['short_version'] = '.'.join([str(x) for x in version.version[0:2]])


### PR DESCRIPTION
do not attempt to compare the version using LooseVersion when 'latest'
is used.  The case openshift_version == None already sets to use the
last version, so simply reuse that.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>