### PR TITLE
[WIP] Add External etcd store for Calico

### DIFF
--- a/roles/calico/defaults/main.yaml
+++ b/roles/calico/defaults/main.yaml
@@ -1,10 +1,12 @@
 ---
+cali_bgp_interface: "eth0"
 kubeconfig: "{{openshift.common.config_base}}/node/{{ 'system:node:' +  openshift.common.hostname }}.kubeconfig"
-etcd_endpoints: "{{ hostvars[groups.oo_first_master.0].openshift.master.etcd_urls | join(',') }}"
-
+etcd_endpoints: "http://{{ hostvars[groups['masters'][0]]['ansible_' + cali_bgp_interface].ipv4.address }}:{{ calico_etcd_client_port }}"
 cni_conf_dir: "/etc/cni/net.d/"
 cni_bin_dir: "/opt/cni/bin/"
 
-calico_etcd_ca_cert_file: "/etc/origin/calico/calico.etcd-ca.crt"
-calico_etcd_cert_file: "/etc/origin/calico/calico.etcd-client.crt"
-calico_etcd_key_file: "/etc/origin/calico/calico.etcd-client.key"
+calico_etcd_ca_cert_file: ""
+calico_etcd_cert_file: ""
+calico_etcd_key_file: ""
+calico_etcd_client_port: 22379
+calico_etcd_peer_port: 22380

--- a/roles/calico/meta/main.yml
+++ b/roles/calico/meta/main.yml
@@ -14,3 +14,14 @@ galaxy_info:
   - system
 dependencies:
 - role: openshift_facts
+- role: etcd
+  etcd_service: calico-etcd
+  etcd_is_thirdparty: True
+  etcd_peer_port: 22380
+  etcd_client_port: 22379
+  etcd_conf_dir: /etc/calico-etcd/conf-dir
+  etcd_data_dir: /var/lib/calico-etcd/data-dir
+  etcd_ca_host: "{{ inventory_hostname }}"
+  etcd_cert_config_dir: /etc/calico-etcd/cert-config-dir
+  etcd_url_scheme: http
+  etcd_peer_url_scheme: http

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -1,19 +1,4 @@
 ---
-- include: ../../../roles/etcd_client_certificates/tasks/main.yml
-  vars:
-    etcd_cert_prefix: calico.etcd-
-    etcd_cert_config_dir: "{{ openshift.common.config_base }}/calico"
-    embedded_etcd: "{{ hostvars[groups.oo_first_master.0].openshift.master.embedded_etcd }}"
-    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
-    etcd_cert_subdir: "openshift-calico-{{ openshift.common.hostname }}"
-
-- name: Assure the calico certs have been generated
-  stat:
-    path: "{{ item }}"
-  with_items:
-  - "{{ calico_etcd_ca_cert_file }}"
-  - "{{ calico_etcd_cert_file}}"
-  - "{{ calico_etcd_key_file }}"
 
 - name: Configure Calico service unit file
   template:

--- a/roles/calico_master/tasks/main.yml
+++ b/roles/calico_master/tasks/main.yml
@@ -1,12 +1,4 @@
 ---
-- name: Assure the calico certs have been generated
-  stat:
-    path: "{{ item }}"
-  with_items:
-  - "{{ calico_etcd_ca_cert_file }}"
-  - "{{ calico_etcd_cert_file}}"
-  - "{{ calico_etcd_key_file }}"
-
 - name: Create temp directory for policy controller definition
   command: mktemp -d /tmp/openshift-ansible-XXXXXXX
   register: mktemp

--- a/roles/calico_master/templates/calico-policy-controller.yml.j2
+++ b/roles/calico_master/templates/calico-policy-controller.yml.j2
@@ -74,7 +74,7 @@ spec:
       serviceAccountName: calico
       containers:
         - name: calico-policy-controller
-          image: quay.io/calico/kube-policy-controller:v0.5.3
+          image: quay.io/calico/kube-policy-controller:v0.5.4
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS


### PR DESCRIPTION
I'm opening this PR to share work on rolling a separate etcd for use by Calico.

I've been stuck on an error encountered during the ansible script which complains that `'/etc/calico-etcd/conf-dir/ca/openssl.cnf'` does not exist:

```
TASK [etcd_server_certificates : Create the server csr] ************************
skipping: [master1]
fatal: [node2 -> 35.188.81.185]: FAILED! => {"changed": true, "cmd": ["openssl", "req", "-new", "-key
out", "server.key", "-config", "/etc/calico-etcd/conf-dir/ca/openssl.cnf", "-out", "server.csr", "-re
qexts", "etcd_v3_req", "-batch", "-nodes", "-subj", "/CN=turk-openshift-2-snmt"], "delta": "0:00:00.0
10782", "end": "2017-04-05 18:10:51.743506", "failed": true, "rc": 1, "start": "2017-04-05 18:10:51.7
32724", "stderr": "error on line -1 of /etc/calico-etcd/conf-dir/ca/openssl.cnf\n140305594234784:erro
r:02001002:system library:fopen:No such file or directory:bss_file.c:169:fopen('/etc/calico-etcd/conf
-dir/ca/openssl.cnf','rb')\n140305594234784:error:2006D080:BIO routines:BIO_new_file:no such file:bss
_file.c:172:\n140305594234784:error:0E078072:configuration file routines:DEF_LOAD:no such file:conf_d
ef.c:197:", "stdout": "", "stdout_lines": [], "warnings": []}
```

After the failed playbook run, I've logged onto the machine and confirmed that:
- `openssl.cnf` does exist at that location
- Calico is up and healthy
- Calico's policy controller has launched successfully

So this seems to just be a etcd role playbook issue. Any help is appreciated