### PR TITLE
separate out test tool configs from setup.cfg

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+exclude=.tox,utils,inventory
+max_line_length = 120
+ignore = E501,T003

--- a/.pylintrc
+++ b/.pylintrc
@@ -60,7 +60,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-#disable=
+disable=fixme,locally-disabled,file-ignored,duplicate-code
 
 
 [REPORTS]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,18 @@
+[pytest]
+norecursedirs =
+    .*
+    __pycache__
+    cover
+    docs
+    # utils has it's own config
+    utils
+python_files =
+    # TODO(rhcarvalho): rename test files to follow a single pattern. "test*.py"
+    # is Python unittest's default, while pytest discovers both "test_*.py" and
+    # "*_test.py" by default.
+    test_*.py
+    *_tests.py
+addopts =
+    --cov=.
+    --cov-report=term
+    --cov-report=html

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,30 +6,3 @@ universal=1
 
 [yamllint]
 excludes=.tox,utils,files
-
-[lint]
-lint_disable=fixme,locally-disabled,file-ignored,duplicate-code
-
-[flake8]
-exclude=.tox/*,utils/*,inventory/*
-max_line_length = 120
-ignore = E501,T003
-
-[tool:pytest]
-norecursedirs =
-    .*
-    __pycache__
-    cover
-    docs
-    # utils have its own config
-    utils
-python_files =
-    # TODO(rhcarvalho): rename test files to follow a single pattern. "test*.py"
-    # is Python unittest's default, while pytest discovers both "test_*.py" and
-    # "*_test.py" by default.
-    test_*.py
-    *_tests.py
-addopts =
-    --cov=.
-    --cov-report=term
-    --cov-report=html


### PR DESCRIPTION
Since we are moving away from setuptools for invoking tests, lets
move the configs for the different test tools into their own configs.