### PR TITLE
Update logging-deployer.yaml

### DIFF
--- a/roles/openshift_hosted_templates/files/v1.4/enterprise/logging-deployer.yaml
+++ b/roles/openshift_hosted_templates/files/v1.4/enterprise/logging-deployer.yaml
@@ -223,7 +223,7 @@ items:
   -
     description: 'Specify version for logging components; e.g. for "registry.access.redhat.com/openshift3/logging-deployer:3.4.0", set version "3.4.0"'
     name: IMAGE_VERSION
-    value: "3.4.0"
+    value: "v3.4"
   -
     description: "(Deprecated) Specify the name of an existing pull secret to be used for pulling component images from an authenticated registry."
     name: IMAGE_PULL_SECRET


### PR DESCRIPTION
So as the templates are pushed out now, there is a problem in the fact that according to https://access.redhat.com/containers/#/registry.access.redhat.com/openshift3/logging-deployer/images the 3.4.0 tag is not actually getting all the latest releases of the images. Switching this to tag v3.4 fixes this.