### PR TITLE
Fixed version comparing when upgraded to some minor version

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_inventory_vars.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_inventory_vars.yml
@@ -34,4 +34,4 @@
       msg: >
         openshift_release is {{ openshift_release }} which is not a
         valid release for a {{ openshift_upgrade_target }} upgrade
-    when: openshift_release is defined and not openshift_release | version_compare(openshift_upgrade_target ,'=')
+    when: openshift_release is defined and openshift_release | version_compare(openshift_upgrade_target ,'<')


### PR DESCRIPTION
Example if you try upgrade to 1.5.1 OpenShift Origin, there are will be fail on this line.
I changed compare like using 2 version_compare above.