### PR TITLE
bug 1432607.  Allow configuration of ES log destination

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -65,6 +65,7 @@ When both `openshift_logging_install_logging` and `openshift_logging_upgrade_log
 - `openshift_logging_es_cluster_size`: The number of ES cluster members. Defaults to '1'.
 - `openshift_logging_es_cpu_limit`:  The amount of CPU limit for the ES cluster.  Unused if not set
 - `openshift_logging_es_memory_limit`: The amount of RAM that should be assigned to ES. Defaults to '8Gi'.
+- `openshift_logging_es_log_appenders`: The list of rootLogger appenders for ES logs which can be: 'file', 'console'. Defaults to 'file'.
 - `openshift_logging_es_pv_selector`: A key/value map added to a PVC in order to select specific PVs.  Defaults to 'None'.
 - `openshift_logging_es_pvc_dynamic`: Whether or not to add the dynamic PVC annotation for any generated PVCs. Defaults to 'False'.
 - `openshift_logging_es_pvc_size`: The requested size for the ES PVCs, when not provided the role will not generate any PVCs. Defaults to '""'.

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -80,6 +80,8 @@ openshift_logging_es_client_cert: /etc/fluent/keys/cert
 openshift_logging_es_client_key: /etc/fluent/keys/key
 openshift_logging_es_cluster_size: "{{ openshift_hosted_logging_elasticsearch_cluster_size | default(1) }}"
 openshift_logging_es_cpu_limit: null
+# the logging appenders for the root loggers to write ES logs. Valid values: 'file', 'console'
+openshift_logging_es_log_appenders: ['file']
 openshift_logging_es_memory_limit: "{{ openshift_hosted_logging_elasticsearch_instance_ram | default('8Gi') }}"
 openshift_logging_es_pv_selector: null
 openshift_logging_es_pvc_dynamic: "{{ openshift_hosted_logging_elasticsearch_pvc_dynamic | default(False) }}"

--- a/roles/openshift_logging/tasks/generate_configmaps.yaml
+++ b/roles/openshift_logging/tasks/generate_configmaps.yaml
@@ -1,10 +1,20 @@
 ---
 - block:
-    - copy:
-        src: elasticsearch-logging.yml
+    - fail:
+        msg: "The openshift_logging_es_log_appenders '{{openshift_logging_es_log_appenders}}' has an unrecognized option and only supports the following as a list: {{es_log_appenders | join(', ')}}"
+      when:
+        - es_logging_contents is undefined
+        - "{{ openshift_logging_es_log_appenders | list | difference(es_log_appenders) | length != 0 }}"
+      changed_when: no
+
+    - template:
+        src: elasticsearch-logging.yml.j2
         dest: "{{mktemp.stdout}}/elasticsearch-logging.yml"
+      vars:
+        root_logger: "{{openshift_logging_es_log_appenders | join(', ')}}"
       when: es_logging_contents is undefined
       changed_when: no
+      check_mode: no
 
     - local_action: >
         copy content="{{ config_source | combine(override_config,recursive=True) | to_nice_yaml }}"

--- a/roles/openshift_logging/templates/elasticsearch-logging.yml.j2
+++ b/roles/openshift_logging/templates/elasticsearch-logging.yml.j2
@@ -1,13 +1,24 @@
 # you can override this using by setting a system property, for example -Des.logger.level=DEBUG
 es.logger.level: INFO
-rootLogger: ${es.logger.level}, console, file
+rootLogger: ${es.logger.level}, {{root_logger}}
 logger:
   # log action execution errors for easier debugging
   action: WARN
+
+  # deprecation logging, turn to DEBUG to see them
+  deprecation: WARN, deprecation_log_file
+
   # reduce the logging for aws, too much is logged under the default INFO
   com.amazonaws: WARN
+
   io.fabric8.elasticsearch: ${PLUGIN_LOGLEVEL}
   io.fabric8.kubernetes: ${PLUGIN_LOGLEVEL}
+
+  # aws will try to do some sketchy JMX stuff, but its not needed.
+  com.amazonaws.jmx.SdkMBeanRegistrySupport: ERROR
+  com.amazonaws.metrics.AwsSdkMetrics: ERROR
+
+  org.apache.http: INFO
 
   # gateway
   #gateway: DEBUG
@@ -28,13 +39,14 @@ logger:
 additivity:
   index.search.slowlog: false
   index.indexing.slowlog: false
+  deprecation: false
 
 appender:
   console:
     type: console
     layout:
       type: consolePattern
-      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %.10000m%n"
 
   file:
     type: dailyRollingFile
@@ -44,16 +56,13 @@ appender:
       type: pattern
       conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
 
-  # Use the following log4j-extras RollingFileAppender to enable gzip compression of log files.
-  # For more information see https://logging.apache.org/log4j/extras/apidocs/org/apache/log4j/rolling/RollingFileAppender.html
-  #file:
-    #type: extrasRollingFile
-    #file: ${path.logs}/${cluster.name}.log
-    #rollingPolicy: timeBased
-    #rollingPolicy.FileNamePattern: ${path.logs}/${cluster.name}.log.%d{yyyy-MM-dd}.gz
-    #layout:
-      #type: pattern
-      #conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+  deprecation_log_file:
+    type: dailyRollingFile
+    file: ${path.logs}/${cluster.name}_deprecation.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
 
   index_search_slow_log_file:
     type: dailyRollingFile

--- a/roles/openshift_logging/vars/main.yaml
+++ b/roles/openshift_logging/vars/main.yaml
@@ -8,3 +8,5 @@ es_recover_expected_nodes: "{{openshift_logging_es_cluster_size|int}}"
 es_ops_node_quorum: "{{openshift_logging_es_ops_cluster_size|int/2 + 1}}"
 es_ops_recover_after_nodes: "{{openshift_logging_es_ops_cluster_size|int - 1}}"
 es_ops_recover_expected_nodes: "{{openshift_logging_es_ops_cluster_size|int}}"
+
+es_log_appenders: ['file', 'console']


### PR DESCRIPTION
cc @portante
This PR:

* turns console logging off by default.
* allows users to turn it back on via ansible inventory
* encompasses #3687  which should be closed.
