### PR TITLE
Redeploy-certificates will fail for registry and router if user is not system:admin

### DIFF
--- a/playbooks/common/openshift-cluster/redeploy-certificates/registry.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/registry.yml
@@ -66,6 +66,7 @@
         --signer-cert={{ openshift.common.config_base }}/master/ca.crt
         --signer-key={{ openshift.common.config_base }}/master/ca.key
         --signer-serial={{ openshift.common.config_base }}/master/ca.serial.txt
+        --config={{ mktemp.stdout }}/admin.kubeconfig
         --hostnames="{{ docker_registry_service_ip.results.clusterip }},docker-registry.default.svc,docker-registry.default.svc.cluster.local,{{ docker_registry_route_hostname }}"
         --cert={{ openshift.common.config_base }}/master/registry.crt
         --key={{ openshift.common.config_base }}/master/registry.key

--- a/playbooks/common/openshift-cluster/redeploy-certificates/router.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/router.yml
@@ -116,6 +116,7 @@
         tls.crt="{{ mktemp.stdout }}/openshift-hosted-router-certificate.pem"
         tls.key="{{ mktemp.stdout }}/openshift-hosted-router-certificate.key"
         --type=kubernetes.io/tls
+        --config={{ mktemp.stdout }}/admin.kubeconfig
         --confirm
         -o json | {{ openshift.common.client_binary }} replace -f -
 

--- a/playbooks/common/openshift-cluster/redeploy-certificates/router.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/router.yml
@@ -118,7 +118,7 @@
         --type=kubernetes.io/tls
         --config={{ mktemp.stdout }}/admin.kubeconfig
         --confirm
-        -o json | {{ openshift.common.client_binary }} replace -f -
+        -o json | {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig replace -f -
 
     - name: Remove temporary router certificate and key files
       file:


### PR DESCRIPTION
Redeploy-certificates will fail for registry and router if user is not system:admin

Signed-off-by: jkaurredhat <jkaur@redhat.com>