### PR TITLE
Adding way to add labels and nodeselectors to logging project

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -3,6 +3,10 @@ openshift_logging_use_ops: "{{ openshift_hosted_logging_enable_ops_cluster | def
 openshift_logging_master_url: "https://kubernetes.default.svc.{{ openshift.common.dns_domain }}"
 openshift_logging_master_public_url: "{{ openshift_hosted_logging_master_public_url | default('https://' + openshift.common.public_hostname + ':' ~ (openshift_master_api_port | default('8443', true))) }}"
 openshift_logging_namespace: logging
+openshift_logging_nodeselector: null
+openshift_logging_labels: {}
+openshift_logging_label_key: ""
+openshift_logging_label_value: ""
 openshift_logging_install_logging: True
 openshift_logging_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"
 

--- a/roles/openshift_logging/tasks/install_support.yaml
+++ b/roles/openshift_logging/tasks/install_support.yaml
@@ -1,17 +1,36 @@
 ---
 # This is the base configuration for installing the other components
-- name: Check for logging project already exists
-  command: >
-    {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig get project {{openshift_logging_namespace}} --no-headers
-  register: logging_project_result
-  ignore_errors: yes
-  when: not ansible_check_mode
-  changed_when: no
+- name: Set logging project
+  oc_project:
+    state: present
+    name: "{{ openshift_logging_namespace }}"
+    node_selector: "{{ openshift_logging_nodeselector | default(null) }}"
 
-- name: "Create logging project"
-  command: >
-    {{ openshift.common.admin_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig new-project {{openshift_logging_namespace}}
-  when: not ansible_check_mode and "not found" in logging_project_result.stderr
+- name: Labelling logging project
+  oc_label:
+    state: present
+    kind: namespace
+    name: "{{ openshift_logging_namespace }}"
+    labels:
+    - key: "{{ item.key }}"
+      value: "{{ item.value }}"
+  with_dict: "{{ openshift_logging_labels | default({}) }}"
+  when:
+  - openshift_logging_labels is defined
+  - openshift_logging_labels is dict
+
+- name: Labelling logging project
+  oc_label:
+    state: present
+    kind: namespace
+    name: "{{ openshift_logging_namespace }}"
+    labels:
+    - key: "{{ openshift_logging_label_key }}"
+      value: "{{ openshift_logging_label_value }}"
+  when:
+  - openshift_logging_label_key is defined
+  - openshift_logging_label_key != ""
+  - openshift_logging_label_value is defined
 
 - name: Create logging cert directory
   file: path={{openshift.common.config_base}}/logging state=directory mode=0755


### PR DESCRIPTION
To address #4002

There isn't an easy way to specify a dictionary in the ansible inventory so there is also the option to provide a key and value instead (or in addition)

cc @mwoodson 