### PR TITLE
[3.4] Verify matched openshift_upgrade_nodes_label

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
@@ -13,6 +13,13 @@
     changed_when: false
     when: openshift_upgrade_nodes_label is defined
 
+  - name: Fail if no nodes match openshift_upgrade_nodes_label
+    fail:
+      msg: "openshift_upgrade_nodes_label was specified but no nodes matched"
+    when:
+    - openshift_upgrade_nodes_label is defined
+    - "'No resources found' in matching_nodes.stderr"
+
   - set_fact:
       nodes_to_upgrade: "{{ matching_nodes.stdout.split(' ') }}"
     when: openshift_upgrade_nodes_label is defined


### PR DESCRIPTION
Verifies the provided label matches a set of hosts prior to upgrading.
If the label didn't match hosts, the upgrade would silently proceed with
upgrading all nodes given the logic for creating the oo_nodes_to_upgrade
group.

Backports #4498 (slightly different syntax due to using client_binary)
Bug https://bugzilla.redhat.com/show_bug.cgi?id=1457914