### PR TITLE
Add missing mock for locate_oc_binary method

### DIFF
--- a/roles/lib_openshift/src/test/unit/test_oc_adm_registry.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_adm_registry.py
@@ -241,15 +241,9 @@ class RegistryTest(unittest.TestCase):
             (0, '', ''),
         ]
 
-        mock_tmpfile_copy.side_effect = [
-            '/tmp/mocked_kubeconfig',
-            '/tmp/mocked_kubeconfig',
-        ]
+        mock_tmpfile_copy.return_value = '/tmp/mocked_kubeconfig'
 
-        mock_oc_binary.side_effect = [
-            'oc',
-            'oc',
-        ]
+        mock_oc_binary.return_value = 'oc'
 
         results = Registry.run_ansible(params, False)
 

--- a/roles/lib_openshift/src/test/unit/test_oc_adm_registry.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_adm_registry.py
@@ -205,10 +205,11 @@ class RegistryTest(unittest.TestCase):
             }
         ]}'''
 
+    @mock.patch('oc_adm_registry.locate_oc_binary')
     @mock.patch('oc_adm_registry.Utils._write')
     @mock.patch('oc_adm_registry.Utils.create_tmpfile_copy')
     @mock.patch('oc_adm_registry.Registry._run')
-    def test_state_present(self, mock_cmd, mock_tmpfile_copy, mock_write):
+    def test_state_present(self, mock_cmd, mock_tmpfile_copy, mock_write, mock_oc_binary):
         ''' Testing state present '''
         params = {'state': 'present',
                   'debug': False,
@@ -243,6 +244,11 @@ class RegistryTest(unittest.TestCase):
         mock_tmpfile_copy.side_effect = [
             '/tmp/mocked_kubeconfig',
             '/tmp/mocked_kubeconfig',
+        ]
+
+        mock_oc_binary.side_effect = [
+            'oc',
+            'oc',
         ]
 
         results = Registry.run_ansible(params, False)

--- a/roles/lib_openshift/src/test/unit/test_oc_adm_router.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_adm_router.py
@@ -286,10 +286,11 @@ class RouterTest(unittest.TestCase):
     ]
 }'''
 
+    @mock.patch('oc_adm_router.locate_oc_binary')
     @mock.patch('oc_adm_router.Utils._write')
     @mock.patch('oc_adm_router.Utils.create_tmpfile_copy')
     @mock.patch('oc_adm_router.Router._run')
-    def test_state_present(self, mock_cmd, mock_tmpfile_copy, mock_write):
+    def test_state_present(self, mock_cmd, mock_tmpfile_copy, mock_write, mock_oc_binary):
         ''' Testing a create '''
         params = {'state': 'present',
                   'debug': False,
@@ -343,6 +344,10 @@ class RouterTest(unittest.TestCase):
 
         mock_tmpfile_copy.side_effect = [
             '/tmp/mocked_kubeconfig',
+        ]
+
+        mock_oc_binary.side_effect = [
+            'oc',
         ]
 
         results = Router.run_ansible(params, False)

--- a/roles/lib_openshift/src/test/unit/test_oc_objectvalidator.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_objectvalidator.py
@@ -25,9 +25,10 @@ class OCObjectValidatorTest(unittest.TestCase):
 
     maxDiff = None
 
+    @mock.patch('oc_objectvalidator.locate_oc_binary')
     @mock.patch('oc_objectvalidator.Utils.create_tmpfile_copy')
     @mock.patch('oc_objectvalidator.OCObjectValidator._run')
-    def test_no_data(self, mock_cmd, mock_tmpfile_copy):
+    def test_no_data(self, mock_cmd, mock_tmpfile_copy, mock_oc_binary):
         ''' Testing when both all objects are empty '''
 
         # Arrange
@@ -62,6 +63,10 @@ class OCObjectValidatorTest(unittest.TestCase):
             '/tmp/mocked_kubeconfig',
         ]
 
+        mock_oc_binary.side_effect = [
+            'oc',
+        ]
+
         # Act
         results = OCObjectValidator.run_ansible(params)
 
@@ -76,9 +81,10 @@ class OCObjectValidatorTest(unittest.TestCase):
             mock.call(['oc', 'get', 'namespace', '-o', 'json', '-n', 'default'], None),
         ])
 
+    @mock.patch('oc_objectvalidator.locate_oc_binary')
     @mock.patch('oc_objectvalidator.Utils.create_tmpfile_copy')
     @mock.patch('oc_objectvalidator.OCObjectValidator._run')
-    def test_error_code(self, mock_cmd, mock_tmpfile_copy):
+    def test_error_code(self, mock_cmd, mock_tmpfile_copy, mock_oc_binary):
         ''' Testing when we fail to get objects '''
 
         # Arrange
@@ -96,6 +102,10 @@ class OCObjectValidatorTest(unittest.TestCase):
 
         mock_tmpfile_copy.side_effect = [
             '/tmp/mocked_kubeconfig',
+        ]
+
+        mock_oc_binary.side_effect = [
+            'oc'
         ]
 
         error_results = {
@@ -120,9 +130,10 @@ class OCObjectValidatorTest(unittest.TestCase):
             mock.call(['oc', 'get', 'hostsubnet', '-o', 'json', '-n', 'default'], None),
         ])
 
+    @mock.patch('oc_objectvalidator.locate_oc_binary')
     @mock.patch('oc_objectvalidator.Utils.create_tmpfile_copy')
     @mock.patch('oc_objectvalidator.OCObjectValidator._run')
-    def test_valid_both(self, mock_cmd, mock_tmpfile_copy):
+    def test_valid_both(self, mock_cmd, mock_tmpfile_copy, mock_oc_binary):
         ''' Testing when both all objects are valid '''
 
         # Arrange
@@ -427,6 +438,10 @@ class OCObjectValidatorTest(unittest.TestCase):
             '/tmp/mocked_kubeconfig',
         ]
 
+        mock_oc_binary.side_effect = [
+            'oc'
+        ]
+
         # Act
         results = OCObjectValidator.run_ansible(params)
 
@@ -441,9 +456,10 @@ class OCObjectValidatorTest(unittest.TestCase):
             mock.call(['oc', 'get', 'namespace', '-o', 'json', '-n', 'default'], None),
         ])
 
+    @mock.patch('oc_objectvalidator.locate_oc_binary')
     @mock.patch('oc_objectvalidator.Utils.create_tmpfile_copy')
     @mock.patch('oc_objectvalidator.OCObjectValidator._run')
-    def test_invalid_both(self, mock_cmd, mock_tmpfile_copy):
+    def test_invalid_both(self, mock_cmd, mock_tmpfile_copy, mock_oc_binary):
         ''' Testing when all objects are invalid '''
 
         # Arrange
@@ -884,6 +900,10 @@ class OCObjectValidatorTest(unittest.TestCase):
 
         mock_tmpfile_copy.side_effect = [
             '/tmp/mocked_kubeconfig',
+        ]
+
+        mock_oc_binary.side_effect = [
+            'oc'
         ]
 
         # Act


### PR DESCRIPTION
When `locate_oc_binary` has not been mocked, the test suite fails when `oc` executable is available.