### PR TITLE
Add a retry to the docker restart handler

### DIFF
--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -4,6 +4,11 @@
   systemd:
     name: "{{ openshift.docker.service_name }}"
     state: restarted
+  register: r_docker_restart_docker_result
+  until: not r_docker_restart_docker_result | failed
+  retries: 1
+  delay: 30
+
   when: not docker_service_status_changed | default(false) | bool
 
 - name: restart udev


### PR DESCRIPTION
Attempt to workaround this https://gist.github.com/sdodson/5967210c5482de1c31b3685d4378e7d6 which happened against openshift-ansible-3.6.126.1-1

The start task doesn't seem to have been triggered.