### PR TITLE
Updating oc_obj to use get instead of getattr for absent state

### DIFF
--- a/roles/lib_openshift/library/oc_obj.py
+++ b/roles/lib_openshift/library/oc_obj.py
@@ -1548,7 +1548,7 @@ class OCObject(OpenShiftCLI):
         if state == 'absent':
             # verify its not in our results
             if (params['name'] is not None or params['selector'] is not None) and \
-               (len(api_rval['results']) == 0 or len(api_rval['results'][0].getattr('items', [])) == 0):
+               (len(api_rval['results']) == 0 or len(api_rval['results'][0].get('items', [])) == 0):
                 return {'changed': False, 'state': state}
 
             if check_mode:

--- a/roles/lib_openshift/src/class/oc_obj.py
+++ b/roles/lib_openshift/src/class/oc_obj.py
@@ -117,7 +117,7 @@ class OCObject(OpenShiftCLI):
         if state == 'absent':
             # verify its not in our results
             if (params['name'] is not None or params['selector'] is not None) and \
-               (len(api_rval['results']) == 0 or len(api_rval['results'][0].getattr('items', [])) == 0):
+               (len(api_rval['results']) == 0 or len(api_rval['results'][0].get('items', [])) == 0):
                 return {'changed': False, 'state': state}
 
             if check_mode:


### PR DESCRIPTION
Was getting
```
failed: [m01.example.com] (item=templates) => {
    "failed": true, 
    "invocation": {
        "module_name": "oc_obj"
    }, 
    "item": "templates", 
    "module_stderr": "Shared connection to m01.example.com closed.\r\n", 
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_40lCby/ansible_module_oc_obj.py\", line 1665, in <module>\r\n    main()\r\n  File \"/tmp/ansible_40lCby/ansible_module_oc_obj.py\", line 1658, in main\r\n    rval = OCObject.run_ansible(module.params, module.check_mode)\r\n  File \"/tmp/ansible_40lCby/ansible_module_oc_obj.py\", line 1551, in run_ansible\r\n    (len(api_rval['results']) == 0 or len(api_rval['results'][0].getattr('items', [])) == 0):\r\nAttributeError: 'dict' object has no attribute 'getattr'\r\n", 
    "msg": "MODULE FAILURE"
```

This resolved it.