### PR TITLE
Fixed for python3 with Fedora 25 Atomic

### DIFF
--- a/roles/openshift_logging/library/openshift_logging_facts.py
+++ b/roles/openshift_logging/library/openshift_logging_facts.py
@@ -37,7 +37,7 @@ LOGGING_INFRA_KEY = "logging-infra"
 # selectors for filtering resources
 DS_FLUENTD_SELECTOR = LOGGING_INFRA_KEY + "=" + "fluentd"
 LOGGING_SELECTOR = LOGGING_INFRA_KEY + "=" + "support"
-ROUTE_SELECTOR = "component=support, logging-infra=support, provider=openshift"
+ROUTE_SELECTOR = "component=support,logging-infra=support,provider=openshift"
 COMPONENTS = ["kibana", "curator", "elasticsearch", "fluentd", "kibana_ops", "curator_ops", "elasticsearch_ops"]
 
 


### PR DESCRIPTION
This is not the only required fix, but this does fix one of the many issues.

The route command fails 
fatal: [master-3.example.com]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "admin_kubeconfig": "/tmp/openshift-logging-ansible-N3Dgbv/admin.kubeconfig", 
            "oc_bin": "/usr/local/bin/oc", 
            "openshift_logging_namespace": "logging"
        }, 
        "module_name": "openshift_logging_facts"
    }
}

MSG:

There was an exception trying to run the command '/usr/local/bin/oc get routes -n logging --user=system:admin/master-example-com:8443 --config=/tmp/openshift-logging-ansible-N3Dgbv/admin.kubeconfig -o json -l component=support, logging-infra=support, provider=openshift' 

When you try this command from the command line the error is as follows 
/usr/local/bin/oc get routes -n logging  config -o json -l component=support, logging-infra=support, provider=openshift
error: the provided selector "component=support," is not valid: found '', expected: identifier after ','

Removing the spaces resolves the issue. 
/usr/local/bin/oc get routes -n logging -o json -l component=support,logging-infra=support,provider=openshift




