### PR TITLE
Add a readiness probe to the Kibana container

### DIFF
--- a/roles/openshift_logging/templates/kibana.j2
+++ b/roles/openshift_logging/templates/kibana.j2
@@ -61,6 +61,13 @@ spec:
             - name: kibana
               mountPath: /etc/kibana/keys
               readOnly: true
+          readinessProbe:
+            exec:
+              command:
+              - "/usr/share/kibana/probe/readiness.sh"
+            initialDelaySeconds: 5
+            timeoutSeconds: 4
+            periodSeconds: 5
         -
           name: "kibana-proxy"
           image: {{proxy_image}}


### PR DESCRIPTION
In order to ensure that the Kubernetes machinery can determine when the
Kibana Pods are becoming ready, we need to add a readiness probe to the
Containers that make up those pods. The Kibana readiness probe simply
hits the base URL at `http://localhost:5601/` and expects a 200.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @richm @ewolinetz  @lukas-vlcek 

depends on https://github.com/openshift/origin-aggregated-logging/pull/423/files