### PR TITLE
Revert module_utils six for openshift_health_checker

### DIFF
--- a/roles/openshift_facts/vars/main.yml
+++ b/roles/openshift_facts/vars/main.yml
@@ -2,6 +2,7 @@
 required_packages:
   - iproute
   - python-dbus
+  - python-six
   - PyYAML
   - yum-utils
 

--- a/roles/openshift_health_checker/openshift_checks/__init__.py
+++ b/roles/openshift_health_checker/openshift_checks/__init__.py
@@ -8,9 +8,11 @@ import os
 from abc import ABCMeta, abstractmethod, abstractproperty
 from importlib import import_module
 
+# add_metaclass is not available in the embedded six from module_utils in Ansible 2.2.1
+from six import add_metaclass
 # pylint import-error disabled because pylint cannot find the package
 # when installed in a virtualenv
-from ansible.module_utils.six.moves import add_metaclass, reduce  # pylint: disable=import-error, redefined-builtin
+from ansible.module_utils.six.moves import reduce  # pylint: disable=import-error, redefined-builtin
 
 
 class OpenShiftCheckException(Exception):


### PR DESCRIPTION
Embedded version of six in Ansible 2.2.1 does not support add_metaclass,
so revert to using python-six.