### PR TITLE
Cleanup of openshift_version tasks

### DIFF
--- a/DEPLOYMENT_TYPES.md
+++ b/DEPLOYMENT_TYPES.md
@@ -1,18 +1,17 @@
 #Deployment Types
 
-This module supports OpenShift Origin, OpenShift Enterprise, and Atomic
-Enterprise Platform. Each deployment type sets various defaults used throughout
-your environment.
+This module supports OpenShift Origin and OpenShift Enterprise Each deployment
+type sets various defaults used throughout your environment.
 
 The table below outlines the defaults per `deployment_type`.
 
-| deployment_type                                                 | origin                                   | enterprise (< 3.1)                     | atomic-enterprise                | openshift-enterprise (>= 3.1)    |
-|-----------------------------------------------------------------|------------------------------------------|----------------------------------------|----------------------------------|----------------------------------|
-| **openshift.common.service_type** (also used for package names) | origin                                   | openshift                              | atomic-openshift                 |                                  |
-| **openshift.common.config_base**                                | /etc/origin                              | /etc/openshift                         | /etc/origin                      | /etc/origin                      |
-| **openshift.common.data_dir**                                   | /var/lib/origin                          | /var/lib/openshift                     | /var/lib/origin                  | /var/lib/origin                  |
-| **openshift.master.registry_url openshift.node.registry_url**   | openshift/origin-${component}:${version} | openshift3/ose-${component}:${version} | aos3/aos-${component}:${version} | aos3/aos-${component}:${version} |
-| **Image Streams**                                               | centos                                   | rhel + xpaas                           | N/A                              | rhel                             |
+| deployment_type                                                 | origin                                   | enterprise (< 3.1)                     | openshift-enterprise (>= 3.1)    |
+|-----------------------------------------------------------------|------------------------------------------|----------------------------------------|----------------------------------|
+| **openshift.common.service_type** (also used for package names) | origin                                   | openshift                              |                                  |
+| **openshift.common.config_base**                                | /etc/origin                              | /etc/openshift                         | /etc/origin                      |
+| **openshift.common.data_dir**                                   | /var/lib/origin                          | /var/lib/openshift                     | /var/lib/origin                  |
+| **openshift.master.registry_url openshift.node.registry_url**   | openshift/origin-${component}:${version} | openshift3/ose-${component}:${version} | aos3/aos-${component}:${version} |
+| **Image Streams**                                               | centos                                   | rhel + xpaas                           | rhel                             |
 
 
 **NOTE** `enterprise` deployment type is used for OpenShift Enterprise version

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -9,16 +9,36 @@
 # be used by default. Users must indicate what they want.
 - fail:
     msg: "Must specify openshift_release or openshift_image_tag in inventory to install origin. (suggestion: add openshift_release=\"1.2\" to inventory)"
-  when: is_containerized | bool and openshift.common.deployment_type == 'origin' and openshift_release is not defined and openshift_image_tag is not defined
+  when:
+  - is_containerized | bool
+  - openshift.common.deployment_type == 'origin'
+  - openshift_release is not defined
+  - openshift_image_tag is not defined
 
 # Normalize some values that we need in a certain format that might be confusing:
 - set_fact:
+    openshift_release: "{{ openshift_release[1:] }}"
+  when:
+  - openshift_release is defined
+  - openshift_release[0] == 'v'
+
+- set_fact:
+    openshift_release: "{{ openshift_release | string }}"
+  when: openshift_release is defined
+
+# Add a v to the start of the openshift_image_tag if one was not provided
+- set_fact:
     openshift_image_tag: "{{ 'v' + openshift_image_tag }}"
-  when: openshift_image_tag is defined and openshift_image_tag[0] != 'v' and openshift_image_tag != 'latest'
+  when:
+  - openshift_image_tag is defined
+  - openshift_image_tag[0] != 'v'
+  - openshift_image_tag != 'latest'
 
 - set_fact:
     openshift_pkg_version: "{{ '-' + openshift_pkg_version }}"
-  when: openshift_pkg_version is defined and openshift_pkg_version[0] != '-'
+  when:
+  - openshift_pkg_version is defined
+  - openshift_pkg_version[0] != '-'
 
 # Make sure we copy this to a fact if given a var:
 - set_fact:
@@ -30,7 +50,10 @@
 - name: Use openshift.common.version fact as version to configure if already installed
   set_fact:
     openshift_version: "{{ openshift.common.version }}"
-  when: openshift.common.version is defined and openshift_version is not defined and openshift_protect_installed_version | bool
+  when:
+  - openshift.common.version is defined
+  - openshift_version is not defined
+  - openshift_protect_installed_version | bool
 
 - name: Set openshift_version for rpm installation
   include: set_version_rpm.yml
@@ -67,13 +90,18 @@
 
 - fail:
     msg: "No OpenShift version available, please ensure your systems are fully registered and have access to appropriate yum repositories."
-  when: not is_containerized | bool and openshift_version == '0.0'
+  when:
+  - not is_containerized | bool
+  - openshift_version == '0.0'
 
 # We can't map an openshift_release to full rpm version like we can with containers, make sure
 # the rpm version we looked up matches the release requested and error out if not.
 - fail:
     msg: "Detected OpenShift version {{ openshift_version }} does not match requested openshift_release {{ openshift_release }}. You may need to adjust your yum repositories, inventory, or run the appropriate OpenShift upgrade playbook."
-  when: not is_containerized | bool and openshift_release is defined and not openshift_version.startswith(openshift_release) | bool
+  when:
+  - not is_containerized | bool
+  - openshift_release is defined
+  - not openshift_version.startswith(openshift_release) | bool
 
 # The end result of these three variables is quite important so make sure they are displayed and logged:
 - debug: var=openshift_release

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -57,20 +57,6 @@
   - openshift_image_tag is defined
   - openshift_image_tag != "latest"
 
-# Add a v to the start of the openshift_image_tag if one was not provided
-- set_fact:
-    openshift_image_tag: "{{ 'v' + openshift_image_tag }}"
-  when:
-  - openshift_image_tag is defined
-  - openshift_image_tag[0] != 'v'
-  - openshift_image_tag != 'latest'
-
-- set_fact:
-    openshift_pkg_version: "{{ '-' + openshift_pkg_version }}"
-  when:
-  - openshift_pkg_version is defined
-  - openshift_pkg_version[0] != '-'
-
 # Make sure we copy this to a fact if given a var:
 - set_fact:
     openshift_version: "{{ openshift_version | string }}"

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -94,6 +94,18 @@
   include: set_version_containerized.yml
   when: is_containerized | bool
 
+# Warn if the user has provided an openshift_image_tag but is not doing a containerized install
+# NOTE: This will need to be modified/removed for future container + rpm installations work.
+- name: Warn if openshift_image_tag is defined when not doing a containerized install
+  debug:
+    msg: >
+      openshift_image_tag is used for containerized installs. If you are trying to
+      specify an image for a non-container install see oreg_url.
+  when:
+  - not is_containerized | bool
+  - openshift_image_tag is defined
+
+
 # At this point we know openshift_version is set appropriately. Now we set
 # openshift_image_tag and openshift_pkg_version, so all roles can always assume
 # each of this variables *will* be set correctly and can use them per their

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -26,6 +26,37 @@
     openshift_release: "{{ openshift_release | string }}"
   when: openshift_release is defined
 
+# Verify that the image tag is in a valid format
+- block:
+
+  # Verifies that when the deployment type is origin the version:
+  # - starts with a v
+  # - Has 3 integers seperated by dots
+  # It also allows for optional trailing data which:
+  # - must start with a dash
+  # - may contain numbers, letters, dashes and dots.
+  - assert:
+      that:
+      - "{{ openshift_image_tag|match('(^v?\\d+\\.\\d+\\.\\d+(-[\\w\\-\\.]*)?$)') }}"
+      msg: "openshift_image_tag must be in the format v#.#.#[-optional.#]. Examples: v1.2.3, v3.5.1-alpha.1"
+    when: openshift.common.deployment_type == 'origin'
+
+  # Verifies that when the deployment type is openshift-enterprise the version:
+  # - starts with a v
+  # - Has at least 2 integers seperated by dots
+  # It also allows for optional trailing data which:
+  # - must start with a dash
+  # - may contain numbers
+  - assert:
+      that:
+      - "{{ openshift_image_tag|match('(^v\\d+\\.\\d+[\\.\\d+]*(-\\d+)?$)') }}"
+      msg: "openshift_image_tag must be in the format v#.#[.#[.#]]. Examples: v1.2, v3.4.1, v3.5.1.3, v1.2-1, v1.2.3-4"
+    when: openshift.common.deployment_type == 'openshift-enterprise'
+
+  when:
+  - openshift_image_tag is defined
+  - openshift_image_tag != "latest"
+
 # Add a v to the start of the openshift_image_tag if one was not provided
 - set_fact:
     openshift_image_tag: "{{ 'v' + openshift_image_tag }}"

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -68,12 +68,22 @@
 # each of this variables *will* be set correctly and can use them per their
 # intended purpose.
 
-- set_fact:
-    openshift_image_tag: v{{ openshift_version }}
+- block:
+  - debug:
+      msg: "openshift_image_tag was not defined. Falling back to v{{ openshift_version }}"
+
+  - set_fact:
+      openshift_image_tag: v{{ openshift_version }}
+
   when: openshift_image_tag is not defined
 
-- set_fact:
-    openshift_pkg_version: -{{ openshift_version }}
+- block:
+  - debug:
+      msg: "openshift_pkg_version was not defined. Falling back to -{{ openshift_version }}"
+
+  - set_fact:
+      openshift_pkg_version: -{{ openshift_version }}
+
   when: openshift_pkg_version is not defined
 
 - fail:

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -35,7 +35,8 @@
   # It also allows for optional trailing data which:
   # - must start with a dash
   # - may contain numbers, letters, dashes and dots.
-  - assert:
+  - name: Verify Origin openshift_image_tag is valid
+    assert:
       that:
       - "{{ openshift_image_tag|match('(^v?\\d+\\.\\d+\\.\\d+(-[\\w\\-\\.]*)?$)') }}"
       msg: "openshift_image_tag must be in the format v#.#.#[-optional.#]. Examples: v1.2.3, v3.5.1-alpha.1"
@@ -47,7 +48,8 @@
   # It also allows for optional trailing data which:
   # - must start with a dash
   # - may contain numbers
-  - assert:
+  - name: Verify Enterprise openshift_image_tag is valid
+    assert:
       that:
       - "{{ openshift_image_tag|match('(^v\\d+\\.\\d+[\\.\\d+]*(-\\d+)?$)') }}"
       msg: "openshift_image_tag must be in the format v#.#[.#[.#]]. Examples: v1.2, v3.4.1, v3.5.1.3, v1.2-1, v1.2.3-4"

--- a/roles/openshift_version/tasks/set_version_containerized.yml
+++ b/roles/openshift_version/tasks/set_version_containerized.yml
@@ -4,12 +4,16 @@
     # Expects a leading "v" in inventory, strip it off here unless
     # openshift_image_tag=latest
     openshift_version: "{{ openshift_image_tag[1:].split('-')[0] if openshift_image_tag != 'latest' else openshift_image_tag }}"
-  when: openshift_image_tag is defined and openshift_version is not defined
+  when:
+  - openshift_image_tag is defined
+  - openshift_version is not defined
 
 - name: Set containerized version to configure if openshift_release specified
   set_fact:
     openshift_version: "{{ openshift_release }}"
-  when: openshift_release is defined and openshift_version is not defined
+  when:
+  - openshift_release is defined
+  - openshift_version is not defined
 
 - name: Lookup latest containerized version if no version specified
   command: >
@@ -20,7 +24,10 @@
 # Origin latest = pre-release version (i.e. v1.3.0-alpha.1-321-gb095e3a)
 - set_fact:
     openshift_version: "{{ (cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0:2] | join('-'))[1:] }}"
-  when: openshift_version is not defined and openshift.common.deployment_type == 'origin' and cli_image_version.stdout_lines[0].split('-') | length > 1
+  when:
+  - openshift_version is not defined
+  - openshift.common.deployment_type == 'origin'
+  - cli_image_version.stdout_lines[0].split('-') | length > 1
 
 - set_fact:
     openshift_version: "{{ cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0][1:] }}"
@@ -32,11 +39,15 @@
   command: >
     docker run --rm {{ openshift.common.cli_image }}:v{{ openshift_version }} version
   register: cli_image_version
-  when: openshift_version is defined and openshift_version.split('.') | length == 2
+  when:
+  - openshift_version is defined
+  - openshift_version.split('.') | length == 2
 
 - set_fact:
     openshift_version: "{{ cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0:2][1:] | join('-') if openshift.common.deployment_type == 'origin' else cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0][1:] }}"
-  when: openshift_version is defined and openshift_version.split('.') | length == 2
+  when:
+  - openshift_version is defined
+  - openshift_version.split('.') | length == 2
 
 # We finally have the specific version. Now we clean up any strange
 # dangly +c0mm1t-offset tags in the version. See also,

--- a/roles/openshift_version/tasks/set_version_rpm.yml
+++ b/roles/openshift_version/tasks/set_version_rpm.yml
@@ -3,7 +3,9 @@
   set_fact:
     # Expects a leading "-" in inventory, strip it off here, and remove trailing release,
     openshift_version: "{{ openshift_pkg_version[1:].split('-')[0] }}"
-  when: openshift_pkg_version is defined and openshift_version is not defined
+  when:
+  - openshift_pkg_version is defined
+  - openshift_version is not defined
 
 # if {{ openshift.common.service_type}}-excluder is enabled,
 # the repoquery for {{ openshift.common.service_type}} will not work.


### PR DESCRIPTION
- ``when`` in openshift_version tasks are multiline
- Add openshift_version fact fallback debug messages
- Verify ``openshift_image_tag`` is valid during openshift_version main
- Add debug message when ``openshift_image_tag`` is defined for non container installs
- Remove ``atomic-enterprise`` deployment type from documentation