### PR TITLE
etcd v3 for clean installs

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -20,6 +20,15 @@
     - node
     - .config_managed
 
+  - name: Check for existing configuration
+    stat:
+      path: /etc/origin/master/master-config.yaml
+    register: master_config_stat
+
+  - name: Set clean install fact
+    set_fact:
+      l_clean_install: "{{ not master_config_stat.stat.exists }}"
+
   - set_fact:
       openshift_master_pod_eviction_timeout: "{{ lookup('oo_option', 'openshift_master_pod_eviction_timeout') | default(none, true) }}"
     when: openshift_master_pod_eviction_timeout is not defined
@@ -122,6 +131,7 @@
     etcd_cert_subdir: "openshift-master-{{ openshift.common.hostname }}"
     etcd_cert_config_dir: "{{ openshift.common.config_base }}/master"
     etcd_cert_prefix: "master.etcd-"
+    r_openshift_master_clean_install: hostvars[groups.oo_first_master.0].l_clean_install
   - role: nuage_master
     when: openshift.common.use_nuage | bool
   - role: calico_master

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 openshift_node_ips: []
-# TODO: update setting these values based on the facts
-#openshift_version: "{{ openshift_pkg_version | default(openshift_image_tag | default(openshift.docker.openshift_image_tag | default(''))) }}"
+r_openshift_master_clean_install: false

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -164,6 +164,26 @@
     - restart master api
     - restart master controllers
 
+- name: Configure master to use etcd3 storage backend on 3.6 clean installs
+  yedit:
+    src: /etc/origin/master/master-config.yaml
+    key: "{{ item.key }}"
+    value: "{{ item.value }}"
+  with_items:
+    - key: kubernetesMasterConfig.apiServerArguments.storage-backend
+      value:
+        - etcd3
+    - key: kubernetesMasterConfig.apiServerArguments.storage-media-type
+      value:
+        - application/vnd.kubernetes.protobuf
+  when:
+    - r_openshift_master_clean_install
+    - openshift.common.version_gte_3_6
+  notify:
+    - restart master
+    - restart master api
+    - restart master controllers
+
 - include: set_loopback_context.yml
   when: openshift.common.version_gte_3_2_or_1_2
 


### PR DESCRIPTION
If we have no master config assume that we're a clean install.
If we're a clean install and we're 3.6 or greater use etcd v3 storage.

Ensures that clean installs get the following config
```
kubernetesMasterConfig:
  apiServerArguments:
    storage-backend:
    - etcd3
    storage-media-type:
    - application/vnd.kubernetes.protobuf
```