### PR TITLE
Metrics: grant hawkular namespace listener role

### DIFF
--- a/roles/openshift_metrics/tasks/generate_rolebindings.yaml
+++ b/roles/openshift_metrics/tasks/generate_rolebindings.yaml
@@ -13,3 +13,27 @@
     - kind: ServiceAccount
       name: hawkular
   changed_when: no
+
+- name: generate hawkular-metrics cluster role binding for the hawkular service account
+  template:
+    src: rolebinding.j2
+    dest: "{{ mktemp.stdout }}/templates/hawkular-cluster-rolebinding.yaml"
+  vars:
+    cluster: True
+    obj_name: hawkular-namespace-watcher
+    labels:
+      metrics-infra: hawkular
+    roleRef:
+      kind: ClusterRole
+      name: hawkular-metrics
+    subjects:
+    - kind: ServiceAccount
+      name: hawkular
+      namespace: "{{openshift_metrics_project}}"
+  changed_when: no
+
+- name: generate the hawkular cluster role
+  template:
+    src: hawkular_metrics_role.j2
+    dest: "{{ mktemp.stdout }}/templates/hawkular-cluster-role.yaml"
+  changed_when: no

--- a/roles/openshift_metrics/tasks/uninstall_metrics.yaml
+++ b/roles/openshift_metrics/tasks/uninstall_metrics.yaml
@@ -6,7 +6,7 @@
   command: >
     {{ openshift.common.client_binary }} -n {{ openshift_metrics_project }} --config={{ mktemp.stdout }}/admin.kubeconfig
     delete --ignore-not-found --selector=metrics-infra
-    all,sa,secrets,templates,routes,pvc,rolebindings,clusterrolebindings
+    all,sa,secrets,templates,routes,pvc,rolebindings,clusterrolebindings,clusterrole
   register: delete_metrics
   changed_when: delete_metrics.stdout != 'No resources found'
 
@@ -16,4 +16,5 @@
     delete --ignore-not-found
     rolebinding/hawkular-view
     clusterrolebinding/heapster-cluster-reader
+    clusterrolebinding/hawkular-metrics
   changed_when: delete_metrics.stdout != 'No resources found'

--- a/roles/openshift_metrics/templates/hawkular_metrics_role.j2
+++ b/roles/openshift_metrics/templates/hawkular_metrics_role.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  name: hawkular-metrics
+  labels:
+    metrics-infra: hawkular-metrics
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - get
+  - watch


### PR DESCRIPTION
An update to the Hawkular component requires that it be able to list and listen on namespace events.

This will create a new cluster role and grant it to the hawkular service account