### PR TITLE
[3.6] Fixing podpresets perms for service-catalog-controller

### DIFF
--- a/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
+++ b/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
@@ -99,7 +99,6 @@ objects:
     - ""
     resources:
     - secrets
-    - podpresets
     verbs:
     - create
     - update
@@ -149,6 +148,11 @@ objects:
     - podpresets
     verbs:
     - create
+    - update
+    - delete
+    - get
+    - list
+    - watch
 
 - kind: ClusterRoleBinding
   apiVersion: v1


### PR DESCRIPTION
Moving podpresets permissions to the correct permissions api group so that the service-catalog-controller can correctly create/delete/etc podpresets objects.

To address https://bugzilla.redhat.com/show_bug.cgi?id=1471881
Backport of https://github.com/openshift/openshift-ansible/pull/4876