### PR TITLE
[RFE] move excluder upgrade validation tasks under openshift_excluder role

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/disable_excluder.yml
+++ b/playbooks/common/openshift-cluster/upgrades/disable_excluder.yml
@@ -3,15 +3,10 @@
   hosts: oo_masters_to_config:oo_nodes_to_config
   gather_facts: no
   tasks:
-  - include: pre/validate_excluder.yml
-    vars:
-      excluder: "{{ openshift.common.service_type }}-docker-excluder"
-    when: enable_docker_excluder | default(enable_excluders) | default(True) | bool
-  - include: pre/validate_excluder.yml
-    vars:
-      excluder: "{{ openshift.common.service_type }}-excluder"
-    when: enable_openshift_excluder | default(enable_excluders) | default(True) | bool
-
+  # verify the excluders can be upgraded
+  - include_role:
+      name: openshift_excluder
+      tasks_from: verify_upgrade
 
   # disable excluders based on their status
   - include_role:

--- a/roles/openshift_excluder/tasks/verify_excluder.yml
+++ b/roles/openshift_excluder/tasks/verify_excluder.yml
@@ -11,7 +11,7 @@
     failed_when: false
     changed_when: false
 
-  - name: Docker excluder version detected
+  - name: "{{ excluder }} version detected"
     debug:
       msg: "{{ excluder }}: {{ excluder_version.stdout }}"
 

--- a/roles/openshift_excluder/tasks/verify_upgrade.yml
+++ b/roles/openshift_excluder/tasks/verify_upgrade.yml
@@ -1,0 +1,15 @@
+---
+# input variables
+# - repoquery_cmd
+# - openshift_upgrade_target
+- include: init.yml
+
+- include: verify_excluder.yml
+  vars:
+    excluder: "{{ openshift.common.service_type }}-docker-excluder"
+  when: docker_excluder_on
+
+- include: verify_excluder.yml
+  vars:
+    excluder: "{{ openshift.common.service_type }}-excluder"
+  when: openshift_excluder_on


### PR DESCRIPTION
Move the `enable_openshift_excluder | default(enable_excluders) | default(True) | bool` logic under the excluders so it is not duplicated.

Continuing with https://github.com/openshift/openshift-ansible/pull/3867