### PR TITLE
releases: enable build/push with multiple tags

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -47,7 +47,7 @@ if [ "$help" = true ]; then
   echo "  default: openshift/origin-ansible"
   echo
   echo "  --version=VERSION"
-  echo "  The version used to tag the image"
+  echo "  The version used to tag the image (can be a comma-separated list)"
   echo "  default: latest"
   echo 
   echo "  --no-cache"
@@ -62,25 +62,33 @@ if [ "$help" = true ]; then
   exit 0
 fi
 
+
 if [ "$verbose" = true ]; then
   set -x
 fi
 
 BUILD_STARTTIME=$(date +%s)
 comp_path=$source_root/
-docker_tag=${prefix}:${version}
+
+# turn comma-separated versions into -t args for docker build
+IFS=',' read -r -a version_arr <<< "$version"
+docker_tags=()
+for tag in "${version_arr[@]}"; do
+  docker_tags+=("-t" "${prefix}:${tag}")
+done
+
 echo
 echo
-echo "--- Building component '$comp_path' with docker tag '$docker_tag' ---"
-docker build ${options} -t $docker_tag $comp_path
-BUILD_ENDTIME=$(date +%s); echo "--- $docker_tag took $(($BUILD_ENDTIME - $BUILD_STARTTIME)) seconds ---"
+echo "--- Building component '$comp_path' with docker tag(s) '$version' ---"
+docker build ${options} "${docker_tags[@]}" $comp_path
+BUILD_ENDTIME=$(date +%s); echo "--- ${version} took $(($BUILD_ENDTIME - $BUILD_STARTTIME)) seconds ---"
 echo
 echo
 
 echo
 echo
 echo "++ Active images"
-docker images | grep ${prefix} | grep ${version} | sort
+docker images | grep ${prefix} | sort
 echo
 
 


### PR DESCRIPTION
Update the release scripts so that either at build or push time we can specify multiple tags we want the same image to end up with.