### PR TITLE
Fix g_glusterfs_hosts variable never set

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_config.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_config.yml
@@ -17,6 +17,6 @@
     glusterfs_heketi_topology_load: "{{ openshift_storage_glusterfs_heketi_topology_load }}"
     glusterfs_heketi_wipe: "{{ openshift_storage_glusterfs_heketi_wipe }}"
     glusterfs_heketi_url: "{{ openshift_storage_glusterfs_heketi_url }}"
-    glusterfs_nodes: "{{ g_glusterfs_hosts }}"
+    glusterfs_nodes: "{{ groups.oo_glusterfs_to_config }}"
 
 - include: glusterfs_common.yml

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
@@ -61,7 +61,7 @@
 
 - name: Label GlusterFS nodes
   oc_label:
-    name: "{{ glusterfs_host }}"
+    name: "{{ hostvars[glusterfs_host].glusterfs_hostname | default(glusterfs_host) }}"
     kind: node
     state: add
     labels: "{{ glusterfs_nodeselector | oo_dict_to_list_of_dict }}"

--- a/roles/openshift_storage_glusterfs/tasks/main.yml
+++ b/roles/openshift_storage_glusterfs/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - include: glusterfs_config.yml
   when:
-  - g_glusterfs_hosts | default([]) | count > 0
+  - groups.oo_glusterfs_to_config | default([]) | count > 0
 
 - include: glusterfs_registry.yml
   when:


### PR DESCRIPTION
Hi,
I was trying to install glusterfs using the playbook located at `playbooks/byo/openshift-glusterfs/config.yml` but the common playbook (`playbooks/common/openshift-glusterfs/config.yml`) was not setting the `g_glusterfs_hosts` variable, so the whole glusterfs installation was skipped everytime.

Changing this variable to groups.oo_glusterfs_to_config fixed the issue.

I also added the support of glusterfs_hostname host variable when labelling the nodes as I use different nodenames than the hostnames in my configuration. 