### PR TITLE
Create member/snap directory encase it doesn't exist

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/etcd/backup.yml
+++ b/playbooks/common/openshift-cluster/upgrades/etcd/backup.yml
@@ -85,10 +85,15 @@
       path: "{{ openshift.etcd.etcd_data_dir }}/member/snap/db"
     register: v3_db
 
+  - name: Ensure v3 backup directory exists
+    file:
+      path: "{{ openshift.common.data_dir }}/etcd-backup-{{ backup_tag | default('') }}{{ timestamp }}/member/snap"
+      state: directory
+
   - name: Copy etcd v3 data store
     command: >
-      cp -a {{ openshift.etcd.etcd_data_dir }}/member/snap
-      {{ openshift.common.data_dir }}/etcd-backup-{{ backup_tag | default('') }}{{ timestamp }}/member/
+      cp -a {{ openshift.etcd.etcd_data_dir }}/member/snap/db
+      {{ openshift.common.data_dir }}/etcd-backup-{{ backup_tag | default('') }}{{ timestamp }}/member/snap/
     when: v3_db.stat.exists
 
   - set_fact:


### PR DESCRIPTION
If the member/snap didn't exist after running etcdctl backup create it.

Fixes
```
TASK [Copy etcd v3 data store]
*************************************************
fatal: [host.redhat.com]: FAILED! => {
    "changed": true,
    "cmd": [
        "cp",
        "-a",
        "/var/lib/etcd//member/snap",
        "/var/lib/origin/etcd-backup-pre-upgrade-20170407055413/member/"
    ],
    "delta": "0:00:00.003152",
    "end": "2017-04-07 01:54:17.584685",
    "failed": true,
    "rc": 1,
    "start": "2017-04-07 01:54:17.581533",
    "warnings": []
}

STDERR:

cp: cannot create directory
?/var/lib/origin/etcd-backup-pre-upgrade-20170407055413/member/?: No
such file or directory
```