### PR TITLE
Fix containerized openvswitch race

### DIFF
--- a/roles/openshift_node/templates/openshift.docker.node.service
+++ b/roles/openshift_node/templates/openshift.docker.node.service
@@ -6,6 +6,8 @@ PartOf=docker.service
 Requires=docker.service
 {% if openshift.common.use_openshift_sdn %}
 Requires=openvswitch.service
+After=ovsdb-server.service
+After=ovs-vswitchd.service
 {% endif %}
 Wants={{ openshift.common.service_type }}-master.service
 Requires={{ openshift.common.service_type }}-node-dep.service


### PR DESCRIPTION
We wait until openvswitch is started, but openvswitch doesn't wait until ovsdb-server.service has started so we must do that on our own.

See https://github.com/openshift/origin/issues/13318