### PR TITLE
Bug 1420219 - No log entry can be found in Kibana UI after deploying logging stacks with ansible

### DIFF
--- a/roles/openshift_logging/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging/templates/elasticsearch.yml.j2
@@ -38,6 +38,11 @@ gateway:
 
 io.fabric8.elasticsearch.authentication.users: ["system.logging.kibana", "system.logging.fluentd", "system.logging.curator", "system.admin"]
 
+openshift.config:
+  use_common_data_model: true
+  project_index_prefix: "project"
+  time_field_name: "@timestamp"
+
 openshift.searchguard:
   keystore.path: /etc/elasticsearch/secret/admin.jks
   truststore.path: /etc/elasticsearch/secret/searchguard.truststore


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1420219
The elasticsearch config was missing the common data model stanza
@jcantrill @ewolinetz PTAL
aos-ci-test