### PR TITLE
upgrade: fix name for the etcd system container

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/etcd/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/etcd/upgrade.yml
@@ -36,7 +36,7 @@
       - not openshift.common.is_etcd_system_container | bool
 
     - name: Record containerized etcd version (runc)
-      command: runc exec etcd_container rpm -qa --qf '%{version}' etcd\*
+      command: runc exec etcd rpm -qa --qf '%{version}' etcd\*
       register: etcd_container_version_runc
       failed_when: false
       # AUDIT:changed_when: `false` because we are only inspecting


### PR DESCRIPTION
Fixes this error when running upgrade_etcd.yml:

The conditional check 'etcd_container_version | default('99') |
version_compare(etcd_upgrade_version,'<')' failed. The error was:
Version comparison: LooseVersion instance has no attribute 'version'

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>