### PR TITLE
Allow setting certificates validity period during installation

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -388,6 +388,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # based on the number of nodes matching the openshift registry selector.
 #openshift_hosted_registry_replicas=2
 #
+# Validity of the auto-generated certificate in days (optional)
+#openshift_hosted_registry_cert_expire_days=730
+#
 # Disable management of the OpenShift Registry
 #openshift_hosted_manage_registry=false
 
@@ -753,6 +756,13 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Enable origin repos that point at Centos PAAS SIG, defaults to true, only used
 # by deployment_type=origin
 #openshift_enable_origin_repo=false
+
+# Validity of the auto-generated certificates in days.
+# See also openshift_hosted_registry_cert_expire_days above.
+#
+#openshift_ca_cert_expire_days=1825
+#openshift_node_cert_expire_days=730
+#openshift_master_cert_expire_days=730
 
 # host group for masters
 [masters]

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -388,6 +388,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # based on the number of nodes matching the openshift registry selector.
 #openshift_hosted_registry_replicas=2
 #
+# Validity of the auto-generated certificate in days (optional)
+#openshift_hosted_registry_cert_expire_days=730
+#
 # Disable management of the OpenShift Registry
 #openshift_hosted_manage_registry=false
 
@@ -750,6 +753,13 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 
 # Enable API service auditing, available as of 3.2
 #openshift_master_audit_config={"basicAuditEnabled": true}
+
+# Validity of the auto-generated certificates in days.
+# See also openshift_hosted_registry_cert_expire_days above.
+#
+#openshift_ca_cert_expire_days=1825
+#openshift_node_cert_expire_days=730
+#openshift_master_cert_expire_days=730
 
 # host group for masters
 [masters]

--- a/playbooks/common/openshift-cluster/redeploy-certificates/registry.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/registry.yml
@@ -69,6 +69,9 @@
         --hostnames="{{ docker_registry_service_ip.results.clusterip }},docker-registry.default.svc.cluster.local,{{ docker_registry_route_hostname }}"
         --cert={{ openshift.common.config_base }}/master/registry.crt
         --key={{ openshift.common.config_base }}/master/registry.key
+        {% if openshift_version | oo_version_gte_3_5_or_1_5(openshift.common.deployment_type) | bool %}
+        --expire-days={{ openshift_hosted_registry_cert_expire_days | default(730) }}
+        {% endif %}
 
     - name: Update registry certificates secret
       oc_secret:

--- a/roles/lib_openshift/library/oc_adm_ca_server_cert.py
+++ b/roles/lib_openshift/library/oc_adm_ca_server_cert.py
@@ -130,6 +130,12 @@ options:
     required: false
     default: True
     aliases: []
+  expire_days:
+    description
+    - Validity of the certificate in days
+    required: false
+    default: None
+    aliases: []
 author:
 - "Kenny Woodson <kwoodson@redhat.com>"
 extends_documentation_fragment: []
@@ -1480,6 +1486,7 @@ class CAServerCert(OpenShiftCLI):
                                      'signer_cert':   {'value': params['signer_cert'], 'include': True},
                                      'signer_key':    {'value': params['signer_key'], 'include': True},
                                      'signer_serial': {'value': params['signer_serial'], 'include': True},
+                                     'expire_days':   {'value': params['expire_days'], 'include': True},
                                      'backup':        {'value': params['backup'], 'include': False},
                                     })
 
@@ -1538,6 +1545,7 @@ def main():
             signer_key=dict(default='/etc/origin/master/ca.key', type='str'),
             signer_serial=dict(default='/etc/origin/master/ca.serial.txt', type='str'),
             hostnames=dict(default=[], type='list'),
+            expire_days=dict(default=None, type='int'),
         ),
         supports_check_mode=True,
     )

--- a/roles/lib_openshift/src/ansible/oc_adm_ca_server_cert.py
+++ b/roles/lib_openshift/src/ansible/oc_adm_ca_server_cert.py
@@ -20,6 +20,7 @@ def main():
             signer_key=dict(default='/etc/origin/master/ca.key', type='str'),
             signer_serial=dict(default='/etc/origin/master/ca.serial.txt', type='str'),
             hostnames=dict(default=[], type='list'),
+            expire_days=dict(default=None, type='int'),
         ),
         supports_check_mode=True,
     )

--- a/roles/lib_openshift/src/class/oc_adm_ca_server_cert.py
+++ b/roles/lib_openshift/src/class/oc_adm_ca_server_cert.py
@@ -102,6 +102,7 @@ class CAServerCert(OpenShiftCLI):
                                      'signer_cert':   {'value': params['signer_cert'], 'include': True},
                                      'signer_key':    {'value': params['signer_key'], 'include': True},
                                      'signer_serial': {'value': params['signer_serial'], 'include': True},
+                                     'expire_days':   {'value': params['expire_days'], 'include': True},
                                      'backup':        {'value': params['backup'], 'include': False},
                                     })
 

--- a/roles/lib_openshift/src/doc/ca_server_cert
+++ b/roles/lib_openshift/src/doc/ca_server_cert
@@ -79,6 +79,12 @@ options:
     required: false
     default: True
     aliases: []
+  expire_days:
+    description
+    - Validity of the certificate in days
+    required: false
+    default: None
+    aliases: []
 author:
 - "Kenny Woodson <kwoodson@redhat.com>"
 extends_documentation_fragment: []

--- a/roles/openshift_ca/README.md
+++ b/roles/openshift_ca/README.md
@@ -19,6 +19,8 @@ From this role:
 | openshift_ca_key        | `{{ openshift_ca_config_dir }}/ca.key`        | CA key path including CA key filename.                                      |
 | openshift_ca_serial     | `{{ openshift_ca_config_dir }}/ca.serial.txt` | CA serial path including CA serial filename.                                |
 | openshift_version       | `{{ openshift_pkg_version }}`                 | OpenShift package version.                                                  |
+| openshift_master_cert_expire_days | `730` (2 years)                     | Validity of the certificates in days. Works only with OpenShift version 1.5 (3.5) and later. |
+| openshift_ca_cert_expire_days     | `1825` (5 years)                    | Validity of the CA certificates in days. Works only with OpenShift version 1.5 (3.5) and later. |
 
 Dependencies
 ------------

--- a/roles/openshift_ca/defaults/main.yml
+++ b/roles/openshift_ca/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+openshift_ca_cert_expire_days: 1825
+openshift_master_cert_expire_days: 730

--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -88,7 +88,7 @@
 # This should NOT replace the CA due to --overwrite=false when a CA already exists.
 - name: Create the master certificates if they do not already exist
   command: >
-    {{ hostvars[openshift_ca_host].openshift.common.client_binary }} adm create-master-certs
+    {{ hostvars[openshift_ca_host].openshift.common.client_binary }} adm ca create-master-certs
     {% for named_ca_certificate in openshift.master.named_certificates | default([]) | oo_collect('cafile') %}
     --certificate-authority {{ named_ca_certificate }}
     {% endfor %}
@@ -99,6 +99,10 @@
     --master={{ openshift.master.api_url }}
     --public-master={{ openshift.master.public_api_url }}
     --cert-dir={{ openshift_ca_config_dir }}
+    {% if openshift_version | oo_version_gte_3_5_or_1_5(openshift.common.deployment_type) | bool %}
+    --expire-days={{ openshift_master_cert_expire_days }}
+    --signer-expire-days={{ openshift_ca_cert_expire_days }}
+    {% endif %}
     --overwrite=false
   when: master_ca_missing | bool or openshift_certificates_redeploy | default(false) | bool
   delegate_to: "{{ openshift_ca_host }}"

--- a/roles/openshift_hosted/README.md
+++ b/roles/openshift_hosted/README.md
@@ -26,6 +26,7 @@ From this role:
 | openshift_hosted_registry_registryurl | 'openshift3/ose-${component}:${version}' | The image to base the OpenShift registry on.                                                                             |
 | openshift_hosted_registry_replicas    | Number of nodes matching selector        | The number of replicas to configure.                                                                                     |
 | openshift_hosted_registry_selector    | region=infra                             | Node selector used when creating registry. The OpenShift registry will only be deployed to nodes matching this selector. |
+| openshift_hosted_registry_cert_expire_days | `730` (2 years)                     | Validity of the certificates in days. Works only with OpenShift version 1.5 (3.5) and later.                             |
 
 Dependencies
 ------------

--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -28,3 +28,4 @@ openshift_hosted_routers:
 
 
 openshift_hosted_router_certificates: {}
+openshift_hosted_registry_cert_expire_days: 730

--- a/roles/openshift_hosted/tasks/registry/secure.yml
+++ b/roles/openshift_hosted/tasks/registry/secure.yml
@@ -57,6 +57,7 @@
     - "{{ docker_registry_route_hostname }}"
     cert: "{{ openshift_master_config_dir }}/registry.crt"
     key: "{{ openshift_master_config_dir }}/registry.key"
+    expire_days: "{{ openshift_hosted_registry_cert_expire_days if openshift_version | oo_version_gte_3_5_or_1_5(openshift.common.deployment_type) | bool else omit }}"
   register: server_cert_out
 
 - name: Create the secret for the registry certificates

--- a/roles/openshift_master_certificates/README.md
+++ b/roles/openshift_master_certificates/README.md
@@ -21,6 +21,7 @@ From this role:
 |---------------------------------------|---------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
 | openshift_generated_configs_dir       | `{{ openshift.common.config_base }}/generated-configs`                    | Directory in which per-master generated config directories will be created on the `openshift_ca_host`.                        |
 | openshift_master_cert_subdir          | `master-{{ openshift.common.hostname }}`                                  | Directory within `openshift_generated_configs_dir` where per-master configurations will be placed on the `openshift_ca_host`. |
+| openshift_master_cert_expire_days     | `730` (2 years)                                                           | Validity of the certificates in days. Works only with OpenShift version 1.5 (3.5) and later.                                  |
 | openshift_master_config_dir           | `{{ openshift.common.config_base }}/master`                               | Master configuration directory in which certificates will be deployed on masters.                                             |
 | openshift_master_generated_config_dir | `{{ openshift_generated_configs_dir }}/{{ openshift_master_cert_subdir }` | Full path to the per-master generated config directory.                                                                       |
 

--- a/roles/openshift_master_certificates/defaults/main.yml
+++ b/roles/openshift_master_certificates/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+openshift_master_cert_expire_days: 730

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -57,6 +57,9 @@
     --hostnames={{ hostvars[item].openshift.common.all_hostnames | join(',') }}
     --cert={{ openshift_generated_configs_dir }}/master-{{ hostvars[item].openshift.common.hostname }}/master.server.crt
     --key={{ openshift_generated_configs_dir }}/master-{{ hostvars[item].openshift.common.hostname }}/master.server.key
+    {% if openshift_version | oo_version_gte_3_5_or_1_5(openshift.common.deployment_type) | bool %}
+    --expire-days={{ openshift_master_cert_expire_days }}
+    {% endif %}
     --signer-cert={{ openshift_ca_cert }}
     --signer-key={{ openshift_ca_key }}
     --signer-serial={{ openshift_ca_serial }}
@@ -84,6 +87,9 @@
       --signer-serial={{ openshift_ca_serial }}
       --user=system:openshift-master
       --basename=openshift-master
+      {% if openshift_version | oo_version_gte_3_5_or_1_5(openshift.common.deployment_type) | bool %}
+      --expire-days={{ openshift_master_cert_expire_days }}
+      {% endif %}
   args:
     creates: "{{ openshift_generated_configs_dir }}/master-{{ hostvars[item].openshift.common.hostname }}/openshift-master.kubeconfig"
   with_items: "{{ hostvars

--- a/roles/openshift_node_certificates/README.md
+++ b/roles/openshift_node_certificates/README.md
@@ -23,6 +23,7 @@ From this role:
 |-------------------------------------|-------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
 | openshift_generated_configs_dir     | `{{ openshift.common.config_base }}/generated-configs`                  | Directory in which per-node generated config directories will be created on the `openshift_ca_host`.                      |
 | openshift_node_cert_subdir          | `node-{{ openshift.common.hostname }}`                                  | Directory within `openshift_generated_configs_dir` where per-node certificates will be placed on the `openshift_ca_host`. |
+| openshift_node_cert_expire_days     | `730` (2 years)                                                         | Validity of the certificates in days. Works only with OpenShift version 1.5 (3.5) and later.                              |
 | openshift_node_config_dir           | `{{ openshift.common.config_base }}/node`                               | Node configuration directory in which certificates will be deployed on nodes.                                             |
 | openshift_node_generated_config_dir | `{{ openshift_generated_configs_dir }}/{{ openshift_node_cert_subdir }` | Full path to the per-node generated config directory.                                                                     |
 

--- a/roles/openshift_node_certificates/defaults/main.yml
+++ b/roles/openshift_node_certificates/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+openshift_node_cert_expire_days: 730

--- a/roles/openshift_node_certificates/tasks/main.yml
+++ b/roles/openshift_node_certificates/tasks/main.yml
@@ -66,6 +66,9 @@
     --signer-key={{ openshift_ca_key }}
     --signer-serial={{ openshift_ca_serial }}
     --user=system:node:{{ hostvars[item].openshift.common.hostname }}
+    {% if openshift_version | oo_version_gte_3_5_or_1_5(openshift.common.deployment_type) | bool %}
+    --expire-days={{ openshift_node_cert_expire_days }}
+    {% endif %}
   args:
     creates: "{{ openshift_generated_configs_dir }}/node-{{ hostvars[item].openshift.common.hostname }}"
   with_items: "{{ hostvars
@@ -79,6 +82,9 @@
     {{ hostvars[openshift_ca_host].openshift.common.client_binary }} adm ca create-server-cert
     --cert={{ openshift_generated_configs_dir }}/node-{{ hostvars[item].openshift.common.hostname }}/server.crt
     --key={{ openshift_generated_configs_dir }}/node-{{ hostvars[item].openshift.common.hostname }}/server.key
+    {% if openshift_version | oo_version_gte_3_5_or_1_5(openshift.common.deployment_type) | bool %}
+    --expire-days={{ openshift_node_cert_expire_days }}
+    {% endif %}
     --overwrite=true
     --hostnames={{ hostvars[item].openshift.common.hostname }},{{ hostvars[item].openshift.common.public_hostname }},{{ hostvars[item].openshift.common.ip }},{{ hostvars[item].openshift.common.public_ip }}
     --signer-cert={{ openshift_ca_cert }}


### PR DESCRIPTION
This PR is adding support for setting certificates validity period during installation. It's done by passing `--expire-days` and `--signer-expire-days` options to `oc adm` that were adding in v1.5 (see https://github.com/openshift/origin/pull/11814)

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1275176
Trello: https://trello.com/c/MV4uHYdW/367-leverage-the-new-expire-days-in-the-ansible-playbooks

PTAL @abutcher @tbielawa 
CC @mfojtik