### PR TITLE
install the latest excluders

### DIFF
--- a/roles/openshift_excluder/tasks/status.yml
+++ b/roles/openshift_excluder/tasks/status.yml
@@ -20,6 +20,7 @@
 - name: Update to latest excluder packages
   package:
     name: "{{ openshift.common.service_type }}-excluder"
+    state: latest
   when:
   - "{{ openshift_excluder_installed.installed_versions | default([]) | length > 0 }}"
   - not openshift.common.is_containerized | bool
@@ -27,6 +28,7 @@
 - name: Update to the latest docker-excluder packages
   package:
     name: "{{ openshift.common.service_type }}-docker-excluder"
+    state: latest
   when:
   - "{{ docker_excluder_installed.installed_versions | default([]) | length > 0 }}"
   - not openshift.common.is_containerized | bool


### PR DESCRIPTION
We want the latest version installed during upgrade

Tested the upgrade, rpms are updating when 3.4 versions installed.

Fixes: 1426070