### PR TITLE
Remove invalid when: from vars:

### DIFF
--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -47,8 +47,7 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+
   roles:
   - role: openshift_node
     openshift_ca_host: "{{ groups.oo_first_master.0 }}"
@@ -64,8 +63,6 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
   roles:
   - role: openshift_node
     openshift_ca_host: "{{ groups.oo_first_master.0 }}"


### PR DESCRIPTION
This PR removes a couple of `when:` statements which were listed in the `vars:` section of a play.  They are essentially doing nothing.  Fixes Ansible WARNING for use of reserved name `when:`.