### PR TITLE
filter_plugins: Allow for multiple pairs in map_from_pairs()

### DIFF
--- a/roles/openshift_logging/filter_plugins/openshift_logging.py
+++ b/roles/openshift_logging/filter_plugins/openshift_logging.py
@@ -42,7 +42,7 @@ def map_from_pairs(source, delim="="):
     if source == '':
         return dict()
 
-    return dict(source.split(delim) for item in source.split(","))
+    return dict(item.split(delim) for item in source.split(","))
 
 
 # pylint: disable=too-few-public-methods

--- a/roles/openshift_storage_glusterfs/filter_plugins/openshift_storage_glusterfs.py
+++ b/roles/openshift_storage_glusterfs/filter_plugins/openshift_storage_glusterfs.py
@@ -8,7 +8,7 @@ def map_from_pairs(source, delim="="):
     if source == '':
         return dict()
 
-    return dict(source.split(delim) for item in source.split(","))
+    return dict(item.split(delim) for item in source.split(","))
 
 
 # pylint: disable=too-few-public-methods


### PR DESCRIPTION
Not hit previously because, best I could find, it's only been used for single pairs.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>