### PR TITLE
openshift_storage_nfs_lvm: fix with_sequence

### DIFF
--- a/roles/openshift_storage_nfs_lvm/tasks/nfs.yml
+++ b/roles/openshift_storage_nfs_lvm/tasks/nfs.yml
@@ -19,8 +19,5 @@
   lineinfile: dest=/etc/exports
               regexp="^{{ osnl_mount_dir }}/{{ item }} "
               line="{{ osnl_mount_dir }}/{{ item }} {{osnl_nfs_export_options}}"
-  with_sequence:
-    start: "{{osnl_volume_num_start}}"
-    count: "{{osnl_number_of_volumes}}"
-    format: "{{osnl_volume_prefix}}{{osnl_volume_size}}g%04d"
+  with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
   notify: restart nfs


### PR DESCRIPTION
Workaround known bug with with_sequence https://github.com/ansible/ansible/pull/22989#pullrequestreview-29199242

Should be fixed in a later ansible release but for now we can use the (less readable) string-like parameters