### PR TITLE
Build full chains out of named_certificates that come with CAs

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -804,6 +804,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # be added to the OpenShift CA bundle which allows for the named
 # certificate to be served for internal cluster communication.
 #
+# When a CA is provided it is combined with the certificate as a full chain
+# to ensure consumers are able to validate the certificate.
+#
 # If you would like openshift_master_named_certificates to be overwritten with
 # the provided value, specify openshift_master_overwrite_named_certificates.
 #openshift_master_overwrite_named_certificates=true

--- a/roles/openshift_named_certificates/tasks/main.yml
+++ b/roles/openshift_named_certificates/tasks/main.yml
@@ -24,10 +24,17 @@
     state: directory
     mode: 0700
 
-- name: Land named certificates
+- name: Ensure temporary fragment directories exist for building full chain cert files
+  file:
+    path: "{{ named_certs_dir }}/fragments/{{ item.certfile | basename }}"
+    state: directory
+    mode: 0700
+  with_items: "{{ named_certificates }}"
+
+- name: Land named certificates in temporary fragment directories
   copy:
     src: "{{ item.certfile }}"
-    dest: "{{ named_certs_dir }}/{{ item.certfile | basename }}"
+    dest: "{{ named_certs_dir }}/fragments/{{ item.certfile | basename }}/00_{{ item.certfile | basename }}"
   with_items: "{{ named_certificates }}"
 
 - name: Land named certificate keys
@@ -39,7 +46,29 @@
 
 - name: Land named CA certificates
   copy:
-    src: "{{ item }}"
-    dest: "{{ named_certs_dir }}/{{ item | basename }}"
+    src: "{{ item.cafile }}"
+    dest: "{{ named_certs_dir }}/{{ item.cafile | basename }}"
     mode: 0600
-  with_items: "{{ named_certificates | lib_utils_oo_collect('cafile') }}"
+  with_items: "{{ named_certificates }}"
+  when: "'cafile' in item"
+
+- name: Land named CA certificates in temporary fragment directories
+  copy:
+    src: "{{ item.cafile }}"
+    dest: "{{ named_certs_dir }}/fragments/{{ item.certfile | basename }}/01_{{ item.cafile | basename }}"
+    mode: 0600
+  with_items: "{{ named_certificates }}"
+  when: "'cafile' in item"
+
+- name: Compile cert files from fragments
+  assemble:
+    src: "{{ named_certs_dir }}/fragments/{{ item.certfile | basename }}"
+    dest: "{{ named_certs_dir }}/{{ item.certfile | basename }}"
+    mode: 0600
+    validate: "openssl verify %s"
+  with_items: "{{ named_certificates }}"
+
+- name: Clear out fragments
+  file:
+    path: "{{ named_certs_dir }}/fragments"
+    state: absent


### PR DESCRIPTION
I've spent that last little bit trying to figure out why our custom CA wasn't always working. Turns out on 2 of our 3 masters it just wasn't behaving properly.  @abutcher and @damaestro helped me troubleshoot.

We were validating with

```
for x in {1..3}; do echo Q | openssl s_client -showcerts -connect master${x}.example.com:8443 -servername openshift.example.com; done
```
and
```
for x in {1..3}; do IP=$(host master${x}.example.com | awk '{print $4}'); echo "Testing ${host}: $(curl -s --resolve openshift.example.com:8443:$IP https://openshift.example.com:8443/healthz/ready || echo fail)"; done
```

We could never find out why master1 was working, but when we put the full chain (cert+int+root) in the certfile, things started working properly.

So after a quick convo on how to just make this happen, without changing people's inventory files, i created this change set.

You can validate this off to the side fairly easy with this attached playbook.

[named_certs.yml.txt](https://github.com/openshift/openshift-ansible/files/1182016/named_certs.yml.txt)
