### PR TITLE
Fix creation of tmp Directory on localhost

### DIFF
--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -25,6 +25,7 @@
   local_action: command mktemp -d
   register: local_tmp
   changed_when: False
+  become: false
 
 - name: Copy the admin client config(s)
   command: >


### PR DESCRIPTION
When I run an openshift-ansible deployment with `ansible-playbook -b ....` Ansible tries to create an  tmp directory on the localhost with `root` which isnt necessary / fails if the user starting the Ansible Run doesn't have `root` privileges on the localhost he is using.

This patches solves this issue by not becoming `root` for creating a `tmp` directory on the localhost.