### PR TITLE
Retry docker startup once

### DIFF
--- a/roles/openshift_node_upgrade/tasks/restart.yml
+++ b/roles/openshift_node_upgrade/tasks/restart.yml
@@ -16,7 +16,11 @@
 - name: Restart docker
   service:
     name: "{{ openshift.docker.service_name }}"
-    state: restarted
+    state: started
+  register: docker_start_result
+  until: not docker_start_result | failed
+  retries: 1
+  delay: 30
 
 - name: Update docker facts
   openshift_facts:


### PR DESCRIPTION
Large environments frequently see docker fail to start up after an
upgrade. Not sure why but we can retry once.