### PR TITLE
Disable negative caching, set cache TTL to 1s

### DIFF
--- a/roles/openshift_node_dnsmasq/templates/origin-dns.conf.j2
+++ b/roles/openshift_node_dnsmasq/templates/origin-dns.conf.j2
@@ -1,3 +1,5 @@
 no-resolv
 domain-needed
 server=/{{ openshift.common.dns_domain }}/{{ openshift.common.kube_svc_ip }}
+no-negcache
+max-cache-ttl=1


### PR DESCRIPTION
When running headless services as pods on OpenShift, no ClusterIP is
assigned. In these cases, peer pods are relying on DNS to locate the
service endpoints. When a pod is deleted or another trigger causes the
endpoint to change, the OpenShift DNS is updated immediately. However,
dnsmasq has a default TTL of 30s, so the wrong response is returned
on name resolution. Removing negative caching and turning the TTL to
a very short 1s should resolve the issue.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @sdodson @bparees @csrwng 

[test]