### PR TITLE
Upgrade specific rpms instead of just master/node.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
@@ -1,7 +1,26 @@
 ---
 # We verified latest rpm available is suitable, so just yum update.
-- name: Upgrade packages
-  package: "name={{ openshift.common.service_type }}-{{ component }}{{ openshift_pkg_version }} state=present"
+
+# Master package upgrade ends up depending on node and sdn packages, we need to be explicit
+# with all versions to avoid yum from accidentally jumping to something newer than intended:
+- name: Upgrade master packages
+  package: name={{ item }} state=present
+  when: component == "master"
+  with_items:
+  - "{{ openshift.common.service_type }}{{ openshift_pkg_version }}"
+  - "{{ openshift.common.service_type }}-master{{ openshift_pkg_version }}"
+  - "{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
+  - "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version }}"
+  - "{{ openshift.common.service_type }}-clients{{ openshift_pkg_version }}"
+
+- name: Upgrade node packages
+  package: name={{ item }} state=present
+  when: component == "node"
+  with_items:
+  - "{{ openshift.common.service_type }}{{ openshift_pkg_version }}"
+  - "{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
+  - "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version }}"
+  - "{{ openshift.common.service_type }}-clients{{ openshift_pkg_version }}"
 
 - name: Ensure python-yaml present for config upgrade
   package: name=PyYAML state=present


### PR DESCRIPTION
Dependencies for these, particularly the SDN package, can cause the
entire transaction to jump to a newer openshift than we requested, if
something newer is available in the repositories. By being specific for
multiple packages, we avoid this problem and get the actual version we
require.