### PR TITLE
Refactor openshift_facts BIOS vendor discovery

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -2222,14 +2222,10 @@ class OpenShiftFacts(object):
         product_version = self.system_facts['ansible_product_version']
         virt_type = self.system_facts['ansible_virtualization_type']
         virt_role = self.system_facts['ansible_virtualization_role']
+        bios_vendor = self.system_facts['ansible_system_vendor']
         provider = None
         metadata = None
 
-        # TODO: this is not exposed through module_utils/facts.py in ansible,
-        # need to create PR for ansible to expose it
-        bios_vendor = get_file_content(  # noqa: F405
-            '/sys/devices/virtual/dmi/id/bios_vendor'
-        )
         if bios_vendor == 'Google':
             provider = 'gce'
             metadata_url = ('http://metadata.google.internal/'


### PR DESCRIPTION
In Ansible 2.4, `get_file_content` is moving
 from ansible.module_utils.facts
 to   ansible.module_utils.facts.utils

However, the method is no longer needed as the BIOS vendor fact can be
retrieved
from a standard Ansible fact, `ansible_system_vendor`.

i.e.:
        "ansible_system_vendor": "Google",