### PR TITLE
Use tuned recommend profiles instead of a hard-coded atomic-guest.

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -29,6 +29,9 @@
     state: present
   when: not openshift.common.is_containerized | bool
 
+- name: Configure tuned profiles
+  include: ../../tuned/tasks/main.yml
+
 - name: Create openshift.common.data_dir
   file:
     path: "{{ openshift.common.data_dir }}"

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -74,17 +74,8 @@
     state: present
   when: not openshift.common.is_containerized | bool
 
-- name: Check for tuned package
-  command: rpm -q tuned
-  args:
-    warn: no
-  register: tuned_installed
-  changed_when: false
-  failed_when: false
-
-- name: Set atomic-guest tuned profile
-  command: "tuned-adm profile atomic-guest"
-  when: tuned_installed.rc == 0 and openshift.common.is_atomic | bool
+- name: Configure tuned profiles
+  include: ../../tuned/tasks/main.yml
 
 - name: Install sdn-ovs package
   package:

--- a/roles/tuned/meta/main.yml
+++ b/roles/tuned/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  author: Jiri Mencak
+  description: Restart the tuned daemon if present and make it use the recommended profile
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 2.2
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud

--- a/roles/tuned/tasks/main.yml
+++ b/roles/tuned/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Check for tuned package
+  command: rpm -q tuned
+  args:
+    warn: no
+  register: tuned_installed
+  changed_when: false
+  failed_when: false
+
+- name: Make tuned use the recommended tuned profile on restart
+  file: path=/etc/tuned/active_profile state=absent
+  when: tuned_installed.rc == 0 | bool
+
+- name: Restart tuned service
+  systemd:
+    state: restarted
+    daemon_reload: yes
+    name: tuned
+  when: tuned_installed.rc == 0 | bool


### PR DESCRIPTION
This PR is part of restructuring the tuned profile hierarchy within OpenShift.  The current installer code forces the use of atomic-guest profile instead of using the "recommend"ed profile, resulting in inconsistencies like https://bugzilla.redhat.com/show_bug.cgi?id=1459146

An associated PR to origin coming soon.