### PR TITLE
Sync environment variables FLUENTD/MUX_CPU_LIMIT FLUENTD/MUX_MEMORY_L…

### DIFF
--- a/roles/openshift_logging_fluentd/templates/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/fluentd.j2
@@ -98,9 +98,15 @@ spec:
         - name: "BUFFER_SIZE_LIMIT"
           value: "{{ openshift_logging_fluentd_buffer_size_limit }}"
         - name: "FLUENTD_CPU_LIMIT"
-          value: "{{ openshift_logging_fluentd_cpu_limit }}"
+          valueFrom:
+            resourceFieldRef:
+              containerName: "{{ daemonset_container_name }}"
+              resource: limits.cpu
         - name: "FLUENTD_MEMORY_LIMIT"
-          value: "{{ openshift_logging_fluentd_memory_limit }}"
+          valueFrom:
+            resourceFieldRef:
+              containerName: "{{ daemonset_container_name }}"
+              resource: limits.memory
       volumes:
       - name: runlogjournal
         hostPath:

--- a/roles/openshift_logging_mux/templates/mux.j2
+++ b/roles/openshift_logging_mux/templates/mux.j2
@@ -108,9 +108,15 @@ spec:
         - name: "BUFFER_SIZE_LIMIT"
           value: "{{ openshift_logging_mux_buffer_size_limit }}"
         - name: "MUX_CPU_LIMIT"
-          value: "{{ openshift_logging_mux_cpu_limit }}"
+          valueFrom:
+            resourceFieldRef:
+              containerName: "mux"
+              resource: limits.cpu
         - name: "MUX_MEMORY_LIMIT"
-          value: "{{ openshift_logging_mux_memory_limit }}"
+          valueFrom:
+            resourceFieldRef:
+              containerName: "mux"
+              resource: limits.memory
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
…IMIT with the resource limit values.

The environment variables {FLUENTD,MUX}_MEMORY_LIMIT are to be used to pass the resource limit values to the fluentd run.sh. (They won't be advertised in the doc.) 