### PR TITLE
Capture exceptions when resolving available checks

### DIFF
--- a/roles/openshift_health_checker/action_plugins/openshift_health_check.py
+++ b/roles/openshift_health_checker/action_plugins/openshift_health_check.py
@@ -38,13 +38,12 @@ class ActionModule(ActionBase):
 
         try:
             known_checks = self.load_known_checks()
+            args = self._task.args
+            resolved_checks = resolve_checks(args.get("checks", []), known_checks.values())
         except OpenShiftCheckException as e:
             result["failed"] = True
             result["msg"] = str(e)
             return result
-
-        args = self._task.args
-        resolved_checks = resolve_checks(args.get("checks", []), known_checks.values())
 
         result["checks"] = check_results = {}
 

--- a/roles/openshift_health_checker/test/action_plugin_test.py
+++ b/roles/openshift_health_checker/test/action_plugin_test.py
@@ -59,7 +59,7 @@ def failed(result, msg_has=None):
     if msg_has is not None:
         assert 'msg' in result
         for term in msg_has:
-            assert term in result['msg']
+            assert term.lower() in result['msg'].lower()
     return result.get('failed', False)
 
 
@@ -174,6 +174,16 @@ def test_action_plugin_run_check_exception(plugin, task_vars, monkeypatch):
 
     assert failed(result['checks']['fake_check'], msg_has=exception_msg)
     assert failed(result, msg_has=['failed'])
+    assert not changed(result)
+    assert not skipped(result)
+
+
+def test_action_plugin_resolve_checks_exception(plugin, task_vars, monkeypatch):
+    monkeypatch.setattr(plugin, 'load_known_checks', lambda: {})
+
+    result = plugin.run(tmp=None, task_vars=task_vars)
+
+    assert failed(result, msg_has=['unknown', 'name'])
     assert not changed(result)
     assert not skipped(result)
 


### PR DESCRIPTION
Calling the action plugin (e.g. when running a playbook) with an
incorrect check name was raising an unhandled exception, leading to poor
output in Ansible (requiring a higher verbosity level to see what is
going wrong).

Fixes a bug that was not reported so far.