### PR TITLE
Backport 1.5: Replace original router cert variable names.

### DIFF
--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -24,7 +24,7 @@ openshift_hosted_routers:
   ports:
   - 80:80
   - 443:443
-  certificates: "{{ openshift_hosted_router_certificate | default({}) }}"
+  certificate: "{{ openshift_hosted_router_certificate | default({}) }}"
 
 
-openshift_hosted_router_certificates: {}
+openshift_hosted_router_certificate: {}

--- a/roles/openshift_hosted/tasks/router/router.yml
+++ b/roles/openshift_hosted/tasks/router/router.yml
@@ -19,7 +19,7 @@
     backup: True
     dest: "/etc/origin/master/{{ item | basename }}"
     src: "{{ item }}"
-  with_items: "{{ openshift_hosted_routers | oo_collect(attribute='certificates') |
+  with_items: "{{ openshift_hosted_routers | oo_collect(attribute='certificate') |
                   oo_select_keys_from_list(['keyfile', 'certfile', 'cafile']) }}"
 
 - name: Create the router service account(s)
@@ -56,9 +56,9 @@
     service_account: "{{ item.serviceaccount | default('router') }}"
     selector: "{{ item.selector | default(none) }}"
     images: "{{ item.images | default(omit) }}"
-    cert_file: "{{ ('/etc/origin/master/' ~ (item.certificates.certfile | basename)) if 'certfile' in item.certificates else omit }}"
-    key_file: "{{ ('/etc/origin/master/' ~ (item.certificates.keyfile | basename)) if 'keyfile' in item.certificates else omit }}"
-    cacert_file: "{{ ('/etc/origin/master/' ~ (item.certificates.cafile | basename)) if 'cafile' in item.certificates else omit }}"
+    cert_file: "{{ ('/etc/origin/master/' ~ (item.certificate.certfile | basename)) if 'certfile' in item.certificate else omit }}"
+    key_file: "{{ ('/etc/origin/master/' ~ (item.certificate.keyfile | basename)) if 'keyfile' in item.certificate else omit }}"
+    cacert_file: "{{ ('/etc/origin/master/' ~ (item.certificate.cafile | basename)) if 'cafile' in item.certificate else omit }}"
     edits: "{{ openshift_hosted_router_edits | union(item.edits)  }}"
     ports: "{{ item.ports }}"
     stats_port: "{{ item.stats_port }}"


### PR DESCRIPTION
Backports https://github.com/openshift/openshift-ansible/pull/3988