### PR TITLE
Fixes to storage migration

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -5,13 +5,13 @@
 
 # oc adm migrate storage should be run prior to etcd v3 upgrade
 # See: https://github.com/openshift/origin/pull/14625#issuecomment-308467060
-- name: Pre master upgrade - Upgrade job storage
+- name: Pre master upgrade - Upgrade all storage
   hosts: oo_first_master
   tasks:
-  - name: Upgrade job storage
+  - name: Upgrade all storage
     command: >
       {{ openshift.common.client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-      migrate storage --include=jobs --confirm
+      migrate storage --include=* --confirm
 
 # If facts cache were for some reason deleted, this fact may not be set, and if not set
 # it will always default to true. This causes problems for the etcd data dir fact detection
@@ -143,13 +143,13 @@
   - set_fact:
       master_update_complete: True
 
-- name: Post master upgrade - Upgrade job storage
+- name: Post master upgrade - Upgrade clusterpolicies storage
   hosts: oo_first_master
   tasks:
-  - name: Upgrade job storage
+  - name: Upgrade clusterpolicies storage
     command: >
       {{ openshift.common.client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-      migrate storage --include=jobs --confirm
+      migrate storage --include=clusterpolicies --confirm
 
 ##############################################################################
 # Gate on master update complete
@@ -228,6 +228,12 @@
     changed_when:
     - reconcile_scc_result.stdout != ''
     - reconcile_scc_result.rc == 0
+    run_once: true
+
+  - name: Upgrade job storage
+    command: >
+      {{ openshift.common.client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      migrate storage --include=* --confirm
     run_once: true
 
   - set_fact:


### PR DESCRIPTION
This changes to perform a complete storage migration pre upgrade, a migration of clusterpolices after upgrade but before policy reconciliation, and a complete storage migration after policy reconciliation.

