### PR TITLE
CloudFront oc_secret contents should be a list

### DIFF
--- a/roles/openshift_hosted/tasks/registry/storage/s3.yml
+++ b/roles/openshift_hosted/tasks/registry/storage/s3.yml
@@ -31,8 +31,8 @@
         namespace: "{{ openshift.hosted.registry.namespace | default('default') }}"
         name: docker-registry-s3-cloudfront
         contents:
-          path: cloudfront.pem
-          data: "{{ lookup('file', openshift_hosted_registry_storage_s3_cloudfront_privatekeyfile) }}"
+          - path: cloudfront.pem
+            data: "{{ lookup('file', openshift_hosted_registry_storage_s3_cloudfront_privatekeyfile) }}"
 
     - name: Add cloudfront secret to the registry deployment config
       command: >


### PR DESCRIPTION
Fixes "argument contents is of type <type 'dict'> and we were unable to
convert to list"

The error mislead me until @tbielawa pointed out it was the argument **named** contents and not the contents of an argument.