### PR TITLE
[master] evalute groups when running etcd upgrade from byo/openshift-cluster/upgrades/upgrade_etcd.yml

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/upgrade_etcd.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/upgrade_etcd.yml
@@ -1,4 +1,6 @@
 ---
 - include: ../initialize_groups.yml
 
+- include: ../../../common/openshift-cluster/evaluate_groups.yml
+
 - include: ../../../common/openshift-cluster/upgrades/etcd/main.yml


### PR DESCRIPTION
When running etcd upgrade via ``playbooks/byo/openshift-cluster/upgrades/upgrade_etcd.yml``, only the basic groups are initialized. Causing the playbook fail due to `oo_etcd_hosts_to_backup` group missing.

Tested on 3.6 cluster, the playbook ended successfully in 3m6.848s.

Bug: 1460617

3.5 backport: https://github.com/openshift/openshift-ansible/pull/4621
3.4 backport: https://github.com/openshift/openshift-ansible/pull/4622