### PR TITLE
preflight int tests: fix test flake

### DIFF
--- a/test/integration/openshift_health_checker/teardown_container.yml
+++ b/test/integration/openshift_health_checker/teardown_container.yml
@@ -21,3 +21,4 @@
       docker_container:
         name: "{{ inventory_hostname }}"
         state: absent
+      failed_when: False


### PR DESCRIPTION
These tests spin up docker images and remove them at the end.
The removal seems to fail randomly on test systems.
Changed the removal task to ignore errors.

Fixes https://github.com/openshift/origin/issues/14254