### PR TITLE
ansible.cfg: improve ssh ControlPath

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -29,3 +29,7 @@ nocows = True
 # Additional ssh options for OpenShift Ansible
 [ssh_connection]
 pipelining = True
+# shorten the ControlPath which is often too long; when it is,
+# ssh connection reuse silently fails, making everything slower.
+control_path = %(directory)s/%%h-%%r
+

--- a/utils/etc/ansible.cfg
+++ b/utils/etc/ansible.cfg
@@ -28,3 +28,9 @@ deprecation_warnings = False
 # remote_tmp - set if provided by user (cli)
 # ssh_args - set if provided by user (cli)
 # control_path
+
+# Additional ssh options for OpenShift Ansible
+[ssh_connection]
+# shorten the ControlPath which is often too long; when it is,
+# ssh connection reuse silently fails, making everything slower.
+control_path = %(directory)s/%%h-%%r


### PR DESCRIPTION
AWS hosts and user names frequently make the default Ansible ControlPath
too long. This prevents ssh persistent connections, significantly
impacting runtime. More detail: https://github.com/ansible/ansible/issues/11536

This config change shortens the ControlPath to make this less likely. It
would be better to change it to the %C hash, as extremely long hostnames
or usernames could still encounter this problem, but that is not yet
available with RHEL's openssh. This at least improves the situation.