### PR TITLE
[3.4] Guard check for container install based on openshift dictionary key

### DIFF
--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -43,7 +43,8 @@
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_become: "{{ g_sudo | default(omit) }}"
     with_items: "{{ groups.oo_nodes_to_config | default([]) }}"
-    when: hostvars[item].openshift.common is defined and hostvars[item].openshift.common.is_containerized | bool and (item in groups.oo_nodes_to_config and item in groups.oo_masters_to_config)
+    when: hostvars[item].openshift is defined and hostvars[item].openshift.common is defined and hostvars[item].openshift.common.is_containerized | bool and (item in groups.oo_nodes_to_config and item in groups.oo_masters_to_config)
+    changed_when: False
 
 - name: Configure containerized nodes
   hosts: oo_containerized_master_nodes


### PR DESCRIPTION
Backports #4384
Bug [1466501](https://bugzilla.redhat.com/show_bug.cgi?id=1466501)