### PR TITLE
System Container and Ansible Retries

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -14,6 +14,7 @@ callback_plugins = callback_plugins/
 forks = 20
 host_key_checking = False
 retry_files_enabled = False
+retry_files_save_path = ~/ansible-installer-retries
 nocows = True
 
 # Uncomment to use the provided BYO inventory

--- a/images/installer/system-container/root/exports/config.json.template
+++ b/images/installer/system-container/root/exports/config.json.template
@@ -102,7 +102,7 @@
         },
         {
             "type": "bind",
-            "source": "$SSH_ROOT",
+            "source": "$HOME_ROOT/.ssh",
             "destination": "/opt/app-root/src/.ssh",
             "options": [
                 "bind",
@@ -112,8 +112,8 @@
         },
         {
             "type": "bind",
-            "source": "$SSH_ROOT",
-            "destination": "/root/.ssh",
+            "source": "$HOME_ROOT",
+            "destination": "/root",
             "options": [
                 "bind",
                 "rw",

--- a/images/installer/system-container/root/exports/manifest.json
+++ b/images/installer/system-container/root/exports/manifest.json
@@ -5,7 +5,7 @@
         "VAR_LIB_OPENSHIFT_INSTALLER" : "/var/lib/openshift-installer",
         "VAR_LOG_OPENSHIFT_LOG": "/var/log/ansible.log",
         "PLAYBOOK_FILE": "/usr/share/ansible/openshift-ansible/playbooks/byo/config.yml",
-        "SSH_ROOT": "/root/.ssh",
+	"HOME_ROOT": "/root",
         "INVENTORY_FILE": "/dev/null"
     }
 }


### PR DESCRIPTION
- Add retry location to ``ansible.cfg``
- Replaces ``SSH_ROOT`` with ``HOME_ROOT`` in the system container.
- Mount ``HOME_ROOT`` in the system container as ``/root``