### PR TITLE
tox tests: pin test requirement versions (release-1.4)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+# Versions are pinned to prevent pypi releases arbitrarily breaking
+# tests with new APIs/semantics. We want to update versions deliberately.
 ansible==2.2.2.0
 six==1.10.0
 pyOpenSSL==16.2.0
-PyYAML
+PyYAML==3.12

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,11 +1,14 @@
-six
-pyOpenSSL
-flake8
-flake8-mutable
-flake8-print
-pylint
-setuptools-lint
-PyYAML
-yamllint
-nose
-coverage
+# Versions are pinned to prevent pypi releases arbitrarily breaking
+# tests with new APIs/semantics. We want to update versions deliberately.
+
+six==1.10.0
+pyOpenSSL==16.2.0
+flake8==3.3.0
+flake8-mutable==1.1.0
+flake8-print==2.0.2
+pylint==1.6.5
+setuptools-lint==0.5.2
+PyYAML==3.12
+yamllint==1.6.1
+nose==1.3.7
+coverage==4.3.4

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,7 @@ skip_missing_interpreters=True
 [testenv]
 deps =
     -rtest-requirements.txt
-    py35-flake8: flake8-bugbear
-    ansible22: ansible~=2.2
+    py35-flake8: flake8-bugbear==17.3.0
 
 commands =
     flake8: flake8


### PR DESCRIPTION
Tests once again randomly broke due to a PyPI release.
This makes req versions explicit so they only change deliberately.