### PR TITLE
Fix python3 error in repoquery

### DIFF
--- a/roles/lib_utils/library/repoquery.py
+++ b/roles/lib_utils/library/repoquery.py
@@ -465,7 +465,7 @@ class Repoquery(RepoqueryCLI):
 
         version_dict = defaultdict(dict)
 
-        for version in query_output.split('\n'):
+        for version in query_output.decode().split('\n'):
             pkg_info = version.split("|")
 
             pkg_version = {}

--- a/roles/lib_utils/src/class/repoquery.py
+++ b/roles/lib_utils/src/class/repoquery.py
@@ -48,7 +48,7 @@ class Repoquery(RepoqueryCLI):
 
         version_dict = defaultdict(dict)
 
-        for version in query_output.split('\n'):
+        for version in query_output.decode().split('\n'):
             pkg_info = version.split("|")
 
             pkg_version = {}

--- a/roles/lib_utils/src/test/unit/test_repoquery.py
+++ b/roles/lib_utils/src/test/unit/test_repoquery.py
@@ -45,7 +45,7 @@ class RepoQueryTest(unittest.TestCase):
 
         # Return values of our mocked function call. These get returned once per call.
         mock_cmd.side_effect = [
-            (0, '4.2.46|21.el7_3|x86_64|rhel-7-server-rpms|4.2.46-21.el7_3', valid_stderr),  # first call to the mock
+            (0, b'4.2.46|21.el7_3|x86_64|rhel-7-server-rpms|4.2.46-21.el7_3', valid_stderr),  # first call to the mock
         ]
 
         # Act


### PR DESCRIPTION
Explicitly convert from bytes to string so that splitting the string is
successful. This change works with python 2 as well.

Closes #4182