### PR TITLE
Petset early fail

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_5/validator.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/validator.yml
@@ -16,3 +16,52 @@
   tasks:
   - name: Check for invalid namespaces and SDN errors
     oc_objectvalidator:
+
+  # What's all this PetSet business about?
+  #
+  # 'PetSets' were ALPHA resources in Kube <= 3.4. In >= 3.5 they are
+  # no longer supported. The BETA resource 'StatefulSets' replaces
+  # them. We can't migrate clients PetSets to
+  # StatefulSets. Additionally, Red Hat has never officially supported
+  # these resource types. Sorry users, but if you were using
+  # unsupported resources from the Kube documentation then we can't
+  # help you at this time.
+  #
+  # Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1428229
+  - name: Check if legacy PetSets exist
+    oc_obj:
+      state: list
+      all_namespaces: true
+      kind: petsets
+    register: l_do_petsets_exist
+
+  - name: FAIL ON Resource migration 'PetSets' unsupported
+    fail:
+      msg: >
+        PetSet objects were detected in your cluster. These are an
+        Alpha feature in upstream Kubernetes 1.4 and are not supported
+        by Red Hat. In Kubernetes 1.5, they are replaced by the Beta
+        feature StatefulSets. Red Hat currently does not offer support
+        for either PetSets or StatefulSets.
+
+        Automatically migrating PetSets to StatefulSets in OpenShift
+        Container Platform (OCP) 3.5 is not supported. See the
+        Kubernetes "Upgrading from PetSets to StatefulSets"
+        documentation for additional information:
+
+        https://kubernetes.io/docs/tasks/manage-stateful-set/upgrade-pet-set-to-stateful-set/
+
+        PetSets MUST be removed before upgrading to OCP 3.5. Red Hat
+        strongly recommends reading the above referenced documentation
+        in its entirety before taking any destructive actions.
+
+        If you want to simply remove all PetSets without manually
+        migrating to StatefulSets, run this command as a user with
+        cluster-admin privileges:
+
+        $ oc get petsets --all-namespaces -o yaml | oc delete -f - --cascale=false
+    when:
+    # Search did not fail, valid resource type found
+    - l_do_petsets_exist.results.returncode == "0"
+    # Items do exist in the search results
+    - l_do_petsets_exist.results.results.0['items'] | length > 0

--- a/roles/openshift_logging/filter_plugins/openshift_logging.py
+++ b/roles/openshift_logging/filter_plugins/openshift_logging.py
@@ -28,9 +28,10 @@ def entry_from_named_pair(register_pairs, key):
 def map_from_pairs(source, delim="="):
     ''' Returns a dict given the source and delim delimited '''
     if source == '':
-      return dict()
+        return dict()
 
     return dict(source.split(delim) for item in source.split(","))
+
 
 # pylint: disable=too-few-public-methods
 class FilterModule(object):

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -77,8 +77,8 @@
   loop_control:
     loop_var: sa_account
   when:
-  - openshift_logging_image_pull_secret is defined
-  - openshift_logging_image_pull_secret != ''
+    - openshift_logging_image_pull_secret is defined
+    - openshift_logging_image_pull_secret != ''
   failed_when: link_pull_secret.rc != 0
 
 - name: Scaling up cluster


### PR DESCRIPTION
Based on @sdodson's [Add oc_objectvalidator to upgrade check](https://github.com/openshift/openshift-ansible/pull/3574) PR

* PetSets are deprecated in 3.5, replaced with StatefulSets                                                                                                                                                          
* We can not automatically migrate between the two                                                                                                                                                                   
* Red Hat has never supported PetSets nor do we support StatefulSets                                                                                                                                                 
* Gracefully handles invalid resource queries if ran against 3.5+                                                                                                                                                    
  clusters                                                                                                                                                                                                           
* Fails out with explanation and ref docs if petsets are detected                                                                                                                                                    
                                                                                                                                                                                                                     
Reference bug: https://bugzilla.redhat.com/show_bug.cgi?id=1428229                                                                                                                                                   
