### PR TITLE
oc_atomic_container: fix version check for atomic

### DIFF
--- a/roles/lib_openshift/library/oc_atomic_container.py
+++ b/roles/lib_openshift/library/oc_atomic_container.py
@@ -194,7 +194,7 @@ def main():
         )
 
     # Verify that the platform supports atomic command
-    rc, version_out, err = module.run_command('atomic -v', check_rc=False)
+    rc, version_out, err = module.run_command('rpm -q --queryformat "%{VERSION}\n" atomic', check_rc=False)
     if rc != 0:
         module.fail_json(msg="Error in running atomic command", err=err)
     # This module requires atomic version 1.17.2 or later

--- a/roles/lib_openshift/src/ansible/oc_atomic_container.py
+++ b/roles/lib_openshift/src/ansible/oc_atomic_container.py
@@ -130,7 +130,7 @@ def main():
         )
 
     # Verify that the platform supports atomic command
-    rc, version_out, err = module.run_command('atomic -v', check_rc=False)
+    rc, version_out, err = module.run_command('rpm -q --queryformat "%{VERSION}\n" atomic', check_rc=False)
     if rc != 0:
         module.fail_json(msg="Error in running atomic command", err=err)
     # This module requires atomic version 1.17.2 or later


### PR DESCRIPTION
Some versions of atomic write their version to stderr,
consider that as well.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>