### PR TITLE
Separate s3 cloudfront set_fact calls

### DIFF
--- a/roles/openshift_hosted/tasks/registry/storage/s3.yml
+++ b/roles/openshift_hosted/tasks/registry/storage/s3.yml
@@ -36,13 +36,14 @@
       - path: cloudfront.pem
         data: "{{ lookup('file', openshift_hosted_registry_storage_s3_cloudfront_privatekeyfile) }}"
 
-  - name: Add cloudfront secret to the registry volumes
+  - name: Append cloudfront secret registry volume to openshift_hosted_registry_volumes
     set_fact:
+      openshift_hosted_registry_volumes: "{{ openshift_hosted_registry_volumes | union(s3_volume_mount) }}"
+    vars:
       s3_volume_mount:
       - name: cloudfront-vol
         path: /etc/origin
         type: secret
         secret_name: docker-registry-s3-cloudfront
-      openshift_hosted_registry_volumes: "{{ openshift_hosted_registry_volumes | union(s3_volume_mount) }}"
 
   when: openshift_hosted_registry_storage_s3_cloudfront_baseurl | default(none) is not none


### PR DESCRIPTION
7cf5cc14 cleaned up how the registry was being created. However the s3
cloudfront calls ended up setting and using a fact in the same block.
This change pulls the set_fact calls apart.