### PR TITLE
Fix Centos PaaS SIG GPG path

### DIFF
--- a/roles/openshift_repos/files/origin/repos/openshift-ansible-centos-paas-sig.repo
+++ b/roles/openshift_repos/files/origin/repos/openshift-ansible-centos-paas-sig.repo
@@ -3,7 +3,7 @@ name=CentOS OpenShift Origin
 baseurl=http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/
 enabled=1
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/openshift-ansible-CentOS-SIG-PaaS
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 
 [centos-openshift-origin-testing]
 name=CentOS OpenShift Origin Testing


### PR DESCRIPTION
#4196 changed where we drop the gpg key but the repo wasn't similarly updated