### PR TITLE
Allow user to specify additions to ES config

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -78,6 +78,8 @@ openshift_logging_es_pvc_prefix: "{{ openshift_hosted_logging_elasticsearch_pvc_
 openshift_logging_es_recover_after_time: 5m
 openshift_logging_es_storage_group: "{{ openshift_hosted_logging_elasticsearch_storage_group | default('65534') }}"
 openshift_logging_es_nodeselector: "{{ openshift_hosted_logging_elasticsearch_nodeselector | default('') | map_from_pairs }}"
+# openshift_logging_es_config is a hash to be merged into the defaults for the elasticsearch.yaml
+openshift_logging_es_config: {}
 
 # allow cluster-admin or cluster-reader to view operations index
 openshift_logging_es_ops_allow_cluster_reader: False

--- a/roles/openshift_logging/tasks/generate_configmaps.yaml
+++ b/roles/openshift_logging/tasks/generate_configmaps.yaml
@@ -6,8 +6,17 @@
       when: es_logging_contents is undefined
       changed_when: no
 
+    - local_action: >
+        copy content="{{ config_source | combine(override_config,recursive=True) | to_nice_yaml }}"
+        dest="{{local_tmp.stdout}}/elasticsearch-gen-template.yml"
+      vars:
+        config_source: "{{lookup('file','templates/elasticsearch.yml.j2') | from_yaml }}"
+        override_config: "{{openshift_logging_es_config | from_yaml}}"
+      when: es_logging_contents is undefined
+      changed_when: no
+
     - template:
-        src: elasticsearch.yml.j2
+        src: "{{local_tmp.stdout}}/elasticsearch-gen-template.yml"
         dest: "{{mktemp.stdout}}/elasticsearch.yml"
       vars:
         - allow_cluster_reader: "{{openshift_logging_es_ops_allow_cluster_reader | lower | default('false')}}"

--- a/roles/openshift_logging/tasks/generate_jks.yaml
+++ b/roles/openshift_logging/tasks/generate_jks.yaml
@@ -20,12 +20,6 @@
   register: truststore_jks
   check_mode: no
 
-- name: Create temp directory for doing work in
-  local_action: command mktemp -d /tmp/openshift-logging-ansible-XXXXXX
-  register: local_tmp
-  changed_when: False
-  check_mode: no
-
 - name: Create placeholder for previously created JKS certs to prevent recreating...
   local_action: file path="{{local_tmp.stdout}}/elasticsearch.jks" state=touch mode="u=rw,g=r,o=r"
   when: elasticsearch_jks.stat.exists
@@ -92,7 +86,3 @@
     src: "{{local_tmp.stdout}}/truststore.jks"
     dest: "{{generated_certs_dir}}/truststore.jks"
   when: not truststore_jks.stat.exists
-
-- name: Cleaning up temp dir
-  local_action: file path="{{local_tmp.stdout}}" state=absent
-  changed_when: False

--- a/roles/openshift_logging/tasks/main.yaml
+++ b/roles/openshift_logging/tasks/main.yaml
@@ -12,6 +12,14 @@
 
 - debug: msg="Created temp dir {{mktemp.stdout}}"
 
+- name: Create local temp directory for doing work in
+  local_action: command mktemp -d /tmp/openshift-logging-ansible-XXXXXX
+  register: local_tmp
+  changed_when: False
+  check_mode: no
+
+- debug: msg="Created local temp dir {{local_tmp.stdout}}"
+
 - name: Copy the admin client config(s)
   command: >
     cp {{ openshift_master_config_dir }}/admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
@@ -37,3 +45,8 @@
   tags: logging_cleanup
   changed_when: False
   check_mode: no
+
+- name: Cleaning up local temp dir
+  local_action: file path="{{local_tmp.stdout}}" state=absent
+  tags: logging_cleanup
+  changed_when: False

--- a/roles/openshift_logging/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging/templates/elasticsearch.yml.j2
@@ -47,7 +47,7 @@ openshift.searchguard:
   keystore.path: /etc/elasticsearch/secret/admin.jks
   truststore.path: /etc/elasticsearch/secret/searchguard.truststore
 
-openshift.operations.allow_cluster_reader: {{allow_cluster_reader | default ('false')}}
+openshift.operations.allow_cluster_reader: "{{allow_cluster_reader | default (false)}}"
 
 path:
   data: /elasticsearch/persistent/${CLUSTER_NAME}/data


### PR DESCRIPTION
This PRs allow a user to define a hash for the ES config that will be merged into the defaults that are defined for templates/elasticsearcy.yaml so to allow further tweaking of ES.

cc @richm