### PR TITLE
Sync all openshift.common.use_openshift_sdn uses in yaml files

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -8,7 +8,7 @@ os_firewall_allow:
   port: 443/tcp
 - service: OpenShift OVS sdn
   port: 4789/udp
-  when: openshift.common.use_openshift_sdn | bool
+  when: openshift.common.use_openshift_sdn | default(true) | bool
 - service: Calico BGP Port
   port: 179/tcp
   when: openshift.common.use_calico | bool

--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -3,7 +3,7 @@
   systemd:
     name: openvswitch
     state: restarted
-  when: (not skip_node_svc_handlers | default(False) | bool) and not (ovs_service_status_changed | default(false) | bool) and openshift.common.use_openshift_sdn | bool
+  when: (not skip_node_svc_handlers | default(False) | bool) and not (ovs_service_status_changed | default(false) | bool) and openshift.common.use_openshift_sdn | default(true) | bool
   register: l_openshift_node_stop_openvswitch_result
   until: not l_openshift_node_stop_openvswitch_result | failed
   retries: 3

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -30,7 +30,7 @@ dependencies:
   os_firewall_allow:
   - service: OpenShift OVS sdn
     port: 4789/udp
-  when: openshift.common.use_openshift_sdn | bool
+  when: openshift.common.use_openshift_sdn | default(true) | bool
 - role: os_firewall
   os_firewall_allow:
   - service: Calico BGP Port

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -90,7 +90,9 @@
   package:
     name: "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version | oo_image_tag_to_rpm_version(include_dash=True) }}"
     state: present
-  when: openshift.common.use_openshift_sdn and not openshift.common.is_containerized | bool
+  when:
+    - openshift.common.use_openshift_sdn | default(true) | bool
+    - not openshift.common.is_containerized | bool
 
 - name: Install conntrack-tools package
   package:
@@ -119,7 +121,9 @@
     enabled: yes
     state: started
     daemon_reload: yes
-  when: openshift.common.is_containerized | bool and openshift.common.use_openshift_sdn | bool
+  when:
+    - openshift.common.is_containerized | bool
+    - openshift.common.use_openshift_sdn | default(true) | bool
   register: ovs_start_result
   until: not ovs_start_result | failed
   retries: 3

--- a/roles/openshift_node_upgrade/handlers/main.yml
+++ b/roles/openshift_node_upgrade/handlers/main.yml
@@ -3,7 +3,10 @@
   systemd:
     name: openvswitch
     state: restarted
-  when: (not skip_node_svc_handlers | default(False) | bool) and not (ovs_service_status_changed | default(false) | bool) and openshift.common.use_openshift_sdn | bool
+  when:
+  - not skip_node_svc_handlers | default(False) | bool
+  - not (ovs_service_status_changed | default(false) | bool)
+  - openshift.common.use_openshift_sdn | default(true) | bool
   register: l_openshift_node_upgrade_stop_openvswitch_result
   until: not l_openshift_node_upgrade_stop_openvswitch_result | failed
   retries: 3

--- a/roles/openshift_node_upgrade/tasks/main.yml
+++ b/roles/openshift_node_upgrade/tasks/main.yml
@@ -43,7 +43,9 @@
     docker pull {{ openshift.node.ovs_image }}:{{ openshift_image_tag }}
   register: pull_result
   changed_when: "'Downloaded newer image' in pull_result.stdout"
-  when: openshift.common.is_containerized | bool and openshift.common.use_openshift_sdn | bool
+  when:
+  - openshift.common.is_containerized | bool
+  - openshift.common.use_openshift_sdn | default(true) | bool
 
 - include: docker/upgrade.yml
   vars:


### PR DESCRIPTION
Most occurrences are in a form:
    
```yaml
openshift.common.use_openshift_sdn | default(true) | bool
```
    
Let's make all occurences this way given the `use_openshift_sdn` is set to `true` anyway.
See https://github.com/openshift/openshift-ansible/blob/0c350dcc7d06d62be5ba3a8e468dff85cdd96dd7/roles/openshift_facts/library/openshift_facts.py#L2035
