### PR TITLE
Add python-boto requirement

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -20,9 +20,10 @@ LABEL name="openshift3/openshift-ansible" \
 # because all content and dependencies (like 'oc') is already
 # installed via yum.
 USER root
-RUN INSTALL_PKGS="atomic-openshift-utils atomic-openshift-clients" && \
+RUN INSTALL_PKGS="atomic-openshift-utils atomic-openshift-clients python-boto" && \
     yum repolist > /dev/null && \
     yum-config-manager --enable rhel-7-server-ose-3.4-rpms && \
+    yum-config-manager --enable rhel-7-server-rh-common-rpms && \
     yum install -y $INSTALL_PKGS && \
     yum clean all
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
 ansible==2.2.2.0
+boto==2.45.0
 click==6.7
 pyOpenSSL==16.2.0
 # We need to disable ruamel.yaml for now because of test failures


### PR DESCRIPTION
The [AWS inventory](https://github.com/openshift/openshift-ansible/blob/master/inventory/aws/hosts/ec2.py) uses the Boto library.

In order for containerized openshift-ansible to be able to use that inventory, the container image needs to include that package.

By adding it to `requirements.txt`, the container image build will install it at build time.

For the productized version: adding a dependency on `python-boto` to the specfile does not sound like a good idea: it would introduce a dependency on the *Common* RPM repo - and right now we don't even package the inventories (other than the sample static inventories that are part of the *-docs* package). Therefore, just install the RPM into the image.