### PR TITLE
Removing dependency on master facts for master_public_url default

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -3,7 +3,7 @@ openshift_logging_image_prefix: "{{ openshift_hosted_logging_deployer_prefix | d
 openshift_logging_image_version: "{{ openshift_hosted_logging_deployer_version | default('latest') }}"
 openshift_logging_use_ops: "{{ openshift_hosted_logging_enable_ops_cluster | default('false') | bool }}"
 openshift_logging_master_url: "https://kubernetes.default.svc.{{ openshift.common.dns_domain }}"
-openshift_logging_master_public_url: "{{ openshift_hosted_logging_master_public_url | default('https://' + openshift.common.public_hostname + ':' + openshift.master.api_port) }}"
+openshift_logging_master_public_url: "{{ openshift_hosted_logging_master_public_url | default('https://' + openshift.common.public_hostname + ':' ~ (openshift_master_api_port | default('8443', true))) }}"
 openshift_logging_namespace: logging
 openshift_logging_install_logging: True
 openshift_logging_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"


### PR DESCRIPTION
To address issues in origin-aggregated-logging CI where we see 
```
AnsibleUndefinedVariable: {{ openshift_hosted_logging_master_public_url | default('https://' + openshift.common.public_hostname + ':' + openshift.master.api_port) }}: 'dict object' has no attribute 'master'
```

@jcantrill @richm 