### PR TITLE
tox tests: pin test requirement versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# Versions are pinned to prevent pypi releases arbitrarily breaking
+# tests with new APIs/semantics. We want to update versions deliberately.
 ansible==2.2.2.0
 click==6.7
 pyOpenSSL==16.2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,11 +1,14 @@
+# Versions are pinned to prevent pypi releases arbitrarily breaking
+# tests with new APIs/semantics. We want to update versions deliberately.
+
 # flake8 must be listed before pylint to avoid dependency conflicts
-flake8
-flake8-mutable
-flake8-print
-pylint
-setuptools-lint
-yamllint
-coverage
-mock
-pytest
-pytest-cov
+flake8==3.3.0
+flake8-mutable==1.1.0
+flake8-print==2.0.2
+pylint==1.6.5
+setuptools-lint==0.5.2
+yamllint==1.6.1
+coverage==4.3.4
+mock==2.0.0
+pytest==3.0.7
+pytest-cov==2.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ skip_install=True
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
-    py35-flake8: flake8-bugbear
+    py35-flake8: flake8-bugbear==17.3.0
 
 commands =
     unit: pip install -e utils


### PR DESCRIPTION
Tests once again randomly broke due to a PyPI release.
This makes test req versions explicit so they only change deliberately.