### PR TITLE
Added Container Registry Port 5000 to Firewalld

### DIFF
--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -30,3 +30,8 @@ openshift_hosted_routers:
 openshift_hosted_router_certificate: {}
 openshift_hosted_registry_cert_expire_days: 730
 openshift_hosted_router_create_certificate: False
+
+os_firewall_allow:
+- service: Docker Registry Port
+  port: 5000/tcp
+  when: openshift.common.use_calico | bool

--- a/roles/openshift_hosted/meta/main.yml
+++ b/roles/openshift_hosted/meta/main.yml
@@ -15,3 +15,8 @@ dependencies:
 - role: openshift_cli
 - role: openshift_hosted_facts
 - role: lib_openshift
+- role: os_firewall
+  os_firewall_allow:
+  - service: Docker Registry Port
+    port: 5000/tcp
+  when: openshift.common.use_calico | bool


### PR DESCRIPTION
That the integrated Container Registry works properly the port 5000 has to be added to firewalld.
Otherwise no images can be pushed to or pulled from the registry on CentOS.