### PR TITLE
Adding pods/logs to manageiq role

### DIFF
--- a/roles/openshift_manageiq/tasks/main.yaml
+++ b/roles/openshift_manageiq/tasks/main.yaml
@@ -24,6 +24,12 @@
     - apiGroups:
       - ""
       resources:
+      - pods/log
+      verbs:
+      - "get"
+    - apiGroups:
+      - ""
+      resources:
       - pods/proxy
       verbs:
       - "*"

--- a/roles/openshift_manageiq/vars/main.yml
+++ b/roles/openshift_manageiq/vars/main.yml
@@ -3,9 +3,9 @@ manage_iq_tasks:
 - resource_kind: role
   resource_name: admin
   user: management-admin
-- resource_kind: role
+- resource_kind: cluster-role
   resource_name: management-infra-admin
-  user: management-admin
+  user: system:serviceaccount:management-infra:management-admin
 - resource_kind: cluster-role
   resource_name: cluster-reader
   user: system:serviceaccount:management-infra:management-admin


### PR DESCRIPTION
This will allow manageiq to read the logs from elasticsearch in the logging project.

Based on the changes from https://github.com/fabric8io/openshift-elasticsearch-plugin/pull/73 