### PR TITLE
skip installation of base package in openshift_ca when scalling up master

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -111,6 +111,7 @@
                                                 }}"
   roles:
   - role: openshift_master
+    r_openshift_ca_skip_installation: "{{ 'true' if scaleup_master | default(false) | bool else 'false' }}"
     openshift_ca_host: "{{ groups.oo_first_master.0 }}"
     openshift_master_etcd_hosts: "{{ hostvars
                                      | oo_select_keys(groups['oo_etcd_to_config'] | default([]))

--- a/playbooks/common/openshift-master/scaleup.yml
+++ b/playbooks/common/openshift-master/scaleup.yml
@@ -51,7 +51,7 @@
     changed_when: false
 
 - name: Configure docker hosts
-  hosts: oo_masters_to-config:oo_nodes_to_config
+  hosts: oo_masters_to_config:oo_nodes_to_config
   vars:
     docker_additional_registries: "{{ lookup('oo_option', 'docker_additional_registries') | oo_split }}"
     docker_insecure_registries: "{{ lookup('oo_option',  'docker_insecure_registries') | oo_split }}"
@@ -71,6 +71,8 @@
     r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
 
 - include: ../openshift-master/config.yml
+  vars:
+    scaleup_master: true
 
 - include: ../openshift-loadbalancer/config.yml
 

--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -11,7 +11,9 @@
   package:
     name: "{{ openshift.common.service_type }}{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
     state: present
-  when: not openshift.common.is_containerized | bool
+  when:
+  - not openshift.common.is_containerized | bool
+  - not r_openshift_ca_skip_installation | bool
   register: install_result
   delegate_to: "{{ openshift_ca_host }}"
   run_once: true

--- a/roles/openshift_ca/vars/main.yml
+++ b/roles/openshift_ca/vars/main.yml
@@ -4,3 +4,5 @@ openshift_ca_cert: "{{ openshift_ca_config_dir }}/ca.crt"
 openshift_ca_key: "{{ openshift_ca_config_dir }}/ca.key"
 openshift_ca_serial: "{{ openshift_ca_config_dir }}/ca.serial.txt"
 openshift_version: "{{ openshift_pkg_version | default('') }}"
+
+r_openshift_ca_skip_installation: false


### PR DESCRIPTION
Backport part of https://github.com/openshift/openshift-ansible/pull/4045 and skipping installation of atomic-openshift on the first master during master scaleup (since excluders are disabled on the new master node only).