### PR TITLE
Correct master-config update during upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_5/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/master_config_upgrade.yml
@@ -1,0 +1,16 @@
+---
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'admissionConfig.pluginConfig'
+    yaml_value: "{{ openshift.master.admission_plugin_config }}"
+  when: "'admission_plugin_config' in openshift.master"
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'admissionConfig.pluginOrderOverride'
+    yaml_value:
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'kubernetesMasterConfig.admissionConfig'
+    yaml_value:

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
@@ -115,6 +115,8 @@
   - include: ../cleanup_unused_images.yml
 
 - include: ../upgrade_control_plane.yml
+  vars:
+    master_config_hook: "v3_5/master_config_upgrade.yml"
 
 - include: ../post_control_plane.yml
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/master_config_upgrade.yml
@@ -1,0 +1,16 @@
+---
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'admissionConfig.pluginConfig'
+    yaml_value: "{{ openshift.master.admission_plugin_config }}"
+  when: "'admission_plugin_config' in openshift.master"
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'admissionConfig.pluginOrderOverride'
+    yaml_value:
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'kubernetesMasterConfig.admissionConfig'
+    yaml_value:

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
@@ -115,6 +115,8 @@
   - include: ../cleanup_unused_images.yml
 
 - include: ../upgrade_control_plane.yml
+  vars:
+    master_config_hook: "v3_6/master_config_upgrade.yml"
 
 - include: ../post_control_plane.yml
 


### PR DESCRIPTION
Master config is updated during an upgrade.

Bug 1456096

See also: https://github.com/openshift/openshift-ansible/pull/4199