### PR TITLE
fixed decode switch so it works on OSX

### DIFF
--- a/roles/openshift_metrics/files/import_jks_certs.sh
+++ b/roles/openshift_metrics/files/import_jks_certs.sh
@@ -20,8 +20,8 @@ set -ex
 
 function import_certs() {
   dir=$CERT_DIR
-  hawkular_metrics_keystore_password=$(echo $METRICS_KEYSTORE_PASSWD | base64 -d)
-  hawkular_metrics_truststore_password=$(echo $METRICS_TRUSTSTORE_PASSWD | base64 -d)
+  hawkular_metrics_keystore_password=$(echo $METRICS_KEYSTORE_PASSWD | base64 --decode)
+  hawkular_metrics_truststore_password=$(echo $METRICS_TRUSTSTORE_PASSWD | base64 --decode)
   hawkular_alias=`keytool -noprompt -list -keystore $dir/hawkular-metrics.truststore -storepass ${hawkular_metrics_truststore_password} | sed -n '7~2s/,.*$//p'`
 
   if [ ! -f $dir/hawkular-metrics.keystore ]; then


### PR DESCRIPTION
`base64 -d` breaks the playbook on OSX