### PR TITLE
enable docker excluder since the time it is installed

### DIFF
--- a/playbooks/common/openshift-cluster/initialize_openshift_version.yml
+++ b/playbooks/common/openshift-cluster/initialize_openshift_version.yml
@@ -23,6 +23,9 @@
   vars:
     # the excluders needs to be disabled no matter what status says
     with_status_check: false
+    # Only openshift excluder needs to be temporarily disabled
+    # So ignore the docker one
+    enable_docker_excluder: false
   tags:
   - always
   when: openshift_upgrade_target is not defined
@@ -44,6 +47,10 @@
 
   # Re-enable excluders if they are meant to be enabled (and only during installation, upgrade disables the excluders before this play)
 - include: reset_excluder.yml
+  vars:
+    # Only openshift excluder needs to be re-enabled
+    # So ignore the docker one
+    enable_docker_excluder: false
   tags:
   - always
   when: openshift_upgrade_target is not defined

--- a/roles/openshift_excluder/tasks/adjust.yml
+++ b/roles/openshift_excluder/tasks/adjust.yml
@@ -8,16 +8,18 @@
   - include: exclude.yml
     vars:
       # Enable the docker excluder only if it is overrided
-      enable_docker_excluder: "{{ enable_docker_excluder_override | default(false) | bool }}"
+      # BZ #1430612: docker excluders should be enabled even during installation and upgrade
+      exclude_docker_excluder: "{{ enable_docker_excluder | default(true) | bool }}"
       # excluder is to be disabled by default
-      enable_openshift_excluder: false
+      exclude_openshift_excluder: false
   # All excluders that are to be disabled are disabled
   - include: unexclude.yml
     vars:
       # If the docker override  is not set, default to the generic behaviour
-      disable_docker_excluder: "{{ not enable_docker_excluder_override | default(not docker_excluder_on) | bool }}"
+      # BZ #1430612: docker excluders should be enabled even during installation and upgrade
+      unexclude_docker_excluder: false
       # disable openshift excluder is never overrided to be enabled
       # disable it if the docker excluder is enabled
-      disable_openshift_excluder: "{{ openshift_excluder_on | bool }}"
+      unexclude_openshift_excluder: "{{ openshift_excluder_on | bool }}"
   when:
   - not openshift.common.is_atomic | bool

--- a/roles/openshift_excluder/tasks/enable.yml
+++ b/roles/openshift_excluder/tasks/enable.yml
@@ -13,9 +13,9 @@
   - include: exclude.yml
     vars:
       # Enable the docker excluder only if it is overrided, resp. enabled by default (in that order)
-      enable_docker_excluder: "{{ enable_docker_excluder_override | default(docker_excluder_on) | bool }}"
+      exclude_docker_excluder: "{{ enable_docker_excluder_override | default(docker_excluder_on) | bool }}"
       # Enable the openshift excluder only if it is not overrided, resp. enabled by default (in that order)
-      enable_openshift_excluder: "{{ not disable_openshift_excluder_override | default(not openshift_excluder_on) | bool }}"
+      exclude_openshift_excluder: "{{ not disable_openshift_excluder_override | default(not openshift_excluder_on) | bool }}"
 
   when:
   - not openshift.common.is_atomic | bool

--- a/roles/openshift_excluder/tasks/exclude.yml
+++ b/roles/openshift_excluder/tasks/exclude.yml
@@ -1,20 +1,20 @@
 ---
 # input variables:
-# - enable_docker_excluder
-# - enable_openshift_excluder
+# - exclude_docker_excluder
+# - exclude_openshift_excluder
 - block:
   - name: Enable docker excluder
     command: "{{ openshift.common.service_type }}-docker-excluder exclude"
     # if the docker override is set, it means the docker excluder needs to be enabled no matter what
     # if the docker override is not set, the excluder is set based on enable_docker_excluder
     when:
-    - enable_docker_excluder | default(false) | bool
+    - exclude_docker_excluder | default(false) | bool
 
   - name: Enable openshift excluder
     command: "{{ openshift.common.service_type }}-excluder exclude"
     # if the openshift override is set, it means the openshift excluder is disabled no matter what
     # if the openshift override is not set, the excluder is set based on enable_openshift_excluder
     when:
-    - enable_openshift_excluder | default(false) | bool
+    - exclude_openshift_excluder | default(false) | bool
   when:
   - not openshift.common.is_atomic | bool

--- a/roles/openshift_excluder/tasks/unexclude.yml
+++ b/roles/openshift_excluder/tasks/unexclude.yml
@@ -1,19 +1,17 @@
 ---
 # input variables:
-# - disable_docker_excluder
-# - disable_openshift_excluder
+# - unexclude_docker_excluder
+# - unexclude_openshift_excluder
 - block:
-  - include: init.yml
-
   - name: disable docker excluder
     command: "{{ openshift.common.service_type }}-docker-excluder unexclude"
     when:
-    - disable_docker_excluder | default(false) | bool
+    - unexclude_docker_excluder | default(false) | bool
 
   - name: disable openshift excluder
     command: "{{ openshift.common.service_type }}-excluder unexclude"
     when:
-    - disable_openshift_excluder | default(false) | bool
+    - unexclude_openshift_excluder | default(false) | bool
 
   when:
   - not openshift.common.is_atomic | bool


### PR DESCRIPTION
Once again.

If the docker-excluder is installed and enabled by a user, it must by enabled even during installation, resp. upgrade. If a user unexclude the excluder, the gets excluded at the end of the installation/upgrade.

Bug 1430612