### PR TITLE
Rename container image to origin-ansible / ose-ansible

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -26,16 +26,18 @@ tito build --rpm
 
 ## Build an openshift-ansible container image
 
+**NOTE**: the examples below use "openshift-ansible" as the name of the image to build for simplicity and illustration purposes, and also to prevent potential confusion between custom built images and official releases. See [README_CONTAINER_IMAGE.md](README_CONTAINER_IMAGE.md) for details about the released container images for openshift-ansible.
+
 To build a container image of `openshift-ansible` using standalone **Docker**:
 
         cd openshift-ansible
-        docker build -f images/installer/Dockerfile -t openshift/openshift-ansible .
+        docker build -f images/installer/Dockerfile -t openshift-ansible .
 
 ### Building on OpenShift
 
 To build an openshift-ansible image using an **OpenShift** [build and image stream](https://docs.openshift.org/latest/architecture/core_concepts/builds_and_image_streams.html) the straightforward command would be:
 
-        oc new-build docker.io/aweiteka/playbook2image~https://github.com/openshift/openshift-ansible
+        oc new-build registry.centos.org/openshift/playbook2image~https://github.com/openshift/openshift-ansible
 
 However: because the `Dockerfile` for this repository is not in the top level directory, and because we can't change the build context to the `images/installer` path as it would cause the build to fail, the `oc new-app` command above will create a build configuration using the *source to image* strategy, which is the default approach of the [playbook2image](https://github.com/openshift/playbook2image) base image. This does build an image successfully, but unfortunately the resulting image will be missing some customizations that are handled by the [Dockerfile](images/installer/Dockerfile) in this repo.
 
@@ -48,7 +50,7 @@ At the time of this writing there is no straightforward option to [set the docke
 ```
 curl -s https://raw.githubusercontent.com/openshift/openshift-ansible/master/images/installer/Dockerfile |
      oc new-build -D - \
-        --docker-image=docker.io/aweiteka/playbook2image \
+        --docker-image=registry.centos.org/openshift/playbook2image \
 	    https://github.com/openshift/openshift-ansible
 ```
 
@@ -76,5 +78,5 @@ Once the container image is built, we can import it into the OSTree
 storage:
 
 ```
-atomic pull --storage ostree docker:openshift/openshift-ansible:latest
+atomic pull --storage ostree docker:openshift-ansible:latest
 ```

--- a/README_CONTAINER_IMAGE.md
+++ b/README_CONTAINER_IMAGE.md
@@ -6,6 +6,12 @@ The image is designed to **run as a non-root user**. The container's UID is mapp
 
 **Note**: at this time there are known issues that prevent to run this image for installation/upgrade purposes (i.e. run one of the config/upgrade playbooks) from within one of the hosts that is also an installation target at the same time: if the playbook you want to run attempts to manage the docker daemon and restart it (like install/upgrade playbooks do) this would kill the container itself during its operation.
 
+## A note about the name of the image
+
+The released container images for openshift-ansible follow the naming scheme determined by OpenShift's `imageConfig.format` configuration option. This means that the released image name is `openshift/origin-ansible` instead of `openshift/openshift-ansible`.
+
+This provides consistency with other images used by the platform and it's also a requirement for some use cases like using the image from [`oc cluster up`](https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md).
+
 ## Usage
 
 The `playbook2image` base image provides several options to control the behaviour of the containers. For more details on these options see the [playbook2image](https://github.com/openshift/playbook2image) documentation.
@@ -26,7 +32,7 @@ Here is an example of how to run a containerized `openshift-ansible` playbook th
            -e INVENTORY_FILE=/tmp/inventory \
            -e PLAYBOOK_FILE=playbooks/byo/openshift-checks/certificate_expiry/default.yaml \
            -e OPTS="-v" -t \
-           openshift/openshift-ansible
+           openshift/origin-ansible
 
 You might want to adjust some of the options in the example to match your environment and/or preferences. For example: you might want to create a separate directory on the host where you'll copy the ssh key and inventory files prior to invocation to avoid unwanted SELinux re-labeling of the original files or paths (see below).
 
@@ -46,7 +52,7 @@ Here is a detailed explanation of the options used in the command above:
 
 Further usage examples are available in the [examples directory](examples/) with samples of how to use the image from within OpenShift.
 
-Additional usage information for images built from `playbook2image` like this one can be found in the [playbook2image examples](https://github.com/aweiteka/playbook2image/tree/master/examples).
+Additional usage information for images built from `playbook2image` like this one can be found in the [playbook2image examples](https://github.com/openshift/playbook2image/tree/master/examples).
 
 ## Running openshift-ansible as a System Container
 
@@ -59,8 +65,8 @@ If the inventory file needs additional files then it can use the path `/var/lib/
 Run the ansible system container:
 
 ```sh
-atomic install --system --set INVENTORY_FILE=$(pwd)/inventory.origin openshift/openshift-ansible
-systemctl start openshift-ansible
+atomic install --system --set INVENTORY_FILE=$(pwd)/inventory.origin openshift/origin-ansible
+systemctl start origin-ansible
 ```
 
 The `INVENTORY_FILE` variable says to the installer what inventory file on the host will be bind mounted inside the container.  In the example above, a file called `inventory.origin` in the current directory is used as the inventory file for the installer.
@@ -68,5 +74,5 @@ The `INVENTORY_FILE` variable says to the installer what inventory file on the h
 And to finally cleanup the container:
 
 ```
-atomic uninstall openshift-ansible
+atomic uninstall origin-ansible
 ```

--- a/examples/certificate-check-upload.yaml
+++ b/examples/certificate-check-upload.yaml
@@ -4,10 +4,10 @@
 # The generated reports are uploaded to a location in the master
 # hosts, using the playbook 'easy-mode-upload.yaml'.
 #
-# This example uses the openshift/openshift-ansible container image.
+# This example uses the openshift/origin-ansible container image.
 # (see README_CONTAINER_IMAGE.md in the top level dir for more details).
 #
-# The following objects are xpected to be configured before the creation
+# The following objects are expected to be configured before the creation
 # of this Job:
 #   - A ConfigMap named 'inventory' with a key named 'hosts' that
 #     contains the the Ansible inventory file
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: openshift-ansible
-        image: openshift/openshift-ansible
+        image: openshift/origin-ansible
         env:
         - name: PLAYBOOK_FILE
           value: playbooks/certificate_expiry/easy-mode-upload.yaml

--- a/examples/certificate-check-volume.yaml
+++ b/examples/certificate-check-volume.yaml
@@ -4,10 +4,10 @@
 # The generated reports are stored in a Persistent Volume using
 # the playbook 'html_and_json_timestamp.yaml'.
 #
-# This example uses the openshift/openshift-ansible container image.
+# This example uses the openshift/origin-ansible container image.
 # (see README_CONTAINER_IMAGE.md in the top level dir for more details).
 #
-# The following objects are xpected to be configured before the creation
+# The following objects are expected to be configured before the creation
 # of this Job:
 #   - A ConfigMap named 'inventory' with a key named 'hosts' that
 #     contains the the Ansible inventory file
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: openshift-ansible
-        image: openshift/openshift-ansible
+        image: openshift/origin-ansible
         env:
         - name: PLAYBOOK_FILE
           value: playbooks/certificate_expiry/html_and_json_timestamp.yaml

--- a/examples/scheduled-certcheck-upload.yaml
+++ b/examples/scheduled-certcheck-upload.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
           - name: openshift-ansible
-            image: openshift/openshift-ansible
+            image: openshift/origin-ansible
             env:
             - name: PLAYBOOK_FILE
               value: playbooks/certificate_expiry/easy-mode-upload.yaml

--- a/examples/scheduled-certcheck-volume.yaml
+++ b/examples/scheduled-certcheck-volume.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
           - name: openshift-ansible
-            image: openshift/openshift-ansible
+            image: openshift/origin-ansible
             env:
             - name: PLAYBOOK_FILE
               value: playbooks/certificate_expiry/html_and_json_timestamp.yaml

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -7,7 +7,7 @@ set -o pipefail
 STARTTIME=$(date +%s)
 source_root=$(dirname "${0}")/..
 
-prefix="openshift/openshift-ansible"
+prefix="openshift/origin-ansible"
 version="latest"
 verbose=false
 options="-f images/installer/Dockerfile"
@@ -44,7 +44,7 @@ if [ "$help" = true ]; then
   echo "Options: "
   echo "  --prefix=PREFIX"
   echo "  The prefix to use for the image names."
-  echo "  default: openshift/openshift-ansible"
+  echo "  default: openshift/origin-ansible"
   echo
   echo "  --version=VERSION"
   echo "  The version used to tag the image"

--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -12,7 +12,7 @@ set -o pipefail
 STARTTIME=$(date +%s)
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-PREFIX="${PREFIX:-openshift/openshift-ansible}"
+PREFIX="${PREFIX:-openshift/origin-ansible}"
 
 # Go to the top of the tree.
 cd "${OS_ROOT}"

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -1,11 +1,11 @@
 # Using playbook2image as a base
-# See https://github.com/aweiteka/playbook2image for details on the image
+# See https://github.com/openshift/playbook2image for details on the image
 # including documentation for the settings/env vars referenced below
-FROM docker.io/aweiteka/playbook2image:latest
+FROM registry.centos.org/openshift/playbook2image:latest
 
 MAINTAINER OpenShift Team <dev@lists.openshift.redhat.com>
 
-LABEL name="openshift-ansible" \
+LABEL name="openshift/origin-ansible" \
       summary="OpenShift's installation and configuration tool" \
       description="A containerized openshift-ansible image to let you run playbooks to install, upgrade, maintain and check an OpenShift cluster" \
       url="https://github.com/openshift/openshift-ansible" \

--- a/images/installer/Dockerfile.rhel7
+++ b/images/installer/Dockerfile.rhel7
@@ -2,7 +2,7 @@ FROM openshift3/playbook2image
 
 MAINTAINER OpenShift Team <dev@lists.openshift.redhat.com>
 
-LABEL name="openshift3/openshift-ansible" \
+LABEL name="openshift3/ose-ansible" \
       summary="OpenShift's installation and configuration tool" \
       description="A containerized openshift-ansible image to let you run playbooks to install, upgrade, maintain and check an OpenShift cluster" \
       url="https://github.com/openshift/openshift-ansible" \


### PR DESCRIPTION
As discussed in #4279 the container image is being renamed to `openshift/origin-ansible` (upstream) and `openshift3/ose-ansible` (downstream) for the `oc cluster up` use case, and more generally to make it fit the `imageConfig.format` configuration option.

This updates references to the image name accordingly.

Also updating references to `playbook2image` to account for recent moves of the repo/image.