### PR TITLE
Remove package_update from install playbook

### DIFF
--- a/playbooks/byo/openshift-cluster/config.yml
+++ b/playbooks/byo/openshift-cluster/config.yml
@@ -16,7 +16,6 @@
       - disk_availability
       - memory_availability
       - package_availability
-      - package_update
       - package_version
       - docker_image_availability
       - docker_storage


### PR DESCRIPTION
We observed in our CI environment that this check can't guarantee that
an install would fail when the check fails, thus unless we can make its
output match the fate of an install we shall keep it disabled.

Example PRs that failed to merge:
- https://github.com/openshift/openshift-ansible/pull/4498