### PR TITLE
use master etcd certificates when delegating oadm migrate etcd-ttl

### DIFF
--- a/roles/etcd_common/defaults/main.yml
+++ b/roles/etcd_common/defaults/main.yml
@@ -44,6 +44,10 @@ etcd_ca_serial: "{{ etcd_ca_dir }}/serial"
 etcd_ca_crl_number: "{{ etcd_ca_dir }}/crlnumber"
 etcd_ca_default_days: 1825
 
+r_etcd_common_master_peer_cert_file: /etc/origin/master/master.etcd-client.crt
+r_etcd_common_master_peer_key_file: /etc/origin/master/master.etcd-client.key
+r_etcd_common_master_peer_ca_file: /etc/origin/master/master.etcd-ca.crt
+
 # etcd server & certificate vars
 etcd_hostname: "{{ inventory_hostname }}"
 etcd_ip: "{{ ansible_default_ipv4.address }}"

--- a/roles/etcd_migrate/tasks/migrate.yml
+++ b/roles/etcd_migrate/tasks/migrate.yml
@@ -36,9 +36,9 @@
 - name: Re-introduce leases (as a replacement for key TTLs)
   command: >
     oadm migrate etcd-ttl \
-    --cert {{ etcd_peer_cert_file }} \
-    --key {{ etcd_peer_key_file }} \
-    --cacert {{ etcd_peer_ca_file }} \
+    --cert {{ r_etcd_common_master_peer_cert_file }} \
+    --key {{ r_etcd_common_master_peer_key_file }} \
+    --cacert {{ r_etcd_common_master_peer_ca_file }} \
     --etcd-address 'https://{{ etcd_peer }}:{{ etcd_client_port }}' \
     --ttl-keys-prefix {{ item }} \
     --lease-duration 1h


### PR DESCRIPTION
When the etcd cluster is dedicated, the first master has etcd client certificates under `/etc/origin/master` instead of `/etc/etcd`.

Tested with:
- containerized etcd deployment
- rpm based deployment