### PR TITLE
run etcd_container with type:spc_t label

### DIFF
--- a/roles/etcd/templates/etcd.docker.service
+++ b/roles/etcd/templates/etcd.docker.service
@@ -7,7 +7,7 @@ PartOf={{ openshift.docker.service_name }}.service
 [Service]
 EnvironmentFile={{ etcd_conf_file }}
 ExecStartPre=-/usr/bin/docker rm -f {{ etcd_service }}
-ExecStart=/usr/bin/docker run --name {{ etcd_service }} --rm -v {{ etcd_data_dir }}:{{ etcd_data_dir }}:z -v {{ etcd_conf_dir }}:{{ etcd_conf_dir }}:ro --env-file={{ etcd_conf_file }} --net=host --entrypoint=/usr/bin/etcd {{ openshift.etcd.etcd_image }}
+ExecStart=/usr/bin/docker run --name {{ etcd_service }} --rm -v {{ etcd_data_dir }}:{{ etcd_data_dir }}:z -v {{ etcd_conf_dir }}:{{ etcd_conf_dir }}:ro --env-file={{ etcd_conf_file }} --net=host --security-opt label=type:spc_t --entrypoint=/usr/bin/etcd {{ openshift.etcd.etcd_image }}
 ExecStop=/usr/bin/docker stop {{ etcd_service }}
 SyslogIdentifier=etcd_container
 Restart=always


### PR DESCRIPTION
When the etcd cluster is dedicated (deployed on non-master nodes), the `docker exec etcdctl backup` fails due to SELinux AVC denial. Labelling the running container with `type:spc_t` no longer generates the denial.

Bug: 1460959

Tested on 3.6 OCP cluster with dedicated etcd cluster.