### PR TITLE
Bz1466783 etcd ips in masters no proxy

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -194,10 +194,10 @@ def oo_select_keys_from_list(data, keys):
     """
 
     if not isinstance(data, list):
-        raise errors.AnsibleFilterError("|failed expects to filter on a list")
+        raise errors.AnsibleFilterError("|oo_select_keys_from_list failed expects to filter on a list")
 
     if not isinstance(keys, list):
-        raise errors.AnsibleFilterError("|failed expects first param is a list")
+        raise errors.AnsibleFilterError("|oo_select_keys_from_list failed expects first param is a list")
 
     # Gather up the values for the list of keys passed in
     retval = [oo_select_keys(item, keys) for item in data]
@@ -213,10 +213,10 @@ def oo_select_keys(data, keys):
     """
 
     if not isinstance(data, Mapping):
-        raise errors.AnsibleFilterError("|failed expects to filter on a dict or object")
+        raise errors.AnsibleFilterError("|oo_select_keys failed expects to filter on a dict or object")
 
     if not isinstance(keys, list):
-        raise errors.AnsibleFilterError("|failed expects first param is a list")
+        raise errors.AnsibleFilterError("|oo_select_keys failed expects first param is a list")
 
     # Gather up the values for the list of keys passed in
     retval = [data[key] for key in keys if key in data]

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -127,7 +127,7 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    openshift_no_proxy_etcd_host_ips: "{{ hostvars | oo_select_keys(groups['oo_etcd_to_config'])
+    openshift_no_proxy_etcd_host_ips: "{{ hostvars | oo_select_keys(groups['oo_etcd_to_config'] | default([]))
                                                 | oo_collect('openshift.common.ip') | default([]) | join(',')
                                                 }}"
   roles:

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -127,6 +127,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
+    openshift_no_proxy_etcd_host_ips: "{{ hostvars | oo_select_keys(groups['oo_etcd_to_config'])
+                                                | oo_collect('openshift.common.ip') | default([]) | join(',')
+                                                }}"
   roles:
   - role: openshift_master
     openshift_ca_host: "{{ groups.oo_first_master.0 }}"

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1647,6 +1647,13 @@ def set_proxy_facts(facts):
                 common['no_proxy'] = common['no_proxy'].split(",")
             elif 'no_proxy' not in common:
                 common['no_proxy'] = []
+
+            # See https://bugzilla.redhat.com/show_bug.cgi?id=1466783
+            # masters behind a proxy need to connect to etcd via IP
+            if 'no_proxy_etcd_host_ips' in common:
+                if isinstance(common['no_proxy_etcd_host_ips'], string_types):
+                    common['no_proxy'].extend(common['no_proxy_etcd_host_ips'].split(','))
+
             if 'generate_no_proxy_hosts' in common and safe_get_bool(common['generate_no_proxy_hosts']):
                 if 'no_proxy_internal_hostnames' in common:
                     common['no_proxy'].extend(common['no_proxy_internal_hostnames'].split(','))

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -140,6 +140,12 @@
     - set_fact:
         openshift_push_via_dns: "{{ (openshift_use_dnsmasq | default(true) and openshift.common.version_gte_3_6) or (already_set.stdout | match('OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000')) }}"
 
+- name: Set fact of all etcd host IPs
+  openshift_facts:
+    role: common
+    local_facts:
+      no_proxy_etcd_host_ips: "{{ openshift_no_proxy_etcd_host_ips }}"
+
 - name: Install the systemd units
   include: systemd_units.yml
 


### PR DESCRIPTION
# Depends on...

* ~~Depends on https://github.com/openshift/openshift-ansible/pull/4794~~
* that got merged

----

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1466783

Add etcd host IPs to master config files in HA environments when a proxy is in use.