### PR TITLE
Support unicode output when dumping yaml

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -21,12 +21,15 @@ import pkg_resources
 import yaml
 
 from ansible import errors
-# pylint no-name-in-module and import-error disabled here because pylint
-# fails to properly detect the packages when installed in a virtualenv
-from ansible.compat.six import string_types  # pylint:disable=no-name-in-module,import-error
-from ansible.compat.six.moves.urllib.parse import urlparse  # pylint:disable=no-name-in-module,import-error
-from ansible.module_utils._text import to_text
 from ansible.parsing.yaml.dumper import AnsibleDumper
+
+# ansible.compat.six goes away with Ansible 2.4
+try:
+    from ansible.compat.six import string_types, u
+    from ansible.compat.six.moves.urllib.parse import urlparse
+except ImportError:
+    from ansible.module_utils.six import string_types, u
+    from ansible.module_utils.six.moves.urllib.parse import urlparse
 
 HAS_OPENSSL = False
 try:
@@ -655,11 +658,11 @@ def to_padded_yaml(data, level=0, indent=2, **kw):
         return ""
 
     try:
-        transformed = yaml.dump(data, indent=indent, allow_unicode=True,
-                                default_flow_style=False,
-                                Dumper=AnsibleDumper, **kw)
+        transformed = u(yaml.dump(data, indent=indent, allow_unicode=True,
+                                  default_flow_style=False,
+                                  Dumper=AnsibleDumper, **kw))
         padded = "\n".join([" " * level * indent + line for line in transformed.splitlines()])
-        return to_text("\n{0}".format(padded))
+        return "\n{0}".format(padded)
     except Exception as my_e:
         raise errors.AnsibleFilterError('Failed to convert: %s' % my_e)
 

--- a/roles/openshift_master_facts/filter_plugins/openshift_master.py
+++ b/roles/openshift_master_facts/filter_plugins/openshift_master.py
@@ -14,9 +14,12 @@ from distutils.version import LooseVersion  # pylint: disable=no-name-in-module,
 from ansible import errors
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.plugins.filter.core import to_bool as ansible_bool
-# pylint import-error disabled because pylint cannot find the package
-# when installed in a virtualenv
-from ansible.compat.six import string_types  # pylint: disable=no-name-in-module,import-error
+
+# ansible.compat.six goes away with Ansible 2.4
+try:
+    from ansible.compat.six import string_types, u
+except ImportError:
+    from ansible.module_utils.six import string_types, u
 
 import yaml
 
@@ -490,10 +493,10 @@ class FilterModule(object):
             idp_list.append(idp_inst)
 
         IdentityProviderBase.validate_idp_list(idp_list, openshift_version, deployment_type)
-        return yaml.dump([idp.to_dict() for idp in idp_list],
-                         allow_unicode=True,
-                         default_flow_style=False,
-                         Dumper=AnsibleDumper)
+        return u(yaml.dump([idp.to_dict() for idp in idp_list],
+                           allow_unicode=True,
+                           default_flow_style=False,
+                           Dumper=AnsibleDumper))
 
     @staticmethod
     def validate_pcs_cluster(data, masters=None):

--- a/utils/src/ooinstall/ansible_plugins/facts_callback.py
+++ b/utils/src/ooinstall/ansible_plugins/facts_callback.py
@@ -7,6 +7,12 @@ import yaml
 from ansible.plugins.callback import CallbackBase
 from ansible.parsing.yaml.dumper import AnsibleDumper
 
+# ansible.compat.six goes away with Ansible 2.4
+try:
+    from ansible.compat.six import u
+except ImportError:
+    from ansible.module_utils.six import u
+
 
 # pylint: disable=super-init-not-called
 class CallbackModule(CallbackBase):
@@ -39,10 +45,10 @@ class CallbackModule(CallbackBase):
             facts = abridged_result['result']['ansible_facts']['openshift']
             hosts_yaml = {}
             hosts_yaml[res._host.get_name()] = facts
-            to_dump = yaml.dump(hosts_yaml,
-                                allow_unicode=True,
-                                default_flow_style=False,
-                                Dumper=AnsibleDumper)
+            to_dump = u(yaml.dump(hosts_yaml,
+                                  allow_unicode=True,
+                                  default_flow_style=False,
+                                  Dumper=AnsibleDumper))
             os.write(self.hosts_yaml, to_dump)
 
     def v2_runner_on_skipped(self, res):


### PR DESCRIPTION
When using `allow_unicode=True` in yaml.dump statements, if the output contains a unicode character it will cause the module to fail.  Using `six.u` to properly pass through all unicode characters. This can have the side effect of passing unicode characters even if they were not intentionally included, such as non-breaking spaces in URLs.  See bug 1416877.