### PR TITLE
redhat-ci: use requirements.txt

### DIFF
--- a/.redhat-ci.sh
+++ b/.redhat-ci.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 set -xeuo pipefail
 
-# F25 currently has 2.2.1, so install from pypi
-pip install ansible==2.2.2.0
+pip install -r requirements.txt
 
-# do a simple ping to make sure the nodes are available
+# ping the nodes to check they're responding and register their ostree versions
 ansible -vvv -i .redhat-ci.inventory nodes -a 'rpm-ostree status'
 
 upload_journals() {

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -24,7 +24,7 @@ env:
   OPENSHIFT_IMAGE_TAG: v3.6.0-alpha.1
 
 tests:
-  - sh .redhat-ci.sh
+  - ./.redhat-ci.sh
 
 artifacts:
   - journals/


### PR DESCRIPTION
Use requirements.txt rather than hardcoding the ansible version here.
Also update the comment re. `rpm-ostree status`.