### PR TITLE
tox tests: pin test requirement versions (release-1.4)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible>=2.2
-six
-pyOpenSSL
+ansible==2.2.2.0
+six==1.10.0
+pyOpenSSL==16.2.0
 PyYAML


### PR DESCRIPTION
Tests started failing once ansible 2.3 was released. It seems wise to
pin the dependencies to particular versions until we make a conscious
decision to change them (and have tested with them).