### PR TITLE
Remove pytest-related dependencies from setup.py

### DIFF
--- a/utils/setup.py
+++ b/utils/setup.py
@@ -65,9 +65,6 @@ setup(
         'ooinstall': ['ansible.cfg', 'ansible-quiet.cfg', 'ansible_plugins/*'],
     },
 
-    setup_requires=['pytest-runner'],
-    tests_require=['pytest'],
-
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.


### PR DESCRIPTION
The `setup_requires` line prevents builds in internal environments
without Internet access / pythonX-pytest-runner RPM installed.

In fact, we're running tests with `pytest`, outside of `setup.py`, so we
don't need those dependencies there.

Note: we decided not to run tests through `python setup.py pytest`
because pytest-runner was limited in how we can pass arguments to pytest
/ enable plugins. E.g., I could not get the coverage plugin working when
running `python setup.py pytest`.