### PR TITLE
Allow Open vSwitch 2.7 on OpenShift 3.5 and 3.6

### DIFF
--- a/roles/openshift_health_checker/library/aos_version.py
+++ b/roles/openshift_health_checker/library/aos_version.py
@@ -19,6 +19,10 @@ the inventory, the version comparison checks just pass.
 '''
 
 from ansible.module_utils.basic import AnsibleModule
+# NOTE: because of the dependency on yum (Python 2-only), this module does not
+# work under Python 3. But since we run unit tests against both Python 2 and
+# Python 3, we use six for cross compatibility in this module alone:
+from ansible.module_utils.six import string_types
 
 IMPORT_EXCEPTION = None
 try:
@@ -122,12 +126,15 @@ def _check_precise_version_found(pkgs, expected_pkgs_dict):
     for pkg in pkgs:
         if pkg.name not in expected_pkgs_dict:
             continue
-        # does the version match, to the precision requested?
-        # and, is it strictly greater, at the precision requested?
-        expected_pkg_version = expected_pkgs_dict[pkg.name]["version"]
-        match_version = '.'.join(pkg.version.split('.')[:expected_pkg_version.count('.') + 1])
-        if match_version == expected_pkg_version:
-            pkgs_precise_version_found.add(pkg.name)
+        expected_pkg_versions = expected_pkgs_dict[pkg.name]["version"]
+        if isinstance(expected_pkg_versions, string_types):
+            expected_pkg_versions = [expected_pkg_versions]
+        for expected_pkg_version in expected_pkg_versions:
+            # does the version match, to the precision requested?
+            # and, is it strictly greater, at the precision requested?
+            match_version = '.'.join(pkg.version.split('.')[:expected_pkg_version.count('.') + 1])
+            if match_version == expected_pkg_version:
+                pkgs_precise_version_found.add(pkg.name)
 
     not_found = []
     for name, pkg in expected_pkgs_dict.items():
@@ -157,8 +164,13 @@ def _check_higher_version_found(pkgs, expected_pkgs_dict):
     for pkg in pkgs:
         if pkg.name not in expected_pkg_names:
             continue
-        expected_pkg_version = expected_pkgs_dict[pkg.name]["version"]
-        req_release_arr = [int(segment) for segment in expected_pkg_version.split(".")]
+        expected_pkg_versions = expected_pkgs_dict[pkg.name]["version"]
+        if isinstance(expected_pkg_versions, string_types):
+            expected_pkg_versions = [expected_pkg_versions]
+        # NOTE: the list of versions is assumed to be sorted so that the highest
+        # desirable version is the last.
+        highest_desirable_version = expected_pkg_versions[-1]
+        req_release_arr = [int(segment) for segment in highest_desirable_version.split(".")]
         version = [int(segment) for segment in pkg.version.split(".")]
         too_high = version[:len(req_release_arr)] > req_release_arr
         higher_than_seen = version > higher_version_for_pkg.get(pkg.name, [])

--- a/roles/openshift_health_checker/openshift_checks/package_version.py
+++ b/roles/openshift_health_checker/openshift_checks/package_version.py
@@ -10,8 +10,8 @@ class PackageVersion(NotContainerizedMixin, OpenShiftCheck):
     tags = ["preflight"]
 
     openshift_to_ovs_version = {
-        "3.6": "2.6",
-        "3.5": "2.6",
+        "3.6": ["2.6", "2.7"],
+        "3.5": ["2.6", "2.7"],
         "3.4": "2.4",
     }
 

--- a/roles/openshift_health_checker/test/package_version_test.py
+++ b/roles/openshift_health_checker/test/package_version_test.py
@@ -72,36 +72,6 @@ def test_package_version(openshift_release):
     assert result is return_value
 
 
-@pytest.mark.parametrize('deployment_type,openshift_release,expected_ovs_version', [
-    ("openshift-enterprise", "3.5", "2.6"),
-    ("origin", "3.6", "2.6"),
-    ("openshift-enterprise", "3.4", "2.4"),
-    ("origin", "3.3", "2.4"),
-])
-def test_ovs_package_version(deployment_type, openshift_release, expected_ovs_version):
-    task_vars = dict(
-        openshift=dict(common=dict(service_type='origin')),
-        openshift_release=openshift_release,
-        openshift_image_tag='v' + openshift_release,
-        openshift_deployment_type=deployment_type,
-    )
-    return_value = object()
-
-    def execute_module(module_name=None, module_args=None, tmp=None, task_vars=None):
-        assert module_name == 'aos_version'
-        assert "package_list" in module_args
-
-        for pkg in module_args["package_list"]:
-            if pkg["name"] == "openvswitch":
-                assert pkg["version"] == expected_ovs_version
-
-        return return_value
-
-    check = PackageVersion(execute_module=execute_module)
-    result = check.run(tmp=None, task_vars=task_vars)
-    assert result is return_value
-
-
 @pytest.mark.parametrize('deployment_type,openshift_release,expected_docker_version', [
     ("origin", "3.5", "1.12"),
     ("openshift-enterprise", "3.4", "1.12"),


### PR DESCRIPTION
Change the package_version check to tolerate either OVS 2.6 or 2.7.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1465882