### PR TITLE
Set auto_expand_replicas to Default of 'false'

### DIFF
--- a/roles/openshift_logging/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging/templates/elasticsearch.yml.j2
@@ -8,7 +8,6 @@ script:
 index:
   number_of_shards: 1
   number_of_replicas: 0
-  auto_expand_replicas: 0-2
   unassigned.node_left.delayed_timeout: 2m
   translog:
     flush_threshold_size: 256mb


### PR DESCRIPTION
 to avoid https://github.com/elastic/elasticsearch/issues/1873.

This will require users to explicitly configure the option and avoid OpenShift clusters unnecessarily wasting resources based on what is described in the issue.