### PR TITLE
Fix possible access to undefined variable

### DIFF
--- a/playbooks/common/openshift-cluster/evaluate_groups.yml
+++ b/playbooks/common/openshift-cluster/evaluate_groups.yml
@@ -155,5 +155,5 @@
       groups: oo_glusterfs_to_config
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_become: "{{ g_sudo | default(omit) }}"
-    with_items: "{{ g_glusterfs_hosts | union(g_glusterfs_registry_hosts) | default([]) }}"
+    with_items: "{{ g_glusterfs_hosts | union(g_glusterfs_registry_hosts | default([])) }}"
     changed_when: no


### PR DESCRIPTION
Fixes #4306.

- g_glusterfs_hosts is verified to be defined in the beginning of the
playbook.
- g_glusterfs_registry_hosts is only defined when
playbooks/byo/openshift-cluster/cluster_hosts.yml is loaded, which seems
to not always be the case.

Instead of trying to find all entrypoints where cluster_hosts should be
loaded to defined the variable, simply use the `default()` filter to
consider it empty when not defined.