### PR TITLE
Set clean install and etcd storage on first master to fix scaleup

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -20,25 +20,6 @@
     - node
     - .config_managed
 
-  - name: Check for existing configuration
-    stat:
-      path: /etc/origin/master/master-config.yaml
-    register: master_config_stat
-
-  - name: Set clean install fact
-    set_fact:
-      l_clean_install: "{{ not master_config_stat.stat.exists | bool }}"
-
-  - name: Determine if etcd3 storage is in use
-    command: grep  -Pzo  "storage-backend:\n.*etcd3" /etc/origin/master/master-config.yaml -q
-    register: etcd3_grep
-    failed_when: false
-    changed_when: false
-
-  - name: Set etcd3 fact
-    set_fact:
-      l_etcd3_enabled: "{{ etcd3_grep.rc == 0 | bool }}"
-
   - set_fact:
       openshift_master_pod_eviction_timeout: "{{ lookup('oo_option', 'openshift_master_pod_eviction_timeout') | default(none, true) }}"
     when: openshift_master_pod_eviction_timeout is not defined
@@ -88,7 +69,7 @@
         ha: "{{ openshift_master_ha | default(groups.oo_masters | length > 1) }}"
         master_count: "{{ openshift_master_count | default(groups.oo_masters | length) }}"
 
-- name: Determine if session secrets must be generated
+- name: Inspect state of first master session secrets and config
   hosts: oo_first_master
   roles:
   - role: openshift_facts
@@ -98,6 +79,24 @@
       local_facts:
         session_auth_secrets: "{{ openshift_master_session_auth_secrets | default(openshift.master.session_auth_secrets | default(None)) }}"
         session_encryption_secrets: "{{ openshift_master_session_encryption_secrets | default(openshift.master.session_encryption_secrets | default(None)) }}"
+  - name: Check for existing configuration
+    stat:
+      path: /etc/origin/master/master-config.yaml
+    register: master_config_stat
+
+  - name: Set clean install fact
+    set_fact:
+      l_clean_install: "{{ not master_config_stat.stat.exists | bool }}"
+
+  - name: Determine if etcd3 storage is in use
+    command: grep  -Pzo  "storage-backend:\n.*etcd3" /etc/origin/master/master-config.yaml -q
+    register: etcd3_grep
+    failed_when: false
+    changed_when: false
+
+  - name: Set etcd3 fact
+    set_fact:
+      l_etcd3_enabled: "{{ etcd3_grep.rc == 0 | bool }}"
 
 - name: Generate master session secrets
   hosts: oo_first_master


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1464011

In scaleup scenarios we need to explicitly gather this state from the first master as it wouldn't be included in oo_masters_to_config. For non scaleup scenarios, ie: re-running config.yml that's the correct host to use anyway.