### PR TITLE
Workaround #4438 by replacing seboolean module with command.

### DIFF
--- a/roles/openshift_node/tasks/storage_plugins/glusterfs.yml
+++ b/roles/openshift_node/tasks/storage_plugins/glusterfs.yml
@@ -3,30 +3,52 @@
   package: name=glusterfs-fuse state=present
   when: not openshift.common.is_atomic | bool
 
-- name: Check for existence of virt_use_fusefs seboolean
-  command: getsebool virt_use_fusefs
-  register: virt_use_fusefs_output
-  when: ansible_selinux and ansible_selinux.status == "enabled"
+- name: Check for existence of fusefs sebooleans
+  command: getsebool {{ item }}
+  register: fusefs_getsebool_status
+  when:
+  - ansible_selinux
+  - ansible_selinux.status == "enabled"
   failed_when: false
   changed_when: false
+  with_items:
+  - virt_use_fusefs
+  - virt_sandbox_use_fusefs
 
 - name: Set seboolean to allow gluster storage plugin access from containers
   seboolean:
-    name: virt_use_fusefs
+    name: "{{ item.item }}"
     state: yes
     persistent: yes
-  when: ansible_selinux and ansible_selinux.status == "enabled" and virt_use_fusefs_output.rc == 0
+  when:
+  - ansible_selinux
+  - ansible_selinux.status == "enabled"
+  - item.rc == 0
+  # We need to detect whether or not the boolean is an alias, since `seboolean`
+  # will error if it is an alias.  We do this by inspecting stdout for the boolean name,
+  # since getsebool prints the resolved name.  (At some point Ansible's seboolean module
+  # should learn to deal with aliases)
+  - item.item in item.stdout  # Boolean does not have an alias.
+  - ansible_python_version | version_compare('3', '<')
+  with_items: "{{ fusefs_getsebool_status.results }}"
 
-- name: Check for existence of virt_sandbox_use_fusefs seboolean
-  command: getsebool virt_sandbox_use_fusefs
-  register: virt_sandbox_use_fusefs_output
-  when: ansible_selinux and ansible_selinux.status == "enabled"
-  failed_when: false
-  changed_when: false
-
-- name: Set seboolean to allow gluster storage plugin access from containers(sandbox)
-  seboolean:
-    name: virt_sandbox_use_fusefs
-    state: yes
-    persistent: yes
-  when: ansible_selinux and ansible_selinux.status == "enabled" and virt_sandbox_use_fusefs_output.rc == 0
+# Workaround for https://github.com/openshift/openshift-ansible/issues/4438
+# Use command module rather than seboolean module to set GlusterFS booleans.
+# TODO: Remove this task and the ansible_python_version comparison in
+# the previous task when the problem has been addressed in current
+# ansible release.
+- name: Set seboolean to allow gluster storage plugin access from containers (python 3)
+  command: >
+    setsebool -P {{ item.item }} on
+  when:
+  - ansible_selinux
+  - ansible_selinux.status == "enabled"
+  - item.rc == 0
+  # We need to detect whether or not the boolean is an alias, since `seboolean`
+  # will error if it is an alias.  We do this by inspecting stdout for the boolean name,
+  # since getsebool prints the resolved name.  (At some point Ansible's seboolean module
+  # should learn to deal with aliases)
+  - item.item in item.stdout  # Boolean does not have an alias.
+  - ('--> off' in item.stdout)  # Boolean is currently off.
+  - ansible_python_version | version_compare('3', '>=')
+  with_items: "{{ fusefs_getsebool_status.results }}"

--- a/roles/openshift_node/tasks/storage_plugins/nfs.yml
+++ b/roles/openshift_node/tasks/storage_plugins/nfs.yml
@@ -3,24 +3,52 @@
   package: name=nfs-utils state=present
   when: not openshift.common.is_atomic | bool
 
-- name: Check for existence of seboolean
+- name: Check for existence of nfs sebooleans
   command: getsebool {{ item }}
-  register: getsebool_status
-  when: ansible_selinux and ansible_selinux.status == "enabled"
+  register: nfs_getsebool_status
+  when:
+  - ansible_selinux
+  - ansible_selinux.status == "enabled"
   failed_when: false
   changed_when: false
   with_items:
-    - virt_use_nfs
-    - virt_sandbox_use_nfs
+  - virt_use_nfs
+  - virt_sandbox_use_nfs
 
 - name: Set seboolean to allow nfs storage plugin access from containers
   seboolean:
     name: "{{ item.item }}"
     state: yes
     persistent: yes
+  when:
+  - ansible_selinux
+  - ansible_selinux.status == "enabled"
+  - item.rc == 0
   # We need to detect whether or not the boolean is an alias, since `seboolean`
   # will error if it is an alias.  We do this by inspecting stdout for the boolean name,
   # since getsebool prints the resolved name.  (At some point Ansible's seboolean module
   # should learn to deal with aliases)
-  when: ansible_selinux and ansible_selinux.status == "enabled" and item.rc == 0 and item.stdout.find(item.item) != -1
-  with_items: "{{ getsebool_status.results }}"
+  - item.item in item.stdout  # Boolean does not have an alias.
+  - ansible_python_version | version_compare('3', '<')
+  with_items: "{{ nfs_getsebool_status.results }}"
+
+# Workaround for https://github.com/openshift/openshift-ansible/issues/4438
+# Use command module rather than seboolean module to set NFS booleans.
+# TODO: Remove this task and the ansible_python_version comparison in
+# the previous task when the problem has been addressed in current
+# ansible release.
+- name: Set seboolean to allow nfs storage plugin access from containers (python 3)
+  command: >
+    setsebool -P {{ item.item }} on
+  when:
+  - ansible_selinux
+  - ansible_selinux.status == "enabled"
+  - item.rc == 0
+  # We need to detect whether or not the boolean is an alias, since `seboolean`
+  # will error if it is an alias.  We do this by inspecting stdout for the boolean name,
+  # since getsebool prints the resolved name.  (At some point Ansible's seboolean module
+  # should learn to deal with aliases)
+  - item.item in item.stdout  # Boolean does not have an alias.
+  - ('--> off' in item.stdout)  # Boolean is currently off.
+  - ansible_python_version | version_compare('3', '>=')
+  with_items: "{{ nfs_getsebool_status.results }}"


### PR DESCRIPTION
~This is kind of junky. I can't think of a clean way to identify that the python3 interpreter is being used and only workaround in that case.~

https://github.com/openshift/openshift-ansible/issues/4438