### PR TITLE
Deleting fluentd pods after DS patching to ensure pods are updated

### DIFF
--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -48,6 +48,25 @@
     loop_var: file
   when: not ansible_check_mode
 
+# TODO: this is only required while the rollingUpdate parameter for the DS is not supported (kube 1.6+)
+- name: Get list of current Fluentd pods
+  oc_obj:
+    state: list
+    kind: pod
+    selector: "component=fluentd"
+    namespace: "{{ openshift_logging_namespace }}"
+  register: fluentd_pods
+
+- name: Delete current Fluentd pods to redeploy
+  oc_obj:
+    state: absent
+    kind: pod
+    name: "{{ object }}"
+    namespace: "{{ openshift_logging_namespace }}"
+  with_items: "{{ fluentd_pods.results.results[0]['items'] | map( attribute='metadata.name' ) | list }}"
+  loop_control:
+    loop_var: object
+
 - include: update_master_config.yaml
 
 - name: Printing out objects to create


### PR DESCRIPTION
rollingUpdate isn't supported pre kube 1.6 so we need to delete the fluentd pods so that they use the most recent daemonset spec.

The fix for this on master can take advantage of the fact that `oc_obj` with a `state: absent` doesn't require a name.

cc @dgoodwin 