### PR TITLE
Update byo hosts examples with stronger warnings about Docker subnet overlap

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -571,9 +571,16 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # network blocks should be private and should not conflict with network blocks
 # in your infrastructure that pods may require access to. Can not be changed
 # after deployment.
+#
+# WARNING : Do not pick subnets that overlap with the default Docker bridge subnet of
+# 172.17.0.0/16.  Your installation will fail and/or your configuration change will
+# cause the Pod SDN or Cluster SDN to fail.
+#
+# WORKAROUND : If you must use an overlapping subnet, you can configure a non conflicting
+# docker0 CIDR range by adding '--bip=192.168.2.1/24' to DOCKER_NETWORK_OPTIONS
+# environment variable located in /etc/sysconfig/docker-network.
 #osm_cluster_network_cidr=10.128.0.0/14
 #openshift_portal_net=172.30.0.0/16
-
 
 # ExternalIPNetworkCIDRs controls what values are acceptable for the
 # service external IP field. If empty, no externalIP may be set. It

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -572,9 +572,16 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # network blocks should be private and should not conflict with network blocks
 # in your infrastructure that pods may require access to. Can not be changed
 # after deployment.
+#
+# WARNING : Do not pick subnets that overlap with the default Docker bridge subnet of
+# 172.17.0.0/16.  Your installation will fail and/or your configuration change will
+# cause the Pod SDN or Cluster SDN to fail.
+#
+# WORKAROUND : If you must use an overlapping subnet, you can configure a non conflicting
+# docker0 CIDR range by adding '--bip=192.168.2.1/24' to DOCKER_NETWORK_OPTIONS
+# environment variable located in /etc/sysconfig/docker-network.
 #osm_cluster_network_cidr=10.128.0.0/14
 #openshift_portal_net=172.30.0.0/16
-
 
 # ExternalIPNetworkCIDRs controls what values are acceptable for the
 # service external IP field. If empty, no externalIP may be set. It


### PR DESCRIPTION
Takes warnings from:
https://docs.openshift.com/container-platform/3.4/install_config/install/advanced_install.html#configuring-host-variables
https://docs.openshift.com/container-platform/3.4/admin_guide/sdn_troubleshooting.html#debugging-steps

and makes them stronger and provides potential workaround.