### PR TITLE
Lower memory requirements in fedora-ci jobs

### DIFF
--- a/.redhat-ci.inventory
+++ b/.redhat-ci.inventory
@@ -9,6 +9,7 @@ ansible_python_interpreter=/usr/bin/python3
 deployment_type=origin
 openshift_image_tag="{{ lookup('env', 'OPENSHIFT_IMAGE_TAG') }}"
 openshift_master_default_subdomain="{{ lookup('env', 'RHCI_ocp_node1_IP') }}.xip.io"
+openshift_check_min_host_memory_gb=1.9
 
 [masters]
 ocp-master


### PR DESCRIPTION
The fedora ci hosts don't have enough memory to pass our health validation checks so lower the check threshold to 2gb which they have. We may need to revisit sizing of those instances if we start enabling logging and metrics as 2gb hosts won't be large enough and we'd want 8gb.

Example from https://s3.amazonaws.com/aos-ci/ghprb/openshift/openshift-ansible/cbe4e4f25bb82527dc0a9e9bb42fd672aa573f65.0.1495821184119730491/output.log
```
MSG:

One or more checks failed

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0   
ocp-master                 : ok=38   changed=8    unreachable=0    failed=1   
ocp-node1                  : ok=37   changed=8    unreachable=0    failed=1   
ocp-node2                  : ok=37   changed=8    unreachable=0    failed=1   


Failure summary:

  1. Host:     ocp-master
     Play:     Verify Requirements
     Task:     openshift_health_check
     Message:  One or more checks failed
     Details:  check "memory_availability":
               Available memory (2.0 GB) below recommended value (16.0 GB)

  2. Host:     ocp-node1
     Play:     Verify Requirements
     Task:     openshift_health_check
     Message:  One or more checks failed
     Details:  check "memory_availability":
               Available memory (2.0 GB) below recommended value (8.0 GB)

  3. Host:     ocp-node2
     Play:     Verify Requirements
     Task:     openshift_health_check
     Message:  One or more checks failed
     Details:  check "memory_availability":
               Available memory (2.0 GB) below recommended value (8.0 GB)

The execution of "playbooks/byo/config.yml"
includes checks designed to fail early if the requirements
of the playbook are not met. One or more of these checks
failed. To disregard these results, you may choose to
disable failing checks by setting an Ansible variable:

   openshift_disable_check=memory_availability

Failing check names are shown in the failure details above.
Some checks may be configurable by variables if your requirements
are different from the defaults; consult check documentation.
Variables can be set in the inventory or passed on the
command line using the -e flag to ansible-playbook.
```

