### PR TITLE
Bug 1427003: Failed to add masters if openshift_master_ca_certificate is defined

### DIFF
--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -60,6 +60,7 @@
   copy:
     src: "{{ item.src }}"
     dest: "{{ openshift_ca_config_dir }}/{{ item.dest }}"
+    force: no
   with_items:
   - src: "{{ (openshift_master_ca_certificate | default({'certfile':none})).certfile }}"
     dest: ca.crt

--- a/roles/openshift_master_facts/filter_plugins/openshift_master.py
+++ b/roles/openshift_master_facts/filter_plugins/openshift_master.py
@@ -527,7 +527,7 @@ class FilterModule(object):
                  'master.kubelet-client.crt',
                  'master.kubelet-client.key']
         if bool(include_ca):
-            certs += ['ca.crt', 'ca.key']
+            certs += ['ca.crt', 'ca.key', 'ca-bundle.crt']
         if bool(include_keys):
             certs += ['serviceaccounts.private.key',
                       'serviceaccounts.public.key']


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1427003
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1426677