### PR TITLE
Stop all services prior to upgrading, start all services after

### DIFF
--- a/roles/openshift_node_upgrade/tasks/docker/upgrade.yml
+++ b/roles/openshift_node_upgrade/tasks/docker/upgrade.yml
@@ -6,20 +6,6 @@
 # - docker_version
 # - skip_docker_restart
 
-# We need docker service up to remove all the images, but these services will keep
-# trying to re-start and thus re-pull the images we're trying to delete.
-- name: Stop containerized services
-  service: name={{ item }} state=stopped
-  with_items:
-    - "{{ openshift.common.service_type }}-master"
-    - "{{ openshift.common.service_type }}-master-api"
-    - "{{ openshift.common.service_type }}-master-controllers"
-    - "{{ openshift.common.service_type }}-node"
-    - etcd_container
-    - openvswitch
-  failed_when: false
-  when: openshift.common.is_containerized | bool
-
 - name: Check Docker image count
   shell: "docker images -aq | wc -l"
   register: docker_image_count
@@ -45,5 +31,4 @@
 - name: Upgrade Docker
   package: name=docker{{ '-' + docker_version }} state=present
 
-- include: restart.yml
-  when: not skip_docker_restart | default(False) | bool
+# starting docker happens back in ../main.yml where it calls ../restart.yml

--- a/roles/openshift_node_upgrade/tasks/main.yml
+++ b/roles/openshift_node_upgrade/tasks/main.yml
@@ -9,6 +9,28 @@
 # - openshift_release
 
 # tasks file for openshift_node_upgrade
+
+- name: Stop node and openvswitch services
+  service:
+    name: "{{ item }}"
+    state: stopped
+  with_items:
+  - "{{ openshift.common.service_type }}-node"
+  - openvswitch
+  failed_when: false
+
+- name: Stop additional containerized services
+  service:
+    name: "{{ item }}"
+    state: stopped
+  with_items:
+    - "{{ openshift.common.service_type }}-master"
+    - "{{ openshift.common.service_type }}-master-controllers"
+    - "{{ openshift.common.service_type }}-master-api"
+    - etcd_container
+  failed_when: false
+  when: openshift.common.is_containerized | bool
+
 - include: docker/upgrade.yml
   vars:
     # We will restart Docker ourselves after everything is ready:
@@ -16,7 +38,6 @@
   when:
   - l_docker_upgrade is defined
   - l_docker_upgrade | bool
-  - not openshift.common.is_containerized | bool
 
 - include: "{{ node_config_hook }}"
   when: node_config_hook is defined
@@ -37,51 +58,14 @@
 - include: containerized_node_upgrade.yml
   when: openshift.common.is_containerized | bool
 
-- name: Ensure containerized services stopped before Docker restart
-  service:
-    name: "{{ item }}"
-    state: stopped
-  with_items:
-  - etcd_container
-  - openvswitch
-  - "{{ openshift.common.service_type }}-master"
-  - "{{ openshift.common.service_type }}-master-api"
-  - "{{ openshift.common.service_type }}-master-controllers"
-  - "{{ openshift.common.service_type }}-node"
-  failed_when: false
-  when: openshift.common.is_containerized | bool
-
-- name: Stop rpm based services
-  service:
-    name: "{{ item }}"
-    state: stopped
-  with_items:
-  - "{{ openshift.common.service_type }}-node"
-  - openvswitch
-  failed_when: false
-  when: not openshift.common.is_containerized | bool
-
 - name: Upgrade openvswitch
   package:
     name: openvswitch
     state: latest
   when: not openshift.common.is_containerized | bool
 
-- name: Restart openvswitch
-  systemd:
-    name: openvswitch
-    state: started
-  when:
-  - not openshift.common.is_containerized | bool
-
-# Mandatory Docker restart, ensure all containerized services are running:
-- include: docker/restart.yml
-
-- name: Restart rpm node service
-  service:
-    name: "{{ openshift.common.service_type }}-node"
-    state: restarted
-  when: not openshift.common.is_containerized | bool
+# Restart all services
+- include: restart.yml
 
 - name: Wait for node to be ready
   oc_obj:

--- a/roles/openshift_node_upgrade/tasks/restart.yml
+++ b/roles/openshift_node_upgrade/tasks/restart.yml
@@ -12,7 +12,7 @@
   openshift_facts:
     role: docker
 
-- name: Restart containerized services
+- name: Start services
   service: name={{ item }} state=started
   with_items:
     - etcd_container
@@ -22,7 +22,6 @@
     - "{{ openshift.common.service_type }}-master-controllers"
     - "{{ openshift.common.service_type }}-node"
   failed_when: false
-  when: openshift.common.is_containerized | bool
 
 - name: Wait for master API to come back online
   wait_for:


### PR DESCRIPTION
If the node service was not stopped before we attempted to upgrade docker then the node service may cause docker to restart due to service dependencies. So just stop all related services as soon as the node has been drained.