### PR TITLE
Remove supported/implemented checks for registry object storage provider

### DIFF
--- a/roles/openshift_hosted/tasks/registry/storage/object_storage.yml
+++ b/roles/openshift_hosted/tasks/registry/storage/object_storage.yml
@@ -1,20 +1,4 @@
 ---
-- name: Assert supported openshift.hosted.registry.storage.provider
-  assert:
-    that:
-    - openshift.hosted.registry.storage.provider in ['azure_blob', 's3', 'swift']
-    msg: >
-      Object Storage Provider: "{{ openshift.hosted.registry.storage.provider }}"
-      is not currently supported
-
-- name: Assert implemented openshift.hosted.registry.storage.provider
-  assert:
-    that:
-    - openshift.hosted.registry.storage.provider not in ['azure_blob', 'swift']
-    msg: >
-      Support for provider: "{{ openshift.hosted.registry.storage.provider }}"
-      not implemented yet
-
 - include: s3.yml
   when: openshift.hosted.registry.storage.provider == 's3'
 


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-ansible/issues/4366

We have variables for the following providers within the registry config template but we only allow `s3`.
* `azure_blob`
* `gcs`
* `s3`
* `swift`

We could just add all of these to supported/implemented (or at least `gcs`) but I'm not sure it makes sense to have this check. If there are issues with a particular provider we can address them.