### PR TITLE
Move common openshift node systemd unit tasks into separete files

### DIFF
--- a/roles/openshift_node/tasks/config/configure-node-settings.yml
+++ b/roles/openshift_node/tasks/config/configure-node-settings.yml
@@ -1,0 +1,16 @@
+---
+- name: Configure Node settings
+  lineinfile:
+    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
+    regexp: "{{ item.regex }}"
+    line: "{{ item.line }}"
+    create: true
+  with_items:
+  - regex: '^OPTIONS='
+    line: "OPTIONS=--loglevel={{ openshift.node.debug_level | default(2) }}"
+  - regex: '^CONFIG_FILE='
+    line: "CONFIG_FILE={{ openshift.common.config_base }}/node/node-config.yaml"
+  - regex: '^IMAGE_VERSION='
+    line: "IMAGE_VERSION={{ openshift_image_tag }}"
+  notify:
+  - restart node

--- a/roles/openshift_node/tasks/config/configure-proxy-settings.yml
+++ b/roles/openshift_node/tasks/config/configure-proxy-settings.yml
@@ -1,0 +1,17 @@
+---
+- name: Configure Proxy Settings
+  lineinfile:
+    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
+    regexp: "{{ item.regex }}"
+    line: "{{ item.line }}"
+    create: true
+  with_items:
+  - regex: '^HTTP_PROXY='
+    line: "HTTP_PROXY={{ openshift.common.http_proxy | default('') }}"
+  - regex: '^HTTPS_PROXY='
+    line: "HTTPS_PROXY={{ openshift.common.https_proxy | default('') }}"
+  - regex: '^NO_PROXY='
+    line: "NO_PROXY={{ openshift.common.no_proxy | default([]) }},{{ openshift.common.portal_net }},{{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }}"
+  when: ('http_proxy' in openshift.common and openshift.common.http_proxy != '')
+  notify:
+  - restart node

--- a/roles/openshift_node/tasks/config/install-node-deps-docker-service-file.yml
+++ b/roles/openshift_node/tasks/config/install-node-deps-docker-service-file.yml
@@ -1,0 +1,8 @@
+---
+- name: Install Node dependencies docker service file
+  template:
+    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node-dep.service"
+    src: openshift.docker.node.dep.service
+  notify:
+  - reload systemd units
+  - restart node

--- a/roles/openshift_node/tasks/config/install-node-docker-service-file.yml
+++ b/roles/openshift_node/tasks/config/install-node-docker-service-file.yml
@@ -1,0 +1,8 @@
+---
+- name: Install Node docker service file
+  template:
+    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
+    src: openshift.docker.node.service
+  notify:
+  - reload systemd units
+  - restart node

--- a/roles/openshift_node/tasks/config/install-ovs-docker-service-file.yml
+++ b/roles/openshift_node/tasks/config/install-ovs-docker-service-file.yml
@@ -1,0 +1,8 @@
+---
+- name: Install OpenvSwitch docker service file
+  template:
+    dest: "/etc/systemd/system/openvswitch.service"
+    src: openvswitch.docker.service
+  notify:
+  - reload systemd units
+  - restart openvswitch

--- a/roles/openshift_node/tasks/config/install-ovs-service-env-file.yml
+++ b/roles/openshift_node/tasks/config/install-ovs-service-env-file.yml
@@ -1,0 +1,8 @@
+---
+- name: Create the openvswitch service env file
+  template:
+    src: openvswitch.sysconfig.j2
+    dest: /etc/sysconfig/openvswitch
+  notify:
+  - reload systemd units
+  - restart openvswitch

--- a/roles/openshift_node/tasks/config/workaround-bz1331590-ovs-oom-fix.yml
+++ b/roles/openshift_node/tasks/config/workaround-bz1331590-ovs-oom-fix.yml
@@ -1,0 +1,13 @@
+---
+# May be a temporary workaround.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1331590
+- name: Create OpenvSwitch service.d directory
+  file: path=/etc/systemd/system/openvswitch.service.d/ state=directory
+
+- name: Install OpenvSwitch service OOM fix
+  template:
+    dest: "/etc/systemd/system/openvswitch.service.d/01-avoid-oom.conf"
+    src: openvswitch-avoid-oom.conf
+  notify:
+  - reload systemd units
+  - restart openvswitch

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -2,15 +2,8 @@
 # This file is included both in the openshift_master role and in the upgrade
 # playbooks.
 
-- name: Install Node dependencies docker service file
-  template:
-    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node-dep.service"
-    src: openshift.docker.node.dep.service
-  register: install_node_dep_result
+- include: config/install-node-deps-docker-service-file.yml
   when: openshift.common.is_containerized | bool
-  notify:
-  - reload systemd units
-  - restart node
 
 - block:
   - name: Pre-pull node image
@@ -19,14 +12,7 @@
     register: pull_result
     changed_when: "'Downloaded newer image' in pull_result.stdout"
 
-  - name: Install Node docker service file
-    template:
-      dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
-      src: openshift.docker.node.service
-    register: install_node_result
-    notify:
-    - reload systemd units
-    - restart node
+  - include: config/install-node-docker-service-file.yml
   when:
   - openshift.common.is_containerized | bool
   - not openshift.common.is_node_system_container | bool
@@ -35,21 +21,13 @@
   template:
     dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
     src: "node.service.j2"
-  register: install_node_result
   when: not openshift.common.is_containerized | bool
   notify:
   - reload systemd units
   - restart node
 
-- name: Create the openvswitch service env file
-  template:
-    src: openvswitch.sysconfig.j2
-    dest: /etc/sysconfig/openvswitch
+- include: config/install-ovs-service-env-file.yml
   when: openshift.common.is_containerized | bool
-  register: install_ovs_sysconfig
-  notify:
-  - reload systemd units
-  - restart openvswitch
 
 - name: Install Node system container
   include: node_system_container.yml
@@ -64,21 +42,8 @@
   - openshift.common.is_containerized | bool
   - openshift.common.is_openvswitch_system_container | bool
 
-# May be a temporary workaround.
-# https://bugzilla.redhat.com/show_bug.cgi?id=1331590
-- name: Create OpenvSwitch service.d directory
-  file: path=/etc/systemd/system/openvswitch.service.d/ state=directory
+- include: config/workaround-bz1331590-ovs-oom-fix.yml
   when: openshift.common.use_openshift_sdn | default(true) | bool
-
-- name: Install OpenvSwitch service OOM fix
-  template:
-    dest: "/etc/systemd/system/openvswitch.service.d/01-avoid-oom.conf"
-    src: openvswitch-avoid-oom.conf
-  when: openshift.common.use_openshift_sdn | default(true) | bool
-  register: install_oom_fix_result
-  notify:
-  - reload systemd units
-  - restart openvswitch
 
 - block:
   - name: Pre-pull openvswitch image
@@ -87,47 +52,11 @@
     register: pull_result
     changed_when: "'Downloaded newer image' in pull_result.stdout"
 
-  - name: Install OpenvSwitch docker service file
-    template:
-      dest: "/etc/systemd/system/openvswitch.service"
-      src: openvswitch.docker.service
-    notify:
-    - reload systemd units
-    - restart openvswitch
+  - include: config/install-ovs-docker-service-file.yml
   when:
   - openshift.common.is_containerized | bool
   - openshift.common.use_openshift_sdn | default(true) | bool
   - not openshift.common.is_openvswitch_system_container | bool
 
-- name: Configure Node settings
-  lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
-    regexp: "{{ item.regex }}"
-    line: "{{ item.line }}"
-    create: true
-  with_items:
-  - regex: '^OPTIONS='
-    line: "OPTIONS=--loglevel={{ openshift.node.debug_level | default(2) }}"
-  - regex: '^CONFIG_FILE='
-    line: "CONFIG_FILE={{ openshift.common.config_base }}/node/node-config.yaml"
-  - regex: '^IMAGE_VERSION='
-    line: "IMAGE_VERSION={{ openshift_image_tag }}"
-  notify:
-  - restart node
-
-- name: Configure Proxy Settings
-  lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
-    regexp: "{{ item.regex }}"
-    line: "{{ item.line }}"
-    create: true
-  with_items:
-  - regex: '^HTTP_PROXY='
-    line: "HTTP_PROXY={{ openshift.common.http_proxy | default('') }}"
-  - regex: '^HTTPS_PROXY='
-    line: "HTTPS_PROXY={{ openshift.common.https_proxy | default('') }}"
-  - regex: '^NO_PROXY='
-    line: "NO_PROXY={{ openshift.common.no_proxy | default([]) }},{{ openshift.common.portal_net }},{{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }}"
-  when: ('http_proxy' in openshift.common and openshift.common.http_proxy != '')
-  notify:
-  - restart node
+- include: config/configure-node-settings.yml
+- include: config/configure-proxy-settings.yml

--- a/roles/openshift_node_upgrade/tasks/config/configure-node-settings.yml
+++ b/roles/openshift_node_upgrade/tasks/config/configure-node-settings.yml
@@ -1,0 +1,16 @@
+---
+- name: Configure Node settings
+  lineinfile:
+    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
+    regexp: "{{ item.regex }}"
+    line: "{{ item.line }}"
+    create: true
+  with_items:
+  - regex: '^OPTIONS='
+    line: "OPTIONS=--loglevel={{ openshift.node.debug_level | default(2) }}"
+  - regex: '^CONFIG_FILE='
+    line: "CONFIG_FILE={{ openshift.common.config_base }}/node/node-config.yaml"
+  - regex: '^IMAGE_VERSION='
+    line: "IMAGE_VERSION={{ openshift_image_tag }}"
+  notify:
+  - restart node

--- a/roles/openshift_node_upgrade/tasks/config/configure-proxy-settings.yml
+++ b/roles/openshift_node_upgrade/tasks/config/configure-proxy-settings.yml
@@ -1,0 +1,17 @@
+---
+- name: Configure Proxy Settings
+  lineinfile:
+    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
+    regexp: "{{ item.regex }}"
+    line: "{{ item.line }}"
+    create: true
+  with_items:
+  - regex: '^HTTP_PROXY='
+    line: "HTTP_PROXY={{ openshift.common.http_proxy | default('') }}"
+  - regex: '^HTTPS_PROXY='
+    line: "HTTPS_PROXY={{ openshift.common.https_proxy | default('') }}"
+  - regex: '^NO_PROXY='
+    line: "NO_PROXY={{ openshift.common.no_proxy | default([]) }},{{ openshift.common.portal_net }},{{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }}"
+  when: ('http_proxy' in openshift.common and openshift.common.http_proxy != '')
+  notify:
+  - restart node

--- a/roles/openshift_node_upgrade/tasks/config/install-node-deps-docker-service-file.yml
+++ b/roles/openshift_node_upgrade/tasks/config/install-node-deps-docker-service-file.yml
@@ -1,0 +1,8 @@
+---
+- name: Install Node dependencies docker service file
+  template:
+    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node-dep.service"
+    src: openshift.docker.node.dep.service
+  notify:
+  - reload systemd units
+  - restart node

--- a/roles/openshift_node_upgrade/tasks/config/install-node-docker-service-file.yml
+++ b/roles/openshift_node_upgrade/tasks/config/install-node-docker-service-file.yml
@@ -1,0 +1,8 @@
+---
+- name: Install Node docker service file
+  template:
+    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
+    src: openshift.docker.node.service
+  notify:
+  - reload systemd units
+  - restart node

--- a/roles/openshift_node_upgrade/tasks/config/install-ovs-docker-service-file.yml
+++ b/roles/openshift_node_upgrade/tasks/config/install-ovs-docker-service-file.yml
@@ -1,0 +1,8 @@
+---
+- name: Install OpenvSwitch docker service file
+  template:
+    dest: "/etc/systemd/system/openvswitch.service"
+    src: openvswitch.docker.service
+  notify:
+  - reload systemd units
+  - restart openvswitch

--- a/roles/openshift_node_upgrade/tasks/config/install-ovs-service-env-file.yml
+++ b/roles/openshift_node_upgrade/tasks/config/install-ovs-service-env-file.yml
@@ -1,0 +1,8 @@
+---
+- name: Create the openvswitch service env file
+  template:
+    src: openvswitch.sysconfig.j2
+    dest: /etc/sysconfig/openvswitch
+  notify:
+  - reload systemd units
+  - restart openvswitch

--- a/roles/openshift_node_upgrade/tasks/config/workaround-bz1331590-ovs-oom-fix.yml
+++ b/roles/openshift_node_upgrade/tasks/config/workaround-bz1331590-ovs-oom-fix.yml
@@ -1,0 +1,13 @@
+---
+# May be a temporary workaround.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1331590
+- name: Create OpenvSwitch service.d directory
+  file: path=/etc/systemd/system/openvswitch.service.d/ state=directory
+
+- name: Install OpenvSwitch service OOM fix
+  template:
+    dest: "/etc/systemd/system/openvswitch.service.d/01-avoid-oom.conf"
+    src: openvswitch-avoid-oom.conf
+  notify:
+  - reload systemd units
+  - restart openvswitch

--- a/roles/openshift_node_upgrade/tasks/systemd_units.yml
+++ b/roles/openshift_node_upgrade/tasks/systemd_units.yml
@@ -18,86 +18,20 @@
 
 # This file is included both in the openshift_master role and in the upgrade
 # playbooks.
-- name: Install Node dependencies docker service file
-  template:
-    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node-dep.service"
-    src: openshift.docker.node.dep.service
+- include: config/install-node-deps-docker-service-file.yml
   when: openshift.common.is_containerized | bool
-  notify:
-  - reload systemd units
-  - restart node
 
-- name: Install Node docker service file
-  template:
-    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
-    src: openshift.docker.node.service
+- include: config/install-node-docker-service-file.yml
   when: openshift.common.is_containerized | bool
-  notify:
-  - reload systemd units
-  - restart node
 
-- name: Create the openvswitch service env file
-  template:
-    src: openvswitch.sysconfig.j2
-    dest: /etc/sysconfig/openvswitch
+- include: config/install-ovs-service-env-file.yml
   when: openshift.common.is_containerized | bool
-  notify:
-  - reload systemd units
-  - restart openvswitch
 
-# May be a temporary workaround.
-# https://bugzilla.redhat.com/show_bug.cgi?id=1331590
-- name: Create OpenvSwitch service.d directory
-  file: path=/etc/systemd/system/openvswitch.service.d/ state=directory
+- include: config/workaround-bz1331590-ovs-oom-fix.yml
   when: openshift.common.use_openshift_sdn | default(true) | bool
 
-- name: Install OpenvSwitch service OOM fix
-  template:
-    dest: "/etc/systemd/system/openvswitch.service.d/01-avoid-oom.conf"
-    src: openvswitch-avoid-oom.conf
-  when: openshift.common.use_openshift_sdn | default(true) | bool
-  notify:
-  - reload systemd units
-  - restart openvswitch
-
-- name: Install OpenvSwitch docker service file
-  template:
-    dest: "/etc/systemd/system/openvswitch.service"
-    src: openvswitch.docker.service
+- include: config/install-ovs-docker-service-file.yml
   when: openshift.common.is_containerized | bool and openshift.common.use_openshift_sdn | default(true) | bool
-  notify:
-  - reload systemd units
-  - restart openvswitch
 
-- name: Configure Node settings
-  lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
-    regexp: "{{ item.regex }}"
-    line: "{{ item.line }}"
-    create: true
-  with_items:
-  - regex: '^OPTIONS='
-    line: "OPTIONS=--loglevel={{ openshift.node.debug_level | default(2) }}"
-  - regex: '^CONFIG_FILE='
-    line: "CONFIG_FILE={{ openshift.common.config_base }}/node/node-config.yaml"
-  - regex: '^IMAGE_VERSION='
-    line: "IMAGE_VERSION={{ openshift_image_tag }}"
-  notify:
-  - restart node
-
-- name: Configure Proxy Settings
-  lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
-    regexp: "{{ item.regex }}"
-    line: "{{ item.line }}"
-    create: true
-  with_items:
-  - regex: '^HTTP_PROXY='
-    line: "HTTP_PROXY={{ openshift.common.http_proxy | default('') }}"
-  - regex: '^HTTPS_PROXY='
-    line: "HTTPS_PROXY={{ openshift.common.https_proxy | default('') }}"
-  - regex: '^NO_PROXY='
-    line: "NO_PROXY={{ openshift.common.no_proxy | default([]) }},{{ openshift.common.portal_net }},{{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }}"
-  when: ('http_proxy' in openshift.common and openshift.common.http_proxy != '')
-  notify:
-  - restart node
+- include: config/configure-node-settings.yml
+- include: config/configure-proxy-settings.yml


### PR DESCRIPTION
Sync what we can so it is easier to merge both `openshift_node` and `openshift_node_upgrade` roles.

Depends on https://github.com/openshift/openshift-ansible/pull/4897. Once that one gets merged, I will rebase.