### PR TITLE
Stop all services before upgrading openvswitch

### DIFF
--- a/roles/openshift_node_upgrade/tasks/main.yml
+++ b/roles/openshift_node_upgrade/tasks/main.yml
@@ -51,20 +51,28 @@
   failed_when: false
   when: openshift.common.is_containerized | bool
 
+- name: Stop rpm based services
+  service:
+    name: "{{ item }}"
+    state: stopped
+  with_items:
+  - "{{ openshift.common.service_type }}-node"
+  - openvswitch
+  failed_when: false
+  when: not openshift.common.is_containerized | bool
+
 - name: Upgrade openvswitch
   package:
     name: openvswitch
     state: latest
-  register: ovs_pkg
   when: not openshift.common.is_containerized | bool
 
 - name: Restart openvswitch
   systemd:
     name: openvswitch
-    state: restarted
+    state: started
   when:
   - not openshift.common.is_containerized | bool
-  - ovs_pkg | changed
 
 # Mandatory Docker restart, ensure all containerized services are running:
 - include: docker/restart.yml


### PR DESCRIPTION
It appears that openshift was holding a lock or perhaps openvswitch on
its own does not restart cleanly when upgrading the package so just
stop it before updating the package.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1434287
Backported #3747 