### PR TITLE
Removing initial setting of metrics image prefix/version

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -48,12 +48,6 @@
   - set_fact:
       openshift_hosted_metrics_resolution: "{{ lookup('oo_option', 'openshift_hosted_metrics_resolution') | default('10s', true) }}"
     when: openshift_hosted_metrics_resolution is not defined
-  - set_fact:
-      openshift_hosted_metrics_deployer_prefix: "{{ lookup('oo_option', 'openshift_hosted_metrics_deployer_prefix') | default('openshift') }}"
-    when: openshift_hosted_metrics_deployer_prefix is not defined
-  - set_fact:
-      openshift_hosted_metrics_deployer_version: "{{ lookup('oo_option', 'openshift_hosted_metrics_deployer_version') | default('latest') }}"
-    when: openshift_hosted_metrics_deployer_version is not defined
   roles:
   - openshift_facts
   post_tasks:


### PR DESCRIPTION
This was setting the `openshift_hosted_metrics_deployer_prefix` and version to `""` which was then used as the value within `openshift_metrics`

The value should be evaluated only within the role now.