### PR TITLE
[3.6] use mux_client_mode instead of use_mux_client

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -135,16 +135,23 @@ Elasticsearch OPS too, if using an OPS cluster:
   secure_forward forwarder for the node agent Fluentd daemonsets running in the
   cluster.  This can be used to reduce the number of connections to the
   OpenShift API server, by using `mux` and configuring each node Fluentd to
-  send raw logs to mux and turn off the k8s metadata plugin.
+  send raw logs to mux and turn off the k8s metadata plugin.  This requires the
+  use of `openshift_logging_mux_client_mode` (see below).
 - `openshift_logging_mux_allow_external`: Default `False`.  If this is `True`,
   the `mux` service will be deployed, and it will be configured to allow
   Fluentd clients running outside of the cluster to send logs using
   secure_forward.  This allows OpenShift logging to be used as a central
   logging service for clients other than OpenShift, or other OpenShift
   clusters.
-- `openshift_logging_use_mux_client`: Default `False`.  If this is `True`, the
-  node agent Fluentd services will be configured to send logs to the mux
-  service rather than directly to Elasticsearch.
+- `openshift_logging_mux_client_mode`: Values - `minimal`, `maximal`.
+  Default is unset.  Setting this value will cause the Fluentd node agent to
+  send logs to mux rather than directly to Elasticsearch.  The value
+  `maximal` means that Fluentd will do as much processing as possible at the
+  node before sending the records to mux.  This is the current recommended
+  way to use mux due to current scaling issues.
+  The value `minimal` means that Fluentd will do *no* processing at all, and
+  send the raw logs to mux for processing.  We do not currently recommend using
+  this mode, and ansible will warn you about this.
 - `openshift_logging_mux_hostname`: Default is "mux." +
   `openshift_master_default_subdomain`.  This is the hostname *external*_
   clients will use to connect to mux, and will be used in the TLS server cert

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -157,8 +157,6 @@ openshift_logging_storage_access_modes: "{{ openshift_hosted_logging_storage_acc
 # mux - secure_forward listener service
 openshift_logging_mux_allow_external: False
 openshift_logging_use_mux: "{{ openshift_logging_mux_allow_external | default(False) }}"
-# this tells the fluentd node agent to use mux instead of sending directly to Elasticsearch
-openshift_logging_use_mux_client: False
 openshift_logging_mux_hostname: "{{ 'mux.' ~ (openshift_master_default_subdomain | default('router.default.svc.cluster.local', true)) }}"
 openshift_logging_mux_port: 24284
 openshift_logging_mux_cpu_limit: 500m

--- a/roles/openshift_logging_fluentd/defaults/main.yml
+++ b/roles/openshift_logging_fluentd/defaults/main.yml
@@ -48,7 +48,6 @@ openshift_logging_fluentd_aggregating_strict: "no"
 openshift_logging_fluentd_aggregating_cert_path: none
 openshift_logging_fluentd_aggregating_key_path: none
 openshift_logging_fluentd_aggregating_passphrase: none
-openshift_logging_use_mux_client: False
 
 ### Deprecating in 3.6
 openshift_logging_fluentd_es_copy: false

--- a/roles/openshift_logging_fluentd/tasks/main.yaml
+++ b/roles/openshift_logging_fluentd/tasks/main.yaml
@@ -23,6 +23,14 @@
     msg: openshift_hosted_logging_use_journal is deprecated.  Fluentd will automatically detect which logging driver is being used.
   when: openshift_hosted_logging_use_journal is defined
 
+- fail:
+    msg: Invalid openshift_logging_mux_client_mode [{{ openshift_logging_mux_client_mode }}], one of {{ __allowed_mux_client_modes }} allowed
+  when: openshift_logging_mux_client_mode is defined and not openshift_logging_mux_client_mode in __allowed_mux_client_modes
+
+- debug:
+    msg: WARNING Use of openshift_logging_mux_client_mode=minimal is not recommended due to current scaling issues
+  when: openshift_logging_mux_client_mode is defined and openshift_logging_mux_client_mode == 'minimal'
+
 - include: determine_version.yaml
 
 # allow passing in a tempdir

--- a/roles/openshift_logging_fluentd/templates/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/fluentd.j2
@@ -64,7 +64,7 @@ spec:
           readOnly: true
         - name: filebufferstorage
           mountPath: /var/lib/fluentd
-{% if openshift_logging_use_mux_client | bool %}
+{% if openshift_logging_mux_client_mode is defined %}
         - name: muxcerts
           mountPath: /etc/fluent/muxkeys
           readOnly: true
@@ -112,10 +112,12 @@ spec:
             resourceFieldRef:
               containerName: "{{ daemonset_container_name }}"
               resource: limits.memory
-        - name: "USE_MUX_CLIENT"
-          value: "{{ openshift_logging_use_mux_client | default('false') | lower }}"
         - name: "FILE_BUFFER_LIMIT"
           value: "{{ openshift_logging_fluentd_file_buffer_limit | default('1Gi') }}"
+{% if openshift_logging_mux_client_mode is defined %}
+        - name: "MUX_CLIENT_MODE"
+          value: "{{ openshift_logging_mux_client_mode }}"
+{% endif %}
       volumes:
       - name: runlogjournal
         hostPath:
@@ -144,7 +146,7 @@ spec:
       - name: dockerdaemoncfg
         hostPath:
           path: /etc/docker
-{% if openshift_logging_use_mux_client | bool %}
+{% if openshift_logging_mux_client_mode is defined %}
       - name: muxcerts
         secret:
           secretName: logging-mux

--- a/roles/openshift_logging_fluentd/vars/main.yml
+++ b/roles/openshift_logging_fluentd/vars/main.yml
@@ -2,3 +2,4 @@
 __latest_fluentd_version: "3_5"
 __allowed_fluentd_versions: ["3_5", "3_6"]
 __allowed_fluentd_types: ["hosted", "secure-aggregator", "secure-host"]
+__allowed_mux_client_modes: ["minimal", "maximal"]

--- a/roles/openshift_logging_mux/defaults/main.yml
+++ b/roles/openshift_logging_mux/defaults/main.yml
@@ -28,6 +28,7 @@ openshift_logging_mux_journal_source: "{{ openshift_hosted_logging_journal_sourc
 openshift_logging_mux_journal_read_from_head: "{{ openshift_hosted_logging_journal_read_from_head | default('') }}"
 
 openshift_logging_mux_allow_external: False
+openshift_logging_use_mux: "{{ openshift_logging_mux_allow_external | default(False) }}"
 openshift_logging_mux_hostname: "{{ 'mux.' ~ (openshift_master_default_subdomain | default('router.default.svc.cluster.local', true)) }}"
 openshift_logging_mux_port: 24284
 # the namespace to use for undefined projects should come first, followed by any

--- a/roles/openshift_logging_mux/templates/mux.j2
+++ b/roles/openshift_logging_mux/templates/mux.j2
@@ -101,8 +101,6 @@ spec:
           value: "{{ openshift_logging_mux_port }}"
         - name: USE_MUX
           value: "true"
-        - name: MUX_ALLOW_EXTERNAL
-          value: "{{ openshift_logging_mux_allow_external | default('false') | lower }}"
         - name: "BUFFER_QUEUE_LIMIT"
           value: "{{ openshift_logging_mux_buffer_queue_limit }}"
         - name: "BUFFER_SIZE_LIMIT"


### PR DESCRIPTION
Instead of the `openshift_logging_use_mux_client` boolean parameter,
use `openshift_logging_mux_client_mode` which will allow us to support
different mux client use cases:
The value `maximal` will cause Fluentd to perform as much of the
processing as possible at the local node.  This currently means all of
the processing *except* for the Kubernetes metadata processing, which will
be done by mux.  This is the currently recommended mode to use due to
current scaling issues.
The value `minimal` means that Fluentd will do *no* processing at all,
and send the raw logs to mux for processing.  This is currently not
recommended to use due to current scaling issues.  Ansible will warn
you if you try to use this mode.

`MUX_ALLOW_EXTERNAL` is no longer needed in the mux dc.  mux now always
operates to process external logs.  The ansible setting
`openshift_logging_mux_allow_external` is still required in order to
set up the mux service to accept connections from outside of the
cluster.
@jcantrill this is the cherry-pick for release-3.6
(cherry picked from commit 780b9481c124656f15b97aa373e4ad14103d4b7f)