### PR TITLE
Stop masters before backing up, block migration for supported configs

### DIFF
--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -17,6 +17,26 @@
   tags:
   - always
 
+- name: Prepare masters for etcd data migration
+  hosts: oo_masters_to_config
+  tasks:
+  - set_fact:
+      master_services:
+      - "{{ openshift.common.service_type + '-master' }}"
+  - set_fact:
+      master_services:
+      - "{{ openshift.common.service_type + '-master-controllers' }}"
+      - "{{ openshift.common.service_type + '-master-api' }}"
+    when:
+    - (openshift_master_cluster_method is defined and openshift_master_cluster_method == "native") or openshift.common.is_master_system_container | bool
+  - debug:
+      msg: "master service name: {{ master_services }}"
+  - name: Stop masters
+    service:
+      name: "{{ item }}"
+      state: stopped
+    with_items: "{{ master_services }}"
+
 - name: Backup v2 data
   hosts: oo_etcd_to_migrate
   gather_facts: no
@@ -46,26 +66,6 @@
       msg: "Migration cannot continue. The following hosts did not complete etcd backup: {{ etcd_backup_failed | join(',') }}"
     when:
     - etcd_backup_failed | length > 0
-
-- name: Prepare masters for etcd data migration
-  hosts: oo_masters_to_config
-  tasks:
-  - set_fact:
-      master_services:
-      - "{{ openshift.common.service_type + '-master' }}"
-  - set_fact:
-      master_services:
-      - "{{ openshift.common.service_type + '-master-controllers' }}"
-      - "{{ openshift.common.service_type + '-master-api' }}"
-    when:
-    - (openshift_master_cluster_method is defined and openshift_master_cluster_method == "native") or openshift.common.is_master_system_container | bool
-  - debug:
-      msg: "master service name: {{ master_services }}"
-  - name: Stop masters
-    service:
-      name: "{{ item }}"
-      state: stopped
-    with_items: "{{ master_services }}"
 
 - name: Migrate etcd data from v2 to v3
   hosts: oo_etcd_to_migrate

--- a/roles/etcd_migrate/tasks/check.yml
+++ b/roles/etcd_migrate/tasks/check.yml
@@ -1,4 +1,8 @@
 ---
+- fail:
+    msg: "Currently etcd v3 migration is unsupported while we test it more thoroughly"
+  when: not openshift_enable_unsupported_configurations | default(false) | bool
+
 # Check the cluster is healthy
 - include: check_cluster_health.yml
 


### PR DESCRIPTION
- Stop master api/controllers before we perform our backup
- Block migration in supported environments until we isolate a data inconsistency issue

See https://bugzilla.redhat.com/show_bug.cgi?id=1475351 for more info on the data issue