### PR TITLE
Use local variables for daemon.json template

### DIFF
--- a/roles/docker/tasks/systemcontainer_docker.yml
+++ b/roles/docker/tasks/systemcontainer_docker.yml
@@ -114,6 +114,14 @@
     dest: "{{ docker_systemd_dir }}/custom.conf"
     src: systemcontainercustom.conf.j2
 
+# Set local versions of facts that must be in json format for daemon.json
+# NOTE: When jinja2.9+ is used the daemon.json file can move to using tojson
+- set_fact:
+    l_docker_insecure_registries: "{{ docker_insecure_registries | default([]) | to_json }}"
+    l_docker_log_options: "{{ docker_log_options | default({}) | to_json }}"
+    l_docker_additional_registries: "{{ docker_additional_registries | default([]) | to_json }}"
+    l_docker_blocked_registries: "{{ docker_blocked_registries | default([]) | to_json }}"
+
 # Configure container-engine using the daemon.json file
 - name: Configure Container Engine
   template:

--- a/roles/docker/templates/daemon.json
+++ b/roles/docker/templates/daemon.json
@@ -12,7 +12,7 @@
     "default-gateway": "",
     "default-gateway-v6": "",
     "default-runtime": "oci",
-    "containerd": "/var/run/containerd.sock",
+    "containerd": "/run/containerd.sock",
     "default-ulimits": {},
     "disable-legacy-registry": false,
     "dns": [],
@@ -26,7 +26,7 @@
     "group": "",
     "hosts": [],
     "icc": false,
-    "insecure-registries": {{ docker_insecure_registries|default([]) }},
+    "insecure-registries": {{ l_docker_insecure_registries }},
     "ip": "0.0.0.0",
     "iptables": false,
     "ipv6": false,
@@ -36,9 +36,9 @@
     "live-restore": true,
 {% if docker_log_driver is defined  %}
     "log-driver": "{{ docker_log_driver }}",
-{% endif %}
+{%- endif %}
     "log-level": "",
-    "log-opts": {{ docker_log_options|default({}) }},
+    "log-opts": {{ l_docker_log_options }},
     "max-concurrent-downloads": 3,
     "max-concurrent-uploads": 5,
     "mtu": 0,
@@ -60,7 +60,7 @@
     "tlskey": "",
     "tlsverify": true,
     "userns-remap": "",
-    "add-registry": {{  docker_additional_registries|default([]) }},
-    "blocked-registries": {{ docker_blocked_registries|default([]) }},
+    "add-registry": {{ l_docker_additional_registries }},
+    "blocked-registries": {{ l_docker_blocked_registries }},
     "userland-proxy-path": "/usr/libexec/docker/docker-proxy-current"
 }


### PR DESCRIPTION
Instead of using bare ``list``s and ``dict``s this change converts variables
into json for use with daemon.json. ``jinja2`` does have an ability to do
this in side of templates, however it is only available in 2.9+. Until
then the use of ansible's ``to_json`` in the playbook is being used.

Refs:
- http://jinja.pocoo.org/docs/2.9/templates/#tojson
- http://docs.ansible.com/ansible/playbooks_filters.html#filters-for-formatting-data