### PR TITLE
Run some basic etcd checks after migration to ensure leases are good

### DIFF
--- a/roles/etcd_migrate/tasks/migrate.yml
+++ b/roles/etcd_migrate/tasks/migrate.yml
@@ -31,6 +31,15 @@
     name: "{{ l_etcd_service }}"
     state: started
 
+- name: Wait for cluster to become healthy after migration
+  command: >
+    etcdctl --cert-file {{ etcd_peer_cert_file }} --key-file {{ etcd_peer_key_file }} --ca-file {{ etcd_peer_ca_file }} --endpoint https://{{ etcd_peer }}:{{ etcd_client_port }} cluster-health
+  register: l_etcd_migrate_health
+  until: l_etcd_migrate_health.rc == 0
+  retries: 3
+  delay: 30
+  run_once: true
+
 # NOTE: /usr/local/bin may be removed from the PATH by ansible hence why
 #       it's added to the environment in this task.
 - name: Re-introduce leases (as a replacement for key TTLs)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1468187

No idea if this will work yet. Just including the existing checks. Is there a way to loop these? Should I add retries in the included file? What's the best approach here?