### PR TITLE
Use v3.4 OCP images on the release-1.4 branch

### DIFF
--- a/roles/openshift_version/tasks/set_version_containerized.yml
+++ b/roles/openshift_version/tasks/set_version_containerized.yml
@@ -10,9 +10,14 @@
     openshift_version: "{{ openshift_release }}"
   when: openshift_release is defined and openshift_version is not defined
 
+
+- name: Set default image tag based on OCP versus origin
+  set_fact:
+    l_image_tag: "{{ 'v3.4' if openshift.common.deployment_type == 'openshift-enterprise' else 'latest' }}"
+
 - name: Lookup latest containerized version if no version specified
   command: >
-    docker run --rm {{ openshift.common.cli_image }}:latest version
+    docker run --rm {{ openshift.common.cli_image }}:{{ l_image_tag }} version
   register: cli_image_version
   when: openshift_version is not defined
 


### PR DESCRIPTION
For origin we have no generic tags that point at 1.5, 3.6, so just keep
using latest there