### PR TITLE
Revert "fix quoting issues in logging es template"

### DIFF
--- a/roles/openshift_logging/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging/templates/elasticsearch.yml.j2
@@ -6,8 +6,8 @@ script:
   indexed: on
 
 index:
-  number_of_shards: "{{ es_number_of_shards | default ('1') }}"
-  number_of_replicas: "{{ es_number_of_replicas | default ('0') }}"
+  number_of_shards: {{ es_number_of_shards | default ('1') }}
+  number_of_replicas: {{ es_number_of_replicas | default ('0') }}
   unassigned.node_left.delayed_timeout: 2m
   translog:
     flush_threshold_size: 256mb
@@ -28,7 +28,7 @@ cloud:
 discovery:
   type: kubernetes
   zen.ping.multicast.enabled: false
-  zen.minimum_master_nodes: "{{es_min_masters}}"
+  zen.minimum_master_nodes: {{es_min_masters}}
 
 gateway:
   expected_master_nodes: ${NODE_QUORUM}


### PR DESCRIPTION
Reverts openshift/openshift-ansible#3766

This was trying to fix something that was only broken in master due to changes likely introduced here
https://github.com/openshift/openshift-ansible/pull/3647/files

With the extra quotes we end up with entries like this in the configmap:
```
    index:
      number_of_shards: "1"
      number_of_replicas: "0"
```

They should look like this, which we get when we don't have quotes:
```
    index:
      number_of_shards: 1
      number_of_replicas: 0
```

I confirmed this locally