### PR TITLE
logging routes insecure edge termination policy defaults empty

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -46,7 +46,7 @@ When both `openshift_logging_install_logging` and `openshift_logging_upgrade_log
 - `openshift_logging_kibana_proxy_memory_limit`: The amount of memory to allocate to Kibana proxy or unset if not specified.
 - `openshift_logging_kibana_replica_count`: The number of replicas Kibana should be scaled up to. Defaults to 1.
 - `openshift_logging_kibana_nodeselector`: A map of labels (e.g. {"node":"infra","region":"west"} to select the nodes where the pod will land.
-- `openshift_logging_kibana_edge_term_policy`: Insecure Edge Termination Policy. Defaults to Redirect.
+- `openshift_logging_kibana_edge_term_policy`: Insecure Edge Termination Policy or unset if not specified.
 
 - `openshift_logging_fluentd_nodeselector`: The node selector that the Fluentd daemonset uses to determine where to deploy to. Defaults to '"logging-infra-fluentd": "true"'.
 - `openshift_logging_fluentd_cpu_limit`: The CPU limit for Fluentd pods. Defaults to '100m'.

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -27,7 +27,7 @@ openshift_logging_kibana_proxy_debug: false
 openshift_logging_kibana_proxy_cpu_limit: null
 openshift_logging_kibana_proxy_memory_limit: null
 openshift_logging_kibana_replica_count: 1
-openshift_logging_kibana_edge_term_policy: Redirect
+openshift_logging_kibana_edge_term_policy: null
 
 openshift_logging_kibana_nodeselector: "{{ openshift_hosted_logging_kibana_nodeselector | default('') | map_from_pairs }}"
 openshift_logging_kibana_ops_nodeselector: "{{ openshift_hosted_logging_kibana_ops_nodeselector | default('') | map_from_pairs }}"


### PR DESCRIPTION
The logging routes are not edge terminated by default (AFAIK). they are reencrypt and so the can't have their insecure edge termination policy to be "Redirect".

This is the error that I am getting from ansible log when it creates the routes with "Redirect" as the intended InsecureEdgeTerminationPolicy:
```
STDERR:

The Route "logging-kibana" is invalid: spec.tls.insecureEdgeTerminationPolicy: Invalid value: "Redirect": InsecureEdgeTerminationPolicy is only allowed for edge-terminated routes
```