### PR TITLE
tox tests: pin test requirement versions (release-1.5)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-ansible>=2.2
-click
-pyOpenSSL
+ansible==2.2.2.0
+click==6.7
+pyOpenSSL==16.2.0
 # We need to disable ruamel.yaml for now because of test failures
 #ruamel.yaml
-six
+six==1.10.0


### PR DESCRIPTION
Tests started failing once ansible 2.3 was released. It seems wise to
pin the dependencies to particular versions until we make a conscious
decision to change them (and have tested with them).