### PR TITLE
bug 1417261. Quote name and secrets in logging templates

### DIFF
--- a/roles/openshift_logging/templates/secret.j2
+++ b/roles/openshift_logging/templates/secret.j2
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{secret_name}}
+  name: "{{secret_name}}"
 type: Opaque
 data:
 {% for s in secrets %}
-  {{s.key}}: {{s.value | b64encode}}
+  "{{s.key}}" : "{{s.value | b64encode}}"
 {% endfor %}


### PR DESCRIPTION
I am unable to reproduce but this seems to be a reasonable change.