### PR TITLE
Remove userland-proxy-path from daemon.json

### DIFF
--- a/roles/docker/templates/daemon.json
+++ b/roles/docker/templates/daemon.json
@@ -16,6 +16,5 @@
     },
     "selinux-enabled": {{ l_docker_selinux_enabled | lower }},
     "add-registry": {{ l_docker_additional_registries }},
-    "block-registry": {{ l_docker_blocked_registries }},
-    "userland-proxy-path": "/usr/libexec/docker/docker-proxy-current"
+    "block-registry": {{ l_docker_blocked_registries }}
 }


### PR DESCRIPTION
This flag is currently being set within the system container via the init.sh

https://bugzilla.redhat.com/show_bug.cgi?id=1448384