### PR TITLE
Bug 1446745 - [3.3] Redeploy certificates fails with custom openshift_hosted_router_certificate

### DIFF
--- a/playbooks/common/openshift-cluster/redeploy-certificates/router.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/router.yml
@@ -65,7 +65,66 @@
         service.alpha.openshift.io/serving-cert-secret-name=router-certs
         --config={{ mktemp.stdout }}/admin.kubeconfig
         -n default
-    when: l_router_dc.rc == 0 and 'router-certs' in router_secrets
+    when: l_router_dc.rc == 0 and 'router-certs' in router_secrets and openshift_hosted_router_certificate is undefined
+
+  - block:
+    - assert:
+        that:
+        - "'certfile' in openshift_hosted_router_certificate"
+        - "'keyfile' in openshift_hosted_router_certificate"
+        - "'cafile' in openshift_hosted_router_certificate"
+        msg: |-
+          openshift_hosted_router_certificate has been set in the inventory but is
+          missing one or more required keys. Ensure that 'certfile', 'keyfile',
+          and 'cafile' keys have been specified for the openshift_hosted_router_certificate
+          inventory variable.
+
+    - name: Read router certificate and key
+      become: no
+      local_action:
+        module: slurp
+        src: "{{ item }}"
+      register: openshift_router_certificate_output
+      # Defaulting dictionary keys to none to avoid deprecation warnings
+      # (future fatal errors) during template evaluation. Dictionary keys
+      # won't be accessed unless openshift_hosted_router_certificate is
+      # defined and has all keys (certfile, keyfile, cafile) which we
+      # check above.
+      with_items:
+      - "{{ (openshift_hosted_router_certificate | default({'certfile':none})).certfile }}"
+      - "{{ (openshift_hosted_router_certificate | default({'keyfile':none})).keyfile }}"
+      - "{{ (openshift_hosted_router_certificate | default({'cafile':none})).cafile }}"
+
+    - name: Write temporary router certificate file
+      copy:
+        content: "{% for certificate in openshift_router_certificate_output.results -%}{{ certificate.content | b64decode }}{% endfor -%}"
+        dest: "{{ mktemp.stdout }}/openshift-hosted-router-certificate.pem"
+        mode: 0600
+
+    - name: Write temporary router key file
+      copy:
+        content: "{{ (openshift_router_certificate_output.results
+                         | oo_collect('content', {'source':(openshift_hosted_router_certificate | default({'keyfile':none})).keyfile}))[0] | b64decode }}"
+        dest: "{{ mktemp.stdout }}/openshift-hosted-router-certificate.key"
+        mode: 0600
+
+    - name: Replace router-certs secret
+      shell: >
+        {{ openshift.common.client_binary }} secrets new router-certs
+        tls.crt="{{ mktemp.stdout }}/openshift-hosted-router-certificate.pem"
+        tls.key="{{ mktemp.stdout }}/openshift-hosted-router-certificate.key"
+        --type=kubernetes.io/tls
+        --confirm
+        -o json | {{ openshift.common.client_binary }} replace -f -
+
+    - name: Remove temporary router certificate and key files
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+      - "{{ mktemp.stdout }}/openshift-hosted-router-certificate.pem"
+      - "{{ mktemp.stdout }}/openshift-hosted-router-certificate.key"
+    when: l_router_dc.rc == 0 and 'router-certs' in router_secrets and openshift_hosted_router_certificate is defined
 
   - name: Redeploy router
     command: >


### PR DESCRIPTION
Backports #3990
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1446745