### PR TITLE
[Upgrade] Firewall check - switch from ignoring to passing on checks

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -70,8 +70,8 @@
   tasks:
   - name: Check if iptables is running
     command: systemctl status iptables
-    ignore_errors: true
     changed_when: false
+    failed_when: false
     register: service_iptables_status
 
   - name: Set fact os_firewall_use_firewalld FALSE for iptables


### PR DESCRIPTION
Ignoring errors is prone to cause misinterpretation of the status of task completion.  This change switches from showing `...ignoring` to passing with `ok:`.  This task does not make changes on the host.

