### PR TITLE
Bumping up default_ose_version for registering a 3.5 system

### DIFF
--- a/roles/rhel_subscribe/tasks/enterprise.yml
+++ b/roles/rhel_subscribe/tasks/enterprise.yml
@@ -7,7 +7,7 @@
   when: deployment_type == 'enterprise'
 
 - set_fact:
-    default_ose_version: '3.4'
+    default_ose_version: '3.5'
   when: deployment_type in ['atomic-enterprise', 'openshift-enterprise']
 
 - set_fact:
@@ -16,7 +16,7 @@
 - fail:
     msg: "{{ ose_version }} is not a valid version for {{ deployment_type }} deployment type"
   when: ( deployment_type == 'enterprise' and ose_version not in ['3.0'] ) or
-        ( deployment_type in ['atomic-enterprise', 'openshift-enterprise'] and ose_version not in ['3.1', '3.2', '3.3', '3.4'] )
+        ( deployment_type in ['atomic-enterprise', 'openshift-enterprise'] and ose_version not in ['3.1', '3.2', '3.3', '3.4', '3.5'] )
 
 - name: Enable RHEL repositories
   command: subscription-manager repos \


### PR DESCRIPTION
When trying to register a system with the release-1.5 branch it kept trying to register as 3.4 and caused issues trying to upgrade from 3.4 -> 3.5