### PR TITLE
add check for required installation ports

### DIFF
--- a/roles/openshift_health_checker/library/portavail.py
+++ b/roles/openshift_health_checker/library/portavail.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+"""Attempt to bind to a given set of ports, or return errors encountered"""
+
+import socket
+import errno
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    """Bind to a given set of ports and return any errors this might cause."""
+    module = AnsibleModule(
+        argument_spec=dict(
+            # ports is a list of dicts consisting of a port_name and a port field:
+            #   [
+            #     {
+            #       "port_name": "mysql",
+            #       "port": 3306,
+            #     }
+            #   ]
+            ports=dict(type="list", required=True),
+        ),
+    )
+
+    errors = list()
+
+    ports = module.params["ports"]
+    for port in ports:
+        if not port.get("port"):
+            continue
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.bind(('localhost', port["port"]))
+        except socket.error as error:
+            if error.errno == errno.EADDRINUSE:
+                error = "Port is in use by another process."
+            port["error"] = str(error)
+            errors.append(port)
+        finally:
+            sock.close()
+
+    module.exit_json(
+        changed=False,
+        failed=len(errors),
+        error_ports=errors,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/openshift_health_checker/openshift_checks/port_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/port_availability.py
@@ -1,0 +1,49 @@
+# pylint: disable=missing-docstring
+from openshift_checks import OpenShiftCheck, get_var
+
+
+class PortAvailability(OpenShiftCheck):
+    """Check that required ports are not in use by another process."""
+
+    name = "port_availability"
+    tags = ["preflight"]
+
+    @classmethod
+    def is_active(cls, task_vars):
+        return super(PortAvailability, cls).is_active(task_vars)
+
+    def run(self, tmp, task_vars):
+        required_ports = [{
+            "port_name": "dnsmasq",
+            "port": 53,
+        }]
+
+        args = {
+            "ports": required_ports,
+        }
+
+        check_ports = self.execute_module("portavail", args, task_vars)
+        if check_ports["failed"]:
+            failed_ports = check_ports.get("error_ports", [])
+            msg = ("The following ports are required for a successful OpenShift installation,\n"
+                   "but an error occurred attempting to verify their availability:\n\n{}\n\n{}")
+
+            msg = msg.format(
+                "\n".join(
+                    [
+                        '  - {} (required by "{}")\n    error: {}\n'.format(
+                            str(p.get("port", "n/a")),
+                            p.get("port_name", "n/a"),
+                            p.get("error", "n/a"),
+                        )
+                        for p in failed_ports
+                    ]
+                ),
+                ('Please refer to the following article for more information\n'
+                 'on freeing the required ports listed above:\n\n'
+                 'https://access.redhat.com/solutions/45294')
+            )
+
+            return {"failed": True, "msg": msg}
+
+        return {}


### PR DESCRIPTION
Related Trello card: https://trello.com/c/SlxFU8I5

Adds a pre-flight check that attempts to bind to a given set of
required of required ports. If any ports are already in use, they
are displayed along with the name of the service that requires 
the port.

*Sample Output*
```
Failure summary:

  1. Host:     34.227.83.160
     Play:     Run OpenShift health checks
     Task:     openshift_health_check
     Message:  One or more checks failed
     Details:  check "port_availability":
               The following ports are required for a successful OpenShift installation,
               but an error occurred attempting to verify their availability:

                 - 53 (required by "dnsmasq")
                   error: Port is in use by another process.

                 - 22 (required by "sample")
                   error: Port is in use by another process.


               Please refer to the following article for more information
               on freeing the required ports listed above:

               https://access.redhat.com/solutions/45294

You may choose to configure or disable failing checks by
setting Ansible variables. To disable those above:

    openshift_disable_check=port_availability

Consult check documentation for configurable variables.
Variables can be set in the inventory or passed on the
command line using the -e flag to ansible-playbook.
```

*TODO*
- [ ] add tests

cc @brenton @sosiouxme @rhcarvalho 