### PR TITLE
Temporarily revert to OSEv3 host group usage

### DIFF
--- a/playbooks/byo/openshift-preflight/check.yml
+++ b/playbooks/byo/openshift-preflight/check.yml
@@ -1,8 +1,9 @@
 ---
 - include: ../openshift-cluster/initialize_groups.yml
 
-- hosts: g_all_hosts
-  name: run OpenShift health checks
+- name: Run OpenShift health checks
+  # Temporarily reverting to OSEv3 until group standardization is complete
+  hosts: OSEv3
   roles:
     - openshift_health_checker
   post_tasks:

--- a/playbooks/byo/openshift_facts.yml
+++ b/playbooks/byo/openshift_facts.yml
@@ -8,7 +8,8 @@
   - always
 
 - name: Gather Cluster facts
-  hosts: g_all_hosts
+  # Temporarily reverting to OSEv3 until group standardization is complete
+  hosts: OSEv3
   roles:
   - openshift_facts
   tasks:

--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -4,7 +4,8 @@
   - always
 
 - name: Subscribe hosts, update repos and update OS packages
-  hosts: g_all_hosts
+  # Temporarily reverting to OSEv3 until group standardization is complete
+  hosts: OSEv3
   roles:
   - role: rhel_subscribe
     when: deployment_type in ['atomic-enterprise', 'enterprise', 'openshift-enterprise'] and


### PR DESCRIPTION
Group normalization has caused an issue when calling new group names that have not been populated.  Temporarily reverting host groups to resolve issues while working out a long-term path forward.

Fixes bug 1447939