### PR TITLE
Allow intermediate CA for Aggregated Logging

### DIFF
--- a/roles/openshift_logging/files/generate-jks.sh
+++ b/roles/openshift_logging/files/generate-jks.sh
@@ -73,6 +73,7 @@ function generate_JKS_chain() {
         -keystore $dir/$NODE_NAME.jks \
         -storepass $ks_pass \
         -noprompt \
+        -trustcacerts \
         -alias $NODE_NAME
 
     echo All done for $NODE_NAME
@@ -132,6 +133,7 @@ function generate_JKS_client_cert() {
         -keystore $dir/$NODE_NAME.jks \
         -storepass $ks_pass \
         -noprompt \
+        -trustcacerts \
         -alias $NODE_NAME
 
     echo All done for $NODE_NAME


### PR DESCRIPTION
openshift_logging role is not able to generate all the internal certificates when an Intermediate CA is provided. Keytool will fail with the following error

```
echo 'Import back to keystore (including CA chain)'
/bin/keytool -import -file /etc/deploy/scratch/ca.crt -keystore /etc/deploy/scratch/system.admin.jks -storepass kspass -noprompt -alias sig-ca
Import back to keystore (including CA chain)
Certificate was added to keystore
/bin/keytool -import -file /etc/deploy/scratch/system.admin.crt -keystore /etc/deploy/scratch/system.admin.jks -storepass kspass -noprompt -alias system.admin
keytool error: java.lang.Exception: Failed to establish chain from reply
```