### PR TITLE
Only store failures that were not ignored.

### DIFF
--- a/roles/openshift_health_checker/callback_plugins/zz_failure_summary.py
+++ b/roles/openshift_health_checker/callback_plugins/zz_failure_summary.py
@@ -39,7 +39,8 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
         super(CallbackModule, self).v2_runner_on_failed(result, ignore_errors)
-        self.__failures.append(dict(result=result, ignore_errors=ignore_errors))
+        if not ignore_errors:
+            self.__failures.append(dict(result=result, ignore_errors=ignore_errors))
 
     def v2_playbook_on_stats(self, stats):
         super(CallbackModule, self).v2_playbook_on_stats(stats)


### PR DESCRIPTION
In the past, health checks were implemented with ignore_errors: True in
the playbook level, requiring us to store all failures, ignored or not,
so that we could report on all failed checks.

Now checks are run from a single action plugin entry point, without
ignoring errors (all errors are aggregated via the action plugin).

Since the integration of the openshift_health_checker role with the
install playbook, failure summaries are part of the output of a lot more
calls to ansible-playbook. We shall report only failures that caused the
execution to stop, as ignored failures in the summary only serve to
confuse users.

----

Note: this change leaves room for some clean up, but to avoid introducing a bug at this point I'm deferring the cleanup to a separate PR.