### PR TITLE
Add docker-registry.default.svc short name to registry service signing

### DIFF
--- a/playbooks/common/openshift-cluster/redeploy-certificates/registry.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/registry.yml
@@ -66,7 +66,7 @@
         --signer-cert={{ openshift.common.config_base }}/master/ca.crt
         --signer-key={{ openshift.common.config_base }}/master/ca.key
         --signer-serial={{ openshift.common.config_base }}/master/ca.serial.txt
-        --hostnames="{{ docker_registry_service_ip.results.clusterip }},docker-registry.default.svc.cluster.local,{{ docker_registry_route_hostname }}"
+        --hostnames="{{ docker_registry_service_ip.results.clusterip }},docker-registry.default.svc,docker-registry.default.svc.cluster.local,{{ docker_registry_route_hostname }}"
         --cert={{ openshift.common.config_base }}/master/registry.crt
         --key={{ openshift.common.config_base }}/master/registry.key
         {% if openshift_version | oo_version_gte_3_5_or_1_5(openshift.common.deployment_type) | bool %}

--- a/roles/openshift_hosted/tasks/registry/secure.yml
+++ b/roles/openshift_hosted/tasks/registry/secure.yml
@@ -53,7 +53,8 @@
     signer_serial: "{{ openshift_master_config_dir }}/ca.serial.txt"
     hostnames:
     - "{{ docker_registry_service_ip.results.clusterip }}"
-    - docker-registry.default.svc.cluster.local
+    - "{{ openshift_hosted_registry_name }}.default.svc"
+    - "{{ openshift_hosted_registry_name }}.default.svc.{{ openshift.common.dns_domain }}"
     - "{{ docker_registry_route_hostname }}"
     cert: "{{ openshift_master_config_dir }}/registry.crt"
     key: "{{ openshift_master_config_dir }}/registry.key"


### PR DESCRIPTION
Today this isn't necessary, but we may need to push to the registry via a short name in the future to facilitate easier cluster dns zone changes.