### PR TITLE
Fix Quick Installer failed due to a Python method failure

### DIFF
--- a/utils/src/ooinstall/ansible_plugins/facts_callback.py
+++ b/utils/src/ooinstall/ansible_plugins/facts_callback.py
@@ -5,6 +5,7 @@
 import os
 import yaml
 from ansible.plugins.callback import CallbackBase
+from ansible.parsing.yaml.dumper import AnsibleDumper
 
 
 # pylint: disable=super-init-not-called
@@ -38,7 +39,11 @@ class CallbackModule(CallbackBase):
             facts = abridged_result['result']['ansible_facts']['openshift']
             hosts_yaml = {}
             hosts_yaml[res._host.get_name()] = facts
-            os.write(self.hosts_yaml, yaml.safe_dump(hosts_yaml))
+            to_dump = yaml.dump(hosts_yaml,
+                                allow_unicode=True,
+                                default_flow_style=False,
+                                Dumper=AnsibleDumper)
+            os.write(self.hosts_yaml, to_dump)
 
     def v2_runner_on_skipped(self, res):
         pass


### PR DESCRIPTION
Fixes issues dumping various objects to YAML. This change updates the
quick installer fact caching callback to use the improved
AnsibleDumper when writing out the facts to storage.

* https://bugzilla.redhat.com/show_bug.cgi?id=1421053
* https://bugzilla.redhat.com/show_bug.cgi?id=1421061
* https://bugzilla.redhat.com/show_bug.cgi?id=1421059

**NOTE** usage of the `yaml.safe_dump` function was replaced with just `yaml.dump`. This change is inherently and technically incompatible with the `safe_dump` function. The `safe_dump` function already specifies the specific `Dumper` to use. Use of `Dumper=AnsibleDumper` in the `safe_dump` function will cause the error:

> dump_all() got multiple values for keyword argument 'Dumper'
