### PR TITLE
openshift_logging: increasing *_elasticsearch_* default CPU and memory

### DIFF
--- a/roles/openshift_logging_elasticsearch/defaults/main.yml
+++ b/roles/openshift_logging_elasticsearch/defaults/main.yml
@@ -5,10 +5,10 @@ openshift_logging_elasticsearch_image_version: "{{ openshift_hosted_logging_depl
 openshift_logging_elasticsearch_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"
 openshift_logging_elasticsearch_namespace: logging
 
-openshift_logging_elasticsearch_nodeselector: ""
-openshift_logging_elasticsearch_cpu_limit: 100m
-openshift_logging_elasticsearch_memory_limit: 512Mi
-openshift_logging_elasticsearch_recover_after_time: 5m
+openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_nodeselector | default('') }}"
+openshift_logging_elasticsearch_cpu_limit: 1000m
+openshift_logging_elasticsearch_memory_limit: "{{ openshift_logging_es_memory_limit | default('1Gi') }}"
+openshift_logging_elasticsearch_recover_after_time: "{{ openshift_logging_es_recover_after_time | default('5m') }}"
 
 openshift_logging_elasticsearch_replica_count: 1
 


### PR DESCRIPTION
During my testing, I couldn't ever get a healthy ES pod. Eric has described to me how to fix the defaults to respect the old settings. This works well in my case.

NOTE: openshift_logging_elasticsearch_cpu_limit should also be done in similar fashion as other defaults, I couldn't figure out how to make it work when openshift_logging_es_cpu_limit is undefined.