### PR TITLE
add ability to specify an etcd version

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -89,6 +89,8 @@ openshift_release=v1.4
 # Skip upgrading Docker during an OpenShift upgrade, leaves the current Docker version alone.
 # docker_upgrade=False
 
+# Specify exact version of etcd to configure or upgrade to.
+# etcd_version="3.1.0"
 
 # Upgrade Hooks
 #

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -89,6 +89,8 @@ openshift_release=v3.4
 # Skip upgrading Docker during an OpenShift upgrade, leaves the current Docker version alone.
 # docker_upgrade=False
 
+# Specify exact version of etcd to configure or upgrade to.
+# etcd_version="3.1.0"
 
 # Upgrade Hooks
 #

--- a/roles/etcd/tasks/etcdctl.yml
+++ b/roles/etcd/tasks/etcdctl.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install etcd for etcdctl
-  package: name=etcd state=present
+  package: name=etcd{{ '-' + etcd_version if etcd_version is defined else '' }} state=present
   when: not openshift.common.is_atomic | bool
 
 - name: Configure etcd profile.d alises

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -7,7 +7,7 @@
     etcd_ip: "{{ etcd_ip }}"
 
 - name: Install etcd
-  package: name=etcd state=present
+  package: name=etcd{{ '-' + etcd_version if etcd_version is defined else '' }} state=present
   when: not etcd_is_containerized | bool
 
 - name: Pull etcd container

--- a/roles/etcd_server_certificates/tasks/main.yml
+++ b/roles/etcd_server_certificates/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install etcd
-  package: name=etcd state=present
+  package: name=etcd{{ '-' + etcd_version if etcd_version is defined else '' }} state=present
   when: not etcd_is_containerized | bool
 
 - name: Check status of etcd certificates


### PR DESCRIPTION
I needed this feature when duplicating an existing openshift cluster and needed to match the etcd version. It could also be useful if someone isn't ready to upgrade to etcd 3.x because it changes stuff including how to do backups and restore/disaster recovery.