### PR TITLE
Remove use of local_action with delegate_to

### DIFF
--- a/roles/etcd_client_certificates/tasks/main.yml
+++ b/roles/etcd_client_certificates/tasks/main.yml
@@ -84,7 +84,6 @@
   register: g_etcd_client_mktemp
   changed_when: False
   when: etcd_client_certs_missing | bool
-  delegate_to: localhost
   become: no
 
 - name: Create a tarball of the etcd certs
@@ -133,8 +132,7 @@
   when: etcd_client_certs_missing | bool
 
 - name: Delete temporary directory
-  file: name={{ g_etcd_client_mktemp.stdout }} state=absent
+  local_action: file path="{{ g_etcd_client_mktemp.stdout }}" state=absent
   changed_when: False
   when: etcd_client_certs_missing | bool
-  delegate_to: localhost
   become: no

--- a/roles/etcd_server_certificates/tasks/main.yml
+++ b/roles/etcd_server_certificates/tasks/main.yml
@@ -107,7 +107,6 @@
   register: g_etcd_server_mktemp
   changed_when: False
   when: etcd_server_certs_missing | bool
-  delegate_to: localhost
 
 - name: Create a tarball of the etcd certs
   command: >
@@ -176,11 +175,10 @@
   when: etcd_server_certs_missing | bool
 
 - name: Delete temporary directory
-  file: name={{ g_etcd_server_mktemp.stdout }} state=absent
+  local_action: file path="{{ g_etcd_server_mktemp.stdout }}" state=absent
   become: no
   changed_when: False
   when: etcd_server_certs_missing | bool
-  delegate_to: localhost
 
 - name: Validate permissions on certificate files
   file:

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -124,7 +124,6 @@
   register: g_master_certs_mktemp
   changed_when: False
   when: master_certs_missing | bool
-  delegate_to: localhost
   become: no
 
 - name: Create a tarball of the master certs
@@ -158,10 +157,10 @@
     dest: "{{ openshift_master_config_dir }}"
   when: master_certs_missing | bool and inventory_hostname != openshift_ca_host
 
-- file: name={{ g_master_certs_mktemp.stdout }} state=absent
+- name: Delete local temp directory
+  local_action: file path="{{ g_master_certs_mktemp.stdout }}" state=absent
   changed_when: False
   when: master_certs_missing | bool
-  delegate_to: localhost
   become: no
 
 - name: Lookup default group for ansible_ssh_user

--- a/roles/openshift_node_certificates/tasks/main.yml
+++ b/roles/openshift_node_certificates/tasks/main.yml
@@ -103,7 +103,6 @@
   register: node_cert_mktemp
   changed_when: False
   when: node_certs_missing | bool
-  delegate_to: localhost
   become: no
 
 - name: Create a tarball of the node config directories
@@ -141,10 +140,10 @@
     dest: "{{ openshift_node_cert_dir }}"
   when: node_certs_missing | bool
 
-- file: name={{ node_cert_mktemp.stdout }} state=absent
+- name: Delete local temp directory
+  local_action: file path="{{ node_cert_mktemp.stdout }}" state=absent
   changed_when: False
   when: node_certs_missing | bool
-  delegate_to: localhost
   become: no
 
 - name: Copy OpenShift CA to system CA trust


### PR DESCRIPTION
Remove use of local_action with delegate_to and switch 'delegate_to: localhost' temporary directory cleanup actions to local_actions.

re: discussion in #4205