### PR TITLE
Bug 1434300 - Log entries are generated in ES after deployed logging …

### DIFF
--- a/roles/openshift_logging/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging/templates/elasticsearch.yml.j2
@@ -37,6 +37,8 @@ gateway:
   recover_after_time: ${RECOVER_AFTER_TIME}
 
 io.fabric8.elasticsearch.authentication.users: ["system.logging.kibana", "system.logging.fluentd", "system.logging.curator", "system.admin"]
+io.fabric8.elasticsearch.kibana.mapping.app: /usr/share/elasticsearch/index_patterns/com.redhat.viaq-openshift.index-pattern.json
+io.fabric8.elasticsearch.kibana.mapping.ops: /usr/share/elasticsearch/index_patterns/com.redhat.viaq-openshift.index-pattern.json
 
 openshift.config:
   use_common_data_model: true


### PR DESCRIPTION
…stacks via ansible, but can not be found in kibana.

https://bugzilla.redhat.com/show_bug.cgi?id=1434300
Add support for common data model index pattern files.
Depends on https://github.com/ViaQ/elasticsearch-templates/pull/36
and
https://github.com/openshift/origin-aggregated-logging/pull/357

@ewolinetz ptal