### PR TITLE
Removing the openshift_master_facts dependency

### DIFF
--- a/roles/openshift_logging/meta/main.yaml
+++ b/roles/openshift_logging/meta/main.yaml
@@ -14,4 +14,3 @@ galaxy_info:
 dependencies:
 - role: lib_openshift
 - role: openshift_facts
-- role: openshift_master_facts


### PR DESCRIPTION
Proposed fix for https://bugzilla.redhat.com/show_bug.cgi?id=1425312