### PR TITLE
Fix incorrect comparison when detecting petsets

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_5/validator.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/validator.yml
@@ -35,7 +35,7 @@
       kind: petsets
     register: l_do_petsets_exist
 
-  - name: FAIL ON Resource migration 'PetSets' unsupported
+  - name: Fail on unsupported resource migration 'PetSets'
     fail:
       msg: >
         PetSet objects were detected in your cluster. These are an
@@ -62,6 +62,6 @@
         $ oc get petsets --all-namespaces -o yaml | oc delete -f - --cascale=false
     when:
     # Search did not fail, valid resource type found
-    - l_do_petsets_exist.results.returncode == "0"
+    - l_do_petsets_exist.results.returncode == 0
     # Items do exist in the search results
     - l_do_petsets_exist.results.results.0['items'] | length > 0


### PR DESCRIPTION
Incorrectly quoted the `0` character in the last attempt at this. This fixes the test to actually compare ints to ints.

Testing this now.