### PR TITLE
Allow a hostname to resolve to 127.0.0.1 during validation

### DIFF
--- a/playbooks/common/openshift-cluster/validate_hostnames.yml
+++ b/playbooks/common/openshift-cluster/validate_hostnames.yml
@@ -13,4 +13,6 @@
     pause:
       prompt: "The hostname \"{{ openshift.common.hostname }}\" for \"{{ ansible_nodename }}\" doesn't resolve to an ip address owned by this host. Please set openshift_hostname variable to a hostname that when resolved on the host in question resolves to an IP address matching an interface on this host. This host will fail liveness checks for pods utilizing hostPorts, press ENTER to continue or CTRL-C to abort."
       seconds: "{{ 10 if openshift_override_hostname_check | default(false) | bool else omit }}"
-    when: lookupip.stdout not in ansible_all_ipv4_addresses
+    when:
+    - lookupip.stdout != '127.0.0.1'
+    - lookupip.stdout not in ansible_all_ipv4_addresses


### PR DESCRIPTION
127.0.0.1 does not end up in "ansible_all_ipv4_addresses" and should
be considered valid.
For example, a hostname could be resolving to a public address that is
not bound to the actual server.
Or the host could resolve to 127.0.0.1 from the perspective of
the host since the hostname is set up in /etc/hosts.