### PR TITLE
Revert back to iptables as the default for 3.5

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -46,7 +46,7 @@
     template:
       dest: "{{ docker_systemd_dir }}/custom.conf"
       src: custom.conf.j2
-  when: not os_firewall_use_firewalld | default(True) | bool
+  when: not os_firewall_use_firewalld | default(False) | bool
 
 - include: udev_workaround.yml
   when: docker_udev_workaround | default(False) | bool

--- a/roles/os_firewall/README.md
+++ b/roles/os_firewall/README.md
@@ -17,7 +17,7 @@ Role Variables
 
 | Name                      | Default |                                        |
 |---------------------------|---------|----------------------------------------|
-| os_firewall_use_firewalld | True    | If false, use iptables                 |
+| os_firewall_use_firewalld | False   | If false, use iptables                 |
 | os_firewall_allow         | []      | List of service,port mappings to allow |
 | os_firewall_deny          | []      | List of service, port mappings to deny |
 

--- a/roles/os_firewall/defaults/main.yml
+++ b/roles/os_firewall/defaults/main.yml
@@ -2,6 +2,6 @@
 os_firewall_enabled: True
 # firewalld is not supported on Atomic Host
 # https://bugzilla.redhat.com/show_bug.cgi?id=1403331
-os_firewall_use_firewalld: "{{ False if openshift.common.is_atomic | bool else True }}"
+os_firewall_use_firewalld: "{{ False }}"
 os_firewall_allow: []
 os_firewall_deny: []


### PR DESCRIPTION
Since we don't have a migration strategy to migrate iptables rules to
firewalld during upgrade we should not alter the default.