### PR TITLE
docker_image_availability: fix containerized etcd

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -94,7 +94,8 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
         required = set()
         deployment_type = get_var(task_vars, "openshift_deployment_type")
         host_groups = get_var(task_vars, "group_names")
-        image_tag = get_var(task_vars, "openshift_image_tag")
+        # containerized etcd may not have openshift_image_tag, see bz 1466622
+        image_tag = get_var(task_vars, "openshift_image_tag", default="latest")
         image_info = DEPLOYMENT_IMAGE_INFO[deployment_type]
         if not image_info:
             return required

--- a/roles/openshift_health_checker/test/docker_image_availability_test.py
+++ b/roles/openshift_health_checker/test/docker_image_availability_test.py
@@ -259,3 +259,17 @@ def test_required_images(deployment_type, is_containerized, groups, oreg_url, ex
     )
 
     assert expected == DockerImageAvailability("DUMMY").required_images(task_vars)
+
+
+def test_containerized_etcd():
+    task_vars = dict(
+        openshift=dict(
+            common=dict(
+                is_containerized=True,
+            ),
+        ),
+        openshift_deployment_type="origin",
+        group_names=['etcd'],
+    )
+    expected = set(['registry.access.redhat.com/rhel7/etcd'])
+    assert expected == DockerImageAvailability("DUMMY").required_images(task_vars)


### PR DESCRIPTION
fixes bug 1466622 - docker_image_availability check on etcd host failed for 'openshift_image_tag' is undefined