### PR TITLE
ci/papr: Update to FAH26

### DIFF
--- a/.papr.sh
+++ b/.papr.sh
@@ -26,7 +26,7 @@ ansible-playbook -vvv -i .papr.inventory playbooks/byo/config.yml -e "openshift_
 # check the cluster NB: we run it on the master since we may
 # be in a different OSP network
 ssh ocp-master docker run --rm --net=host --privileged \
-  -v /etc/origin/master/admin.kubeconfig:/config fedora:25 sh -c \
-    '"dnf install -y origin-tests && \
+  -v /etc/origin/master/admin.kubeconfig:/config registry.fedoraproject.org/fedora:26 sh -c \
+    '"yum install -y origin-tests && \
       KUBECONFIG=/config /usr/libexec/origin/extended.test --ginkgo.v=1 \
         --ginkgo.noColor --ginkgo.focus=\"Services.*NodePort|EmptyDir\""'

--- a/.papr.yml
+++ b/.papr.yml
@@ -14,13 +14,19 @@
 cluster:
   hosts:
     - name: ocp-master
-      distro: fedora/25/atomic
+      distro: fedora/26/atomic
+      specs:
+        ram: 4096
     - name: ocp-node1
-      distro: fedora/25/atomic
+      distro: fedora/26/atomic
+      specs:
+        ram: 4096
     - name: ocp-node2
-      distro: fedora/25/atomic
+      distro: fedora/26/atomic
+      specs:
+        ram: 4096
   container:
-    image: fedora:25
+    image: registry.fedoraproject.org/fedora:26
 
 packages:
   - gcc
@@ -30,10 +36,10 @@ packages:
   - openssl-devel
   - redhat-rpm-config
 
-context: 'fedora/25/atomic'
+context: 'fedora/26/atomic'
 
 env:
-  OPENSHIFT_IMAGE_TAG: v3.6.0-alpha.1
+  OPENSHIFT_IMAGE_TAG: v3.6.0
 
 tests:
   - ./.papr.sh

--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -27,6 +27,11 @@
   when:
   - (not skip_node_svc_handlers | default(False) | bool)
   - not (node_service_status_changed | default(false) | bool)
+  notify: node failed
+
+- name: node failed
+  command: journalctl --no-pager -n 100 -u {{ openshift.common.service_type }}-node
+  when: l_openshift_node_restart_node_result | failed
 
 - name: reload sysctl.conf
   command: /sbin/sysctl -p


### PR DESCRIPTION
See https://lists.projectatomic.io/projectatomic-archives/atomic-devel/2017-July/msg00018.html

Two other changes besides just `s/25/26/`:

- While I was here I did `s/dnf/yum/` since the version in F26 is less
  irritating about that, and it reduces friction in projects like this that need
  to span RHEL and Fedora.
- Also we now use `registry.fedoraproject.org/fedora` instead of relying on the Docker Hub.