### PR TITLE
Parameterized Calico/Node Arguments

### DIFF
--- a/roles/calico/README.md
+++ b/roles/calico/README.md
@@ -20,6 +20,15 @@ To install, set the following inventory configuration parameters:
 * `openshift_use_openshift_sdn=False`
 * `os_sdn_network_plugin_name='cni'`
 
+## Additional Calico/Node and Felix Configuration Options
+
+Additional parameters that can be defined in the inventory are:
+
+| Environment | Description | Schema | Default |   
+|---------|----------------------|---------|---------|
+|CALICO_IPV4POOL_CIDR|	The IPv4 Pool to create if none exists at start up. It is invalid to define this variable and NO_DEFAULT_POOLS.	|IPv4 CIDR	| 192.168.0.0/16 |
+| CALICO_IPV4POOL_IPIP | IPIP Mode to use for the IPv4 POOL created at start up.	| off, always, cross-subnet	| always |
+| CALICO_LOG_DIR | Directory on the host machine where Calico Logs are written.| String	| /var/log/calico |
 
 ### Contact Information
 

--- a/roles/calico/defaults/main.yaml
+++ b/roles/calico/defaults/main.yaml
@@ -12,3 +12,9 @@ calico_etcd_key_file: "/etc/origin/calico/calico.etcd-client.key"
 
 calico_url_cni: "https://github.com/projectcalico/cni-plugin/releases/download/v1.5.5/calico"
 calico_url_ipam: "https://github.com/projectcalico/cni-plugin/releases/download/v1.5.5/calico-ipam"
+
+calico_ipv4pool_ipip: "always"
+calico_ipv4pool_cidr: "192.168.0.0/16"
+
+calico_log_dir: "/var/log/calico"
+calico_node_image: "calico/node:v1.1.0"

--- a/roles/calico/templates/calico.service.j2
+++ b/roles/calico/templates/calico.service.j2
@@ -10,7 +10,8 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
  --name=calico-node \
  -e WAIT_FOR_DATASTORE=true \
  -e FELIX_DEFAULTENDPOINTTOHOSTACTION=ACCEPT \
- -e CALICO_IPV4POOL_IPIP=always \
+ -e CALICO_IPV4POOL_IPIP={{ calico_ipv4pool_ipip }} \
+ -e CALICO_IPV4POOL_CIDR={{ calico_ipv4pool_cidr }} \
  -e FELIX_IPV6SUPPORT=false \
  -e ETCD_ENDPOINTS={{ etcd_endpoints }} \
  -v /etc/origin/calico:/etc/origin/calico \
@@ -18,10 +19,11 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
  -e ETCD_CERT_FILE={{ calico_etcd_cert_file }} \
  -e ETCD_KEY_FILE={{ calico_etcd_key_file }} \
  -e NODENAME={{ openshift.common.hostname }} \
- -v /var/log/calico:/var/log/calico \
+ -v {{ calico_log_dir }}:/var/log/calico\
  -v /lib/modules:/lib/modules \
  -v /var/run/calico:/var/run/calico \
- calico/node:v1.1.0
+ {{ calico_node_image }}
+
 
 ExecStop=-/usr/bin/docker stop calico-node
 

--- a/roles/calico_master/README.md
+++ b/roles/calico_master/README.md
@@ -21,6 +21,18 @@ To install, set the following inventory configuration parameters:
 * `os_sdn_network_plugin_name='cni'`
 
 
+
+## Additional Calico/Node and Felix Configuration Options
+
+Additional parameters that can be defined in the inventory are:
+
+
+| Environment | Description | Schema | Default |   
+|---------|----------------------|---------|---------|
+|CALICO_IPV4POOL_CIDR|	The IPv4 Pool to create if none exists at start up. It is invalid to define this variable and NO_DEFAULT_POOLS.	|IPv4 CIDR	| 192.168.0.0/16 |
+| CALICO_IPV4POOL_IPIP | IPIP Mode to use for the IPv4 POOL created at start up.	| off, always, cross-subnet	| always |
+| CALICO_LOG_DIR | Directory on the host machine where Calico Logs are written.| String	| /var/log/calico |
+
 ### Contact Information
 
 Author: Dan Osborne <dan@projectcalico.org>


### PR DESCRIPTION
Parameterized Calico/Node configuration to be able to change selected arguments in the Ansible Inventory and documented these arguments in the README files of the Calico Roles.