### PR TITLE
[3.5] Verify matched openshift_upgrade_nodes_label

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
@@ -6,27 +6,32 @@
   - lib_openshift
 
   tasks:
-  - name: Retrieve list of openshift nodes matching upgrade label
-    oc_obj:
-      state: list
-      kind: node
-      selector: "{{ openshift_upgrade_nodes_label }}"
-    register: nodes_to_upgrade
-    when: openshift_upgrade_nodes_label is defined
+  - when: openshift_upgrade_nodes_label is defined
+    block:
+    - name: Retrieve list of openshift nodes matching upgrade label
+      oc_obj:
+        state: list
+        kind: node
+        selector: "{{ openshift_upgrade_nodes_label }}"
+      register: nodes_to_upgrade
 
-  # We got a list of nodes with the label, now we need to match these with inventory hosts
-  # using their openshift.common.hostname fact.
-  - name: Map labelled nodes to inventory hosts
-    add_host:
-      name: "{{ item }}"
-      groups: temp_nodes_to_upgrade
-      ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
-      ansible_become: "{{ g_sudo | default(omit) }}"
-    with_items: " {{ groups['oo_nodes_to_config'] }}"
-    when:
-    - openshift_upgrade_nodes_label is defined
-    - hostvars[item].openshift.common.hostname in nodes_to_upgrade.results.results[0]['items'] | map(attribute='metadata.name') | list
-    changed_when: false
+    - name: Fail if no nodes match openshift_upgrade_nodes_label
+      fail:
+        msg: "openshift_upgrade_nodes_label was specified but no nodes matched"
+      when: nodes_to_upgrade.results.results[0]['items'] | length == 0
+
+    # We got a list of nodes with the label, now we need to match these with inventory hosts
+    # using their openshift.common.hostname fact.
+    - name: Map labelled nodes to inventory hosts
+      add_host:
+        name: "{{ item }}"
+        groups: temp_nodes_to_upgrade
+        ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
+        ansible_become: "{{ g_sudo | default(omit) }}"
+      with_items: " {{ groups['oo_nodes_to_config'] }}"
+      when:
+      - hostvars[item].openshift.common.hostname in nodes_to_upgrade.results.results[0]['items'] | map(attribute='metadata.name') | list
+      changed_when: false
 
   # Build up the oo_nodes_to_upgrade group, use the list filtered by label if
   # present, otherwise hit all nodes:


### PR DESCRIPTION
Verifies the provided label matches a set of hosts prior to upgrading.
If the label didn't match hosts, the upgrade would silently proceed with
upgrading all nodes given the logic for creating the oo_nodes_to_upgrade
group.

Backports #4498 
Bug https://bugzilla.redhat.com/show_bug.cgi?id=1462995