### PR TITLE
Fix passlib check for metrics installation

### DIFF
--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
-- local_action: shell rpm -q python-passlib || echo not installed
+- local_action: shell python -c 'import passlib' 2>/dev/null || echo not installed
   register: passlib_result
 
 - name: Check that python-passlib is available on the control host


### PR DESCRIPTION
see #4134 that is not correct on Centos7, Fedora, and other distribution where pacakge is named python2-passlib.