### PR TITLE
WIP: Check the excluders are in a proper state

### DIFF
--- a/playbooks/common/openshift-cluster/check-excluders.yml
+++ b/playbooks/common/openshift-cluster/check-excluders.yml
@@ -1,0 +1,28 @@
+---
+# input variables:
+# - repoquery_cmd
+# - excluder
+# - openshift_upgrade_target
+- name:
+  debug:
+    msg: "{{ openshift.common.service_type }}"
+
+- name: Determine if openshift excluder package is installed
+  rpm_q:
+    name: "{{ openshift.common.service_type }}-excluder"
+    state: present
+  register: openshift_excluder_installed
+  failed_when: false
+
+- name: "Warn user about {{ openshift.common.service_type }}-excluder being installed but not enabled"
+  pause:
+    prompt: "The {{ openshift.common.service_type }}-excluder is installed but the \"enable_openshift_excluder\" is not set to \"true\". Please, make sure the \"{{ openshift.common.service_type }}-excluder unexclude\" was run. Press ENTER to continue or CTRL-C to abort."
+    seconds: "10"
+  when:
+  - "{{ openshift_excluder_installed.installed_versions | default([]) | length > 0 }}"
+  # If enable_excluders is not defined, it defaults to true (see openshift_excluders/defaults/main.yml).
+  # So if the enable_excluders is set to false, we need to check if enable_openshift_excluder is set to false.
+  # So the openshift excluder is disabled when both enable_excluders is set to false and enable_openshift_excluder is set to false.
+  # If the enable_excluders is set to false, enable_openshift_excluder is set to false automatically.
+  - "{{ (enable_excluders is defined) and (not enable_excluders | bool) }}"
+  - "{{ (enable_openshift_excluder is not defined) or ((enable_openshift_excluder is defined) and (not enable_openshift_excluder | bool)) }}"

--- a/playbooks/common/openshift-cluster/initialize_openshift_version.yml
+++ b/playbooks/common/openshift-cluster/initialize_openshift_version.yml
@@ -18,6 +18,12 @@
       msg: Incompatible versions of yum and subscription-manager found. You may need to update yum and yum-utils.
     when: "not openshift.common.is_atomic | bool and 'Plugin \"search-disabled-repos\" requires API 2.7. Supported API is 2.6.' in yum_ver_test.stdout"
 
+- name: Check the excluders are in a proper state
+  hosts: l_oo_all_hosts
+  gather_facts: no
+  tasks:
+    - include: check-excluders.yml
+
 - include: disable_excluder.yml
   vars:
     # the excluders needs to be disabled no matter what status says

--- a/roles/openshift_excluder/tasks/status.yml
+++ b/roles/openshift_excluder/tasks/status.yml
@@ -1,5 +1,5 @@
 ---
-- name: Determine if excluder packages are installed
+- name: Determine if openshift excluder package is installed
   rpm_q:
     name: "{{ openshift.common.service_type }}-excluder"
     state: present
@@ -7,7 +7,7 @@
   failed_when: false
 
 # docker excluder needs to be enable by default
-- name: Determine if docker packages are installed
+- name: Determine if docker excluder packages is installed
   rpm_q:
     name: "{{ openshift.common.service_type }}-docker-excluder"
     state: present


### PR DESCRIPTION
This will warn a user if the openshift excluder is installed but not enabled. To make sure the user runs exclude command before continuing.

The prompt message is not printed from some reason.