### PR TITLE
Set the node facts outside of the openshift-node role

### DIFF
--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -47,7 +47,8 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-
+  pre_tasks:
+  - include: set_node_facts.yml
   roles:
   - role: openshift_node
     openshift_ca_host: "{{ groups.oo_first_master.0 }}"
@@ -63,6 +64,8 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
+  pre_tasks:
+  - include: set_node_facts.yml
   roles:
   - role: openshift_node
     openshift_ca_host: "{{ groups.oo_first_master.0 }}"

--- a/playbooks/common/openshift-node/set_node_facts.yml
+++ b/playbooks/common/openshift-node/set_node_facts.yml
@@ -1,0 +1,28 @@
+---
+- name: Set node facts
+  openshift_facts:
+    role: "{{ item.role }}"
+    local_facts: "{{ item.local_facts }}"
+  with_items:
+    # Reset node labels to an empty dictionary.
+    - role: node
+      local_facts:
+        labels: {}
+    - role: node
+      local_facts:
+        annotations: "{{ openshift_node_annotations | default(none) }}"
+        debug_level: "{{ openshift_node_debug_level | default(openshift.common.debug_level) }}"
+        iptables_sync_period: "{{ openshift_node_iptables_sync_period | default(None) }}"
+        kubelet_args: "{{ openshift_node_kubelet_args | default(None) }}"
+        labels: "{{ lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true) }}"
+        registry_url: "{{ oreg_url_node | default(oreg_url) | default(None) }}"
+        schedulable: "{{ openshift_schedulable | default(openshift_scheduleable) | default(None) }}"
+        sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
+        storage_plugin_deps: "{{ osn_storage_plugin_deps | default(None) }}"
+        set_node_ip: "{{ openshift_set_node_ip | default(None) }}"
+        node_image: "{{ osn_image | default(None) }}"
+        ovs_image: "{{ osn_ovs_image | default(None) }}"
+        proxy_mode: "{{ openshift_node_proxy_mode | default('iptables') }}"
+        local_quota_per_fsgroup: "{{ openshift_node_local_quota_per_fsgroup | default(None) }}"
+        dns_ip: "{{ openshift_dns_ip | default(none) | get_dns_ip(hostvars[inventory_hostname])}}"
+        env_vars: "{{ openshift_node_env_vars | default(None) }}"

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -6,34 +6,6 @@
     (not ansible_selinux or ansible_selinux.status != 'enabled') and
     deployment_type in ['enterprise', 'online', 'atomic-enterprise', 'openshift-enterprise']
 
-- name: Set node facts
-  openshift_facts:
-    role: "{{ item.role }}"
-    local_facts: "{{ item.local_facts }}"
-  with_items:
-    # Reset node labels to an empty dictionary.
-    - role: node
-      local_facts:
-        labels: {}
-    - role: node
-      local_facts:
-        annotations: "{{ openshift_node_annotations | default(none) }}"
-        debug_level: "{{ openshift_node_debug_level | default(openshift.common.debug_level) }}"
-        iptables_sync_period: "{{ openshift_node_iptables_sync_period | default(None) }}"
-        kubelet_args: "{{ openshift_node_kubelet_args | default(None) }}"
-        labels: "{{ lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true) }}"
-        registry_url: "{{ oreg_url_node | default(oreg_url) | default(None) }}"
-        schedulable: "{{ openshift_schedulable | default(openshift_scheduleable) | default(None) }}"
-        sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
-        storage_plugin_deps: "{{ osn_storage_plugin_deps | default(None) }}"
-        set_node_ip: "{{ openshift_set_node_ip | default(None) }}"
-        node_image: "{{ osn_image | default(None) }}"
-        ovs_image: "{{ osn_ovs_image | default(None) }}"
-        proxy_mode: "{{ openshift_node_proxy_mode | default('iptables') }}"
-        local_quota_per_fsgroup: "{{ openshift_node_local_quota_per_fsgroup | default(None) }}"
-        dns_ip: "{{ openshift_dns_ip | default(none) | get_dns_ip(hostvars[inventory_hostname])}}"
-        env_vars: "{{ openshift_node_env_vars | default(None) }}"
-
 # https://docs.openshift.com/container-platform/3.4/admin_guide/overcommit.html#disabling-swap-memory
 - name: Check for swap usage
   command: grep "^[^#].*swap" /etc/fstab


### PR DESCRIPTION
The role currently refers to various `openshift.node` like variables. Some of the variables like `openshift.node.node_system_image` or `openshift.node.ovs_system_image` are set to default values (hidden under the hood). Some of the variables like `openshift.node.ovs_image` or `openshift.node.node_image`
are set to a user defined variables like `osn_ovs_image` (for the `ovs_image`) or `osn_image` (for the `node_image`).
    
The current `openshift_facts` implementation sets the `node|ovs_system_image` to `node|ovs_image`:

```python
if 'node_image' not in facts['node']:
    facts['node']['node_image'] = node_image
    facts['node']['node_system_image'] = node_image
if 'ovs_image' not in facts['node']:
    facts['node']['ovs_image'] = ovs_image
    facts['node']['ovs_system_image'] = ovs_image
```
Given the node facts are common for more roles, they should be collected outside of a role. Each role can then receive all its variables through role variables. Thus, making the role variable self-contained.