### PR TITLE
openshift_logging default to 2 replicas of primary shards

### DIFF
--- a/roles/openshift_logging/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging/templates/elasticsearch.yml.j2
@@ -8,7 +8,7 @@ script:
 index:
   number_of_shards: 1
   number_of_replicas: 0
-  auto_expand_replicas: 0-3
+  auto_expand_replicas: 0-2
   unassigned.node_left.delayed_timeout: 2m
   translog:
     flush_threshold_size: 256mb


### PR DESCRIPTION
Updated value based on recommendation from Peter Portante