### PR TITLE
Bug 1428711 - [IntService_public_324] ES pod is unable to read searchguard.truststore after upgarde logging from 3.3.1 to 3.5.0

### DIFF
--- a/roles/openshift_logging/tasks/generate_secrets.yaml
+++ b/roles/openshift_logging/tasks/generate_secrets.yaml
@@ -64,7 +64,7 @@
     admin-ca={{generated_certs_dir}}/ca.crt admin.jks={{generated_certs_dir}}/system.admin.jks -o yaml
   vars:
     secret_name: logging-elasticsearch
-    secret_keys: ["admin-cert", "searchguard.key", "admin-ca", "key", "truststore", "admin-key"]
+    secret_keys: ["admin-cert", "searchguard.key", "admin-ca", "key", "truststore", "admin-key", "searchguard.truststore"]
   register: logging_es_secret
   when: secret_name not in openshift_logging_facts.elasticsearch.secrets or
         secret_keys | difference(openshift_logging_facts.elasticsearch.secrets["{{secret_name}}"]["keys"]) | length != 0


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1428711
The list of secrets for elasticsearch was missing searchguard.truststore

@jcantrill @ewolinetz ptal

How does upgrading secrets work?  Does it pull the existing secrets, write
them to {{generated_certs_dir}}/{{secretname}}, and re-use them?

Specifically in the case of this bz - where does the value of
searchguard.truststore come from?  I think it should be the same as the
value of truststore.  That is, when upgrading from 3.3 to 3.5, the ansible
code should pull the secret value of truststore, and use that value for
both truststore and searchguard.truststore.  Is this how it works?