### PR TITLE
pre-pull images before stopping docker

### DIFF
--- a/roles/openshift_node_upgrade/tasks/main.yml
+++ b/roles/openshift_node_upgrade/tasks/main.yml
@@ -31,6 +31,20 @@
   failed_when: false
   when: openshift.common.is_containerized | bool
 
+- name: Pre-pull node image
+  command: >
+    docker pull {{ openshift.node.node_image }}:{{ openshift_image_tag }}
+  register: pull_result
+  changed_when: "'Downloaded newer image' in pull_result.stdout"
+  when: openshift.common.is_containerized | bool
+
+- name: Pre-pull openvswitch image
+  command: >
+    docker pull {{ openshift.node.ovs_image }}:{{ openshift_image_tag }}
+  register: pull_result
+  changed_when: "'Downloaded newer image' in pull_result.stdout"
+  when: openshift.common.is_containerized | bool and openshift.common.use_openshift_sdn | bool
+
 - include: docker/upgrade.yml
   vars:
     # We will restart Docker ourselves after everything is ready:

--- a/roles/openshift_node_upgrade/tasks/systemd_units.yml
+++ b/roles/openshift_node_upgrade/tasks/systemd_units.yml
@@ -18,21 +18,6 @@
 
 # This file is included both in the openshift_master role and in the upgrade
 # playbooks.
-
-- name: Pre-pull node image
-  command: >
-    docker pull {{ openshift.node.node_image }}:{{ openshift_image_tag }}
-  register: pull_result
-  changed_when: "'Downloaded newer image' in pull_result.stdout"
-  when: openshift.common.is_containerized | bool
-
-- name: Pre-pull openvswitch image
-  command: >
-    docker pull {{ openshift.node.ovs_image }}:{{ openshift_image_tag }}
-  register: pull_result
-  changed_when: "'Downloaded newer image' in pull_result.stdout"
-  when: openshift.common.is_containerized | bool and openshift.common.use_openshift_sdn | bool
-
 - name: Install Node dependencies docker service file
   template:
     dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node-dep.service"


### PR DESCRIPTION
For the containerized deployment, during the node upgrade, the docker is stopped before upgrading and started almost at the end of the process. Unfortunately, one (or two) docker images are pulled during the process. Given the docker is stopped, no image can be pulled and the node upgrade fails.

Bug: 1466095

Originally caused by https://github.com/openshift/openshift-ansible/pull/3943 by removing the `not openshift.common.is_containerized | bool` condition when including `docker/upgrade.yml`.