### PR TITLE
systemcontainercustom.conf.j2: use Environment instead of ENVIRONMENT

### DIFF
--- a/roles/docker/templates/systemcontainercustom.conf.j2
+++ b/roles/docker/templates/systemcontainercustom.conf.j2
@@ -2,13 +2,13 @@
 
 [Service]
 {% if "http_proxy" in openshift.common %}
-ENVIRONMENT=HTTP_PROXY={{ docker_http_proxy }}
+Environment=HTTP_PROXY={{ docker_http_proxy }}
 {% endif -%}
 {% if "https_proxy" in openshift.common %}
-ENVIRONMENT=HTTPS_PROXY={{ docker_http_proxy }}
+Environment=HTTPS_PROXY={{ docker_http_proxy }}
 {% endif -%}
 {% if "no_proxy" in openshift.common %}
-ENVIRONMENT=NO_PROXY={{ docker_no_proxy }}
+Environment=NO_PROXY={{ docker_no_proxy }}
 {% endif %}
 {%- if os_firewall_use_firewalld|default(false) %}
 [Unit]


### PR DESCRIPTION
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1451187

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>