### PR TITLE
openshift_logging calculate min_masters to fail early on split brain

### DIFF
--- a/roles/openshift_logging/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging/templates/elasticsearch.yml.j2
@@ -29,6 +29,7 @@ cloud:
 discovery:
   type: kubernetes
   zen.ping.multicast.enabled: false
+  zen.minimum_master_nodes: {{es_min_masters}}
 
 gateway:
   expected_master_nodes: ${NODE_QUORUM}

--- a/roles/openshift_logging/vars/main.yaml
+++ b/roles/openshift_logging/vars/main.yaml
@@ -1,6 +1,8 @@
 ---
 openshift_master_config_dir: "{{ openshift.common.config_base }}/master"
 es_node_quorum: "{{openshift_logging_es_cluster_size|int/2 + 1}}"
+es_min_masters_default: "{{ (openshift_logging_es_cluster_size | int / 2 | round(0,'floor') + 1) | int }}"
+es_min_masters: "{{ (openshift_logging_es_cluster_size == 1) | ternary(1, es_min_masters_default)}}"
 es_recover_after_nodes: "{{openshift_logging_es_cluster_size|int - 1}}"
 es_recover_expected_nodes: "{{openshift_logging_es_cluster_size|int}}"
 es_ops_node_quorum: "{{openshift_logging_es_ops_cluster_size|int/2 + 1}}"


### PR DESCRIPTION
This PR was discussed with @portante to avoid split brain scenarios.  This should cause the start of the cluster to fail early in such situations, as seen in BZ 1424637.

cc @sdodson this is one we should consider cherry-picking into 1.5