### PR TITLE
Use absolute path for excluders

### DIFF
--- a/roles/openshift_excluder/tasks/exclude.yml
+++ b/roles/openshift_excluder/tasks/exclude.yml
@@ -5,7 +5,7 @@
   register: docker_excluder_stat
 
 - name: Enable docker excluder
-  command: "{{ r_openshift_excluder_service_type }}-docker-excluder exclude"
+  command: "/sbin/{{ r_openshift_excluder_service_type }}-docker-excluder exclude"
   when:
   - r_openshift_excluder_enable_docker_excluder | bool
   - docker_excluder_stat.stat.exists
@@ -16,7 +16,7 @@
   register: openshift_excluder_stat
 
 - name: Enable openshift excluder
-  command: "{{ r_openshift_excluder_service_type }}-excluder exclude"
+  command: "/sbin/{{ r_openshift_excluder_service_type }}-excluder exclude"
   when:
   - r_openshift_excluder_enable_openshift_excluder | bool
   - openshift_excluder_stat.stat.exists


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1474246

Use absolute path when executing excluder as it's used when checking for excluder.