### PR TITLE
Remove contiv role and playbook from rpm packages

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -66,6 +66,8 @@ cp inventory/byo/* docs/example-inventories/
 
 # openshift-ansible-playbooks install
 cp -rp playbooks %{buildroot}%{_datadir}/ansible/%{name}/
+# remove contiv plabooks
+rm -rf %{buildroot}%{_datadir}/ansible/%{name}/playbooks/adhoc/contiv
 
 # BZ1330091
 find -L %{buildroot}%{_datadir}/ansible/%{name}/playbooks -name lookup_plugins -type l -delete
@@ -73,6 +75,8 @@ find -L %{buildroot}%{_datadir}/ansible/%{name}/playbooks -name filter_plugins -
 
 # openshift-ansible-roles install
 cp -rp roles %{buildroot}%{_datadir}/ansible/%{name}/
+# remove contiv role
+rm -rf %{buildroot}%{_datadir}/ansible/%{name}/roles/contiv
 # openshift_master_facts symlinks filter_plugins/oo_filters.py from ansible_plugins/filter_plugins
 pushd %{buildroot}%{_datadir}/ansible/%{name}/roles/openshift_master_facts/filter_plugins
 ln -sf ../../../../../ansible_plugins/filter_plugins/oo_filters.py oo_filters.py


### PR DESCRIPTION
The contiv role currently contains binary files which we cannot ship in our ansible roles. As a temporary measure we're going to remove those playbooks and roles from the RPM packaged version of the installer.

```
Provides: openshift-ansible = 3.5.3-1.git.462.2d52f7c.el7
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(PartialHardlinkSets) <= 4.0.4-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires: /usr/bin/python
Processing files: openshift-ansible-docs-3.5.3-1.git.462.2d52f7c.el7.noarch
Executing(%doc): /bin/sh -e /var/tmp/rpm-tmp.dxBmaF
+ umask 022
+ cd /tmp/tito/rpmbuild-openshift-ansibleNgTohJ/BUILD
+ cd openshift-ansible-git-462.2d52f7c
+ DOCDIR=/tmp/tito/rpmbuild-openshift-ansibleNgTohJ/BUILDROOT/openshift-ansible-3.5.3-1.git.462.2d52f7c.el7.x86_64/usr/share/doc/openshift-ansible-docs-3.5.3
+ export DOCDIR
+ /usr/bin/mkdir -p /tmp/tito/rpmbuild-openshift-ansibleNgTohJ/BUILDROOT/openshift-ansible-3.5.3-1.git.462.2d52f7c.el7.x86_64/usr/share/doc/openshift-ansible-docs-3.5.3
+ cp -pr docs /tmp/tito/rpmbuild-openshift-ansibleNgTohJ/BUILDROOT/openshift-ansible-3.5.3-1.git.462.2d52f7c.el7.x86_64/usr/share/doc/openshift-ansible-docs-3.5.3
+ exit 0
Provides: openshift-ansible-docs = 3.5.3-1.git.462.2d52f7c.el7
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Processing files: openshift-ansible-playbooks-3.5.3-1.git.462.2d52f7c.el7.noarch
Provides: openshift-ansible-playbooks = 3.5.3-1.git.462.2d52f7c.el7
Requires(rpmlib): rpmlib(BuiltinLuaScripts) <= 4.2.2-1 rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(PartialHardlinkSets) <= 4.0.4-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires: /usr/bin/python
Processing files: openshift-ansible-roles-3.5.3-1.git.462.2d52f7c.el7.noarch
Provides: openshift-ansible-roles = 3.5.3-1.git.462.2d52f7c.el7
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(PartialHardlinkSets) <= 4.0.4-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires: /bin/bash /usr/bin/env /usr/bin/python
error: Arch dependent binaries in noarch package


RPM build errors:
    Arch dependent binaries in noarch package


ERROR: Error running command: rpmbuild --define "_source_filedigest_algorithm md5" --define "_binary_filedigest_algorithm md5"   --eval '%undefine scl' --define "_topdir /tmp/tito/rpmbuild-openshift-ansibleNgTohJ" --define "_sourcedir /tmp/tito/rpmbuild-openshift-ansibleNgTohJ/SOURCES" --define "_builddir /tmp/tito/rpmbuild-openshift-ansibleNgTohJ/BUILD" --define "_srcrpmdir /tmp/tito" --define "_rpmdir /tmp/tito"   --clean  -ba /tmp/tito/rpmbuild-openshift-ansibleNgTohJ/SOURCES/openshift-ansible-git-462.2d52f7c/openshift-ansible.spec
```