### PR TITLE
Removing no_log from htpasswd invocation so not to supress errors

### DIFF
--- a/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
@@ -26,7 +26,6 @@
 
 - name: generate htpasswd file for hawkular metrics
   local_action: htpasswd path="{{ local_tmp.stdout }}/hawkular-metrics.htpasswd" name=hawkular password="{{ hawkular_metrics_pwd.content | b64decode }}"
-  no_log: true
   become: false
 
 - name: copy local generated passwords to target


### PR DESCRIPTION
Even with `-vvv` running of the playbook we don't see the password in the output, so this is safe to remove
```yaml
changed: [m01.example.com -> localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "attributes": null,
            "backup": null,
            "content": null,
            "create": true,
            "crypt_scheme": "apr_md5_crypt",
            "delimiter": null,
            "directory_mode": null,
            "follow": false,
            "force": null,
            "group": null,
            "mode": null,
            "name": "hawkular",
            "owner": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "path": "/tmp/tmp.KyjCM0HT3x/hawkular-metrics.htpasswd",
            "regexp": null,
            "remote_src": null,
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "src": null,
            "state": "present",
            "unsafe_writes": null
        }
    },
    "msg": "Created /tmp/tmp.KyjCM0HT3x/hawkular-metrics.htpasswd and added hawkular"
}
```