### PR TITLE
BZ 1441922: Add evaluate_groups to openshift_logging

### DIFF
--- a/playbooks/common/openshift-cluster/openshift_logging.yml
+++ b/playbooks/common/openshift-cluster/openshift_logging.yml
@@ -1,4 +1,6 @@
 ---
+- include: evaluate_groups.yml
+
 - name: OpenShift Aggregated Logging
   hosts: oo_first_master
   roles:


### PR DESCRIPTION
Groups denoted by `oo_` are not being created and therefore plays are being skipped.

This is already fixed in master by:
https://github.com/openshift/openshift-ansible/pull/3895/files#diff-82c4f81310da88a584a96c1a647388f3R2

Resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=1441922