### PR TITLE
Prevent line wrap in yaml dump of IDP, fixes #3912

### DIFF
--- a/roles/openshift_master_facts/filter_plugins/openshift_master.py
+++ b/roles/openshift_master_facts/filter_plugins/openshift_master.py
@@ -496,6 +496,7 @@ class FilterModule(object):
         return u(yaml.dump([idp.to_dict() for idp in idp_list],
                            allow_unicode=True,
                            default_flow_style=False,
+                           width=float("inf"),
                            Dumper=AnsibleDumper))
 
     @staticmethod


### PR DESCRIPTION
Prevents YAML lines from ever wrapping. Fixes #3912 