### PR TITLE
skip "yum update" sanity check if not running on rhel

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/package_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/package_availability.py
@@ -9,6 +9,10 @@ class PackageAvailability(NotContainerizedMixin, OpenShiftCheck):
     name = "package_availability"
     tags = ["preflight"]
 
+    @classmethod
+    def is_active(cls, task_vars):
+        return super(PackageAvailability, cls).is_active(task_vars) and task_vars["ansible_pkg_mgr"] == "yum"
+
     def run(self, tmp, task_vars):
         rpm_prefix = get_var(task_vars, "openshift", "common", "service_type")
         group_names = get_var(task_vars, "group_names", default=[])

--- a/roles/openshift_health_checker/test/package_availability_test.py
+++ b/roles/openshift_health_checker/test/package_availability_test.py
@@ -3,6 +3,20 @@ import pytest
 from openshift_checks.package_availability import PackageAvailability
 
 
+@pytest.mark.parametrize('pkg_mgr,is_containerized,is_active', [
+    ('yum', False, True),
+    ('yum', True, False),
+    ('dnf', True, False),
+    ('dnf', False, False),
+])
+def test_is_active(pkg_mgr, is_containerized, is_active):
+    task_vars = dict(
+        ansible_pkg_mgr=pkg_mgr,
+        openshift=dict(common=dict(is_containerized=is_containerized)),
+    )
+    assert PackageAvailability.is_active(task_vars=task_vars) == is_active
+
+
 @pytest.mark.parametrize('task_vars,must_have_packages,must_not_have_packages', [
     (
         dict(openshift=dict(common=dict(service_type='openshift'))),


### PR DESCRIPTION
Related Trello card: https://trello.com/c/5pr2WcQH/43-diagnostics-additional-pre-flight-checks
Detect ansible host's OS using output of `docker info` and skip check if it is not being run on RHEL.

cc @brenton @sosiouxme @rhcarvalho 