### PR TITLE
logging: ops cluser to allow cluster-reader to read logs

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -116,7 +116,7 @@ openshift_logging_es_key: ""
 openshift_logging_es_ca_ext: ""
 
 # allow cluster-admin or cluster-reader to view operations index
-openshift_logging_es_ops_allow_cluster_reader: False
+openshift_logging_es_ops_allow_cluster_reader: True
 
 openshift_logging_es_ops_host: logging-es-ops
 openshift_logging_es_ops_port: 9200


### PR DESCRIPTION
Requiring cluster-admin to view logs is too much. This will activate the option to allow cluster-reader role to read the logs from ES.

BZ reference from CFME: https://bugzilla.redhat.com/show_bug.cgi?id=1454867