### PR TITLE
Add support for rhel, aci, vxlan

### DIFF
--- a/playbooks/adhoc/contiv/delete_contiv.yml
+++ b/playbooks/adhoc/contiv/delete_contiv.yml
@@ -1,5 +1,5 @@
 ---
-- name: delete contiv
+- name: Uninstall contiv
   hosts: all
   gather_facts: False
   tasks:

--- a/roles/contiv/defaults/main.yml
+++ b/roles/contiv/defaults/main.yml
@@ -1,12 +1,12 @@
 ---
 # The version of Contiv binaries to use
-contiv_version: 1.0.0-beta.3-02-21-2017.20-52-42.UTC
+contiv_version: 1.0.1
 
 # The version of cni binaries
 cni_version: v0.4.0
 
-contiv_default_subnet: "20.1.1.1/24"
-contiv_default_gw: "20.1.1.254"
+contiv_default_subnet: "10.128.0.0/16"
+contiv_default_gw: "10.128.254.254"
 # TCP port that Netmaster listens for network connections
 netmaster_port: 9999
 
@@ -69,6 +69,9 @@ netplugin_fwd_mode: bridge
 # Contiv fabric mode aci|default
 contiv_fabric_mode: default
 
+# Global VLAN range
+contiv_vlan_range: "2900-3000"
+
 # Encapsulation type vlan|vxlan to use for instantiating container networks
 contiv_encap_mode: vlan
 
@@ -78,8 +81,8 @@ netplugin_driver: ovs
 # Create a default Contiv network for use by pods
 contiv_default_network: true
 
-# VLAN/ VXLAN tag value to be used for the default network
-contiv_default_network_tag: 1
+# Statically configured tag for default network (if needed)
+contiv_default_network_tag: ""
 
 #SRFIXME (use the openshift variables)
 https_proxy: ""
@@ -95,6 +98,9 @@ apic_leaf_nodes: ""
 apic_phys_dom: ""
 apic_contracts_unrestricted_mode: no
 apic_epg_bridge_domain: not_specified
+apic_configure_default_policy: false
+apic_default_external_contract: "uni/tn-common/brc-default"
+apic_default_app_profile: "contiv-infra-app-profile"
 is_atomic: False
 kube_cert_dir: "/data/src/github.com/openshift/origin/openshift.local.config/master"
 master_name: "{{ groups['masters'][0] }}"
@@ -104,3 +110,12 @@ kube_ca_cert: "{{ kube_cert_dir }}/ca.crt"
 kube_key: "{{ kube_cert_dir }}/admin.key"
 kube_cert: "{{ kube_cert_dir }}/admin.crt"
 kube_master_api_port: 8443
+
+# contivh1 default subnet and gateway
+#contiv_h1_subnet_default: "132.1.1.0/24"
+#contiv_h1_gw_default: "132.1.1.1"
+contiv_h1_subnet_default: "10.129.0.0/16"
+contiv_h1_gw_default: "10.129.0.1"
+
+# contiv default private subnet for ext access
+contiv_private_ext_subnet: "10.130.0.0/16"

--- a/roles/contiv/meta/main.yml
+++ b/roles/contiv/meta/main.yml
@@ -26,3 +26,5 @@ dependencies:
   etcd_url_scheme: http
   etcd_peer_url_scheme: http
   when: contiv_role == "netmaster"
+- role: contiv_auth_proxy
+  when: (contiv_role == "netmaster") and (contiv_enable_auth_proxy == true)

--- a/roles/contiv/tasks/default_network.yml
+++ b/roles/contiv/tasks/default_network.yml
@@ -6,10 +6,53 @@
   retries: 9
   delay: 10
 
+- name: Contiv | Set globals
+  command: 'netctl --netmaster "http://{{ inventory_hostname }}:{{ netmaster_port }}" global set --fabric-mode {{ contiv_fabric_mode }} --vlan-range {{ contiv_vlan_range }} --fwd-mode {{ netplugin_fwd_mode }} --private-subnet {{ contiv_private_ext_subnet }}'
+
+- name: Contiv | Set arp mode to flood if ACI
+  command: 'netctl --netmaster "http://{{ inventory_hostname }}:{{ netmaster_port }}" global set --arp-mode flood'
+  when: contiv_fabric_mode == "aci"
+
 - name: Contiv | Check if default-net exists
   command: 'netctl --netmaster "http://{{ inventory_hostname }}:{{ netmaster_port }}" net ls'
   register: net_result
 
 - name: Contiv | Create default-net
-  command: 'netctl --netmaster "http://{{ inventory_hostname }}:{{ netmaster_port }}" net create --subnet={{ contiv_default_subnet }} -e {{ contiv_encap_mode }} -p {{ contiv_default_network_tag }} --gateway={{ contiv_default_gw }} default-net'
+  command: 'netctl --netmaster "http://{{ inventory_hostname }}:{{ netmaster_port }}" net create --subnet={{ contiv_default_subnet }} -e {{ contiv_encap_mode }} -p {{ contiv_default_network_tag }} --gateway {{ contiv_default_gw }} default-net'
   when: net_result.stdout.find("default-net") == -1
+
+- name: Contiv | Create host access infra network for VxLan routing case
+  command: 'netctl --netmaster "http://{{ inventory_hostname }}:{{ netmaster_port }}" net create --subnet={{ contiv_h1_subnet_default }} --gateway={{ contiv_h1_gw_default }} --nw-type="infra" contivh1'
+  when: (contiv_encap_mode == "vxlan") and (netplugin_fwd_mode == "routing")
+
+#- name: Contiv | Create an allow-all policy for the default-group
+#  command: 'netctl --netmaster "http://{{ inventory_hostname }}:{{ netmaster_port }}" policy create ose-allow-all-policy'
+#  when: contiv_fabric_mode == "aci"
+
+- name: Contiv | Set up aci external contract to consume default external contract
+  command: 'netctl --netmaster "http://{{ inventory_hostname }}:{{ netmaster_port }}" external-contracts create -c -a {{ apic_default_external_contract }} oseExtToConsume'
+  when: (contiv_fabric_mode == "aci") and (apic_configure_default_policy == true)
+
+- name: Contiv | Set up aci external contract to provide default external contract
+  command: 'netctl --netmaster "http://{{ inventory_hostname }}:{{ netmaster_port }}" external-contracts create -p -a {{ apic_default_external_contract }} oseExtToProvide'
+  when: (contiv_fabric_mode == "aci") and (apic_configure_default_policy == true)
+
+- name: Contiv | Create aci default-group
+  command: 'netctl --netmaster "http://{{ inventory_hostname }}:{{ netmaster_port }}" group create default-net default-group'
+  when: contiv_fabric_mode == "aci"
+
+- name: Contiv | Add external contracts to the default-group
+  command: 'netctl --netmaster "http://{{ inventory_hostname }}:{{ netmaster_port }}" group create -e oseExtToConsume -e oseExtToProvide default-net default-group'
+  when: (contiv_fabric_mode == "aci") and (apic_configure_default_policy == true)
+
+#- name: Contiv | Add policy rule 1 for allow-all policy
+#  command: 'netctl --netmaster "http://{{ inventory_hostname }}:{{ netmaster_port }}" policy rule-add -d in --action allow ose-allow-all-policy 1'
+#  when: contiv_fabric_mode == "aci"
+
+#- name: Contiv | Add policy rule 2 for allow-all policy
+#  command: 'netctl --netmaster "http://{{ inventory_hostname }}:{{ netmaster_port }}" policy rule-add -d out --action allow ose-allow-all-policy 2'
+#  when: contiv_fabric_mode == "aci"
+
+- name: Contiv | Create default aci app profile
+  command: 'netctl --netmaster "http://{{ inventory_hostname }}:{{ netmaster_port }}" app-profile create -g default-group {{ apic_default_app_profile }}'
+  when: contiv_fabric_mode == "aci"

--- a/roles/contiv/tasks/netmaster.yml
+++ b/roles/contiv/tasks/netmaster.yml
@@ -23,7 +23,7 @@
     line: "{{ hostvars[item]['ansible_' + netmaster_interface].ipv4.address }} netmaster"
     state: present
   when: hostvars[item]['ansible_' + netmaster_interface].ipv4.address is defined
-  with_items: groups['masters']
+  with_items: "{{ groups['masters'] }}"
 
 - name: Netmaster | Create netmaster symlinks
   file:

--- a/roles/contiv/tasks/netplugin_iptables.yml
+++ b/roles/contiv/tasks/netplugin_iptables.yml
@@ -23,7 +23,36 @@
   notify: Save iptables rules
 
 - name: Netplugin IPtables | Open vxlan port with iptables
-  command: /sbin/iptables -I INPUT 1 -p udp --dport 8472 -j ACCEPT -m comment --comment "vxlan"
+  command: /sbin/iptables -I INPUT 1 -p udp --dport 8472 -j ACCEPT -m comment --comment "netplugin vxlan 8472"
+  when: iptablesrules.stdout.find("netplugin vxlan 8472") == -1
+  notify: Save iptables rules
 
 - name: Netplugin IPtables | Open vxlan port with iptables
-  command: /sbin/iptables -I INPUT 1 -p udp --dport 4789 -j ACCEPT -m comment --comment "vxlan"
+  command: /sbin/iptables -I INPUT 1 -p udp --dport 4789 -j ACCEPT -m comment --comment "netplugin vxlan 4789"
+  when: iptablesrules.stdout.find("netplugin vxlan 4789") == -1
+  notify: Save iptables rules
+
+- name: Netplugin IPtables | Allow from contivh0
+  command: /sbin/iptables -I FORWARD 1 -i contivh0 -j ACCEPT -m comment --comment "contivh0 FORWARD input"
+  when: iptablesrules.stdout.find("contivh0 FORWARD input") == -1
+  notify: Save iptables rules
+
+- name: Netplugin IPtables | Allow to contivh0
+  command: /sbin/iptables -I FORWARD 1 -o contivh0 -j ACCEPT -m comment --comment "contivh0 FORWARD output"
+  when: iptablesrules.stdout.find("contivh0 FORWARD output") == -1
+  notify: Save iptables rules
+
+- name: Netplugin IPtables | Allow from contivh1
+  command: /sbin/iptables -I FORWARD 1 -i contivh1 -j ACCEPT -m comment --comment "contivh1 FORWARD input"
+  when: iptablesrules.stdout.find("contivh1 FORWARD input") == -1
+  notify: Save iptables rules
+
+- name: Netplugin IPtables | Allow to contivh1
+  command: /sbin/iptables -I FORWARD 1 -o contivh1 -j ACCEPT -m comment --comment "contivh1 FORWARD output"
+  when: iptablesrules.stdout.find("contivh1 FORWARD output") == -1
+  notify: Save iptables rules
+
+- name: Netplugin IPtables | Allow dns
+  command: /sbin/iptables -I INPUT 1 -p udp --dport 53 -j ACCEPT -m comment --comment "contiv dns"
+  when: iptablesrules.stdout.find("contiv dns") == -1
+  notify: Save iptables rules

--- a/roles/contiv/tasks/packageManagerInstall.yml
+++ b/roles/contiv/tasks/packageManagerInstall.yml
@@ -4,9 +4,10 @@
     did_install: false
 
 - include: pkgMgrInstallers/centos-install.yml
-  when: ansible_distribution == "CentOS" and not is_atomic
+  when: (ansible_os_family == "RedHat") and
+        not is_atomic
 
 - name: Package Manager | Set fact saying we did CentOS package install
   set_fact:
     did_install: true
-  when: ansible_distribution == "CentOS"
+  when: (ansible_os_family == "RedHat")

--- a/roles/contiv/tasks/pkgMgrInstallers/centos-install.yml
+++ b/roles/contiv/tasks/pkgMgrInstallers/centos-install.yml
@@ -1,13 +1,13 @@
 ---
-- name: PkgMgr CentOS | Install net-tools pkg for route
+- name: PkgMgr RHEL/CentOS | Install net-tools pkg for route
   yum:
     pkg=net-tools
     state=latest
 
-- name: PkgMgr CentOS | Get openstack kilo rpm
+- name: PkgMgr RHEL/CentOS | Get openstack ocata rpm
   get_url:
-    url: https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-2.noarch.rpm
-    dest: /tmp/rdo-release-kilo-2.noarch.rpm
+    url: https://repos.fedorapeople.org/repos/openstack/openstack-ocata/rdo-release-ocata-2.noarch.rpm
+    dest: /tmp/rdo-release-ocata-2.noarch.rpm
     validate_certs: False
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
@@ -16,15 +16,15 @@
   tags:
     - ovs_install
 
-- name: PkgMgr CentOS | Install openstack kilo rpm
-  yum: name=/tmp/rdo-release-kilo-2.noarch.rpm state=present
+- name: PkgMgr RHEL/CentOS | Install openstack ocata rpm
+  yum: name=/tmp/rdo-release-ocata-2.noarch.rpm state=present
   tags:
     - ovs_install
 
-- name: PkgMgr CentOS | Install ovs
+- name: PkgMgr RHEL/CentOS | Install ovs
   yum:
-    pkg=openvswitch
-    state=latest
+    pkg=openvswitch-2.5.0-2.el7.x86_64
+    state=present
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"

--- a/roles/contiv/templates/netplugin.j2
+++ b/roles/contiv/templates/netplugin.j2
@@ -1,9 +1,7 @@
 {% if contiv_encap_mode == "vlan" %}
 NETPLUGIN_ARGS='-vlan-if {{ netplugin_interface }} -ctrl-ip {{ netplugin_ctrl_ip }} -plugin-mode kubernetes -cluster-store etcd://{{ etcd_url }}'
 {% endif %}
-{#   Note: Commenting out vxlan encap mode support until it is fully supported
 {% if contiv_encap_mode == "vxlan" %}
-NETPLUGIN_ARGS='-vtep-ip {{ netplugin_ctrl_ip }} -e {{contiv_encap_mode}} -ctrl-ip {{ netplugin_ctrl_ip }} -plugin-mode kubernetes -cluster-store etcd://{{ etcd_url }}'
+NETPLUGIN_ARGS='-vtep-ip {{ netplugin_ctrl_ip }} -ctrl-ip {{ netplugin_ctrl_ip }} -plugin-mode kubernetes -cluster-store etcd://{{ etcd_url }}'
 {% endif %}
-#}
 

--- a/roles/contiv_auth_proxy/README.md
+++ b/roles/contiv_auth_proxy/README.md
@@ -1,0 +1,29 @@
+Role Name
+=========
+
+Role to install Contiv API Proxy and UI
+
+Requirements
+------------
+
+Docker needs to be installed to run the auth proxy container.
+
+Role Variables
+--------------
+
+auth_proxy_image specifies the image with version tag to be used to spin up the auth proxy container.
+auth_proxy_cert, auth_proxy_key specify files to use for the proxy server certificates.
+auth_proxy_port is the host port and auth_proxy_datastore the cluster data store address.
+
+Dependencies
+------------
+
+docker
+
+Example Playbook
+----------------
+
+- hosts: netplugin-node
+  become: true
+      roles:
+        - { role: auth_proxy, auth_proxy_port: 10000, auth_proxy_datastore: etcd://netmaster:22379 }

--- a/roles/contiv_auth_proxy/defaults/main.yml
+++ b/roles/contiv_auth_proxy/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+auth_proxy_image: "contiv/auth_proxy:1.0.0-beta.2"
+auth_proxy_port: 10000
+contiv_certs: "/var/contiv/certs"
+cluster_store: "{{ hostvars[groups['masters'][0]]['ansible_' + netmaster_interface].ipv4.address }}:22379"
+auth_proxy_cert: "{{ contiv_certs }}/auth_proxy_cert.pem"
+auth_proxy_key: "{{ contiv_certs }}/auth_proxy_key.pem"
+auth_proxy_datastore: "{{ cluster_store }}"
+auth_proxy_binaries: "/var/contiv_cache"
+auth_proxy_local_install: False
+auth_proxy_rule_comment: "Contiv auth proxy service"

--- a/roles/contiv_auth_proxy/files/auth-proxy.service
+++ b/roles/contiv_auth_proxy/files/auth-proxy.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Contiv Proxy and UI
+After=auditd.service systemd-user-sessions.service time-sync.target docker.service
+
+[Service]
+ExecStart=/usr/bin/auth_proxy.sh start
+ExecStop=/usr/bin/auth_proxy.sh stop
+KillMode=control-group
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/contiv_auth_proxy/handlers/main.yml
+++ b/roles/contiv_auth_proxy/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for auth_proxy

--- a/roles/contiv_auth_proxy/tasks/cleanup.yml
+++ b/roles/contiv_auth_proxy/tasks/cleanup.yml
@@ -1,0 +1,10 @@
+---
+
+- name: stop auth-proxy container
+  service: name=auth-proxy state=stopped
+
+- name: cleanup iptables for auth proxy
+  shell: iptables -D INPUT -p tcp --dport {{ item }} -j ACCEPT -m comment --comment "{{ auth_proxy_rule_comment }} ({{ item }})"
+  become: true
+  with_items:
+    - "{{ auth_proxy_port }}"

--- a/roles/contiv_auth_proxy/tasks/main.yml
+++ b/roles/contiv_auth_proxy/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+# tasks file for auth_proxy
+- name: setup iptables for auth proxy
+  shell: >
+      ( iptables -L INPUT | grep "{{ auth_proxy_rule_comment }} ({{ item }})" ) || \
+      iptables -I INPUT 1 -p tcp --dport {{ item }} -j ACCEPT -m comment --comment "{{ auth_proxy_rule_comment }} ({{ item }})"
+  become: true
+  with_items:
+    - "{{ auth_proxy_port }}"
+
+# Load the auth-proxy-image from local tar. Ignore any errors to handle the
+# case where the image is not built in
+- name: copy auth-proxy image
+  copy: src={{ auth_proxy_binaries }}/auth-proxy-image.tar dest=/tmp/auth-proxy-image.tar
+  when: auth_proxy_local_install == True
+
+- name: load auth-proxy image
+  shell: docker load -i /tmp/auth-proxy-image.tar
+  when: auth_proxy_local_install == True
+
+- name: create cert folder for proxy
+  file: path=/var/contiv/certs state=directory
+
+- name: copy shell script for starting auth-proxy
+  template: src=auth_proxy.j2 dest=/usr/bin/auth_proxy.sh mode=u=rwx,g=rx,o=rx
+
+- name: copy cert for starting auth-proxy
+  copy: src=cert.pem dest=/var/contiv/certs/auth_proxy_cert.pem mode=u=rw,g=r,o=r
+
+- name: copy key for starting auth-proxy
+  copy: src=key.pem dest=/var/contiv/certs/auth_proxy_key.pem mode=u=rw,g=r,o=r
+
+- name: copy systemd units for auth-proxy
+  copy: src=auth-proxy.service dest=/etc/systemd/system/auth-proxy.service
+
+- name: start auth-proxy container
+  systemd: name=auth-proxy daemon_reload=yes state=started enabled=yes

--- a/roles/contiv_auth_proxy/templates/auth_proxy.j2
+++ b/roles/contiv_auth_proxy/templates/auth_proxy.j2
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+usage="$0 start/stop"
+if [ $# -ne 1 ]; then
+    echo USAGE: $usage
+    exit 1
+fi
+
+case $1 in
+start)
+    set -e
+
+    /usr/bin/docker run --rm \
+      -p 10000:{{ auth_proxy_port }} \
+      --net=host --name=auth-proxy \
+      -e NO_NETMASTER_STARTUP_CHECK=1 \
+      -v /var/contiv:/var/contiv \
+      {{ auth_proxy_image }} \
+      --tls-key-file={{ auth_proxy_key }} \
+      --tls-certificate={{ auth_proxy_cert }} \
+      --data-store-address={{ auth_proxy_datastore }} \
+      --netmaster-address={{ service_vip }}:9999 \
+      --listen-address=:10000 
+    ;;
+
+stop)
+    # don't stop on error
+    /usr/bin/docker stop auth-proxy
+    /usr/bin/docker rm -f -v  auth-proxy
+    ;;
+
+*)
+    echo USAGE: $usage
+    exit 1
+    ;;
+esac

--- a/roles/contiv_auth_proxy/tests/inventory
+++ b/roles/contiv_auth_proxy/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/roles/contiv_auth_proxy/tests/test.yml
+++ b/roles/contiv_auth_proxy/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - auth_proxy

--- a/roles/contiv_auth_proxy/vars/main.yml
+++ b/roles/contiv_auth_proxy/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for auth_proxy

--- a/roles/contiv_facts/defaults/main.yaml
+++ b/roles/contiv_facts/defaults/main.yaml
@@ -8,3 +8,6 @@ bin_dir: /usr/bin
 ansible_temp_dir: /tmp/.ansible/files
 
 source_type: packageManager
+
+# Whether or not to also install and enable the Contiv auth_proxy
+contiv_enable_auth_proxy: false


### PR DESCRIPTION
Fixes & updates for Contiv networking plugin
1) Enable support for RHEL hosts, Openshift Enterprise, ACI mode, VXLAN mode
2) Update contiv version to 1.0.1
