### PR TITLE
Add overlay to supported Docker storage drivers

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/docker_storage.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_storage.py
@@ -17,7 +17,7 @@ class DockerStorage(DockerHostMixin, OpenShiftCheck):
     tags = ["pre-install", "health", "preflight"]
 
     dependencies = ["python-docker-py"]
-    storage_drivers = ["devicemapper", "overlay2"]
+    storage_drivers = ["devicemapper", "overlay", "overlay2"]
     max_thinpool_data_usage_percent = 90.0
     max_thinpool_meta_usage_percent = 90.0
 

--- a/roles/openshift_health_checker/test/docker_storage_test.py
+++ b/roles/openshift_health_checker/test/docker_storage_test.py
@@ -65,8 +65,8 @@ non_atomic_task_vars = {"openshift": {"common": {"is_atomic": False}}}
         dict(info={
             "Driver": "overlay",
         }),
-        True,
-        ["unsupported Docker storage driver"],
+        False,
+        [],
     ),
     (
         dict(info={


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1467809

As a next step, we can refine under which conditions the overlay driver
is supported.