### PR TITLE
[WIP] Elasticsearch 5 standalone ansible role.

### DIFF
--- a/roles/openshift_elasticsearch/README.md
+++ b/roles/openshift_elasticsearch/README.md
@@ -1,0 +1,70 @@
+# The role deploys Elasticsearch cluster on top of OpenShift
+
+## Topology
+
+The deployment supports 2 kinds of node roles at the moment:
+* master
+* data-client
+
+We explicitly don't support combining masters with any other node type.
+`es_node_topology` variable holds the description of the cluster node
+topology.
+
+### Masters
+
+`es_node_topology.masters` describes how many masters will run. Single
+DeploymentConfig will be created for all masters.
+`replicas` field define how many masters to spin up (replicas in Kubernetes
+notation).
+`limits` define Kubernetes pod limits
+`nodeSelector` define Kuberenetes pod selector
+
+### Client Data nodes
+
+`es_node_topology.clientdata` is an array that describes how each data client is structured. Each entry in the array corresponds to individual DeploymentConfig.
+`limits` define Kubernetes pod limits
+`nodeSelector` define Kuberenetes pod selector
+
+# Deployment
+
+## Prerequisites
+
+### Node assignment
+
+It is highly recommended that the nodes where Elasticsearch is run are labelled
+appropriately. Including the nodes for master and client pods, then the
+appropriate `nodeSelector` is used in the topology.
+
+### Virtual memory
+
+Host-level setting `vm.max_map_count=262144` is required on all the nodes where
+Elasticsearch pods will be run.
+https://www.elastic.co/guide/en/elasticsearch/reference/5.3/vm-max-map-count.html
+
+### Host-mount settings for data nodes
+
+In case `hostmount` option is used, create mount points on the data nodes
+prior to starting the deployment.
+Mount point permissions: make sure that everyone in group `root` has all the
+permissions.
+
+Label the folder appropriately:
+
+`# chcon -Rt svirt_sandbox_file_t <dir_name>`
+
+for details please consult with : http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/
+
+## Execute deployment
+
+Define the node topology (`es_node_topology` var), define namespace.
+
+Define storage that you're going to use for Elasticsearch:
+* PersistentVolumeClaim - type `pvc`.
+* Ephemeral - type `emptydir`
+* Host-mounted directories - type `hostmount`
+
+Run the role.
+
+## Upgrade
+
+TODO: needs to be implemented.

--- a/roles/openshift_elasticsearch/defaults/main.yml
+++ b/roles/openshift_elasticsearch/defaults/main.yml
@@ -1,0 +1,68 @@
+---
+### Default images
+openshift_elasticsearch_image: "{{ openshift_hosted_deployer_prefix | default('docker.io/openshift/origin-') }}elasticsearch"
+openshift_elasticsearch_image_version: "{{ openshift_hosted_deployer_version | default('latest') }}"
+openshift_elasticsearch_image_pull_secret: "{{ openshift_hosted_image_pull_secret | default('') }}"
+
+openshift_elasticsearch_init_image: "{{ openshift_hosted_deployer_prefix | default('docker.io/openshift/origin-') }}elasticsearch-init"
+openshift_elasticsearch_init_image_version: "{{ openshift_hosted_deployer_version | default('latest') }}"
+
+
+openshift_master_url: "https://kubernetes.default.svc.{{ openshift.common.dns_domain }}"
+
+### Elasticsearch cluster topology
+openshift_elasticsearch_namespace: logging
+openshift_elasticsearch_sa_name: elasticsearch-sa
+openshift_elasticsearch_secure: true
+openshift_elasticsearch_clustername: "elastic1"
+openshift_elasticsearch_cluster_size: 1
+## TODO: replace with computable cluster size
+openshift_elasticsearch_recover_after_time: 5m
+
+es_node_topology:
+  masters:
+    replicas: 2
+    limits:
+      cpu: 200m
+    requests:
+      memory: 512Mi
+  clientdata:
+  -
+    nodeSelector:
+      kubernetes.io/hostname: asherkho-ocp-rhel1.os1.phx2.redhat.com
+    node_storage_type: hostmount
+    hostmount_path:
+    - /mnt/data1
+    - /mnt/data2
+    limits:
+      memory: 2048Mi
+      cpu: 200m
+  -
+    node_storage_type: emptydir
+    hostmount_path:
+    - /mnt/data
+    limits:
+      memory: 2048Mi
+      cpu: 200m
+
+### Elasticsearch storage layout
+
+# required if the PVC does not already exist
+openshift_elasticsearch_pvc_size: "20Gi"
+openshift_elasticsearch_pvc_dynamic: false
+openshift_elasticsearch_pvc_pv_selector: false
+openshift_elasticsearch_pvc_access_modes: ['ReadWriteOnce']
+openshift_elasticsearch_storage_group: '65534'
+openshift_logging_es_pvc_prefix: 'es-data-pvc'
+
+openshift_es_pvc_prefix: "{{ openshift_hosted_elasticsearch_pvc_prefix | default('logging-es') }}"
+
+openshift_logging_elasticsearch_ops_allow_cluster_reader: false
+
+# following can be uncommented to provide values for configmaps -- take care when providing file contents as it may cause your cluster to not operate correctly
+#es_contents:
+#es_config_contents:
+
+
+openshift_logging_es_ops_cluster_size: "{{ openshift_hosted_logging_elasticsearch_ops_cluster_size | default(1) }}"
+openshift_elasticsearch_integration: false

--- a/roles/openshift_elasticsearch/files/rolebinding-reader.yml
+++ b/roles/openshift_elasticsearch/files/rolebinding-reader.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  name: rolebinding-reader
+rules:
+- resources:
+    - clusterrolebindings
+  verbs:
+    - get

--- a/roles/openshift_elasticsearch/library/openshift_elasticsearch_facts.py
+++ b/roles/openshift_elasticsearch/library/openshift_elasticsearch_facts.py
@@ -1,0 +1,351 @@
+'''
+---
+module: openshift_elasticsearch_facts
+version_added: ""
+short_description: Gather facts about the OpenShift logging stack
+description:
+  - Determine the current facts about the OpenShift logging stack (e.g. cluster size)
+options:
+author: Red Hat, Inc
+'''
+
+import copy
+import json
+
+# pylint: disable=redefined-builtin, unused-wildcard-import, wildcard-import
+from subprocess import *   # noqa: F402,F403
+
+# ignore pylint errors related to the module_utils import
+# pylint: disable=redefined-builtin, unused-wildcard-import, wildcard-import
+from ansible.module_utils.basic import *   # noqa: F402,F403
+
+import yaml
+
+EXAMPLES = """
+- action: opneshift_logging_facts
+"""
+
+RETURN = """
+"""
+
+DEFAULT_OC_OPTIONS = ["-o", "json"]
+
+# constants used for various labels and selectors
+COMPONENT_KEY = "component"
+LOGGING_INFRA_KEY = "logging-infra"
+CLUSTER_NAME_LABEL = "cluster-name"
+ES_ROLE_LABEL = "es-node-role"
+# selectors for filtering resources
+DS_FLUENTD_SELECTOR = LOGGING_INFRA_KEY + "=" + "fluentd"
+LOGGING_SELECTOR = LOGGING_INFRA_KEY + "=" + "support"
+ROUTE_SELECTOR = "component=support, logging-infra=support, provider=openshift"
+COMPONENTS = ["elasticsearch"]
+
+
+class OCBaseCommand(object):
+    ''' The base class used to query openshift '''
+
+    def __init__(self, binary, kubeconfig, namespace):
+        ''' the init method of OCBaseCommand class '''
+        self.binary = binary
+        self.kubeconfig = kubeconfig
+        self.user = self.get_system_admin(self.kubeconfig)
+        self.namespace = namespace
+
+    # pylint: disable=no-self-use
+    def get_system_admin(self, kubeconfig):
+        ''' Retrieves the system admin '''
+        with open(kubeconfig, 'r') as kubeconfig_file:
+            config = yaml.load(kubeconfig_file)
+            for user in config["users"]:
+                if user["name"].startswith("system"):
+                    return user["name"]
+        raise Exception("Unable to find system:admin in: " + kubeconfig)
+
+    # pylint: disable=too-many-arguments, dangerous-default-value
+    def oc_command(self, sub, kind, namespace=None, name=None, add_options=None):
+        ''' Wrapper method for the "oc" command '''
+        cmd = [self.binary, sub, kind]
+        if name is not None:
+            cmd = cmd + [name]
+        if namespace is not None:
+            cmd = cmd + ["-n", namespace]
+        if add_options is None:
+            add_options = []
+        cmd = cmd + ["--user=" + self.user, "--config=" + self.kubeconfig] + DEFAULT_OC_OPTIONS + add_options
+        try:
+            process = Popen(cmd, stdout=PIPE, stderr=PIPE)   # noqa: F405
+            out, err = process.communicate(cmd)
+            if len(err) > 0:
+                if 'not found' in err:
+                    return {'items': []}
+                if 'No resources found' in err:
+                    return {'items': []}
+                raise Exception(err)
+        except Exception as excp:
+            err = "There was an exception trying to run the command '" + " ".join(cmd) + "' " + str(excp)
+            raise Exception(err)
+
+        return json.loads(out)
+
+
+class OpenshiftLoggingFacts(OCBaseCommand):
+    ''' The class structure for holding the OpenshiftLogging Facts'''
+    name = "facts"
+
+    def __init__(self, logger, binary, kubeconfig, namespace, cluster_name):
+        ''' The init method for OpenshiftLoggingFacts '''
+        super(OpenshiftLoggingFacts, self).__init__(binary, kubeconfig, namespace)
+        self.logger = logger
+        self.cluster_name = cluster_name
+        self.facts = dict()
+
+    def default_keys_for(self, kind):
+        ''' Sets the default key values for kind '''
+        for comp in COMPONENTS:
+            self.add_facts_for(comp, kind)
+
+    def add_facts_for(self, comp, kind, name=None, facts=None):
+        ''' Add facts for the provided kind '''
+        if comp not in self.facts:
+            self.facts[comp] = dict()
+        if kind not in self.facts[comp]:
+            self.facts[comp][kind] = dict()
+        if name:
+            self.facts[comp][kind][name] = facts
+
+    def facts_for_routes(self, namespace):
+        ''' Gathers facts for Routes in logging namespace '''
+        self.default_keys_for("routes")
+        route_list = self.oc_command("get", "routes", namespace=namespace, add_options=["-l", ROUTE_SELECTOR])
+        if len(route_list["items"]) == 0:
+            return None
+        for route in route_list["items"]:
+            name = route["metadata"]["name"]
+            comp = self.comp(name)
+            if comp is not None:
+                self.add_facts_for(comp, "routes", name, dict(host=route["spec"]["host"]))
+        self.facts["agl_namespace"] = namespace
+
+    def facts_for_daemonsets(self, namespace):
+        ''' Gathers facts for Daemonsets in logging namespace '''
+        self.default_keys_for("daemonsets")
+        ds_list = self.oc_command("get", "daemonsets", namespace=namespace,
+                                  add_options=["-l", LOGGING_INFRA_KEY + "=fluentd"])
+        if len(ds_list["items"]) == 0:
+            return
+        for ds_item in ds_list["items"]:
+            name = ds_item["metadata"]["name"]
+            comp = self.comp(name)
+            spec = ds_item["spec"]["template"]["spec"]
+            container = spec["containers"][0]
+            result = dict(
+                selector=ds_item["spec"]["selector"],
+                image=container["image"],
+                resources=container["resources"],
+                nodeSelector=spec["nodeSelector"],
+                serviceAccount=spec["serviceAccount"],
+                terminationGracePeriodSeconds=spec["terminationGracePeriodSeconds"]
+            )
+            self.add_facts_for(comp, "daemonsets", name, result)
+
+    def facts_for_pvcs(self, namespace):
+        ''' Gathers facts for PVCS in logging namespace'''
+        self.default_keys_for("pvcs")
+        pvclist = self.oc_command("get", "pvc", namespace=namespace, add_options=["-l", LOGGING_INFRA_KEY])
+        if len(pvclist["items"]) == 0:
+            return
+        for pvc in pvclist["items"]:
+            name = pvc["metadata"]["name"]
+            comp = self.comp(name)
+            self.add_facts_for(comp, "pvcs", name, dict())
+
+    def facts_for_deploymentconfigs(self, namespace, es_role):
+        ''' Gathers facts for DeploymentConfigs in logging namespace '''
+        self.default_keys_for("deploymentconfigs")
+        dclist = self.oc_command("get", "deploymentconfigs",
+                                 namespace=namespace,
+                                 add_options=["-l",
+                                              CLUSTER_NAME_LABEL + "=" +\
+                                              self.cluster_name, "-l",
+                                              ES_ROLE_LABEL + "=" +\
+                                              es_role])
+        if len(dclist["items"]) == 0:
+            self.add_facts_for("node_topology", es_role)
+            return
+        dcs = dclist["items"]
+        for dc_item in dcs:
+            name = dc_item["metadata"]["name"]
+            spec = dc_item["spec"]["template"]["spec"]
+            facts = dict(
+                selector=dc_item["spec"]["selector"],
+                replicas=dc_item["spec"]["replicas"],
+                serviceAccount=spec["serviceAccount"],
+                containers=dict(),
+                volumes=dict()
+            )
+            if "volumes" in spec:
+                for vol in spec["volumes"]:
+                    clone = copy.deepcopy(vol)
+                    clone.pop("name", None)
+                    facts["volumes"][vol["name"]] = clone
+            for container in spec["containers"]:
+                facts["containers"][container["name"]] = dict(
+                    image=container["image"],
+                    resources=container["resources"],
+                )
+            self.add_facts_for("node_topology", es_role, name, facts)
+
+    def facts_for_services(self, namespace):
+        ''' Gathers facts for services in logging namespace '''
+        self.default_keys_for("services")
+        servicelist = self.oc_command("get", "services", namespace=namespace)
+        if len(servicelist["items"]) == 0:
+            return
+        for service in servicelist["items"]:
+            name = service["metadata"]["name"]
+            comp = self.comp(name)
+            if comp is not None:
+                self.add_facts_for(comp, "services", name, dict())
+
+    def facts_for_configmaps(self, namespace):
+        ''' Gathers facts for configmaps in logging namespace '''
+        self.default_keys_for("configmaps")
+        cm_name = self.cluster_name + "-configuration"
+        a_list = self.oc_command("get", "configmaps", namespace=namespace)
+        if len(a_list["items"]) == 0:
+            return
+        for item in a_list["items"]:
+            name = item["metadata"]["name"]
+            comp = self.comp(name)
+            if comp is not None:
+                self.add_facts_for(comp, "configmaps", name, item["data"])
+
+    def facts_for_oauthclients(self, namespace):
+        ''' Gathers facts for oauthclients used with logging '''
+        self.default_keys_for("oauthclients")
+        a_list = self.oc_command("get", "oauthclients", namespace=namespace, add_options=["-l", LOGGING_SELECTOR])
+        if len(a_list["items"]) == 0:
+            return
+        for item in a_list["items"]:
+            name = item["metadata"]["name"]
+            comp = self.comp(name)
+            if comp is not None:
+                result = dict(
+                    redirectURIs=item["redirectURIs"]
+                )
+                self.add_facts_for(comp, "oauthclients", name, result)
+
+    def facts_for_secrets(self, namespace):
+        ''' Gathers facts for secrets in the logging namespace '''
+        self.default_keys_for("secrets")
+        a_list = self.oc_command("get", "secrets", namespace=namespace)
+        if len(a_list["items"]) == 0:
+            return
+        for item in a_list["items"]:
+            name = item["metadata"]["name"]
+            comp = self.comp(name)
+            if comp is not None and item["type"] == "Opaque":
+                result = dict(
+                    keys=item["data"].keys()
+                )
+                self.add_facts_for(comp, "secrets", name, result)
+
+    def facts_for_sccs(self):
+        ''' Gathers facts for SCCs used with logging '''
+        self.default_keys_for("sccs")
+        scc = self.oc_command("get", "scc", name="privileged")
+        if len(scc["users"]) == 0:
+            return
+        for item in scc["users"]:
+            comp = self.comp(item)
+            if comp is not None:
+                self.add_facts_for(comp, "sccs", "privileged", dict())
+
+    def facts_for_clusterrolebindings(self, namespace):
+        ''' Gathers ClusterRoleBindings used with logging '''
+        self.default_keys_for("clusterrolebindings")
+        role = self.oc_command("get", "clusterrolebindings", name="cluster-readers")
+        if "subjects" not in role or len(role["subjects"]) == 0:
+            return
+        for item in role["subjects"]:
+            comp = self.comp(item["name"])
+            if comp is not None and namespace == item["namespace"]:
+                self.add_facts_for(comp, "clusterrolebindings", "cluster-readers", dict())
+
+# this needs to end up nested under the service account...
+    def facts_for_rolebindings(self, namespace):
+        ''' Gathers facts for RoleBindings used with logging '''
+        self.default_keys_for("rolebindings")
+        role = self.oc_command("get", "rolebindings", namespace=namespace, name="logging-elasticsearch-view-role")
+        if "subjects" not in role or len(role["subjects"]) == 0:
+            return
+        for item in role["subjects"]:
+            comp = self.comp(item["name"])
+            if comp is not None and namespace == item["namespace"]:
+                self.add_facts_for(comp, "rolebindings", "logging-elasticsearch-view-role", dict())
+
+    # pylint: disable=no-self-use, too-many-return-statements
+    def comp(self, name):
+        ''' Does a comparison to evaluate the logging component '''
+        if name.startswith("logging-curator-ops"):
+            return "curator_ops"
+        elif name.startswith("logging-kibana-ops") or name.startswith("kibana-ops"):
+            return "kibana_ops"
+        elif name.startswith("logging-es-ops") or name.startswith("logging-elasticsearch-ops"):
+            return "elasticsearch_ops"
+        elif name.startswith("logging-curator"):
+            return "curator"
+        elif name.startswith("logging-kibana") or name.startswith("kibana"):
+            return "kibana"
+        elif name.startswith(self.cluster_name):
+            return "elasticsearch"
+        elif name.startswith("logging-fluentd") or name.endswith("aggregated-logging-fluentd"):
+            return "fluentd"
+        else:
+            return None
+
+    def build_facts(self):
+        ''' Builds the logging facts and returns them '''
+        self.facts_for_deploymentconfigs(self.namespace, "master")
+        self.facts_for_deploymentconfigs(self.namespace, "clientdata")
+
+        self.facts_for_daemonsets(self.namespace)
+        self.facts_for_services(self.namespace)
+        self.facts_for_configmaps(self.namespace)
+        self.facts_for_sccs()
+        self.facts_for_oauthclients(self.namespace)
+        self.facts_for_clusterrolebindings(self.namespace)
+        self.facts_for_rolebindings(self.namespace)
+        self.facts_for_secrets(self.namespace)
+        self.facts_for_pvcs(self.namespace)
+
+        return self.facts
+
+
+def main():
+    ''' The main method '''
+    module = AnsibleModule(   # noqa: F405
+        argument_spec=dict(
+            admin_kubeconfig={"default": "/etc/origin/master/admin.kubeconfig", "type": "str"},
+            oc_bin={"required": True, "type": "str"},
+            openshift_namespace={"required": True, "type": "str"},
+            elasticsearch_clustername={"required": True, "type": "str"}
+        ),
+        supports_check_mode=False
+    )
+    try:
+        cmd = OpenshiftLoggingFacts(module, module.params['oc_bin'], module.params['admin_kubeconfig'],
+                                    module.params['openshift_namespace'],
+                                    module.params['elasticsearch_clustername'])
+        module.exit_json(
+            ansible_facts={"openshift_elasticsearch_facts": cmd.build_facts()}
+        )
+    # ignore broad-except error to avoid stack trace to ansible user
+    # pylint: disable=broad-except
+    except Exception as error:
+        module.fail_json(msg=str(error))
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/openshift_elasticsearch/meta/main.yaml
+++ b/roles/openshift_elasticsearch/meta/main.yaml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: OpenShift Red Hat
+  description: OpenShift Aggregated Logging Elasticsearch Component
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 2.2
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+dependencies:
+- role: lib_openshift

--- a/roles/openshift_elasticsearch/tasks/determine_version.yaml
+++ b/roles/openshift_elasticsearch/tasks/determine_version.yaml
@@ -1,0 +1,19 @@
+---
+# debating making this a module instead?
+- fail:
+    msg: Missing version to install provided by 'openshift_elasticsearch_image_version'
+  when: not openshift_elasticsearch_image_version or openshift_elasticsearch_image_version == ''
+
+- set_fact:
+    es_version: "{{ __latest_es_version }}"
+  when: openshift_elasticsearch_image_version == 'latest'
+
+- debug: var=openshift_elasticsearch_image_version
+
+# should we just assume that we will have the correct major version?
+- set_fact: es_version="{{ openshift_elasticsearch_image_version | regex_replace('^v?(?P<major>\d)\.(?P<minor>\d).*$', '3_\\g<minor>') }}"
+  when: openshift_elasticsearch_image_version != 'latest'
+
+- fail:
+    msg: Invalid version specified for Elasticsearch
+  when: es_version not in __allowed_es_versions

--- a/roles/openshift_elasticsearch/tasks/es_node_configuration.yaml
+++ b/roles/openshift_elasticsearch/tasks/es_node_configuration.yaml
@@ -1,0 +1,71 @@
+---
+# configmap
+- template:
+    src: jvm.options.j2
+    dest: "{{ tempdir }}/jvm.options"
+  when: jvm_options_contents is undefined
+  changed_when: no
+
+- template:
+    src: log4j2.properties.j2
+    dest: "{{ tempdir }}/log4j2.properties"
+  when: es_log4j_contents is undefined
+  changed_when: no
+
+- template:
+    src: elasticsearch.yml.j2
+    dest: "{{ tempdir }}/elasticsearch.yml"
+  vars:
+    allow_cluster_reader: "{{ openshift_logging_elasticsearch_ops_allow_cluster_reader | lower | default('false') }}"
+  when: es_config_contents is undefined
+  changed_when: no
+
+- copy:
+    content: "{{ jvm_options_contents }}"
+    dest: "{{ tempdir }}/jvm.options"
+  when: jvm_options_contents is defined
+  changed_when: no
+
+- copy:
+    content: "{{ es_config_contents }}"
+    dest: "{{ tempdir }}/elasticsearch.yml"
+  when: es_config_contents is defined
+  changed_when: no
+
+- name: Set ES configmap
+  oc_configmap:
+    state: present
+    name: "{{ node_configmap }}"
+    namespace: "{{ openshift_elasticsearch_namespace }}"
+    from_file:
+      elasticsearch.yml: "{{ tempdir }}/elasticsearch.yml"
+      jvm.options: "{{ tempdir }}/jvm.options"
+      log4j2.properties: "{{ tempdir  }}/log4j2.properties"
+    kubeconfig: '{{ kubeconfig }}'
+#  when:
+
+# secret
+- name: Set ES secret
+  oc_secret:
+    state: present
+    name: "{{ openshift_elasticsearch_clustername }}-certs"
+    namespace: "{{ openshift_elasticsearch_namespace }}"
+    files:
+    - name: key
+      path: "{{ generated_certs_dir }}/{{ openshift_elasticsearch_clustername }}.jks"
+    - name: truststore
+      path: "{{ generated_certs_dir }}/truststore.jks"
+    - name: searchguard.key
+      path: "{{ generated_certs_dir }}/{{ openshift_elasticsearch_clustername }}-cluster.jks"
+    - name: searchguard.truststore
+      path: "{{ generated_certs_dir }}/truststore.jks"
+    - name: admin-key
+      path: "{{ generated_certs_dir }}/system.admin.key"
+    - name: admin-cert
+      path: "{{ generated_certs_dir }}/system.admin.crt"
+    - name: admin-ca
+      path: "{{ generated_certs_dir }}/ca.crt"
+    - name: admin.jks
+      path: "{{ generated_certs_dir }}/system.admin.jks"
+    kubeconfig: '{{ kubeconfig }}'
+  when: openshift_elasticsearch_secure

--- a/roles/openshift_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_elasticsearch/tasks/main.yaml
@@ -1,0 +1,105 @@
+---
+
+- include: determine_version.yaml
+
+- name: Gather OpenShift Logging Facts
+  openshift_elasticsearch_facts:
+    oc_bin: "{{client_binary}}"
+    openshift_namespace: "{{openshift_elasticsearch_namespace}}"
+    elasticsearch_clustername: "{{ openshift_elasticsearch_clustername }}"
+    admin_kubeconfig: "{{ kubeconfig }}"
+
+- name: Validate Elasticsearch cluster size
+  fail: msg="The openshift_elasticsearch_cluster_size may only be scaled down manually. Please see official documentation on how to do this."
+  when: openshift_elasticsearch_facts.node_topology.clientdata | length > es_node_topology.clientdata | length
+
+- name: Set Elasticsearch project
+  oc_project:
+    state: present
+    name: "{{ openshift_elasticsearch_namespace }}"
+    kubeconfig: '{{ kubeconfig }}'
+
+# Set up service accounts and roles
+- include: "{{ role_path }}/tasks/service_accounts.yaml"
+
+# Services
+- name: create Elasticsearch 9200 service
+  oc_service:
+    namespace: "{{ openshift_elasticsearch_namespace }}"
+    name: "{{ openshift_elasticsearch_clustername  }}"
+    ports:
+    - name: 9200-tcp
+      port: 9200
+      protocol: TCP
+      targetPort: restapi
+    selector:
+      cluster-name: "{{ openshift_elasticsearch_clustername }}"
+      elasticsearch-http: "true"
+    session_affinity: ClientIP
+    service_type: ClusterIP
+    kubeconfig: '{{ kubeconfig }}'
+
+- name: create Elasticsearch 9300 service
+  oc_service:
+    namespace: "{{ openshift_elasticsearch_namespace }}"
+    name: "{{ openshift_elasticsearch_clustername  }}-cluster"
+    ports:
+    - name: 9300-tcp
+      port: 9300
+      protocol: TCP
+    selector:
+      cluster-name: "{{ openshift_elasticsearch_clustername }}"
+      es-node-role: "master"
+    clusterip: None
+    kubeconfig: '{{ kubeconfig }}'
+
+# Set variables common for all DCs
+- set_fact:
+    logging_component: "{{ openshift_elasticsearch_clustername }}"
+
+# Deploy masters
+- include: "{{ role_path }}/tasks/provision_node.yaml"
+  vars:
+    replicas: "{{ es_node_topology.masters.replicas }}"
+    es_role: master
+    node_master: "true"
+    node_data: "false"
+    node_client: "false"
+    es_http_service: "false"
+    openshift_elasticsearch_deployment_name: "{{ openshift_elasticsearch_clustername }}-master"
+    generated_certs_dir: "{{ certs_dir }}"
+    limits: "{{ es_node_topology.masters.limits }}"
+    es_node_selector: "{{ es_node_topology.masters.nodeSelector | default({}) }}"
+    node_storage_type: emptydir
+    image: "{{ openshift_elasticsearch_image }}:{{ openshift_elasticsearch_image_version }}"
+
+# Deploy client-data nodes
+- include: "{{ role_path }}/tasks/provision_node.yaml"
+  vars:
+    es_cluster_name: "{{ openshift_elasticsearch_clustername }}"
+    es_role: clientdata
+    es_http_service: "true"
+    node_master: "false"
+    node_data: "true"
+    node_client: "false"
+    openshift_elasticsearch_deployment_name: "{{ openshift_elasticsearch_clustername }}-clientdata-{{ item.0 }}"
+    generated_certs_dir: "{{ certs_dir }}"
+    limits: "{{ item.1.limits }}"
+    es_node_selector: "{{ item.1.nodeSelector | default({}) }}"
+    node_storage_type: "{{ item.1.node_storage_type | default(emptydir) }}"
+    openshift_elasticsearch_pvc_name: "{{ openshift_logging_es_pvc_prefix }}-{{ item.0 | int }}"
+    hostmount_path: "{{ item.1.hostmount_path |default ({})}}"
+    image: "{{ openshift_elasticsearch_image }}:{{ openshift_elasticsearch_image_version }}"
+  with_indexed_items: "{{ es_node_topology.clientdata }}"
+
+# Deploy Elasticsearch init pod
+# TODO: fix to change to use job?
+- include: "{{ role_path }}/tasks/provision_init_node.yaml"
+  vars:
+    es_svc_name: "{{ openshift_elasticsearch_clustername }}"
+    es_role: elasticsearch-init
+    es_deploy_name: "{{ openshift_elasticsearch_clustername }}-es-init"
+    generated_certs_dir: "{{ certs_dir }}"
+    image: "{{ openshift_elasticsearch_init_image }}:{{ openshift_elasticsearch_init_image_version }}"
+
+- debug: var=openshift_elasticsearch_facts

--- a/roles/openshift_elasticsearch/tasks/provision_init_node.yaml
+++ b/roles/openshift_elasticsearch/tasks/provision_init_node.yaml
@@ -1,0 +1,68 @@
+---
+- fail:
+    msg: "Invalid node role '{{ es_role }}' provide, one of {{ __allowed_es_roles }} is allowed"
+  when: not es_role in __allowed_es_roles
+
+- include: determine_version.yaml
+
+# allow passing in a tempdir
+- name: Create temp directory for doing work in for role {{ es_role }}
+  command: mktemp -d /tmp/openshift-logging-ansible-XXXXXX
+  register: mktemp
+  changed_when: False
+
+- set_fact:
+    tempdir: "{{ mktemp.stdout }}"
+
+# This may not be necessary in this role
+- name: Create templates subdirectory
+  file:
+    state: directory
+    path: "{{ tempdir }}/templates"
+    mode: 0755
+  changed_when: False
+
+# Setup all configmaps and secrets
+- include: "{{ role_path }}/tasks/es_node_configuration.yaml"
+  vars:
+    node_configmap: "{{ es_deploy_name }}"
+    storage_type: "emptydir"
+
+# DC
+- name: Set ES dc templates for role {{ es_role }}
+  template:
+    src: es-init.j2
+    dest: "{{ tempdir }}/templates/logging-es-dc.yml"
+  vars:
+    es_svc_name: "{{ es_svc_name }}"
+    component: "{{ es_svc_name }}"
+    deploy_name: "{{ es_deploy_name }}"
+  changed_when: false
+
+- name: Set ES dc for role {{ es_role }}
+  oc_obj:
+    state: present
+    name: "{{ es_deploy_name }}"
+    namespace: "{{ openshift_elasticsearch_namespace }}"
+    kind: dc
+    files:
+    - "{{ tempdir }}/templates/logging-es-dc.yml"
+    delete_after: true
+    kubeconfig: '{{ kubeconfig }}'
+
+# scale up
+- name: Start Elasticsearch
+  oc_scale:
+    kind: dc
+    name: "{{ es_deploy_name }}"
+    namespace: "{{ openshift_elasticsearch_namespace }}"
+    replicas: "{{ replicas | default(1) }}"
+    kubeconfig: '{{ kubeconfig }}'
+
+## Placeholder for migration when necessary ##
+
+- name: Delete temp directory
+  file:
+    name: "{{ tempdir }}"
+    state: absent
+  changed_when: False

--- a/roles/openshift_elasticsearch/tasks/provision_node.yaml
+++ b/roles/openshift_elasticsearch/tasks/provision_node.yaml
@@ -1,0 +1,119 @@
+---
+- fail:
+    msg: "Invalid node role '{{ es_role }}' provide, one of {{ __allowed_es_roles }} is allowed"
+  when: not es_role in __allowed_es_roles
+
+- include: determine_version.yaml
+
+# allow passing in a tempdir
+- name: Create temp directory for doing work in for role {{ es_role }}
+  command: mktemp -d /tmp/openshift-logging-ansible-XXXXXX
+  register: mktemp
+  changed_when: False
+
+- set_fact:
+    tempdir: "{{ mktemp.stdout }}"
+
+# This may not be necessary in this role
+- name: Create templates subdirectory
+  file:
+    state: directory
+    path: "{{ tempdir }}/templates"
+    mode: 0755
+  changed_when: False
+
+# we want to make sure we have all the necessary components here
+
+- name: Creating ES storage template
+  template:
+    src: pvc.j2
+    dest: "{{ tempdir }}/templates/logging-es-pvc.yml"
+  vars:
+    obj_name: "{{ openshift_elasticsearch_pvc_name }}"
+    size: "{{ openshift_elasticsearch_pvc_size }}"
+    access_modes: "{{ openshift_elasticsearch_pvc_access_modes | list }}"
+    pv_selector: "{{ openshift_elasticsearch_pvc_pv_selector }}"
+  when:
+  - node_storage_type == "pvc"
+  - not openshift_elasticsearch_pvc_dynamic
+
+- name: Creating ES storage template
+  template:
+    src: pvc.j2
+    dest: "{{ tempdir }}/templates/logging-es-pvc.yml"
+  vars:
+    obj_name: "{{ openshift_elasticsearch_pvc_name }}"
+    size: "{{ openshift_elasticsearch_pvc_size }}"
+    access_modes: "{{ openshift_elasticsearch_pvc_access_modes | list }}"
+    pv_selector: "{{ openshift_elasticsearch_pvc_pv_selector }}"
+    annotations:
+      volume.alpha.kubernetes.io/storage-class: "dynamic"
+  when:
+  - node_storage_type == "pvc"
+  - openshift_elasticsearch_pvc_dynamic
+
+- name: Set ES data node storage
+  oc_obj:
+    state: present
+    kind: pvc
+    name: "{{ openshift_elasticsearch_pvc_name }}"
+    namespace: "{{ openshift_elasticsearch_namespace }}"
+    files:
+    - "{{ tempdir }}/templates/logging-es-pvc.yml"
+    delete_after: true
+    kubeconfig: '{{ kubeconfig }}'
+  when:
+  - node_storage_type == "pvc"
+
+- set_fact:
+    es_deploy_name: "{{ openshift_elasticsearch_deployment_name }}"
+
+# Setup all configmaps and secrets
+- include: "{{ role_path }}/tasks/es_node_configuration.yaml"
+  vars:
+    node_configmap: "{{ es_deploy_name }}"
+    storage_type: "{{ node_storage_type }}"
+
+# DC
+- name: Set ES dc templates for role {{ es_role }}
+  template:
+    src: es.j2
+    dest: "{{ tempdir }}/templates/logging-es-dc.yml"
+  vars:
+    es_configmap: "{{ es_deploy_name }}"
+    es_cluster_name: "{{ openshift_elasticsearch_clustername }}"
+    # TODO: add ability to add arbitrary label to ES deployments,
+    # remove mandatory logging_component
+    # TODO: component below needs to be changed
+    component: "{{ openshift_elasticsearch_clustername }}"
+    deploy_name: "{{ es_deploy_name }}"
+    storage_type: "{{ node_storage_type | default(emptydir) }}"
+  changed_when: false
+
+- name: Set ES dc for role {{ es_role }}
+  oc_obj:
+    state: present
+    name: "{{ es_deploy_name }}"
+    namespace: "{{ openshift_elasticsearch_namespace }}"
+    kind: dc
+    files:
+    - "{{ tempdir }}/templates/logging-es-dc.yml"
+    delete_after: true
+    kubeconfig: '{{ kubeconfig }}'
+
+# scale up
+- name: Start Elasticsearch for role {{ es_role }}
+  oc_scale:
+    kind: dc
+    name: "{{ es_deploy_name }}"
+    namespace: "{{ openshift_elasticsearch_namespace }}"
+    replicas: "{{ replicas | default(1) }}"
+    kubeconfig: '{{ kubeconfig }}'
+
+## Placeholder for migration when necessary ##
+
+- name: Delete temp directory
+  file:
+    name: "{{ tempdir }}"
+    state: absent
+  changed_when: False

--- a/roles/openshift_elasticsearch/tasks/service_accounts.yaml
+++ b/roles/openshift_elasticsearch/tasks/service_accounts.yaml
@@ -1,0 +1,109 @@
+---
+# service account
+- name: Create ES service account
+  oc_serviceaccount:
+    state: present
+    name: "{{ openshift_elasticsearch_sa_name }}"
+    namespace: "{{ openshift_elasticsearch_namespace }}"
+    image_pull_secrets: "{{ openshift_elasticsearch_image_pull_secret }}"
+    kubeconfig: '{{ kubeconfig }}'
+  when: openshift_elasticsearch_image_pull_secret != ''
+
+- name: Create ES service account
+  oc_serviceaccount:
+    state: present
+    name: "{{ openshift_elasticsearch_sa_name }}"
+    namespace: "{{ openshift_elasticsearch_namespace }}"
+    kubeconfig: '{{ kubeconfig }}'
+  when:
+  - openshift_elasticsearch_image_pull_secret == ''
+
+# allow passing in a tempdir
+- name: Create temp directory for doing work in
+  command: mktemp -d /tmp/openshift-logging-ansible-XXXXXX
+  register: mktemp
+  changed_when: False
+
+- set_fact:
+    tempdir: "{{ mktemp.stdout }}"
+
+# This may not be necessary in this role
+- name: Create templates subdirectory
+  file:
+    state: directory
+    path: "{{ tempdir }}/templates"
+    mode: 0755
+  changed_when: False
+
+# rolebinding reader
+- copy:
+    src: rolebinding-reader.yml
+    dest: "{{ tempdir }}/rolebinding-reader.yml"
+  changed_when: no
+  when: openshift_elasticsearch_integration
+
+- name: Create rolebinding-reader role
+  oc_obj:
+    state: present
+    name: "rolebinding-reader"
+    kind: clusterrole
+    namespace: "{{ openshift_elasticsearch_namespace }}"
+    files:
+    - "{{ tempdir }}/rolebinding-reader.yml"
+    delete_after: true
+    kubeconfig: '{{ kubeconfig }}'
+  when: openshift_elasticsearch_integration
+
+
+# SA roles
+- name: Set rolebinding-reader permissions for ES
+  oc_adm_policy_user:
+    state: present
+    namespace: "{{ openshift_elasticsearch_namespace }}"
+    resource_kind: cluster-role
+    resource_name: rolebinding-reader
+    user: "system:serviceaccount:{{ openshift_elasticsearch_namespace }}:{{ openshift_elasticsearch_sa_name }}"
+    kubeconfig: '{{ kubeconfig }}'
+  when: openshift_elasticsearch_integration
+
+# View role and binding
+- name: Generate logging-elasticsearch-view-role
+  template:
+    src: rolebinding.j2
+    dest: "{{mktemp.stdout}}/logging-elasticsearch-view-role.yaml"
+  vars:
+    obj_name: logging-elasticsearch-view-role
+    roleRef:
+      name: view
+    subjects:
+      - kind: ServiceAccount
+        name: "{{ openshift_elasticsearch_sa_name }}"
+  changed_when: no
+
+- name: Set logging-elasticsearch-view-role role
+  oc_obj:
+    state: present
+    name: "logging-elasticsearch-view-role"
+    kind: rolebinding
+    namespace: "{{ openshift_elasticsearch_namespace }}"
+    files:
+    - "{{ tempdir }}/logging-elasticsearch-view-role.yaml"
+    delete_after: true
+    kubeconfig: '{{ kubeconfig }}'
+
+
+# Add hostmount SCC to the service account if required
+- name: Add hostaccess SCC to the service account in case nodes use hostmount
+  oc_adm_policy_user:
+    resource_kind: scc
+    resource_name: hostaccess
+    user: "system:serviceaccount:{{ openshift_elasticsearch_namespace }}:{{ openshift_elasticsearch_sa_name }}"
+    kubeconfig: '{{ kubeconfig }}'
+  when: item.node_storage_type == 'hostmount'
+  with_items: "{{ es_node_topology.clientdata }}"
+
+- name: Delete temp directory
+  file:
+    name: "{{ tempdir }}"
+    state: absent
+  changed_when: False

--- a/roles/openshift_elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/openshift_elasticsearch/templates/elasticsearch.yml.j2
@@ -1,0 +1,95 @@
+cluster:
+  name: ${CLUSTER_NAME}
+
+script:
+  inline: true
+  stored: true
+
+node:
+  master: ${IS_MASTER}
+  data: ${HAS_DATA}
+  name: ${NODE_NAME}
+  ingest: ${NODE_INGEST}
+
+network:
+  host: 0.0.0.0
+
+http:
+  enabled: true
+  compression: true
+
+cloud:
+  kubernetes:
+    service: ${SERVICE_DNS}
+    namespace: ${NAMESPACE}
+
+discovery:
+  zen.hosts_provider: kubernetes
+  zen.ping.unicast.hosts: ${SERVICE_DNS}
+  zen.minimum_master_nodes: ${MASTERS_QUORUM}
+
+plugin.mandatory: discovery-kubernetes
+
+gateway:
+  expected_master_nodes: ${MASTERS_QUORUM}
+  # ^^^ should be full number of master nodes.
+  recover_after_nodes: ${RECOVER_AFTER_NODES}
+  ## ^^ node quorum
+  expected_nodes: ${RECOVER_EXPECTED_NODES}
+  expected_data_nodes: ${RECOVER_EXPECTED_DATA_NODES}
+  recover_after_time: ${RECOVER_AFTER_TIME}
+# add recover_after_master - masters quorum.
+
+#io.fabric8.elasticsearch.authentication.users: ["system.logging.kibana", "system.logging.fluentd", "system.logging.curator", "system.admin"]
+
+#openshift.config:
+#  use_common_data_model: true
+#  project_index_prefix: "project"
+#  time_field_name: "@timestamp"
+#
+#openshift.searchguard:
+#  keystore.path: /etc/elasticsearch/secret/admin.jks
+#  truststore.path: /etc/elasticsearch/secret/searchguard.truststore
+#
+  #openshift.operations.allow_cluster_reader: {{allow_cluster_reader | default ('false')}}
+
+path:
+  data:
+{% if storage_type == 'hostmount' %}
+{% for item in hostmount_path %}
+  - /elasticsearch/persistent/{{ loop.index0 }}
+{% endfor %}
+{% else %}
+  - /elasticsearch/persistent/
+{% endif %}
+  logs: /elasticsearch/${CLUSTER_NAME}/logs
+#  work: /elasticsearch/${CLUSTER_NAME}/work
+  scripts: /elasticsearch/${CLUSTER_NAME}/scripts
+
+{% if openshift_elasticsearch_secure %}
+searchguard:
+  authcz.admin_dn:
+  - CN=system.admin,OU=OpenShift,O=Logging
+#  config_index_name: ".searchguard.${HOSTNAME}"
+  ssl:
+    transport:
+      enabled: true
+      enforce_hostname_verification: false
+      keystore_type: JKS
+      keystore_filepath: /etc/elasticsearch/secret/searchguard.key
+      keystore_alias: {{ openshift_elasticsearch_clustername }}-cluster
+      keystore_password: kspass
+      truststore_type: JKS
+      truststore_filepath: /etc/elasticsearch/secret/searchguard.truststore
+      truststore_password: tspass
+    http:
+      enabled: true
+      keystore_type: JKS
+      keystore_filepath: /etc/elasticsearch/secret/key
+      keystore_alias: {{ openshift_elasticsearch_clustername }}
+      keystore_password: kspass
+      clientauth_mode: OPTIONAL
+      truststore_type: JKS
+      truststore_filepath: /etc/elasticsearch/secret/truststore
+      truststore_password: tspass
+{% endif %}

--- a/roles/openshift_elasticsearch/templates/es-init.j2
+++ b/roles/openshift_elasticsearch/templates/es-init.j2
@@ -1,0 +1,84 @@
+apiVersion: "v1"
+kind: "DeploymentConfig"
+metadata:
+  name: "{{deploy_name}}"
+  labels:
+    provider: openshift
+    component: "{{component}}"
+    deployment: "{{deploy_name}}"
+    cluster-name: "{{ es_svc_name }}"
+    logging-infra: "{{logging_component}}"
+    es-node-role: "{{ es_role }}"
+spec:
+  replicas: {{replicas|default(0)}}
+  selector:
+    provider: openshift
+    component: "{{component}}"
+    deployment: "{{deploy_name}}"
+    logging-infra: "{{logging_component}}"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: "{{deploy_name}}"
+      labels:
+        logging-infra: "{{logging_component}}"
+        provider: openshift
+        component: "{{component}}"
+        deployment: "{{deploy_name}}"
+        cluster-name: "{{ es_svc_name }}"
+        es-node-role: "{{ es_role }}"
+    spec:
+      terminationGracePeriod: 600
+      serviceAccountName: {{ openshift_elasticsearch_sa_name }}
+      containers:
+        -
+          name: "elasticsearch-init"
+          image: {{image}}
+          imagePullPolicy: Always
+          resources:
+{% if limits is defined %}
+            limits:
+{% for key, value in limits.iteritems() %}
+              {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
+{% if requests is defined %}
+            requests:
+{% for key, value in requests.iteritems() %}
+              {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
+#          livenessProbe:
+#            tcpSocket:
+#              port: 9300
+#            initialDelaySeconds: 480
+#            periodSeconds: 5
+          env:
+            -
+              name: "NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            -
+              name: "ES_API_SERVICE"
+              value: "{{ es_svc_name }}"
+            -
+              name: "INSTANCE_RAM"
+{% if limits is defined and limits.memory is defined %}
+              value: "{{ limits.memory }}"
+{% else %}
+              value: "512m"
+{% endif %}
+          volumeMounts:
+{% if openshift_elasticsearch_secure %}
+            - name: elasticsearch
+              mountPath: /etc/elasticsearch/secret
+              readOnly: true
+{% endif %}
+      volumes:
+{% if openshift_elasticsearch_secure %}
+        - name: elasticsearch
+          secret:
+            secretName: {{ es_svc_name }}-certs
+{% endif %}

--- a/roles/openshift_elasticsearch/templates/es.j2
+++ b/roles/openshift_elasticsearch/templates/es.j2
@@ -1,0 +1,188 @@
+apiVersion: "v1"
+kind: "DeploymentConfig"
+metadata:
+  name: "{{deploy_name}}"
+  labels:
+    provider: openshift
+    component: "{{component}}"
+    deployment: "{{deploy_name}}"
+    cluster-name: "{{ es_cluster_name }}"
+    logging-infra: "{{logging_component}}"
+    es-node-role: "{{ es_role }}"
+    elasticsearch-http: "{{ es_http_service }}"
+spec:
+  replicas: {{replicas|default(0)}}
+  selector:
+    provider: openshift
+    component: "{{component}}"
+    deployment: "{{deploy_name}}"
+    logging-infra: "{{logging_component}}"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: "{{deploy_name}}"
+      labels:
+        logging-infra: "{{logging_component}}"
+        provider: openshift
+        component: "{{component}}"
+        deployment: "{{deploy_name}}"
+        cluster-name: "{{ es_cluster_name }}"
+        es-node-role: "{{ es_role }}"
+        elasticsearch-http: "{{ es_http_service }}"
+#      annotations:
+#        pod.beta.kubernetes.io/init-containers: '[
+#          {
+#          "name": "sysctl",
+#            "image": "centos",
+#            "command": ["sysctl", "-w", "vm.max_map_count=262144"],
+#            "serviceAccountName": "{{ openshift_elasticsearch_sa_name }}",
+#            "serviceAccount": "{{ openshift_elasticsearch_sa_name }}",
+#            "securityContext": {
+#              "privileged": true
+#            }
+#          }
+#        ]'
+    spec:
+      terminationGracePeriod: 600
+      serviceAccountName: {{ openshift_elasticsearch_sa_name }}
+      securityContext:
+        supplementalGroups:
+        - {{openshift_elasticsearch_storage_group}}
+{% if es_node_selector is iterable and es_node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in es_node_selector.iteritems() %}
+        {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
+      containers:
+        -
+          name: "elasticsearch"
+          image: {{image}}
+          imagePullPolicy: Always
+          resources:
+{% if limits is defined %}
+            limits:
+{% for key, value in limits.iteritems() %}
+              {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
+{% if requests is defined %}
+            requests:
+{% for key, value in requests.iteritems() %}
+              {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
+          livenessProbe:
+            tcpSocket:
+              port: 9300
+            initialDelaySeconds: 480
+            periodSeconds: 5
+          readinessProbe:
+{% if es_role == "master" %}
+            tcpSocket:
+              port: 9300
+{% else %}
+            exec:
+              command:
+              - "/usr/share/elasticsearch/probe/readiness.sh"
+              initialDelaySeconds: 10
+              timeoutSeconds: 30
+              periodSeconds: 5
+{% endif %}
+          ports:
+            -
+              containerPort: 9200
+              name: "restapi"
+            -
+              containerPort: 9300
+              name: "cluster"
+          env:
+            -
+              name: "NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            -
+              name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            -
+              name: "SERVICE_DNS"
+              value: "{{es_cluster_name}}-cluster"
+            -
+              name: "CLUSTER_NAME"
+              value: "{{es_cluster_name}}"
+            -
+              name: "INSTANCE_RAM"
+{% if limits is defined and limits.memory is defined %}
+              value: "{{ limits.memory }}"
+{% else %}
+              value: "512m"
+{% endif %}
+            -
+              name: "MASTERS_QUORUM"
+              value: "{{es_masters_quorum | int}}"
+            -
+              name: "RECOVER_AFTER_NODES"
+              value: "{{es_recover_after_nodes}}"
+            -
+              name: "RECOVER_EXPECTED_DATA_NODES"
+              value: "{{es_recover_expected_data_nodes}}"
+            -
+              name: "RECOVER_EXPECTED_NODES"
+              value: "{{es_recover_expected_nodes}}"
+            -
+              name: "RECOVER_AFTER_TIME"
+              value: "{{openshift_elasticsearch_recover_after_time}}"
+            -
+              name: IS_MASTER
+              value: "{{ node_master }}"
+            -
+              name: HAS_DATA
+              value: "{{ node_data }}"
+            -
+              name: NODE_INGEST
+              value: "false"
+          volumeMounts:
+{% if openshift_elasticsearch_secure %}
+            - name: elasticsearch
+              mountPath: /etc/elasticsearch/secret
+              readOnly: true
+{% endif %}
+            - name: elasticsearch-config
+              mountPath: /usr/share/java/elasticsearch/config
+              readOnly: true
+{% if storage_type == 'hostmount' %}
+{% for item in hostmount_path %}
+            - name: elasticsearch-storage-{{ loop.index0 }}
+              mountPath: /elasticsearch/persistent/{{ loop.index0 }}
+{% endfor %}
+{% else %}
+            - name: elasticsearch-storage
+              mountPath: /elasticsearch/persistent
+{% endif %}
+      volumes:
+{% if openshift_elasticsearch_secure %}
+        - name: elasticsearch
+          secret:
+            secretName: {{ es_cluster_name }}-certs
+{% endif %}
+        - name: elasticsearch-config
+          configMap:
+            name: {{ es_configmap }}
+{% if storage_type == 'pvc' %}
+        - name: elasticsearch-storage
+          persistentVolumeClaim:
+            claimName: {{ openshift_elasticsearch_pvc_name }}
+{% elif storage_type == 'hostmount' %}
+{% for item in hostmount_path %}
+        - name: elasticsearch-storage-{{ loop.index0 }}
+          hostPath:
+            path: {{ item }}
+{% endfor %}
+{% else %}
+        - name: elasticsearch-storage
+          emptydir: {}
+{% endif %}

--- a/roles/openshift_elasticsearch/templates/jvm.options.j2
+++ b/roles/openshift_elasticsearch/templates/jvm.options.j2
@@ -1,0 +1,115 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+#-Xms2g
+#-Xmx2g
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# disable calls to System#gc
+-XX:+DisableExplicitGC
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# force the server VM (remove on 32-bit client JVMs)
+-server
+
+# explicitly set the stack size (reduce to 320k on 32-bit client JVMs)
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# use old-style file permissions on JDK9
+-Djdk.io.permissionsUseCanonicalPath=true
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps
+# ensure the directory exists and has sufficient space
+#-XX:HeapDumpPath=${heap.dump.path}
+
+## GC logging
+
+#-XX:+PrintGCDetails
+#-XX:+PrintGCTimeStamps
+#-XX:+PrintGCDateStamps
+#-XX:+PrintClassHistogram
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+
+# log GC status to a file with time stamps
+# ensure the directory exists
+#-Xloggc:${loggc}
+
+# By default, the GC log file will not rotate.
+# By uncommenting the lines below, the GC log file
+# will be rotated every 128MB at most 32 times.
+#-XX:+UseGCLogFileRotation
+#-XX:NumberOfGCLogFiles=32
+#-XX:GCLogFileSize=128M
+
+# Elasticsearch 5.0.0 will throw an exception on unquoted field names in JSON.
+# If documents were already indexed with unquoted fields in a previous version
+# of Elasticsearch, some operations may throw errors.
+#
+# WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
+# only for migration purposes.
+#-Delasticsearch.json.allow_unquoted_field_names=true
+

--- a/roles/openshift_elasticsearch/templates/log4j2.properties.j2
+++ b/roles/openshift_elasticsearch/templates/log4j2.properties.j2
@@ -1,0 +1,15 @@
+status = warn
+
+#logger.deprecation.level = warn
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console
+
+logger.action.name = org.elasticsearch.action
+logger.action.level = debug
+logger.action.appenderRef.console.ref = console

--- a/roles/openshift_elasticsearch/templates/pvc.j2
+++ b/roles/openshift_elasticsearch/templates/pvc.j2
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{obj_name}}
+  labels:
+    logging-infra: support
+{% if annotations is defined %}
+  annotations:
+{% for key,value in annotations.iteritems() %}
+    {{key}}: {{value}}
+{% endfor %}
+{% endif %}
+spec:
+{% if pv_selector is defined and pv_selector is mapping %}
+  selector:
+    matchLabels:
+{% for key,value in pv_selector.iteritems() %}
+      {{key}}: {{value}}
+{% endfor %}
+{% endif %}
+  accessModes:
+{% for mode in access_modes %}
+    - {{ mode }}
+{% endfor %}
+  resources:
+    requests:
+      storage: {{size}}

--- a/roles/openshift_elasticsearch/templates/rolebinding.j2
+++ b/roles/openshift_elasticsearch/templates/rolebinding.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: RoleBinding
+metadata:
+  name: {{obj_name}}
+roleRef:
+{% if roleRef.kind is defined %}
+  kind: {{ roleRef.kind }}
+{% endif %}
+  name: {{ roleRef.name }}
+subjects:
+{% for sub in subjects %}
+  - kind: {{ sub.kind }}
+    name: {{ sub.name }}
+{% endfor %}

--- a/roles/openshift_elasticsearch/vars/main.yml
+++ b/roles/openshift_elasticsearch/vars/main.yml
@@ -1,0 +1,17 @@
+---
+__latest_es_version: "3_5"
+__allowed_es_versions: ["3_5", "3_6"]
+__allowed_es_roles: ["clientdata", "master", "elasticsearch-init"]
+
+# Helper
+client_binary: oc
+
+# TODO: integrate these
+#openshift_master_config_dir: "{{ openshift.common.config_base }}/master"
+es_masters_quorum: "{{ es_node_topology.masters.replicas |int /2 + 1 }}"
+es_node_quorum: "{{openshift_elasticsearch_cluster_size|int/2 + 1}}"
+es_min_masters_default: "{{ (openshift_elasticsearch_cluster_size | int / 2 | round(0,'floor') + 1) | int }}"
+es_min_masters: "{{ (openshift_elasticsearch_cluster_size == 1) | ternary(1, es_min_masters_default)}}"
+es_recover_after_nodes: "{{openshift_elasticsearch_cluster_size|int - 1}}"
+es_recover_expected_data_nodes: "{{ es_node_topology.clientdata|length }}"
+es_recover_expected_nodes: "{{openshift_elasticsearch_cluster_size|int}}"


### PR DESCRIPTION
Here is my idea of a separate `openshift_elasticsearch` role for deployment of Elasticsearch 5
on OpenShift. It should be used in combination with `openshift_logging` role, though it is not integrated yet. This way hopefully we can transition smoothly to ES5, while keeping ES2.
I'll be submitting a companion pr to `origin_aggregated_logging` soon.

The role support 2 different node types: master and client-data.
The SearchGuard initialization is done via separate elasticsearch-init pod(this is still a TODO item).

/cc @richm @jcantrill @portante @ewolinetz 