### PR TITLE
Change default key for gce

### DIFF
--- a/roles/openshift_default_storage_class/defaults/main.yml
+++ b/roles/openshift_default_storage_class/defaults/main.yml
@@ -4,7 +4,7 @@ openshift_storageclass_defaults:
     name: gp2
     provisioner: kubernetes.io/aws-ebs
     type: gp2
-  gcp:
+  gce:
     name: standard
     provisioner: kubernetes.io/gce-pd
     type: pd-standard


### PR DESCRIPTION
The usual convention is to use gce not gcp. 

Fixes https://github.com/openshift/openshift-ansible/issues/4405