### PR TITLE
openshift_node: Use meta/main.yml for role dependencies

### DIFF
--- a/playbooks/common/openshift-cluster/redeploy-certificates/registry.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/registry.yml
@@ -48,10 +48,6 @@
 
   # Replace dc/docker-registry certificate secret contents if set.
   - block:
-    - name: Load lib_openshift modules
-      include_role:
-        name: lib_openshift
-
     - name: Retrieve registry service IP
       oc_service:
         namespace: default

--- a/roles/etcd/meta/main.yml
+++ b/roles/etcd/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
   - cloud
   - system
 dependencies:
+- role: lib_openshift
 - role: os_firewall
   os_firewall_allow:
   - service: etcd

--- a/roles/etcd/tasks/system_container.yml
+++ b/roles/etcd/tasks/system_container.yml
@@ -1,8 +1,4 @@
 ---
-- name: Load lib_openshift modules
-  include_role:
-    name: lib_openshift
-
 - name: Pull etcd system container
   command: atomic pull --storage=ostree {{ openshift.etcd.etcd_image }}
   register: pull_result

--- a/roles/openshift_master/meta/main.yml
+++ b/roles/openshift_master/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
+- role: lib_openshift
 - role: openshift_master_facts
 - role: openshift_hosted_facts
 - role: openshift_master_certificates

--- a/roles/openshift_master/tasks/system_container.yml
+++ b/roles/openshift_master/tasks/system_container.yml
@@ -1,8 +1,4 @@
 ---
-- name: Load lib_openshift modules
-  include_role:
-    name: lib_openshift
-
 - name: Pre-pull master system container image
   command: >
     atomic pull --storage=ostree {{ openshift.common.system_images_registry }}/{{ openshift.master.master_system_image }}:{{ openshift_image_tag }}

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
+- role: lib_openshift
 - role: openshift_common
 - role: openshift_clock
 - role: openshift_docker

--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -1,8 +1,4 @@
 ---
-- name: Load lib_openshift modules
-  include_role:
-    name: lib_openshift
-
 - name: Pre-pull node system container image
   command: >
     atomic pull --storage=ostree {{ openshift.common.system_images_registry }}/{{ openshift.node.node_system_image }}:{{ openshift_image_tag }}

--- a/roles/openshift_node/tasks/openvswitch_system_container.yml
+++ b/roles/openshift_node/tasks/openvswitch_system_container.yml
@@ -1,8 +1,4 @@
 ---
-- name: Load lib_openshift modules
-  include_role:
-    name: lib_openshift
-
 - name: Pre-pull OpenVSwitch system container image
   command: >
     atomic pull --storage=ostree {{ openshift.common.system_images_registry }}/{{ openshift.node.ovs_system_image }}:{{ openshift_image_tag }}


### PR DESCRIPTION
If the role uses oc_* modules, lib_openshift should be added to the dependencies in meta/main.yml.

cc: @giuseppe 