### PR TITLE
openvswitch, syscontainer: specify the Docker service name

### DIFF
--- a/roles/openshift_node/tasks/openvswitch_system_container.yml
+++ b/roles/openshift_node/tasks/openvswitch_system_container.yml
@@ -10,3 +10,5 @@
     name: openvswitch
     image: "{{ openshift.common.system_images_registry }}/{{ openshift.node.ovs_system_image }}:{{ openshift_image_tag }}"
     state: latest
+    values:
+      - "DOCKER_SERVICE={{ openshift.docker.service_name }}.service"


### PR DESCRIPTION
it fixes a failure when using the openvswitch system container with container-engine.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>