### PR TITLE
[3.4] Fix Ansible conditional syntax

### DIFF
--- a/roles/openshift_serviceaccounts/tasks/main.yml
+++ b/roles/openshift_serviceaccounts/tasks/main.yml
@@ -29,7 +29,10 @@
   command: >
       {{ openshift.common.client_binary }} adm policy add-scc-to-user
       {{ item.1.item }} system:serviceaccount:{{ openshift_serviceaccounts_namespace }}:{{ item.0 }}
-  when: "openshift.common.version_gte_3_1_or_1_1 and item.1.rc == 0 and 'system:serviceaccount:{{ openshift_serviceaccounts_namespace }}:{{ item.0 }}' not in {{ (item.1.stdout | from_yaml).users | default([]) }}"
+  when:
+  - openshift.common.version_gte_3_1_or_1_1
+  - item.1.rc == 0
+  - "'system:serviceaccount:{{ openshift_serviceaccounts_namespace }}:{{ item.0 }}' not in {{ (item.1.stdout | from_yaml).users | default([]) }}"
   with_nested:
   - "{{ openshift_serviceaccounts_names }}"
   - "{{ scc_test.results }}"


### PR DESCRIPTION
Converting the conditional to a list resolves the issue we are seeing in CI when performing 1.4.1 installs.  Due to the complex nature of `with_nested`, the conditional could not be further simplified to remove the jinja2 delimiters.

This issue only exists in the 1.4 branch because this role was removed since 1.5.
The problem surfaced once Ansible 2.3.1 was introduced.

Error:
```
TASK [openshift_serviceaccounts : Grant the user access to the appropriate scc] ***
task path: /usr/share/ansible/openshift-ansible/roles/openshift_serviceaccounts/tasks/main.yml:28
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: openshift.common.version_gte_3_1_or_1_1 and
item.1.rc == 0 and 'system:serviceaccount:{{
openshift_serviceaccounts_namespace }}:{{ item.0 }}' not in {{ (item.1.stdout |
from_yaml).users | default([]) }}
fatal: [localhost]: FAILED! => {
    "failed": true, 
    "generated_timestamp": "2017-06-21 09:31:15.689947", 
    "msg": "The conditional check 'openshift.common.version_gte_3_1_or_1_1 and item.1.rc == 0 and 'system:serviceaccount:{{ openshift_serviceaccounts_namespace }}:{{ item.0 }}' not in {{ (item.1.stdout | from_yaml).users | default([]) }}' failed. The error was: Invalid conditional detected: invalid syntax (<unknown>, line 1)\n\nThe error appears to have been in '/usr/share/ansible/openshift-ansible/roles/openshift_serviceaccounts/tasks/main.yml': line 28, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Grant the user access to the appropriate scc\n  ^ here\n"
}
```

Tested with change:
```
TASK [openshift_serviceaccounts : Grant the user access to the appropriate scc] **************************************************************
task path: /home/rteague/dev/clusters/aws-c1/openshift-ansible/roles/openshift_serviceaccounts/tasks/main.yml:28
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: 'system:serviceaccount:{{
openshift_serviceaccounts_namespace }}:{{ item.0 }}' not in {{ (item.1.stdout | from_yaml).users | default([]) }}

changed: [ec2-54-91-34-203.compute-1.amazonaws.com] => (item=[u'router', {'_ansible_parsed': True, 'stderr_lines': [], '_ansible_item_result': True, u'end': u'2017-06-21 14:24:02.589718', '_ansible_no_log': False, u'stdout': u'allowHostDirVolumePlugin: false\nallowHostIPC: false\nallowHostNetwork: true\nallowHostPID: false\nallowHostPorts: true\nallowPrivilegedContainer: false\nallowedCapabilities: null\napiVersion: v1\ndefaultAddCapabilities: null\nfsGroup:\n  type: MustRunAs\nkind: SecurityContextConstraints\nmetadata:\n  annotations:\n    kubernetes.io/description: hostnetwork allows using host networking and host ports\n      but still requires pods to be run with a UID and SELinux context that are allocated\n      to the namespace.\n  creationTimestamp: 2017-06-21T18:16:02Z\n  name: hostnetwork\n  resourceVersion: "105"\n  selfLink: /api/v1/securitycontextconstraints/hostnetwork\n  uid: aef451c3-56ad-11e7-96a7-0e6fad14f9bc\npriority: null\nreadOnlyRootFilesystem: false\nrequiredDropCapabilities:\n- KILL\n- MKNOD\n- SYS_CHROOT\n- SETUID\n- SETGID\nrunAsUser:\n  type: MustRunAsRange\nseLinuxContext:\n  type: MustRunAs\nsupplementalGroups:\n  type: MustRunAs\nvolumes:\n- configMap\n- downwardAPI\n- emptyDir\n- persistentVolumeClaim\n- secret', u'cmd': [u'oc', u'get', u'scc', u'hostnetwork', u'-o', u'yaml'], u'rc': 0, 'item': u'hostnetwork', u'delta': u'0:00:00.231373', u'stderr': u'', u'changed': False, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': False, u'_raw_params': u'oc get scc hostnetwork -o yaml', u'removes': None, u'creates': None, u'chdir': None}}, 'stdout_lines': [u'allowHostDirVolumePlugin: false', u'allowHostIPC: false', u'allowHostNetwork: true', u'allowHostPID: false', u'allowHostPorts: true', u'allowPrivilegedContainer: false', u'allowedCapabilities: null', u'apiVersion: v1', u'defaultAddCapabilities: null', u'fsGroup:', u'  type: MustRunAs', u'kind: SecurityContextConstraints', u'metadata:', u'  annotations:', u'    kubernetes.io/description: hostnetwork allows using host networking and host ports', u'      but still requires pods to be run with a UID and SELinux context that are allocated', u'      to the namespace.', u'  creationTimestamp: 2017-06-21T18:16:02Z', u'  name: hostnetwork', u'  resourceVersion: "105"', u'  selfLink: /api/v1/securitycontextconstraints/hostnetwork', u'  uid: aef451c3-56ad-11e7-96a7-0e6fad14f9bc', u'priority: null', u'readOnlyRootFilesystem: false', u'requiredDropCapabilities:', u'- KILL', u'- MKNOD', u'- SYS_CHROOT', u'- SETUID', u'- SETGID', u'runAsUser:', u'  type: MustRunAsRange', u'seLinuxContext:', u'  type: MustRunAs', u'supplementalGroups:', u'  type: MustRunAs', u'volumes:', u'- configMap', u'- downwardAPI', u'- emptyDir', u'- persistentVolumeClaim', u'- secret'], 'failed_when_result': False, u'start': u'2017-06-21 14:24:02.358345', 'failed': False}]) => {
    "changed": true, 
    "cmd": [
        "oc", 
        "adm", 
        "policy", 
        "add-scc-to-user", 
        "hostnetwork", 
        "system:serviceaccount:default:router"
    ], 
    "delta": "0:00:00.221464", 
    "end": "2017-06-21 14:24:03.474071", 
    "item": [
        "router", 
        {
            "_ansible_item_result": true, 
            "_ansible_no_log": false, 
            "_ansible_parsed": true, 
            "changed": false, 
            "cmd": [
                "oc", 
                "get", 
                "scc", 
                "hostnetwork", 
                "-o", 
                "yaml"
            ], 
            "delta": "0:00:00.231373", 
            "end": "2017-06-21 14:24:02.589718", 
            "failed": false, 
            "failed_when_result": false, 
            "invocation": {
                "module_args": {
                    "_raw_params": "oc get scc hostnetwork -o yaml", 
                    "_uses_shell": false, 
                    "chdir": null, 
                    "creates": null, 
                    "executable": null, 
                    "removes": null, 
                    "warn": true
                }
            }, 
            "item": "hostnetwork", 
            "rc": 0, 
            "start": "2017-06-21 14:24:02.358345", 
            "stderr": "", 
            "stderr_lines": [], 
            "stdout": "allowHostDirVolumePlugin: false\nallowHostIPC: false\nallowHostNetwork: true\nallowHostPID: false\nallowHostPorts: true\nallowPrivilegedContainer: false\nallowedCapabilities: null\napiVersion: v1\ndefaultAddCapabilities: null\nfsGroup:\n  type: MustRunAs\nkind: SecurityContextConstraints\nmetadata:\n  annotations:\n    kubernetes.io/description: hostnetwork allows using host networking and host ports\n      but still requires pods to be run with a UID and SELinux context that are allocated\n      to the namespace.\n  creationTimestamp: 2017-06-21T18:16:02Z\n  name: hostnetwork\n  resourceVersion: \"105\"\n  selfLink: /api/v1/securitycontextconstraints/hostnetwork\n  uid: aef451c3-56ad-11e7-96a7-0e6fad14f9bc\npriority: null\nreadOnlyRootFilesystem: false\nrequiredDropCapabilities:\n- KILL\n- MKNOD\n- SYS_CHROOT\n- SETUID\n- SETGID\nrunAsUser:\n  type: MustRunAsRange\nseLinuxContext:\n  type: MustRunAs\nsupplementalGroups:\n  type: MustRunAs\nvolumes:\n- configMap\n- downwardAPI\n- emptyDir\n- persistentVolumeClaim\n- secret", 
            "stdout_lines": [
                "allowHostDirVolumePlugin: false", 
                "allowHostIPC: false", 
                "allowHostNetwork: true", 
                "allowHostPID: false", 
                "allowHostPorts: true", 
                "allowPrivilegedContainer: false", 
                "allowedCapabilities: null", 
                "apiVersion: v1", 
                "defaultAddCapabilities: null", 
                "fsGroup:", 
                "  type: MustRunAs", 
                "kind: SecurityContextConstraints", 
                "metadata:", 
                "  annotations:", 
                "    kubernetes.io/description: hostnetwork allows using host networking and host ports", 
                "      but still requires pods to be run with a UID and SELinux context that are allocated", 
                "      to the namespace.", 
                "  creationTimestamp: 2017-06-21T18:16:02Z", 
                "  name: hostnetwork", 
                "  resourceVersion: \"105\"", 
                "  selfLink: /api/v1/securitycontextconstraints/hostnetwork", 
                "  uid: aef451c3-56ad-11e7-96a7-0e6fad14f9bc", 
                "priority: null", 
                "readOnlyRootFilesystem: false", 
                "requiredDropCapabilities:", 
                "- KILL", 
                "- MKNOD", 
                "- SYS_CHROOT", 
                "- SETUID", 
                "- SETGID", 
                "runAsUser:", 
                "  type: MustRunAsRange", 
                "seLinuxContext:", 
                "  type: MustRunAs", 
                "supplementalGroups:", 
                "  type: MustRunAs", 
                "volumes:", 
                "- configMap", 
                "- downwardAPI", 
                "- emptyDir", 
                "- persistentVolumeClaim", 
                "- secret"
            ]
        }
    ], 
    "rc": 0, 
    "start": "2017-06-21 14:24:03.252607"
}
```