### PR TITLE
oc_obj: Allow for multiple kinds in delete

### DIFF
--- a/roles/lib_openshift/library/oc_obj.py
+++ b/roles/lib_openshift/library/oc_obj.py
@@ -98,7 +98,7 @@ options:
     aliases: []
   kind:
     description:
-    - The kind attribute of the object. e.g. dc, bc, svc, route
+    - The kind attribute of the object. e.g. dc, bc, svc, route. May be a comma-separated list, e.g. "dc,po,svc".
     required: True
     default: None
     aliases: []
@@ -1539,12 +1539,9 @@ class OCObject(OpenShiftCLI):
         # Delete
         ########
         if state == 'absent':
-            # if we were passed a name, verify its not in our results
-            if params['name'] is not None and not Utils.exists(api_rval['results'], params['name']):
-                return {'changed': False, 'state': state}
-
-            # verify results are empty for the selector
-            if params['selector'] is not None and len(api_rval['results']) == 0:
+            # verify its not in our results
+            if (params['name'] is not None or params['selector'] is not None) and \
+               (len(api_rval['results']) == 0 or len(api_rval['results'][0].getattr('items', [])) == 0):
                 return {'changed': False, 'state': state}
 
             if check_mode:

--- a/roles/lib_openshift/src/class/oc_obj.py
+++ b/roles/lib_openshift/src/class/oc_obj.py
@@ -115,12 +115,9 @@ class OCObject(OpenShiftCLI):
         # Delete
         ########
         if state == 'absent':
-            # if we were passed a name, verify its not in our results
-            if params['name'] is not None and not Utils.exists(api_rval['results'], params['name']):
-                return {'changed': False, 'state': state}
-
-            # verify results are empty for the selector
-            if params['selector'] is not None and len(api_rval['results']) == 0:
+            # verify its not in our results
+            if (params['name'] is not None or params['selector'] is not None) and \
+               (len(api_rval['results']) == 0 or len(api_rval['results'][0].getattr('items', [])) == 0):
                 return {'changed': False, 'state': state}
 
             if check_mode:

--- a/roles/lib_openshift/src/doc/obj
+++ b/roles/lib_openshift/src/doc/obj
@@ -47,7 +47,7 @@ options:
     aliases: []
   kind:
     description:
-    - The kind attribute of the object. e.g. dc, bc, svc, route
+    - The kind attribute of the object. e.g. dc, bc, svc, route. May be a comma-separated list, e.g. "dc,po,svc".
     required: True
     default: None
     aliases: []


### PR DESCRIPTION
This is to allow "kind" to include a string like "svc,ep" to delete both Services and Endpoints matching a given name or selector.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>