### PR TITLE
Fix certificate check Job examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -69,19 +69,19 @@ To run these examples we prepare the inventory and ssh keys as in the other exam
 
 Additionally we allocate a `PersistentVolumeClaim` to store the reports:
 
-	oc create -f - <<PVC
-	---
-	apiVersion: v1
-	kind: PersistentVolumeClaim
-	metadata:
-	  name: certcheck-reports
-	spec:
-	  accessModes:
-		- ReadWriteOnce
-	  resources:
-		requests:
-		  storage: 1Gi
-	PVC
+    oc create -f - <<PVC
+    ---
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: certcheck-reports
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+    PVC
 
 With that we can run the `Job` once:
 

--- a/examples/certificate-check-upload.yaml
+++ b/examples/certificate-check-upload.yaml
@@ -20,28 +20,34 @@ kind: Job
 metadata:
   name: certificate-check
 spec:
-  containers:
-  - name: openshift-ansible
-    image: openshift/openshift-ansible
-    env:
-    - name: PLAYBOOK_FILE
-      value: playbooks/certificate_expiry/easy-mode-upload.yaml
-    - name: INVENTORY_FILE
-      value: /tmp/inventory/hosts       # from configmap vol below
-    - name: ANSIBLE_PRIVATE_KEY_FILE    # from secret vol below
-      value: /opt/app-root/src/.ssh/id_rsa/ssh-privatekey
-    - name: CERT_EXPIRY_WARN_DAYS
-      value: "45"      # must be a string, don't forget the quotes
-    volumeMounts:
-    - name: sshkey
-      mountPath: /opt/app-root/src/.ssh/id_rsa
-    - name: inventory
-      mountPath: /tmp/inventory
-  volumes:
-  - name: sshkey
-    secret:
-      secretName: sshkey
-  - name: inventory
-    configMap:
-      name: inventory
-  restartPolicy: Never
+  parallelism: 1
+  completions: 1
+  template:
+    metadata:
+      name: certificate-check
+    spec:
+      containers:
+      - name: openshift-ansible
+        image: openshift/openshift-ansible
+        env:
+        - name: PLAYBOOK_FILE
+          value: playbooks/certificate_expiry/easy-mode-upload.yaml
+        - name: INVENTORY_FILE
+          value: /tmp/inventory/hosts       # from configmap vol below
+        - name: ANSIBLE_PRIVATE_KEY_FILE    # from secret vol below
+          value: /opt/app-root/src/.ssh/id_rsa/ssh-privatekey
+        - name: CERT_EXPIRY_WARN_DAYS
+          value: "45"      # must be a string, don't forget the quotes
+        volumeMounts:
+        - name: sshkey
+          mountPath: /opt/app-root/src/.ssh/id_rsa
+        - name: inventory
+          mountPath: /tmp/inventory
+      volumes:
+      - name: sshkey
+        secret:
+          secretName: sshkey
+      - name: inventory
+        configMap:
+          name: inventory
+      restartPolicy: Never

--- a/examples/certificate-check-volume.yaml
+++ b/examples/certificate-check-volume.yaml
@@ -22,33 +22,39 @@ kind: Job
 metadata:
   name: certificate-check
 spec:
-  containers:
-  - name: openshift-ansible
-    image: openshift/openshift-ansible
-    env:
-    - name: PLAYBOOK_FILE
-      value: playbooks/certificate_expiry/html_and_json_timestamp.yaml
-    - name: INVENTORY_FILE
-      value: /tmp/inventory/hosts       # from configmap vol below
-    - name: ANSIBLE_PRIVATE_KEY_FILE    # from secret vol below
-      value: /opt/app-root/src/.ssh/id_rsa/ssh-privatekey
-    - name: CERT_EXPIRY_WARN_DAYS
-      value: "45"      # must be a string, don't forget the quotes
-    volumeMounts:
-    - name: sshkey
-      mountPath: /opt/app-root/src/.ssh/id_rsa
-    - name: inventory
-      mountPath: /tmp/inventory
-    - name: reports
-      mountPath: /var/lib/certcheck
-  volumes:
-  - name: sshkey
-    secret:
-      secretName: sshkey
-  - name: inventory
-    configMap:
-      name: inventory
-  - name: reports
-    persistentVolumeClaim:
-      claimName: certcheck-reports
-  restartPolicy: Never
+  parallelism: 1
+  completions: 1
+  template:
+    metadata:
+      name: certificate-check
+    spec:
+      containers:
+      - name: openshift-ansible
+        image: openshift/openshift-ansible
+        env:
+        - name: PLAYBOOK_FILE
+          value: playbooks/certificate_expiry/html_and_json_timestamp.yaml
+        - name: INVENTORY_FILE
+          value: /tmp/inventory/hosts       # from configmap vol below
+        - name: ANSIBLE_PRIVATE_KEY_FILE    # from secret vol below
+          value: /opt/app-root/src/.ssh/id_rsa/ssh-privatekey
+        - name: CERT_EXPIRY_WARN_DAYS
+          value: "45"      # must be a string, don't forget the quotes
+        volumeMounts:
+        - name: sshkey
+          mountPath: /opt/app-root/src/.ssh/id_rsa
+        - name: inventory
+          mountPath: /tmp/inventory
+        - name: reports
+          mountPath: /var/lib/certcheck
+      volumes:
+      - name: sshkey
+        secret:
+          secretName: sshkey
+      - name: inventory
+        configMap:
+          name: inventory
+      - name: reports
+        persistentVolumeClaim:
+          claimName: certcheck-reports
+      restartPolicy: Never


### PR DESCRIPTION
The example Job specifications were wrong (they had a Pod spec instead). This fixes them.

Also fixing a tabs-vs-spaces problem in `examples/README.md` that prevented copy&paste of the example PVC definition.