### PR TITLE
uninstall: handle container-engine

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -305,8 +305,15 @@
   - shell: systemctl daemon-reload
     changed_when: False
 
+  - name: restart container-engine
+    service: name=container-engine state=restarted
+    ignore_errors: true
+    register: container_engine
+
   - name: restart docker
     service: name=docker state=restarted
+    ignore_errors: true
+    when: "container_engine.state != 'started'"
 
   - name: restart NetworkManager
     service: name=NetworkManager state=restarted


### PR DESCRIPTION
Try to restart the docker service only when there is not already
a running container-engine service.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>