### PR TITLE
acceptschema2 default: true

### DIFF
--- a/roles/openshift_hosted/templates/registry_config.j2
+++ b/roles/openshift_hosted/templates/registry_config.j2
@@ -71,7 +71,7 @@ middleware:
   - name: openshift
     options:
       pullthrough: {{ openshift_hosted_registry_pullthrough | default(true) }}
-      acceptschema2: {{ openshift_hosted_registry_acceptschema2 | default(false) }}
+      acceptschema2: {{ openshift_hosted_registry_acceptschema2 | default(true) }}
       enforcequota: {{ openshift_hosted_registry_enforcequota | default(false) }}
 {% if openshift_hosted_registry_storage_provider | default('') == 's3' and openshift_hosted_registry_storage_s3_cloudfront_baseurl is defined %}
   storage:


### PR DESCRIPTION
Given the maturity of docker clients it seems time to default to schema2. See https://github.com/openshift/origin/pull/13428

Signed-off-by: Aaron Weitekamp <aweiteka@redhat.com>