### PR TITLE
Fix Bug 1426705 - Quote ansible_ssh_user when determining group id

### DIFF
--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -149,7 +149,7 @@
   become: no
 
 - name: Lookup default group for ansible_ssh_user
-  command: "/usr/bin/id -g {{ ansible_ssh_user }}"
+  command: "/usr/bin/id -g {{ ansible_ssh_user | quote }}"
   changed_when: false
   register: _ansible_ssh_user_gid
 


### PR DESCRIPTION
So that domain users of the format 'dom\user' may be used for
ansible_ssh_user