### PR TITLE
calculate replicas depending on the number of shards

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -97,7 +97,7 @@ openshift_logging_es_nodeselector: "{{ openshift_hosted_logging_elasticsearch_no
 # openshift_logging_es_config is a hash to be merged into the defaults for the elasticsearch.yaml
 openshift_logging_es_config: {}
 openshift_logging_es_number_of_shards: 1
-openshift_logging_es_number_of_replicas: 0
+openshift_logging_es_number_of_replicas: "{{ openshift_logging_es_cluster_size - openshift_logging_es_number_of_shards | default(0) }}"
 
 # for exposing es to external (outside of the cluster) clients
 openshift_logging_es_allow_external: False


### PR DESCRIPTION
I think the number of replicas should be calculated based on the number of instances - the number of primary shards