### PR TITLE
validate excluders on non-atomic hosts only

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/validate_excluder.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/validate_excluder.yml
@@ -3,20 +3,23 @@
 # - repoquery_cmd
 # - excluder
 # - openshift_upgrade_target
-- name: Get available excluder version
-  command: >
-    {{ repoquery_cmd }} --qf '%{version}' "{{ excluder }}"
-  register: excluder_version
-  failed_when: false
-  changed_when: false
+- block:
+  - name: Get available excluder version
+    command: >
+      {{ repoquery_cmd }} --qf '%{version}' "{{ excluder }}"
+    register: excluder_version
+    failed_when: false
+    changed_when: false
 
-- name: Docker excluder version detected
-  debug:
-    msg: "{{ excluder }}: {{ excluder_version.stdout }}"
+  - name: Docker excluder version detected
+    debug:
+      msg: "{{ excluder }}: {{ excluder_version.stdout }}"
 
-- name: Check the available {{ excluder }} version is at most of the upgrade target version
-  fail:
-    msg: "Available {{ excluder }} version {{ excluder_version.stdout }} is higher than the upgrade target version {{ openshift_upgrade_target }}"
-  when:
+  - name: Check the available {{ excluder }} version is at most of the upgrade target version
+    fail:
+      msg: "Available {{ excluder }} version {{ excluder_version.stdout }} is higher than the upgrade target version {{ openshift_upgrade_target }}"
+    when:
     - "{{ excluder_version.stdout != '' }}"
     - "{{ excluder_version.stdout.split('.')[0:2] | join('.') | version_compare(openshift_upgrade_target, '>', strict=True) }}"
+  when:
+  - not openshift.common.is_atomic | bool


### PR DESCRIPTION
Don't check for available excluders in atomic host since we don't support them on AH.