### PR TITLE
byo: correct option name

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -735,7 +735,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_node_env_vars={"ENABLE_HTTP2": "true"}
 
 # Enable API service auditing, available as of 1.3
-#openshift_master_audit_config={"basicAuditEnabled": true}
+#openshift_master_audit_config={"enabled": true}
 
 # Enable origin repos that point at Centos PAAS SIG, defaults to true, only used
 # by deployment_type=origin

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -736,7 +736,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_node_env_vars={"ENABLE_HTTP2": "true"}
 
 # Enable API service auditing, available as of 3.2
-#openshift_master_audit_config={"basicAuditEnabled": true}
+#openshift_master_audit_config={"enabled": true}
 
 # host group for masters
 [masters]


### PR DESCRIPTION
The correct name is "enabled', not "basicAuditEnabled"

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1439619

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit 5774e6b08b36bb5aaa0bf03fb43cc123b1090403)