### PR TITLE
repo: start testing PRs on Fedora Atomic Host

### DIFF
--- a/.redhat-ci.inventory
+++ b/.redhat-ci.inventory
@@ -1,0 +1,22 @@
+[OSEv3:children]
+masters
+nodes
+etcd
+
+[OSEv3:vars]
+ansible_ssh_user=root
+ansible_python_interpreter=/usr/bin/python3
+deployment_type=origin
+openshift_image_tag="{{ lookup('env', 'OPENSHIFT_IMAGE_TAG') }}"
+openshift_master_default_subdomain="{{ lookup('env', 'RHCI_ocp_node1_IP') }}.xip.io"
+
+[masters]
+ocp-master
+
+[etcd]
+ocp-master
+
+[nodes]
+ocp-master openshift_schedulable=false
+ocp-node1  openshift_node_labels="{'region':'infra'}"
+ocp-node2  openshift_node_labels="{'region':'infra'}"

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -1,0 +1,45 @@
+---
+
+cluster:
+  hosts:
+    - name: ocp-master
+      distro: fedora/25/atomic
+    - name: ocp-node1
+      distro: fedora/25/atomic
+    - name: ocp-node2
+      distro: fedora/25/atomic
+  container:
+    image: fedora:25
+
+packages:
+  - gcc
+  - python-pip
+  - python-devel
+  - openssl-devel
+  - redhat-rpm-config
+
+context: 'fedora/25/atomic | origin/v1.5.0-rc.0'
+
+env:
+  OPENSHIFT_IMAGE_TAG: v1.5.0-rc.0
+
+tests:
+  - pip install ansible==2.2.2.0  # F25 currently has 2.2.1, so install from pypi
+  - ansible -vvv -i .redhat-ci.inventory nodes -a 'rpm-ostree status'
+  - ansible-playbook -vvv -i .redhat-ci.inventory playbooks/byo/config.yml
+  # run a small subset of origin conformance tests to sanity check the cluster
+  # NB: we run it on the master since we may be in a different OSP network
+  - ssh ocp-master docker run --rm --net=host --privileged
+    -v /etc/origin/master/admin.kubeconfig:/config fedora:25 sh -c
+    '"dnf install -y origin-tests &&
+      KUBECONFIG=/config /usr/libexec/origin/extended.test --ginkgo.v=1
+      --ginkgo.noColor --ginkgo.focus=\"Services.*NodePort|EmptyDir\""'
+
+---
+
+inherit: true
+
+context: 'fedora/25/atomic | origin/v3.6.0-alpha.0'
+
+env:
+  OPENSHIFT_IMAGE_TAG: v3.6.0-alpha.0


### PR DESCRIPTION
This patch adds a YAML file to hook up the repo to redhat-ci:
https://github.com/jlebon/redhat-ci

It is much like Travis CI: a YAML file describes the testing environment
as well as the tests themselves. However, it is more powerful than
Travis CI in terms of what it can provision. (For example, in this
patch, we're running two testsuites, each of them provisioning three
nodes and one container). For more details on supported fields, see:

https://github.com/jlebon/redhat-ci/blob/master/sample.redhat-ci.yml

The tests we add here simply check that the installer runs successfully
on Fedora Atomic Host and that the resulting cluster passes some basic
conformance tests. We target both `v1.5.0-rc.0` and `v3.6.0-alpha.0`.

---

Let's just see how this goes for now, though it be great if we could
eventually gate merges on this!

/cc @detiber @sdodson @arilivigni