### PR TITLE
Make the OCP available version detection excluder free

### DIFF
--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -27,9 +27,6 @@
     when: openshift_docker_selinux_enabled is not defined
 
 - include: disable_excluder.yml
-  vars:
-    # the excluders needs to be disabled no matter what status says
-    with_status_check: false
   tags:
   - always
 

--- a/playbooks/common/openshift-cluster/initialize_openshift_version.yml
+++ b/playbooks/common/openshift-cluster/initialize_openshift_version.yml
@@ -18,18 +18,6 @@
       msg: Incompatible versions of yum and subscription-manager found. You may need to update yum and yum-utils.
     when: "not openshift.common.is_atomic | bool and 'Plugin \"search-disabled-repos\" requires API 2.7. Supported API is 2.6.' in yum_ver_test.stdout"
 
-# TODO(jchaloup): find a different way how to make repoquery --qf '%version` atomic-openshift work without disabling the excluders
-- include: disable_excluder.yml
-  vars:
-    # the excluders needs to be disabled no matter what status says
-    with_status_check: false
-    # Only openshift excluder needs to be temporarily disabled
-    # So ignore the docker one
-    enable_docker_excluder: false
-  tags:
-  - always
-  when: openshift_upgrade_target is not defined
-
 - name: Determine openshift_version to configure on first master
   hosts: oo_first_master
   roles:
@@ -44,13 +32,3 @@
     openshift_version: "{{ hostvars[groups.oo_first_master.0].openshift_version }}"
   roles:
   - openshift_version
-
-  # Re-enable excluders if they are meant to be enabled (and only during installation, upgrade disables the excluders before this play)
-- include: reset_excluder.yml
-  vars:
-    # Only openshift excluder needs to be re-enabled
-    # So ignore the docker one
-    enable_docker_excluder: false
-  tags:
-  - always
-  when: openshift_upgrade_target is not defined

--- a/playbooks/common/openshift-master/scaleup.yml
+++ b/playbooks/common/openshift-master/scaleup.yml
@@ -61,9 +61,6 @@
   - openshift_docker
 
 - include: ../openshift-cluster/disable_excluder.yml
-  vars:
-    # the excluders needs to be disabled no matter what status says
-    with_status_check: false
   tags:
   - always
 

--- a/playbooks/common/openshift-node/scaleup.yml
+++ b/playbooks/common/openshift-node/scaleup.yml
@@ -28,9 +28,6 @@
   - openshift_docker
 
 - include: ../openshift-cluster/disable_excluder.yml
-  vars:
-    # the excluders needs to be disabled no matter what status says
-    with_status_check: false
   tags:
   - always
 

--- a/roles/openshift_excluder/tasks/disable.yml
+++ b/roles/openshift_excluder/tasks/disable.yml
@@ -1,6 +1,5 @@
 ---
 # input variables
-# - with_status_check
 # - excluder_package_state
 # - docker_excluder_package_state
 - include: init.yml
@@ -35,6 +34,6 @@
       unexclude_docker_excluder: false
       # disable openshift excluder is never overrided to be enabled
       # disable it if the docker excluder is enabled
-      unexclude_openshift_excluder: true
+      unexclude_openshift_excluder: "{{ openshift_excluder_on | bool }}"
   when:
   - not openshift.common.is_atomic | bool

--- a/roles/openshift_version/tasks/set_version_rpm.yml
+++ b/roles/openshift_version/tasks/set_version_rpm.yml
@@ -5,13 +5,40 @@
     openshift_version: "{{ openshift_pkg_version[1:].split('-')[0] }}"
   when: openshift_pkg_version is defined and openshift_version is not defined
 
+# if {{ openshift.common.service_type}}-excluder is enabled,
+# the repoquery for {{ openshift.common.service_type}} will not work.
+# Thus, create a temporary yum,conf file where exclude= is set to an empty list
+- name: Create temporary yum.conf file
+  command: mktemp -d /tmp/yum.conf.XXXXXX
+  register: yum_conf_temp_file_result
+
+- set_fact:
+    yum_conf_temp_file: "{{yum_conf_temp_file_result.stdout}}/yum.conf"
+
+- name: Copy yum.conf into the temporary file
+  copy:
+    src: /etc/yum.conf
+    dest: "{{ yum_conf_temp_file }}"
+
+- name: Clear the exclude= list in the temporary yum.conf
+  lineinfile:
+    # since ansible 2.3 s/dest/path
+    dest: "{{ yum_conf_temp_file }}"
+    regexp: '^exclude='
+    line: 'exclude='
+
 - name: Gather common package version
   command: >
-    {{ repoquery_cmd }} --qf '%{version}' "{{ openshift.common.service_type}}"
+    {{ repoquery_cmd }} --config "{{ yum_conf_temp_file }}" --qf '%{version}' "{{ openshift.common.service_type}}"
   register: common_version
   failed_when: false
   changed_when: false
   when: openshift_version is not defined
+
+- name: Delete the temporary yum.conf
+  file:
+    path: "{{ yum_conf_temp_file_result.stdout }}"
+    state: absent
 
 - set_fact:
     openshift_version: "{{ common_version.stdout | default('0.0', True) }}"


### PR DESCRIPTION
When detecting available OCP version via repoquery,
use yum.conf file with exclude= set to an empty array.
So the detection is independent of the OCP excluder.