### PR TITLE
Fix additional master cert & client config creation

### DIFF
--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -64,7 +64,7 @@
     --signer-key={{ openshift_ca_key }}
     --signer-serial={{ openshift_ca_serial }}
     --overwrite=false
-  when: inventory_hostname != openshift_ca_host
+  when: item != openshift_ca_host
   with_items: "{{ hostvars
                   | oo_select_keys(groups['oo_masters_to_config'])
                   | oo_collect(attribute='inventory_hostname', filters={'master_certs_missing':True}) }}"
@@ -95,7 +95,7 @@
   with_items: "{{ hostvars
                   | oo_select_keys(groups['oo_masters_to_config'])
                   | oo_collect(attribute='inventory_hostname', filters={'master_certs_missing':True}) }}"
-  when: inventory_hostname != openshift_ca_host
+  when: item != openshift_ca_host
   delegate_to: "{{ openshift_ca_host }}"
   run_once: true
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1448824.

This regression was introduced in 828ccd86df772bc5dbf5617dd257740338e81e30 which removes set operations from these tasks as a temporary workaround for python 3 + ansible2.3.

Compare `item` to `openshift_ca_host` rather than `inventory_hostname` since the `inventory_hostname` will always be `openshift_ca_host` due to delegation.