### PR TITLE
inventory: rename certificates->certificate in router example

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -345,7 +345,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #  selector: type=router1
 #  images: "openshift3/ose-${component}:${version}"
 #  edits: []
-#  certificates:
+#  certificate:
 #    certfile: /path/to/certificate/abc.crt
 #    keyfile: /path/to/certificate/abc.key
 #    cafile: /path/to/certificate/ca.crt
@@ -359,7 +359,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #  serviceaccount: router
 #  selector: type=router2
 #  images: "openshift3/ose-${component}:${version}"
-#  certificates:
+#  certificate:
 #    certfile: /path/to/certificate/xyz.crt
 #    keyfile: /path/to/certificate/xyz.key
 #    cafile: /path/to/certificate/ca.crt

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -345,7 +345,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #  selector: type=router1
 #  images: "openshift3/ose-${component}:${version}"
 #  edits: []
-#  certificates:
+#  certificate:
 #    certfile: /path/to/certificate/abc.crt
 #    keyfile: /path/to/certificate/abc.key
 #    cafile: /path/to/certificate/ca.crt
@@ -359,7 +359,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #  serviceaccount: router
 #  selector: type=router2
 #  images: "openshift3/ose-${component}:${version}"
-#  certificates:
+#  certificate:
 #    certfile: /path/to/certificate/xyz.crt
 #    keyfile: /path/to/certificate/xyz.key
 #    cafile: /path/to/certificate/ca.crt


### PR DESCRIPTION
Per change 9397727e433cbd9bfd865fb5ad773c7b6b4590e8, router replaced
certificates with certificate.

References:
- https://bugzilla.redhat.com/show_bug.cgi?id=1452012
- https://bugzilla.redhat.com/show_bug.cgi?id=1452013