### PR TITLE
Update metrics-deployer.yaml

### DIFF
--- a/roles/openshift_hosted_templates/files/v1.4/enterprise/metrics-deployer.yaml
+++ b/roles/openshift_hosted_templates/files/v1.4/enterprise/metrics-deployer.yaml
@@ -105,7 +105,7 @@ parameters:
 -
   description: 'Specify version for metrics components; e.g. for "openshift/origin-metrics-deployer:latest", set version "latest"'
   name: IMAGE_VERSION
-  value: "3.4.0"
+  value: "v3.4"
 -
   description: "Internal URL for the master, for authentication retrieval"
   name: MASTER_URL


### PR DESCRIPTION
So as the templates are pushed out now, there is a problem in the fact that according to https://access.redhat.com/containers/#/registry.access.redhat.com/openshift3/metrics-deployer/images the 3.4.0 tag is not actually getting all the latest releases of the images. Switching this to tag v3.4 fixes this.