### PR TITLE
Bug 1436371 - Failed to "SetupNetwork" for "router-1-deploy_default" ( default project ) is faced when OCP is installed with docker version 1.12.6 defined into openshift-ansible scripts (edit)

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -84,7 +84,7 @@ openshift_release=v1.5
 
 # Specify exact version of Docker to configure or upgrade to.
 # Downgrades are not supported and will error out. Be careful when upgrading docker from < 1.10 to > 1.10.
-# docker_version="1.12.1"
+# docker_version="1.10.3"
 
 # Skip upgrading Docker during an OpenShift upgrade, leaves the current Docker version alone.
 # docker_upgrade=False

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -84,7 +84,7 @@ openshift_release=v3.5
 
 # Specify exact version of Docker to configure or upgrade to.
 # Downgrades are not supported and will error out. Be careful when upgrading docker from < 1.10 to > 1.10.
-# docker_version="1.12.1"
+# docker_version="1.10.3"
 
 # Skip upgrading Docker during an OpenShift upgrade, leaves the current Docker version alone.
 # docker_upgrade=False

--- a/playbooks/common/openshift-cluster/upgrades/docker/upgrade_check.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/upgrade_check.yml
@@ -30,8 +30,8 @@
   changed_when: false
 
 - fail:
-    msg: This playbook requires access to Docker 1.12 or later
-  # Disable the 1.12 requirement if the user set a specific Docker version
+    msg: This playbook requires access to Docker 1.10 or later
+  # Disable the 1.10 requirement if the user set a specific Docker version
   when: docker_version is not defined and (docker_upgrade is not defined or docker_upgrade | bool == True) and (pkg_check.rc == 0 and (avail_docker_version.stdout == "" or avail_docker_version.stdout | version_compare('1.12','<')))
 
 # Default l_docker_upgrade to False, we'll set to True if an upgrade is required:

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_docker_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_docker_upgrade_targets.yml
@@ -19,5 +19,5 @@
     when: openshift.common.is_atomic | bool
 
   - fail:
-      msg: This playbook requires access to Docker 1.12 or later
+      msg: This playbook requires access to Docker 1.10 or later
     when: openshift.common.is_atomic | bool and l_docker_version.avail_version | default(l_docker_version.curr_version, true) | version_compare('1.12','<')


### PR DESCRIPTION
Ref. Bug 1436371 - Failed to "SetupNetwork" for "router-1-deploy_default" ( default project ) is faced when OCP is installed with docker version 1.12.6 defined into openshift-ansible scripts (edit)

Revert changes made into the PR: https://github.com/openshift/openshift-ansible/pull/2786
The OpenShift 3.4 still not compatible with docker version upper than 1.10 