### PR TITLE
Fix test compatibility with OpenSSL 1.1.0

### DIFF
--- a/roles/openshift_certificate_expiry/library/openshift_cert_expiry.py
+++ b/roles/openshift_certificate_expiry/library/openshift_cert_expiry.py
@@ -135,7 +135,7 @@ platforms missing the Python OpenSSL library.
                 continue
 
             elif l.startswith('Subject:'):
-                # O=system:nodes, CN=system:node:m01.example.com
+                # O = system:nodes, CN = system:node:m01.example.com
                 self.subject = FakeOpenSSLCertificateSubjects(l.partition(': ')[-1])
 
     def get_serial_number(self):
@@ -202,7 +202,7 @@ object"""
         """
         self.subjects = []
         for s in subject_string.split(', '):
-            name, _, value = s.partition('=')
+            name, _, value = s.partition(' = ')
             self.subjects.append((name, value))
 
     def get_components(self):

--- a/roles/openshift_certificate_expiry/test/test_fakeopensslclasses.py
+++ b/roles/openshift_certificate_expiry/test/test_fakeopensslclasses.py
@@ -17,7 +17,8 @@ from openshift_cert_expiry import FakeOpenSSLCertificate  # noqa: E402
 
 @pytest.fixture(scope='module')
 def fake_valid_cert(valid_cert):
-    cmd = ['openssl', 'x509', '-in', str(valid_cert['cert_file']), '-text']
+    cmd = ['openssl', 'x509', '-in', str(valid_cert['cert_file']), '-text',
+           '-nameopt', 'oneline']
     cert = subprocess.check_output(cmd)
     return FakeOpenSSLCertificate(cert.decode('utf8'))
 


### PR DESCRIPTION
Since OpenSSL 1.1.0, default name options for `x509` command include `space_eq`([see](https://github.com/openssl/openssl/commit/9cf315ef90d0cfeb8bb7a38873eea07a8f0dffec)). This pull request disable `space_eq` because [`test_get_subject`](https://github.com/openshift/openshift-ansible/blob/293f18593307f5a90890848d77c439b3d3f1dd0d/roles/openshift_certificate_expiry/test/test_fakeopensslclasses.py#L40) assumes that this option is disabled.