### PR TITLE
Disable TLS verification in skopeo inspect

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -169,7 +169,7 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
             registries = [registry]
 
         for registry in registries:
-            args = {"_raw_params": "skopeo inspect docker://{}/{}".format(registry, image)}
+            args = {"_raw_params": "skopeo inspect --tls-verify=false docker://{}/{}".format(registry, image)}
             result = self.execute_module("command", args, task_vars=task_vars)
             if result.get("rc", 0) == 0 and not result.get("failed"):
                 return True


### PR DESCRIPTION
Some registries are not configured with valid certificates and thus the
check fails with 'http: server gave HTTP response to HTTPS client'.
Since this is not fetching images, but only checking for existence,
trade security for convenience.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1461675.

**Alternatives**

- Instead of always disabling it require an extra flag to disable it.
- Force users to always use registries with valid certificates.