### PR TITLE
[1.3] Stop restarting node after upgrading master rpms

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
@@ -5,7 +5,3 @@
 - name: Ensure python-yaml present for config upgrade
   action: "{{ ansible_pkg_mgr }} name=PyYAML state=present"
   when: not openshift.common.is_atomic | bool
-
-- name: Restart node service
-  service: name="{{ openshift.common.service_type }}-node" state=restarted
-  when: component == "node"


### PR DESCRIPTION
This looks to be causing a customer issue where some HA upgrades fail,
due to a missing EgressNetworkPolicy API. We update master rpms, we
don't restart services yet, but then restart node service which tries to
talk to an API that does not yet exist. (pending restart)

Restarting node here is very out of place and appears to not be
required.

Bug 1426888