### PR TITLE
Fix instantiation of action plugin test to support Ansible 2.3

### DIFF
--- a/roles/openshift_health_checker/test/action_plugin_test.py
+++ b/roles/openshift_health_checker/test/action_plugin_test.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ansible.playbook.play_context import PlayContext
+
 from openshift_health_check import ActionModule, resolve_checks
 from openshift_checks import OpenShiftCheckException
 
@@ -34,7 +36,7 @@ def fake_check(name='fake_check', tags=None, is_active=True, run_return=None, ru
 @pytest.fixture
 def plugin():
     task = FakeTask('openshift_health_check', {'checks': ['fake_check']})
-    plugin = ActionModule(task, None, None, None, None, None)
+    plugin = ActionModule(task, None, PlayContext(), None, None, None)
     return plugin
 
 


### PR DESCRIPTION
In Ansible 2.3+, the base action plugin class' run method accesses attributes (check_mode) of its play_context.

In older versions play_context was not involved in run, and thus None was passed in.

~~**Note**: the second commit, reverting the pinning of test requirements, is meant to demonstrate how we can run with Ansible 2.3 just fine, and may be dropped later.~~