### PR TITLE
Preserve etcd3 storage if it's already in use

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -27,7 +27,17 @@
 
   - name: Set clean install fact
     set_fact:
-      l_clean_install: "{{ not master_config_stat.stat.exists }}"
+      l_clean_install: "{{ not master_config_stat.stat.exists | bool }}"
+
+  - name: Determine if etcd3 storage is in use
+    command: grep  -Pzo  "storage-backend:\n.*etcd3" /etc/origin/master/master-config.yaml -q
+    register: etcd3_grep
+    failed_when: false
+    changed_when: false
+
+  - name: Set etcd3 fact
+    set_fact:
+      l_etcd3_enabled: "{{ etcd3_grep.rc == 0 | bool }}"
 
   - set_fact:
       openshift_master_pod_eviction_timeout: "{{ lookup('oo_option', 'openshift_master_pod_eviction_timeout') | default(none, true) }}"
@@ -131,7 +141,8 @@
     etcd_cert_subdir: "openshift-master-{{ openshift.common.hostname }}"
     etcd_cert_config_dir: "{{ openshift.common.config_base }}/master"
     etcd_cert_prefix: "master.etcd-"
-    r_openshift_master_clean_install: hostvars[groups.oo_first_master.0].l_clean_install
+    r_openshift_master_clean_install: "{{ hostvars[groups.oo_first_master.0].l_clean_install }}"
+    r_openshift_master_etcd3_storage: "{{ hostvars[groups.oo_first_master.0].l_etcd3_enabled }}"
   - role: nuage_master
     when: openshift.common.use_nuage | bool
   - role: calico_master

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 openshift_node_ips: []
 r_openshift_master_clean_install: false
+r_openshift_master_etcd3_storage: false

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -164,26 +164,6 @@
     - restart master api
     - restart master controllers
 
-- name: Configure master to use etcd3 storage backend on 3.6 clean installs
-  yedit:
-    src: /etc/origin/master/master-config.yaml
-    key: "{{ item.key }}"
-    value: "{{ item.value }}"
-  with_items:
-    - key: kubernetesMasterConfig.apiServerArguments.storage-backend
-      value:
-        - etcd3
-    - key: kubernetesMasterConfig.apiServerArguments.storage-media-type
-      value:
-        - application/vnd.kubernetes.protobuf
-  when:
-    - r_openshift_master_clean_install
-    - openshift.common.version_gte_3_6
-  notify:
-    - restart master
-    - restart master api
-    - restart master controllers
-
 - include: set_loopback_context.yml
   when: openshift.common.version_gte_3_2_or_1_2
 

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -139,6 +139,12 @@ kubernetesMasterConfig:
   - v1
 {% endif %}
   apiServerArguments: {{ openshift.master.api_server_args | default(None) | to_padded_yaml( level=2 ) }}
+{% if r_openshift_master_etcd3_storage or ( r_openshift_master_clean_install and openshift.common.version_gte_3_6 ) %}
+    storage-backend:
+    - etcd3
+    storage-media-type:
+    - application/vnd.kubernetes.protobuf
+{% endif %}
   controllerArguments: {{ openshift.master.controller_args | default(None) | to_padded_yaml( level=2 ) }}
   masterCount: {{ openshift.master.master_count if openshift.master.cluster_method | default(None) == 'native' else 1 }}
   masterIP: {{ openshift.common.ip }}


### PR DESCRIPTION
This would be the case if for instance they'd upgraded and then
migrated.

I've tested 
- [x] byo/config.yml 3.6 existing install that's using etcd3 storage already -> etcd3 storage
- [x] byo/config.yml 3.6 existing install, no etcd3 -> no etcd3 storage
- [x] byo/config.yml 3.6 clean install -> etcd3 storage
- [x] byo/config.yml 3.5 clean install -> no etcd3 storage