### PR TITLE
Metrics: update the imagePullPolicy to be always

### DIFF
--- a/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
@@ -30,6 +30,7 @@ spec:
 {% endif %}
       containers:
       - image: "{{ openshift_metrics_image_prefix }}metrics-cassandra:{{ openshift_metrics_image_version }}"
+        imagePullPolicy: Always
         name: hawkular-cassandra-{{ node }}
         ports:
         - name: cql-port

--- a/roles/openshift_metrics/templates/hawkular_metrics_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_metrics_rc.j2
@@ -25,6 +25,7 @@ spec:
 {% endif %}
       containers:
       - image: {{openshift_metrics_image_prefix}}metrics-hawkular-metrics:{{openshift_metrics_image_version}}
+        imagePullPolicy: Always
         name: hawkular-metrics
         ports:
         - name: http-endpoint

--- a/roles/openshift_metrics/templates/heapster.j2
+++ b/roles/openshift_metrics/templates/heapster.j2
@@ -27,6 +27,7 @@ spec:
       containers:
       - name: heapster
         image: {{openshift_metrics_image_prefix}}metrics-heapster:{{openshift_metrics_image_version}}
+        imagePullPolicy: Always
         ports:
         - containerPort: 8082
           name: "http-endpoint"


### PR DESCRIPTION
The corresponding backport for https://github.com/openshift/openshift-ansible/pull/4298

We have gotten a few bugzilla's about people not getting the updated images like they are expecting (see https://bugzilla.redhat.com/show_bug.cgi?id=1455736). This change should fix that problem as well as bring the behaviour of the metric images more inline with the logging images.