### PR TITLE
[RFE] report and fail if rpm version differs from docker image version

### DIFF
--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -86,8 +86,16 @@
   include: set_version_rpm.yml
   when: not is_containerized | bool
 
-- name: Set openshift_version for containerized installation
-  include: set_version_containerized.yml
+- block:
+  - name: Set openshift_version for containerized installation
+    include: set_version_containerized.yml
+  - name: Determine openshift rpm version
+    include: rpm_version.yml
+  - name: Fail if rpm version and docker image version are different
+    fail:
+      msg: "OCP rpm version {{ openshift_rpm_version }} is different from OCP image version {{ openshift_version }}"
+    # Both versions have the same string representation
+    when: openshift_rpm_version != openshift_version
   when: is_containerized | bool
 
 # Warn if the user has provided an openshift_image_tag but is not doing a containerized install

--- a/roles/openshift_version/tasks/rpm_version.yml
+++ b/roles/openshift_version/tasks/rpm_version.yml
@@ -1,0 +1,44 @@
+---
+# input_variables:
+# - repoquery_cmd
+# - openshift.common.service_type
+# output_variables:
+# - openshift_rpm_version
+
+# if {{ openshift.common.service_type}}-excluder is enabled,
+# the repoquery for {{ openshift.common.service_type}} will not work.
+# Thus, create a temporary yum,conf file where exclude= is set to an empty list
+- name: Create temporary yum.conf file
+  command: mktemp -d /tmp/yum.conf.XXXXXX
+  register: yum_conf_temp_file_result
+
+- set_fact:
+    yum_conf_temp_file: "{{yum_conf_temp_file_result.stdout}}/yum.conf"
+
+- name: Copy yum.conf into the temporary file
+  copy:
+    src: /etc/yum.conf
+    dest: "{{ yum_conf_temp_file }}"
+    remote_src: True
+
+- name: Clear the exclude= list in the temporary yum.conf
+  lineinfile:
+    # since ansible 2.3 s/dest/path
+    dest: "{{ yum_conf_temp_file }}"
+    regexp: '^exclude='
+    line: 'exclude='
+
+- name: Gather common package version
+  command: >
+    {{ repoquery_cmd }} --config "{{ yum_conf_temp_file }}" --qf '%{version}' "{{ openshift.common.service_type}}"
+  register: common_version
+  failed_when: false
+  changed_when: false
+
+- name: Delete the temporary yum.conf
+  file:
+    path: "{{ yum_conf_temp_file_result.stdout }}"
+    state: absent
+
+- set_fact:
+    openshift_rpm_version: "{{ common_version.stdout | default('0.0', True) }}"

--- a/roles/openshift_version/tasks/set_version_rpm.yml
+++ b/roles/openshift_version/tasks/set_version_rpm.yml
@@ -7,42 +7,8 @@
   - openshift_pkg_version is defined
   - openshift_version is not defined
 
-# if {{ openshift.common.service_type}}-excluder is enabled,
-# the repoquery for {{ openshift.common.service_type}} will not work.
-# Thus, create a temporary yum,conf file where exclude= is set to an empty list
-- name: Create temporary yum.conf file
-  command: mktemp -d /tmp/yum.conf.XXXXXX
-  register: yum_conf_temp_file_result
-
-- set_fact:
-    yum_conf_temp_file: "{{yum_conf_temp_file_result.stdout}}/yum.conf"
-
-- name: Copy yum.conf into the temporary file
-  copy:
-    src: /etc/yum.conf
-    dest: "{{ yum_conf_temp_file }}"
-    remote_src: True
-
-- name: Clear the exclude= list in the temporary yum.conf
-  lineinfile:
-    # since ansible 2.3 s/dest/path
-    dest: "{{ yum_conf_temp_file }}"
-    regexp: '^exclude='
-    line: 'exclude='
-
-- name: Gather common package version
-  command: >
-    {{ repoquery_cmd }} --config "{{ yum_conf_temp_file }}" --qf '%{version}' "{{ openshift.common.service_type}}"
-  register: common_version
-  failed_when: false
-  changed_when: false
-  when: openshift_version is not defined
-
-- name: Delete the temporary yum.conf
-  file:
-    path: "{{ yum_conf_temp_file_result.stdout }}"
-    state: absent
-
-- set_fact:
-    openshift_version: "{{ common_version.stdout | default('0.0', True) }}"
+- block:
+  - include: rpm_version.yml
+  - set_fact:
+      openshift_version: "{{ openshift_rpm_version }}"
   when: openshift_version is not defined


### PR DESCRIPTION
Fixes: #4023 

E.g.
```yaml
TASK [openshift_version : Report rpm version and docker image version] *********
ok: [10.8.172.211] => {}

MSG:

openshift_rpm_version: 3.5.5.10, openshift_containerized_version: 3.5.5.9
```