### PR TITLE
Do not require python-six via openshift_facts

### DIFF
--- a/roles/openshift_facts/vars/main.yml
+++ b/roles/openshift_facts/vars/main.yml
@@ -2,7 +2,6 @@
 required_packages:
   - iproute
   - python-dbus
-  - python-six
   - PyYAML
   - yum-utils
 

--- a/roles/openshift_health_checker/openshift_checks/__init__.py
+++ b/roles/openshift_health_checker/openshift_checks/__init__.py
@@ -8,11 +8,8 @@ import os
 from abc import ABCMeta, abstractmethod, abstractproperty
 from importlib import import_module
 
-# add_metaclass is not available in the embedded six from module_utils in Ansible 2.2.1
-from six import add_metaclass
-# pylint import-error disabled because pylint cannot find the package
-# when installed in a virtualenv
-from ansible.module_utils.six.moves import reduce  # pylint: disable=import-error, redefined-builtin
+from ansible.module_utils import six
+from ansible.module_utils.six.moves import reduce  # pylint: disable=import-error,redefined-builtin
 
 
 class OpenShiftCheckException(Exception):
@@ -20,7 +17,7 @@ class OpenShiftCheckException(Exception):
     pass
 
 
-@add_metaclass(ABCMeta)
+@six.add_metaclass(ABCMeta)
 class OpenShiftCheck(object):
     """A base class for defining checks for an OpenShift cluster environment."""
 


### PR DESCRIPTION
It turns out the code in
`roles/openshift_health_checker/openshift_checks/__init__.py` had a
mistake in the import statement, and not the case that `add_metaclass`
is not available in the embedded `six` from `ansible.module_utils`.

The fix is to correct the import and do not require python-six to be
installed on target hosts.

Note: now that we have some unit tests in the role, errors like that
would have been caught.

Follows up #3641.