### PR TITLE
Ensure only one ES pod per PV

### DIFF
--- a/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
@@ -16,6 +16,7 @@ index:
 node:
   master: ${IS_MASTER}
   data: ${HAS_DATA}
+  max_local_storage_nodes: 1
 
 network:
   host: 0.0.0.0


### PR DESCRIPTION
Unfortunately, the defaults for Elasticsearch prior to v5 allow more
than one "node" to access the same configured storage volume(s).

This change forces this value to `1` to ensure we don't have an ES pod
starting up accessing a volume while another ES pod is shutting down
when reploying. This can lead to "`1`" directories being created in
`/elasticsearch/persistent/${CLUSTER_NAME}/data/${CLUSTER_NAME}/nodes/`. By
default ES uses a "`0`" directory there when only one node is accessing
it.

Fixes BZ https://bugzilla.redhat.com/show_bug.cgi?id=1460564.