### PR TITLE
Adding in permissions to edit and admin cluster roles

### DIFF
--- a/roles/openshift_service_catalog/tasks/install.yml
+++ b/roles/openshift_service_catalog/tasks/install.yml
@@ -66,6 +66,40 @@
     template_name: kube-system-service-catalog
     namespace: kube-system
 
+- oc_obj:
+    name: edit
+    kind: clusterrole
+    state: list
+  register: edit_yaml
+
+- name: Generate apply template for clusterrole/edit
+  template:
+    src: sc_role_patching.j2
+    dest: "{{ mktemp.stdout }}/edit_sc_patch.yml"
+  vars:
+    original_content: "{{ edit_yaml.results.results[0] | to_yaml }}"
+
+- name: update edit role for service catalog and pod preset access
+  command: >
+    oc apply -f {{ mktemp.stdout }}/edit_sc_patch.yml
+
+- oc_obj:
+    name: admin
+    kind: clusterrole
+    state: list
+  register: admin_yaml
+
+- name: Generate apply template for clusterrole/admin
+  template:
+    src: sc_role_patching.j2
+    dest: "{{ mktemp.stdout }}/admin_sc_patch.yml"
+  vars:
+    original_content: "{{ admin_yaml.results.results[0] | to_yaml }}"
+
+- name: update admin role for service catalog and pod preset access
+  command: >
+    oc apply -f {{ mktemp.stdout }}/admin_sc_patch.yml
+
 - shell: >
     oc get policybindings/kube-system:default -n kube-system || echo "not found"
   register: get_kube_system

--- a/roles/openshift_service_catalog/templates/sc_role_patching.j2
+++ b/roles/openshift_service_catalog/templates/sc_role_patching.j2
@@ -1,0 +1,26 @@
+{{ original_content }}
+- apiGroups:
+  - "servicecatalog.k8s.io"
+  attributeRestrictions: null
+  resources:
+  - instances
+  - bindings
+  verbs:
+  - create
+  - update
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "settings.k8s.io"
+  attributeRestrictions: null
+  resources:
+  - podpresets
+  verbs:
+  - create
+  - update
+  - delete
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Should address installer side of https://bugzilla.redhat.com/show_bug.cgi?id=1471040

There isn't a way to easily add to the current roles using modules (they would replace rather than be additive), hence the round about manner. Should be updated to use `oc_clusterrole` when it can do this.

CC @spadgett @bparees 