### PR TITLE
[3.5] Fix parsing certs with very large serial numbers

### DIFF
--- a/roles/openshift_certificate_expiry/library/openshift_cert_expiry.py
+++ b/roles/openshift_certificate_expiry/library/openshift_cert_expiry.py
@@ -103,6 +103,7 @@ platforms missing the Python OpenSSL library.
         self.extensions = []
 
         PARSING_ALT_NAMES = False
+        PARSING_HEX_SERIAL = False
         for line in self.cert_string.split('\n'):
             l = line.strip()
             if PARSING_ALT_NAMES:
@@ -113,10 +114,26 @@ platforms missing the Python OpenSSL library.
                 PARSING_ALT_NAMES = False
                 continue
 
+            if PARSING_HEX_SERIAL:
+                # Hex serials arrive colon-delimited
+                serial_raw = l.replace(':', '')
+                # Convert to decimal
+                self.serial = int('0x' + serial_raw, base=16)
+                PARSING_HEX_SERIAL = False
+                continue
+
             # parse out the bits that we can
             if l.startswith('Serial Number:'):
-                # Serial Number: 11 (0xb)
-                # => 11
+                # Decimal format:
+                #   Serial Number: 11 (0xb)
+                #   => 11
+                # Hex Format (large serials):
+                #   Serial Number:
+                #       0a:de:eb:24:04:75:ab:56:39:14:e9:5a:22:e2:85:bf
+                #   => 14449739080294792594019643629255165375
+                if l.endswith(':'):
+                    PARSING_HEX_SERIAL = True
+                    continue
                 self.serial = int(l.split()[-2])
 
             elif l.startswith('Not After :'):

--- a/roles/openshift_certificate_expiry/test/conftest.py
+++ b/roles/openshift_certificate_expiry/test/conftest.py
@@ -23,7 +23,10 @@ VALID_CERTIFICATE_PARAMS = [
     {
         'short_name': 'combined',
         'cn': 'combined.example.com',
-        'serial': 6,
+        # Verify that HUGE serials parse correctly.
+        # Frobs PARSING_HEX_SERIAL in _parse_cert
+        # See https://bugzilla.redhat.com/show_bug.cgi?id=1464240
+        'serial': 14449739080294792594019643629255165375,
         'uses': b'clientAuth, serverAuth',
         'dns': ['etcd'],
         'ip': ['10.0.0.2', '192.168.0.2']


### PR DESCRIPTION
https://github.com/openshift/openshift-ansible/pull/4573

Certificates with large serial numbers (such as those from commercial
vendors) previously failed to parse due to absent logic in the
FakeOpenSSLCertificate parser. This would cause the module to abort
and break any other roles depending on the cert expiry checking
results.

* Identifies large serials in HEX format for decimal conversion
* Update unit tests to parse a large serial