### PR TITLE
singletonize some role tasks that repeat a lot

### DIFF
--- a/roles/openshift_excluder/tasks/install.yml
+++ b/roles/openshift_excluder/tasks/install.yml
@@ -1,14 +1,24 @@
 ---
-- name: Install docker excluder
-  package:
-    name: "{{ r_openshift_excluder_service_type }}-docker-excluder{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) +  '*' }}"
-    state: "{{ r_openshift_excluder_docker_package_state }}"
-  when:
-  - r_openshift_excluder_enable_docker_excluder | bool
 
-- name: Install openshift excluder
-  package:
-    name: "{{ r_openshift_excluder_service_type }}-excluder{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) + '*' }}"
-    state: "{{ r_openshift_excluder_package_state }}"
-  when:
-  - r_openshift_excluder_enable_openshift_excluder | bool
+- when:
+  - not openshift.common.is_atomic | bool
+  - r_openshift_excluder_install_ran is not defined
+
+  block:
+
+  - name: Install docker excluder
+    package:
+      name: "{{ r_openshift_excluder_service_type }}-docker-excluder{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) +  '*' }}"
+      state: "{{ r_openshift_excluder_docker_package_state }}"
+    when:
+    - r_openshift_excluder_enable_docker_excluder | bool
+
+  - name: Install openshift excluder
+    package:
+      name: "{{ r_openshift_excluder_service_type }}-excluder{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) + '*' }}"
+      state: "{{ r_openshift_excluder_package_state }}"
+    when:
+    - r_openshift_excluder_enable_openshift_excluder | bool
+
+  - set_fact:
+      r_openshift_excluder_install_ran: True

--- a/roles/openshift_facts/tasks/main.yml
+++ b/roles/openshift_facts/tasks/main.yml
@@ -24,12 +24,18 @@
     msg: |
       openshift-ansible requires Python 3 for {{ ansible_distribution }};
       For information on enabling Python 3 with Ansible, see https://docs.ansible.com/ansible/python_3_support.html
-  when: ansible_distribution == 'Fedora' and ansible_python['version']['major'] != 3
+  when:
+  - ansible_distribution == 'Fedora'
+  - ansible_python['version']['major'] != 3
+  - r_openshift_facts_ran is not defined
 
 - name: Validate python version
   fail:
     msg: "openshift-ansible requires Python 2 for {{ ansible_distribution }}"
-  when: ansible_distribution != 'Fedora' and ansible_python['version']['major'] != 2
+  when:
+  - ansible_distribution != 'Fedora'
+  - ansible_python['version']['major'] != 2
+  - r_openshift_facts_ran is not defined
 
 # Fail as early as possible if Atomic and old version of Docker
 - block:
@@ -48,7 +54,9 @@
       that:
       - l_atomic_docker_version.stdout | replace('"', '') | version_compare('1.12','>=')
 
-  when: l_is_atomic | bool
+  when:
+  - l_is_atomic | bool
+  - r_openshift_facts_ran is not defined
 
 - name: Load variables
   include_vars: "{{ item }}"
@@ -59,7 +67,9 @@
 - name: Ensure various deps are installed
   package: name={{ item }} state=present
   with_items: "{{ required_packages }}"
-  when: not l_is_atomic | bool
+  when:
+  - not l_is_atomic | bool
+  - r_openshift_facts_ran is not defined
 
 - name: Ensure various deps for running system containers are installed
   package: name={{ item }} state=present
@@ -67,6 +77,7 @@
   when:
   - not l_is_atomic | bool
   - l_any_system_container | bool
+  - r_openshift_facts_ran is not defined
 
 - name: Gather Cluster facts and set is_containerized if needed
   openshift_facts:
@@ -99,3 +110,7 @@
 - name: Set repoquery command
   set_fact:
     repoquery_cmd: "{{ 'dnf repoquery --latest-limit 1 -d 0' if ansible_pkg_mgr == 'dnf' else 'repoquery --plugins' }}"
+
+- name: Register that this already ran
+  set_fact:
+    r_openshift_facts_ran: True

--- a/roles/openshift_repos/tasks/main.yaml
+++ b/roles/openshift_repos/tasks/main.yaml
@@ -4,7 +4,8 @@
     path: /run/ostree-booted
   register: ostree_booted
 
-- block:
+- when: not ostree_booted.stat.exists
+  block:
   - name: Ensure libselinux-python is installed
     package: name=libselinux-python state=present
 
@@ -24,41 +25,40 @@
     - openshift_additional_repos | length == 0
     notify: refresh cache
 
-  # Note: OpenShift repositories under CentOS may be shipped through the
-  # "centos-release-openshift-origin" package which configures the repository.
-  # This task matches the file names provided by the package so that they are
-  # not installed twice in different files and remains idempotent.
-  - name: Configure origin gpg keys if needed
-    copy:
-      src: "{{ item.src }}"
-      dest: "{{ item.dest }}"
-    with_items:
-    - src: origin/gpg_keys/openshift-ansible-CentOS-SIG-PaaS
-      dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
-    - src: origin/repos/openshift-ansible-centos-paas-sig.repo
-      dest: /etc/yum.repos.d/CentOS-OpenShift-Origin.repo
-    notify: refresh cache
-    when:
-    - ansible_os_family == "RedHat"
-    - ansible_distribution != "Fedora"
-    - openshift_deployment_type == 'origin'
-    - openshift_enable_origin_repo | default(true) | bool
-
   # Singleton block
-  - when: r_osr_first_run | default(true)
+  - when: r_openshift_repos_has_run is not defined
     block:
+
+    # Note: OpenShift repositories under CentOS may be shipped through the
+    # "centos-release-openshift-origin" package which configures the repository.
+    # This task matches the file names provided by the package so that they are
+    # not installed twice in different files and remains idempotent.
+    - name: Configure origin gpg keys if needed
+      copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+      with_items:
+      - src: origin/gpg_keys/openshift-ansible-CentOS-SIG-PaaS
+        dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
+      - src: origin/repos/openshift-ansible-centos-paas-sig.repo
+        dest: /etc/yum.repos.d/CentOS-OpenShift-Origin.repo
+      notify: refresh cache
+      when:
+      - ansible_os_family == "RedHat"
+      - ansible_distribution != "Fedora"
+      - openshift_deployment_type == 'origin'
+      - openshift_enable_origin_repo | default(true) | bool
+
     - name: Ensure clean repo cache in the event repos have been changed manually
       debug:
         msg: "First run of openshift_repos"
       changed_when: true
       notify: refresh cache
 
-    - name: Set fact r_osr_first_run false
+    - name: Record that openshift_repos already ran
       set_fact:
-        r_osr_first_run: false
+        r_openshift_repos_has_run: True
 
   # Force running ALL handlers now, because we expect repo cache to be cleared
   # if changes have been made.
   - meta: flush_handlers
-
-  when: not ostree_booted.stat.exists


### PR DESCRIPTION
AIUI there are things in openshift_facts and other roles that actually do need to run repeatedly. However it seems like at least some of the tasks that we see multiple times could be skipped after the first time. This is an attempt to do that for some of them, to reduce iterative development time if nothing else.