### PR TITLE
BZ1414276 - Quote ansible_ssh_user when determining group id

### DIFF
--- a/playbooks/common/openshift-cluster/redeploy-certificates/ca.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/ca.yml
@@ -294,7 +294,7 @@
       client_path: "{{ openshift.common.config_base }}/master/admin.kubeconfig"
       ca_path: "{{ openshift.common.config_base }}/master/ca-bundle.crt"
   - name: Lookup default group for ansible_ssh_user
-    command: "/usr/bin/id -g {{ ansible_ssh_user }}"
+    command: "/usr/bin/id -g {{ ansible_ssh_user | quote }}"
     changed_when: false
     register: _ansible_ssh_user_gid
   - set_fact:

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -159,7 +159,7 @@
   become: no
 
 - name: Lookup default group for ansible_ssh_user
-  command: "/usr/bin/id -g {{ ansible_ssh_user }}"
+  command: "/usr/bin/id -g {{ ansible_ssh_user | quote }}"
   changed_when: false
   register: _ansible_ssh_user_gid
 


### PR DESCRIPTION
So that domain users of the format 'dom\user' may be used for
ansible_ssh_user