### PR TITLE
remove use of oadm in logging for 'oc cluster up'

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -22,7 +22,7 @@ USER root
 # configurations for the two images.
 RUN mkdir -p /usr/share/ansible/ && ln -s /opt/app-root/src /usr/share/ansible/openshift-ansible
 
-RUN INSTALL_PKGS="skopeo" && \
+RUN INSTALL_PKGS="skopeo openssl java-1.8.0-openjdk-headless httpd-tools" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyOpenSSL==16.2.0
 # We need to disable ruamel.yaml for now because of test failures
 #ruamel.yaml
 six==1.10.0
+passlib==1.6.5

--- a/roles/openshift_logging/tasks/generate_certs.yaml
+++ b/roles/openshift_logging/tasks/generate_certs.yaml
@@ -17,7 +17,7 @@
 
 - name: Generate certificates
   command: >
-    {{ openshift.common.admin_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig ca create-signer-cert
+    {{ openshift.common.client_binary }} adm --config={{ mktemp.stdout }}/admin.kubeconfig ca create-signer-cert
     --key={{generated_certs_dir}}/ca.key --cert={{generated_certs_dir}}/ca.crt
     --serial={{generated_certs_dir}}/ca.serial.txt --name=logging-signer-test
   check_mode: no

--- a/roles/openshift_logging/tasks/procure_server_certs.yaml
+++ b/roles/openshift_logging/tasks/procure_server_certs.yaml
@@ -27,7 +27,7 @@
 
 - name: Creating signed server cert and key for {{ cert_info.procure_component }}
   command: >
-     {{ openshift.common.admin_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig ca create-server-cert
+     {{ openshift.common.client_binary }} adm --config={{ mktemp.stdout }}/admin.kubeconfig ca create-server-cert
      --key={{generated_certs_dir}}/{{cert_info.procure_component}}.key --cert={{generated_certs_dir}}/{{cert_info.procure_component}}.crt
      --hostnames={{cert_info.hostnames|quote}} --signer-cert={{generated_certs_dir}}/ca.crt --signer-key={{generated_certs_dir}}/ca.key
      --signer-serial={{generated_certs_dir}}/ca.serial.txt

--- a/roles/openshift_metrics/tasks/generate_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_certificates.yaml
@@ -1,7 +1,7 @@
 ---
 - name: generate ca certificate chain
   command: >
-    {{ openshift.common.admin_binary }} ca create-signer-cert
+    {{ openshift.common.client_binary }} adm ca create-signer-cert
     --config={{ mktemp.stdout }}/admin.kubeconfig
     --key='{{ mktemp.stdout }}/ca.key'
     --cert='{{ mktemp.stdout }}/ca.crt'

--- a/roles/openshift_metrics/tasks/setup_certificate.yaml
+++ b/roles/openshift_metrics/tasks/setup_certificate.yaml
@@ -1,7 +1,7 @@
 ---
 - name: generate {{ component }} keys
   command: >
-    {{ openshift.common.admin_binary }} ca create-server-cert
+    {{ openshift.common.client_binary }} adm ca create-server-cert
     --config={{ mktemp.stdout }}/admin.kubeconfig
     --key='{{ mktemp.stdout }}/{{ component }}.key'
     --cert='{{ mktemp.stdout }}/{{ component }}.crt'


### PR DESCRIPTION
This PR makes modifications to the openshift-ansible image to support its use with 'oc cluster up'.  Specifically:
* Replaces 'oadm' with 'oc adm'
* Adds java to the image for keytool
* Adds openssl for logging cert generation
* Adds httpd-tools
* Adds python-passlib