### PR TITLE
[3.3] Set metrics url even if metrics_deploy is false

### DIFF
--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -18,8 +18,8 @@ assetConfig:
 {% if 'logging_public_url' in openshift.master %}
   loggingPublicURL: {{ openshift.master.logging_public_url }}
 {% endif %}
-{% if 'metrics_public_url' in openshift.master %}
-  metricsPublicURL: {{ openshift.master.metrics_public_url }}
+{% if openshift_hosted_metrics_deploy_url is defined %}
+  metricsPublicURL: {{ openshift_hosted_metrics_deploy_url }}
 {% endif %}
 {% if 'extension_scripts' in openshift.master %}
   extensionScripts: {{ openshift.master.extension_scripts | to_padded_yaml(1, 2) }}

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -8,6 +8,26 @@
     openshift_master_default_subdomain: "{{ lookup('oo_option', 'openshift_master_default_subdomain') | default(None, true) }}"
   when: openshift_master_default_subdomain is not defined
 
+- fail:
+    msg: openshift_master_default_subdomain must be set to deploy metrics
+  when: openshift_hosted_metrics_deploy | default(false) | bool and openshift_master_default_subdomain | default("") == ""
+
+# NOTE: These metrics variables are unfortunately needed by both the master and the metrics roles
+# to properly configure the master-config.yaml file.
+#
+# NOTE: Today only changing the hostname for the metrics public URL is supported, the
+# path must stay consistent. As such if openshift_hosted_metrics_public_url is set in
+# inventory, we extract the hostname, and then reset openshift_hosted_metrics_public_url
+# to the format that we know is valid. (This may change in future)
+- set_fact:
+    g_metrics_hostname: "{{ openshift_hosted_metrics_public_url
+                        | default('hawkular-metrics.' ~ (openshift_master_default_subdomain))
+                        | oo_hostname_from_url }}"
+
+- set_fact:
+    openshift_hosted_metrics_deploy_url: "https://{{ g_metrics_hostname }}/hawkular/metrics"
+  when: (openshift_hosted_metrics_deploy | default(false) | bool) or (openshift_hosted_metrics_public_url is defined)
+
 - name: Set master facts
   openshift_facts:
     role: master

--- a/roles/openshift_metrics/tasks/install.yml
+++ b/roles/openshift_metrics/tasks/install.yml
@@ -103,7 +103,7 @@
   modify_yaml:
     dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
     yaml_key: assetConfig.metricsPublicURL
-    yaml_value: "https://{{ metrics_hostname }}/hawkular/metrics"
+    yaml_value: "{{ openshift_hosted_metrics_deploy_url }}"
   notify: restart master
 
 - name: Store metrics public_url


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1452690
Backports https://github.com/openshift/openshift-ansible/pull/2973