### PR TITLE
Push to the registry via dns

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -296,6 +296,7 @@
   - openshift_facts
   - docker
   - openshift_node_upgrade
+  - openshift_node_dnsmasq
 
   post_tasks:
   - name: Set node schedulability

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -34,6 +34,7 @@
   - openshift_facts
   - docker
   - openshift_node_upgrade
+  - openshift_node_dnsmasq
   - role: openshift_excluder
     r_openshift_excluder_action: enable
     r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1654,6 +1654,7 @@ def set_proxy_facts(facts):
                     common['no_proxy'].extend(common['no_proxy_internal_hostnames'].split(','))
             # We always add local dns domain and ourselves no matter what
             common['no_proxy'].append('.' + common['dns_domain'])
+            common['no_proxy'].append('.svc')
             common['no_proxy'].append(common['hostname'])
             common['no_proxy'] = ','.join(sort_unique(common['no_proxy']))
         facts['common'] = common

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -128,6 +128,9 @@
   when: openshift.master.request_header_ca is defined and item.kind == 'RequestHeaderIdentityProvider' and item.clientCA | default('') != ''
   with_items: "{{ openshift.master.identity_providers }}"
 
+- set_fact:
+    openshift_push_via_dns: "{{ openshift_use_dnsmasq | default(true) and openshift.common.version_gte_3_6 and r_openshift_master_clean_install }}"
+
 - name: Install the systemd units
   include: systemd_units.yml
 

--- a/roles/openshift_master/templates/atomic-openshift-master.j2
+++ b/roles/openshift_master/templates/atomic-openshift-master.j2
@@ -1,6 +1,6 @@
 OPTIONS=--loglevel={{ openshift.master.debug_level | default(2) }}
 CONFIG_FILE={{ openshift_master_config_file }}
-{% if openshift_push_via_dns %}
+{% if openshift_push_via_dns | default(false) %}
 OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000
 {% endif %}
 {% if openshift.common.is_containerized | bool %}

--- a/roles/openshift_master/templates/atomic-openshift-master.j2
+++ b/roles/openshift_master/templates/atomic-openshift-master.j2
@@ -1,6 +1,6 @@
 OPTIONS=--loglevel={{ openshift.master.debug_level | default(2) }}
 CONFIG_FILE={{ openshift_master_config_file }}
-{% if openshift_use_dnsmasq | default(true) %}
+{% if openshift_use_dnsmasq | default(true) and openshift_push_via_dns | default(false) %}
 OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000
 {% endif %}
 {% if openshift.common.is_containerized | bool %}

--- a/roles/openshift_master/templates/atomic-openshift-master.j2
+++ b/roles/openshift_master/templates/atomic-openshift-master.j2
@@ -1,6 +1,6 @@
 OPTIONS=--loglevel={{ openshift.master.debug_level | default(2) }}
 CONFIG_FILE={{ openshift_master_config_file }}
-{% if openshift_use_dnsmasq | default(true) and openshift_push_via_dns | default(false) %}
+{% if openshift_push_via_dns %}
 OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000
 {% endif %}
 {% if openshift.common.is_containerized | bool %}

--- a/roles/openshift_master/templates/atomic-openshift-master.j2
+++ b/roles/openshift_master/templates/atomic-openshift-master.j2
@@ -1,5 +1,8 @@
 OPTIONS=--loglevel={{ openshift.master.debug_level | default(2) }}
 CONFIG_FILE={{ openshift_master_config_file }}
+{% if openshift_use_dnsmasq | default(true) %}
+OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000
+{% endif %}
 {% if openshift.common.is_containerized | bool %}
 IMAGE_VERSION={{ openshift_image_tag }}
 {% endif %}

--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -96,6 +96,9 @@ EOF
       if ! grep -q '99-origin-dns.sh' ${NEW_RESOLV_CONF}; then
           echo "# nameserver updated by /etc/NetworkManager/dispatcher.d/99-origin-dns.sh" >> ${NEW_RESOLV_CONF}
       fi
+      if ! grep -q 'search.*cluster.local' ${NEW_RESOLV_CONF}; then
+        sed -i '/^search/ s/$/ cluster.local/' ${NEW_RESOLV_CONF}
+      fi
       cp -Z ${NEW_RESOLV_CONF} /etc/resolv.conf
     fi
   fi

--- a/roles/openshift_node_upgrade/tasks/main.yml
+++ b/roles/openshift_node_upgrade/tasks/main.yml
@@ -147,3 +147,6 @@
   # Give the node two minutes to come back online.
   retries: 24
   delay: 5
+
+- include_role:
+    name: openshift_node_dnsmasq


### PR DESCRIPTION
Configures OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc
Adds 'cluster.local' to dns search on nodes via dispatcher script
Adds '.svc' to NO_PROXY defaults