### PR TITLE
bug 1428249. Use ES hostmount storage if it exists

### DIFF
--- a/roles/openshift_logging/filter_plugins/openshift_logging.py
+++ b/roles/openshift_logging/filter_plugins/openshift_logging.py
@@ -5,6 +5,18 @@
 import random
 
 
+def es_storage(os_logging_facts, dc_name, pvc_claim, root='elasticsearch'):
+    '''Return a hash with the desired storage for the given ES instance'''
+    deploy_config = os_logging_facts[root]['deploymentconfigs'].get(dc_name)
+    if deploy_config:
+        storage = deploy_config['volumes']['elasticsearch-storage']
+        if storage.get('hostPath'):
+            return dict(kind='hostpath', path=storage.get('hostPath').get('path'))
+    if len(pvc_claim.strip()) > 0:
+        return dict(kind='pvc', pvc_claim=pvc_claim)
+    return dict(kind='emptydir')
+
+
 def random_word(source_alpha, length):
     ''' Returns a random word given the source of characters to pick from and resulting length '''
     return ''.join(random.choice(source_alpha) for i in range(length))
@@ -44,4 +56,5 @@ class FilterModule(object):
             'random_word': random_word,
             'entry_from_named_pair': entry_from_named_pair,
             'map_from_pairs': map_from_pairs,
+            'es_storage': es_storage
         }

--- a/roles/openshift_logging/tasks/install_elasticsearch.yaml
+++ b/roles/openshift_logging/tasks/install_elasticsearch.yaml
@@ -2,6 +2,8 @@
 - name: Getting current ES deployment size
   set_fact: openshift_logging_current_es_size={{ openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | length }}
 
+- set_fact: es_pvc_pool={{[]}}
+
 - name: Generate PersistentVolumeClaims
   include: "{{ role_path}}/tasks/generate_pvcs.yaml"
   vars:
@@ -42,10 +44,10 @@
     es_cluster_name: "{{component}}"
     es_cpu_limit: "{{openshift_logging_es_cpu_limit }}"
     es_memory_limit: "{{openshift_logging_es_memory_limit}}"
-    volume_names: "{{es_pvc_pool | default([])}}"
-    pvc_claim: "{{(volume_names | length > item.0) | ternary(volume_names[item.0], None)}}"
+    pvc_claim: "{{(es_pvc_pool | length > item.0) | ternary(es_pvc_pool[item.0], None)}}"
     deploy_name: "{{item.1}}"
     es_node_selector: "{{openshift_logging_es_nodeselector | default({}) }}"
+    es_storage: "{{openshift_logging_facts|es_storage(deploy_name, pvc_claim)}}"
   with_indexed_items:
     - "{{ es_dc_pool }}"
   check_mode: no
@@ -111,8 +113,7 @@
     logging_component: elasticsearch
     deploy_name_prefix: "logging-{{component}}"
     image: "{{openshift_logging_image_prefix}}logging-elasticsearch:{{openshift_logging_image_version}}"
-    volume_names: "{{es_pvc_pool | default([])}}"
-    pvc_claim: "{{(volume_names | length > item.0) | ternary(volume_names[item.0], None)}}"
+    pvc_claim: "{{(es_pvc_pool | length > item.0) | ternary(es_pvc_pool[item.0], None)}}"
     deploy_name: "{{item.1}}"
     es_cluster_name: "{{component}}"
     es_cpu_limit: "{{openshift_logging_es_ops_cpu_limit }}"
@@ -121,7 +122,8 @@
     es_recover_after_nodes: "{{es_ops_recover_after_nodes}}"
     es_recover_expected_nodes: "{{es_ops_recover_expected_nodes}}"
     openshift_logging_es_recover_after_time: "{{openshift_logging_es_ops_recover_after_time}}"
-    es_node_selector: "{{openshift_logging_es_ops_nodeselector | default({}) | map_from_pairs }}"
+    es_node_selector: "{{openshift_logging_es_ops_nodeselector | default({}) }}"
+    es_storage: "{{openshift_logging_facts|es_storage(deploy_name, pvc_claim,root='elasticsearch_ops')}}"
   with_indexed_items:
     - "{{ es_ops_dc_pool | default([]) }}"
   when:

--- a/roles/openshift_logging/templates/es-storage-emptydir.partial
+++ b/roles/openshift_logging/templates/es-storage-emptydir.partial
@@ -1,0 +1,1 @@
+          emptyDir: {}

--- a/roles/openshift_logging/templates/es-storage-hostpath.partial
+++ b/roles/openshift_logging/templates/es-storage-hostpath.partial
@@ -1,0 +1,2 @@
+          hostPath:
+            path: {{es_storage['path']}}

--- a/roles/openshift_logging/templates/es-storage-pvc.partial
+++ b/roles/openshift_logging/templates/es-storage-pvc.partial
@@ -1,0 +1,2 @@
+          persistentVolumeClaim:
+            claimName: {{es_storage['pvc_claim']}}

--- a/roles/openshift_logging/templates/es.j2
+++ b/roles/openshift_logging/templates/es.j2
@@ -103,9 +103,4 @@ spec:
           configMap:
             name: logging-elasticsearch
         - name: elasticsearch-storage
-{% if pvc_claim is defined and pvc_claim | trim | length > 0 %}
-          persistentVolumeClaim:
-            claimName: {{pvc_claim}}
-{% else %}
-          emptyDir: {}
-{% endif %}
+{% include 'es-storage-'+ es_storage['kind'] + '.partial' %}


### PR DESCRIPTION
Seems like this could be done without the use of the filter, but given the approach I took, using tasks directly would seem to require us to jump through a bunch of hoops.  Thoughts?