### PR TITLE
[openshift_version] Correct copy task to use remote source

### DIFF
--- a/roles/openshift_version/tasks/set_version_rpm.yml
+++ b/roles/openshift_version/tasks/set_version_rpm.yml
@@ -19,6 +19,7 @@
   copy:
     src: /etc/yum.conf
     dest: "{{ yum_conf_temp_file }}"
+    remote_src: True
 
 - name: Clear the exclude= list in the temporary yum.conf
   lineinfile:


### PR DESCRIPTION
By default the copy module copies files from the control machine to the remote machine.  Adding remote_src: True allows copying from the remote host.

#3781