### PR TITLE
Add parameters to allow overriding minTLSVersion and cipherSuites

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -263,6 +263,15 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Override master servingInfo.maxRequestsInFlight
 #openshift_master_max_requests_inflight=500
 
+# Override master and node servingInfo.minTLSVersion and .cipherSuites
+# valid TLS versions are VersionTLS10, VersionTLS11, VersionTLS12
+# example cipher suites override, valid cipher suites are https://golang.org/pkg/crypto/tls/#pkg-constants
+#openshift_master_min_tls_version=VersionTLS12
+#openshift_master_cipher_suites=['TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256', '...']
+#
+#openshift_node_min_tls_version=VersionTLS12
+#openshift_node_cipher_suites=['TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256', '...']
+
 # default storage plugin dependencies to install, by default the ceph and
 # glusterfs plugin dependencies will be installed, if available.
 #osn_storage_plugin_deps=['ceph','glusterfs','iscsi']

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -263,6 +263,15 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Override master servingInfo.maxRequestsInFlight
 #openshift_master_max_requests_inflight=500
 
+# Override master and node servingInfo.minTLSVersion and .cipherSuites
+# valid TLS versions are VersionTLS10, VersionTLS11, VersionTLS12
+# example cipher suites override, valid cipher suites are https://golang.org/pkg/crypto/tls/#pkg-constants
+#openshift_master_min_tls_version=VersionTLS12
+#openshift_master_cipher_suites=['TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256', '...']
+#
+#openshift_node_min_tls_version=VersionTLS12
+#openshift_node_cipher_suites=['TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256', '...']
+
 # default storage plugin dependencies to install, by default the ceph and
 # glusterfs plugin dependencies will be installed, if available.
 #osn_storage_plugin_deps=['ceph','glusterfs']

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -35,6 +35,15 @@ assetConfig:
     keyFile: master.server.key
     maxRequestsInFlight: 0
     requestTimeoutSeconds: 0
+{% if openshift_master_min_tls_version is defined %}
+    minTLSVersion: {{ openshift_master_min_tls_version }}
+{% endif %}
+{% if openshift_master_cipher_suites is defined %}
+    cipherSuites:
+{% for cipher_suite in openshift_master_cipher_suites %}
+    - {{ cipher_suite }}
+{% endfor %}
+{% endif %}
 {% if openshift_master_ha | bool %}
 {% if openshift.master.audit_config | default(none) is not none and openshift.common.version_gte_3_2_or_1_2 | bool %}
 auditConfig:{{ openshift.master.audit_config | to_padded_yaml(level=1) }}
@@ -254,6 +263,15 @@ servingInfo:
 {% for name in named_certificate['names'] %}
     - "{{ name }}"
 {% endfor %}
+{% endfor %}
+{% endif %}
+{% if openshift_master_min_tls_version is defined %}
+  minTLSVersion: {{ openshift_master_min_tls_version }}
+{% endif %}
+{% if openshift_master_cipher_suites is defined %}
+  cipherSuites:
+{% for cipher_suite in openshift_master_cipher_suites %}
+  - {{ cipher_suite }}
 {% endfor %}
 {% endif %}
 volumeConfig:

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -40,6 +40,15 @@ servingInfo:
   certFile: server.crt
   clientCA: ca.crt
   keyFile: server.key
+{% if openshift_node_min_tls_version is defined %}
+  minTLSVersion: {{ openshift_node_min_tls_version }}
+{% endif %}
+{% if openshift_node_cipher_suites is defined %}
+  cipherSuites:
+{% for cipher_suite in openshift_node_cipher_suites %}
+  - {{ cipher_suite }}
+{% endfor %}
+{% endif %}
 volumeDirectory: {{ openshift.common.data_dir }}/openshift.local.volumes
 proxyArguments:
   proxy-mode:


### PR DESCRIPTION
openshift/origin#13167 allows overriding minimum tls version and cipher suites in any servingInfo config stanza.

Re #3530 this PR adds parameters to set minTLSVersion and cipherSuites in master and node servingInfo config stanzas.