### PR TITLE
WIP -- Disable and re-enable docker-cleanup.timer

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -32,7 +32,6 @@
   roles:
   - lib_openshift
   - openshift_facts
-  - docker
   - openshift_node_upgrade
 
   post_tasks:

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -5,6 +5,8 @@
   # and is evaluated early. Values such as "20%" can also be used.
   serial: "{{ openshift_upgrade_nodes_serial | default(1) }}"
   any_errors_fatal: true
+  vars:
+    skip_docker_role: false
 
   pre_tasks:
   - name: Load lib_openshift modules

--- a/roles/openshift_node_upgrade/tasks/docker/upgrade.yml
+++ b/roles/openshift_node_upgrade/tasks/docker/upgrade.yml
@@ -26,9 +26,23 @@
 - debug: var=docker_image_count.stdout
   when: docker_upgrade_nuke_images is defined and docker_upgrade_nuke_images | bool
 
+# docker-1.12.6-6 adds a systemd timer to run cleanup
+# stop it if it exists
+- systemd:
+    name: docker-cleanup.timer
+    state: stopped
+  failed_when: false
+
 - service: name=docker state=stopped
 
 - name: Upgrade Docker
   package: name=docker{{ '-' + docker_version }} state=present
+
+# And since we may've just upgraded to a version that has the timer
+# stop it again
+- systemd:
+    name: docker-cleanup.timer
+    state: stopped
+  failed_when: false
 
 # starting docker happens back in ../main.yml where it calls ../restart.yml

--- a/roles/openshift_node_upgrade/tasks/restart.yml
+++ b/roles/openshift_node_upgrade/tasks/restart.yml
@@ -23,6 +23,12 @@
     - "{{ openshift.common.service_type }}-node"
   failed_when: false
 
+- name: Re-enable docker-cleanup.timer
+  systemd:
+    name: docker-cleanup.timer
+    state: started
+  failed_when: false
+
 - name: Wait for master API to come back online
   wait_for:
     host: "{{ openshift.common.hostname }}"


### PR DESCRIPTION
There were a few different scenarios where we're either restarting docker gratuitously or having it restarted when we don't expect it to

 - playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml called the docker role
 - roles/openshift_node_upgrade depends on openshift_common -> openshift_version -> docker
 - docker-cleanup.timer introduced in docker-1.12.6-16 starts docker at the top of the hour, which is disasterous

Before, assumes docker upgrade is necessary
```
# journalctl -b0 | egrep  '(Starting|Stopping) Docker Application Container Engine'
May 05 17:31:33 ose3-master.example.com systemd[1]: Starting Docker Application Container Engine...
May 05 17:38:36 ose3-master.example.com systemd[1]: Stopping Docker Application Container Engine...
May 05 17:38:36 ose3-master.example.com systemd[1]: Starting Docker Application Container Engine...
May 05 17:38:40 ose3-master.example.com systemd[1]: Starting Docker Application Container Engine...
May 05 17:38:41 ose3-master.example.com systemd[1]: Stopping Docker Application Container Engine...
May 05 17:38:41 ose3-master.example.com systemd[1]: Starting Docker Application Container Engine...
May 05 17:38:52 ose3-master.example.com systemd[1]: Stopping Docker Application Container Engine...
May 05 17:39:01 ose3-master.example.com systemd[1]: Starting Docker Application Container Engine...
```

After, assumes a docker upgrade is necessary
```
# journalctl -b0 | egrep  '(Starting|Stopping) Docker Application Container Engine'
May 05 17:43:37 ose3-master.example.com systemd[1]: Starting Docker Application Container Engine...
May 05 17:48:57 ose3-master.example.com systemd[1]: Stopping Docker Application Container Engine...
May 05 17:48:57 ose3-master.example.com systemd[1]: Starting Docker Application Container Engine...
May 05 17:49:11 ose3-master.example.com systemd[1]: Stopping Docker Application Container Engine...
May 05 17:49:21 ose3-master.example.com systemd[1]: Starting Docker Application Container Engine...
```

Currently one happens when upgrading the package and another we control. If we were to stop docker before performing the upgrade we can get this down to just one.