### PR TITLE
Update examples to include metrics deployer version

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -521,6 +521,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Currently, you may only alter the hostname portion of the url, alterting the
 # `/hawkular/metrics` path will break installation of metrics.
 #openshift_hosted_metrics_public_url=https://hawkular-metrics.example.com/hawkular/metrics
+# Configure the prefix and version for the component images
+#openshift_hosted_metrics_deployer_prefix=docker.io/openshift/origin-
+#openshift_hosted_metrics_deployer_version=3.6.0
 
 # Logging deployment
 #

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -522,6 +522,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Currently, you may only alter the hostname portion of the url, alterting the
 # `/hawkular/metrics` path will break installation of metrics.
 #openshift_hosted_metrics_public_url=https://hawkular-metrics.example.com/hawkular/metrics
+# Configure the prefix and version for the component images
+#openshift_hosted_metrics_deployer_prefix=registry.example.com:8888/openshift3/
+#openshift_hosted_metrics_deployer_version=3.6.0
 
 # Logging deployment
 #


### PR DESCRIPTION
Without this we can have a mismatch between the OpenShift version and
the metrics version.

Fixes https://github.com/openshift/origin/issues/13532