### PR TITLE
Add unit tests for existing health checks code

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,7 @@ python_files =
     # is Python unittest's default, while pytest discovers both "test_*.py" and
     # "*_test.py" by default.
     test_*.py
+    *_test.py
     *_tests.py
 addopts =
     --cov=.

--- a/roles/openshift_health_checker/openshift_checks/__init__.py
+++ b/roles/openshift_health_checker/openshift_checks/__init__.py
@@ -66,7 +66,8 @@ def get_var(task_vars, *keys, **kwargs):
 
     Ansible task_vars structures are Python dicts, often mapping strings to
     other dicts. This helper makes it easier to get a nested value, raising
-    OpenShiftCheckException when a key is not found.
+    OpenShiftCheckException when a key is not found or returning a default value
+    provided as a keyword argument.
     """
     try:
         value = reduce(operator.getitem, keys, task_vars)

--- a/roles/openshift_health_checker/test/conftest.py
+++ b/roles/openshift_health_checker/test/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# extend sys.path so that tests can import openshift_checks
+sys.path.insert(1, os.path.dirname(os.path.dirname(__file__)))

--- a/roles/openshift_health_checker/test/openshift_check_test.py
+++ b/roles/openshift_health_checker/test/openshift_check_test.py
@@ -1,0 +1,40 @@
+import pytest
+
+from openshift_checks import get_var, OpenShiftCheckException
+
+
+# Fixtures
+
+
+@pytest.fixture()
+def task_vars():
+    return dict(foo=42, bar=dict(baz="openshift"))
+
+
+@pytest.fixture(params=[
+    ("notfound",),
+    ("multiple", "keys", "not", "in", "task_vars"),
+])
+def missing_keys(request):
+    return request.param
+
+
+# Tests
+
+
+@pytest.mark.parametrize("keys,expected", [
+    (("foo",), 42),
+    (("bar", "baz"), "openshift"),
+])
+def test_get_var_ok(task_vars, keys, expected):
+    assert get_var(task_vars, *keys) == expected
+
+
+def test_get_var_error(task_vars, missing_keys):
+    with pytest.raises(OpenShiftCheckException):
+        get_var(task_vars, *missing_keys)
+
+
+def test_get_var_default(task_vars, missing_keys):
+    default = object()
+    assert get_var(task_vars, *missing_keys, default=default) == default


### PR DESCRIPTION
This sets up the structure to unit testing the health checks code base.

More tests to come in follow up PRs.