### PR TITLE
Refactor openshift_storage_nfs_lvm role

### DIFF
--- a/roles/openshift_storage_nfs_lvm/README.md
+++ b/roles/openshift_storage_nfs_lvm/README.md
@@ -15,47 +15,17 @@ create persistent volumes.
 
 ## Role Variables
 
-```
-# Options of NFS exports.
-osnl_nfs_export_options: "*(rw,sync,all_squash)"
-
-# Directory, where the created partitions should be mounted. They will be
-# mounted as <osnl_mount_dir>/<lvm volume name> 
-osnl_mount_dir: /exports/openshift
-
-# Volume Group to use.
-# This role always assumes that there is enough free space on the volume
-#   group for all the partitions you will be making
-osnl_volume_group: openshiftvg
-
-# volume names
-# volume names are {{osnl_volume_prefix}}{{osnl_volume_size}}g{{volume number}}
-#   example: stg5g0004
-
-# osnl_volume_prefix
-# Useful if you are using the nfs server for more than one cluster
-osnl_volume_prefix: "stg"
-
-# osnl_volume_size
-# Size of the volumes/partitions in Gigabytes.
-osnl_volume_size: 5
-
-# osnl_volume_num_start
-# Where to start the volume number numbering.
-osnl_volume_num_start: 3
-
-# osnl_number_of_volumes
-# How many volumes/partitions to build, with the size we stated.
-osnl_number_of_volumes: 2
-
-# osnl_volume_reclaim_policy
-# Volume reclaim policy of a PersistentVolume tells the cluster
-# what to do with the volume after it is released.
-#
-# Valid values are "Retain" or "Recycle" (default).
-osnl_volume_reclaim_policy: "Recycle"
-
-```
+| Name                                              | Default value         | Description                                                                          |
+|---------------------------------------------------|-----------------------|--------------------------------------------------------------------------------------|
+| r_openshift_storage_nfs_lvm_nfs_export_options    | *(rw,sync,all_squash) | Options of NFS exports                                                               |
+| r_openshift_storage_nfs_lvm_mount_dir             | /exports/openshift    | Directory, where the created partitions should be mounted.                           |
+| r_openshift_storage_nfs_lvm_export_dir_mode       | 0700                  | Mode on the nfs-exported directory.                                                  |
+| r_openshift_storage_nfs_lvm_volume_group          | openshiftvg           | Volume Group to use.                                                                 |
+| r_openshift_storage_nfs_lvm_volume_prefix         | os-pv                 | Volume name prefix. Useful if you are using the nfs server for more than one cluster |
+| r_openshift_storage_nfs_lvm_volume_size           | 1                     | Size of the volumes/partitions in Gigabytes.                                         |
+| r_openshift_storage_nfs_lvm_volume_num_start      | 1                     | Where to start the volume number numbering.                                          |
+| r_openshift_storage_nfs_lvm_volume_count          | 0                     | How many volumes/partitions to create. (will not create any volumes by default)      |
+| r_openshift_storage_nfs_lvm_volume_reclaim_policy | Recycle               | Volume reclaim policy of the PersistentVolume.                                       |
 
 ## Dependencies
 
@@ -73,12 +43,12 @@ exported via NFS.  json files are created in /root.
       gather_facts: no
       roles:
         - role: openshift_storage_nfs_lvm
-          osnl_mount_dir: /exports/openshift
-          osnl_volume_prefix: "stg"
-          osnl_volume_size: 5
-          osnl_volume_num_start: 3
-          osnl_number_of_volumes: 2
-          osnl_volume_reclaim_policy: "Recycle"
+          r_openshift_storage_nfs_lvm_mount_dir: /exports/openshift
+          r_openshift_storage_nfs_lvm_volume_prefix: "stg"
+          r_openshift_storage_nfs_lvm_volume_size: 5
+          r_openshift_storage_nfs_lvm_volume_num_start: 3
+          r_openshift_storage_nfs_lvm_volume_count: 2
+          r_openshift_storage_nfs_lvm_volume_reclaim_policy: "Recycle"
 
 
 ## Full example
@@ -99,12 +69,12 @@ exported via NFS.  json files are created in /root.
       gather_facts: no
       roles:
         - role: openshift_storage_nfs_lvm
-          osnl_mount_dir: /exports/stg
-          osnl_volume_prefix: "stg"
-          osnl_volume_size: 5
-          osnl_volume_num_start: 3
-          osnl_number_of_volumes: 2
-          osnl_volume_reclaim_policy: "Recycle"
+          r_openshift_storage_nfs_lvm_mount_dir: /exports/stg
+          r_openshift_storage_nfs_lvm_volume_prefix: "stg"
+          r_openshift_storage_nfs_lvm_volume_size: 5
+          r_openshift_storage_nfs_lvm_volume_num_start: 3
+          r_openshift_storage_nfs_lvm_volume_count: 2
+          r_openshift_storage_nfs_lvm_volume_reclaim_policy: "Recycle"
 
 * Run the playbook:
     ```

--- a/roles/openshift_storage_nfs_lvm/defaults/main.yml
+++ b/roles/openshift_storage_nfs_lvm/defaults/main.yml
@@ -1,17 +1,33 @@
 ---
 # Options of NFS exports.
-osnl_nfs_export_options: "*(rw,sync,all_squash)"
+r_openshift_storage_nfs_lvm_nfs_export_options: "{{ osnl_nfs_export_options | default('*(rw,sync,all_squash)') }}"
 
 # Directory, where the created partitions should be mounted. They will be
-# mounted as <osnl_mount_dir>/test1g0001 etc.
-osnl_mount_dir: /exports/openshift
+# mounted as <r_openshift_storage_nfs_lvm_mount_dir>/test1g0001 etc.
+r_openshift_storage_nfs_lvm_mount_dir: "{{ osnl_mount_dir | default('/exports/openshift') }}"
+
+# Mode for the NFS-exported directories. Defaults to secure mode which may require additional configs depending on the environment.
+# See https://docs.openshift.com/container-platform/3.5/install_config/persistent_storage/persistent_storage_nfs.html#nfs-volume-security
+r_openshift_storage_nfs_lvm_export_dir_mode: 0700
 
 # Volume Group to use.
-osnl_volume_group: openshiftvg
+r_openshift_storage_nfs_lvm_volume_group: "{{ osnl_volume_group | default('openshiftvg') }}"
+
+# Volume name prefix.
+r_openshift_storage_nfs_lvm_volume_prefix: "{{ osnl_volume_prefix | default('os-pv') }}"
+
+# Volume size (in GB)
+r_openshift_storage_nfs_lvm_volume_size: "{{ osnl_volume_size | default(1) }}"
+
+# Where to start the volume number numbering.
+r_openshift_storage_nfs_lvm_volume_num_start: "{{ osnl_volume_num_start | default(1) }}"
+
+# How many volumes to create. (will not create any by default)
+r_openshift_storage_nfs_lvm_volume_count: "{{ osnl_number_of_volumes | default(0) }}"
 
 # Volume reclaim policy of a PersistentVolume tells the cluster
 # what to do with the volume after it is released.
 #
 # Valid values are "Retain" or "Recycle".
 # See https://docs.openshift.com/enterprise/3.0/architecture/additional_concepts/storage.html#pv-recycling-policy
-osnl_volume_reclaim_policy: "Recycle"
+r_openshift_storage_nfs_lvm_volume_reclaim_policy: "{{ osnl_volume_reclaim_policy | default('Recycle') }}"

--- a/roles/openshift_storage_nfs_lvm/tasks/main.yml
+++ b/roles/openshift_storage_nfs_lvm/tasks/main.yml
@@ -5,25 +5,25 @@
   when: openshift.common.is_atomic | bool
 
 - name: Create lvm volumes
-  lvol: vg={{osnl_volume_group}} lv={{ item }} size={{osnl_volume_size}}G
-  with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
+  lvol: vg={{r_openshift_storage_nfs_lvm_volume_group}} lv={{ item }} size={{r_openshift_storage_nfs_lvm_volume_size}}G
+  with_sequence: start={{r_openshift_storage_nfs_lvm_volume_num_start}} count={{r_openshift_storage_nfs_lvm_volume_count}} format={{r_openshift_storage_nfs_lvm_volume_prefix}}{{r_openshift_storage_nfs_lvm_volume_size}}g%04d
 
 - name: create filesystem
-  filesystem: fstype=xfs dev=/dev/{{osnl_volume_group}}/{{ item }}
-  with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
+  filesystem: fstype=xfs dev=/dev/{{r_openshift_storage_nfs_lvm_volume_group}}/{{ item }}
+  with_sequence: start={{r_openshift_storage_nfs_lvm_volume_num_start}} count={{r_openshift_storage_nfs_lvm_volume_count}} format={{r_openshift_storage_nfs_lvm_volume_prefix}}{{r_openshift_storage_nfs_lvm_volume_size}}g%04d
 
 - name: mount volumes
-  mount: name={{osnl_mount_dir}}/{{ item }} src=/dev/{{osnl_volume_group}}/{{ item }} state=mounted fstype=xfs passno=0
-  with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
+  mount: name={{r_openshift_storage_nfs_lvm_mount_dir}}/{{ item }} src=/dev/{{r_openshift_storage_nfs_lvm_volume_group}}/{{ item }} state=mounted fstype=xfs passno=0
+  with_sequence: start={{r_openshift_storage_nfs_lvm_volume_num_start}} count={{r_openshift_storage_nfs_lvm_volume_count}} format={{r_openshift_storage_nfs_lvm_volume_prefix}}{{r_openshift_storage_nfs_lvm_volume_size}}g%04d
 
 - name: Make mounts owned by nfsnobody
-  file: path={{osnl_mount_dir}}/{{ item }} owner=nfsnobody group=nfsnobody mode=0700
-  with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
+  file: path={{r_openshift_storage_nfs_lvm_mount_dir}}/{{ item }} owner=nfsnobody group=nfsnobody mode={{r_openshift_storage_nfs_lvm_export_dir_mode}}
+  with_sequence: start={{r_openshift_storage_nfs_lvm_volume_num_start}} count={{r_openshift_storage_nfs_lvm_volume_count}} format={{r_openshift_storage_nfs_lvm_volume_prefix}}{{r_openshift_storage_nfs_lvm_volume_size}}g%04d
 
 - include: nfs.yml
 
 - name: Create volume json file
   template: src=../templates/nfs.json.j2 dest=/root/persistent-volume.{{ item }}.json
-  with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
+  with_sequence: start={{r_openshift_storage_nfs_lvm_volume_num_start}} count={{r_openshift_storage_nfs_lvm_volume_count}} format={{r_openshift_storage_nfs_lvm_volume_prefix}}{{r_openshift_storage_nfs_lvm_volume_size}}g%04d
 
 # TODO - Get the json files to a master, and load them.

--- a/roles/openshift_storage_nfs_lvm/tasks/nfs.yml
+++ b/roles/openshift_storage_nfs_lvm/tasks/nfs.yml
@@ -17,10 +17,7 @@
 
 - name: Export the directories
   lineinfile: dest=/etc/exports
-              regexp="^{{ osnl_mount_dir }}/{{ item }} "
-              line="{{ osnl_mount_dir }}/{{ item }} {{osnl_nfs_export_options}}"
-  with_sequence:
-    start: "{{osnl_volume_num_start}}"
-    count: "{{osnl_number_of_volumes}}"
-    format: "{{osnl_volume_prefix}}{{osnl_volume_size}}g%04d"
+              regexp="^{{ r_openshift_storage_nfs_lvm_mount_dir }}/{{ item }} "
+              line="{{ r_openshift_storage_nfs_lvm_mount_dir }}/{{ item }} {{ r_openshift_storage_nfs_lvm_nfs_export_options }}"
+  with_sequence: start={{r_openshift_storage_nfs_lvm_volume_num_start}} count={{r_openshift_storage_nfs_lvm_volume_count}} format={{r_openshift_storage_nfs_lvm_volume_prefix}}{{r_openshift_storage_nfs_lvm_volume_size}}g%04d
   notify: restart nfs

--- a/roles/openshift_storage_nfs_lvm/templates/nfs.json.j2
+++ b/roles/openshift_storage_nfs_lvm/templates/nfs.json.j2
@@ -9,13 +9,13 @@
   },
   "spec": {
     "capacity": {
-      "storage": "{{ osnl_volume_size }}Gi"
+      "storage": "{{ r_openshift_storage_nfs_lvm_volume_size }}Gi"
     },
     "accessModes": [ "ReadWriteOnce", "ReadWriteMany" ],
-    "persistentVolumeReclaimPolicy": "{{ osnl_volume_reclaim_policy }}",
+    "persistentVolumeReclaimPolicy": "{{ r_openshift_storage_nfs_lvm_volume_reclaim_policy }}",
     "nfs": {
       "server": "{{ inventory_hostname }}",
-      "path": "{{ osnl_mount_dir }}/{{ item }}"
+      "path": "{{ r_openshift_storage_nfs_lvm_mount_dir }}/{{ item }}"
     }
   }
 }


### PR DESCRIPTION
This is my first semi-large PR to this project. I tried to follow the contribution guidelines as much as possible. I was unable to split this into multiple commits since there are multiple intertwined changes. 

- Update all variables to match new role variable naming convention
- Add new default variables for variables which didn't have one (vol prefix, size, num_start and count)
- Add new variable _r_openshift_storage_nfs_lvm_export_dir_mode_ (same default as previously hardcoded value) to allow setting the mode of the nfs-exported dirs
- Update role README (/w variables table for better readability)
- Include fix from PR #4636 as it was not possible to test the changes without it
- Tested multiple scenarios, with new and old variable names & new defaults
- Tested on a live cluster with existing configs, no changes were applied before/after the role refactor

**Old var prefix**: osnl_
**New var prefix**: r_openshift_storage_nfs_lvm_

**Added vars:**
r_openshift_storage_nfs_lvm_export_dir_mode

**Var name change:**
<var_prefix>_number_of_volumes to <var_prefix>_volume_count

One thing I did not do but is probably worth doing at some point is to change all the occurrences of the old variables in the rest of the playbooks and roles. I can attempt to do this in a separate PR but at the moment old variables are still working and used if found.

Supercedes PR #4636 and #4675