### PR TITLE
fluentd,mux: make buffer_type configurable; defaults buffer type to "…

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -167,8 +167,6 @@ Elasticsearch OPS too, if using an OPS cluster:
   set the value to the file buffer limit.
 - `openshift_logging_mux_file_buffer_storage_type`: Default `[emptydir]` - Storage
   type for the file buffer.  One of [`emptydir`, `pvc`, `hostmount`]
-- `openshift_logging_mux_file_buffer_mount_path`: Default `[/mux/filebufferstorage]`
-  - Mount path for the file buffer; Shared by `pvc` and `hostmount`.
 
 - `openshift_logging_mux_file_buffer_pvc_size`: The requested size for the file buffer
   PVC, when not provided the role will not generate any PVCs. Defaults to `4Gi`.

--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -57,6 +57,8 @@ When both `openshift_logging_install_logging` and `openshift_logging_upgrade_log
 - `openshift_logging_fluentd_hosts`: List of nodes that should be labeled for Fluentd to be deployed to. Defaults to ['--all'].
 - `openshift_logging_fluentd_buffer_queue_limit`: Buffer queue limit for Fluentd. Defaults to 1024.
 - `openshift_logging_fluentd_buffer_size_limit`: Buffer chunk limit for Fluentd. Defaults to 1m.
+- `openshift_logging_fluentd_buffer_type`: Fluentd will set the buffer type.  Defaults to 'file'.
+- `openshift_logging_fluentd_file_buffer_limit`: Fluentd will set the value to the file buffer limit.  Defaults to '1Gi' per output.
 
 
 - `openshift_logging_es_host`: The name of the ES service Fluentd should send logs to. Defaults to 'logging-es'.
@@ -160,3 +162,21 @@ Elasticsearch OPS too, if using an OPS cluster:
   need to set this
 - `openshift_logging_mux_buffer_queue_limit`: Default `[1024]` - Buffer queue limit for Mux.
 - `openshift_logging_mux_buffer_size_limit`: Default `[1m]` - Buffer chunk limit for Mux.
+- `openshift_logging_mux_buffer_type`: Mux will set the buffer type.  Defaults to 'file'.
+- `openshift_logging_mux_file_buffer_limit`: Default `[2Gi]` per output - Mux will
+  set the value to the file buffer limit.
+- `openshift_logging_mux_file_buffer_storage_type`: Default `[emptydir]` - Storage
+  type for the file buffer.  One of [`emptydir`, `pvc`, `hostmount`]
+- `openshift_logging_mux_file_buffer_mount_path`: Default `[/mux/filebufferstorage]`
+  - Mount path for the file buffer; Shared by `pvc` and `hostmount`.
+
+- `openshift_logging_mux_file_buffer_pvc_size`: The requested size for the file buffer
+  PVC, when not provided the role will not generate any PVCs. Defaults to `4Gi`.
+- `openshift_logging_mux_file_buffer_pvc_dynamic`: Whether or not to add the dynamic
+  PVC annotation for any generated PVCs. Defaults to 'False'.
+- `openshift_logging_mux_file_buffer_pvc_pv_selector`: A key/value map added to a PVC
+  in order to select specific PVs.  Defaults to 'None'.
+- `openshift_logging_mux_file_buffer_pvc_prefix`: The prefix for the generated PVCs.
+  Defaults to 'logging-mux'.
+- `openshift_logging_mux_file_buffer_storage_group`: The storage group used for Mux.
+  Defaults to '65534'.

--- a/roles/openshift_logging_fluentd/defaults/main.yml
+++ b/roles/openshift_logging_fluentd/defaults/main.yml
@@ -57,3 +57,7 @@ openshift_logging_fluentd_es_copy: false
 #fluentd_config_contents:
 #fluentd_throttle_contents:
 #fluentd_secureforward_contents:
+
+# Default value of fluentd BUFFER_TYPE
+openshift_logging_fluentd_buffer_type: "file"
+openshift_logging_fluentd_file_buffer_limit: 1Gi

--- a/roles/openshift_logging_fluentd/templates/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/fluentd.j2
@@ -112,6 +112,12 @@ spec:
               resource: limits.memory
         - name: "USE_MUX_CLIENT"
           value: "{{ openshift_logging_use_mux_client | default('false') | lower }}"
+        - name: "BUFFER_TYPE"
+          value: "{{ openshift_logging_fluentd_buffer_type | lower }}"
+        - name: "FILE_BUFFER_PATH"
+          value: "/var/log/fluentd/filebufferstorage"
+        - name: "FILE_BUFFER_LIMIT"
+          value: "{{ openshift_logging_fluentd_file_buffer_limit | default('1Gi') }}"
       volumes:
       - name: runlogjournal
         hostPath:

--- a/roles/openshift_logging_mux/defaults/main.yml
+++ b/roles/openshift_logging_mux/defaults/main.yml
@@ -54,9 +54,6 @@ openshift_logging_mux_buffer_type: "file"
 # One of ['emptydir', 'pvc', 'hostmount']
 openshift_logging_mux_file_buffer_storage_type: "emptydir"
 
-# mount path: shared by hostmount and pvc
-openshift_logging_mux_file_buffer_mount_path: /var/log/mux/filebufferstorage
-
 # pvc options
 # the name of the PVC we will bind to -- create it if it does not exist
 openshift_logging_mux_file_buffer_pvc_name: "logging-mux-pvc"

--- a/roles/openshift_logging_mux/defaults/main.yml
+++ b/roles/openshift_logging_mux/defaults/main.yml
@@ -47,3 +47,26 @@ openshift_logging_mux_ops_ca: /etc/fluent/keys/ca
 #mux_config_contents:
 #mux_throttle_contents:
 #mux_secureforward_contents:
+
+# Default value of mux BUFFER_TYPE
+openshift_logging_mux_buffer_type: "file"
+
+# One of ['emptydir', 'pvc', 'hostmount']
+openshift_logging_mux_file_buffer_storage_type: "emptydir"
+
+# mount path: shared by hostmount and pvc
+openshift_logging_mux_file_buffer_mount_path: /var/log/mux/filebufferstorage
+
+# pvc options
+# the name of the PVC we will bind to -- create it if it does not exist
+openshift_logging_mux_file_buffer_pvc_name: "logging-mux-pvc"
+
+# required if the PVC does not already exist
+openshift_logging_mux_file_buffer_pvc_size: 4Gi
+openshift_logging_mux_file_buffer_pvc_dynamic: false
+openshift_logging_mux_file_buffer_pvc_pv_selector: {}
+openshift_logging_mux_file_buffer_pvc_access_modes: ['ReadWriteOnce']
+openshift_logging_mux_file_buffer_storage_group: '65534'
+
+openshift_logging_mux_file_buffer_pvc_prefix: "logging-mux"
+openshift_logging_mux_file_buffer_limit:  2Gi

--- a/roles/openshift_logging_mux/tasks/main.yaml
+++ b/roles/openshift_logging_mux/tasks/main.yaml
@@ -177,6 +177,34 @@
   check_mode: no
   changed_when: no
 
+# storageclasses are used by default but if static then disable
+# storageclasses with the storageClassName set to "" in pvc.j2
+- name: Creating Mux storage template
+  template:
+    src: pvc.j2
+    dest: "{{ tempdir }}/templates/logging-mux-pvc.yml"
+  vars:
+    obj_name: "{{ openshift_logging_mux_file_buffer_pvc_name }}"
+    size: "{{ openshift_logging_mux_file_buffer_pvc_size }}"
+    access_modes: "{{ openshift_logging_mux_file_buffer_pvc_access_modes | list }}"
+    pv_selector: "{{ openshift_logging_mux_file_buffer_pvc_pv_selector }}"
+    is_dynamic: "{{ openshift_logging_mux_file_buffer_pvc_dynamic }}"
+    storage_class_name: "{{ openshift_logging_mux_file_buffer_pvc_storage_class_name | default('', true) }}"
+  when:
+  - openshift_logging_mux_file_buffer_storage_type == "pvc"
+
+- name: Set Mux storage
+  oc_obj:
+    state: present
+    kind: pvc
+    name: "{{ openshift_logging_mux_file_buffer_pvc_name }}"
+    namespace: "{{ openshift_logging_mux_namespace }}"
+    files:
+    - "{{ tempdir }}/templates/logging-mux-pvc.yml"
+    delete_after: false
+  when:
+  - openshift_logging_mux_file_buffer_storage_type == "pvc"
+
 - name: Set logging-mux DC
   oc_obj:
     state: present

--- a/roles/openshift_logging_mux/templates/mux.j2
+++ b/roles/openshift_logging_mux/templates/mux.j2
@@ -67,13 +67,7 @@ spec:
           mountPath: /etc/fluent/muxkeys
           readOnly: true
         - name: filebufferstorage
-{% if openshift_logging_mux_file_buffer_storage_type == 'pvc' %}
-          mountPath: {{ openshift_logging_mux_file_buffer_mount_path }}
-{% elif openshift_logging_mux_file_buffer_storage_type == 'hostmount' %}
-          mountPath: {{ openshift_logging_mux_file_buffer_mount_path }}
-{% else %}
           mountPath: /var/log/mux/filebufferstorage
-{% endif %}
         env:
         - name: "K8S_HOST_URL"
           value: "{{openshift_logging_mux_master_url}}"
@@ -126,13 +120,7 @@ spec:
         - name: "BUFFER_TYPE"
           value: "{{ openshift_logging_mux_buffer_type | lower }}"
         - name: "FILE_BUFFER_PATH"
-{% if openshift_logging_mux_file_buffer_storage_type == 'pvc' %}
-          value: "{{ openshift_logging_mux_file_buffer_mount_path }}"
-{% elif openshift_logging_mux_file_buffer_storage_type == 'hostmount' %}
-          value: "{{ openshift_logging_mux_file_buffer_mount_path }}"
-{% else %}
           value: "/var/log/mux/filebufferstorage"
-{% endif %}
         - name: "FILE_BUFFER_LIMIT"
           value: "{{ openshift_logging_mux_file_buffer_limit | default('2Gi') }}"
       volumes:
@@ -157,7 +145,7 @@ spec:
           claimName: {{ openshift_logging_mux_file_buffer_pvc_name }}
 {% elif openshift_logging_mux_file_buffer_storage_type == 'hostmount' %}
         hostPath:
-          path: {{ openshift_logging_mux_file_buffer_mount_path }}
+          path: "/var/log/mux/filebufferstorage"
 {% else %}
         emptydir: {}
 {% endif %}

--- a/roles/openshift_logging_mux/templates/mux.j2
+++ b/roles/openshift_logging_mux/templates/mux.j2
@@ -66,6 +66,14 @@ spec:
         - name: muxcerts
           mountPath: /etc/fluent/muxkeys
           readOnly: true
+        - name: filebufferstorage
+{% if openshift_logging_mux_file_buffer_storage_type == 'pvc' %}
+          mountPath: {{ openshift_logging_mux_file_buffer_mount_path }}
+{% elif openshift_logging_mux_file_buffer_storage_type == 'hostmount' %}
+          mountPath: {{ openshift_logging_mux_file_buffer_mount_path }}
+{% else %}
+          mountPath: /var/log/mux/filebufferstorage
+{% endif %}
         env:
         - name: "K8S_HOST_URL"
           value: "{{openshift_logging_mux_master_url}}"
@@ -115,6 +123,18 @@ spec:
             resourceFieldRef:
               containerName: "mux"
               resource: limits.memory
+        - name: "BUFFER_TYPE"
+          value: "{{ openshift_logging_mux_buffer_type | lower }}"
+        - name: "FILE_BUFFER_PATH"
+{% if openshift_logging_mux_file_buffer_storage_type == 'pvc' %}
+          value: "{{ openshift_logging_mux_file_buffer_mount_path }}"
+{% elif openshift_logging_mux_file_buffer_storage_type == 'hostmount' %}
+          value: "{{ openshift_logging_mux_file_buffer_mount_path }}"
+{% else %}
+          value: "/var/log/mux/filebufferstorage"
+{% endif %}
+        - name: "FILE_BUFFER_LIMIT"
+          value: "{{ openshift_logging_mux_file_buffer_limit | default('2Gi') }}"
       volumes:
       - name: config
         configMap:
@@ -131,3 +151,13 @@ spec:
       - name: muxcerts
         secret:
           secretName: logging-mux
+      - name: filebufferstorage
+{% if openshift_logging_mux_file_buffer_storage_type == 'pvc' %}
+        persistentVolumeClaim:
+          claimName: {{ openshift_logging_mux_file_buffer_pvc_name }}
+{% elif openshift_logging_mux_file_buffer_storage_type == 'hostmount' %}
+        hostPath:
+          path: {{ openshift_logging_mux_file_buffer_mount_path }}
+{% else %}
+        emptydir: {}
+{% endif %}

--- a/roles/openshift_logging_mux/templates/pvc.j2
+++ b/roles/openshift_logging_mux/templates/pvc.j2
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{obj_name}}
+  labels:
+    logging-infra: support
+{% if annotations is defined %}
+  annotations:
+{% for key,value in annotations.iteritems() %}
+    {{key}}: {{value}}
+{% endfor %}
+{% endif %}
+spec:
+{% if pv_selector is defined and pv_selector is mapping %}
+  selector:
+    matchLabels:
+{% for key,value in pv_selector.iteritems() %}
+      {{key}}: {{value}}
+{% endfor %}
+{% endif %}
+  accessModes:
+{% for mode in access_modes %}
+    - {{ mode }}
+{% endfor %}
+  resources:
+    requests:
+      storage: {{size}}
+{% if is_dynamic == 'true' and storage_class_name is defined %}
+  storageClassName: {{ storage_class_name }}
+{% endif %}


### PR DESCRIPTION
…file".

Parameters for the upper file buffer limit per output.
  openshift_logging_fluentd_file_buffer_limit: 1Gi
  openshift_logging_mux_file_buffer_limit: 2Gi
E.g., if es and es-ops are configured for outputs, fluentd allocates 1Gi * 2;
mux allocates 2Gi * 2, if the size is available.