### PR TITLE
replace deprecated always_run with check_mode: no

### DIFF
--- a/roles/contiv/tasks/netplugin_iptables.yml
+++ b/roles/contiv/tasks/netplugin_iptables.yml
@@ -2,7 +2,7 @@
 - name: Netplugin IPtables | Get iptables rules
   command: iptables -L --wait
   register: iptablesrules
-  always_run: yes
+  check_mode: no
 
 - name: Netplugin IPtables | Enable iptables at boot
   service:

--- a/roles/contiv_facts/tasks/main.yml
+++ b/roles/contiv_facts/tasks/main.yml
@@ -3,7 +3,7 @@
   stat: path=/run/ostree-booted
   register: s
   changed_when: false
-  always_run: yes
+  check_mode: no
 
 - name: Init the is_atomic fact
   set_fact:
@@ -17,7 +17,7 @@
 - name: Determine if CoreOS
   raw: "grep '^NAME=' /etc/os-release | sed s'/NAME=//'"
   register: distro
-  always_run: yes
+  check_mode: no
 
 - name: Init the is_coreos fact
   set_fact:
@@ -61,7 +61,7 @@
   stat: path=/usr/bin/rpm
   register: s
   changed_when: false
-  always_run: yes
+  check_mode: no
 
 - name: Init the has_rpm fact
   set_fact:

--- a/roles/contiv_facts/tasks/rpm.yml
+++ b/roles/contiv_facts/tasks/rpm.yml
@@ -4,7 +4,7 @@
   register: s
   changed_when: false
   failed_when: false
-  always_run: yes
+  check_mode: no
 
 - name: Set the has_firewalld fact
   set_fact:
@@ -16,7 +16,7 @@
   register: s
   changed_when: false
   failed_when: false
-  always_run: yes
+  check_mode: no
 
 - name: Set the has_iptables fact
   set_fact:


### PR DESCRIPTION
Prior to Ansible 2.2 only the the equivalent of check_mode: no existed. The
notation for that was always_run: yes.

always_run now generates a deprecation warning:

> [DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
> This feature will be removed in version 2.4. Deprecation warnings can be
> disabled by setting deprecation_warnings=False in ansible.cfg.