### PR TITLE
add mux docs; allow to specify mux namespaces

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -124,3 +124,34 @@ Elasticsearch OPS too, if using an OPS cluster:
 - `openshift_logging_es_ops_ca_ext`: The location of the CA cert for the cert
   Elasticsearch uses for the external TLS server cert (default is the internal
   CA)
+
+### mux - secure_forward listener service
+- `openshift_logging_use_mux`: Default `False`.  If this is `True`, a service
+  called `mux` will be deployed.  This service will act as a Fluentd
+  secure_forward forwarder for the node agent Fluentd daemonsets running in the
+  cluster.  This can be used to reduce the number of connections to the
+  OpenShift API server, by using `mux` and configuring each node Fluentd to
+  send raw logs to mux and turn off the k8s metadata plugin.
+- `openshift_logging_mux_allow_external`: Default `False`.  If this is `True`,
+  the `mux` service will be deployed, and it will be configured to allow
+  Fluentd clients running outside of the cluster to send logs using
+  secure_forward.  This allows OpenShift logging to be used as a central
+  logging service for clients other than OpenShift, or other OpenShift
+  clusters.
+- `openshift_logging_use_mux_client`: Default `False`.  If this is `True`, the
+  node agent Fluentd services will be configured to send logs to the mux
+  service rather than directly to Elasticsearch.
+- `openshift_logging_mux_hostname`: Default is "mux." +
+  `openshift_master_default_subdomain`.  This is the hostname *external*_
+  clients will use to connect to mux, and will be used in the TLS server cert
+  subject.
+- `openshift_logging_mux_port`: 24284
+- `openshift_logging_mux_cpu_limit`: 100m
+- `openshift_logging_mux_memory_limit`: 512Mi
+- `openshift_logging_mux_default_namespaces`: Default `["mux-undefined"]` - the
+ first value in the list is the namespace to use for undefined projects,
+ followed by any additional namespaces to create by default - users will
+ typically not need to set this
+- `openshift_logging_mux_namespaces`: Default `[]` - additional namespaces to
+  create for _external_ mux clients to associate with their logs - users will
+  need to set this

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -160,8 +160,13 @@ openshift_logging_use_mux: "{{ openshift_logging_mux_allow_external | default(Fa
 openshift_logging_use_mux_client: False
 openshift_logging_mux_hostname: "{{ 'mux.' ~ (openshift_master_default_subdomain | default('router.default.svc.cluster.local', true)) }}"
 openshift_logging_mux_port: 24284
-openshift_logging_mux_cpu_limit: 100m
-openshift_logging_mux_memory_limit: 512Mi
+openshift_logging_mux_cpu_limit: 500m
+openshift_logging_mux_memory_limit: 1Gi
+# the namespace to use for undefined projects should come first, followed by any
+# additional namespaces to create by default - users will typically not need to set this
+openshift_logging_mux_default_namespaces: ["mux-undefined"]
+# extra namespaces to create for mux clients - users will need to set this
+openshift_logging_mux_namespaces: []
 
 # following can be uncommented to provide values for configmaps -- take care when providing file contents as it may cause your cluster to not operate correctly
 #es_logging_contents:

--- a/roles/openshift_logging/tasks/generate_certs.yaml
+++ b/roles/openshift_logging/tasks/generate_certs.yaml
@@ -125,7 +125,7 @@
     - system.logging.mux
   loop_control:
     loop_var: node_name
-  when: openshift_logging_use_mux
+  when: openshift_logging_use_mux | bool
 
 - name: Generate PEM cert for Elasticsearch external route
   include: generate_pems.yaml component={{node_name}}

--- a/roles/openshift_logging_mux/defaults/main.yml
+++ b/roles/openshift_logging_mux/defaults/main.yml
@@ -9,8 +9,8 @@ openshift_logging_mux_namespace: logging
 
 ### Common settings
 openshift_logging_mux_nodeselector: "{{ openshift_hosted_logging_mux_nodeselector_label | default('') | map_from_pairs }}"
-openshift_logging_mux_cpu_limit: 100m
-openshift_logging_mux_memory_limit: 512Mi
+openshift_logging_mux_cpu_limit: 500m
+openshift_logging_mux_memory_limit: 1Gi
 
 openshift_logging_mux_replicas: 1
 
@@ -26,9 +26,14 @@ openshift_logging_mux_use_journal: "{{ openshift_hosted_logging_use_journal | de
 openshift_logging_mux_journal_source: "{{ openshift_hosted_logging_journal_source | default('') }}"
 openshift_logging_mux_journal_read_from_head: "{{ openshift_hosted_logging_journal_read_from_head | default('') }}"
 
-openshift_logging_mux_allow_external: false
+openshift_logging_mux_allow_external: False
 openshift_logging_mux_hostname: "{{ 'mux.' ~ (openshift_master_default_subdomain | default('router.default.svc.cluster.local', true)) }}"
 openshift_logging_mux_port: 24284
+# the namespace to use for undefined projects should come first, followed by any
+# additional namespaces to create by default - users will typically not need to set this
+openshift_logging_mux_default_namespaces: ["mux-undefined"]
+# extra namespaces to create for mux clients - users will need to set this
+openshift_logging_mux_namespaces: []
 
 openshift_logging_mux_app_client_cert: /etc/fluent/keys/cert
 openshift_logging_mux_app_client_key: /etc/fluent/keys/key

--- a/roles/openshift_logging_mux/tasks/main.yaml
+++ b/roles/openshift_logging_mux/tasks/main.yaml
@@ -130,16 +130,14 @@
     selector:
       component: mux
       provider: openshift
-    # pending #4091
-    #labels:
-    #- logging-infra: 'support'
+    labels:
+      logging-infra: 'support'
     ports:
     - name: mux-forward
       port: "{{ openshift_logging_mux_port }}"
       targetPort: "mux-forward"
-  # pending #4091
-  #  externalIPs:
-  #  - "{{ ansible_eth0.ipv4.address }}"
+    external_ips:
+    - "{{ ansible_eth0.ipv4.address }}"
   when: openshift_logging_mux_allow_external | bool
 
 - name: Set logging-mux service for internal communication
@@ -150,9 +148,8 @@
     selector:
       component: mux
       provider: openshift
-    # pending #4091
-    #labels:
-    #- logging-infra: 'support'
+    labels:
+      logging-infra: 'support'
     ports:
     - name: mux-forward
       port: "{{ openshift_logging_mux_port }}"
@@ -189,6 +186,13 @@
     files:
     - "{{ tempdir }}/templates/logging-mux-dc.yaml"
     delete_after: true
+
+- name: Add mux namespaces
+  oc_project:
+    state: present
+    name: "{{ item }}"
+    node_selector: ""
+  with_items: "{{ openshift_logging_mux_namespaces | union(openshift_logging_mux_default_namespaces) }}"
 
 - name: Delete temp directory
   file:


### PR DESCRIPTION
This adds the necessary documentation for the mux parameters and
behavior.  This also adds new parameters which allow to specify
the namespaces mux must create by default, and which can be
optionally added.
This casts openshift_logging_use_mux to bool wherever it is used
as a boolean.
@jcantrill @ewolinetz @nhosoi PTAL