### PR TITLE
 Parameterize etcd binary path for ansible service broker

### DIFF
--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -14,6 +14,7 @@
 
     ansible_service_broker_etcd_image_prefix: "{{ ansible_service_broker_etcd_image_prefix | default(__ansible_service_broker_etcd_image_prefix) }}"
     ansible_service_broker_etcd_image_tag: "{{ ansible_service_broker_etcd_image_tag | default(__ansible_service_broker_etcd_image_tag) }}"
+    ansible_service_broker_etcd_image_etcd_path: "{{ ansible_service_broker_etcd_image_etcd_path | default(__ansible_service_broker_etcd_image_etcd_path) }}"
 
     ansible_service_broker_registry_type: "{{ ansible_service_broker_registry_type | default(__ansible_service_broker_registry_type) }}"
     ansible_service_broker_registry_url: "{{ ansible_service_broker_registry_url | default(__ansible_service_broker_registry_url) }}"
@@ -144,7 +145,7 @@
                   terminationMessagePath: /tmp/termination-log
                   workingDir: /etcd
                   args:
-                    - /usr/local/bin/etcd
+                    - '{{ ansible_service_broker_etcd_image_etcd_path }}'
                     - --data-dir=/data
                     - "--listen-client-urls=http://0.0.0.0:2379"
                     - "--advertise-client-urls=http://0.0.0.0:2379"

--- a/roles/ansible_service_broker/vars/default_images.yml
+++ b/roles/ansible_service_broker/vars/default_images.yml
@@ -5,6 +5,7 @@ __ansible_service_broker_image_tag: latest
 
 __ansible_service_broker_etcd_image_prefix: quay.io/coreos/
 __ansible_service_broker_etcd_image_tag: latest
+__ansible_service_broker_etcd_image_etcd_path: /usr/local/bin/etcd
 
 __ansible_service_broker_registry_type: dockerhub
 __ansible_service_broker_registry_url: null

--- a/roles/ansible_service_broker/vars/openshift-enterprise.yml
+++ b/roles/ansible_service_broker/vars/openshift-enterprise.yml
@@ -5,6 +5,7 @@ __ansible_service_broker_image_tag: latest
 
 __ansible_service_broker_etcd_image_prefix: rhel7/
 __ansible_service_broker_etcd_image_tag: latest
+__ansible_service_broker_etcd_image_etcd_path: /bin/etcd
 
 __ansible_service_broker_registry_type: rhcc
 __ansible_service_broker_registry_url: "https://registry.access.redhat.com"


### PR DESCRIPTION
Change had already been made, looks like it may have gotten lost in a rebase or something at some point. Just updates the etcd deployment to parameterize the etcd binary path.

Original PR: https://github.com/ewolinetz/openshift-ansible/pull/29

@ewolinetz 