### PR TITLE
Updating metrics role to create serviceaccounts and roles immediately

### DIFF
--- a/roles/openshift_metrics/tasks/generate_rolebindings.yaml
+++ b/roles/openshift_metrics/tasks/generate_rolebindings.yaml
@@ -37,3 +37,12 @@
     src: hawkular_metrics_role.j2
     dest: "{{ mktemp.stdout }}/templates/hawkular-cluster-role.yaml"
   changed_when: no
+
+- name: Set hawkular cluster roles
+  oc_obj:
+    name: hawkular-metrics
+    namespace: "{{ openshift_metrics_hawkular_agent_namespace }}"
+    kind: clusterrole
+    files:
+    - "{{ mktemp.stdout }}/templates/hawkular-cluster-role.yaml"
+    delete_after: true

--- a/roles/openshift_metrics/tasks/generate_serviceaccounts.yaml
+++ b/roles/openshift_metrics/tasks/generate_serviceaccounts.yaml
@@ -13,3 +13,15 @@
   - name: cassandra
     secret: hawkular-cassandra-secrets
   changed_when: no
+
+- name: Set serviceaccounts for hawkular metrics/cassandra
+  oc_obj:
+    name: "{{ item }}"
+    kind: serviceaccount
+    namespace: "{{ openshift_metrics_hawkular_agent_namespace }}"
+    files:
+    - "{{ mktemp.stdout }}/templates/metrics-{{ item }}-sa.yaml"
+    delete_after: true
+  with_items:
+  - hawkular
+  - cassandra


### PR DESCRIPTION
When `oc apply` was being ran against the rolebinding the role it required didn't exist at the time.
This ensures that roles and serviceaccounts are created right away to avoid timing conflicts

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1476195