### PR TITLE
[3.6] GlusterFS: Copy SSH private key to master node.

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
@@ -163,6 +163,11 @@
   - glusterfs_heketi_is_native
   - glusterfs_heketi_user_key is undefined
 
+- name: Copy heketi private key
+  copy:
+    src: "{{ glusterfs_heketi_ssh_keyfile }}"
+    dest: "{{ mktemp.stdout }}/private_key"
+
 - name: Create heketi config secret
   oc_secret:
     namespace: "{{ glusterfs_namespace }}"
@@ -173,7 +178,7 @@
     - name: heketi.json
       path: "{{ mktemp.stdout }}/heketi.json"
     - name: private_key
-      path: "{{ glusterfs_heketi_ssh_keyfile }}"
+      path: "{{ mktemp.stdout }}/private_key"
   when:
   - glusterfs_heketi_is_native
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1477718

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>