### PR TITLE
[3.5] Correct version comparisons to ensure proper evaluation

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -890,17 +890,17 @@ def set_version_facts_if_unset(facts):
                 version_gte_3_1_1_or_1_1_1 = version >= LooseVersion('1.1.1')
                 version_gte_3_2_or_1_2 = version >= LooseVersion('1.2.0')
                 version_gte_3_3_or_1_3 = version >= LooseVersion('1.3.0')
-                version_gte_3_4_or_1_4 = version >= LooseVersion('1.4.0')
-                version_gte_3_5_or_1_5 = version >= LooseVersion('1.5.0')
-                version_gte_3_6_or_1_6 = version >= LooseVersion('3.6.0') or version >= LooseVersion('1.6.0')
+                version_gte_3_4_or_1_4 = version >= LooseVersion('1.4')
+                version_gte_3_5_or_1_5 = version >= LooseVersion('1.5')
+                version_gte_3_6 = version >= LooseVersion('3.6')
             else:
                 version_gte_3_1_or_1_1 = version >= LooseVersion('3.0.2.905')
                 version_gte_3_1_1_or_1_1_1 = version >= LooseVersion('3.1.1')
                 version_gte_3_2_or_1_2 = version >= LooseVersion('3.1.1.901')
                 version_gte_3_3_or_1_3 = version >= LooseVersion('3.3.0')
-                version_gte_3_4_or_1_4 = version >= LooseVersion('3.4.0')
-                version_gte_3_5_or_1_5 = version >= LooseVersion('3.5.0')
-                version_gte_3_6_or_1_6 = version >= LooseVersion('3.6.0')
+                version_gte_3_4_or_1_4 = version >= LooseVersion('3.4')
+                version_gte_3_5_or_1_5 = version >= LooseVersion('3.5')
+                version_gte_3_6 = version >= LooseVersion('3.6')
         else:
             version_gte_3_1_or_1_1 = True
             version_gte_3_1_1_or_1_1_1 = True
@@ -908,14 +908,14 @@ def set_version_facts_if_unset(facts):
             version_gte_3_3_or_1_3 = True
             version_gte_3_4_or_1_4 = True
             version_gte_3_5_or_1_5 = True
-            version_gte_3_6_or_1_6 = False
+            version_gte_3_6 = False
         facts['common']['version_gte_3_1_or_1_1'] = version_gte_3_1_or_1_1
         facts['common']['version_gte_3_1_1_or_1_1_1'] = version_gte_3_1_1_or_1_1_1
         facts['common']['version_gte_3_2_or_1_2'] = version_gte_3_2_or_1_2
         facts['common']['version_gte_3_3_or_1_3'] = version_gte_3_3_or_1_3
         facts['common']['version_gte_3_4_or_1_4'] = version_gte_3_4_or_1_4
         facts['common']['version_gte_3_5_or_1_5'] = version_gte_3_5_or_1_5
-        facts['common']['version_gte_3_6_or_1_6'] = version_gte_3_6_or_1_6
+        facts['common']['version_gte_3_6'] = version_gte_3_6
 
         if version_gte_3_5_or_1_5:
             examples_content_version = 'v1.5'


### PR DESCRIPTION
When a user supplies the openshift_image_tag inventory fact as '3.5',
the evaluation of `version >= LooseVersion('3.5.0')` will return False.
Changing the evaluation against only the X.X release will properly
return True.

Backports #4645
Bug [1443416](https://bugzilla.redhat.com/show_bug.cgi?id=1443416)