### PR TITLE
disable docker excluder before it is updated to remove older excluded packages

### DIFF
--- a/roles/openshift_excluder/tasks/disable.yml
+++ b/roles/openshift_excluder/tasks/disable.yml
@@ -5,10 +5,12 @@
     include: verify_upgrade.yml
 
 # unexclude the current openshift/origin-excluder if it is installed so it can be updated
-- name: Disable OpenShift excluder so it can be updated
+- name: Disable excluders before the upgrade to remove older excluding expressions
   include: unexclude.yml
   vars:
-    unexclude_docker_excluder: false
+    # before the docker excluder can be updated, it needs to be disabled
+    # to remove older excluded packages that are no longer excluded
+    unexclude_docker_excluder: "{{ r_openshift_excluder_enable_docker_excluder }}"
     unexclude_openshift_excluder: "{{ r_openshift_excluder_enable_openshift_excluder }}"
 
 # Install any excluder that is enabled


### PR DESCRIPTION
When updating excluders from 3.3 to 3.4 version the /etc/yum.conf still excludes `docker-1.12*` packages even if the excluding expressing is no longer present in 3.4 docker excluders.
It happens when the docker excluder is still excluding. The older excluding expressions will never get removed after the upgrade.