### PR TITLE
verify upgrade targets separately for each group (masters, nodes, etcd)

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_docker_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_docker_upgrade_targets.yml
@@ -1,23 +1,20 @@
 ---
-- name: Verify docker upgrade targets
-  hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
-  tasks:
-  # Only check if docker upgrade is required if docker_upgrade is not
-  # already set to False.
-  - include: ../docker/upgrade_check.yml
-    when: docker_upgrade is not defined or docker_upgrade | bool and not openshift.common.is_atomic | bool
+# Only check if docker upgrade is required if docker_upgrade is not
+# already set to False.
+- include: ../docker/upgrade_check.yml
+  when: docker_upgrade is not defined or docker_upgrade | bool and not openshift.common.is_atomic | bool
 
-  # Additional checks for Atomic hosts:
+# Additional checks for Atomic hosts:
 
-  - name: Determine available Docker
-    shell: "rpm -q --queryformat '---\ncurr_version: %{VERSION}\navail_version: \n' docker"
-    register: g_atomic_docker_version_result
-    when: openshift.common.is_atomic | bool
+- name: Determine available Docker
+  shell: "rpm -q --queryformat '---\ncurr_version: %{VERSION}\navail_version: \n' docker"
+  register: g_atomic_docker_version_result
+  when: openshift.common.is_atomic | bool
 
-  - set_fact:
-      l_docker_version: "{{ g_atomic_docker_version_result.stdout | from_yaml }}"
-    when: openshift.common.is_atomic | bool
+- set_fact:
+    l_docker_version: "{{ g_atomic_docker_version_result.stdout | from_yaml }}"
+  when: openshift.common.is_atomic | bool
 
-  - fail:
-      msg: This playbook requires access to Docker 1.12 or later
-    when: openshift.common.is_atomic | bool and l_docker_version.avail_version | default(l_docker_version.curr_version, true) | version_compare('1.12','<')
+- fail:
+    msg: This playbook requires access to Docker 1.12 or later
+  when: openshift.common.is_atomic | bool and l_docker_version.avail_version | default(l_docker_version.curr_version, true) | version_compare('1.12','<')

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -1,45 +1,41 @@
 ---
-- name: Verify upgrade targets
-  hosts: oo_masters_to_config:oo_nodes_to_upgrade
+- name: Fail when OpenShift is not installed
+  fail:
+    msg: Verify OpenShift is already installed
+  when: openshift.common.version is not defined
 
-  tasks:
-  - name: Fail when OpenShift is not installed
-    fail:
-      msg: Verify OpenShift is already installed
-    when: openshift.common.version is not defined
+- name: Verify containers are available for upgrade
+  command: >
+    docker pull {{ openshift.common.cli_image }}:{{ openshift_image_tag }}
+  register: pull_result
+  changed_when: "'Downloaded newer image' in pull_result.stdout"
+  when: openshift.common.is_containerized | bool
 
-  - name: Verify containers are available for upgrade
+- when: not openshift.common.is_containerized | bool
+  block:
+  - name: Check latest available OpenShift RPM version
     command: >
-      docker pull {{ openshift.common.cli_image }}:{{ openshift_image_tag }}
-    register: pull_result
-    changed_when: "'Downloaded newer image' in pull_result.stdout"
-    when: openshift.common.is_containerized | bool
+      {{ repoquery_cmd }} --qf '%{version}' "{{ openshift.common.service_type }}"
+    failed_when: false
+    changed_when: false
+    register: avail_openshift_version
 
-  - when: not openshift.common.is_containerized | bool
-    block:
-    - name: Check latest available OpenShift RPM version
-      command: >
-        {{ repoquery_cmd }} --qf '%{version}' "{{ openshift.common.service_type }}"
-      failed_when: false
-      changed_when: false
-      register: avail_openshift_version
-
-    - name: Fail when unable to determine available OpenShift RPM version
-      fail:
-        msg: "Unable to determine available OpenShift RPM version"
-      when:
-      - avail_openshift_version.stdout == ''
-
-    - name: Verify OpenShift RPMs are available for upgrade
-      fail:
-        msg: "OpenShift {{ avail_openshift_version.stdout }} is available, but {{ openshift_upgrade_target }} or greater is required"
-      when:
-      - not avail_openshift_version | skipped
-      - avail_openshift_version.stdout | default('0.0', True) | version_compare(openshift_release, '<')
-
-  - name: Fail when openshift version does not meet minium requirement for Origin upgrade
+  - name: Fail when unable to determine available OpenShift RPM version
     fail:
-      msg: "This upgrade playbook must be run against OpenShift {{ openshift_upgrade_min }} or later"
+      msg: "Unable to determine available OpenShift RPM version"
     when:
-    - deployment_type == 'origin'
-    - openshift.common.version | version_compare(openshift_upgrade_min,'<')
+    - avail_openshift_version.stdout == ''
+
+  - name: Verify OpenShift RPMs are available for upgrade
+    fail:
+      msg: "OpenShift {{ avail_openshift_version.stdout }} is available, but {{ openshift_upgrade_target }} or greater is required"
+    when:
+    - not avail_openshift_version | skipped
+    - avail_openshift_version.stdout | default('0.0', True) | version_compare(openshift_release, '<')
+
+- name: Fail when openshift version does not meet minium requirement for Origin upgrade
+  fail:
+    msg: "This upgrade playbook must be run against OpenShift {{ openshift_upgrade_min }} or later"
+  when:
+  - deployment_type == 'origin'
+  - openshift.common.version | version_compare(openshift_upgrade_min,'<')

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade.yml
@@ -78,11 +78,17 @@
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_upgrade_targets.yml
+- name: Verify upgrade targets
+  hosts: oo_masters_to_config:oo_nodes_to_upgrade
+  tasks:
+  - include: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_docker_upgrade_targets.yml
+- name: Verify docker upgrade targets
+  hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
+  tasks:
+  - include: ../pre/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
@@ -82,11 +82,17 @@
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_upgrade_targets.yml
+- name: Verify upgrade targets
+  hosts: oo_masters_to_config
+  tasks:
+  - include: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_docker_upgrade_targets.yml
+- name: Verify docker upgrade targets
+  hosts: oo_masters_to_config:oo_etcd_to_config
+  tasks:
+  - include: ../pre/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_nodes.yml
@@ -79,11 +79,17 @@
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_upgrade_targets.yml
+- name: Verify upgrade targets
+  hosts: oo_nodes_to_upgrade
+  tasks:
+  - include: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_docker_upgrade_targets.yml
+- name: Verify docker upgrade targets
+  hosts: oo_nodes_to_upgrade
+  tasks:
+  - include: ../pre/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade.yml
@@ -78,11 +78,17 @@
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_upgrade_targets.yml
+- name: Verify upgrade targets
+  hosts: oo_masters_to_config:oo_nodes_to_upgrade
+  tasks:
+  - include: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_docker_upgrade_targets.yml
+- name: Verify docker upgrade targets
+  hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
+  tasks:
+  - include: ../pre/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
@@ -82,11 +82,17 @@
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_upgrade_targets.yml
+- name: Verify upgrade targets
+  hosts: oo_masters_to_config
+  tasks:
+  - include: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_docker_upgrade_targets.yml
+- name: Verify docker upgrade targets
+  hosts: oo_masters_to_config:oo_etcd_to_config
+  tasks:
+  - include: ../pre/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_nodes.yml
@@ -79,11 +79,17 @@
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_upgrade_targets.yml
+- name: Verify upgrade targets
+  hosts: oo_nodes_to_upgrade
+  tasks:
+  - include: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_docker_upgrade_targets.yml
+- name: Verify docker upgrade targets
+  hosts: oo_nodes_to_upgrade
+  tasks:
+  - include: ../pre/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade.yml
@@ -78,11 +78,17 @@
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_upgrade_targets.yml
+- name: Verify upgrade targets
+  hosts: oo_masters_to_config:oo_nodes_to_upgrade
+  tasks:
+  - include: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_docker_upgrade_targets.yml
+- name: Verify docker upgrade targets
+  hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
+  tasks:
+  - include: ../pre/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
@@ -82,11 +82,17 @@
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_upgrade_targets.yml
+- name: Verify upgrade targets
+  hosts: oo_masters_to_config
+  tasks:
+  - include: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_docker_upgrade_targets.yml
+- name: Verify docker upgrade targets
+  hosts: oo_masters_to_config:oo_etcd_to_config
+  tasks:
+  - include: ../pre/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_nodes.yml
@@ -79,11 +79,17 @@
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_upgrade_targets.yml
+- name: Verify upgrade targets
+  hosts: oo_nodes_to_upgrade
+  tasks:
+  - include: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_docker_upgrade_targets.yml
+- name: Verify docker upgrade targets
+  hosts: oo_nodes_to_upgrade
+  tasks:
+  - include: ../pre/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
@@ -78,11 +78,17 @@
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_upgrade_targets.yml
+- name: Verify upgrade targets
+  hosts: oo_masters_to_config:oo_nodes_to_upgrade
+  tasks:
+  - include: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_docker_upgrade_targets.yml
+- name: Verify docker upgrade targets
+  hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
+  tasks:
+  - include: ../pre/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
@@ -82,11 +82,17 @@
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_upgrade_targets.yml
+- name: Verify upgrade targets
+  hosts: oo_masters_to_config
+  tasks:
+  - include: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_docker_upgrade_targets.yml
+- name: Verify docker upgrade targets
+  hosts: oo_masters_to_config:oo_etcd_to_config
+  tasks:
+  - include: ../pre/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
@@ -79,11 +79,17 @@
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_upgrade_targets.yml
+- name: Verify upgrade targets
+  hosts: oo_nodes_to_upgrade
+  tasks:
+  - include: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_docker_upgrade_targets.yml
+- name: Verify docker upgrade targets
+  hosts: oo_nodes_to_upgrade
+  tasks:
+  - include: ../pre/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 


### PR DESCRIPTION
So we don't check docker and rpm version on nodes if we upgrade the control plane only.