### PR TITLE
1471973- default to bootstrapping the broker on startup

### DIFF
--- a/roles/ansible_service_broker/defaults/main.yml
+++ b/roles/ansible_service_broker/defaults/main.yml
@@ -4,6 +4,7 @@ ansible_service_broker_remove: false
 ansible_service_broker_log_level: info
 ansible_service_broker_output_request: false
 ansible_service_broker_recovery: true
+ansible_service_broker_bootstrap_on_startup: true
 # Recommended you do not enable this for now
 ansible_service_broker_dev_broker: false
 ansible_service_broker_launch_apb_on_bind: false

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -254,6 +254,7 @@
               launch_apb_on_bind: {{ ansible_service_broker_launch_apb_on_bind | bool | lower }}
               recovery: {{ ansible_service_broker_recovery | bool | lower }}
               output_request: {{ ansible_service_broker_output_request | bool | lower }}
+              bootstrap_on_startup: {{ ansible_service_broker_bootstrap_on_startup | bool | lower }}
 
 - name: Create the Broker resource in the catalog
   oc_obj:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1471973

This will cause the broker to discover apbs when it comes up, rather than requiring the user to do a manual bootstrap request.