### PR TITLE
bug 1457642. Use same SG index to avoid seeding timeout

### DIFF
--- a/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
@@ -14,6 +14,7 @@ index:
     flush_threshold_period: 5m
 
 node:
+  name: ${DC_NAME}
   master: ${IS_MASTER}
   data: ${HAS_DATA}
 
@@ -60,7 +61,7 @@ path:
 searchguard:
   authcz.admin_dn:
   - CN=system.admin,OU=OpenShift,O=Logging
-  config_index_name: ".searchguard.${HOSTNAME}"
+  config_index_name: ".searchguard.${DC_NAME}"
   ssl:
     transport:
       enabled: true

--- a/roles/openshift_logging_elasticsearch/templates/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/es.j2
@@ -58,6 +58,9 @@ spec:
               name: "cluster"
           env:
             -
+              name: "DC_NAME"
+              value: "{{deploy_name}}"
+            -
               name: "NAMESPACE"
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
This PR:

* sets the node name to be the same as DC name
* sets the SG index name to be same as the DC name
