### PR TITLE
Add play and role to install ansible-service-broker

### DIFF
--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -54,3 +54,10 @@
   - role: openshift_excluder
     r_openshift_excluder_action: enable
     r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
+
+- name: install ansible-service-broker
+  hosts: oo_first_master
+  roles:
+  - role: ansible_service_broker
+    when: install_ansible_service_broker | bool
+    ignore_errors: true

--- a/roles/ansible_service_broker/meta/main.yml
+++ b/roles/ansible_service_broker/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: Fabian von Feilitzsch
+  description: OpenShift Ansible Service Broker
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 2.1
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+dependencies:
+- role: lib_openshift

--- a/roles/ansible_service_broker/tasks/main.yml
+++ b/roles/ansible_service_broker/tasks/main.yml
@@ -1,0 +1,140 @@
+---
+
+- name: create openshift-ansible-service-broker project
+  oc_project:
+    name: openshift-ansible-service-broker
+
+- name: create ansible-service-broker serviceaccount
+  oc_serviceaccount:
+    name: asb
+    namespace: openshift-ansible-service-broker
+    state: present
+
+- name: create ansible-service-broker service
+  oc_service:
+    name: asb
+    namespace: openshift-ansible-service-broker
+    labels:
+      app: ansible-service-broker
+      service: asb
+    ports:
+      - name: port-1338
+        port: 1338
+    selector:
+      app: ansible-service-broker
+      service: asb
+
+- name: create etcd service
+  oc_service:
+    name: etcd
+    namespace: openshift-ansible-service-broker
+    ports:
+      - name: etcd-advertise
+        port: 2379
+    selector:
+      app: ansible-service-broker
+      service: etcd
+
+- name: create route for ansible-service-broker service
+  oc_route:
+    name: asb-1338
+    namespace: openshift-ansible-service-broker
+    service_name: asb
+    port: 1338
+
+- name: create persistent volume claim for etcd
+  oc_pvc:
+    state: present
+    name: etcd
+    namespace: openshift-ansible-service-broker
+    volume_capacity: 1G
+    access_modes:
+    - ReadWriteOnce
+
+- name: create etcd deployment
+  oc_obj:
+    state: present
+    name: etcd
+    namespace: openshift-ansible-service-broker
+    kind: Deployment
+    content:
+      path: /tmp/dcout
+      data:
+        apiVersion: extensions/v1beta1
+        kind: Deployment
+        metadata:
+          name: etcd
+          namespace: openshift-ansible-service-broker
+          labels:
+            app: ansible-service-broker
+            service: etcd
+        spec:
+          strategy:
+            type: Recreate
+          replicas: 1
+          template:
+            metadata:
+              labels:
+                app: ansible-service-broker
+                service: etcd
+            spec:
+              restartPolicy: Always
+              containers:
+                - image: "ansibleapp/ansible-service-broker-etcd:latest"
+                  name: main
+                  imagePullPolicy: IfNotPresent
+                  workingDir: /etcd
+                  args:
+                    - ./etcd
+                    - --data-dir=/data
+                    - "--listen-client-urls=http://0.0.0.0:2379"
+                    - "--advertise-client-urls=http://0.0.0.0:2379"
+                  ports:
+                  - containerPort: 2379
+                    protocol: TCP
+                  env:
+                  - name: ETCDCTL_API
+                    value: "3"
+                  volumeMounts:
+                  - mountPath: /data
+                    name: etcd
+              volumes:
+              - name: etcd
+                persistentVolumeClaim:
+                  claimName: etcd
+
+- name: create ansible-service-broker deployment
+  oc_obj:
+    state: present
+    name: asb
+    namespace: openshift-ansible-service-broker
+    kind: Deployment
+    content:
+      path: /tmp/dcout
+      data:
+        apiVersion: extensions/v1beta1
+        kind: Deployment
+        metadata:
+          name: asb
+          namespace: openshift-ansible-service-broker
+          labels:
+            app: openshift-ansible-service-broker
+            service: asb
+        spec:
+          strategy:
+            type: Recreate
+          replicas: 1
+          template:
+            metadata:
+              labels:
+                app: openshift-ansible-service-broker
+                service: asb
+            spec:
+              restartPolicy: Always
+              containers:
+                - image: "ansibleplaybookbundle/ansible-service-broker:latest"
+                  name: asb
+                  imagePullPolicy: Always
+                  ports:
+                    - containerPort: 1338
+                      protocol: TCP


### PR DESCRIPTION
Currently blocked waiting for https://trello.com/c/Ebx11vsc

This is currently a work in progress, I'm blocked for a bit waiting on some changes to the broker and rcm approvals. I just wanted to submit this PR now to get a good sanity check and some review so that once my blockers are removed I'll be good to merge.

A few questions I have:

1. I just kind of stuck my play in the `openshift-cluster/config.yml` playbook because it was convenient for my testing, but I wasn't sure how to determine where it actually belongs
1. So far I only need to add a variable that determines whether or not to install the broker. I wasn't sure where I should put this variable. Currently it's global (so I guess should be prefixed with `g_`), but I figured this is probably bad and it would end up nested somewhere else, like `openshift_common` or something. Wasn't sure how to determine where it fits, and assumed this would probably also be dependent on where the play ends up.
1. My etcd requires a persistent volume, the way I've done this is just creating the pvc, but since I don't think there are any pvs available by default I wasn't sure what the correct way to handle that would be. Should I just create a hostpath volume or is there a more preferred way to handle this?