### PR TITLE
drop etcdctl before the etcd_container service

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -10,6 +10,12 @@
   package: name=etcd{{ '-' + etcd_version if etcd_version is defined else '' }} state=present
   when: not etcd_is_containerized | bool
 
+- include_role:
+    name: etcd_common
+  vars:
+    r_etcd_common_action: drop_etcdctl
+  when: openshift_etcd_etcdctl_profile | default(true) | bool
+
 - block:
   - name: Pull etcd container
     command: docker pull {{ openshift.etcd.etcd_image }}
@@ -119,12 +125,6 @@
     state: started
     enabled: yes
   register: start_result
-
-- include_role:
-    name: etcd_common
-  vars:
-    r_etcd_common_action: drop_etcdctl
-  when: openshift_etcd_etcdctl_profile | default(true) | bool
 
 - name: Set fact etcd_service_status_changed
   set_fact:

--- a/roles/etcd/templates/etcd.docker.service
+++ b/roles/etcd/templates/etcd.docker.service
@@ -7,7 +7,7 @@ PartOf={{ openshift.docker.service_name }}.service
 [Service]
 EnvironmentFile={{ etcd_conf_file }}
 ExecStartPre=-/usr/bin/docker rm -f {{ etcd_service }}
-ExecStart=/usr/bin/docker run --name {{ etcd_service }} --rm -v {{ etcd_data_dir }}:{{ etcd_data_dir }}:z -v {{ etcd_conf_dir }}:{{ etcd_conf_dir }}:ro --env-file={{ etcd_conf_file }} --net=host --security-opt label=type:spc_t --entrypoint=/usr/bin/etcd {{ openshift.etcd.etcd_image }}
+ExecStart=/usr/bin/docker run --name {{ etcd_service }} --rm -v {{ etcd_data_dir }}:{{ etcd_data_dir }}:z -v {{ etcd_conf_dir }}:{{ etcd_conf_dir }}:ro --env-file={{ etcd_conf_file }} --net=host --entrypoint=/usr/bin/etcd {{ openshift.etcd.etcd_image }}
 ExecStop=/usr/bin/docker stop {{ etcd_service }}
 SyslogIdentifier=etcd_container
 Restart=always


### PR DESCRIPTION
If the etcdctl is dropped after the etcd_container is enabled,
label of /var/lib/etcd directory is set to var_lib_t instead of virt_sandbox_file_t.

Bug: 1460959