### PR TITLE
Fix regression, 'no hosts matched', in rhel_sub

### DIFF
--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -4,7 +4,7 @@
   - always
 
 - name: Subscribe hosts, update repos and update OS packages
-  hosts: g_all_hosts
+  hosts: "{{ hostvars['localhost'].g_all_hosts }}"
   roles:
   - role: rhel_subscribe
     when: deployment_type in ['atomic-enterprise', 'enterprise', 'openshift-enterprise'] and


### PR DESCRIPTION
The rhel_sub playbook broke again for me. Discovered after rebuilding my OS1 nodes. Running the playbook would generate all of the `g_*` groups, but once the second play runs the facts are lost. This references the plays correctly now.

Though I am not sure if this is the ideal solution. Please comment if you have a better idea.