### PR TITLE
Ignore the docker excluder status if it is not enabled by a user

### DIFF
--- a/roles/openshift_excluder/tasks/status.yml
+++ b/roles/openshift_excluder/tasks/status.yml
@@ -78,6 +78,7 @@
     # In order to determine of the excluder needs to be enabled.
     when:
     - "{{ docker_excluder_installed.installed_versions | default([]) | length > 0 }}"
+    - "{{ docker_excluder_on }}"
 
   when:
   - not openshift.common.is_containerized | bool


### PR DESCRIPTION
When the docker excluder is not installed and the ``enable_docker_excluder`` is not set, the docker excluder is ignored. When the docker excluder is installed, no matter what the ``enable_docker_excluder`` is set to, the docker excluder status is always run which may set the docker excluder override. That should not happen. We could argue the user should check if the docker excluder is installed or not and based on that decide if the excluder needs to be removed or the ``enable_docker_excluder`` set to true. However, we should make the openshift ansible as less error prune as possible. So making sure the status is really run only when the user enables the docker excluder and at the same time the excluder is installed.