### PR TITLE
Restart NetworkManager only if dnsmasq was used

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -317,6 +317,7 @@
 
   - name: restart NetworkManager
     service: name=NetworkManager state=restarted
+    when: openshift_use_dnsmasq | default(true) | bool
 
 - hosts: masters
   become: yes


### PR DESCRIPTION
In an environment where `openshift_use_dnsmasq` is set to false because i.e. `NetworkManager` is not in use, this check should prevent `NetworkManager` to be started and overwrite `/etc/resolv.conf`.