### PR TITLE
Skip router/registry cert redeploy when openshift_hosted_manage_{router,registry}=false

### DIFF
--- a/playbooks/byo/openshift-cluster/redeploy-certificates.yml
+++ b/playbooks/byo/openshift-cluster/redeploy-certificates.yml
@@ -20,5 +20,7 @@
 - include: ../../common/openshift-node/restart.yml
 
 - include: ../../common/openshift-cluster/redeploy-certificates/router.yml
+  when: openshift_hosted_manage_router | default(true) | bool
 
 - include: ../../common/openshift-cluster/redeploy-certificates/registry.yml
+  when: openshift_hosted_manage_registry | default(true) | bool


### PR DESCRIPTION
Setting the following will cause `playbooks/byo/openshift-cluster/redeploy-certificates.yml` to skip redeploying router and registry certificates. Note that these are the same variables which the installation playbook uses to skip router and registry management.

```
openshift_hosted_manage_router=false
openshift_hosted_manage_registry=false
```
/cc @stenwt