### PR TITLE
use the storage path for logging from facts

### DIFF
--- a/roles/openshift_logging/tasks/install_elasticsearch.yaml
+++ b/roles/openshift_logging/tasks/install_elasticsearch.yaml
@@ -24,6 +24,7 @@
     es_pv_selector: "{{ openshift_logging_es_pv_selector }}"
     es_cpu_limit: "{{ openshift_logging_es_cpu_limit }}"
     es_memory_limit: "{{ openshift_logging_es_memory_limit }}"
+    es_fact_root: 'elasticsearch'
   with_together:
   - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs.keys() }}"
   - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs.values() }}"
@@ -47,6 +48,7 @@
     es_pv_selector: "{{ openshift_logging_es_pv_selector }}"
     es_cpu_limit: "{{ openshift_logging_es_cpu_limit }}"
     es_memory_limit: "{{ openshift_logging_es_memory_limit }}"
+    es_fact_root: 'elasticsearch'
   with_sequence: count={{ openshift_logging_es_cluster_size | int - openshift_logging_facts.elasticsearch.deploymentconfigs | count }}
 
 # --------- Tasks for Operation clusters ---------
@@ -88,6 +90,7 @@
     es_pv_selector: "{{ openshift_logging_es_ops_pv_selector }}"
     es_cpu_limit: "{{ openshift_logging_es_ops_cpu_limit }}"
     es_memory_limit: "{{ openshift_logging_es_ops_memory_limit }}"
+    es_fact_root: 'elasticsearch_ops'
   with_together:
   - "{{ openshift_logging_facts.elasticsearch_ops.deploymentconfigs.keys() }}"
   - "{{ openshift_logging_facts.elasticsearch_ops.deploymentconfigs.values() }}"
@@ -113,6 +116,7 @@
     es_pv_selector: "{{ openshift_logging_es_ops_pv_selector }}"
     es_cpu_limit: "{{ openshift_logging_es_ops_cpu_limit }}"
     es_memory_limit: "{{ openshift_logging_es_ops_memory_limit }}"
+    es_fact_root: 'elasticsearch_ops'
   with_sequence: count={{ openshift_logging_es_ops_cluster_size | int - openshift_logging_facts.elasticsearch_ops.deploymentconfigs | count }}
   when:
   - openshift_logging_use_ops | bool

--- a/roles/openshift_logging/tasks/set_es_storage.yaml
+++ b/roles/openshift_logging/tasks/set_es_storage.yaml
@@ -75,6 +75,6 @@
     es_cpu_limit: "{{ es_cpu_limit }}"
     es_memory_limit: "{{ es_memory_limit }}"
     es_node_selector: "{{ es_node_selector }}"
-    es_storage: "{{ openshift_logging_facts | es_storage( es_name, es_storage_claim ) }}"
+    es_storage: "{{ openshift_logging_facts | es_storage( es_name, es_storage_claim, es_fact_root ) }}"
   check_mode: no
   changed_when: no


### PR DESCRIPTION
This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1466695 in 1.5 where hostpath was not being honored for the ops deployment.  There is no equivalent logic in master but I wonder if its a 'WONTFIX'.  Shouldn't we be encouraging users to update their inventory to match the state they desire?  @sdodson ??