### PR TITLE
docker_storage check: make vgs return sane output

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/docker_storage.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_storage.py
@@ -143,7 +143,7 @@ class DockerStorage(DockerHostMixin, OpenShiftCheck):
                 "so the available storage in the VG cannot be determined.".format(pool)
             )
         vg_name = match.groups()[0].replace("--", "-")
-        vgs_cmd = "/sbin/vgs --noheadings -o vg_free --select vg_name=" + vg_name
+        vgs_cmd = "/sbin/vgs --noheadings -o vg_free --units g --select vg_name=" + vg_name
         # should return free space like "  12.00g" if the VG exists; empty if it does not
 
         ret = self.execute_module("command", {"_raw_params": vgs_cmd}, task_vars=task_vars)


### PR DESCRIPTION
fix bug 1464974 https://bugzilla.redhat.com/show_bug.cgi?id=1464974

Specify --units on vgs call. In my testing with lvm 2.0.2.171(2) on
RHEL Atomic Host 7.4, this turned a response of "<4.07g" into "4.07g"
which should resolve the issue. I haven't found what the "<" is for
in the first place but I'm thinking this should at least be a safe
change.