### PR TITLE
Fix container image build references

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -29,17 +29,34 @@ tito build --rpm
 To build a container image of `openshift-ansible` using standalone **Docker**:
 
         cd openshift-ansible
-        docker build -t openshift/openshift-ansible .
+        docker build -f images/installer/Dockerfile -t openshift/openshift-ansible .
 
-Alternatively this can be built using on **OpenShift** using a [build and image stream](https://docs.openshift.org/latest/architecture/core_concepts/builds_and_image_streams.html) with this command:
+### Building on OpenShift
+
+To build an openshift-ansible image using an **OpenShift** [build and image stream](https://docs.openshift.org/latest/architecture/core_concepts/builds_and_image_streams.html) the straightforward command would be:
 
         oc new-build docker.io/aweiteka/playbook2image~https://github.com/openshift/openshift-ansible
 
-The progress of the build can be monitored with:
+However: because the `Dockerfile` for this repository is not in the top level directory, and because we can't change the build context to the `images/installer` path as it would cause the build to fail, the `oc new-app` command above will create a build configuration using the *source to image* strategy, which is the default approach of the [playbook2image](https://github.com/openshift/playbook2image) base image. This does build an image successfully, but unfortunately the resulting image will be missing some customizations that are handled by the [Dockerfile](images/installer/Dockerfile) in this repo.
+
+At the time of this writing there is no straightforward option to [set the dockerfilePath](https://docs.openshift.org/latest/dev_guide/builds/build_strategies.html#dockerfile-path) of a `docker` build strategy with `oc new-build`. The alternatives to achieve this are:
+
+- Use the simple `oc new-build` command above to generate the BuildConfig and ImageStream objects, and then manually edit the generated build configuration to change its strategy to `dockerStrategy` and set `dockerfilePath` to `images/installer/Dockerfile`.
+
+- Download and pass the `Dockerfile` to `oc new-build` with the `-D` option:
+
+```
+curl -s https://raw.githubusercontent.com/openshift/openshift-ansible/master/images/installer/Dockerfile |
+     oc new-build -D - \
+        --docker-image=docker.io/aweiteka/playbook2image \
+	    https://github.com/openshift/openshift-ansible
+```
+
+Once a build is started, the progress of the build can be monitored with:
 
         oc logs -f bc/openshift-ansible
 
-Once built, the image will be visible in the Image Stream created by the same command:
+Once built, the image will be visible in the Image Stream created by `oc new-app`:
 
         oc describe imagestream openshift-ansible
 

--- a/README_CONTAINER_IMAGE.md
+++ b/README_CONTAINER_IMAGE.md
@@ -1,6 +1,6 @@
 # Containerized openshift-ansible to run playbooks
 
-The [Dockerfile](Dockerfile) in this repository uses the [playbook2image](https://github.com/aweiteka/playbook2image) source-to-image base image to containerize `openshift-ansible`. The resulting image can run any of the provided playbooks. See [BUILD.md](BUILD.md) for image build instructions.
+The [Dockerfile](images/installer/Dockerfile) in this repository uses the [playbook2image](https://github.com/openshift/playbook2image) source-to-image base image to containerize `openshift-ansible`. The resulting image can run any of the provided playbooks. See [BUILD.md](BUILD.md) for image build instructions.
 
 The image is designed to **run as a non-root user**. The container's UID is mapped to the username `default` at runtime. Therefore, the container's environment reflects that user's settings, and the configuration should match that. For example `$HOME` is `/opt/app-root/src`, so ssh keys are expected to be under `/opt/app-root/src/.ssh`. If you ran a container as `root` you would have to adjust the container's configuration accordingly, e.g. by placing ssh keys under `/root/.ssh` instead. Nevertheless, the expectation is that containers will be run as non-root; for example, this container image can be run inside OpenShift under the default `restricted` [security context constraint](https://docs.openshift.org/latest/architecture/additional_concepts/authorization.html#security-context-constraints).
 
@@ -8,7 +8,7 @@ The image is designed to **run as a non-root user**. The container's UID is mapp
 
 ## Usage
 
-The `playbook2image` base image provides several options to control the behaviour of the containers. For more details on these options see the [playbook2image](https://github.com/aweiteka/playbook2image) documentation.
+The `playbook2image` base image provides several options to control the behaviour of the containers. For more details on these options see the [playbook2image](https://github.com/openshift/playbook2image) documentation.
 
 At the very least, when running a container you must specify:
 

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -10,7 +10,7 @@ source_root=$(dirname "${0}")/..
 prefix="openshift/openshift-ansible"
 version="latest"
 verbose=false
-options=""
+options="-f images/installer/Dockerfile"
 help=false
 
 for args in "$@"

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -46,6 +46,6 @@ ADD . /tmp/src
 RUN /usr/libexec/s2i/assemble
 
 # Add files for running as a system container
-COPY system-container/root /
+COPY images/installer/system-container/root /
 
 CMD [ "/usr/libexec/s2i/run" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
 ansible==2.2.2.0
-boto==2.45.0
+boto==2.34.0
 click==6.7
 pyOpenSSL==16.2.0
 # We need to disable ruamel.yaml for now because of test failures


### PR DESCRIPTION
In #4114 the location of the Dockerfiles changed. Build-related scripts and documentation need some updates accordingly.

The "worst part" is the section about building the image on OpenShift - it seems there's no easy way to have `oc new-app` look for a Dockerfile under a specific path (i.e. set `dockerfilePath`), which makes things a bit clumsy.

Also a couple of build-related updates:
  - playbook2image is now available from the openshift org, so update the references
  - downstream image is building with boto 2.34 (current EL7 version) so use that version upstream too.

