### PR TITLE
Add glusterfs hosts to oo_all_hosts so that hosts set initial facts.

### DIFF
--- a/playbooks/byo/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/byo/openshift-cluster/cluster_hosts.yml
@@ -20,4 +20,5 @@ g_glusterfs_registry_hosts: "{{ groups.glusterfs_registry | default(g_glusterfs_
 g_all_hosts: "{{ g_master_hosts | union(g_node_hosts) | union(g_etcd_hosts)
                  | union(g_lb_hosts) | union(g_nfs_hosts)
                  | union(g_new_node_hosts)| union(g_new_master_hosts)
+                 | union(g_glusterfs_hosts)
                  | default([]) }}"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1474630

I was able to reproduce with settings similar to the BZ and this ensures that facts are accessible for glusterfs hosts.