### PR TITLE
Add evaluate_groups.yml to network_manager playbook

### DIFF
--- a/playbooks/common/openshift-node/network_manager.yml
+++ b/playbooks/common/openshift-node/network_manager.yml
@@ -1,4 +1,6 @@
 ---
+- include: ../openshift-cluster/evaluate_groups.yml
+
 - name: Install and configure NetworkManager
   hosts: oo_all_hosts
   become: yes


### PR DESCRIPTION
The network_manager.yml playbook uses oo_* groups names which are
defined in the evaluate_groups.yml playbook.