### PR TITLE
[1.5] Fix Origin version variant

### DIFF
--- a/utils/src/ooinstall/variants.py
+++ b/utils/src/ooinstall/variants.py
@@ -47,7 +47,7 @@ REG = Variant('openshift-enterprise', 'Registry', [
 ])
 
 origin = Variant('origin', 'OpenShift Origin', [
-    Version('1.4', 'origin'),
+    Version('1.5', 'origin'),
 ])
 
 LEGACY = Variant('openshift-enterprise', 'OpenShift Container Platform', [


### PR DESCRIPTION
Variants were previously corrected for openshift-enterprise and Registry installs, however, the Origin version variant was skipped.  This PR correct the Origin install version variant.