### PR TITLE
Honor proxy settings during installation/health check

### DIFF
--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -17,6 +17,9 @@
       - package_version
       - docker_image_availability
       - docker_storage
+    environment:
+      http_proxy: "{{ openshift_http_proxy | default('')}}"
+      https_proxy: "{{ openshift_https_proxy|default('') }}"
 
 - include: initialize_oo_option_facts.yml
   tags:

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -42,12 +42,14 @@
     openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
     openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
     openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
-    openshift_no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']
+  pre_tasks:
+  - set_fact:
+      openshift_no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']
                                                     | union(groups['oo_masters_to_config'])
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
+      when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
             openshift_generate_no_proxy_hosts | default(True) | bool }}"
   roles:
   - role: openshift_node
@@ -59,7 +61,9 @@
     openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
     openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
     openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
-    openshift_no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']
+  pre_tasks:
+  - set_fact:
+      openshift_no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']
                                                     | union(groups['oo_masters_to_config'])
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -68,7 +68,7 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
+      when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
             openshift_generate_no_proxy_hosts | default(True) | bool }}"
   roles:
   - role: openshift_node

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -103,6 +103,9 @@
         name: "{{ openshift.common.service_type}}"
         ignore_excluders: true
       register: rpm_results
+      environment:
+        http_proxy: "{{ openshift_http_proxy | default('')}}"
+        https_proxy: "{{ openshift_https_proxy|default('') }}"
     - fail:
         msg: "Package {{ openshift.common.service_type}} not found"
       when: not rpm_results.results.package_found

--- a/roles/openshift_version/tasks/set_version_rpm.yml
+++ b/roles/openshift_version/tasks/set_version_rpm.yml
@@ -12,6 +12,9 @@
     repoquery:
       name: "{{ openshift.common.service_type}}"
       ignore_excluders: true
+    environment:
+      http_proxy: "{{ openshift_http_proxy | default('')}}"
+      https_proxy: "{{ openshift_https_proxy|default('') }}"
     register: rpm_results
 
   - fail:


### PR DESCRIPTION
openshift_health_check/docker_image_availability  and repoquery currently ignore proxy settings, thus installation with no direct connection fails.

Remaining issue: "no_proxy" cannot be fed this way.