### PR TITLE
verify sane log times in logging stack

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/logging/logging.py
+++ b/roles/openshift_health_checker/openshift_checks/logging/logging.py
@@ -20,7 +20,7 @@ class LoggingCheck(OpenShiftCheck):
     @staticmethod
     def is_first_master(task_vars):
         """Run only on first master and only when logging is configured. Returns: bool"""
-        logging_deployed = get_var(task_vars, "openshift_hosted_logging_deploy", default=True)
+        logging_deployed = get_var(task_vars, "openshift_hosted_logging_deploy", default=False)
         # Note: It would be nice to use membership in oo_first_master group, however for now it
         # seems best to avoid requiring that setup and just check this is the first master.
         hostname = get_var(task_vars, "ansible_ssh_host") or [None]

--- a/roles/openshift_health_checker/openshift_checks/logging/logging.py
+++ b/roles/openshift_health_checker/openshift_checks/logging/logging.py
@@ -45,7 +45,7 @@ class LoggingCheck(OpenShiftCheck):
                 raise ValueError()
         except ValueError:
             # successful run but non-parsing data generally means there were no pods in the namespace
-            return None, 'There are no pods in the {} namespace. Is logging deployed?'.format(namespace)
+            return None, 'No pods were found for the "{}" logging component.'.format(logging_component)
 
         return pods['items'], None
 

--- a/roles/openshift_health_checker/openshift_checks/logging/logging_index_time.py
+++ b/roles/openshift_health_checker/openshift_checks/logging/logging_index_time.py
@@ -1,0 +1,163 @@
+"""
+Check for ensuring logs from pods can be queried in a reasonable amount of time.
+"""
+
+import json
+import time
+
+from uuid import uuid4
+
+from openshift_checks import get_var, OpenShiftCheckException
+from openshift_checks.logging.logging import LoggingCheck
+
+
+ES_CMD_TIMEOUT_SECONDS = 30
+
+
+class LoggingIndexTime(LoggingCheck):
+    """Check that pod logs are aggregated and indexed in ElasticSearch within a reasonable amount of time."""
+    name = "logging_index_time"
+    tags = ["health", "logging"]
+
+    logging_namespace = "logging"
+
+    def run(self, tmp, task_vars):
+        """Add log entry by making unique request to Kibana. Check for unique entry in the ElasticSearch pod logs."""
+        pod_log_timeout = int(get_var(task_vars, "openshift_check_pod_logs_timeout", default=ES_CMD_TIMEOUT_SECONDS))
+
+        # get all Kibana pods
+        self.logging_namespace = get_var(task_vars, "openshift_logging_namespace", default=self.logging_namespace)
+        pods, error = super(LoggingIndexTime, self).get_pods_for_component(
+            self.execute_module,
+            self.logging_namespace,
+            "kibana",
+            task_vars,
+        )
+
+        if error:
+            msg = 'Unable to retrieve pods for the "Kibanna" logging component: {}'
+            return {"failed": True, "changed": False, "msg": msg.format(error)}
+
+        running_kibana_pods = self.running_pods(pods)
+        if not len(running_kibana_pods):
+            msg = ('No Kibana pods were found to be in the "Running" state.'
+                   'At least one Kibana pod is required in order to perform this check.')
+            return {"failed": True, "changed": False, "msg": msg}
+
+        # get all Elasticsearch pods
+        pods, error = super(LoggingIndexTime, self).get_pods_for_component(
+            self.execute_module,
+            self.logging_namespace,
+            "es",
+            task_vars,
+        )
+
+        if error:
+            msg = 'Unable to retrieve pods for the "Elasticsearch" logging component: {}'
+            return {"failed": True, "changed": False, "msg": msg.format(error)}
+
+        running_es_pods = self.running_pods(pods)
+        if not len(running_es_pods):
+            msg = ('No Elasticsearch pods were found to be in the "Running" state.'
+                   'At least one Elasticsearch pod is required in order to perform this check.')
+            return {"failed": True, "changed": False, "msg": msg}
+
+        uuid = self.curl_kibana_with_uuid(running_kibana_pods[0], task_vars)
+        self.wait_until_cmd_or_err(running_es_pods[0], uuid, pod_log_timeout, task_vars)
+        return {}
+
+    def wait_until_cmd_or_err(self, es_pod, uuid, timeout_secs, task_vars):
+        """Wait a maximum of timeout_secs for the uuid logged in Kibana to be
+        found in the Elasticsearch logs. Since we are querying for a message
+        with the uuid that was set earlier, there should only be a single match.
+        Raise an OpenShiftCheckException if timeout is reached finding a match."""
+        now = int(time.time())
+        time_start = now
+        time_end = time_start + timeout_secs
+        interval = 1  # seconds to wait between retries
+
+        while now < time_end:
+            if self.query_es_from_es(es_pod, uuid, task_vars):
+                return
+
+            time.sleep(interval)
+            now = int(time.time())
+            if now < time_start:  # saw a large clock reset: start the timer again
+                time_start = now
+                time_end = now + timeout_secs
+
+        msg = "expecting match in Elasticsearch for message with uuid {}, but no matches were found after {}s."
+        raise OpenShiftCheckException(msg.format(uuid, timeout_secs))
+
+    def curl_kibana_with_uuid(self, kibanna_pod, task_vars):
+        """curl Kibana with a unique uuid."""
+        uuid = self.generate_uuid()
+        pod_name = kibanna_pod["metadata"]["name"]
+        exec_cmd = "exec {pod_name} -c kibana -- curl --max-time 30 -s http://localhost:5601/{uuid}"
+        exec_cmd = exec_cmd.format(pod_name=pod_name, uuid=uuid)
+
+        error_str = self.oc_cmd(exec_cmd, [], task_vars)
+
+        try:
+            error_code = json.loads(error_str)["statusCode"]
+        except KeyError:
+            msg = ('invalid response returned from Kibana request (Missing "statusCode" key):\n'
+                   'Command: {}\nResponse: {}').format(exec_cmd, error_str)
+            raise OpenShiftCheckException(msg)
+        except ValueError:
+            msg = ('invalid response returned from Kibana request (Non-JSON output):\n'
+                   'Command: {}\nResponse: {}').format(exec_cmd, error_str)
+            raise OpenShiftCheckException(msg)
+
+        if error_code != 404:
+            msg = 'invalid error code returned from Kibana request. Expecting error code "404", but got "{}" instead.'
+            raise OpenShiftCheckException(msg.format(error_code))
+
+        return uuid
+
+    def query_es_from_es(self, es_pod, uuid, task_vars):
+        """curl the Elasticsearch pod and look for a unique uuid in its logs."""
+        pod_name = es_pod["metadata"]["name"]
+        exec_cmd = (
+            "exec {pod_name} -- curl --max-time 30 -s -f "
+            "--cacert /etc/elasticsearch/secret/admin-ca "
+            "--cert /etc/elasticsearch/secret/admin-cert "
+            "--key /etc/elasticsearch/secret/admin-key "
+            "https://logging-es:9200/project.{namespace}*/_count?q=message:{uuid}"
+        )
+        exec_cmd = exec_cmd.format(pod_name=pod_name, namespace=self.logging_namespace, uuid=uuid)
+        result = self.oc_cmd(exec_cmd, [], task_vars)
+
+        try:
+            count = json.loads(result)["count"]
+        except KeyError:
+            msg = 'invalid response from Elasticsearch query:\n"{}"\nMissing "count" key:\n{}'
+            raise OpenShiftCheckException(msg.format(exec_cmd, result))
+        except ValueError:
+            msg = 'invalid response from Elasticsearch query:\n"{}"\nNon-JSON output:\n{}'
+            raise OpenShiftCheckException(msg.format(exec_cmd, result))
+
+        return count
+
+    @staticmethod
+    def running_pods(pods):
+        """Returns: list of pods in a running state"""
+        return [
+            pod for pod in pods
+            if pod['status']['phase'] == 'Running'
+        ]
+
+    @staticmethod
+    def generate_uuid():
+        """Wrap uuid generator. Allows for testing with expected values."""
+        return str(uuid4())
+
+    def oc_cmd(self, cmd_str, extra_args, task_vars):
+        """Wrap parent exec_oc method. Allows for testing without actually invoking other modules."""
+        return super(LoggingIndexTime, self).exec_oc(
+            self.execute_module,
+            self.logging_namespace,
+            cmd_str,
+            extra_args,
+            task_vars
+        )

--- a/roles/openshift_health_checker/test/logging_check_test.py
+++ b/roles/openshift_health_checker/test/logging_check_test.py
@@ -118,7 +118,7 @@ def test_is_active(groups, logging_deployed, is_active):
     (
         'No resources found.',
         None,
-        'There are no pods in the logging namespace',
+        'No pods were found for the "es"',
     ),
     (
         json.dumps({'items': [plain_kibana_pod, plain_es_pod, plain_curator_pod, fluentd_pod_node1]}),

--- a/roles/openshift_health_checker/test/logging_index_time_test.py
+++ b/roles/openshift_health_checker/test/logging_index_time_test.py
@@ -1,0 +1,183 @@
+import json
+
+import pytest
+
+from openshift_checks.logging.logging_index_time import LoggingIndexTime, OpenShiftCheckException
+
+
+SAMPLE_UUID = "unique-test-uuid"
+
+
+def canned_podlogquerytime(exec_oc=None):
+    """Create a check object with a canned exec_oc method"""
+    check = LoggingIndexTime("dummy")  # fails if a module is actually invoked
+    if exec_oc:
+        check.oc_cmd = exec_oc
+    return check
+
+
+plain_running_elasticsearch_pod = {
+    "metadata": {
+        "labels": {"component": "es", "deploymentconfig": "logging-es-data-master"},
+        "name": "logging-es-data-master-1",
+    },
+    "status": {
+        "containerStatuses": [{"ready": True}, {"ready": True}],
+        "phase": "Running",
+    }
+}
+plain_running_kibana_pod = {
+    "metadata": {
+        "labels": {"component": "kibana", "deploymentconfig": "logging-kibana"},
+        "name": "logging-kibana-1",
+    },
+    "status": {
+        "containerStatuses": [{"ready": True}, {"ready": True}],
+        "phase": "Running",
+    }
+}
+not_running_kibana_pod = {
+    "metadata": {
+        "labels": {"component": "kibana", "deploymentconfig": "logging-kibana"},
+        "name": "logging-kibana-2",
+    },
+    "status": {
+        "containerStatuses": [{"ready": True}, {"ready": False}],
+        "conditions": [{"status": "True", "type": "Ready"}],
+        "phase": "pending",
+    }
+}
+
+
+@pytest.mark.parametrize('pods, expect_pods', [
+    (
+        [not_running_kibana_pod],
+        [],
+    ),
+    (
+        [plain_running_kibana_pod],
+        [plain_running_kibana_pod],
+    ),
+    (
+        [],
+        [],
+    )
+])
+def test_check_running_pods(pods, expect_pods):
+    check = canned_podlogquerytime(None)
+    pods = check.running_pods(pods)
+    assert pods == expect_pods
+
+
+@pytest.mark.parametrize('name, json_response, uuid, timeout, expect_exception, extra_words', [
+    (
+        'invalid json response',
+        {
+            "invalid_field": 1,
+        },
+        SAMPLE_UUID,
+        0.001,
+        OpenShiftCheckException,
+        ["invalid response", "Elasticsearch"],
+    ),
+    (
+        'empty response',
+        {},
+        SAMPLE_UUID,
+        0.001,
+        OpenShiftCheckException,
+        ["invalid response", "Elasticsearch"],
+    ),
+    (
+        'valid count in response',
+        {
+            "count": 1,
+        },
+        SAMPLE_UUID,
+        0.001,
+        None,
+        [],
+    ),
+    (
+        'valid response but invalid match count',
+        {
+            "count": 0,
+        },
+        SAMPLE_UUID,
+        0.005,
+        OpenShiftCheckException,
+        ["expecting match", SAMPLE_UUID, "0.005s"],
+    )
+], ids=lambda argval: argval[0])
+def test_wait_until_cmd_or_err(name, json_response, uuid, timeout, expect_exception, extra_words):
+    def exec_oc(exec_cmd, args, task_vars):
+        return json.dumps(json_response)
+
+    check = canned_podlogquerytime(exec_oc)
+
+    error = ""
+    if expect_exception:
+        with pytest.raises(expect_exception) as error:
+            check.wait_until_cmd_or_err(plain_running_elasticsearch_pod, uuid, timeout, None)
+    else:
+        check.wait_until_cmd_or_err(plain_running_elasticsearch_pod, uuid, timeout, None)
+
+    if not expect_exception:
+        assert not error
+
+    for word in extra_words:
+        assert word in str(error)
+
+
+@pytest.mark.parametrize('name, json_response, uuid, expect_exception, extra_words', [
+    (
+        'invalid json response',
+        {
+            "invalid_field": "invalid",
+        },
+        SAMPLE_UUID,
+        OpenShiftCheckException,
+        ["invalid response returned", 'Missing "statusCode" key'],
+    ),
+    (
+        'wrong error code in response',
+        {
+            "statusCode": 500,
+        },
+        SAMPLE_UUID,
+        OpenShiftCheckException,
+        ["Expecting error code", "500"],
+    ),
+    (
+        'correct response code, found unique id is returned',
+        {
+            "statusCode": 404,
+        },
+        "sample unique id",
+        None,
+        ["sample unique id"],
+    ),
+])
+def test_curl_kibana_with_uuid(name, json_response, uuid, expect_exception, extra_words):
+    def exec_oc(exec_cmd, args, task_vars):
+        return json.dumps(json_response)
+
+    check = canned_podlogquerytime(exec_oc)
+    check.generate_uuid = lambda: uuid
+
+    error = ""
+    result = ""
+    if expect_exception:
+        with pytest.raises(expect_exception) as error:
+            check.curl_kibana_with_uuid(plain_running_kibana_pod, None)
+    else:
+        result = check.curl_kibana_with_uuid(plain_running_kibana_pod, None)
+
+    if not expect_exception:
+        assert not error
+
+    for word in extra_words:
+        if error:
+            assert word in str(error)
+        elif result:
+            assert word in result


### PR DESCRIPTION
Related trello card: https://trello.com/c/7uOluOTW
Based on @richm 's script: https://bugzilla.redhat.com/attachment.cgi?id=1258225

This patch verifies that logs sent from logging pods can be queried on
the Elasticsearch pod within a reasonable amount of time.

*TODO*

- [x] add tests

cc @brenton @sosiouxme @rhcarvalho 