### PR TITLE
allow to configure oreg_url specifically for node or master. refs #4233

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -127,6 +127,10 @@ openshift_release=v3.6
 
 
 # Alternate image format string, useful if you've got your own registry mirror
+# Configure this setting just on node or master
+#oreg_url_master=example.com/openshift3/ose-${component}:${version}
+#oreg_url_node=example.com/openshift3/ose-${component}:${version}
+# For setting the configuration globally
 #oreg_url=example.com/openshift3/ose-${component}:${version}
 # If oreg_url points to a registry other than registry.access.redhat.com we can
 # modify image streams to point at that registry by setting the following to true

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -125,8 +125,11 @@ openshift_release=v3.6
 # Tasks to run after each master is upgraded and system/services have been restarted.
 # openshift_master_upgrade_post_hook=/usr/share/custom/post_master.yml
 
-
 # Alternate image format string, useful if you've got your own registry mirror
+# Configure this setting just on node or master
+#oreg_url_master=example.com/openshift3/ose-${component}:${version}
+#oreg_url_node=example.com/openshift3/ose-${component}:${version}
+# For setting the configuration globally
 #oreg_url=example.com/openshift3/ose-${component}:${version}
 # If oreg_url points to a registry other than registry.access.redhat.com we can
 # modify image streams to point at that registry by setting the following to true

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -107,8 +107,8 @@
     yedit:
       src: "{{ openshift.common.config_base }}/master/master-config.yaml"
       key: 'imageConfig.format'
-      value: "{{ oreg_url }}"
-    when: oreg_url is defined
+      value: "{{ oreg_url | default(oreg_url_master) }}"
+    when: oreg_url is defined or oreg_url_master is defined
 
   # Run the upgrade hook prior to restarting services/system if defined:
   - debug: msg="Running master upgrade hook {{ openshift_master_upgrade_hook }}"

--- a/roles/openshift_master/README.md
+++ b/roles/openshift_master/README.md
@@ -15,17 +15,18 @@ Role Variables
 
 From this role:
 
-| Name                                | Default value         |                                                  |
-|-------------------------------------|-----------------------|--------------------------------------------------|
-| openshift_master_debug_level        | openshift_debug_level | Verbosity of the debug logs for master |
+| Name                                | Default value         |                                                                               |
+|-------------------------------------|-----------------------|-------------------------------------------------------------------------------|
+| openshift_master_debug_level        | openshift_debug_level | Verbosity of the debug logs for master                                        |
 | openshift_node_ips                  | []                    | List of the openshift node ip addresses to pre-register when master starts up |
-| oreg_url                            | UNDEF                 | Default docker registry to use |
-| openshift_master_api_port           | UNDEF                 | |
-| openshift_master_console_port       | UNDEF                 | |
-| openshift_master_api_url            | UNDEF                 | |
-| openshift_master_console_url        | UNDEF                 | |
-| openshift_master_public_api_url     | UNDEF                 | |
-| openshift_master_public_console_url | UNDEF                 | |
+| oreg_url                            | UNDEF                 | Default docker registry to use                                                |
+| oreg_url_master                     | UNDEF                 | Default docker registry to use, specifically on the master                    |
+| openshift_master_api_port           | UNDEF                 |                                                                               |
+| openshift_master_console_port       | UNDEF                 |                                                                               |
+| openshift_master_api_url            | UNDEF                 |                                                                               |
+| openshift_master_console_url        | UNDEF                 |                                                                               |
+| openshift_master_public_api_url     | UNDEF                 |                                                                               |
+| openshift_master_public_console_url | UNDEF                 |                                                                               |
 
 From openshift_common:
 

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -74,7 +74,7 @@
       ldap_ca: "{{ openshift_master_ldap_ca | default(lookup('file', openshift_master_ldap_ca_file) if openshift_master_ldap_ca_file is defined else None) }}"
       openid_ca: "{{ openshift_master_openid_ca | default(lookup('file', openshift_master_openid_ca_file) if openshift_master_openid_ca_file is defined else None) }}"
       request_header_ca: "{{ openshift_master_request_header_ca | default(lookup('file', openshift_master_request_header_ca_file) if openshift_master_request_header_ca_file is defined else None) }}"
-      registry_url: "{{ oreg_url | default(None) }}"
+      registry_url: "{{ oreg_url_master | default(oreg_url) | default(None) }}"
       oauth_grant_method: "{{ openshift_master_oauth_grant_method | default(None) }}"
       sdn_cluster_network_cidr: "{{ osm_cluster_network_cidr | default(None) }}"
       sdn_host_subnet_length: "{{ osm_host_subnet_length | default(None) }}"

--- a/roles/openshift_node/README.md
+++ b/roles/openshift_node/README.md
@@ -15,10 +15,11 @@ Role Variables
 --------------
 From this role:
 
-| Name                                     | Default value         |                                                        |
-|------------------------------------------|-----------------------|--------------------------------------------------------|
-| openshift_node_debug_level               | openshift_debug_level | Verbosity of the debug logs for node |
-| oreg_url                                 | UNDEF (Optional)      | Default docker registry to use                         |
+| Name                       | Default value         |                                                          |
+|----------------------------|-----------------------|----------------------------------------------------------|
+| openshift_node_debug_level | openshift_debug_level | Verbosity of the debug logs for node                     |
+| oreg_url                   | UNDEF (Optional)      | Default docker registry to use                           |
+| oreg_url_node              | UNDEF (Optional)      | Default docker registry to use, specifically on the node |
 
 From openshift_common:
 

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -22,7 +22,7 @@
         iptables_sync_period: "{{ openshift_node_iptables_sync_period | default(None) }}"
         kubelet_args: "{{ openshift_node_kubelet_args | default(None) }}"
         labels: "{{ lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true) }}"
-        registry_url: "{{ oreg_url | default(none) }}"
+        registry_url: "{{ oreg_url_node | default(oreg_url) | default(None) }}"
         schedulable: "{{ openshift_schedulable | default(openshift_scheduleable) | default(None) }}"
         sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
         storage_plugin_deps: "{{ osn_storage_plugin_deps | default(None) }}"

--- a/roles/openshift_node_upgrade/tasks/main.yml
+++ b/roles/openshift_node_upgrade/tasks/main.yml
@@ -92,8 +92,8 @@
   yedit:
     src: "{{ openshift.common.config_base }}/node/node-config.yaml"
     key: 'imageConfig.format'
-    value: "{{ oreg_url }}"
-  when: oreg_url is defined
+    value: "{{ oreg_url | default(oreg_url_node) }}"
+  when: oreg_url is defined or oreg_url_node is defined
 
 # https://docs.openshift.com/container-platform/3.4/admin_guide/overcommit.html#disabling-swap-memory
 - name: Check for swap usage

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -117,7 +117,7 @@
   debug:
     msg: >
       openshift_image_tag is used for containerized installs. If you are trying to
-      specify an image for a non-container install see oreg_url.
+      specify an image for a non-container install see oreg_url or oreg_url_master or oreg_url_node.
   when:
   - not is_containerized | bool
   - openshift_image_tag is defined


### PR DESCRIPTION
This commit allows to specify imageConfig.format specifically for master
or for nodes.

One use case of this could be if you want to use customer builder
images. In this case imageConfig.format only needs to be changed in the
master-config.yml but not in the node-config.yml.