### PR TITLE
[WIP] Adding Memcached for Kibana SSO

### DIFF
--- a/roles/openshift_logging_kibana/tasks/main.yaml
+++ b/roles/openshift_logging_kibana/tasks/main.yaml
@@ -95,6 +95,20 @@
     - port: 443
       targetPort: "oaproxy"
 
+- name: Set memcached service
+  oc_service:
+    state: present
+    name: "{{ kibana_name }}-memcached"
+    namespace: "{{ openshift_logging_kibana_namespace }}"
+    selector:
+      component: "{{ kibana_component }}"
+      provider: openshift
+    labels:
+      logging-infra: 'support'
+    ports:
+    - port: 11211
+      targetPort: "memcached"
+
 # create routes
 # TODO: set up these certs differently?
 - set_fact:
@@ -235,6 +249,7 @@
     kibana_proxy_memory_limit: "{{ openshift_logging_kibana_proxy_memory_limit }}"
     replicas: "{{ openshift_logging_kibana_replicas | default (1) }}"
     kibana_node_selector: "{{ openshift_logging_kibana_nodeselector | default({}) }}"
+    memcached_hostname: "{{ kibana_name }}-memcached"
 
 - name: Set Kibana DC
   oc_obj:
@@ -244,6 +259,30 @@
     kind: dc
     files:
     - "{{ tempdir }}/templates/kibana-dc.yaml"
+    delete_after: true
+
+- name: Generate Memcached DC template
+  template:
+    src: memcached.j2
+    dest: "{{ tempdir }}/templates/memcached-dc.yaml"
+  vars:
+    component: "{{ kibana_component }}"
+    logging_component: kibana
+    deploy_name: "memcached-{{ kibana_name }}"
+    image: "{{ openshift_logging_image_prefix }}logging-memcached:{{ openshift_logging_image_version }}"
+    kibana_cpu_limit: "{{ openshift_logging_kibana_cpu_limit }}"
+    kibana_memory_limit: "{{ openshift_logging_kibana_memory_limit }}"
+    kibana_proxy_cpu_limit: "{{ openshift_logging_kibana_proxy_cpu_limit }}"
+    kibana_proxy_memory_limit: "{{ openshift_logging_kibana_proxy_memory_limit }}"
+
+- name: Set Memcached DC
+  oc_obj:
+    state: present
+    name: "memcached-{{ kibana_name }}"
+    namespace: "{{ openshift_logging_namespace }}"
+    kind: dc
+    files:
+    - "{{ tempdir }}/templates/memcached-dc.yaml"
     delete_after: true
 
 # update master configs?

--- a/roles/openshift_logging_kibana/templates/kibana.j2
+++ b/roles/openshift_logging_kibana/templates/kibana.j2
@@ -117,6 +117,9 @@ spec:
              name: "OAP_DEBUG"
              value: "{{ openshift_logging_kibana_proxy_debug }}"
             -
+             name: "OAP_USER_TOKEN_MEMCACHED_HOSTNAME"
+             value: "{{ memcached_hostname }}"
+            -
              name: "OAP_OAUTH_SECRET_FILE"
              value: "/secret/oauth-secret"
             -

--- a/roles/openshift_logging_kibana/templates/memcached.j2
+++ b/roles/openshift_logging_kibana/templates/memcached.j2
@@ -1,0 +1,55 @@
+apiVersion: "v1"
+kind: "DeploymentConfig"
+metadata:
+  name: "{{ deploy_name }}"
+  labels:
+    provider: openshift
+    component: "{{ component }}"
+    logging-infra: "{{ logging_component }}"
+spec:
+  replicas: 1
+  selector:
+    provider: openshift
+    component: "{{ component }}"
+    logging-infra: "{{ logging_component }}"
+  strategy:
+    rollingParams:
+      intervalSeconds: 1
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+    type: Rolling
+  template:
+    metadata:
+      name: "{{ deploy_name }}"
+      labels:
+        logging-infra: "{{ logging_component }}"
+        provider: openshift
+        component: "{{ component }}"
+    spec:
+      serviceAccountName: aggregated-logging-kibana
+      containers:
+        -
+          name: "memcached"
+          image: {{ image }}
+          imagePullPolicy: Always
+{% if (kibana_memory_limit is defined and kibana_memory_limit is not none and kibana_memory_limit != "") or (kibana_cpu_limit is defined and kibana_cpu_limit is not none and kibana_cpu_limit != "") %}
+          resources:
+            limits:
+{% if kibana_cpu_limit is not none and kibana_cpu_limit != "" %}
+              cpu: "{{ kibana_cpu_limit }}"
+{% endif %}
+{% if kibana_memory_limit is not none and kibana_memory_limit != "" %}
+              memory: "{{ kibana_memory_limit }}"
+{% endif %}
+{% endif %}
+          env:
+            -
+              name: "KIBANA_MEMORY_LIMIT"
+              valueFrom:
+                resourceFieldRef:
+                  containerName: memcached
+                  resource: limits.memory
+          ports:
+            -
+              name: "memcached"
+              containerPort: 11211


### PR DESCRIPTION
This will add a memcached pod to be used for the auth-proxy pods. This will allow multiple replicas of the auth-proxy to sync on the User/Access token pairs received and allow users to login from a different pod than the one that was used to setup SSO

![auth_proxy_with_memcached](https://user-images.githubusercontent.com/3123328/28516340-90c72222-7069-11e7-869f-8c5bec3aa7b4.png)


This is intended to solve BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1470022

This is also expecting images with the names like: "docker.io/openshift/origin-logging-memcached" to exist.