### PR TITLE
Bug 1416156: Loosely couple docker to iptables service

### DIFF
--- a/roles/docker/templates/custom.conf.j2
+++ b/roles/docker/templates/custom.conf.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
 
 [Unit]
-Requires=iptables.service
+Wants=iptables.service
 After=iptables.service


### PR DESCRIPTION
The docker service should be loosely coupled to the iptables service to avoid restarting docker when iptables is restarted.

Fixes 1416156
