### PR TITLE
Filter non-strings from the oc_adm_ca_server_cert hostnames parameter.

### DIFF
--- a/roles/lib_openshift/library/oc_adm_ca_server_cert.py
+++ b/roles/lib_openshift/library/oc_adm_ca_server_cert.py
@@ -1534,6 +1534,10 @@ class CAServerCert(OpenShiftCLI):
     def run_ansible(params, check_mode):
         '''run the idempotent ansible code'''
 
+        # Filter non-strings from hostnames list s.t. the omit filter
+        # may be used to conditionally add a hostname.
+        params['hostnames'] = [host for host in params['hostnames'] if isinstance(host, string_types)]
+
         config = CAServerCertConfig(params['kubeconfig'],
                                     params['debug'],
                                     {'cert':          {'value': params['cert'], 'include': True},
@@ -1582,6 +1586,10 @@ class CAServerCert(OpenShiftCLI):
 # -*- -*- -*- End included fragment: class/oc_adm_ca_server_cert.py -*- -*- -*-
 
 # -*- -*- -*- Begin included fragment: ansible/oc_adm_ca_server_cert.py -*- -*- -*-
+
+
+# pylint: disable=wrong-import-position
+from ansible.module_utils.six import string_types
 
 def main():
     '''

--- a/roles/lib_openshift/src/ansible/oc_adm_ca_server_cert.py
+++ b/roles/lib_openshift/src/ansible/oc_adm_ca_server_cert.py
@@ -1,6 +1,10 @@
 # pylint: skip-file
 # flake8: noqa
 
+
+# pylint: disable=wrong-import-position
+from ansible.module_utils.six import string_types
+
 def main():
     '''
     ansible oc adm module for ca create-server-cert

--- a/roles/lib_openshift/src/class/oc_adm_ca_server_cert.py
+++ b/roles/lib_openshift/src/class/oc_adm_ca_server_cert.py
@@ -96,6 +96,10 @@ class CAServerCert(OpenShiftCLI):
     def run_ansible(params, check_mode):
         '''run the idempotent ansible code'''
 
+        # Filter non-strings from hostnames list s.t. the omit filter
+        # may be used to conditionally add a hostname.
+        params['hostnames'] = [host for host in params['hostnames'] if isinstance(host, string_types)]
+
         config = CAServerCertConfig(params['kubeconfig'],
                                     params['debug'],
                                     {'cert':          {'value': params['cert'], 'include': True},


### PR DESCRIPTION
This allows the omit filter to be used in the hostnames parameter list
which simplifies conditionally added hostnames.

Note: I've added the additional import to `src/ansible/oc_adm_ca_server_cert.py` rather than the global/base imports file so that the new import only affects the `oc_adm_ca_server_cert` module.