### PR TITLE
Make atomic-openshift-utils require playbooks of the same version

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -21,7 +21,7 @@ Requires:      ansible >= 2.2.0.0-1
 Requires:      python2
 Requires:      python-six
 Requires:      tar
-Requires:      openshift-ansible-docs = %{version}-%{release}
+Requires:      openshift-ansible-docs = %{version}
 Requires:      java-1.8.0-openjdk-headless
 Requires:      httpd-tools
 Requires:      libselinux-python
@@ -250,7 +250,7 @@ BuildArch:     noarch
 %package -n atomic-openshift-utils
 Summary:       Atomic OpenShift Utilities
 BuildRequires: python-setuptools
-Requires:      %{name}-playbooks >= %{version}
+Requires:      %{name}-playbooks = %{version}
 Requires:      python-click
 Requires:      python-setuptools
 Requires:      PyYAML


### PR DESCRIPTION
Also, uniformly match %{version} rather than %{version}-%{release} in some places.
Prevents this where you're installing 3.4 utils but 3.5 playbooks.
```
Installing:
 atomic-openshift-utils                                noarch                    3.4.56-1.el7                                  centos-paas-sig-openshift-origin-rpms                    189 k
Installing for dependencies:
 apr                                                   x86_64                    1.4.8-3.el7                                   oso-rhui-rhel-server-releases                            103 k
 apr-util                                              x86_64                    1.5.2-6.el7                                   oso-rhui-rhel-server-releases                             92 k
 httpd-tools                                           x86_64                    2.4.6-45.el7                                  oso-rhui-rhel-server-releases                             84 k
 openshift-ansible                                     noarch                    3.5.36-1.git.0.a378c43.el7                    rhel-7-server-ose-3.5-rpms                               205 k
 openshift-ansible-callback-plugins                    noarch                    3.5.36-1.git.0.a378c43.el7                    rhel-7-server-ose-3.5-rpms                               194 k
 openshift-ansible-docs                                noarch                    3.5.36-1.git.0.a378c43.el7                    rhel-7-server-ose-3.5-rpms                               202 k
 openshift-ansible-filter-plugins                      noarch                    3.5.36-1.git.0.a378c43.el7                    rhel-7-server-ose-3.5-rpms                               202 k
 openshift-ansible-lookup-plugins                      noarch                    3.5.36-1.git.0.a378c43.el7                    rhel-7-server-ose-3.5-rpms                               186 k
 openshift-ansible-playbooks                           noarch                    3.5.36-1.git.0.a378c43.el7                    rhel-7-server-ose-3.5-rpms                               282 k
 openshift-ansible-roles                               noarch                    3.5.36-1.git.0.a378c43.el7                    rhel-7-server-ose-3.5-rpms                               1.1 M
```