### PR TITLE
Support byo etcd for Calico

### DIFF
--- a/roles/calico/defaults/main.yaml
+++ b/roles/calico/defaults/main.yaml
@@ -1,14 +1,9 @@
 ---
 kubeconfig: "{{openshift.common.config_base}}/node/{{ 'system:node:' +  openshift.common.hostname }}.kubeconfig"
-etcd_endpoints: "{{ hostvars[groups.oo_first_master.0].openshift.master.etcd_urls | join(',') }}"
 
 cni_conf_dir: "/etc/cni/net.d/"
 cni_bin_dir: "/opt/cni/bin/"
 cni_url: "https://github.com/containernetworking/cni/releases/download/v0.4.0/cni-amd64-v0.4.0.tgz"
-
-calico_etcd_ca_cert_file: "/etc/origin/calico/calico.etcd-ca.crt"
-calico_etcd_cert_file: "/etc/origin/calico/calico.etcd-client.crt"
-calico_etcd_key_file: "/etc/origin/calico/calico.etcd-client.key"
 
 calico_url_cni: "https://github.com/projectcalico/cni-plugin/releases/download/v1.5.5/calico"
 calico_url_ipam: "https://github.com/projectcalico/cni-plugin/releases/download/v1.5.5/calico-ipam"

--- a/roles/calico/tasks/gen_certs.yml
+++ b/roles/calico/tasks/gen_certs.yml
@@ -1,0 +1,17 @@
+---
+- name: Calico Node | Generate OpenShift-etcd certs
+  include: ../../../roles/etcd_client_certificates/tasks/main.yml
+  vars:
+    etcd_cert_prefix: calico.etcd-
+    etcd_cert_config_dir: "{{ openshift.common.config_base }}/calico"
+    embedded_etcd: "{{ hostvars[groups.oo_first_master.0].openshift.master.embedded_etcd }}"
+    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
+    etcd_cert_subdir: "openshift-calico-{{ openshift.common.hostname }}"
+
+- name: Calico Node | Set etcd cert location facts
+  set_fact:
+    calico_etcd_ca_cert_file: "/etc/origin/calico/calico.etcd-ca.crt"
+    calico_etcd_cert_file: "/etc/origin/calico/calico.etcd-client.crt"
+    calico_etcd_key_file: "/etc/origin/calico/calico.etcd-client.key"
+    calico_etcd_endpoints: "{{ hostvars[groups.oo_first_master.0].openshift.master.etcd_urls | join(',') }}"
+    calico_etcd_cert_dir: "/etc/origin/calico/"

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -1,19 +1,36 @@
 ---
-- include: ../../../roles/etcd_client_certificates/tasks/main.yml
-  vars:
-    etcd_cert_prefix: calico.etcd-
-    etcd_cert_config_dir: "{{ openshift.common.config_base }}/calico"
-    embedded_etcd: "{{ hostvars[groups.oo_first_master.0].openshift.master.embedded_etcd }}"
-    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
-    etcd_cert_subdir: "openshift-calico-{{ openshift.common.hostname }}"
+- name: Calico Node | Error if invalid cert arguments
+  fail:
+    msg: "Must provide all or none for the following etcd params: calico_etcd_cert_dir, calico_etcd_ca_cert_file, calico_etcd_cert_file, calico_etcd_key_file, calico_etcd_endpoints"
+  when: (calico_etcd_cert_dir is defined or calico_etcd_ca_cert_file is defined or calico_etcd_cert_file is defined or calico_etcd_key_file is defined or calico_etcd_endpoints is defined) and not (calico_etcd_cert_dir is defined and calico_etcd_ca_cert_file is defined and calico_etcd_cert_file is defined and calico_etcd_key_file is defined and calico_etcd_endpoints is defined)
 
-- name: Calico Node | Assure the calico certs have been generated
+- name: Calico Node | Generate certs if not provided
+  include: gen_certs.yml
+  when: item is not defined
+  with_items:
+    - calico_etcd_ca_cert_file
+    - calico_etcd_cert_file
+    - calico_etcd_key_file
+    - calico_etcd_endpoints
+    - calico_etcd_cert_dir
+
+- name: Calico Node | Error if no certs set.
+  fail:
+    msg: "Invalid etcd configuration for calico."
+  when: item is not defined or item == ''
+  with_items:
+    - calico_etcd_ca_cert_file
+    - calico_etcd_cert_file
+    - calico_etcd_key_file
+    - calico_etcd_endpoints
+
+- name: Calico Node | Assure the calico certs are present
   stat:
     path: "{{ item }}"
   with_items:
-  - "{{ calico_etcd_ca_cert_file }}"
-  - "{{ calico_etcd_cert_file}}"
-  - "{{ calico_etcd_key_file }}"
+    - "{{ calico_etcd_ca_cert_file }}"
+    - "{{ calico_etcd_cert_file}}"
+    - "{{ calico_etcd_key_file }}"
 
 - name: Calico Node | Configure Calico service unit file
   template:

--- a/roles/calico/templates/10-calico.conf.j2
+++ b/roles/calico/templates/10-calico.conf.j2
@@ -4,7 +4,7 @@
   "ipam": {
     "type": "calico-ipam"
   },
-  "etcd_endpoints": "{{ etcd_endpoints }}",
+  "etcd_endpoints": "{{ calico_etcd_endpoints }}",
   "etcd_key_file": "{{ calico_etcd_key_file }}",
   "etcd_cert_file": "{{ calico_etcd_cert_file }}",
   "etcd_ca_cert_file": "{{ calico_etcd_ca_cert_file }}",

--- a/roles/calico/templates/calico.service.j2
+++ b/roles/calico/templates/calico.service.j2
@@ -13,8 +13,8 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
  -e CALICO_IPV4POOL_IPIP={{ calico_ipv4pool_ipip }} \
  -e CALICO_IPV4POOL_CIDR={{ calico_ipv4pool_cidr }} \
  -e FELIX_IPV6SUPPORT=false \
- -e ETCD_ENDPOINTS={{ etcd_endpoints }} \
- -v /etc/origin/calico:/etc/origin/calico \
+ -e ETCD_ENDPOINTS={{ calico_etcd_endpoints }} \
+ -v {{ calico_etcd_cert_dir }}:{{ calico_etcd_cert_dir }}  \
  -e ETCD_CA_CERT_FILE={{ calico_etcd_ca_cert_file }} \
  -e ETCD_CERT_FILE={{ calico_etcd_cert_file }} \
  -e ETCD_KEY_FILE={{ calico_etcd_key_file }} \

--- a/roles/calico/templates/calicoctl.cfg.j2
+++ b/roles/calico/templates/calicoctl.cfg.j2
@@ -3,7 +3,7 @@ kind: calicoApiConfig
 metadata:
 spec:
   datastoreType: "etcdv2"
-  etcdEndpoints: "{{ etcd_endpoints }}"
+  etcdEndpoints: "{{ calico_etcd_endpoints }}"
   etcdKeyFile: "{{ calico_etcd_key_file }}"
   etcdCertFile: "{{ calico_etcd_cert_file }}"
   etcdCaCertFile: "{{ calico_etcd_ca_cert_file }}"

--- a/roles/calico_master/templates/calico-policy-controller.yml.j2
+++ b/roles/calico_master/templates/calico-policy-controller.yml.j2
@@ -78,7 +78,7 @@ spec:
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
-              value: {{ etcd_endpoints }}
+              value: {{ calico_etcd_endpoints }}
             # Location of the CA certificate for etcd.
             - name: ETCD_CA_CERT_FILE
               value: {{ calico_etcd_ca_cert_file }}
@@ -96,10 +96,10 @@ spec:
           volumeMounts:
             # Mount in the etcd TLS secrets.
             - name: certs
-              mountPath: /etc/origin/calico
+              mountPath: {{ calico_etcd_cert_dir }}
 
       volumes:
         # Mount in the etcd TLS secrets.
         - name: certs
           hostPath:
-            path: /etc/origin/calico
+            path: {{ calico_etcd_cert_dir }}


### PR DESCRIPTION
- Moves calico etcd params for certs and etcd location out of defaults. 
- Changed behavior such that 
  - if those params are not provided, the etcd_client_certs role is called and certs are generated for the shared etcd (which is basically the current behavior)
  - if those params are provided, they are used to connect to the external etcd

Note: Implemented such that an externally provided etcd **must be ssl encrypted**