### PR TITLE
Adds null nodeselector when creating logging project

### DIFF
--- a/roles/openshift_hosted_logging/tasks/deploy_logging.yaml
+++ b/roles/openshift_hosted_logging/tasks/deploy_logging.yaml
@@ -25,7 +25,7 @@
 
 - name: "Create logging project"
   command: >
-    {{ openshift.common.client_binary }} adm --config={{ mktemp.stdout }}/admin.kubeconfig new-project logging
+    {{ openshift.common.client_binary }} adm --config={{ mktemp.stdout }}/admin.kubeconfig new-project logging --node-selector=''
   when: logging_project_result.stdout == ""
 
 - name: "Changing projects"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1470394

For whatever reason, when the logging project doesn't already exist and you are running the logging installation against an existing cluster where there is a default node selector for projects, the logging install blows up.

This change adds a null nodeselector to the project creation line.

I'm not sure there's a "better" implementation here.