### PR TITLE
Removed Hardcoded URLs in Calico Role

### DIFF
--- a/roles/calico/defaults/main.yaml
+++ b/roles/calico/defaults/main.yaml
@@ -4,7 +4,11 @@ etcd_endpoints: "{{ hostvars[groups.oo_first_master.0].openshift.master.etcd_url
 
 cni_conf_dir: "/etc/cni/net.d/"
 cni_bin_dir: "/opt/cni/bin/"
+cni_url: "https://github.com/containernetworking/cni/releases/download/v0.4.0/cni-amd64-v0.4.0.tgz"
 
 calico_etcd_ca_cert_file: "/etc/origin/calico/calico.etcd-ca.crt"
 calico_etcd_cert_file: "/etc/origin/calico/calico.etcd-client.crt"
 calico_etcd_key_file: "/etc/origin/calico/calico.etcd-client.key"
+
+calico_url_cni: "https://github.com/projectcalico/cni-plugin/releases/download/v1.5.5/calico"
+calico_url_ipam: "https://github.com/projectcalico/cni-plugin/releases/download/v1.5.5/calico-ipam"

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -46,14 +46,14 @@
 - name: Download Calico CNI Plugin
   become: yes
   get_url:
-    url: https://github.com/projectcalico/cni-plugin/releases/download/v1.5.5/calico
+    url: "{{ calico_url_cni }}"
     dest: "{{ cni_bin_dir }}"
     mode: a+x
 
 - name: Download Calico IPAM Plugin
   become: yes
   get_url:
-    url: https://github.com/projectcalico/cni-plugin/releases/download/v1.5.5/calico-ipam
+    url: "{{ calico_url_ipam }}"
     dest: "{{ cni_bin_dir }}"
     mode: a+x
 
@@ -61,7 +61,7 @@
   become: yes
   unarchive:
     remote_src: True
-    src: https://github.com/containernetworking/cni/releases/download/v0.4.0/cni-amd64-v0.4.0.tgz
+    src: "{{ cni_url }}"
     dest: "{{ cni_bin_dir }}"
 
 - name: Assure Calico conf dir exists


### PR DESCRIPTION
This patch removes the hardcoded Calico URLs in Calico Node and enables users to define alternative URLs in the Ansible inventory for each component. 