### PR TITLE
Add rate limit configurability

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -84,6 +84,13 @@ openshift_release=v3.6
 # See: https://godoc.org/github.com/openshift/origin/pkg/cmd/server/api#ImagePolicyConfig
 #openshift_master_image_policy_config={"maxImagesBulkImportedPerRepository": 3, "disableScheduledImport": true}
 
+# Configure master API rate limits for external clients
+#openshift_master_external_ratelimit_qps=200
+#openshift_master_external_ratelimit_burst=400
+# Configure master API rate limits for loopback clients
+#openshift_master_loopback_ratelimit_qps=300
+#openshift_master_loopback_ratelimit_burst=600
+
 # Docker Configuration
 # Add additional, insecure, and blocked registries to global docker configuration
 # For enterprise deployment types we ensure that registry.access.redhat.com is

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -84,6 +84,13 @@ openshift_release=v3.6
 # See: https://godoc.org/github.com/openshift/origin/pkg/cmd/server/api#ImagePolicyConfig
 #openshift_master_image_policy_config={"maxImagesBulkImportedPerRepository": 3, "disableScheduledImport": true}
 
+# Configure master API rate limits for external clients
+#openshift_master_external_ratelimit_qps=200
+#openshift_master_external_ratelimit_burst=400
+# Configure master API rate limits for loopback clients
+#openshift_master_loopback_ratelimit_qps=300
+#openshift_master_loopback_ratelimit_burst=600
+
 # Docker Configuration
 # Add additional, insecure, and blocked registries to global docker configuration
 # For enterprise deployment types we ensure that registry.access.redhat.com is

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -164,16 +164,16 @@ masterClients:
   externalKubernetesClientConnectionOverrides:
     acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
     contentType: application/vnd.kubernetes.protobuf
-    burst: 400
-    qps: 200
+    burst: {{ openshift_master_external_ratelimit_burst | default(400) }}
+    qps: {{ openshift_master_external_ratelimit_qps | default(200) }}
 {% endif %}
   externalKubernetesKubeConfig: ""
 {% if openshift.common.version_gte_3_3_or_1_3 | bool %}
   openshiftLoopbackClientConnectionOverrides:
     acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
     contentType: application/vnd.kubernetes.protobuf
-    burst: 600
-    qps: 300
+    burst: {{ openshift_master_loopback_ratelimit_burst | default(600) }}
+    qps: {{ openshift_master_loopback_ratelimit_qps | default(300) }}
 {% endif %}
   openshiftLoopbackKubeConfig: openshift-master.kubeconfig
 masterPublicURL: {{ openshift.master.public_api_url }}


### PR DESCRIPTION
# Configure master API rate limits for external clients
#openshift_master_external_ratelimit_qps=200
#openshift_master_external_ratelimit_burst=400
# Configure master API rate limits for loopback clients
#openshift_master_loopback_ratelimit_qps=300
#openshift_master_loopback_ratelimit_burst=600
