### PR TITLE
[3.6] Pass first master's openshift_image_tag to openshift_loadbalancer for…

### DIFF
--- a/playbooks/common/openshift-loadbalancer/config.yml
+++ b/playbooks/common/openshift-loadbalancer/config.yml
@@ -12,5 +12,6 @@
                                                                                openshift_use_nuage | default(false),
                                                                                nuage_mon_rest_server_port | default(none)))
                                           + openshift_loadbalancer_additional_backends | default([]) }}"
+    openshift_image_tag: "{{ hostvars[groups.oo_first_master.0].openshift_image_tag }}"
   roles:
   - role: openshift_loadbalancer

--- a/roles/openshift_loadbalancer/README.md
+++ b/roles/openshift_loadbalancer/README.md
@@ -25,6 +25,7 @@ From this role:
 | openshift_loadbalancer_default_maxconn | 20000         | Maximum per-process number of concurrent connections. |
 | openshift_loadbalancer_frontends       | none          | List of frontends. See example below.                 |
 | openshift_loadbalancer_backends        | none          | List of backends. See example below.                  |
+| openshift_image_tag                    | none          | Image tag for containerized haproxy image.            |
 
 Dependencies
 ------------
@@ -64,6 +65,7 @@ Example Playbook
       - name: master3
         address: "192.168.122.223:8443"
 	opts: check
+    openshift_image_tag: v3.6.153
 ```
 
 License


### PR DESCRIPTION
… containerized haproxy installation.
