### PR TITLE
[1.3] Use local openshift.master.loopback_url when generating initial master loopback kubeconfigs.

### DIFF
--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -105,6 +105,38 @@
   delegate_to: "{{ openshift_ca_host }}"
   run_once: true
 
+- name: Test local loopback context
+  command: >
+    {{ hostvars[openshift_ca_host].openshift.common.client_binary }} config view
+    --config={{ openshift_master_loopback_config }}
+  changed_when: false
+  register: loopback_config
+  delegate_to: "{{ openshift_ca_host }}"
+  run_once: true
+
+- name: Generate the loopback master client config
+  command: >
+    {{ hostvars[openshift_ca_host].openshift.common.client_binary }} adm create-api-client-config
+      {% for named_ca_certificate in openshift.master.named_certificates | default([]) | oo_collect('cafile') %}
+      --certificate-authority {{ named_ca_certificate }}
+      {% endfor %}
+      --certificate-authority={{ openshift_ca_cert }}
+      --client-dir={{ openshift_ca_config_dir }}
+      --groups=system:masters,system:openshift-master
+      --master={{ hostvars[openshift_ca_host].openshift.master.loopback_api_url }}
+      --public-master={{ hostvars[openshift_ca_host].openshift.master.loopback_api_url }}
+      --signer-cert={{ openshift_ca_cert }}
+      --signer-key={{ openshift_ca_key }}
+      --signer-serial={{ openshift_ca_serial }}
+      --user=system:openshift-master
+      --basename=openshift-master
+      {% if openshift_version | oo_version_gte_3_5_or_1_5(openshift.common.deployment_type) | bool %}
+      --expire-days={{ openshift_master_cert_expire_days }}
+      {% endif %}
+  when: loopback_context_string not in loopback_config.stdout
+  delegate_to: "{{ openshift_ca_host }}"
+  run_once: true
+
 - name: Restore original serviceaccount keys
   copy:
     src: "{{ item }}.keep"

--- a/roles/openshift_ca/vars/main.yml
+++ b/roles/openshift_ca/vars/main.yml
@@ -6,3 +6,5 @@ openshift_ca_serial: "{{ openshift_ca_config_dir }}/ca.serial.txt"
 openshift_version: "{{ openshift_pkg_version | default('') }}"
 
 r_openshift_ca_skip_installation: false
+openshift_master_loopback_config: "{{ openshift_ca_config_dir }}/openshift-master.kubeconfig"
+loopback_context_string: "current-context: {{ openshift.master.loopback_context_name }}"

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -68,7 +68,7 @@
   delegate_to: "{{ openshift_ca_host }}"
   run_once: true
 
-- name: Generate the master client config
+- name: Generate the loopback master client config
   command: >
     {{ hostvars[openshift_ca_host].openshift.common.client_binary }} adm create-api-client-config
       {% for named_ca_certificate in openshift.master.named_certificates | default([]) | oo_collect('cafile') %}
@@ -77,8 +77,8 @@
       --certificate-authority={{ openshift_ca_cert }}
       --client-dir={{ openshift_generated_configs_dir }}/master-{{ hostvars[item].openshift.common.hostname }}
       --groups=system:masters,system:openshift-master
-      --master={{ openshift.master.api_url }}
-      --public-master={{ openshift.master.public_api_url }}
+      --master={{ hostvars[item].openshift.master.loopback_api_url }}
+      --public-master={{ hostvars[item].openshift.master.loopback_api_url }}
       --signer-cert={{ openshift_ca_cert }}
       --signer-key={{ openshift_ca_key }}
       --signer-serial={{ openshift_ca_serial }}


### PR DESCRIPTION
Backports #4278
https://bugzilla.redhat.com/show_bug.cgi?id=1462282