### PR TITLE
Bug 1465168 - mux doesn't recognize ansible boolean parameters correctly

### DIFF
--- a/roles/openshift_logging_mux/templates/mux.j2
+++ b/roles/openshift_logging_mux/templates/mux.j2
@@ -102,7 +102,7 @@ spec:
         - name: USE_MUX
           value: "true"
         - name: MUX_ALLOW_EXTERNAL
-          value: "{{ openshift_logging_mux_allow_external | default('false') }}"
+          value: "{{ openshift_logging_mux_allow_external | default('false') | lower }}"
         - name: "BUFFER_QUEUE_LIMIT"
           value: "{{ openshift_logging_mux_buffer_queue_limit }}"
         - name: "BUFFER_SIZE_LIMIT"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1465168
The fix is to pass the value through the `lower` filter.  The value is
set in defaults/main.yaml so it should always have a value.
@ewolinetz @jcantrill PTAL
This is a 3.6 blocker.