### PR TITLE
Add /etc/sysconfig/etcd to etcd_container

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -37,6 +37,12 @@
     mode: 0700
   when: etcd_is_thirdparty | bool
 
+- name: Create configuration file in sysconfig
+  file:
+    path: /etc/sysconfig/etcd
+    state: touch
+  when: etcd_is_thirdparty | bool
+
   # TODO: retest with symlink to confirm it does or does not function
 - name: Copy service file for etcd instance
   copy:

--- a/roles/etcd/templates/etcd.docker.service
+++ b/roles/etcd/templates/etcd.docker.service
@@ -7,7 +7,7 @@ PartOf=docker.service
 [Service]
 EnvironmentFile=/etc/etcd/etcd.conf
 ExecStartPre=-/usr/bin/docker rm -f {{ etcd_service }}
-ExecStart=/usr/bin/docker run --name {{ etcd_service }} --rm -v /var/lib/etcd:/var/lib/etcd:z -v /etc/etcd:/etc/etcd:ro --env-file=/etc/etcd/etcd.conf --net=host --entrypoint=/usr/bin/etcd {{ openshift.etcd.etcd_image }}
+ExecStart=/usr/bin/docker run --name {{ etcd_service }} --rm -v /var/lib/etcd:/var/lib/etcd:z -v /etc/etcd:/etc/etcd:ro --env-file=/etc/etcd/etcd.conf --env-file=/etc/sysconfig/etcd --net=host --entrypoint=/usr/bin/etcd {{ openshift.etcd.etcd_image }}
 ExecStop=/usr/bin/docker stop {{ etcd_service }}
 SyslogIdentifier=etcd_container
 Restart=always


### PR DESCRIPTION
The `/etc/sysconfig/etcd` file is often used to allow the usage of additional variables passed to the etcd daemon.
Example of this is to make some new nodes join an existing cluster.

Having two files simplify the automation around it, since in the `/etc/sysconfig/etcd` is possible to put temporary variables and then nuke the file as soon as they are not used anymore.