### PR TITLE
show correct default value in inventory

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -329,8 +329,8 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # router's default certificate.
 #openshift_hosted_router_certificate={"certfile": "/path/to/router.crt", "keyfile": "/path/to/router.key", "cafile": "/path/to/router-ca.crt"}
 #
-# Disable management of the OpenShift Router
-#openshift_hosted_manage_router=false
+# Manage the OpenShift Router
+#openshift_hosted_manage_router=true
 #
 # Router sharding support has been added and can be achieved by supplying the correct
 # data to the inventory.  The variable to house the data is openshift_hosted_routers
@@ -407,8 +407,8 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Validity of the auto-generated certificate in days (optional)
 #openshift_hosted_registry_cert_expire_days=730
 #
-# Disable management of the OpenShift Registry
-#openshift_hosted_manage_registry=false
+# Manage the OpenShift Registry
+#openshift_hosted_manage_registry=true
 
 # Registry Storage Options
 #

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -328,8 +328,8 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # router's default certificate.
 #openshift_hosted_router_certificate={"certfile": "/path/to/router.crt", "keyfile": "/path/to/router.key", "cafile": "/path/to/router-ca.crt"}
 #
-# Disable management of the OpenShift Router
-#openshift_hosted_manage_router=false
+# Manage the OpenShift Router (optional)
+#openshift_hosted_manage_router=true
 #
 # Router sharding support has been added and can be achieved by supplying the correct
 # data to the inventory.  The variable to house the data is openshift_hosted_routers
@@ -406,8 +406,8 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Validity of the auto-generated certificate in days (optional)
 #openshift_hosted_registry_cert_expire_days=730
 #
-# Disable management of the OpenShift Registry
-#openshift_hosted_manage_registry=false
+# Manage the OpenShift Registry (optional)
+#openshift_hosted_manage_registry=true
 
 # Registry Storage Options
 #


### PR DESCRIPTION
The inventory suggest the default setting for `openshift_hosted_manage_registry` is `false` when its actually `true` in the yaml file: https://github.com/openshift/openshift-ansible/blob/76e4105b6e52cd1f510460d204d37f2b60a790b6/roles/openshift_hosted/tasks/main.yml#L13  . Same for the router https://github.com/openshift/openshift-ansible/blob/76e4105b6e52cd1f510460d204d37f2b60a790b6/roles/openshift_hosted/tasks/main.yml#L10

The current wording is kind of confusing IMHO. With the default setting of `openshift_hosted_manage_registry=true` now it would seem to imply its going to disable management of the openshift registry when it doesn't. This PR should clear that up.