### PR TITLE
[WIP] Simplify test code base by leveraging pytest

### DIFF
--- a/roles/lib_openshift/src/test/unit/test_oc_adm_manage_node.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_adm_manage_node.py
@@ -103,9 +103,9 @@ class ManageNodeTest(unittest.TestCase):
         results = ManageNode.run_ansible(params, False)
 
         # returned a single node
-        self.assertTrue(len(results['results']['nodes']) == 1)
+        assert len(results['results']['nodes']) == 1
         # returned 2 pods
-        self.assertTrue(len(results['results']['nodes']['ip-172-31-49-140.ec2.internal']) == 2)
+        assert len(results['results']['nodes']['ip-172-31-49-140.ec2.internal']) == 2
 
     @mock.patch('oc_adm_manage_node.Utils.create_tmpfile_copy')
     @mock.patch('oc_adm_manage_node.ManageNode.openshift_cmd')
@@ -164,9 +164,9 @@ class ManageNodeTest(unittest.TestCase):
 
         results = ManageNode.run_ansible(params, False)
 
-        self.assertTrue(results['changed'])
-        self.assertEqual(results['results']['nodes'][0]['name'], 'ip-172-31-49-140.ec2.internal')
-        self.assertEqual(results['results']['nodes'][0]['schedulable'], False)
+        assert results['changed']
+        assert results['results']['nodes'][0]['name'] == 'ip-172-31-49-140.ec2.internal'
+        assert results['results']['nodes'][0]['schedulable'] == False
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -178,7 +178,7 @@ class ManageNodeTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda _: False
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -192,7 +192,7 @@ class ManageNodeTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -206,7 +206,7 @@ class ManageNodeTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -220,7 +220,7 @@ class ManageNodeTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -234,7 +234,7 @@ class ManageNodeTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -246,7 +246,7 @@ class ManageNodeTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: None
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -260,7 +260,7 @@ class ManageNodeTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -274,4 +274,4 @@ class ManageNodeTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin

--- a/roles/lib_openshift/src/test/unit/test_oc_adm_manage_node.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_adm_manage_node.py
@@ -8,6 +8,8 @@ import sys
 import unittest
 import mock
 
+import pytest
+
 # Removing invalid variable names for tests so that I can
 # keep them brief
 # pylint: disable=invalid-name,no-name-in-module
@@ -168,7 +170,7 @@ class ManageNodeTest(unittest.TestCase):
         assert results['results']['nodes'][0]['name'] == 'ip-172-31-49-140.ec2.internal'
         assert results['results']['nodes'][0]['schedulable'] == False
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback(self, mock_env_get, mock_path_exists):
@@ -180,7 +182,7 @@ class ManageNodeTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path_py3(self, mock_env_get, mock_shutil_which):
@@ -194,7 +196,7 @@ class ManageNodeTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path(self, mock_env_get, mock_path_exists):
@@ -208,7 +210,7 @@ class ManageNodeTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local(self, mock_env_get, mock_path_exists):
@@ -222,7 +224,7 @@ class ManageNodeTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home(self, mock_env_get, mock_path_exists):
@@ -236,7 +238,7 @@ class ManageNodeTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback_py3(self, mock_env_get, mock_shutil_which):
@@ -248,7 +250,7 @@ class ManageNodeTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local_py3(self, mock_env_get, mock_shutil_which):
@@ -262,7 +264,7 @@ class ManageNodeTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home_py3(self, mock_env_get, mock_shutil_which):

--- a/roles/lib_openshift/src/test/unit/test_oc_env.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_env.py
@@ -125,13 +125,13 @@ class OCEnvTest(unittest.TestCase):
         results = OCEnv.run_ansible(params, False)
 
         # Assert
-        self.assertFalse(results['changed'])
+        assert not results['changed']
         for env_var in results['results']:
             if env_var == {'name': 'DEFAULT_CERTIFICATE_DIR', 'value': '/etc/pki/tls/private'}:
                 break
         else:
             self.fail('Did not find environment variables in results.')
-        self.assertEqual(results['state'], 'list')
+        assert results['state'] == 'list'
 
         # Making sure our mocks were called as we expected
         mock_cmd.assert_has_calls([
@@ -311,13 +311,13 @@ class OCEnvTest(unittest.TestCase):
         results = OCEnv.run_ansible(params, False)
 
         # Assert
-        self.assertTrue(results['changed'])
+        assert results['changed']
         for env_var in results['results']:
             if env_var == {'name': 'SOMEKEY', 'value': 'SOMEVALUE'}:
                 break
         else:
             self.fail('Did not find environment variables in results.')
-        self.assertEqual(results['state'], 'present')
+        assert results['state'] == 'present'
 
         # Making sure our mocks were called as we expected
         mock_cmd.assert_has_calls([
@@ -431,8 +431,8 @@ class OCEnvTest(unittest.TestCase):
         results = OCEnv.run_ansible(params, False)
 
         # Assert
-        self.assertTrue(results['changed'])
-        self.assertEqual(results['state'], 'absent')
+        assert results['changed']
+        assert results['state'] == 'absent'
 
         # Making sure our mocks were called as we expected
         mock_cmd.assert_has_calls([
@@ -449,7 +449,7 @@ class OCEnvTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda _: False
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -463,7 +463,7 @@ class OCEnvTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -477,7 +477,7 @@ class OCEnvTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -491,7 +491,7 @@ class OCEnvTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -503,7 +503,7 @@ class OCEnvTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: None
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -517,7 +517,7 @@ class OCEnvTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -531,7 +531,7 @@ class OCEnvTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -545,4 +545,4 @@ class OCEnvTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin

--- a/roles/lib_openshift/src/test/unit/test_oc_env.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_env.py
@@ -8,6 +8,8 @@ import sys
 import unittest
 import mock
 
+import pytest
+
 # Removing invalid variable names for tests so that I can
 # keep them brief
 # pylint: disable=invalid-name,no-name-in-module
@@ -439,7 +441,7 @@ class OCEnvTest(unittest.TestCase):
             mock.call(['oc', 'get', 'dc', 'router', '-o', 'json', '-n', 'default'], None),
         ])
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback(self, mock_env_get, mock_path_exists):
@@ -451,7 +453,7 @@ class OCEnvTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path(self, mock_env_get, mock_path_exists):
@@ -465,7 +467,7 @@ class OCEnvTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local(self, mock_env_get, mock_path_exists):
@@ -479,7 +481,7 @@ class OCEnvTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home(self, mock_env_get, mock_path_exists):
@@ -493,7 +495,7 @@ class OCEnvTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback_py3(self, mock_env_get, mock_shutil_which):
@@ -505,7 +507,7 @@ class OCEnvTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path_py3(self, mock_env_get, mock_shutil_which):
@@ -519,7 +521,7 @@ class OCEnvTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local_py3(self, mock_env_get, mock_shutil_which):
@@ -533,7 +535,7 @@ class OCEnvTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home_py3(self, mock_env_get, mock_shutil_which):

--- a/roles/lib_openshift/src/test/unit/test_oc_label.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_label.py
@@ -8,6 +8,8 @@ import sys
 import unittest
 import mock
 
+import pytest
+
 # Removing invalid variable names for tests so that I can
 # keep them brief
 # pylint: disable=invalid-name,no-name-in-module
@@ -178,7 +180,7 @@ class OCLabelTest(unittest.TestCase):
             'awesomens': 'testinglabel'
         }
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback(self, mock_env_get, mock_path_exists):
@@ -190,7 +192,7 @@ class OCLabelTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path(self, mock_env_get, mock_path_exists):
@@ -204,7 +206,7 @@ class OCLabelTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local(self, mock_env_get, mock_path_exists):
@@ -218,7 +220,7 @@ class OCLabelTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home(self, mock_env_get, mock_path_exists):
@@ -232,7 +234,7 @@ class OCLabelTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback_py3(self, mock_env_get, mock_shutil_which):
@@ -244,7 +246,7 @@ class OCLabelTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path_py3(self, mock_env_get, mock_shutil_which):
@@ -258,7 +260,7 @@ class OCLabelTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local_py3(self, mock_env_get, mock_shutil_which):
@@ -272,7 +274,7 @@ class OCLabelTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home_py3(self, mock_env_get, mock_shutil_which):

--- a/roles/lib_openshift/src/test/unit/test_oc_label.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_label.py
@@ -78,8 +78,8 @@ class OCLabelTest(unittest.TestCase):
 
         results = OCLabel.run_ansible(params, False)
 
-        self.assertFalse(results['changed'])
-        self.assertTrue(results['results']['labels'] == [{'storage_pv_quota': 'False'}])
+        assert not results['changed']
+        assert results['results']['labels'] == [{'storage_pv_quota': 'False'}]
 
     @mock.patch('oc_label.Utils.create_tmpfile_copy')
     @mock.patch('oc_label.OCLabel._run')
@@ -172,9 +172,11 @@ class OCLabelTest(unittest.TestCase):
 
         results = OCLabel.run_ansible(params, False)
 
-        self.assertTrue(results['changed'])
-        self.assertTrue(results['results']['results']['labels'][0] ==
-                        {'storage_pv_quota': 'False', 'awesomens': 'testinglabel'})
+        assert results['changed']
+        assert results['results']['results']['labels'][0] == {
+            'storage_pv_quota': 'False',
+            'awesomens': 'testinglabel'
+        }
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -186,7 +188,7 @@ class OCLabelTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda _: False
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -200,7 +202,7 @@ class OCLabelTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -214,7 +216,7 @@ class OCLabelTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -228,7 +230,7 @@ class OCLabelTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -240,7 +242,7 @@ class OCLabelTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: None
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -254,7 +256,7 @@ class OCLabelTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -268,7 +270,7 @@ class OCLabelTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -282,4 +284,4 @@ class OCLabelTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin

--- a/roles/lib_openshift/src/test/unit/test_oc_objectvalidator.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_objectvalidator.py
@@ -71,8 +71,8 @@ class OCObjectValidatorTest(unittest.TestCase):
         results = OCObjectValidator.run_ansible(params)
 
         # Assert
-        self.assertNotIn('failed', results)
-        self.assertEqual(results['msg'], 'All objects are valid.')
+        assert 'failed' not in results
+        assert results['msg'] == 'All objects are valid.'
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([
@@ -120,10 +120,10 @@ class OCObjectValidatorTest(unittest.TestCase):
         results = OCObjectValidator.run_ansible(params)
 
         # Assert
-        self.assertTrue(results['failed'])
-        self.assertEqual(results['msg'], 'Failed to GET hostsubnet.')
-        self.assertEqual(results['state'], 'list')
-        self.assertEqual(results['results'], error_results)
+        assert results['failed']
+        assert results['msg'] == 'Failed to GET hostsubnet.'
+        assert results['state'] == 'list'
+        assert results['results'] == error_results
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([
@@ -446,8 +446,8 @@ class OCObjectValidatorTest(unittest.TestCase):
         results = OCObjectValidator.run_ansible(params)
 
         # Assert
-        self.assertNotIn('failed', results)
-        self.assertEqual(results['msg'], 'All objects are valid.')
+        assert 'failed' not in results
+        assert results['msg'] == 'All objects are valid.'
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([
@@ -910,10 +910,10 @@ class OCObjectValidatorTest(unittest.TestCase):
         results = OCObjectValidator.run_ansible(params)
 
         # Assert
-        self.assertTrue(results['failed'])
-        self.assertIn('All objects are not valid.', results['msg'])
-        self.assertEqual(results['state'], 'list')
-        self.assertEqual(results['results'], invalid_results)
+        assert results['failed']
+        assert 'All objects are not valid.' in results['msg']
+        assert results['state'] == 'list'
+        assert results['results'] == invalid_results
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([

--- a/roles/lib_openshift/src/test/unit/test_oc_process.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_process.py
@@ -8,6 +8,8 @@ import sys
 import unittest
 import mock
 
+import pytest
+
 # Removing invalid variable names for tests so that I can
 # keep them brief
 # pylint: disable=invalid-name,no-name-in-module
@@ -463,7 +465,7 @@ class OCProcessTest(unittest.TestCase):
         assert not results['changed']
         assert results['results']['results']['items'][0]['metadata']['name'] == 'testdb'
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback(self, mock_env_get, mock_path_exists):
@@ -475,7 +477,7 @@ class OCProcessTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path(self, mock_env_get, mock_path_exists):
@@ -489,7 +491,7 @@ class OCProcessTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local(self, mock_env_get, mock_path_exists):
@@ -503,7 +505,7 @@ class OCProcessTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home(self, mock_env_get, mock_path_exists):
@@ -517,7 +519,7 @@ class OCProcessTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback_py3(self, mock_env_get, mock_shutil_which):
@@ -529,7 +531,7 @@ class OCProcessTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path_py3(self, mock_env_get, mock_shutil_which):
@@ -543,7 +545,7 @@ class OCProcessTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local_py3(self, mock_env_get, mock_shutil_which):
@@ -557,7 +559,7 @@ class OCProcessTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home_py3(self, mock_env_get, mock_shutil_which):

--- a/roles/lib_openshift/src/test/unit/test_oc_process.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_process.py
@@ -270,8 +270,8 @@ class OCProcessTest(unittest.TestCase):
 
         results = OCProcess.run_ansible(params, False)
 
-        self.assertFalse(results['changed'])
-        self.assertEqual(results['results']['results'][0]['metadata']['name'], 'mysql-ephemeral')
+        assert not results['changed']
+        assert results['results']['results'][0]['metadata']['name'] == 'mysql-ephemeral'
 
     @mock.patch('oc_process.Utils.create_tmpfile_copy')
     @mock.patch('oc_process.OCProcess._run')
@@ -460,8 +460,8 @@ class OCProcessTest(unittest.TestCase):
 
         results = OCProcess.run_ansible(params, False)
 
-        self.assertFalse(results['changed'])
-        self.assertEqual(results['results']['results']['items'][0]['metadata']['name'], 'testdb')
+        assert not results['changed']
+        assert results['results']['results']['items'][0]['metadata']['name'] == 'testdb'
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -473,7 +473,7 @@ class OCProcessTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda _: False
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -487,7 +487,7 @@ class OCProcessTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -501,7 +501,7 @@ class OCProcessTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -515,7 +515,7 @@ class OCProcessTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -527,7 +527,7 @@ class OCProcessTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: None
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -541,7 +541,7 @@ class OCProcessTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -555,7 +555,7 @@ class OCProcessTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -569,4 +569,4 @@ class OCProcessTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin

--- a/roles/lib_openshift/src/test/unit/test_oc_project.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_project.py
@@ -95,10 +95,10 @@ class OCProjectTest(unittest.TestCase):
         results = OCProject.run_ansible(params, False)
 
         # Assert
-        self.assertTrue(results['changed'])
-        self.assertEqual(results['results']['returncode'], 0)
-        self.assertEqual(results['results']['results']['metadata']['name'], 'operations')
-        self.assertEqual(results['state'], 'present')
+        assert results['changed']
+        assert results['results']['returncode'] == 0
+        assert results['results']['results']['metadata']['name'] == 'operations'
+        assert results['state'] == 'present'
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([

--- a/roles/lib_openshift/src/test/unit/test_oc_route.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_route.py
@@ -8,6 +8,8 @@ import sys
 import unittest
 import mock
 
+import pytest
+
 # Removing invalid variable names for tests so that I can
 # keep them brief
 # pylint: disable=invalid-name,no-name-in-module
@@ -258,7 +260,7 @@ metadata:
             mock.call(['oc', 'get', 'route', 'test', '-o', 'json', '-n', 'default'], None),
         ])
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback(self, mock_env_get, mock_path_exists):
@@ -270,7 +272,7 @@ metadata:
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path(self, mock_env_get, mock_path_exists):
@@ -284,7 +286,7 @@ metadata:
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local(self, mock_env_get, mock_path_exists):
@@ -298,7 +300,7 @@ metadata:
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home(self, mock_env_get, mock_path_exists):
@@ -312,7 +314,7 @@ metadata:
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback_py3(self, mock_env_get, mock_shutil_which):
@@ -324,7 +326,7 @@ metadata:
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path_py3(self, mock_env_get, mock_shutil_which):
@@ -338,7 +340,7 @@ metadata:
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local_py3(self, mock_env_get, mock_shutil_which):
@@ -352,7 +354,7 @@ metadata:
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home_py3(self, mock_env_get, mock_shutil_which):

--- a/roles/lib_openshift/src/test/unit/test_oc_route.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_route.py
@@ -117,9 +117,9 @@ class OCRouteTest(unittest.TestCase):
         results = OCRoute.run_ansible(params, False)
 
         # Assert
-        self.assertFalse(results['changed'])
-        self.assertEqual(results['state'], 'list')
-        self.assertEqual(results['results'][0]['metadata']['name'], 'test')
+        assert not results['changed']
+        assert results['state'] == 'list'
+        assert results['results'][0]['metadata']['name'] == 'test'
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([
@@ -247,9 +247,9 @@ metadata:
         results = OCRoute.run_ansible(params, False)
 
         # Assert
-        self.assertTrue(results['changed'])
-        self.assertEqual(results['state'], 'present')
-        self.assertEqual(results['results']['results'][0]['metadata']['name'], 'test')
+        assert results['changed']
+        assert results['state'] == 'present'
+        assert results['results']['results'][0]['metadata']['name'] == 'test'
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([
@@ -268,7 +268,7 @@ metadata:
 
         mock_path_exists.side_effect = lambda _: False
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -282,7 +282,7 @@ metadata:
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -296,7 +296,7 @@ metadata:
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -310,7 +310,7 @@ metadata:
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -322,7 +322,7 @@ metadata:
 
         mock_shutil_which.side_effect = lambda _f, path=None: None
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -336,7 +336,7 @@ metadata:
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -350,7 +350,7 @@ metadata:
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -364,4 +364,4 @@ metadata:
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin

--- a/roles/lib_openshift/src/test/unit/test_oc_scale.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_scale.py
@@ -8,6 +8,8 @@ import sys
 import unittest
 import mock
 
+import pytest
+
 # Removing invalid variable names for tests so that I can
 # keep them brief
 # pylint: disable=invalid-name,no-name-in-module
@@ -147,7 +149,7 @@ class OCScaleTest(unittest.TestCase):
         assert results['failed']
         assert results['msg']['returncode'] == 1
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback(self, mock_env_get, mock_path_exists):
@@ -159,7 +161,7 @@ class OCScaleTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path(self, mock_env_get, mock_path_exists):
@@ -173,7 +175,7 @@ class OCScaleTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local(self, mock_env_get, mock_path_exists):
@@ -187,7 +189,7 @@ class OCScaleTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home(self, mock_env_get, mock_path_exists):
@@ -201,7 +203,7 @@ class OCScaleTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback_py3(self, mock_env_get, mock_shutil_which):
@@ -213,7 +215,7 @@ class OCScaleTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path_py3(self, mock_env_get, mock_shutil_which):
@@ -227,7 +229,7 @@ class OCScaleTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local_py3(self, mock_env_get, mock_shutil_which):
@@ -241,7 +243,7 @@ class OCScaleTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home_py3(self, mock_env_get, mock_shutil_which):

--- a/roles/lib_openshift/src/test/unit/test_oc_scale.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_scale.py
@@ -66,8 +66,8 @@ class OCScaleTest(unittest.TestCase):
 
         results = OCScale.run_ansible(params, False)
 
-        self.assertFalse(results['changed'])
-        self.assertEqual(results['result'][0], 2)
+        assert not results['changed']
+        assert results['result'][0] == 2
 
     @mock.patch('oc_scale.Utils.create_tmpfile_copy')
     @mock.patch('oc_scale.OCScale.openshift_cmd')
@@ -115,8 +115,8 @@ class OCScaleTest(unittest.TestCase):
 
         results = OCScale.run_ansible(params, False)
 
-        self.assertFalse(results['changed'])
-        self.assertEqual(results['result'][0], 3)
+        assert not results['changed']
+        assert results['result'][0] == 3
 
     @mock.patch('oc_scale.Utils.create_tmpfile_copy')
     @mock.patch('oc_scale.OCScale.openshift_cmd')
@@ -144,8 +144,8 @@ class OCScaleTest(unittest.TestCase):
 
         results = OCScale.run_ansible(params, False)
 
-        self.assertTrue(results['failed'])
-        self.assertEqual(results['msg']['returncode'], 1)
+        assert results['failed']
+        assert results['msg']['returncode'] == 1
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -157,7 +157,7 @@ class OCScaleTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda _: False
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -171,7 +171,7 @@ class OCScaleTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -185,7 +185,7 @@ class OCScaleTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -199,7 +199,7 @@ class OCScaleTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -211,7 +211,7 @@ class OCScaleTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: None
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -225,7 +225,7 @@ class OCScaleTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -239,7 +239,7 @@ class OCScaleTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -253,4 +253,4 @@ class OCScaleTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin

--- a/roles/lib_openshift/src/test/unit/test_oc_secret.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_secret.py
@@ -8,6 +8,8 @@ import sys
 import unittest
 import mock
 
+import pytest
+
 # Removing invalid variable names for tests so that I can
 # keep them brief
 # pylint: disable=invalid-name,no-name-in-module
@@ -83,7 +85,7 @@ class OCSecretTest(unittest.TestCase):
             mock.call(mock.ANY, "{'one': 1, 'two': 2, 'three': 3}"),
         ])
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback(self, mock_env_get, mock_path_exists):
@@ -95,7 +97,7 @@ class OCSecretTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path(self, mock_env_get, mock_path_exists):
@@ -109,7 +111,7 @@ class OCSecretTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local(self, mock_env_get, mock_path_exists):
@@ -123,7 +125,7 @@ class OCSecretTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home(self, mock_env_get, mock_path_exists):
@@ -137,7 +139,7 @@ class OCSecretTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback_py3(self, mock_env_get, mock_shutil_which):
@@ -149,7 +151,7 @@ class OCSecretTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path_py3(self, mock_env_get, mock_shutil_which):
@@ -163,7 +165,7 @@ class OCSecretTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local_py3(self, mock_env_get, mock_shutil_which):
@@ -177,7 +179,7 @@ class OCSecretTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home_py3(self, mock_env_get, mock_shutil_which):

--- a/roles/lib_openshift/src/test/unit/test_oc_secret.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_secret.py
@@ -69,9 +69,9 @@ class OCSecretTest(unittest.TestCase):
         results = OCSecret.run_ansible(params, False)
 
         # Assert
-        self.assertTrue(results['changed'])
-        self.assertEqual(results['results']['returncode'], 0)
-        self.assertEqual(results['state'], 'present')
+        assert results['changed']
+        assert results['results']['returncode'] == 0
+        assert results['state'] == 'present'
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([
@@ -93,7 +93,7 @@ class OCSecretTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda _: False
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -107,7 +107,7 @@ class OCSecretTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -121,7 +121,7 @@ class OCSecretTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -135,7 +135,7 @@ class OCSecretTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -147,7 +147,7 @@ class OCSecretTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: None
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -161,7 +161,7 @@ class OCSecretTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -175,7 +175,7 @@ class OCSecretTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -189,4 +189,4 @@ class OCSecretTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin

--- a/roles/lib_openshift/src/test/unit/test_oc_service.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_service.py
@@ -105,8 +105,8 @@ class OCServiceTest(unittest.TestCase):
 
         results = OCService.run_ansible(params, False)
 
-        self.assertFalse(results['changed'])
-        self.assertEqual(results['results']['results'][0]['metadata']['name'], 'router')
+        assert not results['changed']
+        assert results['results']['results'][0]['metadata']['name'] == 'router'
 
     @mock.patch('oc_service.Utils.create_tmpfile_copy')
     @mock.patch('oc_service.OCService._run')
@@ -194,9 +194,9 @@ class OCServiceTest(unittest.TestCase):
 
         results = OCService.run_ansible(params, False)
 
-        self.assertTrue(results['changed'])
-        self.assertTrue(results['results']['returncode'] == 0)
-        self.assertEqual(results['results']['results'][0]['metadata']['name'], 'router')
+        assert results['changed']
+        assert results['results']['returncode'] == 0
+        assert results['results']['results'][0]['metadata']['name'] == 'router'
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -208,7 +208,7 @@ class OCServiceTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda _: False
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -222,7 +222,7 @@ class OCServiceTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -236,7 +236,7 @@ class OCServiceTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -250,7 +250,7 @@ class OCServiceTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -262,7 +262,7 @@ class OCServiceTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: None
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -276,7 +276,7 @@ class OCServiceTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -290,7 +290,7 @@ class OCServiceTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -304,7 +304,7 @@ class OCServiceTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @mock.patch('oc_service.Utils.create_tmpfile_copy')
     @mock.patch('oc_service.OCService._run')
@@ -390,10 +390,10 @@ class OCServiceTest(unittest.TestCase):
 
         results = OCService.run_ansible(params, False)
 
-        self.assertTrue(results['changed'])
-        self.assertTrue(results['results']['returncode'] == 0)
-        self.assertEqual(results['results']['results'][0]['metadata']['name'], 'router')
-        self.assertEqual(results['results']['results'][0]['metadata']['labels'], {"component": "some_component", "infra": "true"})
+        assert results['changed']
+        assert results['results']['returncode'] == 0
+        assert results['results']['results'][0]['metadata']['name'] == 'router'
+        assert results['results']['results'][0]['metadata']['labels'] == {"component": "some_component", "infra": "true"}
 
     @mock.patch('oc_service.Utils.create_tmpfile_copy')
     @mock.patch('oc_service.OCService._run')
@@ -480,8 +480,8 @@ class OCServiceTest(unittest.TestCase):
 
         results = OCService.run_ansible(params, False)
 
-        self.assertTrue(results['changed'])
-        self.assertTrue(results['results']['returncode'] == 0)
-        self.assertEqual(results['results']['results'][0]['metadata']['name'], 'router')
-        self.assertEqual(results['results']['results'][0]['metadata']['labels'], {"component": "some_component", "infra": "true"})
-        self.assertEqual(results['results']['results'][0]['spec']['externalIPs'], ["1.2.3.4", "5.6.7.8"])
+        assert results['changed']
+        assert results['results']['returncode'] == 0
+        assert results['results']['results'][0]['metadata']['name'] == 'router'
+        assert results['results']['results'][0]['metadata']['labels'] == {"component": "some_component", "infra": "true"}
+        assert results['results']['results'][0]['spec']['externalIPs'] == ["1.2.3.4", "5.6.7.8"]

--- a/roles/lib_openshift/src/test/unit/test_oc_service.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_service.py
@@ -8,6 +8,8 @@ import sys
 import unittest
 import mock
 
+import pytest
+
 # Removing invalid variable names for tests so that I can
 # keep them brief
 # pylint: disable=invalid-name,no-name-in-module
@@ -198,7 +200,7 @@ class OCServiceTest(unittest.TestCase):
         assert results['results']['returncode'] == 0
         assert results['results']['results'][0]['metadata']['name'] == 'router'
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback(self, mock_env_get, mock_path_exists):
@@ -210,7 +212,7 @@ class OCServiceTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path(self, mock_env_get, mock_path_exists):
@@ -224,7 +226,7 @@ class OCServiceTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local(self, mock_env_get, mock_path_exists):
@@ -238,7 +240,7 @@ class OCServiceTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home(self, mock_env_get, mock_path_exists):
@@ -252,7 +254,7 @@ class OCServiceTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback_py3(self, mock_env_get, mock_shutil_which):
@@ -264,7 +266,7 @@ class OCServiceTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path_py3(self, mock_env_get, mock_shutil_which):
@@ -278,7 +280,7 @@ class OCServiceTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local_py3(self, mock_env_get, mock_shutil_which):
@@ -292,7 +294,7 @@ class OCServiceTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home_py3(self, mock_env_get, mock_shutil_which):

--- a/roles/lib_openshift/src/test/unit/test_oc_serviceaccount.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_serviceaccount.py
@@ -93,9 +93,9 @@ class OCServiceAccountTest(unittest.TestCase):
         results = OCServiceAccount.run_ansible(params, False)
 
         # Assert
-        self.assertTrue(results['changed'])
-        self.assertEqual(results['results']['returncode'], 0)
-        self.assertEqual(results['state'], 'present')
+        assert results['changed']
+        assert results['results']['returncode'] == 0
+        assert results['state'] == 'present'
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([
@@ -114,7 +114,7 @@ class OCServiceAccountTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda _: False
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -128,7 +128,7 @@ class OCServiceAccountTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -142,7 +142,7 @@ class OCServiceAccountTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -156,7 +156,7 @@ class OCServiceAccountTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -168,7 +168,7 @@ class OCServiceAccountTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: None
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -182,7 +182,7 @@ class OCServiceAccountTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -196,7 +196,7 @@ class OCServiceAccountTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -210,4 +210,4 @@ class OCServiceAccountTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin

--- a/roles/lib_openshift/src/test/unit/test_oc_serviceaccount.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_serviceaccount.py
@@ -8,6 +8,8 @@ import sys
 import unittest
 import mock
 
+import pytest
+
 # Removing invalid variable names for tests so that I can
 # keep them brief
 # pylint: disable=invalid-name,no-name-in-module
@@ -104,7 +106,7 @@ class OCServiceAccountTest(unittest.TestCase):
             mock.call(['oc', 'get', 'sa', 'testserviceaccountname', '-o', 'json', '-n', 'default'], None),
         ])
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback(self, mock_env_get, mock_path_exists):
@@ -116,7 +118,7 @@ class OCServiceAccountTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path(self, mock_env_get, mock_path_exists):
@@ -130,7 +132,7 @@ class OCServiceAccountTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local(self, mock_env_get, mock_path_exists):
@@ -144,7 +146,7 @@ class OCServiceAccountTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home(self, mock_env_get, mock_path_exists):
@@ -158,7 +160,7 @@ class OCServiceAccountTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback_py3(self, mock_env_get, mock_shutil_which):
@@ -170,7 +172,7 @@ class OCServiceAccountTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path_py3(self, mock_env_get, mock_shutil_which):
@@ -184,7 +186,7 @@ class OCServiceAccountTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local_py3(self, mock_env_get, mock_shutil_which):
@@ -198,7 +200,7 @@ class OCServiceAccountTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home_py3(self, mock_env_get, mock_shutil_which):

--- a/roles/lib_openshift/src/test/unit/test_oc_serviceaccount_secret.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_serviceaccount_secret.py
@@ -8,6 +8,8 @@ import sys
 import unittest
 import mock
 
+import pytest
+
 # Removing invalid variable names for tests so that I can
 # keep them brief
 # pylint: disable=invalid-name,no-name-in-module
@@ -305,7 +307,7 @@ secrets:
             mock.call(mock.ANY, yaml_file)
         ])
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback(self, mock_env_get, mock_path_exists):
@@ -317,7 +319,7 @@ secrets:
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path(self, mock_env_get, mock_path_exists):
@@ -331,7 +333,7 @@ secrets:
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local(self, mock_env_get, mock_path_exists):
@@ -345,7 +347,7 @@ secrets:
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home(self, mock_env_get, mock_path_exists):
@@ -359,7 +361,7 @@ secrets:
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback_py3(self, mock_env_get, mock_shutil_which):
@@ -371,7 +373,7 @@ secrets:
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path_py3(self, mock_env_get, mock_shutil_which):
@@ -385,7 +387,7 @@ secrets:
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local_py3(self, mock_env_get, mock_shutil_which):
@@ -399,7 +401,7 @@ secrets:
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home_py3(self, mock_env_get, mock_shutil_which):

--- a/roles/lib_openshift/src/test/unit/test_oc_serviceaccount_secret.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_serviceaccount_secret.py
@@ -163,9 +163,9 @@ secrets:
         results = OCServiceAccountSecret.run_ansible(params, False)
 
         # Assert
-        self.assertTrue(results['changed'])
-        self.assertEqual(results['results']['returncode'], 0)
-        self.assertEqual(results['state'], 'present')
+        assert results['changed']
+        assert results['results']['returncode'] == 0
+        assert results['state'] == 'present'
 
         # Making sure our mocks were called as we expected
         mock_cmd.assert_has_calls([
@@ -286,9 +286,9 @@ secrets:
         results = OCServiceAccountSecret.run_ansible(params, False)
 
         # Assert
-        self.assertTrue(results['changed'])
-        self.assertEqual(results['results']['returncode'], 0)
-        self.assertEqual(results['state'], 'absent')
+        assert results['changed']
+        assert results['results']['returncode'] == 0
+        assert results['state'] == 'absent'
 
         # Making sure our mocks were called as we expected
         mock_cmd.assert_has_calls([
@@ -315,7 +315,7 @@ secrets:
 
         mock_path_exists.side_effect = lambda _: False
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -329,7 +329,7 @@ secrets:
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -343,7 +343,7 @@ secrets:
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -357,7 +357,7 @@ secrets:
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -369,7 +369,7 @@ secrets:
 
         mock_shutil_which.side_effect = lambda _f, path=None: None
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -383,7 +383,7 @@ secrets:
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -397,7 +397,7 @@ secrets:
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -411,4 +411,4 @@ secrets:
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin

--- a/roles/lib_openshift/src/test/unit/test_oc_version.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_version.py
@@ -48,10 +48,10 @@ class OCVersionTest(unittest.TestCase):
 
         results = OCVersion.run_ansible(params)
 
-        self.assertFalse(results['changed'])
-        self.assertEqual(results['results']['oc_short'], '3.4')
-        self.assertEqual(results['results']['oc_numeric'], '3.4.0.39')
-        self.assertEqual(results['results']['kubernetes_numeric'], '1.4.0')
+        assert not results['changed']
+        assert results['results']['oc_short'] == '3.4'
+        assert results['results']['oc_numeric'] == '3.4.0.39'
+        assert results['results']['kubernetes_numeric'] == '1.4.0'
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -63,7 +63,7 @@ class OCVersionTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda _: False
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -77,7 +77,7 @@ class OCVersionTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -91,7 +91,7 @@ class OCVersionTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')
@@ -105,7 +105,7 @@ class OCVersionTest(unittest.TestCase):
 
         mock_path_exists.side_effect = lambda f: f == oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -117,7 +117,7 @@ class OCVersionTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: None
 
-        self.assertEqual(locate_oc_binary(), 'oc')
+        assert locate_oc_binary() == 'oc'
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -131,7 +131,7 @@ class OCVersionTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -145,7 +145,7 @@ class OCVersionTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin
 
     @unittest.skipIf(six.PY2, 'py3 test only')
     @mock.patch('shutil.which')
@@ -159,4 +159,4 @@ class OCVersionTest(unittest.TestCase):
 
         mock_shutil_which.side_effect = lambda _f, path=None: oc_bin
 
-        self.assertEqual(locate_oc_binary(), oc_bin)
+        assert locate_oc_binary() == oc_bin

--- a/roles/lib_openshift/src/test/unit/test_oc_version.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_version.py
@@ -8,6 +8,8 @@ import sys
 import unittest
 import mock
 
+import pytest
+
 # Removing invalid variable names for tests so that I can
 # keep them brief
 # pylint: disable=invalid-name,no-name-in-module
@@ -53,7 +55,7 @@ class OCVersionTest(unittest.TestCase):
         assert results['results']['oc_numeric'] == '3.4.0.39'
         assert results['results']['kubernetes_numeric'] == '1.4.0'
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback(self, mock_env_get, mock_path_exists):
@@ -65,7 +67,7 @@ class OCVersionTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path(self, mock_env_get, mock_path_exists):
@@ -79,7 +81,7 @@ class OCVersionTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local(self, mock_env_get, mock_path_exists):
@@ -93,7 +95,7 @@ class OCVersionTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY3, 'py2 test only')
+    @pytest.mark.skipif(six.PY3, reason='py2 test only')
     @mock.patch('os.path.exists')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home(self, mock_env_get, mock_path_exists):
@@ -107,7 +109,7 @@ class OCVersionTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_fallback_py3(self, mock_env_get, mock_shutil_which):
@@ -119,7 +121,7 @@ class OCVersionTest(unittest.TestCase):
 
         assert locate_oc_binary() == 'oc'
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_path_py3(self, mock_env_get, mock_shutil_which):
@@ -133,7 +135,7 @@ class OCVersionTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_usr_local_py3(self, mock_env_get, mock_shutil_which):
@@ -147,7 +149,7 @@ class OCVersionTest(unittest.TestCase):
 
         assert locate_oc_binary() == oc_bin
 
-    @unittest.skipIf(six.PY2, 'py3 test only')
+    @pytest.mark.skipif(six.PY2, reason='py3 test only')
     @mock.patch('shutil.which')
     @mock.patch('os.environ.get')
     def test_binary_lookup_in_home_py3(self, mock_env_get, mock_shutil_which):

--- a/roles/lib_utils/src/test/unit/test_repoquery.py
+++ b/roles/lib_utils/src/test/unit/test_repoquery.py
@@ -52,15 +52,17 @@ class RepoQueryTest(unittest.TestCase):
         results = Repoquery.run_ansible(params, False)
 
         # Assert
-        self.assertEqual(results['state'], 'list')
-        self.assertFalse(results['changed'])
-        self.assertTrue(results['results']['package_found'])
-        self.assertEqual(results['results']['returncode'], 0)
-        self.assertEqual(results['results']['package_name'], 'bash')
-        self.assertEqual(results['results']['versions'], {'latest_full': '4.2.46-21.el7_3',
-                                                          'available_versions': ['4.2.46'],
-                                                          'available_versions_full': ['4.2.46-21.el7_3'],
-                                                          'latest': '4.2.46'})
+        assert results['state'] == 'list'
+        assert not results['changed']
+        assert results['results']['package_found']
+        assert results['results']['returncode'] == 0
+        assert results['results']['package_name'] == 'bash'
+        assert results['results']['versions'] == {
+            'latest_full': '4.2.46-21.el7_3',
+            'available_versions': ['4.2.46'],
+            'available_versions_full': ['4.2.46-21.el7_3'],
+            'latest': '4.2.46'
+        }
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([

--- a/roles/lib_utils/src/test/unit/test_yedit.py
+++ b/roles/lib_utils/src/test/unit/test_yedit.py
@@ -41,15 +41,15 @@ class YeditTest(unittest.TestCase):
     def test_load(self):
         ''' Testing a get '''
         yed = Yedit('yedit_test.yml')
-        self.assertEqual(yed.yaml_dict, self.data)
+        assert yed.yaml_dict == self.data
 
     def test_write(self):
         ''' Testing a simple write '''
         yed = Yedit('yedit_test.yml')
         yed.put('key1', 1)
         yed.write()
-        self.assertTrue('key1' in yed.yaml_dict)
-        self.assertEqual(yed.yaml_dict['key1'], 1)
+        assert 'key1' in yed.yaml_dict
+        assert yed.yaml_dict['key1'] == 1
 
     def test_write_x_y_z(self):
         '''Testing a write of multilayer key'''
@@ -57,7 +57,7 @@ class YeditTest(unittest.TestCase):
         yed.put('x.y.z', 'modified')
         yed.write()
         yed.load()
-        self.assertEqual(yed.get('x.y.z'), 'modified')
+        assert yed.get('x.y.z') == 'modified'
 
     def test_delete_a(self):
         '''Testing a simple delete '''
@@ -65,7 +65,7 @@ class YeditTest(unittest.TestCase):
         yed.delete('a')
         yed.write()
         yed.load()
-        self.assertTrue('a' not in yed.yaml_dict)
+        assert 'a' not in yed.yaml_dict
 
     def test_delete_b_c(self):
         '''Testing delete of layered key '''
@@ -73,8 +73,8 @@ class YeditTest(unittest.TestCase):
         yed.delete('b:c')
         yed.write()
         yed.load()
-        self.assertTrue('b' in yed.yaml_dict)
-        self.assertFalse('c' in yed.yaml_dict['b'])
+        assert 'b' in yed.yaml_dict
+        assert 'c' not in yed.yaml_dict['b']
 
     def test_create(self):
         '''Testing a create '''
@@ -83,8 +83,8 @@ class YeditTest(unittest.TestCase):
         yed.create('foo', 'bar')
         yed.write()
         yed.load()
-        self.assertTrue('foo' in yed.yaml_dict)
-        self.assertTrue(yed.yaml_dict['foo'] == 'bar')
+        assert 'foo' in yed.yaml_dict
+        assert yed.yaml_dict['foo'] == 'bar'
 
     def test_create_content(self):
         '''Testing a create with content '''
@@ -92,99 +92,99 @@ class YeditTest(unittest.TestCase):
         yed = Yedit("yedit_test.yml", content)
         yed.write()
         yed.load()
-        self.assertTrue('foo' in yed.yaml_dict)
-        self.assertTrue(yed.yaml_dict['foo'], 'bar')
+        assert 'foo' in yed.yaml_dict
+        assert yed.yaml_dict['foo'], 'bar'
 
     def test_array_insert(self):
         '''Testing a create with content '''
         yed = Yedit("yedit_test.yml", separator=':')
         yed.put('b:c:d[0]', 'inject')
-        self.assertTrue(yed.get('b:c:d[0]') == 'inject')
+        assert yed.get('b:c:d[0]') == 'inject'
 
     def test_array_insert_first_index(self):
         '''Testing a create with content '''
         yed = Yedit("yedit_test.yml", separator=':')
         yed.put('b:c:d[0]', 'inject')
-        self.assertTrue(yed.get('b:c:d[1]') == 'f')
+        assert yed.get('b:c:d[1]') == 'f'
 
     def test_array_insert_second_index(self):
         '''Testing a create with content '''
         yed = Yedit("yedit_test.yml", separator=':')
         yed.put('b:c:d[0]', 'inject')
-        self.assertTrue(yed.get('b:c:d[2]') == 'g')
+        assert yed.get('b:c:d[2]') == 'g'
 
     def test_dict_array_dict_access(self):
         '''Testing a create with content'''
         yed = Yedit("yedit_test.yml", separator=':')
         yed.put('b:c:d[0]', [{'x': {'y': 'inject'}}])
-        self.assertTrue(yed.get('b:c:d[0]:[0]:x:y') == 'inject')
+        assert yed.get('b:c:d[0]:[0]:x:y') == 'inject'
 
     def test_dict_array_dict_replace(self):
         '''Testing multilevel delete'''
         yed = Yedit("yedit_test.yml", separator=':')
         yed.put('b:c:d[0]', [{'x': {'y': 'inject'}}])
         yed.put('b:c:d[0]:[0]:x:y', 'testing')
-        self.assertTrue('b' in yed.yaml_dict)
-        self.assertTrue('c' in yed.yaml_dict['b'])
-        self.assertTrue('d' in yed.yaml_dict['b']['c'])
-        self.assertTrue(isinstance(yed.yaml_dict['b']['c']['d'], list))
-        self.assertTrue(isinstance(yed.yaml_dict['b']['c']['d'][0], list))
-        self.assertTrue(isinstance(yed.yaml_dict['b']['c']['d'][0][0], dict))
-        self.assertTrue('y' in yed.yaml_dict['b']['c']['d'][0][0]['x'])
-        self.assertTrue(yed.yaml_dict['b']['c']['d'][0][0]['x']['y'] == 'testing')  # noqa: E501
+        assert 'b' in yed.yaml_dict
+        assert 'c' in yed.yaml_dict['b']
+        assert 'd' in yed.yaml_dict['b']['c']
+        assert isinstance(yed.yaml_dict['b']['c']['d'], list)
+        assert isinstance(yed.yaml_dict['b']['c']['d'][0], list)
+        assert isinstance(yed.yaml_dict['b']['c']['d'][0][0], dict)
+        assert 'y' in yed.yaml_dict['b']['c']['d'][0][0]['x']
+        assert yed.yaml_dict['b']['c']['d'][0][0]['x']['y'] == 'testing'
 
     def test_dict_array_dict_remove(self):
         '''Testing multilevel delete'''
         yed = Yedit("yedit_test.yml", separator=':')
         yed.put('b:c:d[0]', [{'x': {'y': 'inject'}}])
         yed.delete('b:c:d[0]:[0]:x:y')
-        self.assertTrue('b' in yed.yaml_dict)
-        self.assertTrue('c' in yed.yaml_dict['b'])
-        self.assertTrue('d' in yed.yaml_dict['b']['c'])
-        self.assertTrue(isinstance(yed.yaml_dict['b']['c']['d'], list))
-        self.assertTrue(isinstance(yed.yaml_dict['b']['c']['d'][0], list))
-        self.assertTrue(isinstance(yed.yaml_dict['b']['c']['d'][0][0], dict))
-        self.assertFalse('y' in yed.yaml_dict['b']['c']['d'][0][0]['x'])
+        assert 'b' in yed.yaml_dict
+        assert 'c' in yed.yaml_dict['b']
+        assert 'd' in yed.yaml_dict['b']['c']
+        assert isinstance(yed.yaml_dict['b']['c']['d'], list)
+        assert isinstance(yed.yaml_dict['b']['c']['d'][0], list)
+        assert isinstance(yed.yaml_dict['b']['c']['d'][0][0], dict)
+        assert 'y' not in yed.yaml_dict['b']['c']['d'][0][0]['x']
 
     def test_key_exists_in_dict(self):
         '''Testing exist in dict'''
         yed = Yedit("yedit_test.yml", separator=':')
         yed.put('b:c:d[0]', [{'x': {'y': 'inject'}}])
-        self.assertTrue(yed.exists('b:c', 'd'))
+        assert yed.exists('b:c', 'd')
 
     def test_key_exists_in_list(self):
         '''Testing exist in list'''
         yed = Yedit("yedit_test.yml", separator=':')
         yed.put('b:c:d[0]', [{'x': {'y': 'inject'}}])
-        self.assertTrue(yed.exists('b:c:d', [{'x': {'y': 'inject'}}]))
-        self.assertFalse(yed.exists('b:c:d', [{'x': {'y': 'test'}}]))
+        assert yed.exists('b:c:d', [{'x': {'y': 'inject'}}])
+        assert not yed.exists('b:c:d', [{'x': {'y': 'test'}}])
 
     def test_update_to_list_with_index(self):
         '''Testing update to list with index'''
         yed = Yedit("yedit_test.yml", separator=':')
         yed.put('x:y:z', [1, 2, 3])
         yed.update('x:y:z', [5, 6], index=2)
-        self.assertTrue(yed.get('x:y:z') == [1, 2, [5, 6]])
-        self.assertTrue(yed.exists('x:y:z', [5, 6]))
-        self.assertFalse(yed.exists('x:y:z', 4))
+        assert yed.get('x:y:z') == [1, 2, [5, 6]]
+        assert yed.exists('x:y:z', [5, 6])
+        assert not yed.exists('x:y:z', 4)
 
     def test_update_to_list_with_curr_value(self):
         '''Testing update to list with index'''
         yed = Yedit("yedit_test.yml", separator=':')
         yed.put('x:y:z', [1, 2, 3])
         yed.update('x:y:z', [5, 6], curr_value=3)
-        self.assertTrue(yed.get('x:y:z') == [1, 2, [5, 6]])
-        self.assertTrue(yed.exists('x:y:z', [5, 6]))
-        self.assertFalse(yed.exists('x:y:z', 4))
+        assert yed.get('x:y:z') == [1, 2, [5, 6]]
+        assert yed.exists('x:y:z', [5, 6])
+        assert not yed.exists('x:y:z', 4)
 
     def test_update_to_list(self):
         '''Testing update to list'''
         yed = Yedit("yedit_test.yml", separator=':')
         yed.put('x:y:z', [1, 2, 3])
         yed.update('x:y:z', [5, 6])
-        self.assertTrue(yed.get('x:y:z') == [1, 2, 3, [5, 6]])
-        self.assertTrue(yed.exists('x:y:z', [5, 6]))
-        self.assertFalse(yed.exists('x:y:z', 4))
+        assert yed.get('x:y:z') == [1, 2, 3, [5, 6]]
+        assert yed.exists('x:y:z', [5, 6])
+        assert not yed.exists('x:y:z', 4)
 
     def test_append_twice_to_list(self):
         '''Testing append to list'''
@@ -192,59 +192,59 @@ class YeditTest(unittest.TestCase):
         yed.put('x:y:z', [1, 2, 3])
         yed.append('x:y:z', [5, 6])
         yed.append('x:y:z', [5, 6])
-        self.assertTrue(yed.get('x:y:z') == [1, 2, 3, [5, 6], [5, 6]])
-        self.assertFalse(yed.exists('x:y:z', 4))
+        assert yed.get('x:y:z') == [1, 2, 3, [5, 6], [5, 6]]
+        assert not yed.exists('x:y:z', 4)
 
     def test_add_item_to_dict(self):
         '''Testing update to dict'''
         yed = Yedit("yedit_test.yml", separator=':')
         yed.put('x:y:z', {'a': 1, 'b': 2})
         yed.update('x:y:z', {'c': 3, 'd': 4})
-        self.assertTrue(yed.get('x:y:z') == {'a': 1, 'b': 2, 'c': 3, 'd': 4})
-        self.assertTrue(yed.exists('x:y:z', {'c': 3}))
+        assert yed.get('x:y:z') == {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+        assert yed.exists('x:y:z', {'c': 3})
 
     def test_first_level_dict_with_none_value(self):
         '''test dict value with none value'''
         yed = Yedit(content={'a': None}, separator=":")
         yed.put('a:b:c', 'test')
-        self.assertTrue(yed.get('a:b:c') == 'test')
-        self.assertTrue(yed.get('a:b'), {'c': 'test'})
+        assert yed.get('a:b:c') == 'test'
+        assert yed.get('a:b'), {'c': 'test'}
 
     def test_adding_yaml_variable(self):
         '''test dict value with none value'''
         yed = Yedit("yedit_test.yml", separator=':')
         yed.put('z:y', '{{test}}')
-        self.assertTrue(yed.get('z:y') == '{{test}}')
+        assert yed.get('z:y') == '{{test}}'
 
     def test_keys_with_underscore(self):
         '''test dict value with none value'''
         yed = Yedit("yedit_test.yml", separator=':')
         yed.put('z_:y_y', {'test': '{{test}}'})
-        self.assertTrue(yed.get('z_:y_y') == {'test': '{{test}}'})
+        assert yed.get('z_:y_y') == {'test': '{{test}}'}
 
     def test_first_level_array_update(self):
         '''test update on top level array'''
         yed = Yedit(content=[{'a': 1}, {'b': 2}, {'b': 3}], separator=':')
         yed.update('', {'c': 4})
-        self.assertTrue({'c': 4} in yed.get(''))
+        assert {'c': 4} in yed.get('')
 
     def test_first_level_array_delete(self):
         '''test remove top level key'''
         yed = Yedit(content=[{'a': 1}, {'b': 2}, {'b': 3}])
         yed.delete('')
-        self.assertTrue({'b': 3} not in yed.get(''))
+        assert {'b': 3} not in yed.get('')
 
     def test_first_level_array_get(self):
         '''test dict value with none value'''
         yed = Yedit(content=[{'a': 1}, {'b': 2}, {'b': 3}])
         yed.get('')
-        self.assertTrue([{'a': 1}, {'b': 2}, {'b': 3}] == yed.yaml_dict)
+        assert [{'a': 1}, {'b': 2}, {'b': 3}] == yed.yaml_dict
 
     def test_pop_list_item(self):
         '''test dict value with none value'''
         yed = Yedit(content=[{'a': 1}, {'b': 2}, {'b': 3}], separator=':')
         yed.pop('', {'b': 2})
-        self.assertTrue([{'a': 1}, {'b': 3}] == yed.yaml_dict)
+        assert [{'a': 1}, {'b': 3}] == yed.yaml_dict
 
     def test_pop_list_item_2(self):
         '''test dict value with none value'''
@@ -252,13 +252,13 @@ class YeditTest(unittest.TestCase):
         yed = Yedit(content=z, separator=':')
         yed.pop('', 5)
         z.pop(5)
-        self.assertTrue(z == yed.yaml_dict)
+        assert z == yed.yaml_dict
 
     def test_pop_dict_key(self):
         '''test dict value with none value'''
         yed = Yedit(content={'a': {'b': {'c': 1, 'd': 2}}}, separator='#')
         yed.pop('a#b', 'c')
-        self.assertTrue({'a': {'b': {'d': 2}}} == yed.yaml_dict)
+        assert {'a': {'b': {'d': 2}}} == yed.yaml_dict
 
     def test_accessing_path_with_unexpected_objects(self):
         '''test providing source path objects that differ from current object state'''

--- a/roles/lib_utils/src/test/unit/test_yedit.py
+++ b/roles/lib_utils/src/test/unit/test_yedit.py
@@ -7,6 +7,8 @@ import sys
 import unittest
 import mock
 
+import pytest
+
 # Removing invalid variable names for tests so that I can
 # keep them brief
 # pylint: disable=invalid-name,no-name-in-module
@@ -263,19 +265,19 @@ class YeditTest(unittest.TestCase):
     def test_accessing_path_with_unexpected_objects(self):
         '''test providing source path objects that differ from current object state'''
         yed = Yedit(content={'a': {'b': {'c': ['d', 'e']}}})
-        with self.assertRaises(YeditException):
+        with pytest.raises(YeditException):
             yed.put('a.b.c.d', 'x')
 
     def test_creating_new_objects_with_embedded_list(self):
         '''test creating new objects with an embedded list in the creation path'''
         yed = Yedit(content={'a': {'b': 12}})
-        with self.assertRaises(YeditException):
+        with pytest.raises(YeditException):
             yed.put('new.stuff[0].here', 'value')
 
     def test_creating_new_objects_with_trailing_list(self):
         '''test creating new object(s) where the final piece is a list'''
         yed = Yedit(content={'a': {'b': 12}})
-        with self.assertRaises(YeditException):
+        with pytest.raises(YeditException):
             yed.put('new.stuff.here[0]', 'item')
 
     def test_empty_key_with_int_value(self):

--- a/test/unit/modify_yaml_tests.py
+++ b/test/unit/modify_yaml_tests.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import unittest
 
 sys.path = [os.path.abspath(os.path.dirname(__file__) + "/../../library/")] + sys.path
 
@@ -11,27 +10,23 @@ sys.path = [os.path.abspath(os.path.dirname(__file__) + "/../../library/")] + sy
 from modify_yaml import set_key  # noqa: E402
 
 
-class ModifyYamlTests(unittest.TestCase):
+def test_simple_nested_value():
+    cfg = {"section": {"a": 1, "b": 2}}
+    changes = set_key(cfg, 'section.c', 3)
+    assert len(changes) == 1
+    assert cfg['section']['c'] == 3
 
-    def test_simple_nested_value(self):
-        cfg = {"section": {"a": 1, "b": 2}}
-        changes = set_key(cfg, 'section.c', 3)
-        self.assertEquals(1, len(changes))
-        self.assertEquals(3, cfg['section']['c'])
 
-    # Tests a previous bug where property would land in section above where it should,
-    # if the destination section did not yet exist:
-    def test_nested_property_in_new_section(self):
-        cfg = {
-            "masterClients": {
-                "externalKubernetesKubeConfig": "",
-                "openshiftLoopbackKubeConfig": "openshift-master.kubeconfig",
-            },
-        }
-
-        yaml_key = 'masterClients.externalKubernetesClientConnectionOverrides.acceptContentTypes'
-        yaml_value = 'application/vnd.kubernetes.protobuf,application/json'
-        set_key(cfg, yaml_key, yaml_value)
-        self.assertEquals(yaml_value, cfg['masterClients']
-                          ['externalKubernetesClientConnectionOverrides']
-                          ['acceptContentTypes'])
+# Tests a previous bug where property would land in section above where it should,
+# if the destination section did not yet exist:
+def test_nested_property_in_new_section():
+    cfg = {
+        "masterClients": {
+            "externalKubernetesKubeConfig": "",
+            "openshiftLoopbackKubeConfig": "openshift-master.kubeconfig",
+        },
+    }
+    yaml_key = 'masterClients.externalKubernetesClientConnectionOverrides.acceptContentTypes'
+    yaml_value = 'application/vnd.kubernetes.protobuf,application/json'
+    set_key(cfg, yaml_key, yaml_value)
+    assert cfg['masterClients']['externalKubernetesClientConnectionOverrides']['acceptContentTypes'] == yaml_value

--- a/utils/test/cli_installer_tests.py
+++ b/utils/test/cli_installer_tests.py
@@ -489,14 +489,11 @@ class UnattendedCliTests(OOCliFixture):
         self.assert_result(result, 0)
 
         load_facts_args = load_facts_mock.call_args[0]
-        self.assertEquals(os.path.join(self.work_dir, "hosts"),
-            load_facts_args[0])
-        self.assertEquals(os.path.join(self.work_dir,
-            "playbooks/byo/openshift_facts.yml"), load_facts_args[1])
+        assert os.path.join(self.work_dir, "hosts") == load_facts_args[0]
+        assert os.path.join(self.work_dir, "playbooks/byo/openshift_facts.yml") == load_facts_args[1]
         env_vars = load_facts_args[2]
-        self.assertEquals(os.path.join(self.work_dir,
-            '.ansible/callback_facts.yaml'),
-            env_vars['OO_INSTALL_CALLBACK_FACTS_YAML'])
+        assert os.path.join(self.work_dir,
+            '.ansible/callback_facts.yaml') == env_vars['OO_INSTALL_CALLBACK_FACTS_YAML']
         assert '/tmp/ansible.log' == env_vars['ANSIBLE_LOG_PATH']
         # If user running test has rpm installed, this might be set to default:
         assert (
@@ -527,10 +524,8 @@ class UnattendedCliTests(OOCliFixture):
         # Check the inventory file looks as we would expect:
         inventory = configparser.ConfigParser(allow_no_value=True)
         inventory.read(os.path.join(self.work_dir, 'hosts'))
-        self.assertEquals('root',
-            inventory.get('OSEv3:vars', 'ansible_ssh_user'))
-        self.assertEquals('openshift-enterprise',
-            inventory.get('OSEv3:vars', 'deployment_type'))
+        assert 'root' == inventory.get('OSEv3:vars', 'ansible_ssh_user')
+        assert 'openshift-enterprise' == inventory.get('OSEv3:vars', 'deployment_type')
 
         # Check the masters:
         assert 1 == len(inventory.items('masters'))
@@ -570,8 +565,7 @@ class UnattendedCliTests(OOCliFixture):
         # Make sure the correct value was passed to ansible:
         inventory = configparser.ConfigParser(allow_no_value=True)
         inventory.read(os.path.join(self.work_dir, 'hosts'))
-        self.assertEquals('openshift-enterprise',
-            inventory.get('OSEv3:vars', 'deployment_type'))
+        assert 'openshift-enterprise' == inventory.get('OSEv3:vars', 'deployment_type')
 
     @patch('ooinstall.openshift_ansible.run_main_playbook')
     @patch('ooinstall.openshift_ansible.load_system_facts')
@@ -598,8 +592,7 @@ class UnattendedCliTests(OOCliFixture):
 
         inventory = configparser.ConfigParser(allow_no_value=True)
         inventory.read(os.path.join(self.work_dir, 'hosts'))
-        self.assertEquals('openshift-enterprise',
-            inventory.get('OSEv3:vars', 'deployment_type'))
+        assert 'openshift-enterprise' == inventory.get('OSEv3:vars', 'deployment_type')
 
     # unattended with bad config file and no installed hosts (without --force)
     @patch('ooinstall.openshift_ansible.run_main_playbook')

--- a/utils/test/cli_installer_tests.py
+++ b/utils/test/cli_installer_tests.py
@@ -507,8 +507,8 @@ class UnattendedCliTests(OOCliFixture):
         # Make sure we ran on the expected masters and nodes:
         hosts = run_playbook_mock.call_args[0][1]
         hosts_to_run_on = run_playbook_mock.call_args[0][2]
-        self.assertEquals(3, len(hosts))
-        self.assertEquals(3, len(hosts_to_run_on))
+        assert 3 == len(hosts)
+        assert 3 == len(hosts_to_run_on)
 
     @patch('ooinstall.openshift_ansible.run_main_playbook')
     @patch('ooinstall.openshift_ansible.load_system_facts')
@@ -533,8 +533,8 @@ class UnattendedCliTests(OOCliFixture):
             inventory.get('OSEv3:vars', 'deployment_type'))
 
         # Check the masters:
-        self.assertEquals(1, len(inventory.items('masters')))
-        self.assertEquals(3, len(inventory.items('nodes')))
+        assert 1 == len(inventory.items('masters'))
+        assert 3 == len(inventory.items('nodes'))
 
         for item in inventory.items('masters'):
             # ansible host lines do NOT parse nicely:
@@ -634,8 +634,8 @@ class UnattendedCliTests(OOCliFixture):
         # Make sure we ran on the expected masters and nodes:
         hosts = run_playbook_mock.call_args[0][1]
         hosts_to_run_on = run_playbook_mock.call_args[0][2]
-        self.assertEquals(6, len(hosts))
-        self.assertEquals(6, len(hosts_to_run_on))
+        assert 6 == len(hosts)
+        assert 6 == len(hosts_to_run_on)
 
     #unattended with two masters, one node, and haproxy
     @patch('ooinstall.openshift_ansible.run_main_playbook')
@@ -704,8 +704,8 @@ class UnattendedCliTests(OOCliFixture):
         # Make sure we ran on the expected masters and nodes:
         hosts = run_playbook_mock.call_args[0][1]
         hosts_to_run_on = run_playbook_mock.call_args[0][2]
-        self.assertEquals(6, len(hosts))
-        self.assertEquals(6, len(hosts_to_run_on))
+        assert 6 == len(hosts)
+        assert 6 == len(hosts_to_run_on)
 
 class AttendedCliTests(OOCliFixture):
 
@@ -871,7 +871,7 @@ class AttendedCliTests(OOCliFixture):
                                              'openshift_schedulable=True')
 
         assert inventory.has_section('etcd')
-        self.assertEquals(3, len(inventory.items('etcd')))
+        assert 3 == len(inventory.items('etcd'))
 
     #interactive multimaster: identical masters and nodes
     @patch('ooinstall.openshift_ansible.run_main_playbook')
@@ -1013,7 +1013,7 @@ class AttendedCliTests(OOCliFixture):
         self._verify_load_facts(load_facts_mock)
 
         # Make sure run playbook wasn't called:
-        self.assertEquals(0, len(run_playbook_mock.mock_calls))
+        assert 0 == len(run_playbook_mock.mock_calls)
 
         written_config = read_yaml(self.config_file)
         self._verify_config_hosts(written_config, 4)

--- a/utils/test/cli_installer_tests.py
+++ b/utils/test/cli_installer_tests.py
@@ -497,10 +497,12 @@ class UnattendedCliTests(OOCliFixture):
         self.assertEquals(os.path.join(self.work_dir,
             '.ansible/callback_facts.yaml'),
             env_vars['OO_INSTALL_CALLBACK_FACTS_YAML'])
-        self.assertEqual('/tmp/ansible.log', env_vars['ANSIBLE_LOG_PATH'])
+        assert '/tmp/ansible.log' == env_vars['ANSIBLE_LOG_PATH']
         # If user running test has rpm installed, this might be set to default:
-        self.assertTrue('ANSIBLE_CONFIG' not in env_vars or
-            env_vars['ANSIBLE_CONFIG'] == cli.DEFAULT_ANSIBLE_CONFIG)
+        assert (
+            'ANSIBLE_CONFIG' not in env_vars or
+            env_vars['ANSIBLE_CONFIG'] == cli.DEFAULT_ANSIBLE_CONFIG
+        )
 
         # Make sure we ran on the expected masters and nodes:
         hosts = run_playbook_mock.call_args[0][1]
@@ -560,10 +562,10 @@ class UnattendedCliTests(OOCliFixture):
 
         written_config = read_yaml(config_file)
 
-        self.assertEquals('openshift-enterprise', written_config['variant'])
+        assert 'openshift-enterprise' == written_config['variant']
         # We didn't specify a version so the latest should have been assumed,
         # and written to disk:
-        self.assertEquals('3.3', written_config['variant_version'])
+        assert '3.3' == written_config['variant_version']
 
         # Make sure the correct value was passed to ansible:
         inventory = configparser.ConfigParser(allow_no_value=True)
@@ -589,10 +591,10 @@ class UnattendedCliTests(OOCliFixture):
 
         written_config = read_yaml(config_file)
 
-        self.assertEquals('openshift-enterprise', written_config['variant'])
+        assert 'openshift-enterprise' == written_config['variant']
         # Make sure our older version was preserved:
         # and written to disk:
-        self.assertEquals('3.3', written_config['variant_version'])
+        assert '3.3' == written_config['variant_version']
 
         inventory = configparser.ConfigParser(allow_no_value=True)
         inventory.read(os.path.join(self.work_dir, 'hosts'))
@@ -612,9 +614,8 @@ class UnattendedCliTests(OOCliFixture):
         self.cli_args.extend(["-c", config_file, "install"])
         result = self.runner.invoke(cli.cli, self.cli_args)
 
-        self.assertEquals(1, result.exit_code)
-        self.assertTrue("You must specify either an ip or hostname"
-            in result.output)
+        assert 1 == result.exit_code
+        assert "You must specify either an ip or hostname" in result.output
 
     #unattended with three masters, one node, and haproxy
     @patch('ooinstall.openshift_ansible.run_main_playbook')
@@ -919,7 +920,7 @@ class AttendedCliTests(OOCliFixture):
             full_line = "%s=%s" % (a, b)
             tokens = full_line.split()
             if tokens[0] == host:
-                self.assertTrue(variable in tokens[1:], "Unable to find %s in line: %s" % (variable, full_line))
+                assert variable in tokens[1:], "Unable to find %s in line: %s" % (variable, full_line)
                 return
         self.fail("unable to find host %s in inventory" % host)
 

--- a/utils/test/cli_installer_tests.py
+++ b/utils/test/cli_installer_tests.py
@@ -539,10 +539,10 @@ class UnattendedCliTests(OOCliFixture):
             master_line = item[0]
             if item[1] is not None:
                 master_line = "%s=%s" % (master_line, item[1])
-            self.assertTrue('openshift_ip' in master_line)
-            self.assertTrue('openshift_public_ip' in master_line)
-            self.assertTrue('openshift_hostname' in master_line)
-            self.assertTrue('openshift_public_hostname' in master_line)
+            assert 'openshift_ip' in master_line
+            assert 'openshift_public_ip' in master_line
+            assert 'openshift_hostname' in master_line
+            assert 'openshift_public_hostname' in master_line
 
     @patch('ooinstall.openshift_ansible.run_main_playbook')
     @patch('ooinstall.openshift_ansible.load_system_facts')
@@ -651,7 +651,7 @@ class UnattendedCliTests(OOCliFixture):
 
         # This is an invalid config:
         self.assert_result(result, 1)
-        self.assertTrue("A minimum of 3 masters are required" in result.output)
+        assert "A minimum of 3 masters are required" in result.output
 
     #unattended with three masters, one node, but no load balancer specified:
     @patch('ooinstall.openshift_ansible.run_main_playbook')
@@ -668,7 +668,7 @@ class UnattendedCliTests(OOCliFixture):
 
         # This is not a valid input:
         self.assert_result(result, 1)
-        self.assertTrue('No master load balancer specified in config' in result.output)
+        assert 'No master load balancer specified in config' in result.output
 
     #unattended with three masters, one node, and one of the masters reused as load balancer:
     @patch('ooinstall.openshift_ansible.run_main_playbook')
@@ -778,7 +778,7 @@ class AttendedCliTests(OOCliFixture):
 
         # This is testing the install workflow so we want to make sure we
         # exit with the appropriate hint.
-        self.assertTrue('scaleup' in result.output)
+        assert 'scaleup' in result.output
         self.assert_result(result, 1)
 
 
@@ -869,7 +869,7 @@ class AttendedCliTests(OOCliFixture):
         self.assert_inventory_host_var_unset(inventory, 'nodes', '10.0.0.4',
                                              'openshift_schedulable=True')
 
-        self.assertTrue(inventory.has_section('etcd'))
+        assert inventory.has_section('etcd')
         self.assertEquals(3, len(inventory.items('etcd')))
 
     #interactive multimaster: identical masters and nodes
@@ -932,9 +932,7 @@ class AttendedCliTests(OOCliFixture):
             full_line = "%s=%s" % (a, b)
             tokens = full_line.split()
             if tokens[0] == host:
-                self.assertFalse(("%s=" % variable) in full_line,
-                                 msg='%s host variable was set: %s' %
-                                 (variable, full_line))
+                assert variable + "=" not in full_line
                 return
         self.fail("unable to find host %s in inventory" % host)
 

--- a/utils/test/fixture.py
+++ b/utils/test/fixture.py
@@ -91,11 +91,11 @@ class OOCliFixture(OOInstallFixture):
         """ Check that we ran playbook with expected inputs. """
         hosts = run_playbook_mock.call_args[0][1]
         hosts_to_run_on = run_playbook_mock.call_args[0][2]
-        self.assertEquals(exp_hosts_len, len(hosts))
-        self.assertEquals(exp_hosts_to_run_on_len, len(hosts_to_run_on))
+        assert exp_hosts_len == len(hosts)
+        assert exp_hosts_to_run_on_len == len(hosts_to_run_on)
 
     def _verify_config_hosts(self, written_config, host_count):
-        self.assertEquals(host_count, len(written_config['deployment']['hosts']))
+        assert host_count == len(written_config['deployment']['hosts'])
         for host in written_config['deployment']['hosts']:
             assert 'hostname' in host
             assert 'public_hostname' in host
@@ -148,8 +148,8 @@ class OOCliFixture(OOInstallFixture):
             # Make sure we ran on the expected masters and nodes:
             hosts = run_playbook_mock.call_args[0][1]
             hosts_to_run_on = run_playbook_mock.call_args[0][2]
-            self.assertEquals(exp_hosts_len, len(hosts))
-            self.assertEquals(exp_hosts_to_run_on_len, len(hosts_to_run_on))
+            assert exp_hosts_len == len(hosts)
+            assert exp_hosts_to_run_on_len == len(hosts_to_run_on)
 
 
 #pylint: disable=too-many-arguments,too-many-branches,too-many-statements

--- a/utils/test/fixture.py
+++ b/utils/test/fixture.py
@@ -85,7 +85,7 @@ class OOCliFixture(OOInstallFixture):
         self.assertEquals(os.path.join(self.work_dir,
                                        '.ansible/callback_facts.yaml'),
                           env_vars['OO_INSTALL_CALLBACK_FACTS_YAML'])
-        self.assertEqual('/tmp/ansible.log', env_vars['ANSIBLE_LOG_PATH'])
+        assert '/tmp/ansible.log' == env_vars['ANSIBLE_LOG_PATH']
 
     def _verify_run_playbook(self, run_playbook_mock, exp_hosts_len, exp_hosts_to_run_on_len):
         """ Check that we ran playbook with expected inputs. """
@@ -139,7 +139,7 @@ class OOCliFixture(OOInstallFixture):
 
         if "If you want to force reinstall" in result.output:
             # verify we exited on seeing installed hosts
-            self.assertEqual(result.exit_code, 1)
+            assert result.exit_code == 1
         else:
             self.assert_result(result, 0)
             self._verify_load_facts(load_facts_mock)

--- a/utils/test/fixture.py
+++ b/utils/test/fixture.py
@@ -97,13 +97,13 @@ class OOCliFixture(OOInstallFixture):
     def _verify_config_hosts(self, written_config, host_count):
         self.assertEquals(host_count, len(written_config['deployment']['hosts']))
         for host in written_config['deployment']['hosts']:
-            self.assertTrue('hostname' in host)
-            self.assertTrue('public_hostname' in host)
+            assert 'hostname' in host
+            assert 'public_hostname' in host
             if 'preconfigured' not in host:
                 if 'roles' in host:
-                    self.assertTrue('node' in host['roles'] or 'storage' in host['roles'])
-                self.assertTrue('ip' in host)
-                self.assertTrue('public_ip' in host)
+                    assert 'node' in host['roles'] or 'storage' in host['roles']
+                assert 'ip' in host
+                assert 'public_ip' in host
 
     #pylint: disable=too-many-arguments
     def _verify_get_hosts_to_run_on(self, mock_facts, load_facts_mock,

--- a/utils/test/fixture.py
+++ b/utils/test/fixture.py
@@ -76,15 +76,10 @@ class OOCliFixture(OOInstallFixture):
     def _verify_load_facts(self, load_facts_mock):
         """ Check that we ran load facts with expected inputs. """
         load_facts_args = load_facts_mock.call_args[0]
-        self.assertEquals(os.path.join(self.work_dir, "hosts"),
-                          load_facts_args[0])
-        self.assertEquals(os.path.join(self.work_dir,
-                                       "playbooks/byo/openshift_facts.yml"),
-                          load_facts_args[1])
+        assert os.path.join(self.work_dir, "hosts") == load_facts_args[0]
+        assert os.path.join(self.work_dir, "playbooks/byo/openshift_facts.yml") == load_facts_args[1]
         env_vars = load_facts_args[2]
-        self.assertEquals(os.path.join(self.work_dir,
-                                       '.ansible/callback_facts.yaml'),
-                          env_vars['OO_INSTALL_CALLBACK_FACTS_YAML'])
+        assert os.path.join(self.work_dir, '.ansible/callback_facts.yaml') == env_vars['OO_INSTALL_CALLBACK_FACTS_YAML']
         assert '/tmp/ansible.log' == env_vars['ANSIBLE_LOG_PATH']
 
     def _verify_run_playbook(self, run_playbook_mock, exp_hosts_len, exp_hosts_to_run_on_len):

--- a/utils/test/oo_config_tests.py
+++ b/utils/test/oo_config_tests.py
@@ -9,6 +9,7 @@ import shutil
 import yaml
 
 from six.moves import cStringIO
+import pytest
 
 from ooinstall.oo_config import OOConfig, Host, OOConfigInvalidHostError
 import ooinstall.openshift_ansible
@@ -216,7 +217,8 @@ class HostTests(OOInstallFixture):
             'public_hostname': 'a.example.com',
             'master': True
         }
-        self.assertRaises(OOConfigInvalidHostError, Host, **yaml_props)
+        with pytest.raises(OOConfigInvalidHostError):
+            Host(**yaml_props)
 
     def test_load_host_no_master_or_node_specified(self):
         yaml_props = {
@@ -225,7 +227,8 @@ class HostTests(OOInstallFixture):
             'public_ip': '192.168.0.1',
             'public_hostname': 'a.example.com',
         }
-        self.assertRaises(OOConfigInvalidHostError, Host, **yaml_props)
+        with pytest.raises(OOConfigInvalidHostError):
+            Host(**yaml_props)
 
     def test_inventory_file_quotes_node_labels(self):
         """Verify a host entry wraps openshift_node_labels value in double quotes"""

--- a/utils/test/oo_config_tests.py
+++ b/utils/test/oo_config_tests.py
@@ -195,18 +195,18 @@ class OOConfigTests(OOInstallFixture):
 
         self.assertEquals(3, len(written_config['deployment']['hosts']))
         for h in written_config['deployment']['hosts']:
-            self.assertTrue('ip' in h)
-            self.assertTrue('public_ip' in h)
-            self.assertTrue('hostname' in h)
-            self.assertTrue('public_hostname' in h)
+            assert 'ip' in h
+            assert 'public_ip' in h
+            assert 'hostname' in h
+            assert 'public_hostname' in h
 
-        self.assertTrue('ansible_ssh_user' in written_config['deployment'])
-        self.assertTrue('variant' in written_config)
+        assert 'ansible_ssh_user' in written_config['deployment']
+        assert 'variant' in written_config
         self.assertEquals('v2', written_config['version'])
 
         # Some advanced settings should not get written out if they
         # were not specified by the user:
-        self.assertFalse('ansible_inventory_directory' in written_config)
+        assert 'ansible_inventory_directory' not in written_config
 
 
 class HostTests(OOInstallFixture):

--- a/utils/test/oo_config_tests.py
+++ b/utils/test/oo_config_tests.py
@@ -157,12 +157,8 @@ class OOConfigTests(OOInstallFixture):
 
         cfg_path = self.write_config(os.path.join(self.work_dir,
             'ooinstall.conf'), CONFIG_BAD)
-        try:
+        with pytest.raises(OOConfigInvalidHostError):
             OOConfig(cfg_path)
-            assert False
-        except OOConfigInvalidHostError:
-            assert True
-
 
     def test_load_complete_facts(self):
         cfg_path = self.write_config(os.path.join(self.work_dir,

--- a/utils/test/oo_config_tests.py
+++ b/utils/test/oo_config_tests.py
@@ -143,7 +143,7 @@ class OOConfigTests(OOInstallFixture):
             'ooinstall.conf'), SAMPLE_CONFIG)
         ooconfig = OOConfig(cfg_path)
 
-        self.assertEquals(3, len(ooconfig.deployment.hosts))
+        assert 3 == len(ooconfig.deployment.hosts)
         assert "master-private.example.com" == ooconfig.deployment.hosts[0].connect_to
         assert "10.0.0.1" == ooconfig.deployment.hosts[0].ip
         assert "master-private.example.com" == ooconfig.deployment.hosts[0].hostname
@@ -165,7 +165,7 @@ class OOConfigTests(OOInstallFixture):
             'ooinstall.conf'), SAMPLE_CONFIG)
         ooconfig = OOConfig(cfg_path)
         missing_host_facts = ooconfig.calc_missing_facts()
-        self.assertEquals(0, len(missing_host_facts))
+        assert 0 == len(missing_host_facts)
 
     # Test missing optional facts the user must confirm:
     def test_load_host_incomplete_facts(self):
@@ -173,9 +173,9 @@ class OOConfigTests(OOInstallFixture):
             'ooinstall.conf'), CONFIG_INCOMPLETE_FACTS)
         ooconfig = OOConfig(cfg_path)
         missing_host_facts = ooconfig.calc_missing_facts()
-        self.assertEquals(2, len(missing_host_facts))
-        self.assertEquals(1, len(missing_host_facts['10.0.0.2']))
-        self.assertEquals(3, len(missing_host_facts['10.0.0.3']))
+        assert 2 == len(missing_host_facts)
+        assert 1 == len(missing_host_facts['10.0.0.2'])
+        assert 3 == len(missing_host_facts['10.0.0.3'])
 
     def test_write_config(self):
         cfg_path = self.write_config(os.path.join(self.work_dir,
@@ -189,7 +189,7 @@ class OOConfigTests(OOInstallFixture):
 
 
 
-        self.assertEquals(3, len(written_config['deployment']['hosts']))
+        assert 3 == len(written_config['deployment']['hosts'])
         for h in written_config['deployment']['hosts']:
             assert 'ip' in h
             assert 'public_ip' in h

--- a/utils/test/oo_config_tests.py
+++ b/utils/test/oo_config_tests.py
@@ -143,15 +143,14 @@ class OOConfigTests(OOInstallFixture):
         ooconfig = OOConfig(cfg_path)
 
         self.assertEquals(3, len(ooconfig.deployment.hosts))
-        self.assertEquals("master-private.example.com", ooconfig.deployment.hosts[0].connect_to)
-        self.assertEquals("10.0.0.1", ooconfig.deployment.hosts[0].ip)
-        self.assertEquals("master-private.example.com", ooconfig.deployment.hosts[0].hostname)
+        assert "master-private.example.com" == ooconfig.deployment.hosts[0].connect_to
+        assert "10.0.0.1" == ooconfig.deployment.hosts[0].ip
+        assert "master-private.example.com" == ooconfig.deployment.hosts[0].hostname
 
-        self.assertEquals(["10.0.0.1", "10.0.0.2", "10.0.0.3"],
-                          [host.ip for host in ooconfig.deployment.hosts])
+        assert ["10.0.0.1", "10.0.0.2", "10.0.0.3"] == [host.ip for host in ooconfig.deployment.hosts]
 
-        self.assertEquals('openshift-enterprise', ooconfig.settings['variant'])
-        self.assertEquals('v2', ooconfig.settings['version'])
+        assert 'openshift-enterprise' == ooconfig.settings['variant']
+        assert 'v2' == ooconfig.settings['version']
 
     def test_load_bad_config(self):
 
@@ -202,7 +201,7 @@ class OOConfigTests(OOInstallFixture):
 
         assert 'ansible_ssh_user' in written_config['deployment']
         assert 'variant' in written_config
-        self.assertEquals('v2', written_config['version'])
+        assert 'v2' == written_config['version']
 
         # Some advanced settings should not get written out if they
         # were not specified by the user:
@@ -263,6 +262,6 @@ class HostTests(OOInstallFixture):
         node_labels_bad = '''openshift_node_labels={'region': 'infra'}'''  # No quotes around the hash
 
         # The good line is present in the written inventory line
-        self.assertIn(node_labels_expected, legacy_inventory_line)
+        assert node_labels_expected in legacy_inventory_line
         # An unquoted version is not present
-        self.assertNotIn(node_labels_bad, legacy_inventory_line)
+        assert node_labels_bad not in legacy_inventory_line

--- a/utils/test/openshift_ansible_tests.py
+++ b/utils/test/openshift_ansible_tests.py
@@ -46,8 +46,8 @@ class TestOpenShiftAnsible(unittest.TestCase):
         openshift_ansible.generate_inventory(hosts)
         inventory = configparser.ConfigParser(allow_no_value=True)
         inventory.read(self.inventory)
-        self.assertTrue(inventory.has_section('new_nodes'))
-        self.assertTrue(inventory.has_option('new_nodes', 'new_node1'))
+        assert inventory.has_section('new_nodes')
+        assert inventory.has_option('new_nodes', 'new_node1')
 
     def test_write_inventory_vars_role_vars(self):
         with open(self.inventory, 'w') as inv:
@@ -57,9 +57,9 @@ class TestOpenShiftAnsible(unittest.TestCase):
 
         inventory = configparser.ConfigParser(allow_no_value=True)
         inventory.read(self.inventory)
-        self.assertTrue(inventory.has_section('masters:vars'))
+        assert inventory.has_section('masters:vars')
         self.assertEquals('blue', inventory.get('masters:vars', 'color'))
-        self.assertTrue(inventory.has_section('nodes:vars'))
+        assert inventory.has_section('nodes:vars')
         self.assertEquals('green', inventory.get('nodes:vars', 'color'))
 
 

--- a/utils/test/openshift_ansible_tests.py
+++ b/utils/test/openshift_ansible_tests.py
@@ -58,9 +58,9 @@ class TestOpenShiftAnsible(unittest.TestCase):
         inventory = configparser.ConfigParser(allow_no_value=True)
         inventory.read(self.inventory)
         assert inventory.has_section('masters:vars')
-        self.assertEquals('blue', inventory.get('masters:vars', 'color'))
+        assert 'blue' == inventory.get('masters:vars', 'color')
         assert inventory.has_section('nodes:vars')
-        self.assertEquals('green', inventory.get('nodes:vars', 'color'))
+        assert 'green' == inventory.get('nodes:vars', 'color')
 
 
 def generate_hosts(num_hosts, name_prefix, roles=None, new_host=False):

--- a/utils/test/test_utils.py
+++ b/utils/test/test_utils.py
@@ -76,24 +76,24 @@ class TestUtils(unittest.TestCase):
         # A hostname that's empty, None, or more than 255 chars is invalid
         empty_hostname = ''
         res = is_valid_hostname(empty_hostname)
-        self.assertFalse(res)
+        assert not res
 
         none_hostname = None
         res = is_valid_hostname(none_hostname)
-        self.assertFalse(res)
+        assert not res
 
         too_long_hostname = "a" * 256
         res = is_valid_hostname(too_long_hostname)
-        self.assertFalse(res)
+        assert not res
 
     def test_utils_is_valid_hostname_ends_with_dot(self):
         """Verify is_valid_hostname can parse hostnames with trailing periods"""
         hostname = "foo.example.com."
         res = is_valid_hostname(hostname)
-        self.assertTrue(res)
+        assert res
 
     def test_utils_is_valid_hostname_normal_hostname(self):
         """Verify is_valid_hostname can parse regular hostnames"""
         hostname = "foo.example.com"
         res = is_valid_hostname(hostname)
-        self.assertTrue(res)
+        assert res

--- a/utils/test/test_utils.py
+++ b/utils/test/test_utils.py
@@ -61,9 +61,7 @@ class TestUtils(unittest.TestCase):
 
             # The actual number of debug calls was less than the
             # number of items passed to debug_env
-            self.assertLess(
-                _il.debug.call_count,
-                len(debug_some_params))
+            assert _il.debug.call_count < len(debug_some_params)
 
             six.assertCountEqual(
                 self,

--- a/utils/test/test_utils.py
+++ b/utils/test/test_utils.py
@@ -43,10 +43,7 @@ class TestUtils(unittest.TestCase):
             assert len(self.debug_all_params) == _il.debug.call_count
 
             # Each item we expect was logged
-            six.assertCountEqual(
-                self,
-                self.expected,
-                _il.debug.call_args_list)
+            assert sorted(self.expected) == sorted(_il.debug.call_args_list)
 
     def test_utils_debug_env_some_debugged(self):
         """Verify debug_env skips non-wanted env variables"""
@@ -61,10 +58,7 @@ class TestUtils(unittest.TestCase):
             # number of items passed to debug_env
             assert _il.debug.call_count < len(debug_some_params)
 
-            six.assertCountEqual(
-                self,
-                self.expected,
-                _il.debug.call_args_list)
+            assert sorted(self.expected) == sorted(_il.debug.call_args_list)
 
     ######################################################################
     def test_utils_is_valid_hostname_invalid(self):

--- a/utils/test/test_utils.py
+++ b/utils/test/test_utils.py
@@ -40,9 +40,7 @@ class TestUtils(unittest.TestCase):
             debug_env(self.debug_all_params)
 
             # Debug was called for each item we expect
-            self.assertEqual(
-                len(self.debug_all_params),
-                _il.debug.call_count)
+            assert len(self.debug_all_params) == _il.debug.call_count
 
             # Each item we expect was logged
             six.assertCountEqual(


### PR DESCRIPTION
Replace usage of `unittest` and other forms to unify the test code base into a slimmer form.

**NOTE**: not ready for review yet, needs clean up.