### PR TITLE
Fix cluster creation with `bin/cluster`

### DIFF
--- a/playbooks/aws/openshift-cluster/config.yml
+++ b/playbooks/aws/openshift-cluster/config.yml
@@ -1,19 +1,7 @@
 ---
-- hosts: localhost
-  gather_facts: no
-  tasks:
-  - include_vars: vars.yml
-  - include_vars: cluster_hosts.yml
-  - add_host:
-      name: "{{ item }}"
-      groups: l_oo_all_hosts
-    with_items: "{{ g_all_hosts | default([]) }}"
-
-- hosts: l_oo_all_hosts
-  gather_facts: no
-  tasks:
-  - include_vars: vars.yml
-  - include_vars: cluster_hosts.yml
+- include: ../../common/openshift-cluster/std_include.yml
+  tags:
+  - always
 
 - include: ../../common/openshift-cluster/config.yml
   vars:

--- a/playbooks/aws/openshift-cluster/update.yml
+++ b/playbooks/aws/openshift-cluster/update.yml
@@ -30,5 +30,9 @@
     with_items: "{{ g_all_hosts | default([]) }}"
 
 - include: ../../common/openshift-cluster/update_repos_and_packages.yml
+  vars:
+    g_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+    g_sudo: "{{ deployment_vars[deployment_type].become }}"
+    g_nodeonmaster: true
 
 - include: config.yml

--- a/playbooks/gce/openshift-cluster/config.yml
+++ b/playbooks/gce/openshift-cluster/config.yml
@@ -1,21 +1,7 @@
 ---
-- hosts: localhost
-  gather_facts: no
-  tasks:
-  - include_vars: vars.yml
-  - include_vars: cluster_hosts.yml
-  - add_host:
-      name: "{{ item }}"
-      groups: l_oo_all_hosts
-      ansible_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
-      ansible_become: "{{ deployment_vars[deployment_type].become }}"
-    with_items: "{{ g_all_hosts | default([]) }}"
-
-- hosts: l_oo_all_hosts
-  gather_facts: no
-  tasks:
-  - include_vars: vars.yml
-  - include_vars: cluster_hosts.yml
+- include: ../../common/openshift-cluster/std_include.yml
+  tags:
+  - always
 
 - include: ../../common/openshift-cluster/config.yml
   vars:

--- a/playbooks/gce/openshift-cluster/update.yml
+++ b/playbooks/gce/openshift-cluster/update.yml
@@ -30,5 +30,9 @@
     with_items: "{{ g_all_hosts | default([]) }}"
 
 - include: ../../common/openshift-cluster/update_repos_and_packages.yml
+  vars:
+    g_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+    g_sudo: "{{ deployment_vars[deployment_type].become }}"
+    g_nodeonmaster: true
 
 - include: config.yml

--- a/playbooks/libvirt/openshift-cluster/config.yml
+++ b/playbooks/libvirt/openshift-cluster/config.yml
@@ -3,21 +3,9 @@
 # is localhost, so no hostname value (or public_hostname) value is getting
 # assigned
 
-- hosts: localhost
-  gather_facts: no
-  tasks:
-  - include_vars: vars.yml
-  - include_vars: cluster_hosts.yml
-  - add_host:
-      name: "{{ item }}"
-      groups: l_oo_all_hosts
-    with_items: "{{ g_all_hosts | default([]) }}"
-
-- hosts: l_oo_all_hosts
-  gather_facts: no
-  tasks:
-  - include_vars: vars.yml
-  - include_vars: cluster_hosts.yml
+- include: ../../common/openshift-cluster/std_include.yml
+  tags:
+  - always
 
 - include: ../../common/openshift-cluster/config.yml
   vars:

--- a/playbooks/libvirt/openshift-cluster/update.yml
+++ b/playbooks/libvirt/openshift-cluster/update.yml
@@ -33,5 +33,9 @@
     with_items: '{{ g_all_hosts | default([]) }}'
 
 - include: ../../common/openshift-cluster/update_repos_and_packages.yml
+  vars:
+    g_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+    g_sudo: "{{ deployment_vars[deployment_type].become }}"
+    g_nodeonmaster: true
 
 - include: config.yml

--- a/playbooks/openstack/openshift-cluster/config.yml
+++ b/playbooks/openstack/openshift-cluster/config.yml
@@ -1,19 +1,7 @@
 ---
-- hosts: localhost
-  gather_facts: no
-  tasks:
-  - include_vars: vars.yml
-  - include_vars: cluster_hosts.yml
-  - add_host:
-      name: "{{ item }}"
-      groups: l_oo_all_hosts
-    with_items: "{{ g_all_hosts | default([]) }}"
-
-- hosts: l_oo_all_hosts
-  gather_facts: no
-  tasks:
-  - include_vars: vars.yml
-  - include_vars: cluster_hosts.yml
+- include: ../../common/openshift-cluster/std_include.yml
+  tags:
+  - always
 
 - include: ../../common/openshift-cluster/config.yml
   vars:

--- a/playbooks/openstack/openshift-cluster/update.yml
+++ b/playbooks/openstack/openshift-cluster/update.yml
@@ -30,5 +30,9 @@
     with_items: "{{ g_all_hosts | default([]) }}"
 
 - include: ../../common/openshift-cluster/update_repos_and_packages.yml
+  vars:
+    g_ssh_user: "{{ deployment_vars[deployment_type].ssh_user }}"
+    g_sudo: "{{ deployment_vars[deployment_type].become }}"
+    g_nodeonmaster: true
 
 - include: config.yml


### PR DESCRIPTION
On the current master branch, trying to create a cluster on a specific IaaS with `bin/cluster` like with this command:

```
bin/cluster create -p -t openshift-enterprise -o image_name=rhel-guest-image-7.3-35.x86_64.qcow2 -o image_sha256=55a581618199240c5d6ce332653c3e506cb05da863ad2e4a50d5e068e9790d88 libvirt lenaic
```

systematically fails with the following error:

```
TASK [openshift_master_facts : Determine if scheduler config present] **********
ok: [lenaic-master-1fa81]

TASK [openshift_master_facts : set_fact] ***************************************
fatal: [lenaic-master-1fa81]: FAILED! => {"failed": true, "msg": "Unknown short_version {{ openshift_pkg_version | default('') }}"}

NO MORE HOSTS LEFT *************************************************************

PLAY RECAP *********************************************************************
lenaic-master-1fa81        : ok=75   changed=11   unreachable=0    failed=1
```

I bisected the regression and found that it was introduced by the following commit:

```
917e871843192b107776ce8459b87f3960e455ed is the first bad commit
commit 917e871843192b107776ce8459b87f3960e455ed
Author: Andrew Butcher <abutcher@redhat.com>
Date:   Wed Oct 26 14:59:05 2016 -0400

    Restructure certificate redeploy playbooks
```

Comparing the Ansible logs before and after that commits showed that several roles like `openshift-version` were not run anymore before the task that is now failing.

It appears that the refactoring done in commit 917e871 moved some roles invocation to `std_include.yml` which now needs to be included from the topmost playbooks.
This was done in 917e871 in the BYO playbooks. This PR does it for the libvirt, OpenStack, GCE and AWS playbooks.