### PR TITLE
fix es config merge so template does not need quoting. gen then merge

### DIFF
--- a/roles/openshift_logging/tasks/generate_configmaps.yaml
+++ b/roles/openshift_logging/tasks/generate_configmaps.yaml
@@ -7,20 +7,20 @@
       changed_when: no
 
     - local_action: >
-        copy content="{{ config_source | combine(override_config,recursive=True) | to_nice_yaml }}"
+        template src=elasticsearch.yml.j2
         dest="{{local_tmp.stdout}}/elasticsearch-gen-template.yml"
-      vars:
-        config_source: "{{lookup('file','templates/elasticsearch.yml.j2') | from_yaml }}"
-        override_config: "{{openshift_logging_es_config | from_yaml}}"
-      when: es_logging_contents is undefined
-      changed_when: no
-
-    - template:
-        src: "{{local_tmp.stdout}}/elasticsearch-gen-template.yml"
-        dest: "{{mktemp.stdout}}/elasticsearch.yml"
       vars:
         - allow_cluster_reader: "{{openshift_logging_es_ops_allow_cluster_reader | lower | default('false')}}"
       when: es_config_contents is undefined
+      changed_when: no
+
+    - copy:
+        content: "{{ config_source | combine(override_config,recursive=True) | to_nice_yaml }}"
+        dest: "{{mktemp.stdout}}/elasticsearch.yml"
+      vars:
+        config_source: "{{lookup('file','{{local_tmp.stdout}}/elasticsearch-gen-template.yml') | from_yaml }}"
+        override_config: "{{openshift_logging_es_config | from_yaml}}"
+      when: es_logging_contents is undefined
       changed_when: no
 
     - copy:

--- a/roles/openshift_logging/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging/templates/elasticsearch.yml.j2
@@ -49,7 +49,7 @@ openshift.searchguard:
   keystore.path: /etc/elasticsearch/secret/admin.jks
   truststore.path: /etc/elasticsearch/secret/searchguard.truststore
 
-openshift.operations.allow_cluster_reader: "{{allow_cluster_reader | default (false)}}"
+openshift.operations.allow_cluster_reader: {{allow_cluster_reader | default (false)}}
 
 path:
   data: /elasticsearch/persistent/${CLUSTER_NAME}/data


### PR DESCRIPTION
This PR fixes

* Merge failures for es config for values that were not quoted in the jinja template
* Executes template task before merging hash