### PR TITLE
Bug 1433378: ansible-playbook for 3.2 version fails with dict object has no attribute oo_etcd_to_config

### DIFF
--- a/playbooks/common/openshift-cluster/additional_config.yml
+++ b/playbooks/common/openshift-cluster/additional_config.yml
@@ -15,6 +15,6 @@
     when: "{{ openshift.common.use_manageiq | bool }}"
   - role: cockpit
     when: "{{ not openshift.common.is_atomic and ( deployment_type in ['atomic-enterprise','openshift-enterprise'] ) and
-              (osm_use_cockpit | bool or osm_use_cockpit is undefined ) }}"
+              (osm_use_cockpit | default(true) | bool ) }}"
   - role: flannel_register
     when: "{{ openshift.common.use_flannel | bool }}"

--- a/playbooks/common/openshift-cluster/upgrades/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre.yml
@@ -243,7 +243,7 @@
   - openshift_facts:
       role: master
       local_facts:
-        embedded_etcd: "{{ groups.oo_etcd_to_config | length == 0 }}"
+        embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
         debug_level: "{{ openshift_master_debug_level | default(openshift.common.debug_level | default(2)) }}"
 
 - name: Backup etcd


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1433378