### PR TITLE
[3.3] Use openshift_ca_host's hostnames to sign the CA

### DIFF
--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -92,7 +92,7 @@
     {% for legacy_ca_certificate in g_master_legacy_ca_result.files | default([]) | oo_collect('path') %}
     --certificate-authority {{ legacy_ca_certificate }}
     {% endfor %}
-    --hostnames={{ openshift.common.all_hostnames | join(',') }}
+    --hostnames={{ hostvars[openshift_ca_host].openshift.common.all_hostnames | join(',') }}
     --master={{ openshift.master.api_url }}
     --public-master={{ openshift.master.public_api_url }}
     --cert-dir={{ openshift_ca_config_dir }}


### PR DESCRIPTION
If for some reason oo_first_master and openshift_ca_host are different
we could've signed the CA with the wrong hostnames.