### PR TITLE
add ability to expose Elasticsearch as an external route

### DIFF
--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -119,6 +119,12 @@
     openshift_logging_elasticsearch_pvc_size: "{{ openshift_logging_es_pvc_size }}"
     openshift_logging_elasticsearch_pvc_dynamic: "{{ openshift_logging_es_pvc_dynamic }}"
     openshift_logging_elasticsearch_pvc_pv_selector: "{{ openshift_logging_es_pv_selector }}"
+    openshift_logging_es_key: "{{ openshift_logging_es_ops_key }}"
+    openshift_logging_es_cert: "{{ openshift_logging_es_ops_cert }}"
+    openshift_logging_es_ca_ext: "{{ openshift_logging_es_ops_ca_ext }}"
+    openshift_logging_es_hostname: "{{ openshift_logging_es_ops_hostname }}"
+    openshift_logging_es_edge_term_policy: "{{ openshift_logging_es_ops_edge_term_policy | default('') }}"
+    openshift_logging_es_allow_external: "{{ openshift_logging_es_ops_allow_external }}"
 
   with_together:
   - "{{ openshift_logging_facts.elasticsearch_ops.deploymentconfigs }}"
@@ -141,6 +147,12 @@
     openshift_logging_elasticsearch_pvc_size: "{{ openshift_logging_es_pvc_size }}"
     openshift_logging_elasticsearch_pvc_dynamic: "{{ openshift_logging_es_pvc_dynamic }}"
     openshift_logging_elasticsearch_pvc_pv_selector: "{{ openshift_logging_es_pv_selector }}"
+    openshift_logging_es_key: "{{ openshift_logging_es_ops_key }}"
+    openshift_logging_es_cert: "{{ openshift_logging_es_ops_cert }}"
+    openshift_logging_es_ca_ext: "{{ openshift_logging_es_ops_ca_ext }}"
+    openshift_logging_es_hostname: "{{ openshift_logging_es_ops_hostname }}"
+    openshift_logging_es_edge_term_policy: "{{ openshift_logging_es_ops_edge_term_policy | default('') }}"
+    openshift_logging_es_allow_external: "{{ openshift_logging_es_ops_allow_external }}"
 
   with_sequence: count={{ openshift_logging_es_ops_cluster_size | int - openshift_logging_facts.elasticsearch_ops.deploymentconfigs.keys() | count }}
   when:

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -269,6 +269,75 @@
     - "{{ tempdir }}/templates/logging-es-dc.yml"
     delete_after: true
 
+- name: Retrieving the cert to use when generating secrets for the {{ es_component }} component
+  slurp:
+    src: "{{ generated_certs_dir }}/{{ item.file }}"
+  register: key_pairs
+  with_items:
+  - { name: "ca_file", file: "ca.crt" }
+  - { name: "es_key", file: "system.logging.es.key" }
+  - { name: "es_cert", file: "system.logging.es.crt" }
+  when: openshift_logging_es_allow_external | bool
+
+- set_fact:
+    es_key: "{{ lookup('file', openshift_logging_es_key) | b64encode }}"
+  when:
+  - openshift_logging_es_key | trim | length > 0
+  - openshift_logging_es_allow_external | bool
+  changed_when: false
+
+- set_fact:
+    es_cert: "{{ lookup('file', openshift_logging_es_cert) | b64encode  }}"
+  when:
+  - openshift_logging_es_cert | trim | length > 0
+  - openshift_logging_es_allow_external | bool
+  changed_when: false
+
+- set_fact:
+    es_ca: "{{ lookup('file', openshift_logging_es_ca_ext) | b64encode  }}"
+  when:
+  - openshift_logging_es_ca_ext | trim | length > 0
+  - openshift_logging_es_allow_external | bool
+  changed_when: false
+
+- set_fact:
+    es_ca: "{{ key_pairs | entry_from_named_pair('ca_file') }}"
+  when:
+  - es_ca is not defined
+  - openshift_logging_es_allow_external | bool
+  changed_when: false
+
+- name: Generating Elasticsearch {{ es_component }} route template
+  template:
+    src: route_reencrypt.j2
+    dest: "{{mktemp.stdout}}/templates/logging-{{ es_component }}-route.yaml"
+  vars:
+    obj_name: "logging-{{ es_component }}"
+    route_host: "{{ openshift_logging_es_hostname }}"
+    service_name: "logging-{{ es_component }}"
+    tls_key: "{{ es_key | default('') | b64decode }}"
+    tls_cert: "{{ es_cert | default('') | b64decode }}"
+    tls_ca_cert: "{{ es_ca | b64decode }}"
+    tls_dest_ca_cert: "{{ key_pairs | entry_from_named_pair('ca_file') | b64decode }}"
+    edge_term_policy: "{{ openshift_logging_es_edge_term_policy | default('') }}"
+    labels:
+      component: support
+      logging-infra: support
+      provider: openshift
+  changed_when: no
+  when: openshift_logging_es_allow_external | bool
+
+# This currently has an issue if the host name changes
+- name: Setting Elasticsearch {{ es_component }} route
+  oc_obj:
+    state: present
+    name: "logging-{{ es_component }}"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    kind: route
+    files:
+    - "{{ tempdir }}/templates/logging-{{ es_component }}-route.yaml"
+  when: openshift_logging_es_allow_external | bool
+
 ## Placeholder for migration when necessary ##
 
 - name: Delete temp directory

--- a/roles/openshift_logging_elasticsearch/templates/elasticsearch-logging.yml.j2
+++ b/roles/openshift_logging_elasticsearch/templates/elasticsearch-logging.yml.j2
@@ -35,6 +35,12 @@ appender:
     layout:
       type: consolePattern
       conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+    # need this filter until https://github.com/openshift/origin/issues/14515 is fixed
+    filter:
+      1:
+        type: org.apache.log4j.varia.StringMatchFilter
+        StringToMatch: "SSL Problem illegal change cipher spec msg, conn state = 6, handshake state = 1"
+        AcceptOnMatch: false
 
   file:
     type: dailyRollingFile
@@ -43,6 +49,12 @@ appender:
     layout:
       type: pattern
       conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+    # need this filter until https://github.com/openshift/origin/issues/14515 is fixed
+    filter:
+      1:
+        type: org.apache.log4j.varia.StringMatchFilter
+        StringToMatch: "SSL Problem illegal change cipher spec msg, conn state = 6, handshake state = 1"
+        AcceptOnMatch: false
 
   # Use the following log4j-extras RollingFileAppender to enable gzip compression of log files.
   # For more information see https://logging.apache.org/log4j/extras/apidocs/org/apache/log4j/rolling/RollingFileAppender.html

--- a/roles/openshift_logging_elasticsearch/templates/route_reencrypt.j2
+++ b/roles/openshift_logging_elasticsearch/templates/route_reencrypt.j2
@@ -1,0 +1,36 @@
+apiVersion: "v1"
+kind: "Route"
+metadata:
+  name: "{{obj_name}}"
+{% if labels is defined%}
+  labels:
+{% for key, value in labels.iteritems() %}
+    {{key}}: {{value}}
+{% endfor %}
+{% endif %}
+spec:
+  host: {{ route_host }}
+  tls:
+{% if tls_key is defined and tls_key | length > 0 %}
+    key: |
+{{ tls_key|indent(6, true) }}
+{% if tls_cert is defined and tls_cert | length > 0 %}
+    certificate: |
+{{ tls_cert|indent(6, true) }}
+{% endif %}
+{% endif %}
+    caCertificate: |
+{% for line in tls_ca_cert.split('\n') %}
+      {{ line }}
+{% endfor %}
+    destinationCACertificate: |
+{% for line in tls_dest_ca_cert.split('\n') %}
+      {{ line }}
+{% endfor %}
+    termination: reencrypt
+{% if edge_term_policy is defined and edge_term_policy | length > 0 %}
+    insecureEdgeTerminationPolicy: {{ edge_term_policy }}
+{% endif %}
+  to:
+    kind: Service
+    name: {{ service_name }}


### PR DESCRIPTION
This makes the logging es route code work with the new
openshift_logging_elasticsearch role

This adds the ability to expose Elastisearch as a route outside of the
cluster.
- `openshift_logging_es_allow_external`: True (default is False) - if this is
  True, Elasticsearch will be exposed as a Route
- `openshift_logging_es_ops_hostname`: The external facing hostname to use for
  the route and the TLS server certificate (default is "es." +
  `openshift_master_default_subdomain`)

There are other similar parameters for the TLS server cert, key, and CA cert.
There are other similar parameters for when the OPS cluster is deployed e.g.
`openshift_logging_es_ops_allow_external`, etc.
@jcantrill @ewolinetz @noodle PTAL