### PR TITLE
Add CFME external database app template

### DIFF
--- a/roles/openshift_examples/files/examples/v1.5/cfme-templates/cfme-template-ext-db.yaml
+++ b/roles/openshift_examples/files/examples/v1.5/cfme-templates/cfme-template-ext-db.yaml
@@ -1,0 +1,414 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: cloudforms-ext-db
+metadata:
+  name: cloudforms-ext-db
+  annotations:
+    description: "CloudForms appliance with persistent storage using an external DB host"
+    tags: "instant-app,cloudforms,cfme"
+    iconClass: "icon-rails"
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: "${NAME}-secrets"
+  stringData:
+    pg-password: "${DATABASE_PASSWORD}"
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: "Exposes and load balances CloudForms pods"
+      service.alpha.openshift.io/dependencies: '[{"name":"${DATABASE_SERVICE_NAME}","namespace":"","kind":"Service"},{"name":"${MEMCACHED_SERVICE_NAME}","namespace":"","kind":"Service"}]'
+    name: ${NAME}
+  spec:
+    clusterIP: None
+    ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 80
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 443
+    selector:
+      name: ${NAME}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: "${DATABASE_SERVICE_NAME}"
+    annotations:
+      description: Remote database service
+  spec:
+    ports:
+    - name: postgresql
+      port: 5432
+      targetPort: 5432
+    type: ExternalName
+    externalName: "${DATABASE_HOST}"
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: ${NAME}
+  spec:
+    host: ${APPLICATION_DOMAIN}
+    port:
+      targetPort: https
+    tls:
+      termination: passthrough
+    to:
+      kind: Service
+      name: ${NAME}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: cfme-openshift-app
+    annotations:
+      description: "Keeps track of changes in the CloudForms app image"
+  spec:
+    dockerImageRepository: "${APPLICATION_IMG_NAME}"
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: cfme-openshift-memcached
+    annotations:
+      description: "Keeps track of changes in the CloudForms memcached image"
+  spec:
+    dockerImageRepository: "${MEMCACHED_IMG_NAME}"
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: "${NAME}-region"
+  spec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${APPLICATION_REGION_VOLUME_CAPACITY}
+- apiVersion: apps/v1beta1
+  kind: "StatefulSet"
+  metadata:
+    name: ${NAME}
+    annotations:
+      description: "Defines how to deploy the CloudForms appliance"
+  spec:
+    serviceName: "${NAME}"
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          name: ${NAME}
+        name: ${NAME}
+      spec:
+        containers:
+        - name: cloudforms
+          image: "${APPLICATION_IMG_NAME}:${APPLICATION_IMG_TAG}"
+          livenessProbe:
+            tcpSocket:
+              port: 443
+            initialDelaySeconds: 480
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 443
+              scheme: HTTPS
+            initialDelaySeconds: 200
+            timeoutSeconds: 3
+          ports:
+          - containerPort: 80
+            protocol: TCP
+          - containerPort: 443
+            protocol: TCP
+          securityContext:
+            privileged: true
+          volumeMounts:
+              -
+                name: "${NAME}-server"
+                mountPath: "/persistent"
+              -
+                name: "${NAME}-region"
+                mountPath: "/persistent-region"
+          env:
+            -
+              name: "APPLICATION_INIT_DELAY"
+              value: "${APPLICATION_INIT_DELAY}"
+            -
+              name: "DATABASE_SERVICE_NAME"
+              value: "${DATABASE_SERVICE_NAME}"
+            -
+              name: "DATABASE_REGION"
+              value: "${DATABASE_REGION}"
+            -
+              name: "MEMCACHED_SERVICE_NAME"
+              value: "${MEMCACHED_SERVICE_NAME}"
+            -
+              name: "POSTGRESQL_USER"
+              value: "${DATABASE_USER}"
+            -
+              name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "${NAME}-secrets"
+                  key: pg-password
+            -
+              name: "POSTGRESQL_DATABASE"
+              value: "${DATABASE_NAME}"
+            -
+              name: "POSTGRESQL_MAX_CONNECTIONS"
+              value: "${POSTGRESQL_MAX_CONNECTIONS}"
+            -
+              name: "POSTGRESQL_SHARED_BUFFERS"
+              value: "${POSTGRESQL_SHARED_BUFFERS}"
+          resources:
+            requests:
+              memory: "${APPLICATION_MEM_REQ}"
+              cpu: "${APPLICATION_CPU_REQ}"
+            limits:
+              memory: "${APPLICATION_MEM_LIMIT}"
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /opt/rh/cfme-container-scripts/sync-pv-data
+        volumes:
+         -
+           name: "${NAME}-region"
+           persistentVolumeClaim:
+             claimName: ${NAME}-region
+    volumeClaimTemplates:
+      - metadata:
+          name: "${NAME}-server"
+          annotations:
+            # Uncomment this if using dynamic volume provisioning.
+            # https://docs.openshift.org/latest/install_config/persistent_storage/dynamically_provisioning_pvs.html
+            # volume.alpha.kubernetes.io/storage-class: anything
+        spec:
+          accessModes: [ ReadWriteOnce ]
+          resources:
+            requests:
+              storage: "${APPLICATION_VOLUME_CAPACITY}"
+- apiVersion: v1
+  kind: "Service"
+  metadata:
+    name: "${MEMCACHED_SERVICE_NAME}"
+    annotations:
+      description: "Exposes the memcached server"
+  spec:
+    ports:
+      -
+        name: "memcached"
+        port: 11211
+        targetPort: 11211
+    selector:
+      name: "${MEMCACHED_SERVICE_NAME}"
+- apiVersion: v1
+  kind: "DeploymentConfig"
+  metadata:
+    name: "${MEMCACHED_SERVICE_NAME}"
+    annotations:
+      description: "Defines how to deploy memcached"
+  spec:
+    strategy:
+      type: "Recreate"
+    triggers:
+      -
+        type: "ImageChange"
+        imageChangeParams:
+          automatic: true
+          containerNames:
+            - "memcached"
+          from:
+            kind: "ImageStreamTag"
+            name: "cfme-openshift-memcached:${MEMCACHED_IMG_TAG}"
+      -
+        type: "ConfigChange"
+    replicas: 1
+    selector:
+      name: "${MEMCACHED_SERVICE_NAME}"
+    template:
+      metadata:
+        name: "${MEMCACHED_SERVICE_NAME}"
+        labels:
+          name: "${MEMCACHED_SERVICE_NAME}"
+      spec:
+        volumes: []
+        containers:
+          -
+            name: "memcached"
+            image: "${MEMCACHED_IMG_NAME}:${MEMCACHED_IMG_TAG}"
+            ports:
+              -
+                containerPort: 11211
+            readinessProbe:
+              timeoutSeconds: 1
+              initialDelaySeconds: 5
+              tcpSocket:
+                port: 11211
+            livenessProbe:
+              timeoutSeconds: 1
+              initialDelaySeconds: 30
+              tcpSocket:
+                port: 11211
+            volumeMounts: []
+            env:
+              -
+                name: "MEMCACHED_MAX_MEMORY"
+                value: "${MEMCACHED_MAX_MEMORY}"
+              -
+                name: "MEMCACHED_MAX_CONNECTIONS"
+                value: "${MEMCACHED_MAX_CONNECTIONS}"
+              -
+                name: "MEMCACHED_SLAB_PAGE_SIZE"
+                value: "${MEMCACHED_SLAB_PAGE_SIZE}"
+            resources:
+              requests:
+                memory: "${MEMCACHED_MEM_REQ}"
+                cpu: "${MEMCACHED_CPU_REQ}"
+              limits:
+                memory: "${MEMCACHED_MEM_LIMIT}"
+parameters:
+  -
+    name: "NAME"
+    displayName: Name
+    required: true
+    description: "The name assigned to all of the frontend objects defined in this template."
+    value: cloudforms
+  -
+    name: "DATABASE_SERVICE_NAME"
+    displayName: "PostgreSQL Service Name"
+    required: true
+    description: "The name of the OpenShift Service exposed for the PostgreSQL container."
+    value: "postgresql"
+  -
+    name: DATABASE_HOST
+    displayName: PostgreSQL Server Host
+    required: true
+    description: PostgreSQL external server host used to configure service.
+    value: ''
+  -
+    name: "DATABASE_USER"
+    displayName: "PostgreSQL User"
+    required: true
+    description: "PostgreSQL user that will access the database."
+    value: "root"
+  -
+    name: "DATABASE_PASSWORD"
+    displayName: "PostgreSQL Password"
+    required: true
+    description: "Password for the PostgreSQL user."
+    value: "smartvm"
+  -
+    name: "DATABASE_NAME"
+    required: true
+    displayName: "PostgreSQL Database Name"
+    description: "Name of the PostgreSQL database accessed."
+    value: "vmdb_production"
+  -
+    name: "DATABASE_REGION"
+    required: true
+    displayName: "Application Database Region"
+    description: "Database region that will be used for application."
+    value: "0"
+  -
+    name: "MEMCACHED_SERVICE_NAME"
+    required: true
+    displayName: "Memcached Service Name"
+    description: "The name of the OpenShift Service exposed for the Memcached container."
+    value: "memcached"
+  -
+    name: "MEMCACHED_MAX_MEMORY"
+    displayName: "Memcached Max Memory"
+    description: "Memcached maximum memory for memcached object storage in MB."
+    value: "64"
+  -
+    name: "MEMCACHED_MAX_CONNECTIONS"
+    displayName: "Memcached Max Connections"
+    description: "Memcached maximum number of connections allowed."
+    value: "1024"
+  -
+    name: "MEMCACHED_SLAB_PAGE_SIZE"
+    displayName: "Memcached Slab Page Size"
+    description: "Memcached size of each slab page."
+    value: "1m"
+  -
+    name: "APPLICATION_CPU_REQ"
+    displayName: "Application Min CPU Requested"
+    required: true
+    description: "Minimum amount of CPU time the Application container will need (expressed in millicores)."
+    value: "1000m"
+  -
+    name: "MEMCACHED_CPU_REQ"
+    displayName: "Memcached Min CPU Requested"
+    required: true
+    description: "Minimum amount of CPU time the Memcached container will need (expressed in millicores)."
+    value: "200m"
+  -
+    name: "APPLICATION_MEM_REQ"
+    displayName: "Application Min RAM Requested"
+    required: true
+    description: "Minimum amount of memory the Application container will need."
+    value: "6144Mi"
+  -
+    name: "MEMCACHED_MEM_REQ"
+    displayName: "Memcached Min RAM Requested"
+    required: true
+    description: "Minimum amount of memory the Memcached container will need."
+    value: "64Mi"
+  -
+    name: "APPLICATION_MEM_LIMIT"
+    displayName: "Application Max RAM Limit"
+    required: true
+    description: "Maximum amount of memory the Application container can consume."
+    value: "16384Mi"
+  -
+    name: "MEMCACHED_MEM_LIMIT"
+    displayName: "Memcached Max RAM Limit"
+    required: true
+    description: "Maximum amount of memory the Memcached container can consume."
+    value: "256Mi"
+  -
+    name: "MEMCACHED_IMG_NAME"
+    displayName: "Memcached Image Name"
+    description: "This is the Memcached image name requested to deploy."
+    value: "registry.access.redhat.com/cloudforms45/cfme-openshift-memcached"
+  -
+    name: "MEMCACHED_IMG_TAG"
+    displayName: "Memcached Image Tag"
+    description: "This is the Memcached image tag/version requested to deploy."
+    value: "latest"
+  -
+    name: "APPLICATION_IMG_NAME"
+    displayName: "Application Image Name"
+    description: "This is the Application image name requested to deploy."
+    value: "registry.access.redhat.com/cloudforms45/cfme-openshift-app"
+  -
+    name: "APPLICATION_IMG_TAG"
+    displayName: "Application Image Tag"
+    description: "This is the Application image tag/version requested to deploy."
+    value: "latest"
+  -
+    name: "APPLICATION_DOMAIN"
+    displayName: "Application Hostname"
+    description: "The exposed hostname that will route to the application service, if left blank a value will be defaulted."
+    value: ""
+  -
+    name: "APPLICATION_INIT_DELAY"
+    displayName: "Application Init Delay"
+    required: true
+    description: "Delay in seconds before we attempt to initialize the application."
+    value: "15"
+  -
+    name: "APPLICATION_VOLUME_CAPACITY"
+    displayName: "Application Volume Capacity"
+    required: true
+    description: "Volume space available for application data."
+    value: "5Gi"
+  -
+    name: "APPLICATION_REGION_VOLUME_CAPACITY"
+    displayName: "Application Region Volume Capacity"
+    required: true
+    description: "Volume space available for region application data."
+    value: "5Gi"


### PR DESCRIPTION
The Red Hat documentation for Cloudforms install on Openshift references a template for provisioning using a database external to the cluster: [Installing CF on Openshift: Deploy with external DB](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html-single/installing_red_hat_cloudforms_on_openshift_container_platform/#deploying-the-appliance-external-db).

This template provides similar functionality to the cfme-template already included, but with references to ExternalName service instead of a service existing within the cluster.

Edit: Tested against Openshift 3.5