### PR TITLE
mux uses fluentd cert/key to talk to ES

### DIFF
--- a/roles/openshift_logging_mux/templates/mux.j2
+++ b/roles/openshift_logging_mux/templates/mux.j2
@@ -109,7 +109,7 @@ spec:
           name: logging-mux
       - name: certs
         secret:
-          secretName: logging-mux
+          secretName: logging-fluentd
       - name: dockerhostname
         hostPath:
           path: /etc/hostname


### PR DESCRIPTION
mux uses the fluentd secret cert/key to talk to Elasticsearch
@ewolinetz @stevekuznetsov
[test_logging]