### PR TITLE
Start master services in parallel

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -134,7 +134,6 @@
                                      | oo_select_keys(groups['oo_etcd_to_config'] | default([]))
                                      | oo_collect('openshift.common.hostname')
                                      | default(none, true) }}"
-    openshift_master_hosts: "{{ groups.oo_masters_to_config }}"
     r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
     etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
     etcd_cert_subdir: "openshift-master-{{ openshift.common.hostname }}"

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -222,31 +222,12 @@
     openshift.master.cluster_method == 'native' and
     not openshift.common.is_containerized | bool
 
-- name: Start and enable master api on first master
+- name: Start and enable master api
   systemd:
     name: "{{ openshift.common.service_type }}-master-api"
     enabled: yes
     state: started
-  when: openshift_master_ha | bool and openshift.master.cluster_method == 'native' and inventory_hostname == openshift_master_hosts[0]
-  register: start_result
-  until: not start_result | failed
-  retries: 1
-  delay: 60
-
-- set_fact:
-    master_api_service_status_changed: "{{ start_result | changed }}"
-  when: openshift_master_ha | bool and openshift.master.cluster_method == 'native' and inventory_hostname == openshift_master_hosts[0]
-
-- pause:
-    seconds: 15
   when: openshift_master_ha | bool and openshift.master.cluster_method == 'native'
-
-- name: Start and enable master api all masters
-  systemd:
-    name: "{{ openshift.common.service_type }}-master-api"
-    enabled: yes
-    state: started
-  when: openshift_master_ha | bool and openshift.master.cluster_method == 'native' and inventory_hostname != openshift_master_hosts[0]
   register: start_result
   until: not start_result | failed
   retries: 1
@@ -254,7 +235,7 @@
 
 - set_fact:
     master_api_service_status_changed: "{{ start_result | changed }}"
-  when: openshift_master_ha | bool and openshift.master.cluster_method == 'native' and inventory_hostname != openshift_master_hosts[0]
+  when: openshift_master_ha | bool and openshift.master.cluster_method == 'native'
 
 # A separate wait is required here for native HA since notifies will
 # be resolved after all tasks in the role.
@@ -277,28 +258,12 @@
   changed_when: false
   when: openshift_master_ha | bool and openshift.master.cluster_method == 'native' and master_api_service_status_changed | bool
 
-- name: Start and enable master controller on first master
+- name: Start and enable master controllers
   systemd:
     name: "{{ openshift.common.service_type }}-master-controllers"
     enabled: yes
     state: started
-  when: openshift_master_ha | bool and openshift.master.cluster_method == 'native' and inventory_hostname == openshift_master_hosts[0]
-  register: start_result
-  until: not start_result | failed
-  retries: 1
-  delay: 60
-
-- name: Wait for master controller service to start on first master
-  pause:
-    seconds: 15
   when: openshift_master_ha | bool and openshift.master.cluster_method == 'native'
-
-- name: Start and enable master controller on all masters
-  systemd:
-    name: "{{ openshift.common.service_type }}-master-controllers"
-    enabled: yes
-    state: started
-  when: openshift_master_ha | bool and openshift.master.cluster_method == 'native' and inventory_hostname != openshift_master_hosts[0]
   register: start_result
   until: not start_result | failed
   retries: 1


### PR DESCRIPTION
Removes staggered master start and two 15 second pauses. Need to find link to the controllers race condition this was originally working around but I believe it has been fixed. 