### PR TITLE
Metrics: disable become for htpasswd and keytool check

### DIFF
--- a/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
@@ -15,16 +15,19 @@
 
 - name: generate password for hawkular metrics
   local_action: copy dest="{{ local_tmp.stdout }}/{{ item }}.pwd" content="{{ 15 | oo_random_word }}"
+  become: false
   with_items:
   - hawkular-metrics
 
 - local_action: slurp src="{{ local_tmp.stdout }}/hawkular-metrics.pwd"
   register: hawkular_metrics_pwd
   no_log: true
+  become: false
 
 - name: generate htpasswd file for hawkular metrics
   local_action: htpasswd path="{{ local_tmp.stdout }}/hawkular-metrics.htpasswd" name=hawkular password="{{ hawkular_metrics_pwd.content | b64decode }}"
   no_log: true
+  become: false
 
 - name: copy local generated passwords to target
   copy:

--- a/roles/openshift_metrics/tasks/install_support.yaml
+++ b/roles/openshift_metrics/tasks/install_support.yaml
@@ -4,6 +4,7 @@
   register: htpasswd_check
   failed_when: no
   changed_when: no
+  become: false
 
 - fail: msg="'htpasswd' is unavailable. Please install httpd-tools on the control node"
   when: htpasswd_check.rc  == 1
@@ -13,6 +14,7 @@
   register: keytool_check
   failed_when: no
   changed_when: no
+  become: false
 
 - fail: msg="'keytool' is unavailable. Please install java-1.8.0-openjdk-headless on the control node"
   when: keytool_check.rc  == 1

--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -1,6 +1,7 @@
 ---
 - local_action: shell python -c 'import passlib' 2>/dev/null || echo not installed
   register: passlib_result
+  become: false
 
 - name: Check that python-passlib is available on the control host
   assert:
@@ -49,3 +50,4 @@
   tags: metrics_cleanup
   changed_when: False
   check_mode: no
+  become: false


### PR DESCRIPTION
local_actions are also executed with sudo if using Ansible "become". This creates permission problems and requires passwordless sudo on the deployment host.

These commits disable become for all local_actions in the openshift_metrics role.