### PR TITLE
Bug 1427080: The router wasn't upgraded to current ose-haproxy-router image version

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -22,7 +22,7 @@
       selector: 'router'
     register: all_routers
 
-  - set_fact: haproxy_routers="{{ (all_routers.reults.results[0]['items'] | oo_pods_match_component(openshift_deployment_type, 'haproxy-router') | oo_select_keys_from_list(['metadata']) }}"
+  - set_fact: haproxy_routers="{{ all_routers.results.results[0]['items'] | oo_pods_match_component(openshift_deployment_type, 'haproxy-router') | oo_select_keys_from_list(['metadata']) }}"
     when:
     - all_routers.results.returncode == 0
 

--- a/roles/lib_openshift/library/oadm_manage_node.py
+++ b/roles/lib_openshift/library/oadm_manage_node.py
@@ -1015,12 +1015,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_adm_ca_server_cert.py
+++ b/roles/lib_openshift/library/oc_adm_ca_server_cert.py
@@ -1023,12 +1023,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_adm_registry.py
+++ b/roles/lib_openshift/library/oc_adm_registry.py
@@ -1119,12 +1119,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_adm_router.py
+++ b/roles/lib_openshift/library/oc_adm_router.py
@@ -1144,12 +1144,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_edit.py
+++ b/roles/lib_openshift/library/oc_edit.py
@@ -1043,12 +1043,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_env.py
+++ b/roles/lib_openshift/library/oc_env.py
@@ -1010,12 +1010,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_label.py
+++ b/roles/lib_openshift/library/oc_label.py
@@ -1019,12 +1019,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_obj.py
+++ b/roles/lib_openshift/library/oc_obj.py
@@ -1022,12 +1022,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_process.py
+++ b/roles/lib_openshift/library/oc_process.py
@@ -1011,12 +1011,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_route.py
+++ b/roles/lib_openshift/library/oc_route.py
@@ -1053,12 +1053,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_scale.py
+++ b/roles/lib_openshift/library/oc_scale.py
@@ -997,12 +997,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_secret.py
+++ b/roles/lib_openshift/library/oc_secret.py
@@ -1043,12 +1043,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_service.py
+++ b/roles/lib_openshift/library/oc_service.py
@@ -1049,12 +1049,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_serviceaccount.py
+++ b/roles/lib_openshift/library/oc_serviceaccount.py
@@ -995,12 +995,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_serviceaccount_secret.py
+++ b/roles/lib_openshift/library/oc_serviceaccount_secret.py
@@ -995,12 +995,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/library/oc_version.py
+++ b/roles/lib_openshift/library/oc_version.py
@@ -967,12 +967,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/src/lib/base.py
+++ b/roles/lib_openshift/src/lib/base.py
@@ -255,12 +255,12 @@ class OpenShiftCLI(object):
         if oadm:
             cmds.append('adm')
 
+        cmds.extend(cmd)
+
         if self.all_namespaces:
             cmds.extend(['--all-namespaces'])
         elif self.namespace is not None and self.namespace.lower() not in ['none', 'emtpy']:  # E501
             cmds.extend(['-n', self.namespace])
-
-        cmds.extend(cmd)
 
         rval = {}
         results = ''

--- a/roles/lib_openshift/src/test/unit/test_oc_env.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_env.py
@@ -147,7 +147,7 @@ class OCEnvTest(unittest.TestCase):
 
         # Making sure our mocks were called as we expected
         mock_cmd.assert_has_calls([
-            mock.call(['oc', '-n', 'default', 'get', 'dc', 'router', '-o', 'json'], None),
+            mock.call(['oc', 'get', 'dc', 'router', '-o', 'json', '-n', 'default'], None),
         ])
 
     @mock.patch('oc_env.locate_oc_binary')
@@ -333,7 +333,7 @@ class OCEnvTest(unittest.TestCase):
 
         # Making sure our mocks were called as we expected
         mock_cmd.assert_has_calls([
-            mock.call(['oc', '-n', 'default', 'get', 'dc', 'router', '-o', 'json'], None),
+            mock.call(['oc', 'get', 'dc', 'router', '-o', 'json', '-n', 'default'], None),
         ])
 
     @mock.patch('oc_env.locate_oc_binary')
@@ -448,7 +448,7 @@ class OCEnvTest(unittest.TestCase):
 
         # Making sure our mocks were called as we expected
         mock_cmd.assert_has_calls([
-            mock.call(['oc', '-n', 'default', 'get', 'dc', 'router', '-o', 'json'], None),
+            mock.call(['oc', 'get', 'dc', 'router', '-o', 'json', '-n', 'default'], None),
         ])
 
     @unittest.skipIf(six.PY3, 'py2 test only')

--- a/roles/lib_openshift/src/test/unit/test_oc_route.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_route.py
@@ -135,7 +135,7 @@ class OCRouteTest(unittest.TestCase):
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([
-            mock.call(['oc', '-n', 'default', 'get', 'route', 'test', '-o', 'json'], None),
+            mock.call(['oc', 'get', 'route', 'test', '-o', 'json', '-n', 'default'], None),
         ])
 
     @mock.patch('oc_route.locate_oc_binary')
@@ -265,9 +265,9 @@ metadata:
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([
-            mock.call(['oc', '-n', 'default', 'get', 'route', 'test', '-o', 'json'], None),
-            mock.call(['oc', '-n', 'default', 'create', '-f', mock.ANY], None),
-            mock.call(['oc', '-n', 'default', 'get', 'route', 'test', '-o', 'json'], None),
+            mock.call(['oc', 'get', 'route', 'test', '-o', 'json', '-n', 'default'], None),
+            mock.call(['oc', 'create', '-f', mock.ANY, '-n', 'default'], None),
+            mock.call(['oc', 'get', 'route', 'test', '-o', 'json', '-n', 'default'], None),
         ])
 
     @unittest.skipIf(six.PY3, 'py2 test only')

--- a/roles/lib_openshift/src/test/unit/test_oc_secret.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_secret.py
@@ -85,8 +85,8 @@ class OCSecretTest(unittest.TestCase):
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([
-            mock.call(['oc', '-n', 'default', 'get', 'secrets', 'testsecretname', '-o', 'json'], None),
-            mock.call(['oc', '-n', 'default', 'secrets', 'new', 'testsecretname', mock.ANY], None),
+            mock.call(['oc', 'get', 'secrets', 'testsecretname', '-o', 'json', '-n', 'default'], None),
+            mock.call(['oc', 'secrets', 'new', 'testsecretname', mock.ANY, '-n', 'default'], None),
         ])
 
         mock_write.assert_has_calls([

--- a/roles/lib_openshift/src/test/unit/test_oc_serviceaccount.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_serviceaccount.py
@@ -111,9 +111,9 @@ class OCServiceAccountTest(unittest.TestCase):
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([
-            mock.call(['oc', '-n', 'default', 'get', 'sa', 'testserviceaccountname', '-o', 'json'], None),
-            mock.call(['oc', '-n', 'default', 'create', '-f', mock.ANY], None),
-            mock.call(['oc', '-n', 'default', 'get', 'sa', 'testserviceaccountname', '-o', 'json'], None),
+            mock.call(['oc', 'get', 'sa', 'testserviceaccountname', '-o', 'json', '-n', 'default'], None),
+            mock.call(['oc', 'create', '-f', mock.ANY, '-n', 'default'], None),
+            mock.call(['oc', 'get', 'sa', 'testserviceaccountname', '-o', 'json', '-n', 'default'], None),
         ])
 
     @unittest.skipIf(six.PY3, 'py2 test only')

--- a/roles/lib_openshift/src/test/unit/test_oc_serviceaccount_secret.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_serviceaccount_secret.py
@@ -181,10 +181,10 @@ secrets:
 
         # Making sure our mocks were called as we expected
         mock_cmd.assert_has_calls([
-            mock.call(['oc', '-n', 'default', 'get', 'sa', 'builder', '-o', 'json'], None),
-            mock.call(['oc', '-n', 'default', 'get', 'sa', 'builder', '-o', 'json'], None),
-            mock.call(['oc', '-n', 'default', 'replace', '-f', mock.ANY], None),
-            mock.call(['oc', '-n', 'default', 'get', 'sa', 'builder', '-o', 'json'], None)
+            mock.call(['oc', 'get', 'sa', 'builder', '-o', 'json', '-n', 'default'], None),
+            mock.call(['oc', 'get', 'sa', 'builder', '-o', 'json', '-n', 'default'], None),
+            mock.call(['oc', 'replace', '-f', mock.ANY, '-n', 'default'], None),
+            mock.call(['oc', 'get', 'sa', 'builder', '-o', 'json', '-n', 'default'], None)
         ])
 
         yaml_file = builder_pyyaml_file
@@ -304,9 +304,9 @@ secrets:
 
         # Making sure our mocks were called as we expected
         mock_cmd.assert_has_calls([
-            mock.call(['oc', '-n', 'default', 'get', 'sa', 'builder', '-o', 'json'], None),
-            mock.call(['oc', '-n', 'default', 'get', 'sa', 'builder', '-o', 'json'], None),
-            mock.call(['oc', '-n', 'default', 'replace', '-f', mock.ANY], None),
+            mock.call(['oc', 'get', 'sa', 'builder', '-o', 'json', '-n', 'default'], None),
+            mock.call(['oc', 'get', 'sa', 'builder', '-o', 'json', '-n', 'default'], None),
+            mock.call(['oc', 'replace', '-f', mock.ANY, '-n', 'default'], None),
         ])
 
         yaml_file = builder_pyyaml_file


### PR DESCRIPTION
Corrects a typo and moves namespace arg to end of `oc_obj` command to avoid the error seen below with `--all-namespaces`.

```
/bin/oc --all-namespaces get pods --selector=router -o json
Error: unknown command "pods" for "oc"

Did you mean this?
        logs

Run 'oc --help' for usage.
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1427080