### PR TITLE
Properly fail on empty repoquery version checks

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -1,20 +1,12 @@
 ---
 - name: Verify upgrade targets
   hosts: oo_masters_to_config:oo_nodes_to_upgrade
-  vars:
-    openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
-  pre_tasks:
-  - fail:
+
+  tasks:
+  - name: Fail when OpenShift is not installed
+    fail:
       msg: Verify OpenShift is already installed
     when: openshift.common.version is not defined
-
-  - fail:
-      msg: Verify the correct version was found
-    when: verify_upgrade_version is defined and openshift_version != verify_upgrade_version
-
-  - set_fact:
-      g_new_service_name: "{{ 'origin' if deployment_type =='origin' else 'atomic-openshift' }}"
-    when: not openshift.common.is_containerized | bool
 
   - name: Verify containers are available for upgrade
     command: >
@@ -23,19 +15,31 @@
     changed_when: "'Downloaded newer image' in pull_result.stdout"
     when: openshift.common.is_containerized | bool
 
-  - name: Check latest available OpenShift RPM version
-    command: >
-      {{ repoquery_cmd }} --qf '%{version}' "{{ openshift.common.service_type }}"
-    failed_when: false
-    changed_when: false
-    register: avail_openshift_version
-    when: not openshift.common.is_containerized | bool
+  - when: not openshift.common.is_containerized | bool
+    block:
+    - name: Check latest available OpenShift RPM version
+      command: >
+        {{ repoquery_cmd }} --qf '%{version}' "{{ openshift.common.service_type }}"
+      failed_when: false
+      changed_when: false
+      register: avail_openshift_version
 
-  - name: Verify OpenShift RPMs are available for upgrade
+    - name: Fail when unable to determine available OpenShift RPM version
+      fail:
+        msg: "Unable to determine available OpenShift RPM version"
+      when:
+      - avail_openshift_version.stdout == ''
+
+    - name: Verify OpenShift RPMs are available for upgrade
+      fail:
+        msg: "OpenShift {{ avail_openshift_version.stdout }} is available, but {{ openshift_upgrade_target }} or greater is required"
+      when:
+      - not avail_openshift_version | skipped
+      - avail_openshift_version.stdout | default('0.0', True) | version_compare(openshift_release, '<')
+
+  - name: Fail when openshift version does not meet minium requirement for Origin upgrade
     fail:
-      msg: "OpenShift {{ avail_openshift_version.stdout }} is available, but {{ openshift_upgrade_target }} or greater is required"
-    when: not openshift.common.is_containerized | bool and not avail_openshift_version | skipped and avail_openshift_version.stdout | default('0.0', True) | version_compare(openshift_release, '<')
-
-  - fail:
       msg: "This upgrade playbook must be run against OpenShift {{ openshift_upgrade_min }} or later"
-    when: deployment_type == 'origin' and openshift.common.version | version_compare(openshift_upgrade_min,'<')
+    when:
+    - deployment_type == 'origin'
+    - openshift.common.version | version_compare(openshift_upgrade_min,'<')


### PR DESCRIPTION
The `repoquery_cmd` could return an empty string if RPMs are not available.  This PR adds a task to confirm the `repoquery_cmd` returned a result, or fail with a helpful error message.

Fixes #3119