### PR TITLE
Fix generate role binding destination for the HOSA service account

### DIFF
--- a/roles/openshift_metrics/tasks/install_hosa.yaml
+++ b/roles/openshift_metrics/tasks/install_hosa.yaml
@@ -28,7 +28,7 @@
 - name: Generate role binding for the hawkular-openshift-agent service account
   template:
     src: rolebinding.j2
-    dest: "{{ mktemp.stdout }}/templates/metrics-hawkular-agent-rolebinding.yaml"
+    dest: "{{ mktemp.stdout }}/templates/metrics-hawkular-openshift-agent-rolebinding.yaml"
   vars:
     cluster: True
     obj_name: hawkular-openshift-agent-rb


### PR DESCRIPTION
The task `Generate role binding for the hawkular-openshift-agent service account` use wrong template destination:
https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_metrics/tasks/install_metrics.yaml#L47

```
TASK [openshift_metrics : Applying /tmp/openshift-metrics-ansible-JS9xrC/templates/metrics-hawkular-openshift-rolebinding.yaml] ***
Friday 23 June 2017  13:52:39 +0200 (0:00:00.494)       0:01:10.749 ***********
fatal: [openshift-master.example.com]: FAILED! => {
    "changed": false,
    "cmd": [
        "oc",
        "--config=/tmp/openshift-metrics-ansible-JS9xrC/admin.kubeconfig",
        "apply",
        "-f",
        "/tmp/openshift-metrics-ansible-JS9xrC/templates/metrics-hawkular-openshift-rolebinding.yaml",
        "-n",
        "openshift-infra"
    ],
    "delta": "0:00:00.193810",
    "end": "2017-06-23 11:51:49.212799",
    "failed": true,
    "failed_when_result": true,
    "rc": 1,
    "start": "2017-06-23 11:51:49.018989",
    "warnings": []
}

STDERR:

Error from server (NotFound): error when creating "/tmp/openshift-metrics-ansible-JS9xrC/templates/metrics-hawkular-openshift-rolebinding.yaml": role "hawkular-openshift-agent" not found
```