### PR TITLE
Improve configurability of registry and registry-console hosts

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -378,6 +378,11 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_cockpit_deployer_prefix=registry.example.com/myrepo/
 # Override image version, defaults to latest for origin, matches the product version for enterprise
 #openshift_cockpit_deployer_version=1.4.1
+#
+# Registry console host (optional)
+# The host for the registry console route
+# Default value: 'registry-console-default.{{openshift_master_default_subdomain}}'
+#openshift_cockpit_registry_console_routehost=registry-console-default.example.org
 
 # Openshift Registry Options
 #

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -400,6 +400,11 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Default value: 'region=infra'
 #openshift_hosted_registry_selector='region=infra'
 #
+# Registry host (optional)
+# The host for the registry route
+# Default value: 'docker-registry-default.{{openshift_master_default_subdomain}}'
+#openshift_hosted_registry_routehost=docker-registry-default.example.org
+#
 # Registry replicas (optional)
 # Unless specified, openshift-ansible will calculate the replica count
 # based on the number of nodes matching the openshift registry selector.

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -378,6 +378,11 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_cockpit_deployer_prefix=registry.example.com/myrepo/
 # Override image version, defaults to latest for origin, matches the product version for enterprise
 #openshift_cockpit_deployer_version=1.4.1
+#
+# Registry console host (optional)
+# The host for the registry console route
+# Default value: 'registry-console-default.{{openshift_master_default_subdomain}}'
+#openshift_cockpit_registry_console_routehost=registry-console-default.example.org
 
 # Openshift Registry Options
 #

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -400,6 +400,11 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Default value: 'region=infra'
 #openshift_hosted_registry_selector='region=infra'
 #
+# Registry host (optional)
+# The host for the registry route
+# Default value: 'docker-registry-default.{{openshift_master_default_subdomain}}'
+#openshift_hosted_registry_routehost=docker-registry-default.example.org
+#
 # Registry replicas (optional)
 # Unless specified, openshift-ansible will calculate the replica count
 # based on the number of nodes matching the openshift registry selector.

--- a/roles/cockpit-ui/tasks/main.yml
+++ b/roles/cockpit-ui/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 - block:
 
+  - name: Set fact docker_registry_console_route_hostname
+    set_fact:
+      docker_registry_console_route_hostname: "{{ 'registry-console-default.' ~ (openshift_master_default_subdomain | default('router.default.svc.cluster.local', true)) }}"
+
   # When openshift_hosted_manage_registry=true the openshift_hosted
   # role will create the appropriate route for the docker-registry.
   # When openshift_hosted_manage_registry=false then this code will
@@ -21,6 +25,7 @@
       service_name: registry-console
       state: present
       tls_termination: passthrough
+      host: "{{ openshift_cockpit_registry_console_routehost | default(docker_registry_console_route_hostname) }}"
     register: registry_console_cockpit_kube
 
   # XXX: Required for items still using command

--- a/roles/openshift_hosted/tasks/registry/secure.yml
+++ b/roles/openshift_hosted/tasks/registry/secure.yml
@@ -55,6 +55,7 @@
     - "{{ docker_registry_service_ip.results.clusterip }}"
     - "{{ openshift_hosted_registry_name }}.default.svc"
     - "{{ openshift_hosted_registry_name }}.default.svc.{{ openshift.common.dns_domain }}"
+    - "{{ openshift_hosted_registry_routehost | default(omit) }}"
     - "{{ docker_registry_route_hostname }}"
     cert: "{{ openshift_master_config_dir }}/registry.crt"
     key: "{{ openshift_master_config_dir }}/registry.key"


### PR DESCRIPTION
This adds missing docs on the registry host route variable that can be specified to customize the host on the registry route.
Additionally, it adds the ability to customize the registry-console route host which allows to get something other than the provided default.