### PR TITLE
do not need openshift_facts with openshift_master_facts

### DIFF
--- a/roles/openshift_logging/meta/main.yaml
+++ b/roles/openshift_logging/meta/main.yaml
@@ -14,4 +14,3 @@ galaxy_info:
 dependencies:
 - role: lib_openshift
 - role: openshift_master_facts
-- role: openshift_facts


### PR DESCRIPTION
Do not need to use openshift_facts if using openshift_master_facts
openshift_master_facts will pull in openshift_facts, no need to list both.
@detiber @ewolinetz @jcantrill PTAL
aos-ci-test