### PR TITLE
node, systemd: change Requires to Wants for openvswitch

### DIFF
--- a/roles/openshift_node/templates/openshift.docker.node.service
+++ b/roles/openshift_node/templates/openshift.docker.node.service
@@ -5,7 +5,7 @@ After=openvswitch.service
 PartOf={{ openshift.docker.service_name }}.service
 Requires={{ openshift.docker.service_name }}.service
 {% if openshift.common.use_openshift_sdn %}
-Requires=openvswitch.service
+Wants=openvswitch.service
 After=ovsdb-server.service
 After=ovs-vswitchd.service
 {% endif %}

--- a/roles/openshift_node_upgrade/templates/openshift.docker.node.service
+++ b/roles/openshift_node_upgrade/templates/openshift.docker.node.service
@@ -5,7 +5,7 @@ After=openvswitch.service
 PartOf={{ openshift.docker.service_name }}.service
 Requires={{ openshift.docker.service_name }}.service
 {% if openshift.common.use_openshift_sdn %}
-Requires=openvswitch.service
+Wants=openvswitch.service
 {% endif %}
 Wants={{ openshift.common.service_type }}-master.service
 Requires={{ openshift.common.service_type }}-node-dep.service


### PR DESCRIPTION
Sometimes the node container is not started on a container-engine
restart.  Use a weaker dependency on openvswitch that is causing this issue

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1451192

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>