### PR TITLE
Add Ansible syntax checks to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,4 +21,4 @@ commands =
     yamllint: python setup.py yamllint
     generate_validation: python setup.py generate_validation
     # TODO(rhcarvalho): check syntax of other important entrypoint playbooks
-    ansible_syntax: ansible-playbook --syntax-check playbooks/byo/config.yml
+    ansible_syntax: python setup.py ansible_syntax


### PR DESCRIPTION
Adds syntax checking for entry point playbooks to standard tox checks run by CI.  An entry point playbook is identified as being a .yml/.yaml file containing `initialize_groups.yml`.

This PR will fail Travis CI until #3936 and #3937 are merged.