### PR TITLE
libvirt fixups

### DIFF
--- a/README_libvirt.md
+++ b/README_libvirt.md
@@ -15,7 +15,7 @@ Install dependencies
 3.	Install [ebtables](http://ebtables.netfilter.org/)
 4.	Install [qemu and qemu-system-x86](http://wiki.qemu.org/Main_Page)
 5.	Install [libvirt-python and libvirt](http://libvirt.org/)
-6.	Install [genisoimage](http://cdrkit.org/)
+6.	Install [genisoimage](http://cdrkit.org/) or [mkisofs](http://cdrtools.sourceforge.net/private/cdrecord.html)
 7.	Enable and start the libvirt daemon, e.g:
 	-	`systemctl enable libvirtd`
 	-	`systemctl start libvirtd`

--- a/README_libvirt.md
+++ b/README_libvirt.md
@@ -23,6 +23,7 @@ Install dependencies
 9.	Check that your `$HOME` is accessible to the qemu user²
 10.	Configure dns resolution on the host³
 11.	Install libselinux-python
+12.	Ensure you have an SSH private and public keypair at `~/.ssh/id_rsa` and `~/.ssh/id_rsa.pub`⁴
 
 #### ¹ Depending on your distribution, libvirt access may be denied by default or may require a password at each access.
 
@@ -102,6 +103,11 @@ dns=dnsmasq
 sudo vi /etc/NetworkManager/dnsmasq.d/libvirt_dnsmasq.conf
 server=/example.com/192.168.55.1
 ```
+
+#### ⁴ Private and public keypair in ~/.ssh/id_rsa and ~/.ssh/id_rsa.pub
+
+This playbook uses SSH keys to communicate with the libvirt-driven virtual machines.  At this time the names of those keys are fixed and cannot be changed.
+
 
 Test The Setup
 --------------

--- a/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
@@ -49,8 +49,12 @@
     - '{{ instances }}'
     - [ user-data, meta-data ]
 
+- name: Check for genisoimage
+  command: which genisoimage
+  register: which_genisoimage
+
 - name: Create the cloud-init config drive
-  command: 'genisoimage -output {{ libvirt_storage_pool_path }}/{{ item }}_cloud-init.iso -volid cidata -joliet -rock user-data meta-data'
+  command: '{{ 'genisoimage' if which_genisoimage.rc == 0 else 'mkisofs'}} -output {{ libvirt_storage_pool_path }}/{{ item }}_cloud-init.iso -volid cidata -joliet -rock user-data meta-data'
   args:
     chdir: '{{ libvirt_storage_pool_path }}/{{ item }}_configdrive/'
     creates: '{{ libvirt_storage_pool_path }}/{{ item }}_cloud-init.iso'


### PR DESCRIPTION
Fall back to mkisofs if genisoimage isn't available (they use the same arguments).  (thanks to sdodson for the magic on this one)

Update README to document requirement that SSH keys be at specific paths ~/.ssh/id_rsa and ~/id_rsa.pub.

@sdodson 