### PR TITLE
Hacky work-around for rhel-subscribe

### DIFF
--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -1,7 +1,33 @@
 ---
-- include: ../common/openshift-cluster/std_include.yml
+- name: Create initial host groups for localhost
+  hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
   tags:
   - always
+  tasks:
+  - include_vars: openshift-cluster/cluster_hosts.yml
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
+      name: "{{ item }}"
+      groups: l_oo_all_hosts
+    with_items: "{{ g_all_hosts | default([]) }}"
+    changed_when: no
+
+- name: Create initial host groups for all hosts
+  hosts: l_oo_all_hosts
+  gather_facts: no
+  tags:
+  - always
+  tasks:
+  - include_vars: openshift-cluster/cluster_hosts.yml
+  - set_fact:
+      openshift_deployment_type: "{{ deployment_type }}"
+
+# - include: ../common/openshift-cluster/std_include.yml
+#   tags:
+#   - always
 
 - name: Subscribe hosts, update repos and update OS packages
   hosts: l_oo_all_hosts

--- a/roles/rhel_subscribe/meta/main.yml
+++ b/roles/rhel_subscribe/meta/main.yml
@@ -1,3 +1,3 @@
 ---
 dependencies:
-  - role: openshift_facts
+  # - role: openshift_facts

--- a/roles/rhel_subscribe/tasks/main.yml
+++ b/roles/rhel_subscribe/tasks/main.yml
@@ -8,6 +8,7 @@
     rhel_subscription_user: "{{ lookup('oo_option', 'rhel_subscription_user') | default(rhsub_user, True) | default(omit, True) }}"
     rhel_subscription_pass: "{{ lookup('oo_option', 'rhel_subscription_pass') | default(rhsub_pass, True) | default(omit, True) }}"
     rhel_subscription_server: "{{ lookup('oo_option', 'rhel_subscription_server') | default(rhsub_server) }}"
+  no_log: True
 
 - fail:
     msg: "This role is only supported for Red Hat hosts"
@@ -57,5 +58,4 @@
   when: openshift_pool_id.stdout != ''
 
 - include: enterprise.yml
-  when: deployment_type in [ 'enterprise', 'atomic-enterprise', 'openshift-enterprise' ] and
-        not openshift.common.is_atomic | bool
+  when: deployment_type in [ 'enterprise', 'atomic-enterprise', 'openshift-enterprise' ]


### PR DESCRIPTION
I think this needs some work to get into a better form.

This is what I had to do do make the `rhel_subscribe` stuff work again. It USED to work, but then somehow one day it began requiring running `openshift_facts` first but that fails because PyYAML and friends (`required_packages`) aren't installed yet. So the role that gives you packages can't run because the packages it enables you to install aren't present.

Yes, **it is** just like this:

![chicken-or-egg-400x301](https://cloud.githubusercontent.com/assets/33121/23272351/c4bc3aee-f9af-11e6-951f-acc7001431fb.jpg)
