### PR TITLE
openshift_excluders depends on openshift_repos

### DIFF
--- a/roles/openshift_excluder/meta/main.yml
+++ b/roles/openshift_excluder/meta/main.yml
@@ -13,3 +13,4 @@ galaxy_info:
   - cloud
 dependencies:
 - { role: openshift_facts }
+- { role: openshift_repos }


### PR DESCRIPTION
So that centos repos are provisioned before attempting to install the
excluders

Fixes #3603