### PR TITLE
increase implicit 300s default timeout to explicit 600s

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/docker/restart.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/restart.yml
@@ -24,4 +24,5 @@
     state: started
     delay: 10
     port: "{{ openshift.master.api_port }}"
+    timeout: 600
   when: inventory_hostname in groups.oo_masters_to_config

--- a/playbooks/common/openshift-master/restart_hosts.yml
+++ b/playbooks/common/openshift-master/restart_hosts.yml
@@ -37,3 +37,4 @@
     state: started
     delay: 10
     port: "{{ openshift.master.api_port }}"
+    timeout: 600

--- a/playbooks/common/openshift-master/restart_services.yml
+++ b/playbooks/common/openshift-master/restart_services.yml
@@ -15,6 +15,7 @@
     state: started
     delay: 10
     port: "{{ openshift.master.api_port }}"
+    timeout: 600
   when: openshift_master_ha | bool
 - name: Restart master controllers
   service:

--- a/playbooks/common/openshift-node/restart.yml
+++ b/playbooks/common/openshift-node/restart.yml
@@ -36,6 +36,7 @@
       state: started
       delay: 10
       port: "{{ openshift.master.api_port }}"
+      timeout: 600
     when: inventory_hostname in groups.oo_masters_to_config
 
   - name: restart node

--- a/roles/openshift_node_upgrade/tasks/restart.yml
+++ b/roles/openshift_node_upgrade/tasks/restart.yml
@@ -43,4 +43,5 @@
     state: started
     delay: 10
     port: "{{ openshift.master.api_port }}"
+    timeout: 600
   when: inventory_hostname in groups.oo_masters_to_config


### PR DESCRIPTION
Due to https://bugzilla.redhat.com/show_bug.cgi?id=1441994 a node can reboot slowing. Causing in timeout in ansible `wait_for` module. The default is 300s which is not always enough.

Bug: 1455836