### PR TITLE
kibana - only create oauthclient once

### DIFF
--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -161,6 +161,7 @@
     openshift_logging_kibana_es_host: "{{ openshift_logging_es_host }}"
     openshift_logging_kibana_es_port: "{{ openshift_logging_es_port }}"
     openshift_logging_kibana_image_pull_secret: "{{ openshift_logging_image_pull_secret }}"
+    do_oauth_client: True
 
 
 - include_role:

--- a/roles/openshift_logging_kibana/tasks/main.yaml
+++ b/roles/openshift_logging_kibana/tasks/main.yaml
@@ -125,6 +125,7 @@
 - name: Generate proxy session
   set_fact:
     session_secret: "{{ 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789' | random_word(200) }}"
+  when: session_secret is not defined
   check_mode: no
 
 # gen oauth_secret -- if necessary
@@ -132,6 +133,7 @@
 - name: Generate oauth client secret
   set_fact:
     oauth_secret: "{{ 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789' | random_word(64) }}"
+  when: oauth_secret is not defined
   check_mode: no
 
 # create oauth client
@@ -141,7 +143,9 @@
     dest: "{{ tempdir }}/templates/oauth-client.yml"
   vars:
     kibana_hostname: "{{ openshift_logging_kibana_hostname }}"
+    kibana_ops_hostname: "{{ openshift_logging_kibana_ops_hostname }}"
     secret: "{{ oauth_secret }}"
+  when: do_oauth_client is defined and do_oauth_client | bool
 
 - name: Set kibana-proxy oauth-client
   oc_obj:
@@ -152,6 +156,7 @@
     files:
     - "{{ tempdir }}/templates/oauth-client.yml"
     delete_after: true
+  when: do_oauth_client is defined and do_oauth_client | bool
 
 # create Kibana secret
 - name: Set Kibana secret

--- a/roles/openshift_logging_kibana/templates/oauth-client.j2
+++ b/roles/openshift_logging_kibana/templates/oauth-client.j2
@@ -7,6 +7,9 @@ metadata:
 secret: {{secret}}
 redirectURIs:
 - https://{{kibana_hostname}}
+{% if openshift_logging_use_ops %}
+- https://{{kibana_ops_hostname}}
+{% endif %}
 scopeRestrictions:
 - literals:
   - user:info


### PR DESCRIPTION
With this fix, I am able to run kibana against an environment setup
with an ops cluster.
@ewolinetz @jcantrill PTAL