### PR TITLE
.redhat-ci.yml: also publish journal logs

### DIFF
--- a/.redhat-ci.sh
+++ b/.redhat-ci.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# F25 currently has 2.2.1, so install from pypi
+pip install ansible==2.2.2.0
+
+# do a simple ping to make sure the nodes are available
+ansible -vvv -i .redhat-ci.inventory nodes -a 'rpm-ostree status'
+
+upload_journals() {
+  mkdir journals
+  for node in master node1 node2; do
+    ssh ocp-$node 'journalctl --no-pager || true' > journals/ocp-$node.log
+  done
+}
+
+trap upload_journals ERR
+
+# run the actual installer
+ansible-playbook -vvv -i .redhat-ci.inventory playbooks/byo/config.yml
+
+# run a small subset of origin conformance tests to sanity
+# check the cluster NB: we run it on the master since we may
+# be in a different OSP network
+ssh ocp-master docker run --rm --net=host --privileged \
+  -v /etc/origin/master/admin.kubeconfig:/config fedora:25 sh -c \
+    '"dnf install -y origin-tests && \
+      KUBECONFIG=/config /usr/libexec/origin/extended.test --ginkgo.v=1 \
+        --ginkgo.noColor --ginkgo.focus=\"Services.*NodePort|EmptyDir\""'

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -18,28 +18,13 @@ packages:
   - openssl-devel
   - redhat-rpm-config
 
-context: 'fedora/25/atomic | origin/v1.5.0-rc.0'
+context: 'fedora/25/atomic | origin/v3.6.0-alpha.1'
 
 env:
-  OPENSHIFT_IMAGE_TAG: v1.5.0-rc.0
+  OPENSHIFT_IMAGE_TAG: v3.6.0-alpha.1
 
 tests:
-  - pip install ansible==2.2.2.0  # F25 currently has 2.2.1, so install from pypi
-  - ansible -vvv -i .redhat-ci.inventory nodes -a 'rpm-ostree status'
-  - ansible-playbook -vvv -i .redhat-ci.inventory playbooks/byo/config.yml
-  # run a small subset of origin conformance tests to sanity check the cluster
-  # NB: we run it on the master since we may be in a different OSP network
-  - ssh ocp-master docker run --rm --net=host --privileged
-    -v /etc/origin/master/admin.kubeconfig:/config fedora:25 sh -c
-    '"dnf install -y origin-tests &&
-      KUBECONFIG=/config /usr/libexec/origin/extended.test --ginkgo.v=1
-      --ginkgo.noColor --ginkgo.focus=\"Services.*NodePort|EmptyDir\""'
+  - sh .redhat-ci.sh
 
----
-
-inherit: true
-
-context: 'fedora/25/atomic | origin/v3.6.0-alpha.0'
-
-env:
-  OPENSHIFT_IMAGE_TAG: v3.6.0-alpha.0
+artifacts:
+  - journals/


### PR DESCRIPTION
- Update to only target v3.6.0-alpha.1 (will open another PR to target
  the newly released 1.5.0 on the 1.5 branch).
- Move test script to its own file.
- Upload journal logs on failure.

/cc @sdodson 