### PR TITLE
lower case in /etc/daemon.json and correct block-registry

### DIFF
--- a/roles/docker/templates/daemon.json
+++ b/roles/docker/templates/daemon.json
@@ -51,7 +51,7 @@
 	    "path": "/usr/libexec/docker/docker-runc-current"
 	}
     },
-    "selinux-enabled": {{ l_docker_selinux_enabled }},
+    "selinux-enabled": {{ l_docker_selinux_enabled | lower }},
     "storage-driver": "",
     "storage-opts": [],
     "tls": true,
@@ -61,6 +61,6 @@
     "tlsverify": true,
     "userns-remap": "",
     "add-registry": {{ l_docker_additional_registries }},
-    "block-registries": {{ l_docker_blocked_registries }},
+    "block-registry": {{ l_docker_blocked_registries }},
     "userland-proxy-path": "/usr/libexec/docker/docker-proxy-current"
 }


### PR DESCRIPTION
- Only lowercase bool supported in `/etc/docker/daemon.json`  
- Correct `block-registries` to `block-registry`

@ashcrow PTAL :-)