### PR TITLE
With short-lived jobs it is possible for drain to error out 

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -28,6 +28,10 @@
     command: >
       {{ hostvars[groups.oo_first_master.0].openshift.common.admin_binary }} drain {{ openshift.node.nodename | lower }} --force --delete-local-data --ignore-daemonsets
     delegate_to: "{{ groups.oo_first_master.0 }}"
+    register: node_drain
+    until: node_drain|succeeded
+    retries: 10
+    delay: 5
 
   roles:
   - lib_openshift


### PR DESCRIPTION
With short-lived jobs it is possible for drain to error out with "error: jobs.batch \"my-job-name\" not found" this this should resolve itself as the host will already be marked unschedulable preventing more jobs from starting up on the node