### PR TITLE
Implement namespace-reader role for router shards

### DIFF
--- a/roles/openshift_hosted/tasks/router/router.yml
+++ b/roles/openshift_hosted/tasks/router/router.yml
@@ -37,13 +37,39 @@
     resource_name: hostnetwork
   with_items: "{{ openshift_hosted_routers }}"
 
-- name: Set additional permissions for router service account
+- name: Create the role namespace-reader when using Router Shards
+  oc_obj:
+    kind: ClusterRole
+    name: namespace-reader
+    namespace: "{{ item.namespace }}"
+    content:
+      path: /tmp/osh_namespace_reader
+      data:
+        apiVersion: v1
+        kind: ClusterRole
+        metadata:
+          name: namespace-reader
+        rules:
+        - apiGroups:
+          - ""
+          attributeRestrictions: null
+          resources:
+          - namespaces
+          - namespaces/status
+          verbs:
+          - get
+          - list
+          - watch
+  when: ('NAMESPACE_LABELS' in (item | string )) or ('ROUTE_LABELS' in (item | string ))
+  with_items: "{{ openshift_hosted_routers }}"
+
+- name: Set permissions for router service account when using Router Shards
   oc_adm_policy_user:
     user: "system:serviceaccount:{{ item.namespace }}:{{ item.serviceaccount }}"
     namespace: "{{ item.namespace }}"
     resource_kind: cluster-role
-    resource_name: cluster-reader
-  when: item.namespace == 'default'
+    resource_name: namespace-reader
+  when: ('NAMESPACE_LABELS' in (item | string )) or ('ROUTE_LABELS' in (item | string ))
   with_items: "{{ openshift_hosted_routers }}"
 
 - name: Create OpenShift router


### PR DESCRIPTION
Current documented process for using router shards involves adding the `cluster-reader` role to the router service account in order to read namespace labels.
https://docs.openshift.com/container-platform/3.4/install_config/router/default_haproxy_router.html#using-router-shards

This PR takes suggestions for creating a new role `namespace-reader` to provide the only necessary access for the service account.  The role will be created when either `NAMESPACE_LABELS` or `ROUTE_LABELS` is specified in the router configuration.

@knobunc @smarterclayton 