### PR TITLE
Etcd container to system container

### DIFF
--- a/roles/etcd/tasks/system_container.yml
+++ b/roles/etcd/tasks/system_container.yml
@@ -15,6 +15,32 @@
       {%- endif -%}
       {% endfor -%}
 
+- name: Check etcd system container package
+  command: >
+    atomic containers list --no-trunc -a -f container=etcd -f backend=ostree
+  register: etcd_result
+
+- name: Unmask etcd service
+  systemd:
+    name: etcd
+    state: stopped
+    enabled: yes
+    masked: no
+    daemon_reload: yes
+  register: task_result
+  failed_when: task_result|failed and 'could not' not in task_result.msg|lower
+  when: "'etcd' in etcd_result.stdout"
+
+- name: Disable etcd_container
+  systemd:
+    name: etcd_container
+    state: stopped
+    enabled: no
+    masked: yes
+    daemon_reload: yes
+  register: task_result
+  failed_when: task_result|failed and 'could not' not in task_result.msg|lower
+
 - name: Check for previous etcd data store
   stat:
     path: "{{ etcd_data_dir }}/member/"

--- a/roles/etcd/tasks/system_container.yml
+++ b/roles/etcd/tasks/system_container.yml
@@ -85,3 +85,5 @@
       - ETCD_PEER_CA_FILE={{ etcd_system_container_conf_dir }}/ca.crt
       - ETCD_PEER_CERT_FILE={{ etcd_system_container_conf_dir }}/peer.crt
       - ETCD_PEER_KEY_FILE={{ etcd_system_container_conf_dir }}/peer.key
+      - ETCD_TRUSTED_CA_FILE={{ etcd_system_container_conf_dir }}/ca.crt
+      - ETCD_PEER_TRUSTED_CA_FILE={{ etcd_system_container_conf_dir }}/ca.crt

--- a/roles/etcd/tasks/system_container.yml
+++ b/roles/etcd/tasks/system_container.yml
@@ -15,6 +15,30 @@
       {%- endif -%}
       {% endfor -%}
 
+- name: Check for previous etcd data store
+  stat:
+    path: "{{ etcd_data_dir }}/member/"
+  register: src_datastore
+
+- name: Check for etcd system container data store
+  stat:
+    path: "{{ r_etcd_common_system_container_host_dir }}/etcd.etcd/member"
+  register: dest_datastore
+
+- name: Ensure that etcd system container data dirs exist
+  file: path="{{ item }}" state=directory
+  with_items:
+    - "{{ r_etcd_common_system_container_host_dir }}/etc"
+    - "{{ r_etcd_common_system_container_host_dir }}/etcd.etcd"
+
+- name: Copy etcd data store
+  command: >
+    cp -a {{ etcd_data_dir }}/member
+    {{ r_etcd_common_system_container_host_dir }}/etcd.etcd/member
+  when:
+    - src_datastore.stat.exists
+    - not dest_datastore.stat.exists
+
 - name: Install or Update Etcd system container package
   oc_atomic_container:
     name: etcd

--- a/roles/etcd_common/defaults/main.yml
+++ b/roles/etcd_common/defaults/main.yml
@@ -3,7 +3,8 @@
 r_etcd_common_etcd_runtime: "docker"
 
 # etcd server vars
-etcd_conf_dir: "{{ '/etc/etcd' if r_etcd_common_etcd_runtime != 'runc' else '/var/lib/etcd/etcd.etcd/etc'  }}"
+etcd_conf_dir: '/etc/etcd'
+r_etcd_common_system_container_host_dir: /var/lib/etcd/etcd.etcd
 etcd_system_container_conf_dir: /var/lib/etcd/etc
 etcd_conf_file: "{{ etcd_conf_dir }}/etcd.conf"
 etcd_ca_file: "{{ etcd_conf_dir }}/ca.crt"

--- a/roles/etcd_server_certificates/tasks/main.yml
+++ b/roles/etcd_server_certificates/tasks/main.yml
@@ -5,11 +5,14 @@
 
 - name: Check status of etcd certificates
   stat:
-    path: "{{ etcd_cert_config_dir }}/{{ item }}"
+    path: "{{ item }}"
   with_items:
-  - "{{ etcd_cert_prefix }}server.crt"
-  - "{{ etcd_cert_prefix }}peer.crt"
-  - "{{ etcd_cert_prefix }}ca.crt"
+  - "{{ etcd_cert_config_dir }}/{{ etcd_cert_prefix }}server.crt"
+  - "{{ etcd_cert_config_dir }}/{{ etcd_cert_prefix }}peer.crt"
+  - "{{ etcd_cert_config_dir }}/{{ etcd_cert_prefix }}ca.crt"
+  - "{{ etcd_system_container_cert_config_dir }}/{{ etcd_cert_prefix }}server.crt"
+  - "{{ etcd_system_container_cert_config_dir }}/{{ etcd_cert_prefix }}peer.crt"
+  - "{{ etcd_system_container_cert_config_dir }}/{{ etcd_cert_prefix }}ca.crt"
   register: g_etcd_server_cert_stat_result
   when: not etcd_certificates_redeploy | default(false) | bool
 
@@ -132,8 +135,11 @@
 
 - name: Ensure certificate directory exists
   file:
-    path: "{{ etcd_cert_config_dir }}"
+    path: "{{ item }}"
     state: directory
+  with_items:
+  - "{{ etcd_cert_config_dir }}"
+  - "{{ etcd_system_container_cert_config_dir }}"
   when: etcd_server_certs_missing | bool
 
 - name: Unarchive cert tarball
@@ -164,15 +170,28 @@
 
 - name: Ensure ca directory exists
   file:
-    path: "{{ etcd_ca_dir }}"
+    path: "{{ item }}"
     state: directory
+  with_items:
+  - "{{ etcd_ca_dir }}"
+  - "{{ etcd_system_container_cert_config_dir }}/ca"
   when: etcd_server_certs_missing | bool
 
-- name: Unarchive etcd ca cert tarballs
+- name: Unarchive cert tarball for the system container
+  unarchive:
+    src: "{{ g_etcd_server_mktemp.stdout }}/{{ etcd_cert_subdir }}.tgz"
+    dest: "{{ etcd_system_container_cert_config_dir }}"
+  when:
+  - etcd_server_certs_missing | bool
+  - r_etcd_common_etcd_runtime == 'runc'
+
+- name: Unarchive etcd ca cert tarballs for the system container
   unarchive:
     src: "{{ g_etcd_server_mktemp.stdout }}/{{ etcd_ca_name }}.tgz"
-    dest: "{{ etcd_ca_dir }}"
-  when: etcd_server_certs_missing | bool
+    dest: "{{ etcd_system_container_cert_config_dir }}/ca"
+  when:
+  - etcd_server_certs_missing | bool
+  - r_etcd_common_etcd_runtime == 'runc'
 
 - name: Delete temporary directory
   local_action: file path="{{ g_etcd_server_mktemp.stdout }}" state=absent

--- a/roles/openshift_etcd_facts/vars/main.yml
+++ b/roles/openshift_etcd_facts/vars/main.yml
@@ -5,6 +5,6 @@ etcd_hostname: "{{ openshift.common.hostname }}"
 etcd_ip: "{{ openshift.common.ip }}"
 etcd_cert_subdir: "etcd-{{ openshift.common.hostname }}"
 etcd_cert_prefix:
-etcd_cert_config_dir: "{{ '/etc/etcd' if not openshift.common.is_etcd_system_container | bool else '/var/lib/etcd/etcd.etcd/etc' }}"
+etcd_cert_config_dir: "/etc/etcd"
 etcd_peer_url_scheme: https
 etcd_url_scheme: https

--- a/roles/openshift_etcd_facts/vars/main.yml
+++ b/roles/openshift_etcd_facts/vars/main.yml
@@ -6,5 +6,6 @@ etcd_ip: "{{ openshift.common.ip }}"
 etcd_cert_subdir: "etcd-{{ openshift.common.hostname }}"
 etcd_cert_prefix:
 etcd_cert_config_dir: "/etc/etcd"
+etcd_system_container_cert_config_dir: /var/lib/etcd/etcd.etcd/etc
 etcd_peer_url_scheme: https
 etcd_url_scheme: https


### PR DESCRIPTION
Migrate existing etcd storage to the system container location.

Check if there is already an installation of etcd before installing the system container.  If there is one, copy the previous data to the system container location.

Also fixed an issue when the etcd systemd service was previously masked.