### PR TITLE
Update six module path to module_utils.six to stay in line with Ansible

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -23,8 +23,8 @@ import yaml
 from ansible import errors
 # pylint no-name-in-module and import-error disabled here because pylint
 # fails to properly detect the packages when installed in a virtualenv
-from ansible.compat.six import string_types  # pylint:disable=no-name-in-module,import-error
-from ansible.compat.six.moves.urllib.parse import urlparse  # pylint:disable=no-name-in-module,import-error
+from ansible.module_utils.six import string_types  # pylint:disable=no-name-in-module,import-error
+from ansible.module_utils.six.moves.urllib.parse import urlparse  # pylint:disable=no-name-in-module,import-error
 from ansible.module_utils._text import to_text
 from ansible.parsing.yaml.dumper import AnsibleDumper
 

--- a/roles/openshift_master_facts/filter_plugins/openshift_master.py
+++ b/roles/openshift_master_facts/filter_plugins/openshift_master.py
@@ -16,7 +16,7 @@ from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.plugins.filter.core import to_bool as ansible_bool
 # pylint import-error disabled because pylint cannot find the package
 # when installed in a virtualenv
-from ansible.compat.six import string_types  # pylint: disable=no-name-in-module,import-error
+from ansible.module_utils.six import string_types  # pylint: disable=no-name-in-module,import-error
 
 import yaml
 


### PR DESCRIPTION
A recent PR to Ansible (https://github.com/ansible/ansible/pull/22855) removes the copy of the six module from compat and moves it to module_utils. In openshift-ansible there were references to six in ansible.module_utils and ansible.compat, but this is now obsolete.