### PR TITLE
Added includes to specify openshift version for libvirt cluster creat…

### DIFF
--- a/playbooks/libvirt/openshift-cluster/config.yml
+++ b/playbooks/libvirt/openshift-cluster/config.yml
@@ -3,6 +3,8 @@
 # is localhost, so no hostname value (or public_hostname) value is getting
 # assigned
 
+- include: ../../common/openshift-cluster/std_include.yml
+
 - hosts: localhost
   gather_facts: no
   tasks:


### PR DESCRIPTION
…e. Otherwise bin/cluster create fails on unknown version for libvirt deployment.