### PR TITLE
Uninstall: restart docker when container-engine restart hasn't changed.

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -313,7 +313,7 @@
   - name: restart docker
     service: name=docker state=restarted
     ignore_errors: true
-    when: "container_engine.state != 'started'"
+    when: not (container_engine | changed)
 
   - name: restart NetworkManager
     service: name=NetworkManager state=restarted


### PR DESCRIPTION
The result of restarting container engine won't have a 'state' field when container-engine doesn't exist on the system. Restart docker when container-engine restart did not result in a change.

Fixes #4215