### PR TITLE
Tolerate non existence of /etc/sysconfig/atomic-openshift-master

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -133,12 +133,12 @@
 - block:
     - name: check whether our docker-registry setting exists in the env file
       command: "awk '/^OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000/' /etc/sysconfig/{{ openshift.common.service_type }}-master"
-      ignore_errors: true
+      failed_when: false
       changed_when: false
       register: already_set
 
     - set_fact:
-        openshift_push_via_dns: "{{ (openshift_use_dnsmasq | default(true) and openshift.common.version_gte_3_6) or (already_set.stdout | match('OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000')) }}"
+        openshift_push_via_dns: "{{ (openshift_use_dnsmasq | default(true) and openshift.common.version_gte_3_6) or (already_set.stdout is defined and already_set.stdout | match('OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000')) }}"
 
 - name: Set fact of all etcd host IPs
   openshift_facts:


### PR DESCRIPTION
Fixes this
```
TASK [openshift_master : check whether our docker-registry setting exists in the env file] ***
task path: /var/tmp/checkout/roles/openshift_master/tasks/main.yml:134
Using module file /usr/lib/python2.7/site-packages/ansible/modules/commands/command.py
<ocp-master> ESTABLISH SSH CONNECTION FOR USER: root
<ocp-master> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/%h-%r ocp-master '/bin/sh -c '"'"'/usr/bin/python3 && sleep 0'"'"''
<ocp-master> (0, '\n{"cmd": ["awk", "/^OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000/", "/etc/sysconfig/origin-master"], "stdout": "", "stderr": "awk: fatal: cannot open file `/etc/sysconfig/origin-master\' for reading (No such file or directory)", "rc": 2, "start": "2017-07-25 14:36:23.973227", "end": "2017-07-25 14:36:23.975861", "delta": "0:00:00.002634", "changed": true, "warnings": [], "invocation": {"module_args": {"_raw_params": "awk \'/^OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000/\' /etc/sysconfig/origin-master", "_uses_shell": false, "warn": true, "chdir": null, "executable": null, "creates": null, "removes": null}}}\n', '')
fatal: [ocp-master]: FAILED! => {
    "changed": false, 
    "cmd": [
        "awk", 
        "/^OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000/", 
        "/etc/sysconfig/origin-master"
    ], 
    "delta": "0:00:00.002634", 
    "end": "2017-07-25 14:36:23.975861", 
    "failed": true, 
    "invocation": {
        "module_args": {
            "_raw_params": "awk '/^OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000/' /etc/sysconfig/origin-master", 
            "_uses_shell": false, 
            "chdir": null, 
            "creates": null, 
            "executable": null, 
            "removes": null, 
            "warn": true
        }
    }, 
    "rc": 2, 
    "start": "2017-07-25 14:36:23.973227"
}

STDERR:

awk: fatal: cannot open file `/etc/sysconfig/origin-master' for reading (No such file or directory)
...ignoring
```