### PR TITLE
Add an SA policy to the ansible-service-broker

### DIFF
--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -47,7 +47,7 @@
     state: present
     namespace: "openshift-ansible-service-broker"
     resource_kind: cluster-role
-    resource_name: cluster-admin
+    resource_name: admin
     user: "system:serviceaccount:openshift-ansible-service-broker:asb"
 
 - name: create ansible-service-broker service

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -42,6 +42,14 @@
     namespace: openshift-ansible-service-broker
     state: present
 
+- name: Set SA cluster-role
+  oc_adm_policy_user:
+    state: present
+    namespace: "openshift-ansible-service-broker"
+    resource_kind: cluster-role
+    resource_name: cluster-admin
+    user: "system:serviceaccount:openshift-ansible-service-broker:asb"
+
 - name: create ansible-service-broker service
   oc_service:
     name: asb


### PR DESCRIPTION
We are not adding a policy to the service account after creation.
The ansible-service-broker will require cluster-admin permissions
because we do things like: creating service accounts, projects,
and pods.