### PR TITLE
Disable excluder only on nodes that are not masters

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/disable_node_excluders.yml
+++ b/playbooks/common/openshift-cluster/upgrades/disable_node_excluders.yml
@@ -1,6 +1,6 @@
 ---
 - name: Disable excluders
-  hosts: oo_nodes_to_config
+  hosts: oo_nodes_to_upgrade:!oo_masters_to_config
   gather_facts: no
   roles:
   - role: openshift_excluder


### PR DESCRIPTION
If a master is node as well, the node upgrade is skipped. So we should not disable excluders on such nodes.