### PR TITLE
Fixing SA and clusterrole namespaces

### DIFF
--- a/roles/openshift_metrics/tasks/generate_rolebindings.yaml
+++ b/roles/openshift_metrics/tasks/generate_rolebindings.yaml
@@ -41,7 +41,7 @@
 - name: Set hawkular cluster roles
   oc_obj:
     name: hawkular-metrics
-    namespace: "{{ openshift_metrics_hawkular_agent_namespace }}"
+    namespace: "{{ openshift_metrics_project }}"
     kind: clusterrole
     files:
     - "{{ mktemp.stdout }}/templates/hawkular-cluster-role.yaml"

--- a/roles/openshift_metrics/tasks/generate_serviceaccounts.yaml
+++ b/roles/openshift_metrics/tasks/generate_serviceaccounts.yaml
@@ -18,7 +18,7 @@
   oc_obj:
     name: "{{ item }}"
     kind: serviceaccount
-    namespace: "{{ openshift_metrics_hawkular_agent_namespace }}"
+    namespace: "{{ openshift_metrics_project }}"
     files:
     - "{{ mktemp.stdout }}/templates/metrics-{{ item }}-sa.yaml"
     delete_after: true


### PR DESCRIPTION
Was generating SA and clusterroles in the incorrect namespace.
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1477440