### PR TITLE
Clear ansible when statement warning in upgrade plays

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade.yml
@@ -39,8 +39,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - 'openshift_http_proxy is defined or openshift_https_proxy is defined'
+    - 'openshift_generate_no_proxy_hosts | default(True) | bool'
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
@@ -47,8 +47,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - 'openshift_http_proxy is defined or openshift_https_proxy is defined'
+    - 'openshift_generate_no_proxy_hosts | default(True) | bool'
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_nodes.yml
@@ -40,8 +40,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - 'openshift_http_proxy is defined or openshift_https_proxy is defined'
+    - 'openshift_generate_no_proxy_hosts | default(True) | bool'
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade.yml
@@ -39,8 +39,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - 'openshift_http_proxy is defined or openshift_https_proxy is defined'
+    - 'openshift_generate_no_proxy_hosts | default(True) | bool'
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
@@ -47,8 +47,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - 'openshift_http_proxy is defined or openshift_https_proxy is defined'
+    - 'openshift_generate_no_proxy_hosts | default(True) | bool'
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_nodes.yml
@@ -40,8 +40,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - 'openshift_http_proxy is defined or openshift_https_proxy is defined'
+    - 'openshift_generate_no_proxy_hosts | default(True) | bool'
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade.yml
@@ -39,8 +39,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - 'openshift_http_proxy is defined or openshift_https_proxy is defined'
+    - 'openshift_generate_no_proxy_hosts | default(True) | bool'
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
@@ -47,8 +47,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - 'openshift_http_proxy is defined or openshift_https_proxy is defined'
+    - 'openshift_generate_no_proxy_hosts | default(True) | bool'
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_nodes.yml
@@ -40,8 +40,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - 'openshift_http_proxy is defined or openshift_https_proxy is defined'
+    - 'openshift_generate_no_proxy_hosts | default(True) | bool'
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
@@ -39,8 +39,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - 'openshift_http_proxy is defined or openshift_https_proxy is defined'
+    - 'openshift_generate_no_proxy_hosts | default(True) | bool'
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
@@ -47,8 +47,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - 'openshift_http_proxy is defined or openshift_https_proxy is defined'
+    - 'openshift_generate_no_proxy_hosts | default(True) | bool'
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
@@ -40,8 +40,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - 'openshift_http_proxy is defined or openshift_https_proxy is defined'
+    - 'openshift_generate_no_proxy_hosts | default(True) | bool'
 
 - include: ../pre/verify_inventory_vars.yml
   tags:


### PR DESCRIPTION
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: {{ (openshift_http_proxy is defined or
openshift_https_proxy is defined) and openshift_generate_no_proxy_hosts |
default(True) | bool }}