### PR TITLE
Use volume.beta.kubernetes.io annotation for storage-classes

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -217,7 +217,7 @@
     access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
     pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
     annotations:
-      volume.alpha.kubernetes.io/storage-class: "dynamic"
+      volume.beta.kubernetes.io/storage-class: "dynamic"
   when:
   - openshift_logging_elasticsearch_storage_type == "pvc"
   - openshift_logging_elasticsearch_pvc_dynamic

--- a/roles/openshift_metrics/tasks/install_cassandra.yaml
+++ b/roles/openshift_metrics/tasks/install_cassandra.yaml
@@ -50,7 +50,7 @@
     labels:
       metrics-infra: hawkular-cassandra
     annotations:
-      volume.alpha.kubernetes.io/storage-class: dynamic
+      volume.beta.kubernetes.io/storage-class: dynamic
     access_modes: "{{ openshift_metrics_cassandra_pvc_access | list }}"
     size: "{{ openshift_metrics_cassandra_pvc_size }}"
   with_sequence: count={{ openshift_metrics_cassandra_replicas }}


### PR DESCRIPTION
As of kubernetes 1.4 the storage-class annotation is promoted to beta. This change should (most likely) be included in the release-1.5 branch as well.