### PR TITLE
Support enabling the centos-openshift-origin-testing repository

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -156,8 +156,9 @@ openshift_release=v3.6
 # modify image streams to point at that registry by setting the following to true
 #openshift_examples_modify_imagestreams=true
 
-# Origin copr repo
+# OpenShift repository configuration
 #openshift_additional_repos=[{'id': 'openshift-origin-copr', 'name': 'OpenShift Origin COPR', 'baseurl': 'https://copr-be.cloud.fedoraproject.org/results/maxamillion/origin-next/epel-7-$basearch/', 'enabled': 1, 'gpgcheck': 1, 'gpgkey': 'https://copr-be.cloud.fedoraproject.org/results/maxamillion/origin-next/pubkey.gpg'}]
+#openshift_repos_enable_testing=false
 
 # htpasswd auth
 openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -155,8 +155,9 @@ openshift_release=v3.6
 # modify image streams to point at that registry by setting the following to true
 #openshift_examples_modify_imagestreams=true
 
-# Additional yum repos to install
+# OpenShift repository configuration
 #openshift_additional_repos=[{'id': 'ose-devel', 'name': 'ose-devel', 'baseurl': 'http://example.com/puddle/build/AtomicOpenShift/3.1/latest/RH7-RHOSE-3.0/$basearch/os', 'enabled': 1, 'gpgcheck': 0}]
+#openshift_repos_enable_testing=false
 
 # htpasswd auth
 openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]

--- a/roles/openshift_repos/defaults/main.yaml
+++ b/roles/openshift_repos/defaults/main.yaml
@@ -1,2 +1,3 @@
 ---
 openshift_additional_repos: {}
+openshift_repos_enable_testing: false

--- a/roles/openshift_repos/tasks/main.yaml
+++ b/roles/openshift_repos/tasks/main.yaml
@@ -33,7 +33,7 @@
     # "centos-release-openshift-origin" package which configures the repository.
     # This task matches the file names provided by the package so that they are
     # not installed twice in different files and remains idempotent.
-    - name: Configure origin gpg keys if needed
+    - name: Configure origin repositories and gpg keys if needed
       copy:
         src: "{{ item.src }}"
         dest: "{{ item.dest }}"
@@ -48,6 +48,10 @@
       - ansible_distribution != "Fedora"
       - openshift_deployment_type == 'origin'
       - openshift_enable_origin_repo | default(true) | bool
+
+    - name: Enable centos-openshift-origin-testing repository
+      command: yum-config-manager --enable centos-openshift-origin-testing
+      when: openshift_repos_enable_testing | bool
 
     - name: Ensure clean repo cache in the event repos have been changed manually
       debug:


### PR DESCRIPTION
New versions of Origin land in the -testing repository before they
are tagged for release. This effectively adds the ability to easily
test a new unreleased version (currently in this case 1.5.1) by
enabling the correct repository if 'openshift_repos_enable_testing'
is true.