### PR TITLE
migrate embedded etcd

### DIFF
--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -3,6 +3,20 @@
   tags:
   - always
 
+- name: Check masters for embedded etcd
+  hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tags:
+  - always
+  tasks:
+  - fail:
+      msg: "Migration of clustered embedded etcd instances is not supported. Currently there are {{ groups.oo_masters_to_config | length }} masters."
+    when:
+    - groups.oo_masters_to_config | length != 1
+    - groups.oo_etcd_to_config | default([]) | length == 0
+
 - name: Run pre-checks
   hosts: oo_etcd_to_migrate
   tags:

--- a/roles/etcd_common/defaults/main.yml
+++ b/roles/etcd_common/defaults/main.yml
@@ -14,7 +14,7 @@ r_etcd_common_embedded_etcd: false
 r_etcd_common_etcdctl_command: "{{ 'etcdctl' if r_etcd_common_etcd_runtime == 'host' or r_etcd_common_embedded_etcd | bool else 'docker exec etcd_container etcdctl' if r_etcd_common_etcd_runtime == 'docker' else 'runc exec etcd etcdctl' }}"
 
 # etcd server vars
-etcd_conf_dir: '/etc/etcd'
+etcd_conf_dir: "{{ '/etc/origin/master' if r_etcd_common_embedded_etcd | bool else '/etc/etcd' }}"
 r_etcd_common_system_container_host_dir: /var/lib/etcd/etcd.etcd
 etcd_system_container_conf_dir: /var/lib/etcd/etc
 etcd_conf_file: "{{ etcd_conf_dir }}/etcd.conf"
@@ -22,8 +22,8 @@ etcd_ca_file: "{{ etcd_conf_dir }}/ca.crt"
 etcd_cert_file: "{{ etcd_conf_dir }}/server.crt"
 etcd_key_file: "{{ etcd_conf_dir }}/server.key"
 etcd_peer_ca_file: "{{ etcd_conf_dir }}/ca.crt"
-etcd_peer_cert_file: "{{ etcd_conf_dir }}/peer.crt"
-etcd_peer_key_file: "{{ etcd_conf_dir }}/peer.key"
+etcd_peer_cert_file: "{{ etcd_conf_dir + '/admin.crt' if r_etcd_common_embedded_etcd | bool else etcd_conf_dir + '/peer.crt' }}"
+etcd_peer_key_file: "{{ etcd_conf_dir + '/admin.key' if r_etcd_common_embedded_etcd | bool else etcd_conf_dir + '/peer.key' }}"
 
 # etcd ca vars
 etcd_ca_dir: "{{ etcd_conf_dir}}/ca"
@@ -55,7 +55,7 @@ etcd_is_thirdparty: False
 etcd_data_dir: "{{ '/var/lib/origin/openshift.local.etcd' if r_etcd_common_embedded_etcd | bool else '/var/lib/etcd/' if openshift.common.etcd_runtime != 'runc' else '/var/lib/etcd/etcd.etcd/' }}"
 
 # etcd ports and protocols
-etcd_client_port: 2379
-etcd_peer_port: 2380
+etcd_client_port: "{{ '4001' if r_etcd_common_embedded_etcd | bool else '2379' }}"
+etcd_peer_port: "{{ '7001' if r_etcd_common_embedded_etcd | bool else '2380' }}"
 etcd_url_scheme: http
 etcd_peer_url_scheme: http

--- a/roles/etcd_migrate/tasks/migrate.yml
+++ b/roles/etcd_migrate/tasks/migrate.yml
@@ -3,10 +3,13 @@
 - set_fact:
     l_etcd_service: "{{ 'etcd_container' if openshift.common.is_containerized else 'etcd' }}"
 
+# embedded etcd is run as part of the master
 - name: Disable etcd members
   service:
     name: "{{ l_etcd_service }}"
     state: stopped
+  when:
+  - not r_etcd_common_embedded_etcd | bool
 
 # Should we skip all TTL keys? https://bugzilla.redhat.com/show_bug.cgi?id=1389773
 - name: Migrate etcd data
@@ -26,30 +29,60 @@
   debug:
     msg: "Etcd migration finished with: {{ l_etcdctl_migrate.stdout }}"
 
-- name: Enable etcd member
-  service:
-    name: "{{ l_etcd_service }}"
-    state: started
+# For non-embedded etcd, just start the service as it was previously disabled due to offline migration.
+# Then, re-attach the leases
+- block:
+  - name: Enable etcd member (for non-embedded etcd)
+    service:
+      name: "{{ l_etcd_service }}"
+      state: started
+  - name: Re-introduce leases (as a replacement for key TTLs) for non-embedded etcd
+    command: >
+      oadm migrate etcd-ttl \
+      --cert {{ etcd_peer_cert_file }} \
+      --key {{ etcd_peer_key_file }} \
+      --cacert {{ etcd_peer_ca_file }} \
+      --etcd-address 'https://{{ etcd_peer }}:{{ etcd_client_port }}' \
+      --ttl-keys-prefix {{ item }} \
+      --lease-duration 1h
+    environment:
+      ETCDCTL_API: 3
+      PATH: "/usr/local/bin:/var/usrlocal/bin:{{ ansible_env.PATH }}"
+    with_items:
+    - "/kubernetes.io/events"
+    - "/kubernetes.io/masterleases"
+    delegate_to: "{{ groups.oo_first_master[0] }}"
+    run_once: true
+  when:
+  - not r_etcd_common_embedded_etcd | bool
 
-# NOTE: /usr/local/bin may be removed from the PATH by ansible hence why
-#       it's added to the environment in this task.
-- name: Re-introduce leases (as a replacement for key TTLs)
-  command: >
-    oadm migrate etcd-ttl \
-    --cert {{ etcd_peer_cert_file }} \
-    --key {{ etcd_peer_key_file }} \
-    --cacert {{ etcd_peer_ca_file }} \
-    --etcd-address 'https://{{ etcd_peer }}:{{ etcd_client_port }}' \
-    --ttl-keys-prefix {{ item }} \
-    --lease-duration 1h
-  environment:
-    ETCDCTL_API: 3
-    PATH: "/usr/local/bin:/var/usrlocal/bin:{{ ansible_env.PATH }}"
-  with_items:
-  - "/kubernetes.io/events"
-  - "/kubernetes.io/masterleases"
-  delegate_to: "{{ groups.oo_first_master[0] }}"
-  run_once: true
+# For embeddded etcd, start the etcd daemon locally (to re-attach leases).
+# Then, stop the etcd daemon (so the embedded etcd can start again later)
+- block:
+  - name: Enable etcd member (for embedded etcd)
+    service:
+      name: etcd
+      state: started
+  - name: Re-introduce leases (as a replacement for key TTLs) for embedded etcd
+    command: >
+      oadm migrate etcd-ttl \
+      --etcd-address 'http://localhost:2379' \
+      --ttl-keys-prefix {{ item }} \
+      --lease-duration 1h
+    environment:
+      ETCDCTL_API: 3
+      PATH: "/usr/local/bin:/var/usrlocal/bin:{{ ansible_env.PATH }}"
+    with_items:
+    - "/kubernetes.io/events"
+    - "/kubernetes.io/masterleases"
+  # as for embeddded etcd, the etcd daemon was started locally (to re-attach leases)
+  # disable it
+  - name: Disable etcd member (for embedded etcd)
+    service:
+      name: etcd
+      state: stopped
+  when:
+  - r_etcd_common_embedded_etcd | bool
 
 - set_fact:
     r_etcd_migrate_success: true


### PR DESCRIPTION
- if the etcd is embedded, re-attach the leases through locally running etcd daemon
- refactor etcd_common role to set various variables propertly for embedded etcd