### PR TITLE
Add systemctl daemon-reload handler to openshift_node

### DIFF
--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: restart openvswitch
-  systemd: name=openvswitch state=restarted
+  systemd:
+    name: openvswitch
+    state: restarted
   when: (not skip_node_svc_handlers | default(False) | bool) and not (ovs_service_status_changed | default(false) | bool) and openshift.common.use_openshift_sdn | bool
   notify:
   - restart openvswitch pause
@@ -10,8 +12,13 @@
   when: (not skip_node_svc_handlers | default(False) | bool) and openshift.common.is_containerized | bool
 
 - name: restart node
-  systemd: name={{ openshift.common.service_type }}-node state=restarted
+  systemd:
+    name: "{{ openshift.common.service_type }}-node"
+    state: restarted
   when: (not skip_node_svc_handlers | default(False) | bool) and not (node_service_status_changed | default(false) | bool)
 
 - name: reload sysctl.conf
   command: /sbin/sysctl -p
+
+- name: reload systemd units
+  command: systemctl daemon-reload

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -8,6 +8,9 @@
     src: openshift.docker.node.dep.service
   register: install_node_dep_result
   when: openshift.common.is_containerized | bool
+  notify:
+  - reload systemd units
+  - restart node
 
 - block:
   - name: Pre-pull node image
@@ -21,6 +24,9 @@
       dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
       src: openshift.docker.node.service
     register: install_node_result
+    notify:
+    - reload systemd units
+    - restart node
   when:
   - openshift.common.is_containerized | bool
   - not openshift.common.is_node_system_container | bool
@@ -31,6 +37,9 @@
     src: "{{ openshift.common.service_type }}-node.service.j2"
   register: install_node_result
   when: not openshift.common.is_containerized | bool
+  notify:
+  - reload systemd units
+  - restart node
 
 - name: Create the openvswitch service env file
   template:
@@ -39,6 +48,7 @@
   when: openshift.common.is_containerized | bool
   register: install_ovs_sysconfig
   notify:
+  - reload systemd units
   - restart openvswitch
 
 - name: Install Node system container
@@ -67,6 +77,7 @@
   when: openshift.common.use_openshift_sdn | default(true) | bool
   register: install_oom_fix_result
   notify:
+  - reload systemd units
   - restart openvswitch
 
 - block:
@@ -81,6 +92,7 @@
       dest: "/etc/systemd/system/openvswitch.service"
       src: openvswitch.docker.service
     notify:
+    - reload systemd units
     - restart openvswitch
   when:
   - openshift.common.is_containerized | bool
@@ -117,10 +129,5 @@
   - regex: '^NO_PROXY='
     line: "NO_PROXY={{ openshift.common.no_proxy | default([]) }},{{ openshift.common.portal_net }},{{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }}"
   when: ('http_proxy' in openshift.common and openshift.common.http_proxy != '')
-  notify:
-  - restart node
-
-- name: Reload systemd units
-  command: systemctl daemon-reload
   notify:
   - restart node


### PR DESCRIPTION
Notify `reload systemd units` handler within the `openshift_node` role whenever we modify files within `/etc/systemd` instead of reloading every time.

Note that we're using the handler as an alternative to `daemon_reload: yes` via the `systemd` module until we're requiring ansible 2.3+.

I also made some minor cosmetic changes to some existing handlers :nail_care: 