### PR TITLE
Do not use auto_expand_replicas

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -72,6 +72,8 @@ When both `openshift_logging_install_logging` and `openshift_logging_upgrade_log
 - `openshift_logging_es_recover_after_time`: The amount of time ES will wait before it tries to recover. Defaults to '5m'.
 - `openshift_logging_es_storage_group`: The storage group used for ES. Defaults to '65534'.
 - `openshift_logging_es_nodeselector`: A map of labels (e.g. {"node":"infra","region":"west"} to select the nodes where the pod will land.
+- `openshift_logging_es_number_of_shards`: The number of primary shards for every new index created in ES. Defaults to '1'.
+- `openshift_logging_es_number_of_replicas`: The number of replica shards per primary shard for every new index. Defaults to '0'.
 
 When `openshift_logging_use_ops` is `True`, there are some additional vars. These work the
 same as above for their non-ops counterparts, but apply to the OPS cluster instance:
@@ -88,6 +90,8 @@ same as above for their non-ops counterparts, but apply to the OPS cluster insta
 - `openshift_logging_es_ops_pvc_prefix`: logging-es-ops
 - `openshift_logging_es_ops_recover_after_time`: 5m
 - `openshift_logging_es_ops_storage_group`: 65534
+- `openshift_logging_es_ops_number_of_shards`: The number of primary shards for every new index created in ES. Defaults to '1'.
+- `openshift_logging_es_ops_number_of_replicas`: The number of replica shards per primary shard for every new index. Defaults to '0'. 
 - `openshift_logging_kibana_ops_hostname`: The Operations Kibana hostname. Defaults to 'kibana-ops.example.com'.
 - `openshift_logging_kibana_ops_cpu_limit`: The amount of CPU to allocate to Kibana or unset if not specified.
 - `openshift_logging_kibana_ops_memory_limit`: The amount of memory to allocate to Kibana or unset if not specified.

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -92,6 +92,8 @@ openshift_logging_es_storage_group: "{{ openshift_hosted_logging_elasticsearch_s
 openshift_logging_es_nodeselector: "{{ openshift_hosted_logging_elasticsearch_nodeselector | default('') | map_from_pairs }}"
 # openshift_logging_es_config is a hash to be merged into the defaults for the elasticsearch.yaml
 openshift_logging_es_config: {}
+openshift_logging_es_number_of_shards: 1
+openshift_logging_es_number_of_replicas: 0
 
 # allow cluster-admin or cluster-reader to view operations index
 openshift_logging_es_ops_allow_cluster_reader: False
@@ -111,6 +113,8 @@ openshift_logging_es_ops_pvc_prefix: "{{ openshift_hosted_logging_elasticsearch_
 openshift_logging_es_ops_recover_after_time: 5m
 openshift_logging_es_ops_storage_group: "{{ openshift_hosted_logging_elasticsearch_storage_group | default('65534') }}"
 openshift_logging_es_ops_nodeselector: "{{ openshift_hosted_logging_elasticsearch_ops_nodeselector | default('') | map_from_pairs }}"
+openshift_logging_es_ops_number_of_shards: 1
+openshift_logging_es_ops_number_of_replicas: 0
 
 # storage related defaults
 openshift_logging_storage_access_modes: "{{ openshift_hosted_logging_storage_access_modes | default(['ReadWriteOnce']) }}"

--- a/roles/openshift_logging/tasks/install_elasticsearch.yaml
+++ b/roles/openshift_logging/tasks/install_elasticsearch.yaml
@@ -53,6 +53,8 @@
     deploy_name: "{{item.1}}"
     es_node_selector: "{{openshift_logging_es_nodeselector | default({}) }}"
     es_storage: "{{openshift_logging_facts|es_storage(deploy_name, pvc_claim)}}"
+    es_number_of_shards: "{{ openshift_logging_es_number_of_shards }}"
+    es_number_of_replicas: "{{ openshift_logging_es_number_of_replicas }}"
   with_indexed_items:
     - "{{ es_dc_pool }}"
   check_mode: no
@@ -134,6 +136,8 @@
     openshift_logging_es_recover_after_time: "{{openshift_logging_es_ops_recover_after_time}}"
     es_node_selector: "{{openshift_logging_es_ops_nodeselector | default({}) }}"
     es_storage: "{{openshift_logging_facts|es_storage(deploy_name, pvc_claim,root='elasticsearch_ops')}}"
+    es_number_of_shards: "{{ openshift_logging_es_ops_number_of_shards }}"
+    es_number_of_replicas: "{{ openshift_logging_es_ops_number_of_replicas }}"
   with_indexed_items:
     - "{{ es_ops_dc_pool | default([]) }}"
   when:

--- a/roles/openshift_logging/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging/templates/elasticsearch.yml.j2
@@ -6,9 +6,8 @@ script:
   indexed: on
 
 index:
-  number_of_shards: 1
-  number_of_replicas: 0
-  auto_expand_replicas: 0-2
+  number_of_shards: {{ es_number_of_shards | default ('1') }}
+  number_of_replicas: {{ es_number_of_replicas | default ('0') }}
   unassigned.node_left.delayed_timeout: 2m
   translog:
     flush_threshold_size: 256mb


### PR DESCRIPTION
Do not use `auto_expand_replicas` feature. It is associated with unnecessary data recovery from other nodes.

See for details: https://github.com/elastic/elasticsearch/issues/1873