### PR TITLE
[3.4] Use openshift_ca_host's hostnames to sign the CA

### DIFF
--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -94,7 +94,7 @@
     {% for legacy_ca_certificate in g_master_legacy_ca_result.files | default([]) | oo_collect('path') %}
     --certificate-authority {{ legacy_ca_certificate }}
     {% endfor %}
-    --hostnames={{ openshift.common.all_hostnames | join(',') }}
+    --hostnames={{ hostvars[openshift_ca_host].openshift.common.all_hostnames | join(',') }}
     --master={{ openshift.master.api_url }}
     --public-master={{ openshift.master.public_api_url }}
     --cert-dir={{ openshift_ca_config_dir }}


### PR DESCRIPTION
If for some reason oo_first_master and openshift_ca_host (how?!?) are different
we could've signed the CA with the wrong hostnames.

I think ansible sorts the following hosts such that master2 is oo_first_master but somehow openshift_ca_host ends up being master1. So it generates certs on master1 when generating the CA but uses the hostnames from master2 because it's oo_first_master.

```
[masters]
master1  ansible_host=10.10.10.2 openshift_ip=10.10.10.2 openshift_public_ip=10.10.10.2 openshift_hostname=10.10.10.2 openshift_public_hostname=10.10.10.2
master2  ansible_host=10.10.10.1 openshift_ip=10.10.10.1 openshift_public_ip=10.10.10.1 openshift_hostname=10.10.10.1 openshift_public_hostname=10.10.10.1
master3  ansible_host=10.10.10.9 openshift_ip=10.10.10.9 openshift_public_ip=10.10.10.9 openshift_hostname=10.10.10.9 openshift_public_hostname=10.10.10.9
```