### PR TITLE
Don't set-up origin repositories if they've already been configured

### DIFF
--- a/roles/openshift_repos/tasks/main.yaml
+++ b/roles/openshift_repos/tasks/main.yaml
@@ -24,15 +24,19 @@
     - openshift_additional_repos | length == 0
     notify: refresh cache
 
+  # Note: OpenShift repositories under CentOS may be shipped through the
+  # "centos-release-openshift-origin" package which configures the repository.
+  # This task matches the file names provided by the package so that they are
+  # not installed twice in different files and remains idempotent.
   - name: Configure origin gpg keys if needed
     copy:
       src: "{{ item.src }}"
       dest: "{{ item.dest }}"
     with_items:
     - src: origin/gpg_keys/openshift-ansible-CentOS-SIG-PaaS
-      dest: /etc/pki/rpm-gpg/
+      dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
     - src: origin/repos/openshift-ansible-centos-paas-sig.repo
-      dest: /etc/yum.repos.d/
+      dest: /etc/yum.repos.d/CentOS-OpenShift-Origin.repo
     notify: refresh cache
     when:
     - ansible_os_family == "RedHat"


### PR DESCRIPTION
CentOS ships the 'centos-release-openshift-origin' package which is
used to set up the repository and the key. If this package has been
installed prior to running openshift-ansible (i.e, to install
ansible or openshift-ansible from RPM), it leads to the repository
being set up twice in different files.

We're now matching the name of the files and since they are identical,
it will stay idempotent while not configuring the repositories twice.