### PR TITLE
[1.5] Workaround sysctl module issue with py3 by converting task to lineinfile.

### DIFF
--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -12,3 +12,6 @@
 - name: restart node
   systemd: name={{ openshift.common.service_type }}-node state=restarted
   when: (not skip_node_svc_handlers | default(False) | bool) and not (node_service_status_changed | default(false) | bool)
+
+- name: reload sysctl.conf
+  command: /sbin/sysctl -p

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -72,8 +72,14 @@
 # The atomic-openshift-node service will set this parameter on
 # startup, but if the network service is restarted this setting is
 # lost. Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1372388
+#
+# Use lineinfile w/ a handler for this task until
+# https://github.com/ansible/ansible/pull/24277 is included in an
+# ansible release and we can use the sysctl module.
 - name: Persist net.ipv4.ip_forward sysctl entry
-  sysctl: name="net.ipv4.ip_forward" value=1 sysctl_set=yes state=present reload=yes
+  lineinfile: dest=/etc/sysctl.conf regexp='^net.ipv4.ip_forward' line='net.ipv4.ip_forward=1'
+  notify:
+    - reload sysctl.conf
 
 - name: Start and enable openvswitch service
   systemd:


### PR DESCRIPTION
Backports #4248.