### PR TITLE
Set the Metrics version to the OpenShift version if specified

### DIFF
--- a/roles/openshift_metrics/vars/default_images.yml
+++ b/roles/openshift_metrics/vars/default_images.yml
@@ -1,3 +1,3 @@
 ---
 __openshift_metrics_image_prefix: "{{ openshift_hosted_metrics_deployer_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_metrics_image_version: "{{ openshift_hosted_metrics_deployer_version | default('latest') }}"
+__openshift_metrics_image_version: "{{ openshift_image_tag | default(openshift_hosted_metrics_deployer_version) | default('latest') }}"

--- a/roles/openshift_metrics/vars/openshift-enterprise.yml
+++ b/roles/openshift_metrics/vars/openshift-enterprise.yml
@@ -1,3 +1,3 @@
 ---
 __openshift_metrics_image_prefix: "{{ openshift_hosted_metrics_deployer_prefix | default('registry.access.redhat.com/openshift3/') }}"
-__openshift_metrics_image_version: "{{ openshift_hosted_metrics_deployer_version | default ('3.6.0') }}"
+__openshift_metrics_image_version: "{{ openshift_image_tag | default(openshift_hosted_metrics_deployer_version) | default ('v3.6') }}"


### PR DESCRIPTION
Setting the default value to '3.6.0' is problematic (see https://bugzilla.redhat.com/show_bug.cgi?id=1445568)

Since the Metric images starting with 3.6 will be tagged with the same version as OpenShift, we should be using the same image tag for the metric images.

Even if the 'openshift_image_tag' is set, the 'openshift_metrics_image_version' can be used to override this value.

Note: if this PR is deemed acceptable, we will need to have a similar PR for logging.