### PR TITLE
verify the etcd_container is running with spc_t label before upgrading to 3.6

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_containerized_etcd.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_containerized_etcd.yml
@@ -1,0 +1,22 @@
+- name: Verify containerized etcd runs with spc_t selinux label
+  hosts: oo_etcd_hosts_to_upgrade
+  tasks:
+  - block:
+    - name: Inspect running etcd_container
+      command: >
+        docker inspect etcd_container
+      register: l_docker_inspect_result
+
+    - fail:
+        msg: "Unable to inspect etcd_container"
+      when:
+      - l_docker_inspect_result.rc > 0
+
+    - set_fact:
+        l_process_label: "{{ (l_docker_inspect_result.stdout | from_json)[0].ProcessLabel }}"
+
+    - fail:
+        msg: "The 'etcd_container' is missing spc_t label. Available process label: {{ l_process_label }}"
+      when: "'spc_t' not in l_process_label"
+    when:
+    - openshift.common.is_containerized | bool

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
@@ -6,6 +6,10 @@
   tags:
   - pre_upgrade
 
+- include: ../pre/verify_containerized_etcd.yml
+  tags:
+  - pre_upgrade
+
 - name: Configure the upgrade target for the common upgrade tasks
   hosts: oo_all_hosts
   tags:


### PR DESCRIPTION
The `etcd_container` must be run with `--security-opt label=type:spc_t` option in order to run `docker exec etcdctl backup ...` command. Given the option can be set automatically, check if the option is set before running the upgrade at least.

Unfortunately, it takes about 3 minutes to reach the check.