### PR TITLE
Set TimeoutStartSec=300

### DIFF
--- a/roles/openshift_node/templates/node.service.j2
+++ b/roles/openshift_node/templates/node.service.j2
@@ -24,6 +24,7 @@ WorkingDirectory=/var/lib/origin/
 SyslogIdentifier={{ openshift.common.service_type }}-node
 Restart=always
 RestartSec=5s
+TimeoutStartSec=300
 OOMScoreAdjust=-999
 
 [Install]

--- a/roles/openshift_node_upgrade/templates/node.service.j2
+++ b/roles/openshift_node_upgrade/templates/node.service.j2
@@ -24,6 +24,7 @@ WorkingDirectory=/var/lib/origin/
 SyslogIdentifier={{ openshift.common.service_type }}-node
 Restart=always
 RestartSec=5s
+TimeoutStartSec=300
 OOMScoreAdjust=-999
 
 [Install]


### PR DESCRIPTION
On nodes with thousands of services it may take a very long time to
establish all of the network routing rules. The longest we've seen is
about 180s