### PR TITLE
Use local openshift.master.loopback_url when generating loopback kubeconfig.

### DIFF
--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -108,6 +108,38 @@
   delegate_to: "{{ openshift_ca_host }}"
   run_once: true
 
+- name: Test local loopback context
+  command: >
+    {{ hostvars[openshift_ca_host].openshift.common.client_binary }} config view
+    --config={{ openshift_master_loopback_config }}
+  changed_when: false
+  register: loopback_config
+  delegate_to: "{{ openshift_ca_host }}"
+  run_once: true
+
+- name: Generate the loopback master client config
+  command: >
+    {{ hostvars[openshift_ca_host].openshift.common.client_binary }} adm create-api-client-config
+      {% for named_ca_certificate in openshift.master.named_certificates | default([]) | oo_collect('cafile') %}
+      --certificate-authority {{ named_ca_certificate }}
+      {% endfor %}
+      --certificate-authority={{ openshift_ca_cert }}
+      --client-dir={{ openshift_ca_config_dir }}
+      --groups=system:masters,system:openshift-master
+      --master={{ hostvars[openshift_ca_host].openshift.master.loopback_api_url }}
+      --public-master={{ hostvars[openshift_ca_host].openshift.master.loopback_api_url }}
+      --signer-cert={{ openshift_ca_cert }}
+      --signer-key={{ openshift_ca_key }}
+      --signer-serial={{ openshift_ca_serial }}
+      --user=system:openshift-master
+      --basename=openshift-master
+      {% if openshift_version | oo_version_gte_3_5_or_1_5(openshift.common.deployment_type) | bool %}
+      --expire-days={{ openshift_master_cert_expire_days }}
+      {% endif %}
+  when: loopback_context_string not in loopback_config.stdout
+  delegate_to: "{{ openshift_ca_host }}"
+  run_once: true
+
 - name: Restore original serviceaccount keys
   copy:
     src: "{{ item }}.keep"

--- a/roles/openshift_ca/vars/main.yml
+++ b/roles/openshift_ca/vars/main.yml
@@ -4,3 +4,6 @@ openshift_ca_cert: "{{ openshift_ca_config_dir }}/ca.crt"
 openshift_ca_key: "{{ openshift_ca_config_dir }}/ca.key"
 openshift_ca_serial: "{{ openshift_ca_config_dir }}/ca.serial.txt"
 openshift_version: "{{ openshift_pkg_version | default('') }}"
+
+openshift_master_loopback_config: "{{ openshift_ca_config_dir }}/openshift-master.kubeconfig"
+loopback_context_string: "current-context: {{ openshift.master.loopback_context_name }}"

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -71,7 +71,7 @@
   delegate_to: "{{ openshift_ca_host }}"
   run_once: true
 
-- name: Generate the master client config
+- name: Generate the loopback master client config
   command: >
     {{ hostvars[openshift_ca_host].openshift.common.client_binary }} adm create-api-client-config
       {% for named_ca_certificate in openshift.master.named_certificates | default([]) | oo_collect('cafile') %}
@@ -80,8 +80,8 @@
       --certificate-authority={{ openshift_ca_cert }}
       --client-dir={{ openshift_generated_configs_dir }}/master-{{ hostvars[item].openshift.common.hostname }}
       --groups=system:masters,system:openshift-master
-      --master={{ openshift.master.api_url }}
-      --public-master={{ openshift.master.public_api_url }}
+      --master={{ hostvars[item].openshift.master.loopback_api_url }}
+      --public-master={{ hostvars[item].openshift.master.loopback_api_url }}
       --signer-cert={{ openshift_ca_cert }}
       --signer-key={{ openshift_ca_key }}
       --signer-serial={{ openshift_ca_serial }}


### PR DESCRIPTION
Fixes BZ#1454321 https://bugzilla.redhat.com/show_bug.cgi?id=1454321

When we're generating certificates for an HA cluster, we first create a set of certificates for the first master using `oc adm create-master-certs` which generates every certificate/key the first master will need. We pass `--master` and `--public-master` arguments matching the `openshift.master.{public_api_url, api_url}` facts which means that the kubeconfigs (`admin.kubeconfig`, `openshift-master.kubeconfig`) will be configured to talk to the potentially load balanced cluster endpoints.

```
# oc adm create-master-certs -h
...
      --master='https://localhost:8443': The API server's URL.
      --public-master='': The API public facing server's URL (if applicable).
```

The `openshift-master.kubeconfig` is used by the controllers service to talk to the master API so we want it to talk to the local master (loopback) rather than the load balanced endpoints since the controllers are going to talk to the API a lot. So, once we've created the set of certificates for the first master, check to see if the `openshift-master.kubeconfig` contains the loopback server address (it won't right after they are created) and if it doesn't then we create a new `openshift-master.kubeconfig` which does.

Then when we're generating loopback kubeconfigs for additional masters we just pass the loopback API urls to begin with since these configs are generated for additional masters individually.