### PR TITLE
Fix issue where the password would not be passed to the htpasswd command

### DIFF
--- a/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
@@ -42,7 +42,7 @@
 
 - name: generate htpasswd file for hawkular metrics
   shell: >
-    docker run -a STDIN -a STDOUT -v "{{ mktemp.stdout }}"
+    docker run -i -a STDIN -a STDOUT -v "{{ mktemp.stdout }}"
     "{{ openshift_metrics_httpd_image }}" htpasswd -ni hawkular
     > '{{ mktemp.stdout }}/hawkular-metrics.htpasswd'
     < '{{ mktemp.stdout }}/hawkular-metrics.pwd'


### PR DESCRIPTION
If we don't use the interactive mode with the docker command, then it doesn't accept the password being passed.

This means the htpasswd file is created with an empty password instead of an actual password.