### PR TITLE
Cast etcd_debug to a boolean

### DIFF
--- a/roles/etcd/templates/etcd.conf.j2
+++ b/roles/etcd/templates/etcd.conf.j2
@@ -62,7 +62,7 @@ ETCD_PEER_KEY_FILE={{ etcd_peer_key_file }}
 {% endif -%}
 
 #[logging]
-ETCD_DEBUG="{{ etcd_debug | default(false) | string }}"
+ETCD_DEBUG="{{ etcd_debug | default(false) | bool | string }}"
 {% if etcd_log_package_levels is defined %}
 ETCD_LOG_PACKAGE_LEVELS="{{ etcd_log_package_levels }}"
 {% endif %}


### PR DESCRIPTION
In the current implementation, any user-provided string in the
`etcd_debug` variable will be placed into `etcd.conf`. The YAML
and Ansible boolean parsing is more generous than the Golang one,
so valid YAML booleans like `no` will be invalid when passed to
etcd. Casting to a boolean before casting to a string normalizes
the field.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @sdodson 