### PR TITLE
Prepare for origin moving to OCP version scheme

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -875,7 +875,7 @@ def set_version_facts_if_unset(facts):
                 version_gte_3_3_or_1_3 = version >= LooseVersion('1.3.0')
                 version_gte_3_4_or_1_4 = version >= LooseVersion('1.4.0')
                 version_gte_3_5_or_1_5 = version >= LooseVersion('1.5.0')
-                version_gte_3_6_or_1_6 = version >= LooseVersion('1.6.0')
+                version_gte_3_6_or_1_6 = version >= LooseVersion('3.6.0') or version >= LooseVersion('1.6.0')
             else:
                 version_gte_3_1_or_1_1 = version >= LooseVersion('3.0.2.905')
                 version_gte_3_1_1_or_1_1_1 = version >= LooseVersion('3.1.1')

--- a/roles/openshift_master_facts/lookup_plugins/openshift_master_facts_default_predicates.py
+++ b/roles/openshift_master_facts/lookup_plugins/openshift_master_facts_default_predicates.py
@@ -40,7 +40,7 @@ class LookupModule(LookupBase):
                 # pylint: disable=line-too-long
                 raise AnsibleError("Either OpenShift needs to be installed or openshift_release needs to be specified")
         if deployment_type == 'origin':
-            if short_version not in ['1.1', '1.2', '1.3', '1.4', '1.5', '1.6', 'latest']:
+            if short_version not in ['1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '3.6', 'latest']:
                 raise AnsibleError("Unknown short_version %s" % short_version)
         elif deployment_type == 'openshift-enterprise':
             if short_version not in ['3.1', '3.2', '3.3', '3.4', '3.5', '3.6', 'latest']:
@@ -48,17 +48,17 @@ class LookupModule(LookupBase):
         else:
             raise AnsibleError("Unknown deployment_type %s" % deployment_type)
 
-        if deployment_type == 'openshift-enterprise':
-            # convert short_version to origin short_version
-            short_version = re.sub('^3.', '1.', short_version)
+        if deployment_type == 'origin':
+            # convert short_version to enterpise short_version
+            short_version = re.sub('^1.', '3.', short_version)
 
         if short_version == 'latest':
-            short_version = '1.6'
+            short_version = '3.6'
 
         # Predicates ordered according to OpenShift Origin source:
         # origin/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
 
-        if short_version == '1.1':
+        if short_version == '3.1':
             predicates.extend([
                 {'name': 'PodFitsHostPorts'},
                 {'name': 'PodFitsResources'},
@@ -66,7 +66,7 @@ class LookupModule(LookupBase):
                 {'name': 'MatchNodeSelector'},
             ])
 
-        if short_version == '1.2':
+        if short_version == '3.2':
             predicates.extend([
                 {'name': 'PodFitsHostPorts'},
                 {'name': 'PodFitsResources'},
@@ -77,7 +77,7 @@ class LookupModule(LookupBase):
                 {'name': 'MaxGCEPDVolumeCount'}
             ])
 
-        if short_version == '1.3':
+        if short_version == '3.3':
             predicates.extend([
                 {'name': 'NoDiskConflict'},
                 {'name': 'NoVolumeZoneConflict'},
@@ -88,7 +88,7 @@ class LookupModule(LookupBase):
                 {'name': 'CheckNodeMemoryPressure'}
             ])
 
-        if short_version == '1.4':
+        if short_version == '3.4':
             predicates.extend([
                 {'name': 'NoDiskConflict'},
                 {'name': 'NoVolumeZoneConflict'},
@@ -101,7 +101,7 @@ class LookupModule(LookupBase):
                 {'name': 'MatchInterPodAffinity'}
             ])
 
-        if short_version in ['1.5', '1.6']:
+        if short_version in ['3.5', '3.6']:
             predicates.extend([
                 {'name': 'NoVolumeZoneConflict'},
                 {'name': 'MaxEBSVolumeCount'},

--- a/roles/openshift_master_facts/lookup_plugins/openshift_master_facts_default_priorities.py
+++ b/roles/openshift_master_facts/lookup_plugins/openshift_master_facts_default_priorities.py
@@ -41,7 +41,7 @@ class LookupModule(LookupBase):
                 raise AnsibleError("Either OpenShift needs to be installed or openshift_release needs to be specified")
 
         if deployment_type == 'origin':
-            if short_version not in ['1.1', '1.2', '1.3', '1.4', '1.5', '1.6', 'latest']:
+            if short_version not in ['1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '3.6', 'latest']:
                 raise AnsibleError("Unknown short_version %s" % short_version)
         elif deployment_type == 'openshift-enterprise':
             if short_version not in ['3.1', '3.2', '3.3', '3.4', '3.5', '3.6', 'latest']:
@@ -49,21 +49,21 @@ class LookupModule(LookupBase):
         else:
             raise AnsibleError("Unknown deployment_type %s" % deployment_type)
 
-        if deployment_type == 'openshift-enterprise':
+        if deployment_type == 'origin':
             # convert short_version to origin short_version
-            short_version = re.sub('^3.', '1.', short_version)
+            short_version = re.sub('^1.', '3.', short_version)
 
         if short_version == 'latest':
-            short_version = '1.6'
+            short_version = '3.6'
 
-        if short_version == '1.1':
+        if short_version == '3.1':
             priorities.extend([
                 {'name': 'LeastRequestedPriority', 'weight': 1},
                 {'name': 'BalancedResourceAllocation', 'weight': 1},
                 {'name': 'SelectorSpreadPriority', 'weight': 1}
             ])
 
-        if short_version == '1.2':
+        if short_version == '3.2':
             priorities.extend([
                 {'name': 'LeastRequestedPriority', 'weight': 1},
                 {'name': 'BalancedResourceAllocation', 'weight': 1},
@@ -71,7 +71,7 @@ class LookupModule(LookupBase):
                 {'name': 'NodeAffinityPriority', 'weight': 1}
             ])
 
-        if short_version == '1.3':
+        if short_version == '3.3':
             priorities.extend([
                 {'name': 'LeastRequestedPriority', 'weight': 1},
                 {'name': 'BalancedResourceAllocation', 'weight': 1},
@@ -80,7 +80,7 @@ class LookupModule(LookupBase):
                 {'name': 'TaintTolerationPriority', 'weight': 1}
             ])
 
-        if short_version == '1.4':
+        if short_version == '3.4':
             priorities.extend([
                 {'name': 'LeastRequestedPriority', 'weight': 1},
                 {'name': 'BalancedResourceAllocation', 'weight': 1},
@@ -91,7 +91,7 @@ class LookupModule(LookupBase):
                 {'name': 'InterPodAffinityPriority', 'weight': 1}
             ])
 
-        if short_version in ['1.5', '1.6']:
+        if short_version in ['3.5', '3.6']:
             priorities.extend([
                 {'name': 'SelectorSpreadPriority', 'weight': 1},
                 {'name': 'InterPodAffinityPriority', 'weight': 1},

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
@@ -76,6 +76,7 @@ TEST_VARS = [
     ('1.5', 'origin', DEFAULT_PREDICATES_1_5),
     ('3.5', 'openshift-enterprise', DEFAULT_PREDICATES_1_5),
     ('1.6', 'origin', DEFAULT_PREDICATES_1_5),
+    ('3.6', 'origin', DEFAULT_PREDICATES_1_5),
     ('3.6', 'openshift-enterprise', DEFAULT_PREDICATES_1_5),
 ]
 

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
@@ -64,6 +64,7 @@ TEST_VARS = [
     ('1.5', 'origin', DEFAULT_PRIORITIES_1_5),
     ('3.5', 'openshift-enterprise', DEFAULT_PRIORITIES_1_5),
     ('1.6', 'origin', DEFAULT_PRIORITIES_1_5),
+    ('3.6', 'origin', DEFAULT_PRIORITIES_1_5),
     ('3.6', 'openshift-enterprise', DEFAULT_PRIORITIES_1_5),
 ]
 


### PR DESCRIPTION
Origin 1.6 and future releases will be versioned as Origin 3.6+. This
unifies a point of inconsistency and brings Origin in line with the full
release history. Update version numbers to match that 3.x is preferred.

@sdodson @tdawson these are the obvious changes I see.  I need to test
with an RPM repo created from this first.