### PR TITLE
oc_label: Read labels from correct results in current_labels

### DIFF
--- a/roles/lib_openshift/library/oc_label.py
+++ b/roles/lib_openshift/library/oc_label.py
@@ -1446,7 +1446,7 @@ class OCLabel(OpenShiftCLI):
         '''property for the current labels'''
         if self._curr_labels is None:
             results = self.get()
-            self._curr_labels = results['labels']
+            self._curr_labels = results['results']['labels']
 
         return self._curr_labels
 

--- a/roles/lib_openshift/src/class/oc_label.py
+++ b/roles/lib_openshift/src/class/oc_label.py
@@ -29,7 +29,7 @@ class OCLabel(OpenShiftCLI):
         '''property for the current labels'''
         if self._curr_labels is None:
             results = self.get()
-            self._curr_labels = results['labels']
+            self._curr_labels = results['results']['labels']
 
         return self._curr_labels
 


### PR DESCRIPTION
This bug is currently not hit because every instance of `current_labels()` is preceded by a call to `get()`, thus skipping this clause. However, in some testing I removed the aforementioned `get()` call and found that `results` has no key `labels`.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>