### PR TITLE
Flatten package install and upgrade into one transaction

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
@@ -1,27 +1,39 @@
 ---
-# We verified latest rpm available is suitable, so just yum update.
+# When we update package "a-${version}" and a requires b >= ${version} if we
+# don't specify the version of b yum will choose the latest version of b
+# available and the whole set of dependencies end up at the latest version.
+# Since the package module, unlike the yum module, doesn't flatten a list
+# of packages into one transaction we need to do that explicitly. The ansible
+# core team tells us not to rely on yum module transaction flattening anyway.
 
-# Master package upgrade ends up depending on node and sdn packages, we need to be explicit
-# with all versions to avoid yum from accidentally jumping to something newer than intended:
+# TODO: If the sdn package isn't already installed this will install it, we
+# should fix that
+
 - name: Upgrade master packages
-  package: name={{ item }} state=present
-  when: component == "master"
-  with_items:
-  - "{{ openshift.common.service_type }}{{ openshift_pkg_version }}"
-  - "{{ openshift.common.service_type }}-master{{ openshift_pkg_version }}"
-  - "{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
-  - "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version }}"
-  - "{{ openshift.common.service_type }}-clients{{ openshift_pkg_version }}"
+  package: name={{ master_pkgs | join(',') }} state=present
+  vars:
+    master_pkgs:
+      - "{{ openshift.common.service_type }}{{ openshift_pkg_version }}"
+      - "{{ openshift.common.service_type }}-master{{ openshift_pkg_version }}"
+      - "{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
+      - "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version}}"
+      - "{{ openshift.common.service_type }}-clients{{ openshift_pkg_version }}"
+      - "tuned-profiles-{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
+      - PyYAML
+  when:
+    - component == "master"
+    - not openshift.common.is_atomic | bool
 
 - name: Upgrade node packages
-  package: name={{ item }} state=present
-  when: component == "node"
-  with_items:
-  - "{{ openshift.common.service_type }}{{ openshift_pkg_version }}"
-  - "{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
-  - "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version }}"
-  - "{{ openshift.common.service_type }}-clients{{ openshift_pkg_version }}"
-
-- name: Ensure python-yaml present for config upgrade
-  package: name=PyYAML state=present
-  when: not openshift.common.is_atomic | bool
+  package: name={{ node_pkgs | join(',') }} state=present
+  vars:
+    node_pkgs:
+      - "{{ openshift.common.service_type }}{{ openshift_pkg_version }}"
+      - "{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
+      - "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version }}"
+      - "{{ openshift.common.service_type }}-clients{{ openshift_pkg_version }}"
+      - "tuned-profiles-{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
+      - PyYAML
+  when:
+    - component == "node"
+    - not openshift.common.is_atomic | bool


### PR DESCRIPTION
Without this we were pulling in unbounded dependencies and upgrading
to the latest version available in a repo.

Fixes  https://github.com/openshift/origin/issues/13998