### PR TITLE
Add teams attribute to github identity provider

### DIFF
--- a/roles/openshift_master_facts/filter_plugins/openshift_master.py
+++ b/roles/openshift_master_facts/filter_plugins/openshift_master.py
@@ -467,7 +467,8 @@ class GitHubIdentityProvider(IdentityProviderOauthBase):
     """
     def __init__(self, api_version, idp):
         IdentityProviderOauthBase.__init__(self, api_version, idp)
-        self._optional += [['organizations']]
+        self._optional += [['organizations'],
+                           ['teams']]
 
 
 class FilterModule(object):


### PR DESCRIPTION
This is not my work, I am just requesting that it be merged into release-1.5.  Original PR: https://github.com/openshift/openshift-ansible/pull/4211

GitHubIdentityProvider provides the ability to authenticate against
GitHub organization teams [1].
This adds the attribute as optional so that users do not get the error
"provider GitHubIdentityProvider contains unknown keys teams".

[1]: https://docs.openshift.com/container-platform/3.5/install_config/configuring_authentication.html#GitHub

