### PR TITLE
oc_atomic_container: support Skopeo output

### DIFF
--- a/roles/lib_openshift/library/oc_atomic_container.py
+++ b/roles/lib_openshift/library/oc_atomic_container.py
@@ -78,7 +78,7 @@ def _install(module, container, image, values_list):
     if rc != 0:
         return rc, out, err, False
     else:
-        changed = "Extracting" in out
+        changed = "Extracting" in out or "Copying blob" in out
         return rc, out, err, changed
 
 def _uninstall(module, name):
@@ -122,7 +122,7 @@ def do_update(module, container, old_image, image, values_list):
     if rc != 0:
         module.fail_json(rc=rc, msg=err)
     else:
-        changed = "Extracting" in out
+        changed = "Extracting" in out or "Copying blob" in out
         module.exit_json(msg=out, changed=changed)
 
 

--- a/roles/lib_openshift/src/ansible/oc_atomic_container.py
+++ b/roles/lib_openshift/src/ansible/oc_atomic_container.py
@@ -14,7 +14,7 @@ def _install(module, container, image, values_list):
     if rc != 0:
         return rc, out, err, False
     else:
-        changed = "Extracting" in out
+        changed = "Extracting" in out or "Copying blob" in out
         return rc, out, err, changed
 
 def _uninstall(module, name):
@@ -58,7 +58,7 @@ def do_update(module, container, old_image, image, values_list):
     if rc != 0:
         module.fail_json(rc=rc, msg=err)
     else:
-        changed = "Extracting" in out
+        changed = "Extracting" in out or "Copying blob" in out
         module.exit_json(msg=out, changed=changed)
 
 


### PR DESCRIPTION
we are working on using Skopeo to copy images to the OSTree storage.
The output from atomic will be slightly different.  Support also the new
version.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>