### PR TITLE
Use six from ansible.module_utils for remote hosts

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -18,9 +18,9 @@ from collections import Mapping
 from distutils.util import strtobool
 from distutils.version import LooseVersion
 from operator import itemgetter
-from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from six import string_types
+from six.moves.urllib.parse import urlparse
 
 HAS_OPENSSL = False
 try:

--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -1,26 +1,32 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 # vim: expandtab:tabstop=4:shiftwidth=4
-# pylint: disable=no-name-in-module, import-error, wrong-import-order, ungrouped-imports
 """
 Custom filters for use in openshift-ansible
 """
+import json
 import os
 import pdb
-import pkg_resources
-import re
-import json
-import yaml
 import random
+import re
+
+from collections import Mapping
+# pylint no-name-in-module and import-error disabled here because pylint
+# fails to properly detect the packages when installed in a virtualenv
+from distutils.util import strtobool  # pylint:disable=no-name-in-module,import-error
+from distutils.version import LooseVersion  # pylint:disable=no-name-in-module,import-error
+from operator import itemgetter
+
+import pkg_resources
+import yaml
 
 from ansible import errors
-from collections import Mapping
-from distutils.util import strtobool
-from distutils.version import LooseVersion
-from operator import itemgetter
+# pylint no-name-in-module and import-error disabled here because pylint
+# fails to properly detect the packages when installed in a virtualenv
+from ansible.compat.six import string_types  # pylint:disable=no-name-in-module,import-error
+from ansible.compat.six.moves.urllib.parse import urlparse  # pylint:disable=no-name-in-module,import-error
+from ansible.module_utils._text import to_text
 from ansible.parsing.yaml.dumper import AnsibleDumper
-from six import string_types
-from six.moves.urllib.parse import urlparse
 
 HAS_OPENSSL = False
 try:
@@ -28,15 +34,6 @@ try:
     HAS_OPENSSL = True
 except ImportError:
     pass
-
-try:
-    # ansible-2.2
-    # ansible.utils.unicode.to_unicode is deprecated in ansible-2.2,
-    # ansible.module_utils._text.to_text should be used instead.
-    from ansible.module_utils._text import to_text
-except ImportError:
-    # ansible-2.1
-    from ansible.utils.unicode import to_unicode as to_text
 
 
 def oo_pdb(arg):
@@ -117,8 +114,7 @@ def oo_merge_hostvars(hostvars, variables, inventory_hostname):
         raise errors.AnsibleFilterError("|failed expects variables is a dictionary")
     if not isinstance(inventory_hostname, string_types):
         raise errors.AnsibleFilterError("|failed expects inventory_hostname is a string")
-    # pylint: disable=no-member
-    ansible_version = pkg_resources.get_distribution("ansible").version
+    ansible_version = pkg_resources.get_distribution("ansible").version  # pylint: disable=maybe-no-member
     merged_hostvars = {}
     if LooseVersion(ansible_version) >= LooseVersion('2.0.0'):
         merged_hostvars = oo_merge_dicts(

--- a/roles/openshift_certificate_expiry/library/openshift_cert_expiry.py
+++ b/roles/openshift_certificate_expiry/library/openshift_cert_expiry.py
@@ -10,8 +10,9 @@ import os
 import subprocess
 import yaml
 
-from ansible.module_utils.six.moves import configparser
-
+# pylint import-error disabled because pylint cannot find the package
+# when installed in a virtualenv
+from ansible.module_utils.six.moves import configparser  # pylint: disable=import-error
 from ansible.module_utils.basic import AnsibleModule
 
 try:

--- a/roles/openshift_certificate_expiry/library/openshift_cert_expiry.py
+++ b/roles/openshift_certificate_expiry/library/openshift_cert_expiry.py
@@ -10,7 +10,7 @@ import os
 import subprocess
 import yaml
 
-from six.moves import configparser
+from ansible.module_utils.six.moves import configparser
 
 from ansible.module_utils.basic import AnsibleModule
 

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -19,8 +19,8 @@ import struct
 import socket
 from distutils.util import strtobool
 from distutils.version import LooseVersion
-from six import string_types, text_type
-from six.moves import configparser
+from ansible.module_utils.six import string_types, text_type
+from ansible.module_utils.six.moves import configparser
 
 # ignore pylint errors related to the module_utils import
 # pylint: disable=redefined-builtin, unused-wildcard-import, wildcard-import

--- a/roles/openshift_facts/vars/main.yml
+++ b/roles/openshift_facts/vars/main.yml
@@ -2,7 +2,6 @@
 required_packages:
   - iproute
   - python-dbus
-  - python-six
   - PyYAML
   - yum-utils
 

--- a/roles/openshift_health_checker/openshift_checks/__init__.py
+++ b/roles/openshift_health_checker/openshift_checks/__init__.py
@@ -2,12 +2,15 @@
 Health checks for OpenShift clusters.
 """
 
+import operator
 import os
+
 from abc import ABCMeta, abstractmethod, abstractproperty
 from importlib import import_module
-import operator
 
-from ansible.module_utils.six.moves import add_metaclass, reduce
+# pylint import-error disabled because pylint cannot find the package
+# when installed in a virtualenv
+from ansible.module_utils.six.moves import add_metaclass, reduce  # pylint: disable=import-error, redefined-builtin
 
 
 class OpenShiftCheckException(Exception):

--- a/roles/openshift_health_checker/openshift_checks/__init__.py
+++ b/roles/openshift_health_checker/openshift_checks/__init__.py
@@ -7,8 +7,7 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from importlib import import_module
 import operator
 
-import six
-from six.moves import reduce
+from ansible.module_utils.six.moves import add_metaclass, reduce
 
 
 class OpenShiftCheckException(Exception):
@@ -16,7 +15,7 @@ class OpenShiftCheckException(Exception):
     pass
 
 
-@six.add_metaclass(ABCMeta)
+@add_metaclass(ABCMeta)
 class OpenShiftCheck(object):
     """A base class for defining checks for an OpenShift cluster environment."""
 

--- a/roles/openshift_master_facts/filter_plugins/openshift_master.py
+++ b/roles/openshift_master_facts/filter_plugins/openshift_master.py
@@ -7,12 +7,16 @@ Custom filters for use in openshift-master
 import copy
 import sys
 
+# pylint import-error disabled because pylint cannot find the package
+# when installed in a virtualenv
 from distutils.version import LooseVersion  # pylint: disable=no-name-in-module,import-error
 
 from ansible import errors
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.plugins.filter.core import to_bool as ansible_bool
-from six import string_types
+# pylint import-error disabled because pylint cannot find the package
+# when installed in a virtualenv
+from ansible.compat.six import string_types  # pylint: disable=no-name-in-module,import-error
 
 import yaml
 


### PR DESCRIPTION
Remote hosts do not actually need python-six, we can use ansible.module_utils.six.

This removes the remote dependency on python-six.