### PR TITLE
[1.5] Don't check excluder versions when they're not enabled

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/disable_excluder.yml
+++ b/playbooks/common/openshift-cluster/upgrades/disable_excluder.yml
@@ -5,12 +5,13 @@
   tasks:
   - include: pre/validate_excluder.yml
     vars:
-      #repoquery_cmd: repoquery_cmd
-      #openshift_upgrade_target: openshift_upgrade_target
-      excluder: "{{ item }}"
-    with_items:
-    - "{{ openshift.common.service_type }}-docker-excluder"
-    - "{{ openshift.common.service_type }}-excluder"
+      excluder: "{{ openshift.common.service_type }}-docker-excluder"
+    when: enable_docker_excluder | default(enable_excluders) | default(True) | bool
+  - include: pre/validate_excluder.yml
+    vars:
+      excluder: "{{ openshift.common.service_type }}-excluder"
+    when: enable_openshift_excluder | default(enable_excluders) | default(True) | bool
+
 
   # disable excluders based on their status
   - include_role:


### PR DESCRIPTION
Have to call the job twice because the booleans don't map directly to excluder names in a reasonable manner.