### PR TITLE
Stop logging AWS credentials in master role.

### DIFF
--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -90,6 +90,7 @@
     dest: /etc/sysconfig/{{ openshift.common.service_type }}-master-api
     line: "{{ item }}"
   with_items: "{{ master_api_aws.stdout_lines | default([]) }}"
+  no_log: True
 
 - name: Preserve Master Controllers Proxy Config options
   command: grep PROXY /etc/sysconfig/{{ openshift.common.service_type }}-master-controllers


### PR DESCRIPTION
Using lineinfile and with_items, the items end up logged and in this
case include AWS credentials.

Simple us of no_log to hide them.