### PR TITLE
[3.2] Backport fixes to accomodate etcd v3 backup

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre.yml
@@ -250,7 +250,6 @@
   hosts: etcd_hosts_to_backup
   vars:
     embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
-    timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
   roles:
   - openshift_facts
   tasks:
@@ -259,6 +258,8 @@
       role: etcd
       local_facts: {}
     when: "{{ 'etcd' not in openshift }}"
+  - set_fact:
+      etcd_backup_dir: "{{ openshift.common.data_dir }}/etcd-backup-{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
 
   - stat: path=/var/lib/openshift
     register: var_lib_openshift
@@ -296,14 +297,27 @@
   - name: Generate etcd backup
     command: >
       etcdctl backup --data-dir={{ openshift.etcd.etcd_data_dir }}
-      --backup-dir={{ openshift.common.data_dir }}/etcd-backup-{{ timestamp }}
+      --backup-dir={{ etcd_backup_dir }}
+
+  # According to the docs change you can simply copy snap/db
+  # https://github.com/openshift/openshift-docs/commit/b38042de02d9780842dce95cfa0ef45d53b58bc6
+  - name: Check for v3 data store
+    stat:
+      path: "{{ openshift.etcd.etcd_data_dir }}/member/snap/db"
+    register: v3_db
+
+  - name: Copy etcd v3 data store
+    command: >
+      cp -a {{ openshift.etcd.etcd_data_dir }}/member/snap/db
+      {{ etcd_backup_dir }}/member/snap/
+    when: v3_db.stat.exists
 
   - set_fact:
       etcd_backup_complete: True
 
   - name: Display location of etcd backup
     debug:
-      msg: "Etcd backup created in {{ openshift.common.data_dir }}/etcd-backup-{{ timestamp }}"
+      msg: "Etcd backup created in {{ etcd_backup_dir }}"
 
 
 ##############################################################################


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1440303

Roughly backports https://github.com/openshift/openshift-ansible/pull/3878 and https://github.com/openshift/openshift-ansible/pull/3860