### PR TITLE
Default to iptables on master

### DIFF
--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -46,7 +46,7 @@
     template:
       dest: "{{ docker_systemd_dir }}/custom.conf"
       src: custom.conf.j2
-  when: not os_firewall_use_firewalld | default(True) | bool
+  when: not os_firewall_use_firewalld | default(False) | bool
 
 - stat: path=/etc/sysconfig/docker
   register: docker_check

--- a/roles/docker/templates/systemcontainercustom.conf.j2
+++ b/roles/docker/templates/systemcontainercustom.conf.j2
@@ -10,7 +10,7 @@ ENVIRONMENT=HTTPS_PROXY={{ docker_http_proxy }}
 {%- if "no_proxy" in openshift.common %}
 ENVIRONMENT=NO_PROXY={{ docker_no_proxy }}
 {%- endif %}
-{%- if os_firewall_use_firewalld|default(true) %}
+{%- if os_firewall_use_firewalld|default(false) %}
 [Unit]
 Wants=iptables.service
 After=iptables.service

--- a/roles/os_firewall/README.md
+++ b/roles/os_firewall/README.md
@@ -17,7 +17,7 @@ Role Variables
 
 | Name                      | Default |                                        |
 |---------------------------|---------|----------------------------------------|
-| os_firewall_use_firewalld | True    | If false, use iptables                 |
+| os_firewall_use_firewalld | False   | If false, use iptables                 |
 | os_firewall_allow         | []      | List of service,port mappings to allow |
 | os_firewall_deny          | []      | List of service, port mappings to deny |
 

--- a/roles/os_firewall/defaults/main.yml
+++ b/roles/os_firewall/defaults/main.yml
@@ -2,6 +2,6 @@
 os_firewall_enabled: True
 # firewalld is not supported on Atomic Host
 # https://bugzilla.redhat.com/show_bug.cgi?id=1403331
-os_firewall_use_firewalld: "{{ False if openshift.common.is_atomic | bool else True }}"
+os_firewall_use_firewalld: "{{ False }}"
 os_firewall_allow: []
 os_firewall_deny: []


### PR DESCRIPTION
We did this in 3.5 but never on master but we never came back to add
migration support. So we'll revert this on master and if/when we add
migration support we'll switch the default.

Forward ports #3849 