### PR TITLE
[1.3] When trying to grant user to appropriate scc it fails

### DIFF
--- a/roles/openshift_serviceaccounts/tasks/main.yml
+++ b/roles/openshift_serviceaccounts/tasks/main.yml
@@ -28,7 +28,10 @@
   command: >
       {{ openshift.common.client_binary }} adm policy add-scc-to-user
       {{ item.1.item }} system:serviceaccount:{{ openshift_serviceaccounts_namespace }}:{{ item.0 }}
-  when: "openshift.common.version_gte_3_1_or_1_1 and item.1.rc == 0 and 'system:serviceaccount:{{ openshift_serviceaccounts_namespace }}:{{ item.0 }}' not in {{ (item.1.stdout | from_yaml).users | default([]) }}"
+  when:
+  - openshift.common.version_gte_3_1_or_1_1
+  - item.1.rc == 0
+  - "'system:serviceaccount:{{ openshift_serviceaccounts_namespace }}:{{ item.0 }}' not in {{ (item.1.stdout | from_yaml).users | default([]) }}"
   with_nested:
   - "{{ openshift_serviceaccounts_names }}"
   - "{{ scc_test.results }}"


### PR DESCRIPTION
Installation fails with below error:

{"failed": true, "msg": "The conditional check 'openshift.common.version_gte_3_1_or_1_1 and item.1.rc == 0 and 'system:serviceaccount:{{ openshift_serviceaccounts_namespace }}:{{ item.0 }}' not in {{ (item.1.stdout | from_yaml).users | default([]) }}' failed. The error was: Invalid conditional detected: invalid syntax (, line 1)\n\nThe error appears to have been in '/usr/share/ansible/openshift-ansible/roles/openshift_serviceaccounts/tasks/main.yml': line 27, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Grant the user access to the appropriate scc\n ^ here\n"}

Issue observed with : 
ansible-2.3.1.0-3.el7.noarch

Signed-off-by: jkaurredhat <jkaur@redhat.com>