### PR TITLE
Move clean repo cache from upgrade to repos role

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -10,17 +10,6 @@
 
 - include: ../initialize_facts.yml
 
-- name: Ensure clean repo cache in the event repos have been changed manually
-  hosts: oo_all_hosts
-  tags:
-  - pre_upgrade
-  tasks:
-  - name: Clean package cache
-    command: "{{ ansible_pkg_mgr }} clean all"
-    when: not openshift.common.is_atomic | bool
-    args:
-      warn: no
-
 - name: Ensure firewall is not switched during upgrade
   hosts: oo_all_hosts
   tasks:

--- a/roles/openshift_repos/tasks/main.yaml
+++ b/roles/openshift_repos/tasks/main.yaml
@@ -40,4 +40,21 @@
     - openshift_deployment_type == 'origin'
     - openshift_enable_origin_repo | default(true) | bool
 
+  # Singleton block
+  - when: r_osr_first_run | default(true)
+    block:
+    - name: Ensure clean repo cache in the event repos have been changed manually
+      debug:
+        msg: "First run of openshift_repos"
+      changed_when: true
+      notify: refresh cache
+
+    - name: Set fact r_osr_first_run false
+      set_fact:
+        r_osr_first_run: false
+
+  # Force running ALL handlers now, because we expect repo cache to be cleared
+  # if changes have been made.
+  - meta: flush_handlers
+
   when: not ostree_booted.stat.exists


### PR DESCRIPTION
The clean repo cache command is moved from the upgrade init.yml to the
openshift_repos role to remove duplication.  The role previously would
only run the 'clean all' command when the role changed repo files,
however there are situation where manually changed repo files can also
cause issues.  The task is run regardless to ensure a clean cache.