### PR TITLE
openshift_checks/docker_storage: overlay/2 support

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -113,6 +113,11 @@ openshift_release=v3.6
 # Downgrades are not supported and will error out. Be careful when upgrading docker from < 1.10 to > 1.10.
 # docker_version="1.12.1"
 
+# Specify whether to run Docker daemon with SELinux enabled in containers. Default is True.
+# Uncomment below to disable; for example if your kernel does not support the
+# Docker overlay/overlay2 storage drivers with SELinux enabled.
+#openshift_docker_selinux_enabled=False
+
 # Skip upgrading Docker during an OpenShift upgrade, leaves the current Docker version alone.
 # docker_upgrade=False
 

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -109,6 +109,11 @@ openshift_release=v3.6
 # Default value: "--log-driver=journald"
 #openshift_docker_options="-l warn --ipv6=false"
 
+# Specify whether to run Docker daemon with SELinux enabled in containers. Default is True.
+# Uncomment below to disable; for example if your kernel does not support the
+# Docker overlay/overlay2 storage drivers with SELinux enabled.
+#openshift_docker_selinux_enabled=False
+
 # Specify exact version of Docker to configure or upgrade to.
 # Downgrades are not supported and will error out. Be careful when upgrading docker from < 1.10 to > 1.10.
 # docker_version="1.12.1"

--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -93,7 +93,7 @@
     dest: /etc/sysconfig/docker
     regexp: '^OPTIONS=.*$'
     line: "OPTIONS='\
-      {% if ansible_selinux.status | default(None) == '''enabled''' and docker_selinux_enabled | default(true) %} --selinux-enabled {% endif %}\
+      {% if ansible_selinux.status | default(None) == 'enabled' and docker_selinux_enabled | default(true) | bool %} --selinux-enabled {% endif %}\
       {% if docker_log_driver is defined  %} --log-driver {{ docker_log_driver }}{% endif %}\
       {% if docker_log_options is defined %} {{ docker_log_options |  oo_split() | oo_prepend_strings_in_list('--log-opt ') | join(' ')}}{% endif %}\
       {% if docker_options is defined %} {{ docker_options }}{% endif %}\


### PR DESCRIPTION
fix https://bugzilla.redhat.com/show_bug.cgi?id=1469197

When Docker is configured with the overlay or overlay2 storage driver, check that it is supported and usage is below threshold.

Also, document and fix `openshift_docker_selinux_enabled` option so that running the check need not result in the `docker` role reconfiguring and restarting docker with `--selinux-enabled` (which will prevent docker from running with these drivers at all).