### PR TITLE
don't assume openshift_upgrade_target is in a form d.d

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/validate_excluder.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/validate_excluder.yml
@@ -15,11 +15,15 @@
     debug:
       msg: "{{ excluder }}: {{ excluder_version.stdout }}"
 
+  - name: Printing upgrade target version
+    debug:
+      msg: "{{ openshift_upgrade_target }}"
+
   - name: Check the available {{ excluder }} version is at most of the upgrade target version
     fail:
-      msg: "Available {{ excluder }} version {{ excluder_version.stdout }} is higher than the upgrade target version {{ openshift_upgrade_target }}"
+      msg: "Available {{ excluder }} version {{ excluder_version.stdout }} is higher than the upgrade target version"
     when:
     - "{{ excluder_version.stdout != '' }}"
-    - "{{ excluder_version.stdout.split('.')[0:2] | join('.') | version_compare(openshift_upgrade_target, '>', strict=True) }}"
+    - "{{ excluder_version.stdout.split('.')[0:2] | join('.') | version_compare(openshift_upgrade_target.split('.')[0:2] | join('.'), '>', strict=True) }}"
   when:
   - not openshift.common.is_atomic | bool


### PR DESCRIPTION
Just in case the ``openshift_upgrade_target`` is set to something like ` 1.5.0-999.alpha.3+1eb44c7.379.x86_64`