### PR TITLE
Fix defaulting for migration steps

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -13,10 +13,11 @@
       {{ openshift.common.client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
       migrate storage --include=jobs --confirm
     register: l_pb_upgrade_control_plane_pre_upgrade_storage
-    when: openshift_master_upgrade_pre_storage_migration | default(true)
+    when: openshift_upgrade_pre_storage_migration_enabled | default(true,true) | bool
     failed_when:
+    - openshift_upgrade_pre_storage_migration_enabled | default(true,true) | bool
     - l_pb_upgrade_control_plane_pre_upgrade_storage.rc != 0
-    - openshift_upgrade_pre_storage_migration_fatal= | default(true)
+    - openshift_upgrade_pre_storage_migration_fatal | default(true,true) | bool
 
 # If facts cache were for some reason deleted, this fact may not be set, and if not set
 # it will always default to true. This causes problems for the etcd data dir fact detection
@@ -156,10 +157,11 @@
       {{ openshift.common.client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
       migrate storage --include=jobs --confirm
     register: l_pb_upgrade_control_plane_post_upgrade_storage
-    when: openshift_master_upgrade_post_storage_migration | default(true)
+    when: openshift_upgrade_post_storage_migration_enabled | default(true,true) | bool
     failed_when:
+    - openshift_upgrade_post_storage_migration_enabled| default(true,true) | bool
     - l_pb_upgrade_control_plane_post_upgrade_storage.rc != 0
-    - openshift_upgrade_post_storage_migration_fatal= | default(true)
+    - openshift_upgrade_post_storage_migration_fatal | default(true,true) | bool
 
 ##############################################################################
 # Gate on master update complete


### PR DESCRIPTION
Fix two errors
-  variables used didn't match the documentation
- jinja default() requires a second parameter whenever the value passed in could evaluate to false see http://jinja.pocoo.org/docs/2.9/templates/#default