### PR TITLE
Fail if a node_upgrade.yml playbook is run over a master host

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
@@ -38,3 +38,10 @@
       ansible_become: "{{ g_sudo | default(omit) }}"
     with_items: "{{ groups['temp_nodes_to_upgrade'] | default(groups['oo_nodes_to_config']) }}"
     changed_when: False
+
+- name: Fail if any of the target nodes is a master node
+  hosts: localhost
+  tasks:
+  - fail:
+      msg: "The node upgrade can not be run over master"
+    when: groups.oo_nodes_to_upgrade | intersect(groups.oo_masters_to_config) | length > 0


### PR DESCRIPTION
Node part of a master node is upgraded as part of the control plane upgrade.

Bugs: bz#1455857