### PR TITLE
Port 10255 unnecessary.  Removing all instances

### DIFF
--- a/playbooks/openstack/openshift-cluster/files/heat_stack.yaml
+++ b/playbooks/openstack/openshift-cluster/files/heat_stack.yaml
@@ -340,16 +340,6 @@ resources:
           port_range_max: 10250
           remote_mode: remote_group_id
         - direction: ingress
-          protocol: tcp
-          port_range_min: 10255
-          port_range_max: 10255
-          remote_mode: remote_group_id
-        - direction: ingress
-          protocol: udp
-          port_range_min: 10255
-          port_range_max: 10255
-          remote_mode: remote_group_id
-        - direction: ingress
           protocol: udp
           port_range_min: 4789
           port_range_max: 4789

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -6,10 +6,6 @@ os_firewall_allow:
   port: 80/tcp
 - service: https
   port: 443/tcp
-- service: Openshift kubelet ReadOnlyPort
-  port: 10255/tcp
-- service: Openshift kubelet ReadOnlyPort udp
-  port: 10255/udp
 - service: OpenShift OVS sdn
   port: 4789/udp
   when: openshift.node.use_openshift_sdn | bool

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -26,10 +26,6 @@ dependencies:
     port: 80/tcp
   - service: https
     port: 443/tcp
-  - service: Openshift kubelet ReadOnlyPort
-    port: 10255/tcp
-  - service: Openshift kubelet ReadOnlyPort udp
-    port: 10255/udp
 - role: os_firewall
   os_firewall_allow:
   - service: OpenShift OVS sdn


### PR DESCRIPTION
Per @abutcher and @sdodson we confirmed that kublet and metrics are no longer using 10255.  Docs don't mention port 10255 either.  

This PR will ....
remove port 10255 from landing in iptables rules
remove port 10255 from OpenStack Heat template