### PR TITLE
Added Calicoctl to deployment of Master Nodes when Calico is used

### DIFF
--- a/roles/calico_master/defaults/main.yaml
+++ b/roles/calico_master/defaults/main.yaml
@@ -1,2 +1,6 @@
 ---
 kubeconfig: "{{ openshift.common.config_base }}/master/openshift-master.kubeconfig"
+
+calicoctl_bin_dir: "/usr/local/bin/"
+
+calico_url_calicoctl: "https://github.com/projectcalico/calicoctl/releases/download/v1.1.3/calicoctl"

--- a/roles/calico_master/tasks/main.yml
+++ b/roles/calico_master/tasks/main.yml
@@ -39,3 +39,10 @@
     resource_kind: scc
     resource_name: privileged
     state: present
+
+- name: Download Calicoctl
+  become: yes
+  get_url:
+    url: "{{ calico_url_calicoctl }}"
+    dest: "{{ calicoctl_bin_dir }}"
+    mode: a+x


### PR DESCRIPTION
Added Task to `Calico Master Role` that  installs calicoctl on the Master Nodes of the OpenShift cluster when Calico is used.