### PR TITLE
logging_es: temporarily disable readiness probe

### DIFF
--- a/roles/openshift_logging_elasticsearch/templates/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/es.j2
@@ -90,9 +90,6 @@ spec:
               name: "RECOVER_AFTER_TIME"
               value: "{{openshift_logging_elasticsearch_recover_after_time}}"
             -
-              name: "READINESS_PROBE_TIMEOUT"
-              value: "30"
-            -
               name: "IS_MASTER"
               value: "{% if deploy_type in ['data-master', 'master'] %}true{% else %}false{% endif %}"
 
@@ -109,13 +106,6 @@ spec:
               readOnly: true
             - name: elasticsearch-storage
               mountPath: /elasticsearch/persistent
-          readinessProbe:
-            exec:
-              command:
-              - "/usr/share/elasticsearch/probe/readiness.sh"
-            initialDelaySeconds: 10
-            timeoutSeconds: 30
-            periodSeconds: 5
       volumes:
         - name: elasticsearch
           secret:


### PR DESCRIPTION
The readiness probe, as currently implemented, together with the ES master discovery using the logging-es service, causes a deadlock on clusters with more than one node. Readiness probe will be reintroduced in a later release when the issue is properly addressed.

More information in:
https://bugzilla.redhat.com/show_bug.cgi?id=1459430