### PR TITLE
enable excluders by default

### DIFF
--- a/roles/openshift_excluder/defaults/main.yml
+++ b/roles/openshift_excluder/defaults/main.yml
@@ -2,3 +2,5 @@
 # keep the 'current' package or update to 'latest' if available?
 openshift_excluder_package_state: present
 docker_excluder_package_state: present
+
+enable_excluders: true

--- a/roles/openshift_excluder/tasks/init.yml
+++ b/roles/openshift_excluder/tasks/init.yml
@@ -1,12 +1,12 @@
 ---
 - name: Evalute if docker excluder is to be enabled
   set_fact:
-    docker_excluder_on: "{{ enable_docker_excluder | default(enable_excluders | default(false)) | bool }}"
+    docker_excluder_on: "{{ enable_docker_excluder | default(enable_excluders) | bool }}"
 
 - debug: var=docker_excluder_on
 
 - name: Evalute if openshift excluder is to be enabled
   set_fact:
-    openshift_excluder_on: "{{ enable_openshift_excluder | default(enable_excluders | default(false)) | bool }}"
+    openshift_excluder_on: "{{ enable_openshift_excluder | default(enable_excluders) | bool }}"
 
 - debug: var=openshift_excluder_on


### PR DESCRIPTION
Have the excluders be installed and used by default.
If a user does not want to use any of the excluders, he/she can set ``enable_excluders`` to ``false``. Or set ``enable_openshift_excluder``, resp. ``enable_docker_excluder`` to disable particular excluder.