### PR TITLE
Remove openshift_use_dnsmasq from aws and libvirt playbooks

### DIFF
--- a/playbooks/aws/openshift-cluster/config.yml
+++ b/playbooks/aws/openshift-cluster/config.yml
@@ -35,4 +35,3 @@
     openshift_use_flannel: "{{ lookup('oo_option', 'use_flannel') }}"
     openshift_use_calico: "{{ lookup('oo_option', 'use_calico') }}"
     openshift_use_fluentd: "{{ lookup('oo_option', 'use_fluentd') }}"
-    openshift_use_dnsmasq: false

--- a/playbooks/libvirt/openshift-cluster/config.yml
+++ b/playbooks/libvirt/openshift-cluster/config.yml
@@ -37,4 +37,3 @@
     openshift_use_flannel: "{{ lookup('oo_option', 'use_flannel') }}"
     openshift_use_calico: "{{ lookup('oo_option', 'use_calico') }}"
     openshift_use_fluentd: "{{ lookup('oo_option', 'use_fluentd') }}"
-    openshift_use_dnsmasq: false


### PR DESCRIPTION
Fixes #4785 