### PR TITLE
Add docker package for container-engine install

### DIFF
--- a/roles/docker/tasks/systemcontainer_docker.yml
+++ b/roles/docker/tasks/systemcontainer_docker.yml
@@ -27,6 +27,20 @@
     state: present
   when: not openshift.common.is_atomic | bool
 
+# Make sure Docker is installed so we are able to use the client
+- name: Install Docker so we can use the client
+  package: name=docker{{ '-' + docker_version if docker_version is defined else '' }} state=present
+  when: not openshift.common.is_atomic | bool
+
+# Make sure docker is disabled. Errors are ignored.
+- name: Disable Docker
+  systemd:
+    name: docker
+    enabled: no
+    state: stopped
+    daemon_reload: yes
+  ignore_errors: True
+
 # Set http_proxy and https_proxy in /etc/atomic.conf
 - block:
 
@@ -78,17 +92,7 @@
   command: "atomic pull --storage ostree {{ l_docker_image }}"
   changed_when: false
 
-# Make sure docker is disabled Errors are ignored as docker may not
-# be installed.
-- name: Disable Docker
-  systemd:
-    name: docker
-    enabled: no
-    state: stopped
-    daemon_reload: yes
-  ignore_errors: True
-
-- name: Ensure docker.service.d directory exists
+- name: Ensure container-engine.service.d directory exists
   file:
     path: "{{ container_engine_systemd_dir }}"
     state: directory

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1302,7 +1302,7 @@ def get_version_output(binary, version_cmd):
 def get_docker_version_info():
     """ Parses and returns the docker version info """
     result = None
-    if is_service_running('docker'):
+    if is_service_running('docker') or is_service_running('container-engine'):
         version_info = yaml.safe_load(get_version_output('/usr/bin/docker', 'version'))
         if 'Server' in version_info:
             result = {


### PR DESCRIPTION
The package is required so that openshift_facts is able to use the
docker client to gain information on the versions.