### PR TITLE
Removed hardcoded Calico Policy Controller URL

### DIFF
--- a/roles/calico_master/defaults/main.yaml
+++ b/roles/calico_master/defaults/main.yaml
@@ -4,3 +4,4 @@ kubeconfig: "{{ openshift.common.config_base }}/master/openshift-master.kubeconf
 calicoctl_bin_dir: "/usr/local/bin/"
 
 calico_url_calicoctl: "https://github.com/projectcalico/calicoctl/releases/download/v1.1.3/calicoctl"
+calico_url_policy_controller: "quay.io/calico/kube-policy-controller:v0.5.4"

--- a/roles/calico_master/templates/calico-policy-controller.yml.j2
+++ b/roles/calico_master/templates/calico-policy-controller.yml.j2
@@ -74,7 +74,7 @@ spec:
       serviceAccountName: calico
       containers:
         - name: calico-policy-controller
-          image: quay.io/calico/kube-policy-controller:v0.5.4
+          image: {{ calico_url_policy_controller }}
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS


### PR DESCRIPTION
This patch removes the hardcoded Policy Controller URL in the template and moves the URL definition to the `defaults`. 

CC: @ozdanborne 