### PR TITLE
curator config must be in /etc/curator not /usr/curator

### DIFF
--- a/roles/openshift_logging/templates/curator.j2
+++ b/roles/openshift_logging/templates/curator.j2
@@ -87,7 +87,7 @@ spec:
               mountPath: /etc/curator/keys
               readOnly: true
             - name: config
-              mountPath: /usr/curator/settings
+              mountPath: /etc/curator/settings
               readOnly: true
             - name: elasticsearch-storage
               mountPath: /elasticsearch/persistent


### PR DESCRIPTION
Here's another test breaker for test-curator.sh
@jcantrill @ewolinetz PTAL
aos-ci-test