### PR TITLE
Run pylint in more files (incl. tests)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -67,6 +67,13 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=
+    # disabling rules is not to be reported as a violation
+    locally-disabled,
+    # some files are to be ignored
+    file-ignored,
+    # it is expected to have TODO notes
+    fixme,
+    duplicate-code
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,5 @@
 [MASTER]
+
 # Specify a configuration file.
 #rcfile=
 
@@ -8,7 +9,11 @@
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS,setup.py
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
 
 # Pickle collected data for later comparisons.
 persistent=no
@@ -35,7 +40,8 @@ extension-pkg-whitelist=
 # be used to obtain the result of joining multiple strings with the addition
 # operator. Joining a lot of strings can lead to a maximum recursion error in
 # Pylint and this flag can prevent that. It has one side effect, the resulting
-# AST will be different than the one from reality.
+# AST will be different than the one from reality. This option is deprecated
+# and it will be removed in Pylint 2.0.
 optimize-ast=no
 
 
@@ -60,7 +66,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=fixme,locally-disabled,file-ignored,duplicate-code
+disable=
 
 
 [REPORTS]
@@ -72,7 +78,8 @@ output-format=parseable
 
 # Put messages in a separate file for each module / package specified on the
 # command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
+# written in a file name "pylint_global.[txt|html]". This option is deprecated
+# and it will be removed in Pylint 2.0.
 files-output=no
 
 # Tells whether to display a full report or only the messages
@@ -90,25 +97,41 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 #msg-template=
 
 
-[SIMILARITIES]
+[MISCELLANEOUS]
 
-# Minimum lines number of a similarity.
-min-similarity-lines=4
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
 
-# Ignore comments when computing similarities.
-ignore-comments=yes
 
-# Ignore docstrings when computing similarities.
-ignore-docstrings=yes
+[TYPECHECK]
 
-# Ignore imports when computing similarities.
-ignore-imports=yes
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
 
 
 [BASIC]
-
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=map,filter,input
 
 # Good variable names which should always be accepted, separated by a comma
 good-names=i,j,k,ex,Run,_
@@ -122,6 +145,10 @@ name-group=
 
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
 
 # Regular expression matching correct function names
 function-rgx=[a-z_][a-z0-9_]{2,30}$
@@ -198,44 +225,25 @@ docstring-min-length=-1
 max-nested-blocks=5
 
 
-[MISCELLANEOUS]
+[SIMILARITIES]
 
-# List of note tags to take in consideration, separated by a comma.
-notes=FIXME,XXX,TODO
+# Minimum lines number of a similarity.
+min-similarity-lines=4
 
+# Ignore comments when computing similarities.
+ignore-comments=yes
 
-[TYPECHECK]
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
 
-# Tells whether missing members accessed in mixin class should be ignored. A
-# mixin class is detected if its name ends with "mixin" (case insensitive).
-ignore-mixin-members=yes
-
-# List of module names for which member attributes should not be checked
-# (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis. It
-# supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
-
-# List of classes names for which member attributes should not be checked
-# (useful for classes with attributes dynamically set). This supports can work
-# with qualified names.
-ignored-classes=
-
-# List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E1101 when accessed. Python regular
-# expressions are accepted.
-generated-members=
+# Ignore imports when computing similarities.
+ignore-imports=no
 
 
 [SPELLING]
 
-# Spelling dictionary name. Available dictionaries: en_ZW (myspell), en_NG
-# (myspell), en_NA (myspell), en_NZ (myspell), en_PH (myspell), en_AG
-# (myspell), en_BW (myspell), en_IE (myspell), en_ZM (myspell), en_DK
-# (myspell), en_CA (myspell), en_GH (myspell), en_IN (myspell), en_BZ
-# (myspell), en_MW (myspell), en_TT (myspell), en_JM (myspell), en_GB
-# (myspell), en_ZA (myspell), en_SG (myspell), en_AU (myspell), en_US
-# (myspell), en_BS (myspell), en_HK (myspell).
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
 spelling-dict=
 
 # List of comma separated words that should not be checked.
@@ -288,7 +296,7 @@ init-import=no
 
 # A regular expression matching the name of dummy variables (i.e. expectedly
 # not used).
-dummy-variables-rgx=_$|dummy
+dummy-variables-rgx=(_+[a-zA-Z0-9]*?$)|dummy
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid to define new builtins when possible.
@@ -298,12 +306,46 @@ additional-builtins=
 # name must start or end with one of those strings.
 callbacks=cb_,_cb
 
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,future.builtins
+
 
 [LOGGING]
 
 # Logging modules to check that the string format arguments are in logging
 # function parameter format
 logging-modules=logging
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
 
 
 [CLASSES]
@@ -357,24 +399,6 @@ max-public-methods=20
 
 # Maximum number of boolean expressions in a if statement
 max-bool-expr=5
-
-
-[IMPORTS]
-
-# Deprecated modules which should not be used, separated by a comma
-deprecated-modules=regsub,TERMIOS,Bastion,rexec
-
-# Create a graph of every (i.e. internal and external) dependencies in the
-# given file (report RP0402 must not be disabled)
-import-graph=
-
-# Create a graph of external dependencies in the given file (report RP0402 must
-# not be disabled)
-ext-import-graph=
-
-# Create a graph of internal dependencies in the given file (report RP0402 must
-# not be disabled)
-int-import-graph=
 
 
 [EXCEPTIONS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -72,8 +72,7 @@ disable=
     # some files are to be ignored
     file-ignored,
     # it is expected to have TODO notes
-    fixme,
-    duplicate-code
+    fixme
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -72,7 +72,12 @@ disable=
     # some files are to be ignored
     file-ignored,
     # it is expected to have TODO notes
-    fixme
+    fixme,
+    # sometimes it's better to have no docstrings than placeholders or incorrect text
+    missing-docstring,
+    # the occurrences of this are usually because of one-character variable names that
+    # may make sense in the context; leave it up to the author / reviewers
+    invalid-name
 
 
 [REPORTS]

--- a/roles/openshift_master_facts/test/conftest.py
+++ b/roles/openshift_master_facts/test/conftest.py
@@ -5,6 +5,7 @@ import pytest
 
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir, "lookup_plugins"))
 
+# pylint: disable=wrong-import-position
 from openshift_master_facts_default_predicates import LookupModule as PredicatesLookupModule  # noqa: E402
 from openshift_master_facts_default_priorities import LookupModule as PrioritiesLookupModule  # noqa: E402
 

--- a/roles/openshift_master_facts/test/openshift_master_facts_bad_input_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_bad_input_tests.py
@@ -7,6 +7,7 @@ import pytest
 
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir, "lookup_plugins"))
 
+# pylint: disable=wrong-import-position
 from openshift_master_facts_default_predicates import LookupModule  # noqa: E402
 
 

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
@@ -1,3 +1,6 @@
+# pylint: disable=redefined-outer-name
+# Redefined names are fixtures names.
+
 import pytest
 
 

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_priorities_tests.py
@@ -1,3 +1,6 @@
+# pylint: disable=redefined-outer-name
+# Redefined names are fixtures names.
+
 import pytest
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ import yaml
 
 # Always prefer setuptools over distutils
 from setuptools import setup, Command
-from setuptools_lint.setuptools_command import PylintCommand
 from six import string_types
 from six.moves import reload_module
 from yamllint.config import YamlLintConfig
@@ -115,37 +114,6 @@ class OpenShiftAnsibleYamlLint(Command):
         if has_errors or has_warnings:
             print('yammlint issues found')
             raise SystemExit(1)
-
-
-class OpenShiftAnsiblePylint(PylintCommand):
-    ''' Class to override the default behavior of PylintCommand '''
-
-    # Reason: This method needs to be an instance method to conform to the
-    # overridden method's signature
-    # Status: permanently disabled
-    # pylint: disable=no-self-use
-    def find_all_modules(self):
-        ''' find all python files to test '''
-        exclude_dirs = ['.tox', 'utils', 'test', 'tests', 'git']
-        modules = []
-        for match in find_files(os.getcwd(), exclude_dirs, None, r'\.py$'):
-            package = os.path.basename(match).replace('.py', '')
-            modules.append(('openshift_ansible', package, match))
-        return modules
-
-    def get_finalized_command(self, cmd):
-        ''' override get_finalized_command to ensure we use our
-        find_all_modules method '''
-        if cmd == 'build_py':
-            return self
-
-    # Reason: This method needs to be an instance method to conform to the
-    # overridden method's signature
-    # Status: permanently disabled
-    # pylint: disable=no-self-use
-    def with_project_on_sys_path(self, func, func_args, func_kwargs):
-        ''' override behavior, since we don't need to build '''
-        return func(*func_args, **func_kwargs)
 
 
 class OpenShiftAnsibleGenerateValidation(Command):
@@ -286,7 +254,6 @@ setup(
         'build_ext': UnsupportedCommand,
         'egg_info': UnsupportedCommand,
         'sdist': UnsupportedCommand,
-        'lint': OpenShiftAnsiblePylint,
         'yamllint': OpenShiftAnsibleYamlLint,
         'generate_validation': OpenShiftAnsibleGenerateValidation,
         'ansible_syntax': OpenShiftAnsibleSyntaxCheck,

--- a/test/unit/modify_yaml_tests.py
+++ b/test/unit/modify_yaml_tests.py
@@ -7,7 +7,7 @@ import unittest
 
 sys.path = [os.path.abspath(os.path.dirname(__file__) + "/../../library/")] + sys.path
 
-# pylint: disable=import-error
+# pylint: disable=wrong-import-position
 from modify_yaml import set_key  # noqa: E402
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ skip_missing_interpreters=True
 
 [testenv]
 skip_install=True
+whitelist_externals = sh
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
@@ -19,7 +20,7 @@ commands =
     unit: pip install -e utils
     unit: pytest {posargs}
     flake8: flake8 {posargs}
-    pylint: python setup.py lint
+    pylint: sh -c "git ls-files -co --exclude-standard '*.py' | grep -Ev '^(utils|roles/lib_(openshift|utils)/src)/' | xargs pylint"
     yamllint: python setup.py yamllint
     generate_validation: python setup.py generate_validation
     # TODO(rhcarvalho): check syntax of other important entrypoint playbooks


### PR DESCRIPTION
Fixes #3500

- Several misc. fixes to code style
- Reset pylint config to default + automatically use all CPUs + disable some extra rules
- Remove custom runner code from `setup.py` -- use `pylint`