### PR TITLE
 [3.4] scaleup playbook doesn't consider ca certificate specified in openshift_master_overwrite_certificates

### DIFF
--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -62,6 +62,7 @@
   copy:
     src: "{{ item.src }}"
     dest: "{{ openshift_ca_config_dir }}/{{ item.dest }}"
+    force: no
   with_items:
   - src: "{{ (openshift_master_ca_certificate | default({'certfile':none})).certfile }}"
     dest: ca.crt


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1469230