### PR TITLE
Leave an empty contiv role directory

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -76,7 +76,7 @@ find -L %{buildroot}%{_datadir}/ansible/%{name}/playbooks -name filter_plugins -
 # openshift-ansible-roles install
 cp -rp roles %{buildroot}%{_datadir}/ansible/%{name}/
 # remove contiv role
-rm -rf %{buildroot}%{_datadir}/ansible/%{name}/roles/contiv
+rm -rf %{buildroot}%{_datadir}/ansible/%{name}/roles/contiv/*
 # openshift_master_facts symlinks filter_plugins/oo_filters.py from ansible_plugins/filter_plugins
 pushd %{buildroot}%{_datadir}/ansible/%{name}/roles/openshift_master_facts/filter_plugins
 ln -sf ../../../../../ansible_plugins/filter_plugins/oo_filters.py oo_filters.py


### PR DESCRIPTION
Since the role is conditionally included in some playbooks we need to ensure the role exists.