### PR TITLE
Fixes issue #4010

### DIFF
--- a/roles/cockpit/tasks/main.yml
+++ b/roles/cockpit/tasks/main.yml
@@ -3,7 +3,7 @@
   action: "{{ ansible_pkg_mgr }} name={{ item }} state=present"
   with_items:
     - cockpit-ws
-    - cockpit-shell
+    - cockpit-system
     - cockpit-bridge
     - cockpit-docker
     - "{{ cockpit_plugins }}"


### PR DESCRIPTION
Installer fails to install cockpit  due to obsolete package  'cockpit-shell'. This patch should fix the issue.l

Signed-off-by: jkaurredhat <jkaur@redhat.com>