### PR TITLE
nuage: Move role back to config

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -127,6 +127,8 @@
     etcd_cert_subdir: "openshift-master-{{ openshift.common.hostname }}"
     etcd_cert_config_dir: "{{ openshift.common.config_base }}/master"
     etcd_cert_prefix: "master.etcd-"
+  - role: nuage_master
+    when: openshift.common.use_nuage | bool
 
   post_tasks:
   - name: Create group for deployment type

--- a/roles/openshift_master/meta/main.yml
+++ b/roles/openshift_master/meta/main.yml
@@ -40,8 +40,6 @@ dependencies:
     port: 4001/tcp
   when: groups.oo_etcd_to_config | default([]) | length == 0
 - role: nickhammond.logrotate
-- role: nuage_master
-  when: openshift.common.use_nuage | bool
 - role: contiv
   contiv_role: netmaster
   when: openshift.common.use_contiv | bool


### PR DESCRIPTION
d113f03 moved role dependencies out of playbooks. However, this ended up
causing the masters to not be configured before the nuage steps required
configured masters. This change moves the nuage specific change in
d113f03 back to the config.

Resolves #3583