### PR TITLE
Default image policy on new clusters to on

### DIFF
--- a/roles/openshift_master_facts/defaults/main.yml
+++ b/roles/openshift_master_facts/defaults/main.yml
@@ -1,2 +1,24 @@
 ---
 openshift_master_default_subdomain: "{{ lookup('oo_option', 'openshift_master_default_subdomain') | default(None, true) }}"
+openshift_master_admission_plugin_config:
+  openshift.io/ImagePolicy:
+    configuration:
+      kind: ImagePolicyConfig
+      apiVersion: v1
+      # To require that all images running on the platform be imported first, you may uncomment the
+      # following rule. Any image that refers to a registry outside of OpenShift will be rejected unless it
+      # unless it points directly to an image digest (myregistry.com/myrepo/image@sha256:ea83bcf...) and that
+      # digest has been imported via the import-image flow.
+      #resolveImages: Required
+      executionRules:
+      - name: execution-denied
+        # Reject all images that have the annotation images.openshift.io/deny-execution set to true.
+        # This annotation may be set by infrastructure that wishes to flag particular images as dangerous
+        onResources:
+        - resource: pods
+        - resource: builds
+        reject: true
+        matchImageAnnotations:
+        - key: images.openshift.io/deny-execution
+          value: "true"
+        skipOnResolutionFailure: true

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -92,7 +92,7 @@
       master_count: "{{ openshift_master_count | default(None) }}"
       controller_lease_ttl: "{{ osm_controller_lease_ttl | default(None) }}"
       master_image: "{{ osm_image | default(None) }}"
-      admission_plugin_config: "{{openshift_master_admission_plugin_config | default(None) }}"
+      admission_plugin_config: "{{openshift_master_admission_plugin_config }}"
       kube_admission_plugin_config: "{{openshift_master_kube_admission_plugin_config | default(None) }}"  # deprecated, merged with admission_plugin_config
       oauth_template: "{{ openshift_master_oauth_template | default(None) }}"  # deprecated in origin 1.2 / OSE 3.2
       oauth_templates: "{{ openshift_master_oauth_templates | default(None) }}"


### PR DESCRIPTION
Will allow for default image resolution to be used in openshift/origin#13210. We should have had this on from 1.4 onwards.