### PR TITLE
oc_configmap: Add missing check for name

### DIFF
--- a/roles/lib_openshift/library/oc_configmap.py
+++ b/roles/lib_openshift/library/oc_configmap.py
@@ -1524,6 +1524,10 @@ class OCConfigMap(OpenShiftCLI):
         if state == 'list':
             return {'changed': False, 'results': api_rval, 'state': state}
 
+        if not params['name']:
+            return {'failed': True,
+                    'msg': 'Please specify a name when state is absent|present.'}
+
         ########
         # Delete
         ########

--- a/roles/lib_openshift/src/class/oc_configmap.py
+++ b/roles/lib_openshift/src/class/oc_configmap.py
@@ -127,6 +127,10 @@ class OCConfigMap(OpenShiftCLI):
         if state == 'list':
             return {'changed': False, 'results': api_rval, 'state': state}
 
+        if not params['name']:
+            return {'failed': True,
+                    'msg': 'Please specify a name when state is absent|present.'}
+
         ########
         # Delete
         ########


### PR DESCRIPTION
Encountered some errors in testing. Other library modules include this check in similar places, which leads to cleaner and more useful error messages.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>