### PR TITLE
bug 1439451. Fix kibana-auth-proxy inability to find secrets

### DIFF
--- a/roles/openshift_logging/templates/kibana.j2
+++ b/roles/openshift_logging/templates/kibana.j2
@@ -103,6 +103,22 @@ spec:
             -
              name: "OAP_DEBUG"
              value: "{{openshift_logging_kibana_proxy_debug}}"
+            -
+             name: "OAP_OAUTH_SECRET_FILE"
+             value: "/secret/oauth-secret"
+            -
+             name: "OAP_SERVER_CERT_FILE"
+             value: "/secret/server-cert"
+            -
+             name: "OAP_SERVER_KEY_FILE"
+             value: "/secret/server-key"
+            -
+             name: "OAP_SERVER_TLS_FILE"
+             value: "/secret/server-tls.json"
+            -
+             name: "OAP_SERVER_SESSION_SECRET_FILE"
+             value: "/secret/session-secret"
+
           volumeMounts:
             - name: kibana-proxy
               mountPath: /secret


### PR DESCRIPTION
This will most likely require backport to 1.5 though I dont know if a 1.5 image exists yet that has the corresponding change to the openshift-auth-proxy where this was introduced