### PR TITLE
Updating to use openshift.master.etcd_hosts for etcd servers for apis…

### DIFF
--- a/roles/openshift_service_catalog/tasks/install.yml
+++ b/roles/openshift_service_catalog/tasks/install.yml
@@ -98,6 +98,7 @@
     cpu_requests: none
     memory_request: none
     cors_allowed_origin: localhost
+    etcd_servers: "{{ openshift.master.etcd_urls | join(',') }}"
     node_selector: "{{ openshift_service_catalog_nodeselector | default ({'openshift-infra': 'apiserver'}) }}"
 
 - name: Set Service Catalog API Server daemonset

--- a/roles/openshift_service_catalog/tasks/install.yml
+++ b/roles/openshift_service_catalog/tasks/install.yml
@@ -86,6 +86,12 @@
     resource_name: admin
     user: "system:serviceaccount:kube-service-catalog:default"
 
+- name: Checking for master.etcd-ca.crt
+  stat:
+    path: /etc/origin/master/master.etcd-ca.crt
+  register: etcd_ca_crt
+  check_mode: no
+
 ## api server
 - template:
     src: api_server.j2
@@ -99,6 +105,7 @@
     memory_request: none
     cors_allowed_origin: localhost
     etcd_servers: "{{ openshift.master.etcd_urls | join(',') }}"
+    etcd_cafile: "{{ '/etc/origin/master/master.etcd-ca.crt' if etcd_ca_crt.stat.exists else '/etc/origin/master/ca-bundle.crt' }}"
     node_selector: "{{ openshift_service_catalog_nodeselector | default ({'openshift-infra': 'apiserver'}) }}"
 
 - name: Set Service Catalog API Server daemonset

--- a/roles/openshift_service_catalog/templates/api_server.j2
+++ b/roles/openshift_service_catalog/templates/api_server.j2
@@ -31,7 +31,7 @@ spec:
         - --etcd-servers
         - {{ etcd_servers }}
         - --etcd-cafile
-        - /etc/origin/master/master.etcd-ca.crt
+        - {{ etcd_cafile }}
         - --etcd-certfile
         - /etc/origin/master/master.etcd-client.crt
         - --etcd-keyfile

--- a/roles/openshift_service_catalog/templates/api_server.j2
+++ b/roles/openshift_service_catalog/templates/api_server.j2
@@ -29,8 +29,7 @@ spec:
         - --secure-port
         - "6443"
         - --etcd-servers
-# TODO: come back and get openshift.common.hostname to work
-        - https://{{ openshift.common.ip }}:{{ openshift.master.etcd_port }}
+        - {{ etcd_servers }}
         - --etcd-cafile
         - /etc/origin/master/master.etcd-ca.crt
         - --etcd-certfile


### PR DESCRIPTION
…erver

Should address https://bugzilla.redhat.com/show_bug.cgi?id=1466727
We will instead use the list of etcd_hosts which should resolve to actual hostnames not just the IP of the master