### PR TITLE
Require cluster ID be set when using AWS cloudprovider

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -226,6 +226,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Note: IAM profiles may be used instead of storing API credentials on disk.
 #openshift_cloudprovider_aws_access_key=aws_access_key_id
 #openshift_cloudprovider_aws_secret_key=aws_secret_access_key
+# If you will have more than one cluster per account then you must configure a
+# unique cluster id per cluster and you must label your nodes to match
+#openshift_cloudprovider_aws_cluster_id=cluster_id
 #
 # Openstack
 #openshift_cloudprovider_kind=openstack

--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -229,6 +229,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # If you will have more than one cluster per account then you must configure a
 # unique cluster id per cluster and you must label your nodes to match
 #openshift_cloudprovider_aws_cluster_id=cluster_id
+# If you're sure that you have only one cluster in your account you must set
+# openshift_cloudprovider_aws_single_cluster=true to override this check.
+#openshift_cloudprovider_aws_single_cluster=false
 #
 # Openstack
 #openshift_cloudprovider_kind=openstack

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -225,6 +225,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Note: IAM profiles may be used instead of storing API credentials on disk.
 #openshift_cloudprovider_aws_access_key=aws_access_key_id
 #openshift_cloudprovider_aws_secret_key=aws_secret_access_key
+# If you will have more than one cluster per account then you must configure a
+# unique cluster id per cluster and you must label your nodes to match
+#openshift_cloudprovider_aws_cluster_id=cluster_id
 #
 # Openstack
 #openshift_cloudprovider_kind=openstack

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -228,6 +228,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # If you will have more than one cluster per account then you must configure a
 # unique cluster id per cluster and you must label your nodes to match
 #openshift_cloudprovider_aws_cluster_id=cluster_id
+# If you're sure that you have only one cluster in your account you must set
+# openshift_cloudprovider_aws_single_cluster=true to override this check.
+#openshift_cloudprovider_aws_single_cluster=false
 #
 # Openstack
 #openshift_cloudprovider_kind=openstack

--- a/roles/openshift_cloud_provider/tasks/aws.yml
+++ b/roles/openshift_cloud_provider/tasks/aws.yml
@@ -1,4 +1,18 @@
 ---
+- name: Abort if a cluster ID is not specified
+  when:
+    - openshift_cloudprovider_aws_cluster_id | default('') == ''
+    - not openshift_cloudprovider_aws_single_cluster | default(false,true) | bool
+  fail:
+    msg: |-
+      When configuring the AWS cloud provider you must either set
+      openshift_cloudprovider_aws_cluster_id to a unique value per cluster and
+      that your instances are labeled with "kubernetes.io/cluster/xxxx=openshift_cloudprovider_aws_cluster_id"
+      where xxxx is a unique string and openshift_cloudprovider_aws_cluster_id
+      is the value of the aforementioned variable. If you've only got one cluster
+      per AWS account you must set openshift_cloudprovider_aws_single_cluster=true
+      to override this check.
+
 # Work around ini_file create option in 2.2 which defaults to no
 - name: Create cloud config file
   file:
@@ -16,18 +30,21 @@
     option: Zone
     value: "{{ openshift.provider.zone }}"
 
-# 3.6 and newer use KubernetesClusterID
-- name: Configure AWS KubernetesClusterID
-  ini_file:
-    dest: "{{ openshift.common.config_base }}/cloudprovider/aws.conf"
-    section: Global
-    option: KubernetesClusterID
-    value: "{{ openshift_cloudprovider_aws_cluster_id }}"
+- when:
+  - not openshift_cloudprovider_aws_single_cluster | default(false,true) | bool
+  block:
+  # 3.6 and newer use KubernetesClusterID
+  - name: Configure AWS KubernetesClusterID
+    ini_file:
+      dest: "{{ openshift.common.config_base }}/cloudprovider/aws.conf"
+      section: Global
+      option: KubernetesClusterID
+      value: "{{ openshift_cloudprovider_aws_cluster_id }}"
 
-# 3.5 and older use KubernetesClusterTag
-- name: Configure AWS KubernetesClusterTag
-  ini_file:
-    dest: "{{ openshift.common.config_base }}/cloudprovider/aws.conf"
-    section: Global
-    option: KubernetesClusterTag
-    value: "{{ openshift_cloudprovider_aws_cluster_id }}"
+  # 3.5 and older use KubernetesClusterTag
+  - name: Configure AWS KubernetesClusterTag
+    ini_file:
+      dest: "{{ openshift.common.config_base }}/cloudprovider/aws.conf"
+      section: Global
+      option: KubernetesClusterTag
+      value: "{{ openshift_cloudprovider_aws_cluster_id }}"

--- a/roles/openshift_cloud_provider/tasks/aws.yml
+++ b/roles/openshift_cloud_provider/tasks/aws.yml
@@ -15,3 +15,19 @@
     section: Global
     option: Zone
     value: "{{ openshift.provider.zone }}"
+
+# 3.6 and newer use KubernetesClusterID
+- name: Configure AWS KubernetesClusterID
+  ini_file:
+    dest: "{{ openshift.common.config_base }}/cloudprovider/aws.conf"
+    section: Global
+    option: KubernetesClusterID
+    value: "{{ openshift_cloudprovider_aws_cluster_id }}"
+
+# 3.5 and older use KubernetesClusterTag
+- name: Configure AWS KubernetesClusterTag
+  ini_file:
+    dest: "{{ openshift.common.config_base }}/cloudprovider/aws.conf"
+    section: Global
+    option: KubernetesClusterTag
+    value: "{{ openshift_cloudprovider_aws_cluster_id }}"

--- a/roles/openshift_sanitize_inventory/tasks/main.yml
+++ b/roles/openshift_sanitize_inventory/tasks/main.yml
@@ -47,6 +47,21 @@
       openshift_release is "{{ openshift_release }}" which is not a valid version string.
       Please set it to a version string like "3.4".
 
+- name: Abort if a cluster ID is not specified
+  when:
+    - openshift_cloudprovider_kind | default('') == 'aws'
+    - openshift_cloudprovider_aws_cluster_id | default('') == ''
+    - not openshift_cloudprovider_aws_single_cluster | default(false,true) | bool
+  fail:
+    msg: |-
+      When configuring the AWS cloud provider you must either set
+      openshift_cloudprovider_aws_cluster_id to a unique value per cluster and
+      that your instances are labeled with "kubernetes.io/cluster/xxxx=openshift_cloudprovider_aws_cluster_id"
+      where xxxx is a unique string and openshift_cloudprovider_aws_cluster_id
+      is the value of the aforementioned variable. If you've only got one cluster
+      per AWS account you must set openshift_cloudprovider_aws_single_cluster=true
+      to override this check.
+
 - include: unsupported.yml
   when:
     - not openshift_enable_unsupported_configurations | default(false) | bool


### PR DESCRIPTION
Deliberately split into two commits so the addition of the variable can be included in older releases.