### PR TITLE
Update openshift_logging role to detect if journald log driver is use…

### DIFF
--- a/roles/openshift_logging/tasks/install_fluentd.yaml
+++ b/roles/openshift_logging/tasks/install_fluentd.yaml
@@ -5,6 +5,10 @@
 - set_fact: fluentd_ops_port={{ (openshift_logging_use_ops | bool) | ternary(openshift_logging_es_ops_port, openshift_logging_es_port) }}
   check_mode: no
 
+- set_fact: openshift_logging_fluentd_use_journal={{ "journald" in openshift.docker.options }}
+  check_mode: no
+  when: "openshift_logging_fluentd_use_journal == ''"
+
 - name: Generating Fluentd daemonset
   template: src=fluentd.j2 dest={{mktemp.stdout}}/templates/logging-fluentd.yaml
   vars:


### PR DESCRIPTION
…d and set fluentd setting appropriately if not specified

@richm @sdodson 

This evaluates the docker options openshift_facts picked up and tells fluentd to use journal based on whether or not we are using the journald log driver