### PR TITLE
[1.5] Remove std_include from rhel_subscribe playbook.

### DIFF
--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -1,7 +1,29 @@
 ---
-- include: ../common/openshift-cluster/std_include.yml
+- name: Create initial host groups for localhost
+  hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
   tags:
   - always
+  tasks:
+  - include_vars: openshift-cluster/cluster_hosts.yml
+  - name: Evaluate group l_oo_all_hosts
+    add_host:
+      name: "{{ item }}"
+      groups: l_oo_all_hosts
+    with_items: "{{ g_all_hosts | default([]) }}"
+    changed_when: False
+
+- name: Create initial host groups for all hosts
+  hosts: l_oo_all_hosts
+  gather_facts: no
+  tags:
+  - always
+  tasks:
+  - include_vars: ../byo/openshift-cluster/cluster_hosts.yml
+
+- include: ../common/openshift-cluster/evaluate_groups.yml
 
 - name: Subscribe hosts, update repos and update OS packages
   hosts: l_oo_all_hosts


### PR DESCRIPTION
This is a targeted fix to revert `playbooks/byo/rhel_subscribe.yml` to pre `std_include.yml` times. A backport to make this match the master branch would pull in the following commits.

```
4a69dc0 - Temporarily revert to OSEv3 host group usage (11 days ago) <Russell Teague>
eb22505 - Remove std_include from playbooks/byo/rhel_subscribe.yml (3 weeks ago) <Andrew Butcher>
d32d0d2 - Normalizing groups. (3 weeks ago) <Kenny Woodson>
4263f3d - Refactor initialize groups tasks (7 weeks ago) <Russell Teague>
9819608 - validate and normalize inventory variables (8 weeks ago) <Luke Meyer>
```

