### PR TITLE
Use openshift.node.nodename as glusterfs_hostname.

### DIFF
--- a/roles/openshift_storage_glusterfs/README.md
+++ b/roles/openshift_storage_glusterfs/README.md
@@ -63,7 +63,7 @@ their configuration as GlusterFS nodes:
 | Name               | Default value             | Description                             |
 |--------------------|---------------------------|-----------------------------------------|
 | glusterfs_cluster  | 1                         | The ID of the cluster this node should belong to. This is useful when a single heketi service is expected to manage multiple distinct clusters. **NOTE:** For natively-hosted clusters, all pods will be in the same OpenShift namespace
-| glusterfs_hostname | openshift.common.hostname | A hostname (or IP address) that will be used for internal GlusterFS communication
+| glusterfs_hostname | openshift.node.nodename   | A hostname (or IP address) that will be used for internal GlusterFS communication
 | glusterfs_ip       | openshift.common.ip       | An IP address that will be used by pods to communicate with the GlusterFS node
 | glusterfs_zone     | 1                         | A zone number for the node. Zones are used within the cluster for determining how to distribute the bricks of GlusterFS volumes. heketi will try to spread each volumes' bricks as evenly as possible across all zones
 

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
@@ -18,7 +18,7 @@
 
 - name: Unlabel any existing GlusterFS nodes
   oc_label:
-    name: "{{ hostvars[item].openshift.common.hostname }}"
+    name: "{{ hostvars[item].openshift.node.nodename }}"
     kind: node
     state: absent
     labels: "{{ glusterfs_nodeselector | oo_dict_to_list_of_dict }}"
@@ -67,7 +67,7 @@
 
 - name: Label GlusterFS nodes
   oc_label:
-    name: "{{ hostvars[item].openshift.common.hostname }}"
+    name: "{{ hostvars[item].openshift.node.nodename }}"
     kind: node
     state: add
     labels: "{{ glusterfs_nodeselector | oo_dict_to_list_of_dict }}"

--- a/roles/openshift_storage_glusterfs/templates/v3.6/topology.json.j2
+++ b/roles/openshift_storage_glusterfs/templates/v3.6/topology.json.j2
@@ -17,7 +17,7 @@
           "node": {
             "hostnames": {
               "manage": [
-                "{{ hostvars[node].glusterfs_hostname | default(hostvars[node].openshift.common.hostname) }}"
+                "{{ hostvars[node].glusterfs_hostname | default(hostvars[node].openshift.node.nodename) }}"
               ],
               "storage": [
                 "{{ hostvars[node].glusterfs_ip | default(hostvars[node].openshift.common.ip) }}"


### PR DESCRIPTION
Nodename may not match `openshift.common.hostname` in cloud environments.

https://bugzilla.redhat.com/show_bug.cgi?id=1446041
