### PR TITLE
preflight checks: improve output, fix exclusions issue

### DIFF
--- a/roles/openshift_health_checker/library/aos_version.py
+++ b/roles/openshift_health_checker/library/aos_version.py
@@ -32,6 +32,7 @@ def main():  # pylint: disable=missing-docstring,too-many-branches
         bail("prefix must not be empty")
 
     yb = yum.YumBase()  # pylint: disable=invalid-name
+    yb.conf.disable_excludes = ["all"]  # assume the openshift excluder will be managed, ignore current state
 
     # search for package versions available for aos pkgs
     expected_pkgs = [

--- a/roles/openshift_health_checker/library/check_yum_update.py
+++ b/roles/openshift_health_checker/library/check_yum_update.py
@@ -27,6 +27,7 @@ def main():  # pylint: disable=missing-docstring,too-many-branches
         module.fail_json(msg=error)
 
     yb = yum.YumBase()  # pylint: disable=invalid-name
+    yb.conf.disable_excludes = ["all"]  # assume the openshift excluder will be managed, ignore current state
     # determine if the existing yum configuration is valid
     try:
         yb.repos.populateSack(mdtype='metadata', cacheonly=1)


### PR DESCRIPTION
Improves the output of failed checks so that a customer might make sense of it.
https://trello.com/c/K4dPuCHa/98-improve-ansible-diagnostics-failure-output

Also, package content checks need to discount the openshift excluders, as they wouldn't be in effect during an install/upgrade