### PR TITLE
Correctly setting the primary and replica shard count settings

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -89,8 +89,6 @@ same as above for their non-ops counterparts, but apply to the OPS cluster insta
 - `openshift_logging_es_ops_pvc_prefix`: logging-es-ops
 - `openshift_logging_es_ops_recover_after_time`: 5m
 - `openshift_logging_es_ops_storage_group`: 65534
-- `openshift_logging_es_ops_number_of_shards`: The number of primary shards for every new index created in ES. Defaults to '1'.
-- `openshift_logging_es_ops_number_of_replicas`: The number of replica shards per primary shard for every new index. Defaults to '0'. 
 - `openshift_logging_kibana_ops_hostname`: The Operations Kibana hostname. Defaults to 'kibana-ops.example.com'.
 - `openshift_logging_kibana_ops_cpu_limit`: The amount of CPU to allocate to Kibana or unset if not specified.
 - `openshift_logging_kibana_ops_memory_limit`: The amount of memory to allocate to Kibana or unset if not specified.

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -111,8 +111,6 @@ openshift_logging_es_ops_pvc_prefix: "{{ openshift_hosted_logging_elasticsearch_
 openshift_logging_es_ops_recover_after_time: 5m
 openshift_logging_es_ops_storage_group: "{{ openshift_hosted_logging_elasticsearch_storage_group | default('65534') }}"
 openshift_logging_es_ops_nodeselector: "{{ openshift_hosted_logging_elasticsearch_ops_nodeselector | default('') | map_from_pairs }}"
-openshift_logging_es_ops_number_of_shards: 1
-openshift_logging_es_ops_number_of_replicas: 0
 
 # storage related defaults
 openshift_logging_storage_access_modes: "{{ openshift_hosted_logging_storage_access_modes | default(['ReadWriteOnce']) }}"

--- a/roles/openshift_logging/tasks/generate_configmaps.yaml
+++ b/roles/openshift_logging/tasks/generate_configmaps.yaml
@@ -21,6 +21,8 @@
         dest: "{{mktemp.stdout}}/elasticsearch.yml"
       vars:
         - allow_cluster_reader: "{{openshift_logging_es_ops_allow_cluster_reader | lower | default('false')}}"
+        - es_number_of_shards: "{{ openshift_logging_es_number_of_shards | default(1) }}"
+        - es_number_of_replicas: "{{ openshift_logging_es_number_of_replicas | default(0) }}"
       when: es_config_contents is undefined
       changed_when: no
 

--- a/roles/openshift_logging/tasks/install_elasticsearch.yaml
+++ b/roles/openshift_logging/tasks/install_elasticsearch.yaml
@@ -24,8 +24,6 @@
     es_pv_selector: "{{ openshift_logging_es_pv_selector }}"
     es_cpu_limit: "{{ openshift_logging_es_cpu_limit }}"
     es_memory_limit: "{{ openshift_logging_es_memory_limit }}"
-    es_number_of_shards: "{{ openshift_logging_es_number_of_shards }}"
-    es_number_of_replicas: "{{ openshift_logging_es_number_of_replicas }}"
   with_together:
   - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs.keys() }}"
   - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs.values() }}"
@@ -49,8 +47,6 @@
     es_pv_selector: "{{ openshift_logging_es_pv_selector }}"
     es_cpu_limit: "{{ openshift_logging_es_cpu_limit }}"
     es_memory_limit: "{{ openshift_logging_es_memory_limit }}"
-    es_number_of_shards: "{{ openshift_logging_es_number_of_shards }}"
-    es_number_of_replicas: "{{ openshift_logging_es_number_of_replicas }}"
   with_sequence: count={{ openshift_logging_es_cluster_size | int - openshift_logging_facts.elasticsearch.deploymentconfigs | count }}
 
 # --------- Tasks for Operation clusters ---------
@@ -92,8 +88,6 @@
     es_pv_selector: "{{ openshift_logging_es_ops_pv_selector }}"
     es_cpu_limit: "{{ openshift_logging_es_ops_cpu_limit }}"
     es_memory_limit: "{{ openshift_logging_es_ops_memory_limit }}"
-    es_number_of_shards: "{{ openshift_logging_es_ops_number_of_shards }}"
-    es_number_of_replicas: "{{ openshift_logging_es_ops_number_of_replicas }}"
   with_together:
   - "{{ openshift_logging_facts.elasticsearch_ops.deploymentconfigs.keys() }}"
   - "{{ openshift_logging_facts.elasticsearch_ops.deploymentconfigs.values() }}"
@@ -119,8 +113,6 @@
     es_pv_selector: "{{ openshift_logging_es_ops_pv_selector }}"
     es_cpu_limit: "{{ openshift_logging_es_ops_cpu_limit }}"
     es_memory_limit: "{{ openshift_logging_es_ops_memory_limit }}"
-    es_number_of_shards: "{{ openshift_logging_es_ops_number_of_shards }}"
-    es_number_of_replicas: "{{ openshift_logging_es_ops_number_of_replicas }}"
   with_sequence: count={{ openshift_logging_es_ops_cluster_size | int - openshift_logging_facts.elasticsearch_ops.deploymentconfigs | count }}
   when:
   - openshift_logging_use_ops | bool

--- a/roles/openshift_logging/tasks/set_es_storage.yaml
+++ b/roles/openshift_logging/tasks/set_es_storage.yaml
@@ -76,7 +76,5 @@
     es_memory_limit: "{{ es_memory_limit }}"
     es_node_selector: "{{ es_node_selector }}"
     es_storage: "{{ openshift_logging_facts | es_storage( es_name, es_storage_claim ) }}"
-    es_number_of_shards: "{{ es_number_of_shards }}"
-    es_number_of_replicas: "{{ es_number_of_replicas }}"
   check_mode: no
   changed_when: no


### PR DESCRIPTION
As pointed out in #4083 we don't use the shard count settings in the creation of the ES DC, it is set in the configmap