### PR TITLE
openshift_storage_nfs_lvm: parametrize exported directories mode

### DIFF
--- a/roles/openshift_storage_nfs_lvm/defaults/main.yml
+++ b/roles/openshift_storage_nfs_lvm/defaults/main.yml
@@ -6,6 +6,10 @@ osnl_nfs_export_options: "*(rw,sync,all_squash)"
 # mounted as <osnl_mount_dir>/test1g0001 etc.
 osnl_mount_dir: /exports/openshift
 
+# Mode for the NFS-exported directories. Defaults to secure mode which may require additional configs depending on the environment.
+# See https://docs.openshift.com/container-platform/3.5/install_config/persistent_storage/persistent_storage_nfs.html#nfs-volume-security
+r_openshift_storage_nfs_lvm_export_dir_mode: 0700
+
 # Volume Group to use.
 osnl_volume_group: openshiftvg
 

--- a/roles/openshift_storage_nfs_lvm/tasks/main.yml
+++ b/roles/openshift_storage_nfs_lvm/tasks/main.yml
@@ -17,7 +17,7 @@
   with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
 
 - name: Make mounts owned by nfsnobody
-  file: path={{osnl_mount_dir}}/{{ item }} owner=nfsnobody group=nfsnobody mode=0700
+  file: path={{osnl_mount_dir}}/{{ item }} owner=nfsnobody group=nfsnobody mode={{r_openshift_storage_nfs_lvm_export_dir_mode}}
   with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
 
 - include: nfs.yml


### PR DESCRIPTION
Depending on the environment and security requirements, a user may want to set a different mode on the nfs-exported directories.

This PR moves the default mode (0700) to a default role variable to allow a user to change it from a playbook.