### PR TITLE
Add selector matchLabels storage-type support in Cassandra pvc template in openshift_metrics role

### DIFF
--- a/roles/openshift_metrics/defaults/main.yaml
+++ b/roles/openshift_metrics/defaults/main.yaml
@@ -15,6 +15,7 @@ openshift_metrics_hawkular_nodeselector: ""
 
 openshift_metrics_cassandra_replicas: 1
 openshift_metrics_cassandra_storage_type: "{{ openshift_hosted_metrics_storage_kind | default('emptydir') }}"
+openshift_metrics_cassandra_selector_storage_type: "{{ openshift_hosted_metrics_storage_type | default('') }}"
 openshift_metrics_cassandra_pvc_size: "{{ openshift_hosted_metrics_storage_volume_size | default('10Gi') }}"
 openshift_metrics_cassandra_limits_memory: 2G
 openshift_metrics_cassandra_limits_cpu: null

--- a/roles/openshift_metrics/tasks/install_cassandra.yaml
+++ b/roles/openshift_metrics/tasks/install_cassandra.yaml
@@ -35,6 +35,7 @@
       metrics-infra: hawkular-cassandra
     access_modes: "{{ openshift_metrics_cassandra_pvc_access | list }}"
     size: "{{ openshift_metrics_cassandra_pvc_size }}"
+    storage_type: "{{ openshift_metrics_cassandra_selector_storage_type }}"
   with_sequence: count={{ openshift_metrics_cassandra_replicas }}
   when:
   - openshift_metrics_cassandra_storage_type != 'emptydir'

--- a/roles/openshift_metrics/templates/pvc.j2
+++ b/roles/openshift_metrics/templates/pvc.j2
@@ -25,3 +25,8 @@ spec:
   resources:
     requests:
       storage: {{size}}
+{% if storage_type is defined and storage_type %}
+  selector:
+    matchLabels:
+      storage-type: {{ storage_type }}
+{% endif %}


### PR DESCRIPTION
I need to use Ceph PV for Cassandra.

Example in PVC:

```
selector:
   matchLabels:
   storage-type: {{ storage_type }}
```

With this patch, I can specify a selector matchLabels storage-type  in Cassandra pvc template in openshift_metrics role.

Best regards,
Stéphane