### PR TITLE
Fix issue with Travis-CI using old pip version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ python:
   - "3.5"
 
 install:
+  - pip install --upgrade pip
   - pip install tox-travis coveralls
 
 script:


### PR DESCRIPTION
Travis 2.7 test environments use pip 6.0.7 which is very old.  This causes a failure when installing the 2.14 (latest) version of `requests`.  Adding a step to upgrade pip before performing other installs.

See: https://github.com/kennethreitz/requests/issues/4006