### PR TITLE
Remove vim configuration from Python files

### DIFF
--- a/bin/cluster
+++ b/bin/cluster
@@ -1,5 +1,4 @@
 #!/usr/bin/env python2
-# vim: expandtab:tabstop=4:shiftwidth=4
 
 import argparse
 import ConfigParser

--- a/docs/best_practices_guide.adoc
+++ b/docs/best_practices_guide.adoc
@@ -14,25 +14,6 @@ This guide complies with https://www.ietf.org/rfc/rfc2119.txt[RFC2119].
 
 == Python
 
-=== Python Source Files
-
-'''
-[[Python-source-files-MUST-contain-the-following-vim-mode-line]]
-[cols="2v,v"]
-|===
-| <<Python-source-files-MUST-contain-the-following-vim-mode-line, Rule>>
-| Python source files MUST contain the following vim mode line.
-|===
-
-[source]
-----
-# vim: expandtab:tabstop=4:shiftwidth=4
-----
-
-Since most developers contributing to this repository use vim, this rule helps to promote consistency.
-
-If mode lines for other editors are needed, please open a GitHub issue.
-
 === Method Signatures
 
 '''

--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# vim: expandtab:tabstop=4:shiftwidth=4
 # pylint: disable=too-many-lines
 """
 Custom filters for use in openshift-ansible

--- a/filter_plugins/openshift_node.py
+++ b/filter_plugins/openshift_node.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# vim: expandtab:tabstop=4:shiftwidth=4
 '''
 Custom filters for use in openshift-node
 '''

--- a/filter_plugins/openshift_version.py
+++ b/filter_plugins/openshift_version.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
-
 # -*- coding: utf-8 -*-
-# vim: expandtab:tabstop=4:shiftwidth=4
 """
 Custom version comparison filters for use in openshift-ansible
 """

--- a/library/kubeclient_ca.py
+++ b/library/kubeclient_ca.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# vim: expandtab:tabstop=4:shiftwidth=4
-
 ''' kubeclient_ca ansible module '''
 
 import base64

--- a/library/modify_yaml.py
+++ b/library/modify_yaml.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# vim: expandtab:tabstop=4:shiftwidth=4
-
 ''' modify_yaml ansible module '''
 
 import yaml

--- a/lookup_plugins/oo_option.py
+++ b/lookup_plugins/oo_option.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
-# vim: expandtab:tabstop=4:shiftwidth=4
-
 '''
 oo_option lookup plugin for openshift-ansible
 

--- a/playbooks/adhoc/grow_docker_vg/filter_plugins/grow_docker_vg_filters.py
+++ b/playbooks/adhoc/grow_docker_vg/filter_plugins/grow_docker_vg_filters.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# vim: expandtab:tabstop=4:shiftwidth=4
 '''
 Custom filters for use in openshift-ansible
 '''

--- a/playbooks/common/openshift-cluster/upgrades/library/openshift_upgrade_config.py
+++ b/playbooks/common/openshift-cluster/upgrades/library/openshift_upgrade_config.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# vim: expandtab:tabstop=4:shiftwidth=4
-
 """Ansible module for modifying OpenShift configs during an upgrade"""
 
 import os

--- a/roles/lib_openshift/src/test/integration/filter_plugins/filters.py
+++ b/roles/lib_openshift/src/test/integration/filter_plugins/filters.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# vim: expandtab:tabstop=4:shiftwidth=4
 '''
 Custom filters for use in testing
 '''

--- a/roles/openshift_certificate_expiry/filter_plugins/oo_cert_expiry.py
+++ b/roles/openshift_certificate_expiry/filter_plugins/oo_cert_expiry.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# vim: expandtab:tabstop=4:shiftwidth=4
 """
 Custom filters for use in openshift-ansible
 """

--- a/roles/openshift_cli/library/openshift_container_binary_sync.py
+++ b/roles/openshift_cli/library/openshift_container_binary_sync.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# vim: expandtab:tabstop=4:shiftwidth=4
 # pylint: disable=missing-docstring,invalid-name
-#
 
 import random
 import tempfile

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 # pylint: disable=too-many-lines
 # -*- coding: utf-8 -*-
-# vim: expandtab:tabstop=4:shiftwidth=4
 # Reason: Disable pylint too-many-lines because we don't want to split up this file.
 # Status: Permanently disabled to keep this module as self-contained as possible.
 

--- a/roles/openshift_health_checker/callback_plugins/zz_failure_summary.py
+++ b/roles/openshift_health_checker/callback_plugins/zz_failure_summary.py
@@ -1,4 +1,3 @@
-# vim: expandtab:tabstop=4:shiftwidth=4
 '''
 Ansible callback plugin.
 '''

--- a/roles/openshift_health_checker/library/aos_version.py
+++ b/roles/openshift_health_checker/library/aos_version.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# vim: expandtab:tabstop=4:shiftwidth=4
 '''
 Ansible module for yum-based systems determining if multiple releases
 of an OpenShift package are available, and if the release requested

--- a/roles/openshift_health_checker/library/check_yum_update.py
+++ b/roles/openshift_health_checker/library/check_yum_update.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# vim: expandtab:tabstop=4:shiftwidth=4
 '''
 Ansible module to test whether a yum update or install will succeed,
 without actually performing it or running yum.

--- a/roles/openshift_master_facts/filter_plugins/openshift_master.py
+++ b/roles/openshift_master_facts/filter_plugins/openshift_master.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# vim: expandtab:tabstop=4:shiftwidth=4
 '''
 Custom filters for use in openshift-master
 '''

--- a/roles/os_firewall/library/os_firewall_manage_iptables.py
+++ b/roles/os_firewall/library/os_firewall_manage_iptables.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# vim: expandtab:tabstop=4:shiftwidth=4
 # pylint: disable=fixme, missing-docstring
 import subprocess
 


### PR DESCRIPTION
In a project where contributors are free to use whatever editor they want and we have linting tools that verify the proper formatting of Python files, it should not be required to have a vim-specific line in Python files.

---

The intention here is not to proclaim an editor war, but to pragmatically simplify the list of manual rules we want to enforce on contributors.

Inspired by code review in https://github.com/openshift/openshift-ansible/pull/3630#discussion_r115313432.