### PR TITLE
oc_process: Output rval as msg on failure

### DIFF
--- a/roles/lib_openshift/library/oc_process.py
+++ b/roles/lib_openshift/library/oc_process.py
@@ -1588,7 +1588,7 @@ class OCProcess(OpenShiftCLI):
 
         for cmd in rval:
             if cmd['returncode'] != 0:
-                return {"failed": True, "changed": update, "results": rval, "state": "present"}
+                return {"failed": True, "changed": update, "msg": rval, "state": "present"}
 
         return {"changed": update, "results": rval, "state": "present"}
 

--- a/roles/lib_openshift/src/class/oc_process.py
+++ b/roles/lib_openshift/src/class/oc_process.py
@@ -179,7 +179,7 @@ class OCProcess(OpenShiftCLI):
 
         for cmd in rval:
             if cmd['returncode'] != 0:
-                return {"failed": True, "changed": update, "results": rval, "state": "present"}
+                return {"failed": True, "changed": update, "msg": rval, "state": "present"}
 
         return {"changed": update, "results": rval, "state": "present"}
 


### PR DESCRIPTION
`rval` was not being output when the call to `oc process` failed. This follows the pattern for failure reporting found later in the same function.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>