### PR TITLE
Added Calico BGP Port 179 to Firewalld

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -9,3 +9,6 @@ os_firewall_allow:
 - service: OpenShift OVS sdn
   port: 4789/udp
   when: openshift.common.use_openshift_sdn | bool
+- service: Calico BGP Port
+  port: 179/tcp
+  when: openshift.common.use_calico | bool

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -33,6 +33,12 @@ dependencies:
   when: openshift.common.use_openshift_sdn | bool
 - role: os_firewall
   os_firewall_allow:
+  - service: Calico BGP Port
+    port: 179/tcp
+  when: openshift.common.use_calico | bool
+
+- role: os_firewall
+  os_firewall_allow:
   - service: Kubernetes service NodePort TCP
     port: "{{ openshift_node_port_range | default('') }}/tcp"
   - service: Kubernetes service NodePort UDP


### PR DESCRIPTION
Calico uses BGP to sync meta-information between nodes. For BGP to work an additional rule in firewalld for port 179 is required.