### PR TITLE
Fix service catalog image prefixes

### DIFF
--- a/roles/ansible_service_broker/vars/openshift-enterprise.yml
+++ b/roles/ansible_service_broker/vars/openshift-enterprise.yml
@@ -1,6 +1,6 @@
 ---
 
-__ansible_service_broker_image_prefix: openshift3/
+__ansible_service_broker_image_prefix: registry.access.redhat.com/openshift3/
 __ansible_service_broker_image_tag: latest
 
 __ansible_service_broker_etcd_image_prefix: rhel7/

--- a/roles/openshift_service_catalog/vars/openshift-enterprise.yml
+++ b/roles/openshift_service_catalog/vars/openshift-enterprise.yml
@@ -1,3 +1,3 @@
 ---
-__openshift_service_catalog_image_prefix: "registry.access.redhat.com/openshift3/"
+__openshift_service_catalog_image_prefix: "registry.access.redhat.com/openshift3/ose-"
 __openshift_service_catalog_image_version: "3.6.0"


### PR DESCRIPTION
According to dist git the image name for service catalog is `openshift3/ose-service-catalog`
And fully qualify the asb image name