### PR TITLE
Router wildcard certificate created by default

### DIFF
--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -29,7 +29,7 @@ openshift_hosted_routers:
 
 openshift_hosted_router_certificate: {}
 openshift_hosted_registry_cert_expire_days: 730
-openshift_hosted_router_create_certificate: False
+openshift_hosted_router_create_certificate: True
 
 os_firewall_allow:
 - service: Docker Registry Port

--- a/roles/openshift_hosted/tasks/router/router.yml
+++ b/roles/openshift_hosted/tasks/router/router.yml
@@ -37,7 +37,7 @@
         cafile: "{{ openshift_master_config_dir ~ '/ca.crt' }}"
 
   # End Block
-  when: openshift_hosted_router_create_certificate | bool
+  when: ( openshift_hosted_router_create_certificate | bool ) and openshift_hosted_router_certificate == {}
 
 - name: Get the certificate contents for router
   copy:

--- a/roles/openshift_hosted/tasks/router/router.yml
+++ b/roles/openshift_hosted/tasks/router/router.yml
@@ -23,8 +23,8 @@
       signer_key: "{{ openshift_master_config_dir }}/ca.key"
       signer_serial: "{{ openshift_master_config_dir }}/ca.serial.txt"
       hostnames:
-      - "{{ openshift_master_default_subdomain }}"
-      - "*.{{ openshift_master_default_subdomain }}"
+      - "{{ openshift_master_default_subdomain | default('router.default.svc.cluster.local') }}"
+      - "*.{{ openshift_master_default_subdomain | default('router.default.svc.cluster.local') }}"
       cert: "{{ ('/etc/origin/master/' ~ (item.certificate.certfile | basename)) if 'certfile' in item.certificate else ((openshift_master_config_dir) ~ '/openshift-router.crt') }}"
       key: "{{ ('/etc/origin/master/' ~ (item.certificate.keyfile | basename)) if 'keyfile' in item.certificate else ((openshift_master_config_dir) ~ '/openshift-router.key') }}"
     with_items: "{{ openshift_hosted_routers }}"


### PR DESCRIPTION
I suggest setting this parameter default to `True`. Since https://github.com/openshift/openshift-ansible/pull/3821 It seems more useful then using arbitrary hostnames.

cc @kwoodson @simon3z 