### PR TITLE
Add daemon_reload parameter to service tasks

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -177,6 +177,7 @@
 # https://github.com/openshift/origin/issues/6447
 - name: Start and enable master
   systemd:
+    daemon_reload: yes
     name: "{{ openshift.common.service_type }}-master"
     enabled: yes
     state: started

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -206,6 +206,7 @@
 
 - name: Start and enable node dep
   systemd:
+    daemon_reload: yes
     name: "{{ openshift.common.service_type }}-node-dep"
     enabled: yes
     state: started


### PR DESCRIPTION
Fixes "Could not find the requested service atomic-openshift-master:
cannot enable" error during reinstall.

https://bugzilla.redhat.com/show_bug.cgi?id=1451693