### PR TITLE
Don't escalate privileges in local tmpdir creation

### DIFF
--- a/roles/openshift_logging/tasks/main.yaml
+++ b/roles/openshift_logging/tasks/main.yaml
@@ -28,6 +28,7 @@
   register: local_tmp
   changed_when: False
   check_mode: no
+  become: no
 
 - debug: msg="Created local temp dir {{local_tmp.stdout}}"
 


### PR DESCRIPTION
When running `ansible-playbook` as a non-root user, if a local temporary
directory is created without explicitly not escalating privileges, the
directory will not be readable to the user running the playbook on the
controller host, which will lead to tasks like `fetch` failing to place
files into the directory.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @jcantrill @ewolinetz @abutcher 