### PR TITLE
bug 1420256. Initialize openshift_logging pvc_facts to empty

### DIFF
--- a/roles/openshift_logging/tasks/generate_pvcs.yaml
+++ b/roles/openshift_logging/tasks/generate_pvcs.yaml
@@ -2,28 +2,28 @@
 - name: Init pool of PersistentVolumeClaim names
   set_fact: es_pvc_pool={{es_pvc_pool|default([]) + [pvc_name]}}
   vars:
-    pvc_name: "{{openshift_logging_es_pvc_prefix}}-{{item| int}}"
-    start: "{{es_pvc_names | map('regex_search',openshift_logging_es_pvc_prefix+'.*')|select('string')|list|length}}"
-  with_sequence: start={{start}} end={{ (start|int > openshift_logging_es_cluster_size|int - 1) | ternary(start, openshift_logging_es_cluster_size|int - 1)}}
+    pvc_name: "{{es_pvc_prefix}}-{{item| int}}"
+    start: "{{es_pvc_names | map('regex_search', es_pvc_prefix+'.*')|select('string')|list|length}}"
+  with_sequence: start={{start}} end={{ (start|int > es_cluster_size|int - 1) | ternary(start, es_cluster_size|int - 1)}}
   when:
-    - openshift_logging_es_pvc_size | search('^\d.*')
-    - "{{ es_dc_names|default([]) | length < openshift_logging_es_cluster_size|int }}"
+    - es_pvc_size | search('^\d.*')
+    - "{{ es_dc_names|default([]) | length < es_cluster_size|int }}"
   check_mode: no
 
 - name: Generating PersistentVolumeClaims
   template: src=pvc.j2 dest={{mktemp.stdout}}/templates/logging-{{obj_name}}-pvc.yaml
   vars:
     obj_name: "{{claim_name}}"
-    size: "{{openshift_logging_es_pvc_size}}"
+    size: "{{es_pvc_size}}"
     access_modes:
       - ReadWriteOnce
-    pv_selector: "{{openshift_logging_es_pv_selector}}"
+    pv_selector: "{{es_pv_selector}}"
   with_items:
     - "{{es_pvc_pool | default([])}}"
   loop_control:
     loop_var: claim_name
   when:
-    - not openshift_logging_es_pvc_dynamic
+    - not es_pvc_dynamic
     - es_pvc_pool is defined
   check_mode: no
   changed_when: no
@@ -34,16 +34,16 @@
     obj_name: "{{claim_name}}"
     annotations:
       volume.alpha.kubernetes.io/storage-class: "dynamic"
-    size: "{{openshift_logging_es_pvc_size}}"
+    size: "{{es_pvc_size}}"
     access_modes:
       - ReadWriteOnce
-    pv_selector: "{{openshift_logging_es_pv_selector}}"
+    pv_selector: "{{es_pv_selector}}"
   with_items:
     - "{{es_pvc_pool|default([])}}"
   loop_control:
     loop_var: claim_name
   when:
-    - openshift_logging_es_pvc_dynamic
+    - es_pvc_dynamic
     - es_pvc_pool is defined
   check_mode: no
   changed_when: no

--- a/roles/openshift_logging/tasks/install_elasticsearch.yaml
+++ b/roles/openshift_logging/tasks/install_elasticsearch.yaml
@@ -5,9 +5,13 @@
 - name: Generate PersistentVolumeClaims
   include: "{{ role_path}}/tasks/generate_pvcs.yaml"
   vars:
-    es_pvc_pool: []
+    es_pv_selector: "{{openshift_logging_es_pv_selector}}"
+    es_pvc_dynamic: "{{openshift_logging_es_pvc_dynamic | bool}}"
     es_pvc_names: "{{openshift_logging_facts.elasticsearch.pvcs.keys()}}"
+    es_pvc_prefix: "{{openshift_logging_es_pvc_prefix}}"
+    es_pvc_size: "{{openshift_logging_es_pvc_size}}"
     es_dc_names: "{{openshift_logging_facts.elasticsearch.deploymentconfigs.keys()}}"
+    es_cluster_size: "{{openshift_logging_es_cluster_size}}"
 
 # we should initialize the es_dc_pool with the current keys
 - name: Init pool of DeploymentConfig names for Elasticsearch
@@ -61,17 +65,18 @@
     - "{{es_dcs | length - openshift_logging_es_ops_cluster_size|int | abs > 1}}"
   check_mode: no
 
+- set_fact: es_pvc_pool={{[]}}
+
 - name: Generate PersistentVolumeClaims for Ops
   include: "{{ role_path}}/tasks/generate_pvcs.yaml"
   vars:
-    es_pvc_pool: []
     es_pvc_names: "{{openshift_logging_facts.elasticsearch_ops.pvcs.keys()}}"
     es_dc_names: "{{openshift_logging_facts.elasticsearch_ops.deploymentconfigs.keys()}}"
-    openshift_logging_es_pvc_prefix: "{{openshift_logging_es_ops_pvc_prefix}}"
-    openshift_logging_es_cluster_size: "{{openshift_logging_es_ops_cluster_size|int}}"
-    openshift_logging_es_pvc_size: "{{openshift_logging_es_ops_pvc_size}}"
-    openshift_logging_es_pvc_dynamic: "{{openshift_logging_es_ops_pvc_dynamic}}"
-    openshift_logging_es_pv_selector: "{{openshift_logging_es_ops_pv_selector}}"
+    es_pvc_size: "{{openshift_logging_es_ops_pvc_size}}"
+    es_pvc_prefix: "{{openshift_logging_es_ops_pvc_prefix}}"
+    es_cluster_size: "{{openshift_logging_es_ops_cluster_size|int}}"
+    es_pvc_dynamic: "{{openshift_logging_es_ops_pvc_dynamic | bool}}"
+    es_pv_selector: "{{openshift_logging_es_ops_pv_selector}}"
   when:
     - openshift_logging_use_ops | bool
   check_mode: no


### PR DESCRIPTION
This bug fixes an issue where:

* PVCs are not generated because var:es_pvc_pool=[] is not the same as 'setfact=es_pvc_pool'