### PR TITLE
Bump calico policy controller

### DIFF
--- a/roles/calico_master/templates/calico-policy-controller.yml.j2
+++ b/roles/calico_master/templates/calico-policy-controller.yml.j2
@@ -74,7 +74,7 @@ spec:
       serviceAccountName: calico
       containers:
         - name: calico-policy-controller
-          image: quay.io/calico/kube-policy-controller:v0.5.3
+          image: quay.io/calico/kube-policy-controller:v0.5.4
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS


### PR DESCRIPTION
Calico's v0.5.3 policy controller image was a bad release. We cut an emergency v0.5.4. This PR bumps to the correct release.