### PR TITLE
Restart polkitd to workaround a bug in polkitd

### DIFF
--- a/roles/os_firewall/tasks/firewall/firewalld.yml
+++ b/roles/os_firewall/tasks/firewall/firewalld.yml
@@ -34,6 +34,12 @@
   pause: seconds=10
   when: result | changed
 
+- name: Restart polkitd
+  systemd:
+    name: polkit
+    state: restarted
+  when: result | changed
+
 # Fix suspected race between firewalld and polkit BZ1436964
 - name: Wait for polkit action to have been created
   command: pkaction --action-id=org.fedoraproject.FirewallD1.config.info


### PR DESCRIPTION
Friday I ran into a local case where firewalld was failing as detailed in #3213 even after the changes in #3804 we were able to determine that restarting polkit made the problems go away. Unfortunately polkit lacks a reload function so we must restart it. Polkit should get notifications whenever a new policy is deployed but it looks like maybe it's attempting to load the file while it's still being written to?