### PR TITLE
Enable JMX reporting of internal metrics

### DIFF
--- a/roles/openshift_metrics/defaults/main.yaml
+++ b/roles/openshift_metrics/defaults/main.yaml
@@ -59,3 +59,6 @@ openshift_metrics_cassandra_pvc_access: "{{ openshift_hosted_metrics_storage_acc
 openshift_metrics_hawkular_user_write_access: False
 
 openshift_metrics_heapster_allowed_users: system:master-proxy
+
+openshift_metrics_cassandra_disable_prometheus_endpoint: ""
+openshift_metrics_hawkular_disable_prometheus_endpoint: ""

--- a/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
@@ -56,6 +56,8 @@ spec:
           value: "/cassandra_data"
         - name: JVM_OPTS
           value: "-Dcassandra.commitlog.ignorereplayerrors=true"
+        - name: DISABLE_PROMETHEUS_ENDPOINT
+          value: "{{ openshift_metrics_cassandra_disable_prometheus_endpoint }}"
         - name: TRUSTSTORE_NODES_AUTHORITIES
           value: "/hawkular-cassandra-certs/tls.peer.truststore.crt"
         - name: TRUSTSTORE_CLIENT_AUTHORITIES

--- a/roles/openshift_metrics/templates/hawkular_metrics_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_metrics_rc.j2
@@ -55,6 +55,7 @@ spec:
         - "-Dcom.datastax.driver.FORCE_NIO=true"
         - "-DKUBERNETES_MASTER_URL={{openshift_metrics_master_url}}"
         - "-DUSER_WRITE_ACCESS={{openshift_metrics_hawkular_user_write_access}}"
+        - "-Dhawkular.metrics.jmx-reporting-enabled"
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/roles/openshift_metrics/templates/hawkular_metrics_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_metrics_rc.j2
@@ -67,6 +67,8 @@ spec:
           value: "{{ 17 | oo_random_word }}"
         - name: TRUSTSTORE_AUTHORITIES
           value: "/hawkular-metrics-certs/tls.truststore.crt"
+        - name: DISABLE_PROMETHEUS_ENDPOINT
+          value: "{{ openshift_metrics_hawkular_disable_prometheus_endpoint }}"
         - name: OPENSHIFT_KUBE_PING_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
We need to enable jmx reporting of our internal, dropwizard metrics
so that they can be exposed over prometheus endpoint.