### PR TITLE
Fix RPM Package Version in case of Missing declaration

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -845,9 +845,10 @@ def oo_image_tag_to_rpm_version(version, include_dash=False):
         # Strip release from requested version, we no longer support this.
         version = version.split('-')[0]
 
-    if include_dash and version and not version.startswith("-"):
+    if include_dash and version and not version.startswith("-") and not version.equal(""):
         version = "-" + version
-
+    else:
+        version = "-*"
     return version
 
 


### PR DESCRIPTION
I need this fix otherwise is impossible to create a cluster. Do you have any idea to make it in another way?

2017-03-28 15:09:19,884 p=20697 u=gpavesi |  TASK [openshift_common : Install the base package for versioning] **************
2017-03-28 15:09:19,884 p=20697 u=gpavesi |  task path: /home/gpavesi/src/openshift-ansible/roles/openshift_common/tasks/main.yml:44
2017-03-28 15:09:19,923 p=20697 u=gpavesi |  Using module file /usr/lib/python2.7/dist-packages/ansible/modules/core/packaging/os/yum.py
2017-03-28 15:09:20,371 p=20697 u=gpavesi |  fatal: [gianp5-master-0]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "conf_file": null, 
            "disable_gpg_check": false, 
            "disablerepo": null, 
            "enablerepo": null, 
            "exclude": null, 
            "install_repoquery": true, 
            "list": null, 
            "name": [
                "atomic-openshift-"
            ], 
            "state": "present", 
            "update_cache": false, 
            "validate_certs": true
        }
    }, 
    "rc": 126, 
    "results": [
        "No package matching 'atomic-openshift-' found available, installed or updated"
    ]
}

MSG:

No package matching 'atomic-openshift-' found available, installed or updated
