### PR TITLE
New role to fix 'etcd_is_atomic' incorrectly detected during cert redeployment

### DIFF
--- a/playbooks/common/openshift-cluster/redeploy-certificates/ca.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/ca.yml
@@ -31,7 +31,7 @@
 - name: Generate new etcd CA
   hosts: oo_first_etcd
   roles:
-  - role: etcd_ca
+  - role: openshift_etcd_ca
     etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"
     etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
     etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"

--- a/roles/openshift_etcd_ca/meta/main.yml
+++ b/roles/openshift_etcd_ca/meta/main.yml
@@ -1,10 +1,10 @@
 ---
 galaxy_info:
-  author: Jason DeTiberus
-  description: Etcd Server Certificates
+  author: Tim Bielawa
+  description: Meta role around the etcd_ca role
   company: Red Hat, Inc.
   license: Apache License, Version 2.0
-  min_ansible_version: 2.1
+  min_ansible_version: 2.2
   platforms:
   - name: EL
     versions:
@@ -13,4 +13,5 @@ galaxy_info:
   - cloud
   - system
 dependencies:
-- role: openshift_etcd_ca
+- role: openshift_etcd_facts
+- role: etcd_ca

--- a/roles/openshift_etcd_ca/tasks/main.yml
+++ b/roles/openshift_etcd_ca/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Ensure openshift_etcd_ca role is called
+  debug:
+    msg: openshift_etcd_ca role was called

--- a/roles/openshift_etcd_ca/tasks/main.yml
+++ b/roles/openshift_etcd_ca/tasks/main.yml
@@ -1,4 +1,1 @@
 ---
-- name: Ensure openshift_etcd_ca role is called
-  debug:
-    msg: openshift_etcd_ca role was called


### PR DESCRIPTION
`openshift_etcd_ca` is a new **meta-role** that wraps up `openshift_etcd_facts` and `etcd_ca`. This will cause the etcd facts to refresh and set the `etcd_is_atomic` variable correctly.

Presently this variable is not being updated correctly. This leads to an illegal operation on atomic hosts: attempting to use a package manager to install OpenSSL:
```
TASK [etcd_ca : Install openssl] ***********************************************
fatal: [openshift-147.lab.sjc.redhat.com -> openshift-147.lab.sjc.redhat.com]: FAILED! => {
    "changed": false, 
    "failed": true
}
MSG:
Could not find a module for unknown.
```

This message, `Could not find a module for unknown` comes from the ansible [package module](http://docs.ansible.com/ansible/package_module.html). The `...for unknown` part indicates the `package` module could not locate a module to install packages on the target platform (i.e., `apt` on debian, `yum` or `dnf` on RPM distributions). This is an expected error given this scenario.

Later on when the playbook gets to the cert redeploy section it will observe that `etcd_is_atomic` is `True` and will attempt to run the task referenced above, it ultimately fails.

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1427067