### PR TITLE
[1.5] Fix typo in fluentd_secureforward_contents variable

### DIFF
--- a/roles/openshift_logging/tasks/generate_configmaps.yaml
+++ b/roles/openshift_logging/tasks/generate_configmaps.yaml
@@ -93,7 +93,7 @@
     - copy:
         src: secure-forward.conf
         dest: "{{mktemp.stdout}}/secure-forward.conf"
-      when: fluentd_securefoward_contents is undefined
+      when: fluentd_secureforward_contents is undefined
       changed_when: no
 
     - copy:


### PR DESCRIPTION
1.5 backport of https://github.com/openshift/openshift-ansible/pull/4606