### PR TITLE
only provision nfs PVs if cloud_provider not defined

### DIFF
--- a/roles/openshift_cfme/tasks/main.yml
+++ b/roles/openshift_cfme/tasks/main.yml
@@ -24,48 +24,10 @@
 
 ######################################################################
 # NFS
+# In the case that we are not running on a cloud provider, volumes must be statically provisioned
 
-- name: Ensure the /exports/ directory exists
-  file:
-    path: /exports/
-    state: directory
-    mode: 0755
-    owner: root
-    group: root
-
-- name: Ensure the miq-pv0X export directories exist
-  file:
-    path: "/exports/{{ item }}"
-    state: directory
-    mode: 0775
-    owner: root
-    group: root
-  with_items: "{{ openshift_cfme_pv_exports }}"
-
-- name: Ensure the NFS exports for CFME PVs exist
-  copy:
-    src: openshift_cfme.exports
-    dest: /etc/exports.d/openshift_cfme.exports
-  register: nfs_exports_updated
-
-- name: Ensure the NFS export table is refreshed if exports were added
-  command: exportfs -ar
-  when:
-    - nfs_exports_updated.changed
-
-
-######################################################################
-# Create the required CFME PVs. Check out these online docs if you
-# need a refresher on includes looping with items:
-# * http://docs.ansible.com/ansible/playbooks_loops.html#loops-and-includes-in-2-0
-# * http://stackoverflow.com/a/35128533
-#
-# TODO: Handle the case where a PV template is updated in
-# openshift-ansible and the change needs to be landed on the managed
-# cluster.
-
-- include: create_pvs.yml
-  with_items: "{{ openshift_cfme_pv_data }}"
+- include: nfs.yml
+  when: not (openshift_cloudprovider_kind is defined and (openshift_cloudprovider_kind == 'aws' or openshift_cloudprovider_kind == 'gce'))
 
 ######################################################################
 # CFME App Template

--- a/roles/openshift_cfme/tasks/nfs.yml
+++ b/roles/openshift_cfme/tasks/nfs.yml
@@ -1,0 +1,44 @@
+---
+# Tasks to statically provision NFS volumes
+# Include if not using dynamic volume provisioning
+- name: Ensure the /exports/ directory exists
+  file:
+    path: /exports/
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Ensure the miq-pv0X export directories exist
+  file:
+    path: "/exports/{{ item }}"
+    state: directory
+    mode: 0775
+    owner: root
+    group: root
+  with_items: "{{ openshift_cfme_pv_exports }}"
+
+- name: Ensure the NFS exports for CFME PVs exist
+  copy:
+    src: openshift_cfme.exports
+    dest: /etc/exports.d/openshift_cfme.exports
+  register: nfs_exports_updated
+
+- name: Ensure the NFS export table is refreshed if exports were added
+  command: exportfs -ar
+  when:
+    - nfs_exports_updated.changed
+
+
+######################################################################
+# Create the required CFME PVs. Check out these online docs if you
+# need a refresher on includes looping with items:
+# * http://docs.ansible.com/ansible/playbooks_loops.html#loops-and-includes-in-2-0
+# * http://stackoverflow.com/a/35128533
+#
+# TODO: Handle the case where a PV template is updated in
+# openshift-ansible and the change needs to be landed on the managed
+# cluster.
+
+- include: create_pvs.yml
+  with_items: "{{ openshift_cfme_pv_data }}"

--- a/roles/openshift_cfme/tasks/uninstall.yml
+++ b/roles/openshift_cfme/tasks/uninstall.yml
@@ -25,6 +25,7 @@
     kind: pv
     name: "{{ item }}"
   with_items: "{{ openshift_cfme_pv_exports }}"
+  when: not (openshift_cloudprovider_kind is defined and (openshift_cloudprovider_kind == 'aws' or openshift_cloudprovider_kind == 'gce'))
 
 - name: Ensure the CFME user is removed
   oc_user:
@@ -36,8 +37,10 @@
     path: /etc/exports.d/openshift_cfme.exports
     state: absent
   register: nfs_exports_removed
+  when: not (openshift_cloudprovider_kind is defined and (openshift_cloudprovider_kind == 'aws' or openshift_cloudprovider_kind == 'gce'))
 
 - name: Ensure the NFS export table is refreshed if exports were removed
   command: exportfs -ar
   when:
     - nfs_exports_removed.changed
+    - not (openshift_cloudprovider_kind is defined and (openshift_cloudprovider_kind == 'aws' or openshift_cloudprovider_kind == 'gce'))


### PR DESCRIPTION
**This PR is a WIP to resolve #4567 **

This change blocks off the static provisioning of NFS-backed PVs, ensuring they are only created 
```yaml
when: not (openshift_cloudprovider_kind is defined and (openshift_cloudprovider_kind == 'aws' or openshift_cloudprovider_kind == 'gce'))
```

This will allow us to take advantage of dynamic pv provisioning, which should be pre-configured by the `openshift_hosted.yml` playbook if we're running on a hosted environemnt.