### PR TITLE
container-engine: Use dest instead of path for lineinfile

### DIFF
--- a/roles/docker/tasks/systemcontainer_docker.yml
+++ b/roles/docker/tasks/systemcontainer_docker.yml
@@ -46,7 +46,7 @@
 
     - name: Add http_proxy to /etc/atomic.conf
       lineinfile:
-        path: /etc/atomic.conf
+        dest: /etc/atomic.conf
         line: "http_proxy={{ openshift.common.http_proxy | default('') }}"
       when:
         - openshift.common.http_proxy is defined
@@ -54,7 +54,7 @@
 
     - name: Add https_proxy to /etc/atomic.conf
       lineinfile:
-        path: /etc/atomic.conf
+        dest: /etc/atomic.conf
         line: "https_proxy={{ openshift.common.https_proxy | default('') }}"
       when:
         - openshift.common.https_proxy is defined


### PR DESCRIPTION
path has been changed to dest to support pre 2.3 releases of ansible.
For more information see: http://docs.ansible.com/ansible/lineinfile_module.html