### PR TITLE
add ability to expose Elasticsearch as an external route

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -97,3 +97,30 @@ same as above for their non-ops counterparts, but apply to the OPS cluster insta
 - `openshift_logging_kibana_ops_proxy_cpu_limit`: The amount of CPU to allocate to Kibana proxy or unset if not specified.
 - `openshift_logging_kibana_ops_proxy_memory_limit`: The amount of memory to allocate to Kibana proxy or unset if not specified.
 - `openshift_logging_kibana_ops_replica_count`: The number of replicas Kibana ops should be scaled up to. Defaults to 1.
+
+Elasticsearch can be exposed for external clients outside of the cluster.
+- `openshift_logging_es_allow_external`: True (default is False) - if this is
+  True, Elasticsearch will be exposed as a Route
+- `openshift_logging_es_hostname`: The external facing hostname to use for
+  the route and the TLS server certificate (default is "es." +
+  `openshift_master_default_subdomain`)
+- `openshift_logging_es_cert`: The location of the certificate Elasticsearch
+  uses for the external TLS server cert (default is a generated cert)
+- `openshift_logging_es_key`: The location of the key Elasticsearch
+  uses for the external TLS server cert (default is a generated key)
+- `openshift_logging_es_ca_ext`: The location of the CA cert for the cert
+  Elasticsearch uses for the external TLS server cert (default is the internal
+  CA)
+Elasticsearch OPS too, if using an OPS cluster:
+- `openshift_logging_es_ops_allow_external`: True (default is False) - if this is
+  True, Elasticsearch will be exposed as a Route
+- `openshift_logging_es_ops_hostname`: The external facing hostname to use for
+  the route and the TLS server certificate (default is "es-ops." +
+  `openshift_master_default_subdomain`)
+- `openshift_logging_es_ops_cert`: The location of the certificate Elasticsearch
+  uses for the external TLS server cert (default is a generated cert)
+- `openshift_logging_es_ops_key`: The location of the key Elasticsearch
+  uses for the external TLS server cert (default is a generated key)
+- `openshift_logging_es_ops_ca_ext`: The location of the CA cert for the cert
+  Elasticsearch uses for the external TLS server cert (default is the internal
+  CA)

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -99,6 +99,22 @@ openshift_logging_es_config: {}
 openshift_logging_es_number_of_shards: 1
 openshift_logging_es_number_of_replicas: 0
 
+# for exposing es to external (outside of the cluster) clients
+openshift_logging_es_allow_external: False
+openshift_logging_es_hostname: "{{ 'es.' ~ (openshift_master_default_subdomain | default('router.default.svc.cluster.local', true)) }}"
+
+#The absolute path on the control node to the cert file to use
+#for the public facing es certs
+openshift_logging_es_cert: ""
+
+#The absolute path on the control node to the key file to use
+#for the public facing es certs
+openshift_logging_es_key: ""
+
+#The absolute path on the control node to the CA file to use
+#for the public facing es certs
+openshift_logging_es_ca_ext: ""
+
 # allow cluster-admin or cluster-reader to view operations index
 openshift_logging_es_ops_allow_cluster_reader: False
 
@@ -117,6 +133,22 @@ openshift_logging_es_ops_pvc_prefix: "{{ openshift_hosted_logging_elasticsearch_
 openshift_logging_es_ops_recover_after_time: 5m
 openshift_logging_es_ops_storage_group: "{{ openshift_hosted_logging_elasticsearch_storage_group | default('65534') }}"
 openshift_logging_es_ops_nodeselector: "{{ openshift_hosted_logging_elasticsearch_ops_nodeselector | default('') | map_from_pairs }}"
+
+# for exposing es-ops to external (outside of the cluster) clients
+openshift_logging_es_ops_allow_external: False
+openshift_logging_es_ops_hostname: "{{ 'es-ops.' ~ (openshift_master_default_subdomain | default('router.default.svc.cluster.local', true)) }}"
+
+#The absolute path on the control node to the cert file to use
+#for the public facing es-ops certs
+openshift_logging_es_ops_cert: ""
+
+#The absolute path on the control node to the key file to use
+#for the public facing es-ops certs
+openshift_logging_es_ops_key: ""
+
+#The absolute path on the control node to the CA file to use
+#for the public facing es-ops certs
+openshift_logging_es_ops_ca_ext: ""
 
 # storage related defaults
 openshift_logging_storage_access_modes: "{{ openshift_hosted_logging_storage_access_modes | default(['ReadWriteOnce']) }}"

--- a/roles/openshift_logging/tasks/generate_certs.yaml
+++ b/roles/openshift_logging/tasks/generate_certs.yaml
@@ -60,6 +60,24 @@
     - procure_component: mux
   when: openshift_logging_use_mux
 
+- include: procure_server_certs.yaml
+  loop_control:
+    loop_var: cert_info
+  with_items:
+    - procure_component: es
+      hostnames: "es, {{openshift_logging_es_hostname}}"
+  when: openshift_logging_es_allow_external | bool
+
+- include: procure_server_certs.yaml
+  loop_control:
+    loop_var: cert_info
+  with_items:
+    - procure_component: es-ops
+      hostnames: "es-ops, {{openshift_logging_es_ops_hostname}}"
+  when:
+    - openshift_logging_es_allow_external | bool
+    - openshift_logging_use_ops | bool
+
 - name: Copy proxy TLS configuration file
   copy: src=server-tls.json dest={{generated_certs_dir}}/server-tls.json
   when: server_tls_json is undefined
@@ -107,6 +125,14 @@
   loop_control:
     loop_var: node_name
   when: openshift_logging_use_mux
+
+- name: Generate PEM cert for Elasticsearch external route
+  include: generate_pems.yaml component={{node_name}}
+  with_items:
+    - system.logging.es
+  loop_control:
+    loop_var: node_name
+  when: openshift_logging_es_allow_external | bool
 
 - name: Creating necessary JKS certs
   include: generate_jks.yaml

--- a/roles/openshift_logging/tasks/generate_routes.yaml
+++ b/roles/openshift_logging/tasks/generate_routes.yaml
@@ -75,3 +75,95 @@
       provider: openshift
   when: openshift_logging_use_ops | bool
   changed_when: no
+
+- set_fact: es_key={{ lookup('file', openshift_logging_es_key) | b64encode }}
+  when:
+    - openshift_logging_es_key | trim | length > 0
+    - openshift_logging_es_allow_external | bool
+  changed_when: false
+
+- set_fact: es_cert={{ lookup('file', openshift_logging_es_cert)| b64encode  }}
+  when:
+    - openshift_logging_es_cert | trim | length > 0
+    - openshift_logging_es_allow_external | bool
+  changed_when: false
+
+- set_fact: es_ca={{ lookup('file', openshift_logging_es_ca_ext)| b64encode  }}
+  when:
+    - openshift_logging_es_ca_ext | trim | length > 0
+    - openshift_logging_es_allow_external | bool
+  changed_when: false
+
+- set_fact: es_ca={{key_pairs | entry_from_named_pair('ca_file') }}
+  when:
+    - es_ca is not defined
+    - openshift_logging_es_allow_external | bool
+  changed_when: false
+
+- name: Generating Elasticsearch logging routes
+  template: src=route_reencrypt.j2 dest={{mktemp.stdout}}/templates/logging-logging-es-route.yaml
+  tags: routes
+  vars:
+    obj_name: "logging-es"
+    route_host: "{{openshift_logging_es_hostname}}"
+    service_name: "logging-es"
+    tls_key: "{{es_key | default('') | b64decode}}"
+    tls_cert: "{{es_cert | default('') | b64decode}}"
+    tls_ca_cert: "{{es_ca | b64decode}}"
+    tls_dest_ca_cert: "{{key_pairs | entry_from_named_pair('ca_file')| b64decode }}"
+    edge_term_policy: "{{openshift_logging_es_edge_term_policy | default('') }}"
+    labels:
+      component: support
+      logging-infra: support
+      provider: openshift
+  changed_when: no
+  when: openshift_logging_es_allow_external | bool
+
+- set_fact: es_ops_key={{ lookup('file', openshift_logging_es_ops_key) | b64encode }}
+  when:
+  - openshift_logging_es_ops_allow_external | bool
+  - openshift_logging_use_ops | bool
+  - "{{ openshift_logging_es_ops_key | trim | length > 0 }}"
+  changed_when: false
+
+- set_fact: es_ops_cert={{ lookup('file', openshift_logging_es_ops_cert)| b64encode  }}
+  when:
+  - openshift_logging_es_ops_allow_external | bool
+  - openshift_logging_use_ops | bool
+  - "{{openshift_logging_es_ops_cert | trim | length > 0}}"
+  changed_when: false
+
+- set_fact: es_ops_ca={{ lookup('file', openshift_logging_es_ops_ca_ext)| b64encode  }}
+  when:
+  - openshift_logging_es_ops_allow_external | bool
+  - openshift_logging_use_ops | bool
+  - "{{openshift_logging_es_ops_ca_ext | trim | length > 0}}"
+  changed_when: false
+
+- set_fact: es_ops_ca={{key_pairs | entry_from_named_pair('ca_file') }}
+  when:
+  - openshift_logging_es_ops_allow_external | bool
+  - openshift_logging_use_ops | bool
+  - es_ops_ca is not defined
+  changed_when: false
+
+- name: Generating Elasticsearch logging ops routes
+  template: src=route_reencrypt.j2 dest={{mktemp.stdout}}/templates/logging-logging-es-ops-route.yaml
+  tags: routes
+  vars:
+    obj_name: "logging-es-ops"
+    route_host: "{{openshift_logging_es_ops_hostname}}"
+    service_name: "logging-es-ops"
+    tls_key: "{{es_ops_key | default('') | b64decode}}"
+    tls_cert: "{{es_ops_cert | default('') | b64decode}}"
+    tls_ca_cert: "{{es_ops_ca | b64decode}}"
+    tls_dest_ca_cert: "{{key_pairs | entry_from_named_pair('ca_file')| b64decode }}"
+    edge_term_policy: "{{openshift_logging_es_ops_edge_term_policy | default('') }}"
+    labels:
+      component: support
+      logging-infra: support
+      provider: openshift
+  when:
+  - openshift_logging_es_ops_allow_external | bool
+  - openshift_logging_use_ops | bool
+  changed_when: no

--- a/roles/openshift_logging/tasks/generate_secrets.yaml
+++ b/roles/openshift_logging/tasks/generate_secrets.yaml
@@ -99,3 +99,31 @@
   when: logging_es_secret.stdout is defined
   check_mode: no
   changed_when: no
+
+- name: Retrieving the cert to use when generating secrets for Elasticsearch external route
+  slurp: src="{{generated_certs_dir}}/{{item.file}}"
+  register: es_key_pairs
+  with_items:
+    - { name: "ca_file", file: "ca.crt" }
+    - { name: "es_key", file: "system.logging.es.key"}
+    - { name: "es_cert", file: "system.logging.es.crt"}
+  when: openshift_logging_es_allow_external | bool
+
+- name: Generating secrets for Elasticsearch external route
+  template: src=secret.j2 dest={{mktemp.stdout}}/templates/{{secret_name}}-secret.yaml
+  vars:
+    secret_name: "logging-{{component}}"
+    secret_key_file: "{{component}}_key"
+    secret_cert_file: "{{component}}_cert"
+    secrets:
+      - {key: ca, value: "{{es_key_pairs | entry_from_named_pair('ca_file')| b64decode }}"}
+      - {key: key, value: "{{es_key_pairs | entry_from_named_pair(secret_key_file)| b64decode }}"}
+      - {key: cert, value: "{{es_key_pairs | entry_from_named_pair(secret_cert_file)| b64decode }}"}
+    secret_keys: ["ca", "cert", "key"]
+  with_items:
+    - es
+  loop_control:
+    loop_var: component
+  check_mode: no
+  changed_when: no
+  when: openshift_logging_es_allow_external | bool


### PR DESCRIPTION
This adds the ability to expose Elastisearch as a route outside of the
cluster.
- `openshift_logging_es_allow_external`: True (default is False) - if this is
  True, Elasticsearch will be exposed as a Route
- `openshift_logging_es_ops_hostname`: The external facing hostname to use for
  the route and the TLS server certificate (default is "es." +
  `openshift_master_default_subdomain`)

There are other similar parameters for the TLS server cert, key, and CA cert.
There are other similar parameters for when the OPS cluster is deployed e.g.
`openshift_logging_es_ops_allow_external`, etc.
@jcantrill @ewolinetz @lukas-vlcek @enoodle PTAL