### PR TITLE
Replace original router cert variable name

### DIFF
--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -24,9 +24,9 @@ openshift_hosted_routers:
   ports:
   - 80:80
   - 443:443
-  certificates: "{{ openshift_hosted_router_certificates | default({}) }}"
+  certificate: "{{ openshift_hosted_router_certificate | default({}) }}"
 
 
-openshift_hosted_router_certificates: {}
+openshift_hosted_router_certificate: {}
 openshift_hosted_registry_cert_expire_days: 730
 openshift_hosted_router_create_certificate: False

--- a/roles/openshift_hosted/tasks/router/router.yml
+++ b/roles/openshift_hosted/tasks/router/router.yml
@@ -25,13 +25,13 @@
       hostnames:
       - "{{ openshift_master_default_subdomain }}"
       - "*.{{ openshift_master_default_subdomain }}"
-      cert: "{{ ('/etc/origin/master/' ~ (item.certificates.certfile | basename)) if 'certfile' in item.certificates else ((openshift_master_config_dir) ~ '/openshift-router.crt') }}"
-      key: "{{ ('/etc/origin/master/' ~ (item.certificates.keyfile | basename)) if 'keyfile' in item.certificates else ((openshift_master_config_dir) ~ '/openshift-router.key') }}"
+      cert: "{{ ('/etc/origin/master/' ~ (item.certificate.certfile | basename)) if 'certfile' in item.certificate else ((openshift_master_config_dir) ~ '/openshift-router.crt') }}"
+      key: "{{ ('/etc/origin/master/' ~ (item.certificate.keyfile | basename)) if 'keyfile' in item.certificate else ((openshift_master_config_dir) ~ '/openshift-router.key') }}"
     with_items: "{{ openshift_hosted_routers }}"
 
-  - name: set the openshift_hosted_router_certificates
+  - name: set the openshift_hosted_router_certificate
     set_fact:
-      openshift_hosted_router_certificates:
+      openshift_hosted_router_certificate:
         certfile: "{{ openshift_master_config_dir ~ '/openshift-router.crt' }}"
         keyfile: "{{ openshift_master_config_dir ~ '/openshift-router.key' }}"
         cafile: "{{ openshift_master_config_dir ~ '/ca.crt' }}"
@@ -44,7 +44,7 @@
     backup: True
     dest: "/etc/origin/master/{{ item | basename }}"
     src: "{{ item }}"
-  with_items: "{{ openshift_hosted_routers | oo_collect(attribute='certificates') |
+  with_items: "{{ openshift_hosted_routers | oo_collect(attribute='certificate') |
                   oo_select_keys_from_list(['keyfile', 'certfile', 'cafile']) }}"
   when: not openshift_hosted_router_create_certificate
 
@@ -82,9 +82,9 @@
     service_account: "{{ item.serviceaccount | default('router') }}"
     selector: "{{ item.selector | default(none) }}"
     images: "{{ item.images | default(omit) }}"
-    cert_file: "{{ ('/etc/origin/master/' ~ (item.certificates.certfile | basename)) if 'certfile' in item.certificates else omit }}"
-    key_file: "{{ ('/etc/origin/master/' ~ (item.certificates.keyfile | basename)) if 'keyfile' in item.certificates else omit }}"
-    cacert_file: "{{ ('/etc/origin/master/' ~ (item.certificates.cafile | basename)) if 'cafile' in item.certificates else omit }}"
+    cert_file: "{{ ('/etc/origin/master/' ~ (item.certificate.certfile | basename)) if 'certfile' in item.certificate else omit }}"
+    key_file: "{{ ('/etc/origin/master/' ~ (item.certificate.keyfile | basename)) if 'keyfile' in item.certificate else omit }}"
+    cacert_file: "{{ ('/etc/origin/master/' ~ (item.certificate.cafile | basename)) if 'cafile' in item.certificate else omit }}"
     edits: "{{ openshift_hosted_router_edits | union(item.edits)  }}"
     ports: "{{ item.ports }}"
     stats_port: "{{ item.stats_port }}"


### PR DESCRIPTION
This variable got renamed during the router sharding work and these changes rename the variable to `openshift_hosted_router_certificate` which is documented in the example byo inventory.

@kwoodson Is operations using this var? Should we support both `*certificate` and `*certificates`?

Example:
```
openshift_hosted_router_certificate={'certfile': '/tmp/wildcard-flibberty-jibbet.com.crt', 'keyfile': '/tmp/wildcard-flibberty-jibbet.com.key', 'cafile': '/tmp/wildcard-ca.crt'}
```