### PR TITLE
disable become for local actions

### DIFF
--- a/roles/openshift_logging/tasks/generate_certs.yaml
+++ b/roles/openshift_logging/tasks/generate_certs.yaml
@@ -21,6 +21,7 @@
     --key={{generated_certs_dir}}/ca.key --cert={{generated_certs_dir}}/ca.crt
     --serial={{generated_certs_dir}}/ca.serial.txt --name=logging-signer-test
   check_mode: no
+  become: false
   when:
     - not ca_key_file.stat.exists
     - not ca_cert_file.stat.exists

--- a/roles/openshift_logging/tasks/main.yaml
+++ b/roles/openshift_logging/tasks/main.yaml
@@ -20,6 +20,7 @@
   changed_when: False
   check_mode: no
   tags: logging_init
+  become: false
 
 - debug: msg="Created temp dir {{mktemp.stdout}}"
 


### PR DESCRIPTION
When running the playbooks an a bastion host as an unprivileged user, local actions with become will fail or create permission problems.