### PR TITLE
installer: add bind mount for /etc/resolv.conf

### DIFF
--- a/images/installer/system-container/root/exports/config.json.template
+++ b/images/installer/system-container/root/exports/config.json.template
@@ -171,6 +171,16 @@
             ]
         },
         {
+            "destination": "/etc/resolv.conf",
+            "type": "bind",
+            "source": "/etc/resolv.conf",
+            "options": [
+                "ro",
+                "rbind",
+                "rprivate"
+            ]
+        },
+        {
             "destination": "/sys/fs/cgroup",
             "type": "cgroup",
             "source": "cgroup",


### PR DESCRIPTION
Use the DNS configuration from the host.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1460978

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>