### PR TITLE
node: make node service PartOf=openvswitch.service when openshift-sdn is used

### DIFF
--- a/roles/openshift_node/templates/openshift.docker.node.service
+++ b/roles/openshift_node/templates/openshift.docker.node.service
@@ -6,6 +6,7 @@ PartOf={{ openshift.docker.service_name }}.service
 Requires={{ openshift.docker.service_name }}.service
 {% if openshift_node_use_openshift_sdn %}
 Wants=openvswitch.service
+PartOf=openvswitch.service
 After=ovsdb-server.service
 After=ovs-vswitchd.service
 {% endif %}

--- a/roles/openshift_node_upgrade/templates/openshift.docker.node.service
+++ b/roles/openshift_node_upgrade/templates/openshift.docker.node.service
@@ -6,6 +6,7 @@ PartOf={{ openshift.docker.service_name }}.service
 Requires={{ openshift.docker.service_name }}.service
 {% if openshift_use_openshift_sdn %}
 Wants=openvswitch.service
+PartOf=openvswitch.service
 After=ovsdb-server.service
 After=ovs-vswitchd.service
 {% endif %}


### PR DESCRIPTION
This reverts commit 7f805f9a0c41477365dd88b0ac73f0d221bd654a.

The commit causes the behavior seen in
https://bugzilla.redhat.com/show_bug.cgi?id=1453113 because openshift-node
is no longer restarted when openvswitch is.

@giuseppe @sdodson @knobunc 

RE https://github.com/openshift/openshift-ansible/pull/4213 can we get a more detailed explanation of why the various dependencies are not being restarted correctly?