### PR TITLE
Missing tlsv1.2 argument to curl 

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -249,7 +249,7 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent
+    curl --silent --tlsv1.2
     {% if openshift.common.version_gte_3_2_or_1_2 | bool %}
     --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
     {% else %}

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -153,7 +153,7 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent --cacert {{ openshift.common.config_base }}/node/ca.crt
+    curl --silent --tlsv1.2 --cacert {{ openshift.common.config_base }}/node/ca.crt
     {{ openshift_node_master_api_url }}/healthz/ready
   args:
     # Disables the following warning:


### PR DESCRIPTION
Add --tlsv1.2 to curl command (installation failed on RHEL 7.1) 
Related to **https://github.com/openshift/openshift-ansible/pull/2707**
