### PR TITLE
System container honor provided ansible cfg

### DIFF
--- a/images/installer/system-container/README.md
+++ b/images/installer/system-container/README.md
@@ -11,3 +11,21 @@ These files are needed to run the installer using an [Atomic System container](h
 * service.template - Template file for the systemd service.
 
 * tmpfiles.template - Template file for systemd-tmpfiles.
+
+## Options
+
+These options may be set via the ``atomic`` ``--set`` flag. For defaults see ``root/exports/manifest.json``
+
+* OPTS - Additional options to pass to ansible when running the installer
+
+* VAR_LIB_OPENSHIFT_INSTALLER - Full path of the installer code to mount into the container
+
+* VAR_LOG_OPENSHIFT_LOG - Full path of the log file to mount into the container
+
+* PLAYBOOK_FILE - Full path of the playbook inside the container
+
+* HOME_ROOT - Full path on host to mount as the root home directory inside the container (for .ssh/, etc..)
+
+* ANSIBLE_CONFIG - Full path for the ansible configuration file to use inside the container
+
+* INVENTORY_FILE - Full path for the inventory to use from the host

--- a/images/installer/system-container/root/exports/config.json.template
+++ b/images/installer/system-container/root/exports/config.json.template
@@ -21,7 +21,8 @@
             "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
             "TERM=xterm",
             "OPTS=$OPTS",
-            "PLAYBOOK_FILE=$PLAYBOOK_FILE"
+            "PLAYBOOK_FILE=$PLAYBOOK_FILE",
+            "ANSIBLE_CONFIG=$ANSIBLE_CONFIG"
         ],
         "cwd": "/opt/app-root/src/",
         "rlimits": [

--- a/images/installer/system-container/root/exports/manifest.json
+++ b/images/installer/system-container/root/exports/manifest.json
@@ -6,6 +6,7 @@
         "VAR_LOG_OPENSHIFT_LOG": "/var/log/ansible.log",
         "PLAYBOOK_FILE": "/usr/share/ansible/openshift-ansible/playbooks/byo/config.yml",
 	"HOME_ROOT": "/root",
+	"ANSIBLE_CONFIG": "/usr/share/ansible/openshift-ansible/ansible.cfg",
         "INVENTORY_FILE": "/dev/null"
     }
 }


### PR DESCRIPTION
The provided configuration file was not being honored. This change adds
a new variable called ``ANSIBLE_CONFIG`` which points to the ``ansible.cfg``
file within the container. By default it is set to the configuration
provided by ``openshift-ansible`` within the container at ``/usr/share/ansible/openshift-ansible/ansible.cfg``.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1461281

**Note**: Do not run CI tests on this PR! The changes here are not covered by CI.