### PR TITLE
Moved Elasticsearch 2.x deployment entirely into openshift_logging_elasticsearch role

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -90,9 +90,9 @@ openshift_logging_es_cpu_limit: 1000m
 openshift_logging_es_log_appenders: ['file']
 openshift_logging_es_memory_limit: "8Gi"
 openshift_logging_es_pv_selector: "{{ openshift_logging_storage_labels | default({}) }}"
-openshift_logging_es_pvc_dynamic: "{{ openshift_logging_elasticsearch_pvc_dynamic | default(False) }}"
-openshift_logging_es_pvc_size: "{{ openshift_logging_elasticsearch_pvc_size | default('') }}"
-openshift_logging_es_pvc_prefix: "{{ openshift_logging_elasticsearch_pvc_prefix | default('logging-es') }}"
+openshift_logging_es_pvc_dynamic: "{{ openshift_logging_legacy_es_pvc_dynamic | default(False) }}"
+openshift_logging_es_pvc_size: "{{ openshift_logging_legacy_es_pvc_size | default('') }}"
+openshift_logging_es_pvc_prefix: "{{ openshift_logging_legacy_es_pvc_prefix | default('logging-es') }}"
 openshift_logging_es_recover_after_time: 5m
 openshift_logging_es_storage_group: "65534"
 openshift_logging_es_nodeselector: {}
@@ -129,9 +129,9 @@ openshift_logging_es_ops_cluster_size: "{{ openshift_logging_elasticsearch_ops_c
 openshift_logging_es_ops_cpu_limit: 1000m
 openshift_logging_es_ops_memory_limit: "8Gi"
 openshift_logging_es_ops_pv_selector: "{{ openshift_loggingops_storage_labels | default({}) }}"
-openshift_logging_es_ops_pvc_dynamic: "{{ openshift_logging_elasticsearch_ops_pvc_dynamic | default(False) }}"
-openshift_logging_es_ops_pvc_size: "{{ openshift_logging_elasticsearch_ops_pvc_size | default('') }}"
-openshift_logging_es_ops_pvc_prefix: "{{ openshift_logging_elasticsearch_ops_pvc_prefix | default('logging-es-ops') }}"
+openshift_logging_es_ops_pvc_dynamic: "{{ openshift_logging_legacy_es_ops_pvc_dynamic | default(False) }}"
+openshift_logging_es_ops_pvc_size: "{{ openshift_logging_legacy_es_ops_pvc_size | default('') }}"
+openshift_logging_es_ops_pvc_prefix: "{{ openshift_logging_legacy_es_ops_pvc_prefix | default('logging-es-ops') }}"
 openshift_logging_es_ops_recover_after_time: 5m
 openshift_logging_es_ops_storage_group: "65534"
 openshift_logging_es_ops_nodeselector: {}

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -89,7 +89,7 @@ openshift_logging_es_cpu_limit: 1000m
 # the logging appenders for the root loggers to write ES logs. Valid values: 'file', 'console'
 openshift_logging_es_log_appenders: ['file']
 openshift_logging_es_memory_limit: "8Gi"
-openshift_logging_es_pv_selector: "{{ openshift_logging_storage_labels | default('') }}"
+openshift_logging_es_pv_selector: "{{ openshift_logging_storage_labels | default({}) }}"
 openshift_logging_es_pvc_dynamic: "{{ openshift_logging_elasticsearch_pvc_dynamic | default(False) }}"
 openshift_logging_es_pvc_size: "{{ openshift_logging_elasticsearch_pvc_size | default('') }}"
 openshift_logging_es_pvc_prefix: "{{ openshift_logging_elasticsearch_pvc_prefix | default('logging-es') }}"
@@ -128,7 +128,7 @@ openshift_logging_es_ops_client_key: /etc/fluent/keys/key
 openshift_logging_es_ops_cluster_size: "{{ openshift_logging_elasticsearch_ops_cluster_size | default(1) }}"
 openshift_logging_es_ops_cpu_limit: 1000m
 openshift_logging_es_ops_memory_limit: "8Gi"
-openshift_logging_es_ops_pv_selector: "{{ openshift_loggingops_storage_labels | default('') }}"
+openshift_logging_es_ops_pv_selector: "{{ openshift_loggingops_storage_labels | default({}) }}"
 openshift_logging_es_ops_pvc_dynamic: "{{ openshift_logging_elasticsearch_ops_pvc_dynamic | default(False) }}"
 openshift_logging_es_ops_pvc_size: "{{ openshift_logging_elasticsearch_ops_pvc_size | default('') }}"
 openshift_logging_es_ops_pvc_prefix: "{{ openshift_logging_elasticsearch_ops_pvc_prefix | default('logging-es-ops') }}"
@@ -177,3 +177,7 @@ openshift_logging_mux_namespaces: []
 #fluentd_secureforward_contents:
 #fluentd_mux_config_contents:
 #fluentd_mux_secureforward_contents:
+
+openshift_logging_es_node_topology: {}
+
+openshift_logging_es_ops_node_topology: {}

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -49,6 +49,8 @@
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
 
 ## Elasticsearch
+- set_fact:
+    elasticsearch_storage_type: "{{ openshift_logging_elasticsearch_storage_type | default('pvc' if ( openshift_logging_es_pvc_dynamic | bool or openshift_hosted_logging_storage_kind | default('') == 'nfs' or openshift_logging_es_pvc_size | length > 0)  else 'emptydir') }}"
 
 - include_role:
     name: openshift_logging_elasticsearch
@@ -60,17 +62,29 @@
     generated_certs_dir: "{{ openshift.common.config_base }}/logging"
     openshift_logging_elasticsearch_transport_cert_name: "elasticsearch"
     openshift_logging_elasticsearch_api_cert_name: "logging-es"
-
+    openshift_logging_elasticsearch_node_topology: "{{ openshift_logging_es_node_topology }}"
+    openshift_logging_elasticsearch_node_topology_defined: "{{ openshift_logging_es_node_topology_defined }}"
+    # Check if this parameter is still needed
+    openshift_logging_elasticsearch_recover_after_time: "{{ openshift_logging_es_recover_after_time }}"
+    # Var-styled definition, they are only used if openshift_logging_elasticsearch_node_topology_defined is false
+    openshift_logging_elasticsearch_cluster_size: "{{ openshift_logging_es_cluster_size }}"
+    openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_nodeselector }}"
     openshift_logging_elasticsearch_storage_type: "{{ elasticsearch_storage_type }}"
-    openshift_logging_elasticsearch_pvc_pv_selector: "{{ openshift_logging_es_pv_selector }}"
+    openshift_logging_elasticsearch_pvc_size: "{{ openshift_logging_es_pvc_size }}"
+    openshift_logging_elasticsearch_pvc_dynamic: "{{ openshift_logging_es_pvc_dynamic }}"
+
+    openshift_logging_elasticsearch_pv_selector: "{{ openshift_logging_es_pv_selector }}"
+    openshift_logging_elasticsearch_pvc_prefix: "{{ openshift_logging_es_pvc_prefix }}"
+    openshift_logging_elasticsearch_storage_group: "{{ openshift_logging_es_storage_group }}"
     openshift_logging_elasticsearch_memory_limit: "{{ openshift_logging_es_memory_limit }}"
     openshift_logging_elasticsearch_cpu_limit: "{{ openshift_logging_es_cpu_limit }}"
-    openshift_logging_es_key: "{{ openshift_logging_es_key }}"
-    openshift_logging_es_cert: "{{ openshift_logging_es_cert }}"
-    openshift_logging_es_ca_ext: "{{ openshift_logging_es_ca_ext }}"
-    openshift_logging_es_hostname: "{{ openshift_logging_es_hostname }}"
-    openshift_logging_es_edge_term_policy: "{{ openshift_logging_es_edge_term_policy | default('') }}"
-    openshift_logging_es_allow_external: "{{ openshift_logging_es_allow_external }}"
+    # External routes to Elasticsearch
+    openshift_logging_elasticsearch_key: "{{ openshift_logging_es_key }}"
+    openshift_logging_elasticsearch_cert: "{{ openshift_logging_es_cert }}"
+    openshift_logging_elasticsearch_ca_ext: "{{ openshift_logging_es_ca_ext }}"
+    openshift_logging_elasticsearch_hostname: "{{ openshift_logging_es_hostname }}"
+    openshift_logging_elasticsearch_edge_term_policy: "{{ openshift_logging_es_edge_term_policy | default('') }}"
+    openshift_logging_elasticsearch_allow_external: "{{ openshift_logging_es_allow_external }}"
 
 # Elasticsearch Ops cluster
 - include_role:
@@ -83,20 +97,29 @@
     generated_certs_dir: "{{ openshift.common.config_base }}/logging"
     openshift_logging_elasticsearch_transport_cert_name: "elasticsearch"
     openshift_logging_elasticsearch_api_cert_name: "logging-es"
+    openshift_logging_elasticsearch_node_topology: "{{ openshift_logging_es_ops_node_topology }}"
+    openshift_logging_elasticsearch_node_topology_defined: "{{ openshift_logging_es_ops_node_topology_defined }}"
+    # Check if this parameter is still needed
+    openshift_logging_elasticsearch_recover_after_time: "{{ openshift_logging_es_ops_recover_after_time }}"
+    # Var-styled definition, they are only used if openshift_logging_elasticsearch_node_topology_defined is false
+    openshift_logging_elasticsearch_cluster_size: "{{ openshift_logging_es_ops_cluster_size }}"
+    openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_ops_nodeselector }}"
+
     openshift_logging_elasticsearch_storage_type: "{{ elasticsearch_storage_type }}"
     openshift_logging_elasticsearch_pvc_size: "{{ openshift_logging_es_ops_pvc_size }}"
     openshift_logging_elasticsearch_pvc_dynamic: "{{ openshift_logging_es_ops_pvc_dynamic }}"
-    openshift_logging_elasticsearch_pvc_pv_selector: "{{ openshift_logging_es_ops_pv_selector }}"
+    openshift_logging_elasticsearch_pv_selector: "{{ openshift_logging_es_ops_pv_selector }}"
+    openshift_logging_elasticsearch_pvc_prefix: "{{ openshift_logging_es_ops_pvc_prefix }}"
+    openshift_logging_elasticsearch_storage_group: "{{ openshift_logging_es_ops_storage_group }}"
     openshift_logging_elasticsearch_memory_limit: "{{ openshift_logging_es_ops_memory_limit }}"
     openshift_logging_elasticsearch_cpu_limit: "{{ openshift_logging_es_ops_cpu_limit }}"
-    openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_ops_nodeselector }}"
-    openshift_logging_es_key: "{{ openshift_logging_es_ops_key }}"
-    openshift_logging_es_cert: "{{ openshift_logging_es_ops_cert }}"
-    openshift_logging_es_ca_ext: "{{ openshift_logging_es_ops_ca_ext }}"
-    openshift_logging_es_hostname: "{{ openshift_logging_es_ops_hostname }}"
-    openshift_logging_es_edge_term_policy: "{{ openshift_logging_es_ops_edge_term_policy | default('') }}"
-    openshift_logging_es_allow_external: "{{ openshift_logging_es_ops_allow_external }}"
-
+    # External routes to Elasticsearch
+    openshift_logging_elasticsearch_key: "{{ openshift_logging_es_ops_key }}"
+    openshift_logging_elasticsearch_cert: "{{ openshift_logging_es_ops_cert }}"
+    openshift_logging_elasticsearch_ca_ext: "{{ openshift_logging_es_ops_ca_ext }}"
+    openshift_logging_elasticsearch_hostname: "{{ openshift_logging_es_ops_hostname }}"
+    openshift_logging_elasticsearch_edge_term_policy: "{{ openshift_logging_es_ops_edge_term_policy | default('') }}"
+    openshift_logging_elasticsearch_allow_external: "{{ openshift_logging_es_ops_allow_external }}"
   when: openshift_logging_use_ops |bool
 
 ## Kibana

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -50,117 +50,39 @@
 
 ## Elasticsearch
 
-- set_fact: es_indices={{ es_indices | default([]) + [item | int - 1] }}
-  with_sequence: count={{ openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count }}
-  when: openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count > 0
-
-- set_fact: es_indices=[]
-  when: openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count == 0
-
-- set_fact: openshift_logging_es_pvc_prefix="logging-es"
-  when: openshift_logging_es_pvc_prefix == ""
-
-- set_fact:
-    elasticsearch_storage_type: "{{ openshift_logging_elasticsearch_storage_type | default('pvc' if ( openshift_logging_es_pvc_dynamic | bool or openshift_hosted_logging_storage_kind | default('') == 'nfs' or openshift_logging_es_pvc_size | length > 0)  else 'emptydir') }}"
-
-# We don't allow scaling down of ES nodes currently
 - include_role:
     name: openshift_logging_elasticsearch
   vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
-    openshift_logging_elasticsearch_deployment_name: "{{ item.0.name }}"
-    openshift_logging_elasticsearch_pvc_name: "{{ openshift_logging_es_pvc_prefix ~ '-' ~ item.2 if item.1 is none else item.1 }}"
-    openshift_logging_elasticsearch_replica_count: "{{ openshift_logging_es_cluster_size | int }}"
+    openshift_logging_elasticsearch_clustername: "logging-es"
+    openshift_logging_elasticsearch_sa_name: "aggregated-logging-elasticsearch"
+    openshift_logging_elasticsearch_clusterreader: true
+    generated_certs_dir: "{{ openshift.common.config_base }}/logging"
+    openshift_logging_elasticsearch_transport_cert_name: "elasticsearch"
+    openshift_logging_elasticsearch_api_cert_name: "logging-es"
 
     openshift_logging_elasticsearch_storage_type: "{{ elasticsearch_storage_type }}"
     openshift_logging_elasticsearch_pvc_pv_selector: "{{ openshift_logging_es_pv_selector }}"
-    openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_nodeselector if item.0.nodeSelector | default(None) is none else item.0.nodeSelector }}"
-    openshift_logging_elasticsearch_storage_group: "{{ [openshift_logging_es_storage_group] if item.0.storageGroups | default([]) | length == 0 else item.0.storageGroups }}"
-    _es_containers: "{{item.0.containers}}"
+    openshift_logging_elasticsearch_memory_limit: "{{ openshift_logging_es_memory_limit }}"
+    openshift_logging_elasticsearch_cpu_limit: "{{ openshift_logging_es_cpu_limit }}"
+    openshift_logging_es_key: "{{ openshift_logging_es_key }}"
+    openshift_logging_es_cert: "{{ openshift_logging_es_cert }}"
+    openshift_logging_es_ca_ext: "{{ openshift_logging_es_ca_ext }}"
+    openshift_logging_es_hostname: "{{ openshift_logging_es_hostname }}"
+    openshift_logging_es_edge_term_policy: "{{ openshift_logging_es_edge_term_policy | default('') }}"
+    openshift_logging_es_allow_external: "{{ openshift_logging_es_allow_external }}"
 
-  with_together:
-  - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs.values() }}"
-  - "{{ openshift_logging_facts.elasticsearch.pvcs }}"
-  - "{{ es_indices }}"
-  when:
-  - openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count > 0
-
-# Create any new DC that may be required
+# Elasticsearch Ops cluster
 - include_role:
     name: openshift_logging_elasticsearch
   vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
-    openshift_logging_elasticsearch_pvc_name: "{{ openshift_logging_es_pvc_prefix }}-{{ item | int + openshift_logging_facts.elasticsearch.deploymentconfigs | count - 1 }}"
-    openshift_logging_elasticsearch_replica_count: "{{ openshift_logging_es_cluster_size | int }}"
-
-    openshift_logging_elasticsearch_storage_type: "{{ elasticsearch_storage_type }}"
-    openshift_logging_elasticsearch_pvc_pv_selector: "{{ openshift_logging_es_pv_selector }}"
-
-  with_sequence: count={{ openshift_logging_es_cluster_size | int - openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count }}
-
-- set_fact: es_ops_indices={{ es_ops_indices | default([]) + [item | int - 1] }}
-  with_sequence: count={{ openshift_logging_facts.elasticsearch_ops.deploymentconfigs.keys() | count }}
-  when:
-  - openshift_logging_use_ops | bool
-  - openshift_logging_facts.elasticsearch_ops.deploymentconfigs.keys() | count > 0
-
-- set_fact: es_ops_indices=[]
-  when: openshift_logging_facts.elasticsearch_ops.deploymentconfigs.keys() | count == 0
-
-- set_fact: openshift_logging_es_ops_pvc_prefix="logging-es-ops"
-  when: openshift_logging_es_ops_pvc_prefix == ""
-
-- set_fact:
-    elasticsearch_storage_type: "{{ openshift_logging_elasticsearch_storage_type | default('pvc' if ( openshift_logging_es_ops_pvc_dynamic | bool or openshift_hosted_logging_storage_kind | default('') == 'nfs' or openshift_logging_es_ops_pvc_size | length > 0)  else 'emptydir') }}"
-  when:
-  - openshift_logging_use_ops | bool
-
-- include_role:
-    name: openshift_logging_elasticsearch
-  vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
-    openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
-    openshift_logging_elasticsearch_deployment_name: "{{ item.0.name }}"
-    openshift_logging_elasticsearch_pvc_name: "{{ openshift_logging_es_ops_pvc_prefix ~ '-' ~ item.2 if item.1 is none else item.1 }}"
-    openshift_logging_elasticsearch_ops_deployment: true
-    openshift_logging_elasticsearch_replica_count: "{{ openshift_logging_es_ops_cluster_size | int }}"
-
-    openshift_logging_elasticsearch_storage_type: "{{ elasticsearch_storage_type }}"
-    openshift_logging_elasticsearch_pvc_size: "{{ openshift_logging_es_ops_pvc_size }}"
-    openshift_logging_elasticsearch_pvc_dynamic: "{{ openshift_logging_es_ops_pvc_dynamic }}"
-    openshift_logging_elasticsearch_pvc_pv_selector: "{{ openshift_logging_es_ops_pv_selector }}"
-    openshift_logging_elasticsearch_memory_limit: "{{ openshift_logging_es_ops_memory_limit }}"
-    openshift_logging_elasticsearch_cpu_limit: "{{ openshift_logging_es_ops_cpu_limit }}"
-    openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_ops_nodeselector if item.0.nodeSelector | default(None) is none else item.0.nodeSelector }}"
-    openshift_logging_elasticsearch_storage_group: "{{ [openshift_logging_es_ops_storage_group] if item.0.storageGroups | default([]) | length == 0 else item.0.storageGroups }}"
-    openshift_logging_es_key: "{{ openshift_logging_es_ops_key }}"
-    openshift_logging_es_cert: "{{ openshift_logging_es_ops_cert }}"
-    openshift_logging_es_ca_ext: "{{ openshift_logging_es_ops_ca_ext }}"
-    openshift_logging_es_hostname: "{{ openshift_logging_es_ops_hostname }}"
-    openshift_logging_es_edge_term_policy: "{{ openshift_logging_es_ops_edge_term_policy | default('') }}"
-    openshift_logging_es_allow_external: "{{ openshift_logging_es_ops_allow_external }}"
-    _es_containers: "{{item.0.containers}}"
-
-  with_together:
-  - "{{ openshift_logging_facts.elasticsearch_ops.deploymentconfigs.values() }}"
-  - "{{ openshift_logging_facts.elasticsearch_ops.pvcs }}"
-  - "{{ es_ops_indices }}"
-  when:
-  - openshift_logging_use_ops | bool
-  - openshift_logging_facts.elasticsearch_ops.deploymentconfigs.keys() | count > 0
-
-# Create any new DC that may be required
-- include_role:
-    name: openshift_logging_elasticsearch
-  vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
-    openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
-    openshift_logging_elasticsearch_pvc_name: "{{ openshift_logging_es_ops_pvc_prefix }}-{{ item | int + openshift_logging_facts.elasticsearch_ops.deploymentconfigs | count - 1 }}"
-    openshift_logging_elasticsearch_ops_deployment: true
-    openshift_logging_elasticsearch_replica_count: "{{ openshift_logging_es_ops_cluster_size | int }}"
-
+    openshift_logging_elasticsearch_clustername: "logging-es-ops"
+    openshift_logging_elasticsearch_sa_name: "aggregated-logging-elasticsearch"
+    openshift_logging_elasticsearch_clusterreader: true
+    generated_certs_dir: "{{ openshift.common.config_base }}/logging"
+    openshift_logging_elasticsearch_transport_cert_name: "elasticsearch"
+    openshift_logging_elasticsearch_api_cert_name: "logging-es"
     openshift_logging_elasticsearch_storage_type: "{{ elasticsearch_storage_type }}"
     openshift_logging_elasticsearch_pvc_size: "{{ openshift_logging_es_ops_pvc_size }}"
     openshift_logging_elasticsearch_pvc_dynamic: "{{ openshift_logging_es_ops_pvc_dynamic }}"
@@ -175,10 +97,7 @@
     openshift_logging_es_edge_term_policy: "{{ openshift_logging_es_ops_edge_term_policy | default('') }}"
     openshift_logging_es_allow_external: "{{ openshift_logging_es_ops_allow_external }}"
 
-  with_sequence: count={{ openshift_logging_es_ops_cluster_size | int - openshift_logging_facts.elasticsearch_ops.deploymentconfigs.keys() | count }}
-  when:
-  - openshift_logging_use_ops | bool
-
+  when: openshift_logging_use_ops |bool
 
 ## Kibana
 - include_role:

--- a/roles/openshift_logging_elasticsearch/defaults/main.yml
+++ b/roles/openshift_logging_elasticsearch/defaults/main.yml
@@ -1,19 +1,43 @@
 ---
+
 ### Common settings
 openshift_logging_elasticsearch_image_prefix: "{{ openshift_logging_image_prefix | default(__openshift_logging_image_prefix) }}"
 openshift_logging_elasticsearch_image_version: "{{ openshift_logging_image_version | default('latest') }}"
 openshift_logging_elasticsearch_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"
 openshift_logging_elasticsearch_namespace: logging
-
+openshift_logging_elasticsearch_sa_name: aggregated-logging-elasticsearch
+kubeconfig: /etc/origin/master/openshift-master.kubeconfig
 openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_nodeselector | default('') }}"
 openshift_logging_elasticsearch_cpu_limit: "{{ openshift_logging_es_cpu_limit | default('1000m') }}"
 openshift_logging_elasticsearch_memory_limit: "{{ openshift_logging_es_memory_limit | default('1Gi') }}"
 openshift_logging_elasticsearch_recover_after_time: "{{ openshift_logging_es_recover_after_time | default('5m') }}"
+openshift_logging_elasticsearch_clusterreader: true
 
 openshift_logging_elasticsearch_replica_count: 1
 
 # ES deployment type
 openshift_logging_elasticsearch_deployment_type: "data-master"
+openshift_logging_elasticsearch_node_topology:
+  masters:
+    replicas: 1
+    limits:
+      cpu: 200m
+    requests:
+      memory: 512Mi
+      cpu: 100m
+  clientdata:
+  -
+    node_storage_type: emptydir
+    hostmount_path:
+    - /mnt/data1
+    - /mnt/data2
+    limits:
+      memory: 512Mi
+      cpu: 200m
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
 
 # ES deployment name
 openshift_logging_elasticsearch_deployment_name: ""
@@ -29,7 +53,7 @@ openshift_logging_elasticsearch_hostmount_path: ""
 openshift_logging_elasticsearch_pvc_name: ""
 
 # required if the PVC does not already exist
-openshift_logging_elasticsearch_pvc_size: ""
+openshift_logging_elasticsearch_pvc_size: "10Gi"
 openshift_logging_elasticsearch_pvc_dynamic: false
 openshift_logging_elasticsearch_pvc_pv_selector: {}
 openshift_logging_elasticsearch_pvc_access_modes: ['ReadWriteOnce']

--- a/roles/openshift_logging_elasticsearch/defaults/main.yml
+++ b/roles/openshift_logging_elasticsearch/defaults/main.yml
@@ -17,28 +17,35 @@ openshift_logging_elasticsearch_replica_count: 1
 # ES deployment type
 openshift_logging_elasticsearch_deployment_type: "data-master"
 openshift_logging_elasticsearch_node_topology:
-  masters:
+  clientdatamaster:
     replicas: 1
     limits:
-      cpu: 1000m
-    requests:
-      memory: 1Gi
-  clientdata:
-  -
-    node_storage_type: emptydir
-    hostmount_path:
-    - /mnt/data1
-    - /mnt/data2
-    limits:
       memory: 8Gi
-      cpu: 4000m
     requests:
       memory: 8Gi
-    pv_selector:
-      label: value
-    pvc_size: 10Gi
-    pvc_name: pvc1
-    storage_group: 65534
+
+#  masters:
+#    replicas: 1
+#    limits:
+#      cpu: 1000m
+#    requests:
+#      memory: 1Gi
+#  clientdata:
+#  -
+#    node_storage_type: emptydir
+#    hostmount_path:
+#    - /mnt/data1
+#    - /mnt/data2
+#    limits:
+#      memory: 8Gi
+#      cpu: 4000m
+#    requests:
+#      memory: 8Gi
+#    pv_selector:
+#      label: value
+#    pvc_size: 10Gi
+#    pvc_name: pvc1
+#    storage_group: 65534
 
 # ES deployment name
 openshift_logging_elasticsearch_deployment_name: ""

--- a/roles/openshift_logging_elasticsearch/defaults/main.yml
+++ b/roles/openshift_logging_elasticsearch/defaults/main.yml
@@ -6,7 +6,6 @@ openshift_logging_elasticsearch_image_version: "{{ openshift_logging_image_versi
 openshift_logging_elasticsearch_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"
 openshift_logging_elasticsearch_namespace: logging
 openshift_logging_elasticsearch_sa_name: aggregated-logging-elasticsearch
-kubeconfig: /etc/origin/master/openshift-master.kubeconfig
 openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_nodeselector | default('') }}"
 openshift_logging_elasticsearch_cpu_limit: "{{ openshift_logging_es_cpu_limit | default('1000m') }}"
 openshift_logging_elasticsearch_memory_limit: "{{ openshift_logging_es_memory_limit | default('1Gi') }}"
@@ -21,10 +20,9 @@ openshift_logging_elasticsearch_node_topology:
   masters:
     replicas: 1
     limits:
-      cpu: 200m
+      cpu: 1000m
     requests:
-      memory: 512Mi
-      cpu: 100m
+      memory: 1Gi
   clientdata:
   -
     node_storage_type: emptydir
@@ -32,12 +30,15 @@ openshift_logging_elasticsearch_node_topology:
     - /mnt/data1
     - /mnt/data2
     limits:
-      memory: 512Mi
-      cpu: 200m
+      memory: 8Gi
+      cpu: 4000m
     requests:
-      cpu: 100m
-      memory: 256Mi
-
+      memory: 8Gi
+    pv_selector:
+      label: value
+    pvc_size: 10Gi
+    pvc_name: pvc1
+    storage_group: 65534
 
 # ES deployment name
 openshift_logging_elasticsearch_deployment_name: ""

--- a/roles/openshift_logging_elasticsearch/library/openshift_logging_elasticsearch_facts.py
+++ b/roles/openshift_logging_elasticsearch/library/openshift_logging_elasticsearch_facts.py
@@ -1,0 +1,351 @@
+'''
+---
+module: openshift_logging_elasticsearch_facts
+version_added: ""
+short_description: Gather facts about the OpenShift logging stack
+description:
+  - Determine the current facts about the OpenShift logging stack (e.g. cluster size)
+options:
+author: Red Hat, Inc
+'''
+
+import copy
+import json
+
+# pylint: disable=redefined-builtin, unused-wildcard-import, wildcard-import
+from subprocess import *   # noqa: F402,F403
+
+# ignore pylint errors related to the module_utils import
+# pylint: disable=redefined-builtin, unused-wildcard-import, wildcard-import
+from ansible.module_utils.basic import *   # noqa: F402,F403
+
+import yaml
+
+EXAMPLES = """
+- action: opneshift_logging_facts
+"""
+
+RETURN = """
+"""
+
+DEFAULT_OC_OPTIONS = ["-o", "json"]
+
+# constants used for various labels and selectors
+COMPONENT_KEY = "component"
+LOGGING_INFRA_KEY = "logging-infra"
+CLUSTER_NAME_LABEL = "cluster-name"
+ES_ROLE_LABEL = "es-node-role"
+# selectors for filtering resources
+DS_FLUENTD_SELECTOR = LOGGING_INFRA_KEY + "=" + "fluentd"
+LOGGING_SELECTOR = LOGGING_INFRA_KEY + "=" + "support"
+ROUTE_SELECTOR = "component=support, logging-infra=support, provider=openshift"
+COMPONENTS = ["elasticsearch"]
+
+
+class OCBaseCommand(object):
+    ''' The base class used to query openshift '''
+
+    def __init__(self, binary, kubeconfig, namespace):
+        ''' the init method of OCBaseCommand class '''
+        self.binary = binary
+        self.kubeconfig = kubeconfig
+        self.user = self.get_system_admin(self.kubeconfig)
+        self.namespace = namespace
+
+    # pylint: disable=no-self-use
+    def get_system_admin(self, kubeconfig):
+        ''' Retrieves the system admin '''
+        with open(kubeconfig, 'r') as kubeconfig_file:
+            config = yaml.load(kubeconfig_file)
+            for user in config["users"]:
+                if user["name"].startswith("system"):
+                    return user["name"]
+        raise Exception("Unable to find system:admin in: " + kubeconfig)
+
+    # pylint: disable=too-many-arguments, dangerous-default-value
+    def oc_command(self, sub, kind, namespace=None, name=None, add_options=None):
+        ''' Wrapper method for the "oc" command '''
+        cmd = [self.binary, sub, kind]
+        if name is not None:
+            cmd = cmd + [name]
+        if namespace is not None:
+            cmd = cmd + ["-n", namespace]
+        if add_options is None:
+            add_options = []
+        cmd = cmd + ["--user=" + self.user, "--config=" + self.kubeconfig] + DEFAULT_OC_OPTIONS + add_options
+        try:
+            process = Popen(cmd, stdout=PIPE, stderr=PIPE)   # noqa: F405
+            out, err = process.communicate(cmd)
+            if len(err) > 0:
+                if 'not found' in err:
+                    return {'items': []}
+                if 'No resources found' in err:
+                    return {'items': []}
+                raise Exception(err)
+        except Exception as excp:
+            err = "There was an exception trying to run the command '" + " ".join(cmd) + "' " + str(excp)
+            raise Exception(err)
+
+        return json.loads(out)
+
+
+class OpenshiftLoggingFacts(OCBaseCommand):
+    ''' The class structure for holding the OpenshiftLogging Facts'''
+    name = "facts"
+
+    def __init__(self, logger, binary, kubeconfig, namespace, cluster_name):
+        ''' The init method for OpenshiftLoggingFacts '''
+        super(OpenshiftLoggingFacts, self).__init__(binary, kubeconfig, namespace)
+        self.logger = logger
+        self.cluster_name = cluster_name
+        self.facts = dict()
+
+    def default_keys_for(self, kind):
+        ''' Sets the default key values for kind '''
+        for comp in COMPONENTS:
+            self.add_facts_for(comp, kind)
+
+    def add_facts_for(self, comp, kind, name=None, facts=None):
+        ''' Add facts for the provided kind '''
+        if comp not in self.facts:
+            self.facts[comp] = dict()
+        if kind not in self.facts[comp]:
+            self.facts[comp][kind] = dict()
+        if name:
+            self.facts[comp][kind][name] = facts
+
+    def facts_for_routes(self, namespace):
+        ''' Gathers facts for Routes in logging namespace '''
+        self.default_keys_for("routes")
+        route_list = self.oc_command("get", "routes", namespace=namespace, add_options=["-l", ROUTE_SELECTOR])
+        if len(route_list["items"]) == 0:
+            return None
+        for route in route_list["items"]:
+            name = route["metadata"]["name"]
+            comp = self.comp(name)
+            if comp is not None:
+                self.add_facts_for(comp, "routes", name, dict(host=route["spec"]["host"]))
+        self.facts["agl_namespace"] = namespace
+
+    def facts_for_daemonsets(self, namespace):
+        ''' Gathers facts for Daemonsets in logging namespace '''
+        self.default_keys_for("daemonsets")
+        ds_list = self.oc_command("get", "daemonsets", namespace=namespace,
+                                  add_options=["-l", LOGGING_INFRA_KEY + "=fluentd"])
+        if len(ds_list["items"]) == 0:
+            return
+        for ds_item in ds_list["items"]:
+            name = ds_item["metadata"]["name"]
+            comp = self.comp(name)
+            spec = ds_item["spec"]["template"]["spec"]
+            container = spec["containers"][0]
+            result = dict(
+                selector=ds_item["spec"]["selector"],
+                image=container["image"],
+                resources=container["resources"],
+                nodeSelector=spec["nodeSelector"],
+                serviceAccount=spec["serviceAccount"],
+                terminationGracePeriodSeconds=spec["terminationGracePeriodSeconds"]
+            )
+            self.add_facts_for(comp, "daemonsets", name, result)
+
+    def facts_for_pvcs(self, namespace):
+        ''' Gathers facts for PVCS in logging namespace'''
+        self.default_keys_for("pvcs")
+        pvclist = self.oc_command("get", "pvc", namespace=namespace, add_options=["-l", LOGGING_INFRA_KEY])
+        if len(pvclist["items"]) == 0:
+            return
+        for pvc in pvclist["items"]:
+            name = pvc["metadata"]["name"]
+            comp = self.comp(name)
+            self.add_facts_for(comp, "pvcs", name, dict())
+
+    def facts_for_deploymentconfigs(self, namespace, es_role):
+        ''' Gathers facts for DeploymentConfigs in logging namespace '''
+        self.default_keys_for("deploymentconfigs")
+        dclist = self.oc_command("get", "deploymentconfigs",
+                                 namespace=namespace,
+                                 add_options=["-l",
+                                              CLUSTER_NAME_LABEL + "=" +\
+                                              self.cluster_name, "-l",
+                                              ES_ROLE_LABEL + "=" +\
+                                              es_role])
+        if len(dclist["items"]) == 0:
+            self.add_facts_for("node_topology", es_role)
+            return
+        dcs = dclist["items"]
+        for dc_item in dcs:
+            name = dc_item["metadata"]["name"]
+            spec = dc_item["spec"]["template"]["spec"]
+            facts = dict(
+                selector=dc_item["spec"]["selector"],
+                replicas=dc_item["spec"]["replicas"],
+                serviceAccount=spec["serviceAccount"],
+                containers=dict(),
+                volumes=dict()
+            )
+            if "volumes" in spec:
+                for vol in spec["volumes"]:
+                    clone = copy.deepcopy(vol)
+                    clone.pop("name", None)
+                    facts["volumes"][vol["name"]] = clone
+            for container in spec["containers"]:
+                facts["containers"][container["name"]] = dict(
+                    image=container["image"],
+                    resources=container["resources"],
+                )
+            self.add_facts_for("node_topology", es_role, name, facts)
+
+    def facts_for_services(self, namespace):
+        ''' Gathers facts for services in logging namespace '''
+        self.default_keys_for("services")
+        servicelist = self.oc_command("get", "services", namespace=namespace)
+        if len(servicelist["items"]) == 0:
+            return
+        for service in servicelist["items"]:
+            name = service["metadata"]["name"]
+            comp = self.comp(name)
+            if comp is not None:
+                self.add_facts_for(comp, "services", name, dict())
+
+    def facts_for_configmaps(self, namespace):
+        ''' Gathers facts for configmaps in logging namespace '''
+        self.default_keys_for("configmaps")
+        cm_name = self.cluster_name + "-configuration"
+        a_list = self.oc_command("get", "configmaps", namespace=namespace)
+        if len(a_list["items"]) == 0:
+            return
+        for item in a_list["items"]:
+            name = item["metadata"]["name"]
+            comp = self.comp(name)
+            if comp is not None:
+                self.add_facts_for(comp, "configmaps", name, item["data"])
+
+    def facts_for_oauthclients(self, namespace):
+        ''' Gathers facts for oauthclients used with logging '''
+        self.default_keys_for("oauthclients")
+        a_list = self.oc_command("get", "oauthclients", namespace=namespace, add_options=["-l", LOGGING_SELECTOR])
+        if len(a_list["items"]) == 0:
+            return
+        for item in a_list["items"]:
+            name = item["metadata"]["name"]
+            comp = self.comp(name)
+            if comp is not None:
+                result = dict(
+                    redirectURIs=item["redirectURIs"]
+                )
+                self.add_facts_for(comp, "oauthclients", name, result)
+
+    def facts_for_secrets(self, namespace):
+        ''' Gathers facts for secrets in the logging namespace '''
+        self.default_keys_for("secrets")
+        a_list = self.oc_command("get", "secrets", namespace=namespace)
+        if len(a_list["items"]) == 0:
+            return
+        for item in a_list["items"]:
+            name = item["metadata"]["name"]
+            comp = self.comp(name)
+            if comp is not None and item["type"] == "Opaque":
+                result = dict(
+                    keys=item["data"].keys()
+                )
+                self.add_facts_for(comp, "secrets", name, result)
+
+    def facts_for_sccs(self):
+        ''' Gathers facts for SCCs used with logging '''
+        self.default_keys_for("sccs")
+        scc = self.oc_command("get", "scc", name="privileged")
+        if len(scc["users"]) == 0:
+            return
+        for item in scc["users"]:
+            comp = self.comp(item)
+            if comp is not None:
+                self.add_facts_for(comp, "sccs", "privileged", dict())
+
+    def facts_for_clusterrolebindings(self, namespace):
+        ''' Gathers ClusterRoleBindings used with logging '''
+        self.default_keys_for("clusterrolebindings")
+        role = self.oc_command("get", "clusterrolebindings", name="cluster-readers")
+        if "subjects" not in role or len(role["subjects"]) == 0:
+            return
+        for item in role["subjects"]:
+            comp = self.comp(item["name"])
+            if comp is not None and namespace == item["namespace"]:
+                self.add_facts_for(comp, "clusterrolebindings", "cluster-readers", dict())
+
+# this needs to end up nested under the service account...
+    def facts_for_rolebindings(self, namespace):
+        ''' Gathers facts for RoleBindings used with logging '''
+        self.default_keys_for("rolebindings")
+        role = self.oc_command("get", "rolebindings", namespace=namespace, name="logging-elasticsearch-view-role")
+        if "subjects" not in role or len(role["subjects"]) == 0:
+            return
+        for item in role["subjects"]:
+            comp = self.comp(item["name"])
+            if comp is not None and namespace == item["namespace"]:
+                self.add_facts_for(comp, "rolebindings", "logging-elasticsearch-view-role", dict())
+
+    # pylint: disable=no-self-use, too-many-return-statements
+    def comp(self, name):
+        ''' Does a comparison to evaluate the logging component '''
+        if name.startswith("logging-curator-ops"):
+            return "curator_ops"
+        elif name.startswith("logging-kibana-ops") or name.startswith("kibana-ops"):
+            return "kibana_ops"
+        elif name.startswith("logging-es-ops") or name.startswith("logging-elasticsearch-ops"):
+            return "elasticsearch_ops"
+        elif name.startswith("logging-curator"):
+            return "curator"
+        elif name.startswith("logging-kibana") or name.startswith("kibana"):
+            return "kibana"
+        elif name.startswith(self.cluster_name):
+            return "elasticsearch"
+        elif name.startswith("logging-fluentd") or name.endswith("aggregated-logging-fluentd"):
+            return "fluentd"
+        else:
+            return None
+
+    def build_facts(self):
+        ''' Builds the logging facts and returns them '''
+        self.facts_for_deploymentconfigs(self.namespace, "master")
+        self.facts_for_deploymentconfigs(self.namespace, "clientdata")
+
+        self.facts_for_daemonsets(self.namespace)
+        self.facts_for_services(self.namespace)
+        self.facts_for_configmaps(self.namespace)
+        self.facts_for_sccs()
+        self.facts_for_oauthclients(self.namespace)
+        self.facts_for_clusterrolebindings(self.namespace)
+        self.facts_for_rolebindings(self.namespace)
+        self.facts_for_secrets(self.namespace)
+        self.facts_for_pvcs(self.namespace)
+
+        return self.facts
+
+
+def main():
+    ''' The main method '''
+    module = AnsibleModule(   # noqa: F405
+        argument_spec=dict(
+            admin_kubeconfig={"default": "/etc/origin/master/admin.kubeconfig", "type": "str"},
+            oc_bin={"required": True, "type": "str"},
+            openshift_namespace={"required": True, "type": "str"},
+            elasticsearch_clustername={"required": True, "type": "str"}
+        ),
+        supports_check_mode=False
+    )
+    try:
+        cmd = OpenshiftLoggingFacts(module, module.params['oc_bin'], module.params['admin_kubeconfig'],
+                                    module.params['openshift_namespace'],
+                                    module.params['elasticsearch_clustername'])
+        module.exit_json(
+            ansible_facts={"openshift_logging_elasticsearch_facts": cmd.build_facts()}
+        )
+    # ignore broad-except error to avoid stack trace to ansible user
+    # pylint: disable=broad-except
+    except Exception as error:
+        module.fail_json(msg=str(error))
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/openshift_logging_elasticsearch/library/openshift_logging_elasticsearch_facts.py
+++ b/roles/openshift_logging_elasticsearch/library/openshift_logging_elasticsearch_facts.py
@@ -146,8 +146,8 @@ class OpenshiftLoggingFacts(OCBaseCommand):
 
     def facts_for_ex_node_topology(self, namespace, es_role):
         ''' Gathers facts for DeploymentConfigs in logging namespace '''
-        if es_role == "masterclientdata":
-            # masterclientdata role exists only for older deployments,
+        if es_role == "component-aio":
+            # component-aio role exists only for older deployments,
             # so cluster_name will be either "logging-es" or "logging-es-ops"
             selector = "component=" + self.cluster_name[8:] + "," +\
                 CLUSTER_NAME_LABEL + "!=" + self.cluster_name
@@ -274,7 +274,8 @@ class OpenshiftLoggingFacts(OCBaseCommand):
         ''' Builds the logging facts and returns them '''
         self.facts_for_ex_node_topology(self.namespace, "master")
         self.facts_for_ex_node_topology(self.namespace, "clientdata")
-        self.facts_for_ex_node_topology(self.namespace, "masterclientdata")
+        self.facts_for_ex_node_topology(self.namespace, "clientdatamaster")
+        self.facts_for_ex_node_topology(self.namespace, "component-aio")
 
         self.facts_for_services(self.namespace)
         self.facts_for_configmaps(self.namespace)

--- a/roles/openshift_logging_elasticsearch/library/openshift_logging_elasticsearch_topology.py
+++ b/roles/openshift_logging_elasticsearch/library/openshift_logging_elasticsearch_topology.py
@@ -113,7 +113,6 @@ class OpenshiftLoggingTopology(object):
         else:
             self._node_topology = dict(clientdatamaster=clientdata[0])
 
-
     @staticmethod
     def reconcile_masters(masters_ex, masters_des):
         '''We can scale masters however we want'''
@@ -153,7 +152,8 @@ class OpenshiftLoggingTopology(object):
             ex_nd_id = self.find_similar_clientdata_node(desired_clientdata, node)
             del desired_clientdata[ex_nd_id]
 
-    def reconcile_clientdatamaster(self, cdm_ex, cdm_des):
+    @staticmethod
+    def reconcile_clientdatamaster(cdm_ex, cdm_des):
         '''We assume we get just 1 existing clientdata node'''
         # pylint: disable=unused-argument
 
@@ -171,10 +171,10 @@ class OpenshiftLoggingTopology(object):
             self._node_topology.get('masters', {}))
         clientdata = self.reconcile_clientdata(
             self._existing_topology.get('clientdata', []),
-            self._node_topology.get('clientdata',{}))
-        clientdatamaster = self.reconcile_clientdatamaster(
+            self._node_topology.get('clientdata', {}))
+        clientdatamaster = OpenshiftLoggingTopology.reconcile_clientdatamaster(
             self._existing_topology.get('clientdatamaster', []),
-            self._node_topology.get('clientdatamaster',{}))
+            self._node_topology.get('clientdatamaster', {}))
         self._reconciled_topology = dict(masters=masters,
                                          clientdata=clientdata,
                                          clientdatamaster=clientdatamaster)

--- a/roles/openshift_logging_elasticsearch/library/openshift_logging_elasticsearch_topology.py
+++ b/roles/openshift_logging_elasticsearch/library/openshift_logging_elasticsearch_topology.py
@@ -1,0 +1,220 @@
+'''
+---
+module: openshift_logging_elasticsearch_facts
+version_added: ""
+short_description: Gather facts about the OpenShift logging stack
+description:
+  - Determine the current facts about the OpenShift logging stack (e.g. cluster size)
+options:
+author: Red Hat, Inc
+'''
+
+# pylint: disable=redefined-builtin, unused-wildcard-import, wildcard-import
+from subprocess import *   # noqa: F402,F403
+
+# ignore pylint errors related to the module_utils import
+# pylint: disable=redefined-builtin, unused-wildcard-import, wildcard-import
+from ansible.module_utils.basic import *   # noqa: F402,F403
+
+EXAMPLES = """
+- action: openshift_logging_topology
+"""
+
+RETURN = """
+"""
+
+# constants used for various labels and selectors
+# selectors for filtering resources
+MASTER_CPU_LIMIT = "500m"
+MASTER_MEM_LIMIT = "1Gi"
+CLIENTDATA_CPU_LIMIT = "4000m"
+CLIENTDATA_MEM_LIMIT = "8Gi"
+CLIENTDATA_MEM_REQUESTS = "8Gi"
+
+
+class OpenshiftLoggingTopology(object):
+    ''' The class structure for holding the OpenshiftLogging Topologys'''
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(self, logger, existing_topology, node_topology,
+                 cluster_name, cluster_size, cpu_limit, memory_limit,
+                 pv_selector, pvc_dynamic, pvc_size, pvc_prefix,
+                 storage_group, nodeselector, storage_type):
+        # pylint: disable=too-many-arguments
+        ''' The init method for OpenshiftLoggingFacts '''
+        self.logger = logger
+        self.cluster_name = cluster_name
+        self._existing_topology = existing_topology
+        self._node_topology = node_topology
+        self._reconciled_topology = dict()
+        if not node_topology:
+            # Topology is not provided, variables used to create one
+            self._cluster_size = cluster_size
+            self._cpu_limit = cpu_limit if cpu_limit else CLIENTDATA_CPU_LIMIT
+            self._memory_limit = memory_limit if memory_limit else CLIENTDATA_MEM_LIMIT
+            self._pv_selector = pv_selector
+            self._pvc_dynamic = pvc_dynamic
+            self._pvc_size = pvc_size
+            self._pvc_prefix = pvc_prefix
+            self._storage_group = storage_group
+            self._nodeselector = nodeselector
+            self._storage_type = storage_type
+        self.facts = dict()
+
+    def add_facts_for(self, kind, facts=None):
+        ''' Add facts for the provided kind '''
+        self.facts[kind] = facts
+
+    def append_facts_for(self, comp, kind, facts=None):
+        ''' Append facts for the provided kind to the list'''
+        if comp not in self.facts:
+            self.facts[comp] = dict()
+        if kind not in self.facts[comp]:
+            self.facts[comp][kind] = list()
+        if facts:
+            self.facts[comp][kind].append(facts)
+
+    def build_topology_from_vars(self):
+        '''builds ES node topology from the variables passed to the module'''
+        masters = dict(limits=dict(cpu=MASTER_CPU_LIMIT,
+                                   memory=MASTER_MEM_LIMIT),
+                       requests=dict(memory=MASTER_MEM_LIMIT))
+        clientdata_nd = dict(limits=dict(cpu=self._cpu_limit,
+                                         memory=self._memory_limit),
+                             requests=dict(memory=self._memory_limit),
+                             pvc_size=self._pvc_size,
+                             storage_group=self._storage_group)
+        if self._cluster_size <= 3:
+            masters['replicas'] = self._cluster_size
+        else:
+            masters['replicas'] = 3
+
+        if self._nodeselector:
+            masters['nodeSelector'] = self._nodeselector
+            clientdata_nd['nodeSelector'] = self._nodeselector
+
+        if self._storage_type:
+            clientdata_nd['node_storage_type'] = self._storage_type
+        else:
+            clientdata_nd['node_storage_type'] = 'emptydir'
+
+        if self._pv_selector:
+            clientdata_nd['pv_selector'] = self._pv_selector
+
+        clientdata = list()
+        for node in range(self._cluster_size):
+            cur_nd = clientdata_nd.copy()
+            cur_nd['pvc_name'] = self._pvc_prefix + '-' + str(node)
+            clientdata.append(cur_nd)
+        self._node_topology = dict(masters=masters,
+                                   clientdata=clientdata)
+
+    @staticmethod
+    def reconcile_masters(masters_ex, masters_des):
+        '''We can scale masters however we want'''
+        # pylint: disable=unused-argument
+        return masters_des
+
+    @staticmethod
+    def find_similar_clientdata_node(nodes_ex, cur_node):
+        '''Find similar suitable clientdata node among nodes_ex'''
+        nd_storage = cur_node.get('node_storage_type', 'emptydir')
+        for node_idx, _ in enumerate(nodes_ex):
+            # Check that node is the same
+            if nodes_ex[node_idx].get('nodeSelector', {}) == cur_node.get('nodeSelector', {}) and\
+               nodes_ex[node_idx].get('node_storage_type') == nd_storage:
+                if (nd_storage == 'emptydir') or \
+                   ((nd_storage == 'hostmount' and
+                     nodes_ex[node_idx].get('hostmount_path') == cur_node.get('hostmount_path'))):
+                    return node_idx
+                elif nd_storage == 'pvc' and\
+                        nodes_ex[node_idx].get('pv_selector') == cur_node.get('pv_selector') and\
+                        nodes_ex[node_idx].get('pvc_size') <= cur_node.get('pvc_size'):
+                    return node_idx
+        raise Exception("Unable to reconcile Elasticsearch node topology. "
+                        "Existing node doesn't fit in the desired topology")
+
+    def reconcile_clientdata(self, clientdata_ex, clientdata_des):
+        '''Reconsile desired and existing clientdata node topologies'''
+        desired_clientdata = clientdata_des[:]
+        if not clientdata_ex:
+            return True
+        if len(clientdata_ex) > len(clientdata_des):
+            # TODO: Crash and burn, we can't scale down.
+            raise Exception("Scaling down Elasticsearch cluster is not supported")
+        for node in clientdata_ex:
+            ex_nd_id = self.find_similar_clientdata_node(desired_clientdata, node)
+            del desired_clientdata[ex_nd_id]
+
+    def reconcile_node_topology(self):
+        '''Reconcile Elasticsearch node topology'''
+        masters = OpenshiftLoggingTopology.reconcile_masters(
+            self._existing_topology.get('masters', {}),
+            self._node_topology['masters'])
+        clientdata = self.reconcile_clientdata(
+            self._existing_topology.get('clientdata', {}),
+            self._node_topology['clientdata'])
+        self._reconciled_topology = dict(masters=masters,
+                                         clientdata=clientdata)
+
+    def build_facts(self):
+        ''' Builds the logging facts and returns them '''
+
+        self.add_facts_for("existing_topology", self._existing_topology)
+
+        if not self._node_topology:
+            # We assume that no topology was provided and we'll build
+            # the desired topology from vars
+            self.build_topology_from_vars()
+        self.add_facts_for("node_topology", self._node_topology)
+
+        self.reconcile_node_topology()
+
+        return self.facts
+
+
+def main():
+    ''' The main method '''
+    module = AnsibleModule(   # noqa: F405
+        argument_spec=dict(
+            existing_topology={"default": "{}", "type": "dict"},
+            desired_topology={"required": False, "type": "dict", "default": "{}"},
+            elasticsearch_clustername={"required": True, "type": "str"},
+            elasticsearch_cluster_size={"required": False, "type": "int"},
+            elasticsearch_cpu_limit={"required": False, "type": "str"},
+            elasticsearch_memory_limit={"required": False, "type": "str"},
+            elasticsearch_pv_selector={"required": False, "type": "dict"},
+            elasticsearch_pvc_dynamic={"required": False, "type": "bool"},
+            elasticsearch_pvc_size={"required": False, "type": "str"},
+            elasticsearch_pvc_prefix={"required": False, "type": "str"},
+            elasticsearch_storage_group={"required": False, "type": "int"},
+            elasticsearch_nodeselector={"required": False, "type": "dict"},
+            elasticsearch_storage_type={"required": False, "type": "str"}
+        ),
+        supports_check_mode=False
+    )
+    try:
+        cmd = OpenshiftLoggingTopology(module, module.params['existing_topology'],
+                                       module.params['desired_topology'],
+                                       module.params['elasticsearch_clustername'],
+                                       module.params['elasticsearch_cluster_size'],
+                                       module.params['elasticsearch_cpu_limit'],
+                                       module.params['elasticsearch_memory_limit'],
+                                       module.params['elasticsearch_pv_selector'],
+                                       module.params['elasticsearch_pvc_dynamic'],
+                                       module.params['elasticsearch_pvc_size'],
+                                       module.params['elasticsearch_pvc_prefix'],
+                                       module.params['elasticsearch_storage_group'],
+                                       module.params['elasticsearch_nodeselector'],
+                                       module.params['elasticsearch_storage_type'])
+        module.exit_json(
+            ansible_facts={"openshift_logging_elasticsearch_topology": cmd.build_facts()}
+        )
+    # ignore broad-except error to avoid stack trace to ansible user
+    # pylint: disable=broad-except
+    except Exception as error:
+        module.fail_json(msg=str(error))
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -12,11 +12,27 @@
     openshift_logging_elasticsearch_proxy_image_prefix: "{{ openshift_logging_elasticsearch_proxy_image_prefix | default(__openshift_logging_elasticsearch_proxy_image_prefix) }}"
     openshift_logging_elasticsearch_proxy_image_version: "{{ openshift_logging_elasticsearch_proxy_image_version | default(__openshift_logging_elasticsearch_proxy_image_version) }}"
 
-- name: Gather OpenShift Logging Facts
+- name: Gather OpenShift Elasticsearch cluster facts
   openshift_logging_elasticsearch_facts:
     oc_bin: '{{ openshift.common.client_binary |default("oc") }}'
     openshift_namespace: "{{openshift_logging_elasticsearch_namespace}}"
     elasticsearch_clustername: "{{ openshift_logging_elasticsearch_clustername }}"
+
+- name: Reconcile OpenShift Elasticsearch node topology
+  openshift_logging_elasticsearch_topology:
+    existing_topology: '{{ openshift_logging_elasticsearch_facts.existing_node_topology }}'
+    desired_topology: '{{ openshift_logging_elasticsearch_node_topology }}'
+    elasticsearch_clustername: '{{ openshift_logging_elasticsearch_clustername }}'
+    elasticsearch_cluster_size: '{{ openshift_logging_elasticsearch_cluster_size }}'
+    elasticsearch_cpu_limit: '{{ openshift_logging_elasticsearch_cpu_limit }}'
+    elasticsearch_memory_limit: '{{ openshift_logging_elasticsearch_memory_limit }}'
+    elasticsearch_pv_selector: '{{ openshift_logging_elasticsearch_pv_selector }}'
+    elasticsearch_pvc_dynamic: '{{ openshift_logging_elasticsearch_pvc_dynamic }}'
+    elasticsearch_pvc_size: '{{ openshift_logging_elasticsearch_pvc_size }}'
+    elasticsearch_pvc_prefix: '{{ openshift_logging_elasticsearch_pvc_prefix }}'
+    elasticsearch_storage_group: '{{ openshift_logging_elasticsearch_storage_group }}'
+    elasticsearch_nodeselector: '{{ openshift_logging_elasticsearch_nodeselector }}'
+    elasticsearch_storage_type: '{{ openshift_logging_elasticsearch_storage_type }}'
 
 # service account
 - include: "{{ role_path }}/tasks/service_accounts.yaml"
@@ -68,7 +84,7 @@
 # Deploy masters
 - include: "{{ role_path }}/tasks/node_provision.yaml"
   vars:
-    replicas: "{{ openshift_logging_elasticsearch_node_topology.masters.replicas }}"
+    replicas: "{{ openshift_logging_elasticsearch_topology.node_topology.masters.replicas }}"
     es_role: master
     node_master: "true"
     node_data: "false"
@@ -76,8 +92,9 @@
     es_http_service: "false"
     openshift_logging_elasticsearch_deployment_name: "{{ openshift_logging_elasticsearch_clustername }}-master"
     generated_certs_dir: "{{ certs_dir }}"
-    limits: "{{ openshift_logging_elasticsearch_node_topology.masters.limits }}"
-    es_node_selector: "{{ openshift_logging_elasticsearch_node_topology.masters.nodeSelector | default({}) }}"
+    limits: "{{ openshift_logging_elasticsearch_topology.node_topology.masters.limits }}"
+    requests: "{{ openshift_logging_elasticsearch_topology.node_topology.masters.requests }}"
+    es_node_selector: "{{ openshift_logging_elasticsearch_topology.node_topology.masters.nodeSelector | default({}) }}"
     node_storage_type: emptydir
     es_storage_groups: "{{ openshift_logging_elasticsearch_storage_group | default([]) }}"
     es_container_security_context: "{{ _es_containers.elasticsearch.securityContext if _es_containers is defined and 'elasticsearch' in _es_containers and 'securityContext' in _es_containers.elasticsearch else None }}"
@@ -95,11 +112,11 @@
     openshift_logging_elasticsearch_deployment_name: "{{ openshift_logging_elasticsearch_clustername }}-clientdata-{{ item.0 }}"
     generated_certs_dir: "{{ certs_dir }}"
     limits: "{{ item.1.limits }}"
+    requests: "{{ item.1.requests }}"
     es_node_selector: "{{ item.1.nodeSelector | default({}) }}"
     node_storage_type: "{{ item.1.node_storage_type | default(emptydir) }}"
     openshift_logging_elasticsearch_pvc_name: "{{ openshift_logging_es_pvc_prefix }}-{{ item.0 | int }}"
     hostmount_path: "{{ item.1.hostmount_path |default ({})}}"
     es_storage_groups: "{{ openshift_logging_elasticsearch_storage_group | default([]) }}"
     es_container_security_context: "{{ _es_containers.elasticsearch.securityContext if _es_containers is defined and 'elasticsearch' in _es_containers and 'securityContext' in _es_containers.elasticsearch else None }}"
-  with_indexed_items: "{{ openshift_logging_elasticsearch_node_topology.clientdata }}"
-
+  with_indexed_items: "{{ openshift_logging_elasticsearch_topology.node_topology.clientdata }}"

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -81,6 +81,21 @@
 
 - include: "{{ role_path }}/tasks/svcs_routes.yaml"
 
+- debug:
+    var: openshift_logging_elasticsearch_topology
+
+- name: Set ES configuration facts for all-in-one node
+  set_fact:
+    es_masters_quorum: 1
+    es_recover_expected_data_nodes: 1
+  when: openshift_logging_elasticsearch_topology.node_topology.clientdatamaster is defined
+
+- name: Set ES configuration facts for multi-node configuration
+  set_fact:
+    es_masters_quorum: "{{ openshift_logging_elasticsearch_topology.node_topology.masters.replicas |int /2 + 1 }}"
+    es_recover_expected_data_nodes: "{{ openshift_logging_elasticsearch_topology.node_topology.clientdata|length |default(1) }}"
+  when:  openshift_logging_elasticsearch_topology.node_topology.clientdatamaster is not defined
+
 # Deploy masters
 - include: "{{ role_path }}/tasks/node_provision.yaml"
   vars:
@@ -98,7 +113,7 @@
     node_storage_type: emptydir
     es_storage_groups: "{{ openshift_logging_elasticsearch_storage_group | default([]) }}"
     es_container_security_context: "{{ _es_containers.elasticsearch.securityContext if _es_containers is defined and 'elasticsearch' in _es_containers and 'securityContext' in _es_containers.elasticsearch else None }}"
-
+  when: openshift_logging_elasticsearch_topology.node_topology.masters is defined
 
 # Deploy client-data nodes
 - include: "{{ role_path }}/tasks/node_provision.yaml"
@@ -120,3 +135,24 @@
     es_storage_groups: "{{ openshift_logging_elasticsearch_storage_group | default([]) }}"
     es_container_security_context: "{{ _es_containers.elasticsearch.securityContext if _es_containers is defined and 'elasticsearch' in _es_containers and 'securityContext' in _es_containers.elasticsearch else None }}"
   with_indexed_items: "{{ openshift_logging_elasticsearch_topology.node_topology.clientdata }}"
+  when: openshift_logging_elasticsearch_topology.node_topology.clientdata is defined
+
+# Deploy client-data-master nodes
+- include: "{{ role_path }}/tasks/node_provision.yaml"
+  vars:
+    es_cluster_name: "{{ openshift_logging_elasticsearch_clustername }}"
+    es_role: clientdatamaster
+    es_http_service: "true"
+    node_master: "true"
+    node_data: "true"
+    node_client: "false"
+    openshift_logging_elasticsearch_deployment_name: "{{ openshift_logging_elasticsearch_clustername }}-clientdatamaster"
+    generated_certs_dir: "{{ certs_dir }}"
+    node_storage_type: "{{ openshift_logging_elasticsearch_topology.node_topology.clientdatamaster.node_storage_type | default(emptydir) }}"
+    openshift_logging_elasticsearch_pvc_name: "{{ openshift_logging_es_pvc_prefix }}-0"
+    hostmount_path: "{{ openshift_logging_elasticsearch_topology.node_topology.clientdatamaster.hostmount_path |default ({})}}"
+    limits: "{{ openshift_logging_elasticsearch_topology.node_topology.clientdatamaster.limits }}"
+    requests: "{{ openshift_logging_elasticsearch_topology.node_topology.clientdatamaster.requests }}"
+    es_node_selector: "{{ openshift_logging_elasticsearch_topology.node_topology.clientdatamaster.nodeSelector | default({}) }}"
+  when: openshift_logging_elasticsearch_topology.node_topology.clientdatamaster is defined
+

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -94,7 +94,7 @@
   set_fact:
     es_masters_quorum: "{{ openshift_logging_elasticsearch_topology.node_topology.masters.replicas |int /2 + 1 }}"
     es_recover_expected_data_nodes: "{{ openshift_logging_elasticsearch_topology.node_topology.clientdata|length |default(1) }}"
-  when:  openshift_logging_elasticsearch_topology.node_topology.clientdatamaster is not defined
+  when: openshift_logging_elasticsearch_topology.node_topology.clientdatamaster is not defined
 
 # Deploy masters
 - include: "{{ role_path }}/tasks/node_provision.yaml"
@@ -155,4 +155,3 @@
     requests: "{{ openshift_logging_elasticsearch_topology.node_topology.clientdatamaster.requests }}"
     es_node_selector: "{{ openshift_logging_elasticsearch_topology.node_topology.clientdatamaster.nodeSelector | default({}) }}"
   when: openshift_logging_elasticsearch_topology.node_topology.clientdatamaster is defined
-

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -1,20 +1,4 @@
 ---
-- name: Validate Elasticsearch cluster size
-  fail: msg="The openshift_logging_es_cluster_size may only be scaled down manually. Please see official documentation on how to do this."
-  when: openshift_logging_facts.elasticsearch.deploymentconfigs | length > openshift_logging_es_cluster_size|int
-
-- name: Validate Elasticsearch Ops cluster size
-  fail: msg="The openshift_logging_es_ops_cluster_size may only be scaled down manually. Please see official documentation on how to do this."
-  when: openshift_logging_facts.elasticsearch_ops.deploymentconfigs | length > openshift_logging_es_ops_cluster_size|int
-
-- fail:
-    msg: Invalid deployment type, one of ['data-master', 'data-client', 'master', 'client'] allowed
-  when: not openshift_logging_elasticsearch_deployment_type in __allowed_es_types
-
-- set_fact:
-    elasticsearch_name: "{{ 'logging-elasticsearch' ~ ( (openshift_logging_elasticsearch_ops_deployment | default(false) | bool) | ternary('-ops', '')) }}"
-    es_component: "{{ 'es' ~ ( (openshift_logging_elasticsearch_ops_deployment | default(false) | bool) | ternary('-ops', '') ) }}"
-
 - include: determine_version.yaml
 
 - name: Set default image variables based on deployment_type
@@ -28,123 +12,16 @@
     openshift_logging_elasticsearch_proxy_image_prefix: "{{ openshift_logging_elasticsearch_proxy_image_prefix | default(__openshift_logging_elasticsearch_proxy_image_prefix) }}"
     openshift_logging_elasticsearch_proxy_image_version: "{{ openshift_logging_elasticsearch_proxy_image_version | default(__openshift_logging_elasticsearch_proxy_image_version) }}"
 
-# allow passing in a tempdir
-- name: Create temp directory for doing work in
-  command: mktemp -d /tmp/openshift-logging-ansible-XXXXXX
-  register: mktemp
-  changed_when: False
-
-- set_fact:
-    tempdir: "{{ mktemp.stdout }}"
-
-# This may not be necessary in this role
-- name: Create templates subdirectory
-  file:
-    state: directory
-    path: "{{ tempdir }}/templates"
-    mode: 0755
-  changed_when: False
-
-# we want to make sure we have all the necessary components here
+- name: Gather OpenShift Logging Facts
+  openshift_logging_elasticsearch_facts:
+    oc_bin: '{{ openshift.common.client_binary |default("oc") }}'
+    openshift_namespace: "{{openshift_logging_elasticsearch_namespace}}"
+    elasticsearch_clustername: "{{ openshift_logging_elasticsearch_clustername }}"
 
 # service account
-
-- name: Create ES service account
-  oc_serviceaccount:
-    state: present
-    name: "aggregated-logging-elasticsearch"
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    image_pull_secrets: "{{ openshift_logging_image_pull_secret }}"
-  when: openshift_logging_image_pull_secret != ''
-
-- name: Create ES service account
-  oc_serviceaccount:
-    state: present
-    name: "aggregated-logging-elasticsearch"
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-  when:
-    - openshift_logging_image_pull_secret == ''
-
-# rolebinding reader
-- copy:
-    src: rolebinding-reader.yml
-    dest: "{{ tempdir }}/rolebinding-reader.yml"
-
-- name: Create rolebinding-reader role
-  oc_obj:
-    state: present
-    name: "rolebinding-reader"
-    kind: clusterrole
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    files:
-      - "{{ tempdir }}/rolebinding-reader.yml"
-    delete_after: true
-
-# SA roles
-- name: Set rolebinding-reader permissions for ES
-  oc_adm_policy_user:
-    state: present
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    resource_kind: cluster-role
-    resource_name: rolebinding-reader
-    user: "system:serviceaccount:{{ openshift_logging_elasticsearch_namespace }}:aggregated-logging-elasticsearch"
-
-- oc_adm_policy_user:
-    state: present
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    resource_kind: cluster-role
-    resource_name: system:auth-delegator
-    user: "system:serviceaccount:{{ openshift_logging_elasticsearch_namespace}}:aggregated-logging-elasticsearch"
-
-# logging-metrics-reader role
-- template:
-    src: logging-metrics-role.j2
-    dest: "{{mktemp.stdout}}/templates/logging-metrics-role.yml"
+- include: "{{ role_path }}/tasks/service_accounts.yaml"
   vars:
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    role_namespace: "{{ openshift_logging_elasticsearch_prometheus_sa | serviceaccount_namespace(openshift_logging_elasticsearch_namespace) }}"
-    role_user: "{{ openshift_logging_elasticsearch_prometheus_sa | serviceaccount_name }}"
-
-- name: Create logging-metrics-reader-role
-  command: >
-    {{ openshift.common.client_binary }}
-    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-    -n "{{ openshift_logging_elasticsearch_namespace }}"
-    create -f "{{mktemp.stdout}}/templates/logging-metrics-role.yml"
-  register: prometheus_out
-  check_mode: no
-  ignore_errors: yes
-
-- fail:
-    msg: "There was an error creating the logging-metrics-role and binding: {{prometheus_out}}"
-  when:
-    - "prometheus_out.stderr | length > 0"
-    - "'already exists' not in prometheus_out.stderr"
-
-# View role and binding
-- name: Generate logging-elasticsearch-view-role
-  template:
-    src: rolebinding.j2
-    dest: "{{mktemp.stdout}}/logging-elasticsearch-view-role.yaml"
-  vars:
-    obj_name: logging-elasticsearch-view-role
-    roleRef:
-      name: view
-    subjects:
-      - kind: ServiceAccount
-        name: aggregated-logging-elasticsearch
-  changed_when: no
-
-- name: Set logging-elasticsearch-view-role role
-  oc_obj:
-    state: present
-    name: "logging-elasticsearch-view-role"
-    kind: rolebinding
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    files:
-      - "{{ tempdir }}/logging-elasticsearch-view-role.yaml"
-    delete_after: true
-
+    openshift_elasticsearch_namespace: '{{ openshift_logging_elasticsearch_namespace }}'
 # configmap
 - assert:
     that:
@@ -156,61 +33,25 @@
       - "{{ openshift_logging_es_log_appenders | length > 0 }}"
     msg: "The openshift_logging_es_log_appenders '{{ openshift_logging_es_log_appenders }}' has an unrecognized option and only supports the following as a list: {{ __es_log_appenders | join(', ') }}"
 
-- template:
-    src: elasticsearch-logging.yml.j2
-    dest: "{{ tempdir }}/elasticsearch-logging.yml"
-  vars:
-    root_logger: "{{openshift_logging_es_log_appenders | join(', ')}}"
-  when: es_logging_contents is undefined
-  changed_when: no
+# Set variables common for all DCs
+- name: Setting legacy logging_component for the label
+  set_fact:
+    logging_component: "{{ openshift_logging_elasticsearch_clustername }}"
+    es_component: "{{ openshift_logging_elasticsearch_clustername  | regex_replace('^logging-','') }}"
 
-- template:
-    src: elasticsearch.yml.j2
-    dest: "{{ tempdir }}/elasticsearch.yml"
-  vars:
-    allow_cluster_reader: "{{ openshift_logging_elasticsearch_ops_allow_cluster_reader | lower | default('false') }}"
-    es_number_of_shards: "{{ openshift_logging_es_number_of_shards | default(1) }}"
-    es_number_of_replicas: "{{ openshift_logging_es_number_of_replicas | default(0) }}"
-    es_kibana_index_mode: "{{ openshift_logging_elasticsearch_kibana_index_mode | default('unique') }}"
-
-  when: es_config_contents is undefined
-  changed_when: no
-
-- copy:
-    content: "{{ es_logging_contents }}"
-    dest: "{{ tempdir }}/elasticsearch-logging.yml"
-  when: es_logging_contents is defined
-  changed_when: no
-
-- copy:
-    content: "{{ es_config_contents }}"
-    dest: "{{ tempdir }}/elasticsearch.yml"
-  when: es_config_contents is defined
-  changed_when: no
-
-- name: Set ES configmap
-  oc_configmap:
-    state: present
-    name: "{{ elasticsearch_name }}"
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    from_file:
-      elasticsearch.yml: "{{ tempdir }}/elasticsearch.yml"
-      logging.yml: "{{ tempdir }}/elasticsearch-logging.yml"
-
-
-# secret
+# Set secrets for Elasticsearch
 - name: Set ES secret
   oc_secret:
     state: present
-    name: "logging-elasticsearch"
+    name: "{{ openshift_logging_elasticsearch_clustername }}-certs"
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
     files:
       - name: key
-        path: "{{ generated_certs_dir }}/logging-es.jks"
+        path: "{{ generated_certs_dir }}/{{ openshift_logging_elasticsearch_api_cert_name }}.jks"
       - name: truststore
         path: "{{ generated_certs_dir }}/truststore.jks"
       - name: searchguard.key
-        path: "{{ generated_certs_dir }}/elasticsearch.jks"
+        path: "{{ generated_certs_dir }}/{{ openshift_logging_elasticsearch_transport_cert_name }}.jks"
       - name: searchguard.truststore
         path: "{{ generated_certs_dir }}/truststore.jks"
       - name: admin-key
@@ -222,224 +63,43 @@
       - name: admin.jks
         path: "{{ generated_certs_dir }}/system.admin.jks"
 
-# services
-- name: Set logging-{{ es_component }}-cluster service
-  oc_service:
-    state: present
-    name: "logging-{{ es_component }}-cluster"
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    selector:
-      component: "{{ es_component }}"
-      provider: openshift
-    labels:
-      logging-infra: 'support'
-    ports:
-      - port: 9300
+- include: "{{ role_path }}/tasks/svcs_routes.yaml"
 
-- name: Set logging-{{ es_component }} service
-  oc_service:
-    state: present
-    name: "logging-{{ es_component }}"
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    selector:
-      component: "{{ es_component }}"
-      provider: openshift
-    labels:
-      logging-infra: 'support'
-    ports:
-      - port: 9200
-        targetPort: "restapi"
-
-- name: Set logging-{{ es_component}}-prometheus service
-  oc_service:
-    state: present
-    name: "logging-{{es_component}}-prometheus"
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    labels:
-      logging-infra: 'support'
-    ports:
-      - name: proxy
-        port: 443
-        targetPort: 4443
-    selector:
-      component: "{{ es_component }}-prometheus"
-      provider: openshift
-
-- oc_edit:
-    kind: service
-    name: "logging-{{es_component}}-prometheus"
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    separator: '#'
-    content:
-      metadata#annotations#service.alpha.openshift.io/serving-cert-secret-name: "prometheus-tls"
-      metadata#annotations#prometheus.io/scrape: "true"
-      metadata#annotations#prometheus.io/scheme: "https"
-      metadata#annotations#prometheus.io/path: "_prometheus/metrics"
-
-- name: Check to see if PVC already exists
-  oc_obj:
-    state: list
-    kind: pvc
-    name: "{{ openshift_logging_elasticsearch_pvc_name }}"
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-  register: logging_elasticsearch_pvc
-
-# logging_elasticsearch_pvc.results.results | length > 0 returns a false positive
-# so we check for the presence of 'stderr' to determine if the obj exists or not
-# the RC for existing and not existing is both 0
-- when:
-    - logging_elasticsearch_pvc.results.stderr is defined
-    - openshift_logging_elasticsearch_storage_type == "pvc"
-  block:
-    # storageclasses are used by default but if static then disable
-    # storageclasses with the storageClassName set to "" in pvc.j2
-    - name: Creating ES storage template - static
-      template:
-        src: pvc.j2
-        dest: "{{ tempdir }}/templates/logging-es-pvc.yml"
-      vars:
-        obj_name: "{{ openshift_logging_elasticsearch_pvc_name }}"
-        size: "{{ (openshift_logging_elasticsearch_pvc_size | trim | length == 0) | ternary('10Gi', openshift_logging_elasticsearch_pvc_size) }}"
-        access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
-        pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
-        storage_class_name: "{{ openshift_logging_elasticsearch_pvc_storage_class_name | default('', true) }}"
-      when:
-        - not openshift_logging_elasticsearch_pvc_dynamic | bool
-
-    # Storageclasses are used by default if configured
-    - name: Creating ES storage template - dynamic
-      template:
-        src: pvc.j2
-        dest: "{{ tempdir }}/templates/logging-es-pvc.yml"
-      vars:
-        obj_name: "{{ openshift_logging_elasticsearch_pvc_name }}"
-        size: "{{ (openshift_logging_elasticsearch_pvc_size | trim | length == 0) | ternary('10Gi', openshift_logging_elasticsearch_pvc_size) }}"
-        access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
-        pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
-      when:
-        - openshift_logging_elasticsearch_pvc_dynamic | bool
-
-    - name: Set ES storage
-      oc_obj:
-        state: present
-        kind: pvc
-        name: "{{ openshift_logging_elasticsearch_pvc_name }}"
-        namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-        files:
-          - "{{ tempdir }}/templates/logging-es-pvc.yml"
-        delete_after: true
-
-- set_fact:
-    es_deploy_name: "logging-{{ es_component }}-{{ openshift_logging_elasticsearch_deployment_type }}-{{ 8 | oo_random_word('abcdefghijklmnopqrstuvwxyz0123456789') }}"
-  when: openshift_logging_elasticsearch_deployment_name == ""
-
-- set_fact:
-    es_deploy_name: "{{ openshift_logging_elasticsearch_deployment_name }}"
-  when: openshift_logging_elasticsearch_deployment_name != ""
-
-# DC
-- name: Set ES dc templates
-  template:
-    src: es.j2
-    dest: "{{ tempdir }}/templates/logging-es-dc.yml"
+# Deploy masters
+- include: "{{ role_path }}/tasks/node_provision.yaml"
   vars:
-    es_cluster_name: "{{ es_component }}"
-    component: "{{ es_component }}"
-    logging_component: elasticsearch
-    deploy_name: "{{ es_deploy_name }}"
-    image: "{{ openshift_logging_elasticsearch_image_prefix }}logging-elasticsearch:{{ openshift_logging_elasticsearch_image_version }}"
-    proxy_image: "{{ openshift_logging_elasticsearch_proxy_image_prefix }}oauth-proxy:{{ openshift_logging_elasticsearch_proxy_image_version }}"
-    es_cpu_limit: "{{ openshift_logging_elasticsearch_cpu_limit }}"
-    es_memory_limit: "{{ openshift_logging_elasticsearch_memory_limit }}"
-    es_node_selector: "{{ openshift_logging_elasticsearch_nodeselector | default({}) }}"
+    replicas: "{{ openshift_logging_elasticsearch_node_topology.masters.replicas }}"
+    es_role: master
+    node_master: "true"
+    node_data: "false"
+    node_client: "false"
+    es_http_service: "false"
+    openshift_logging_elasticsearch_deployment_name: "{{ openshift_logging_elasticsearch_clustername }}-master"
+    generated_certs_dir: "{{ certs_dir }}"
+    limits: "{{ openshift_logging_elasticsearch_node_topology.masters.limits }}"
+    es_node_selector: "{{ openshift_logging_elasticsearch_node_topology.masters.nodeSelector | default({}) }}"
+    node_storage_type: emptydir
     es_storage_groups: "{{ openshift_logging_elasticsearch_storage_group | default([]) }}"
     es_container_security_context: "{{ _es_containers.elasticsearch.securityContext if _es_containers is defined and 'elasticsearch' in _es_containers and 'securityContext' in _es_containers.elasticsearch else None }}"
-    deploy_type: "{{ openshift_logging_elasticsearch_deployment_type }}"
-    es_replicas: 1
 
-- name: Set ES dc
-  oc_obj:
-    state: present
-    name: "{{ es_deploy_name }}"
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    kind: dc
-    files:
-      - "{{ tempdir }}/templates/logging-es-dc.yml"
-    delete_after: true
 
-- name: Retrieving the cert to use when generating secrets for the {{ es_component }} component
-  slurp:
-    src: "{{ generated_certs_dir }}/{{ item.file }}"
-  register: key_pairs
-  with_items:
-    - { name: "ca_file", file: "ca.crt" }
-    - { name: "es_key", file: "system.logging.es.key" }
-    - { name: "es_cert", file: "system.logging.es.crt" }
-  when: openshift_logging_es_allow_external | bool
-
-- set_fact:
-    es_key: "{{ lookup('file', openshift_logging_es_key) | b64encode }}"
-  when:
-    - openshift_logging_es_key | trim | length > 0
-    - openshift_logging_es_allow_external | bool
-  changed_when: false
-
-- set_fact:
-    es_cert: "{{ lookup('file', openshift_logging_es_cert) | b64encode  }}"
-  when:
-    - openshift_logging_es_cert | trim | length > 0
-    - openshift_logging_es_allow_external | bool
-  changed_when: false
-
-- set_fact:
-    es_ca: "{{ lookup('file', openshift_logging_es_ca_ext) | b64encode  }}"
-  when:
-    - openshift_logging_es_ca_ext | trim | length > 0
-    - openshift_logging_es_allow_external | bool
-  changed_when: false
-
-- set_fact:
-    es_ca: "{{ key_pairs | entry_from_named_pair('ca_file') }}"
-  when:
-    - es_ca is not defined
-    - openshift_logging_es_allow_external | bool
-  changed_when: false
-
-- name: Generating Elasticsearch {{ es_component }} route template
-  template:
-    src: route_reencrypt.j2
-    dest: "{{mktemp.stdout}}/templates/logging-{{ es_component }}-route.yaml"
+# Deploy client-data nodes
+- include: "{{ role_path }}/tasks/node_provision.yaml"
   vars:
-    obj_name: "logging-{{ es_component }}"
-    route_host: "{{ openshift_logging_es_hostname }}"
-    service_name: "logging-{{ es_component }}"
-    tls_key: "{{ es_key | default('') | b64decode }}"
-    tls_cert: "{{ es_cert | default('') | b64decode }}"
-    tls_ca_cert: "{{ es_ca | b64decode }}"
-    tls_dest_ca_cert: "{{ key_pairs | entry_from_named_pair('ca_file') | b64decode }}"
-    edge_term_policy: "{{ openshift_logging_es_edge_term_policy | default('') }}"
-    labels:
-      component: support
-      logging-infra: support
-      provider: openshift
-  changed_when: no
-  when: openshift_logging_es_allow_external | bool
+    es_cluster_name: "{{ openshift_logging_elasticsearch_clustername }}"
+    es_role: clientdata
+    es_http_service: "true"
+    node_master: "false"
+    node_data: "true"
+    node_client: "false"
+    openshift_logging_elasticsearch_deployment_name: "{{ openshift_logging_elasticsearch_clustername }}-clientdata-{{ item.0 }}"
+    generated_certs_dir: "{{ certs_dir }}"
+    limits: "{{ item.1.limits }}"
+    es_node_selector: "{{ item.1.nodeSelector | default({}) }}"
+    node_storage_type: "{{ item.1.node_storage_type | default(emptydir) }}"
+    openshift_logging_elasticsearch_pvc_name: "{{ openshift_logging_es_pvc_prefix }}-{{ item.0 | int }}"
+    hostmount_path: "{{ item.1.hostmount_path |default ({})}}"
+    es_storage_groups: "{{ openshift_logging_elasticsearch_storage_group | default([]) }}"
+    es_container_security_context: "{{ _es_containers.elasticsearch.securityContext if _es_containers is defined and 'elasticsearch' in _es_containers and 'securityContext' in _es_containers.elasticsearch else None }}"
+  with_indexed_items: "{{ openshift_logging_elasticsearch_node_topology.clientdata }}"
 
-# This currently has an issue if the host name changes
-- name: Setting Elasticsearch {{ es_component }} route
-  oc_obj:
-    state: present
-    name: "logging-{{ es_component }}"
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    kind: route
-    files:
-      - "{{ tempdir }}/templates/logging-{{ es_component }}-route.yaml"
-  when: openshift_logging_es_allow_external | bool
-
-## Placeholder for migration when necessary ##
-
-- name: Delete temp directory
-  file:
-    name: "{{ tempdir }}"
-    state: absent
-  changed_when: False

--- a/roles/openshift_logging_elasticsearch/tasks/node_configuration.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/node_configuration.yaml
@@ -39,4 +39,3 @@
     from_file:
       elasticsearch.yml: "{{ tempdir }}/elasticsearch.yml"
       logging.yml: "{{ tempdir }}/elasticsearch-logging.yml"
-

--- a/roles/openshift_logging_elasticsearch/tasks/node_configuration.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/node_configuration.yaml
@@ -1,0 +1,42 @@
+---
+# configmap
+- template:
+    src: elasticsearch-logging.yml.j2
+    dest: "{{ tempdir }}/elasticsearch-logging.yml"
+  vars:
+    root_logger: "{{openshift_logging_es_log_appenders | join(', ')}}"
+  when: es_logging_contents is undefined
+  changed_when: no
+
+- template:
+    src: elasticsearch.yml.j2
+    dest: "{{ tempdir }}/elasticsearch.yml"
+  vars:
+    allow_cluster_reader: "{{ openshift_logging_elasticsearch_ops_allow_cluster_reader | lower | default('false') }}"
+    es_number_of_shards: "{{ openshift_logging_es_number_of_shards | default(1) }}"
+    es_number_of_replicas: "{{ openshift_logging_es_number_of_replicas | default(0) }}"
+    es_kibana_index_mode: "{{ openshift_logging_elasticsearch_kibana_index_mode | default('unique') }}"
+  when: es_config_contents is undefined
+  changed_when: no
+
+- copy:
+    content: "{{ es_logging_contents }}"
+    dest: "{{ tempdir }}/elasticsearch-logging.yml"
+  when: es_logging_contents is defined
+  changed_when: no
+
+- copy:
+    content: "{{ es_config_contents }}"
+    dest: "{{ tempdir }}/elasticsearch.yml"
+  when: es_config_contents is defined
+  changed_when: no
+
+- name: Set ES configmap
+  oc_configmap:
+    state: present
+    name: "{{ node_configmap }}"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    from_file:
+      elasticsearch.yml: "{{ tempdir }}/elasticsearch.yml"
+      logging.yml: "{{ tempdir }}/elasticsearch-logging.yml"
+

--- a/roles/openshift_logging_elasticsearch/tasks/node_provision.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/node_provision.yaml
@@ -122,7 +122,7 @@
     es_component: "{{ es_component }}"
     deploy_name: "{{ es_deploy_name }}"
     storage_type: "{{ node_storage_type | default(emptydir) }}"
-    image: "{{ openshift_logging_elasticsearch_image_prefix }}{{ openshift_logging_elasticsearch_image_name }}:{{ openshift_logging_elasticsearch_image_version }}"
+    image: "{{ openshift_logging_elasticsearch_image_prefix }}logging-elasticsearch:{{ openshift_logging_elasticsearch_image_version }}"
     proxy_image: "{{ openshift_logging_elasticsearch_proxy_image_prefix }}oauth-proxy:{{ openshift_logging_elasticsearch_proxy_image_version }}"
   changed_when: false
 

--- a/roles/openshift_logging_elasticsearch/tasks/node_provision.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/node_provision.yaml
@@ -135,7 +135,6 @@
     files:
       - "{{ tempdir }}/templates/logging-es-dc.yml"
     delete_after: true
-    kubeconfig: '{{ kubeconfig }}'
 
 # scale up
 - name: Start Elasticsearch for role {{ es_role }}
@@ -144,7 +143,6 @@
     name: "{{ es_deploy_name }}"
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
     replicas: "{{ replicas | default(1) }}"
-    kubeconfig: '{{ kubeconfig }}'
 
 ## Placeholder for migration when necessary ##
 

--- a/roles/openshift_logging_elasticsearch/tasks/node_provision.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/node_provision.yaml
@@ -54,36 +54,36 @@
 # so we check for the presence of 'stderr' to determine if the obj exists or not
 # the RC for existing and not existing is both 0
 - when:
-    - logging_elasticsearch_pvc.results.stderr is defined
-    - node_storage_type == "pvc"
+  - logging_elasticsearch_pvc.results.stderr is defined
+  - node_storage_type == "pvc"
   block:
-    # storageclasses are used by default but if static then disable
-    # storageclasses with the storageClassName set to "" in pvc.j2
-    - name: Creating ES storage template - static
-      template:
-        src: pvc.j2
-        dest: "{{ tempdir }}/templates/logging-es-pvc.yml"
-      vars:
-        obj_name: "{{ openshift_logging_elasticsearch_pvc_name }}"
-        size: "{{ openshift_logging_elasticsearch_pvc_size }}"
-        access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
-        pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
-        storage_class_name: "{{ openshift_logging_elasticsearch_pvc_storage_class_name | default('', true) }}"
-      when:
-        - not openshift_logging_elasticsearch_pvc_dynamic | bool
+  # storageclasses are used by default but if static then disable
+  # storageclasses with the storageClassName set to "" in pvc.j2
+  - name: Creating ES storage template - static
+    template:
+      src: pvc.j2
+      dest: "{{ tempdir }}/templates/logging-es-pvc.yml"
+    vars:
+      obj_name: "{{ openshift_logging_elasticsearch_pvc_name }}"
+      size: "{{ openshift_logging_elasticsearch_pvc_size }}"
+      access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
+      pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
+      storage_class_name: "{{ openshift_logging_elasticsearch_pvc_storage_class_name | default('', true) }}"
+    when:
+    - not openshift_logging_elasticsearch_pvc_dynamic | bool
 
     # Storageclasses are used by default if configured
-    - name: Creating ES storage template - dynamic
-      template:
-        src: pvc.j2
-        dest: "{{ tempdir }}/templates/logging-es-pvc.yml"
-      vars:
-        obj_name: "{{ openshift_logging_elasticsearch_pvc_name }}"
-        size: "{{ openshift_logging_elasticsearch_pvc_size }}"
-        access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
-        pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
-      when:
-        - openshift_logging_elasticsearch_pvc_dynamic | bool
+  - name: Creating ES storage template - dynamic
+    template:
+      src: pvc.j2
+      dest: "{{ tempdir }}/templates/logging-es-pvc.yml"
+    vars:
+      obj_name: "{{ openshift_logging_elasticsearch_pvc_name }}"
+      size: "{{ openshift_logging_elasticsearch_pvc_size }}"
+      access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
+      pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
+    when:
+    - openshift_logging_elasticsearch_pvc_dynamic | bool
 
 - name: Set ES data node storage
   oc_obj:
@@ -92,7 +92,7 @@
     name: "{{ openshift_logging_elasticsearch_pvc_name }}"
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
     files:
-      - "{{ tempdir }}/templates/logging-es-pvc.yml"
+    - "{{ tempdir }}/templates/logging-es-pvc.yml"
     delete_after: true
   when:
   - node_storage_type == "pvc"
@@ -135,7 +135,7 @@
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
     kind: dc
     files:
-      - "{{ tempdir }}/templates/logging-es-dc.yml"
+    - "{{ tempdir }}/templates/logging-es-dc.yml"
     delete_after: true
 
 # scale up

--- a/roles/openshift_logging_elasticsearch/tasks/node_provision.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/node_provision.yaml
@@ -124,6 +124,8 @@
     storage_type: "{{ node_storage_type | default(emptydir) }}"
     image: "{{ openshift_logging_elasticsearch_image_prefix }}logging-elasticsearch:{{ openshift_logging_elasticsearch_image_version }}"
     proxy_image: "{{ openshift_logging_elasticsearch_proxy_image_prefix }}oauth-proxy:{{ openshift_logging_elasticsearch_proxy_image_version }}"
+    es_storage_groups: "{{ openshift_logging_elasticsearch_storage_group | default([]) }}"
+    es_container_security_context: "{{ _es_containers.elasticsearch.securityContext if _es_containers is defined and 'elasticsearch' in _es_containers and 'securityContext' in _es_containers.elasticsearch else None }}"
   changed_when: false
 
 - name: Set ES dc for role {{ es_role }}

--- a/roles/openshift_logging_elasticsearch/tasks/node_provision.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/node_provision.yaml
@@ -1,0 +1,155 @@
+---
+- fail:
+    msg: "Invalid node role '{{ es_role }}' provide, one of {{ __allowed_es_types }} is allowed"
+  when: not es_role in __allowed_es_types
+
+- include: determine_version.yaml
+
+# allow passing in a tempdir
+- name: Create temp directory for doing work in for role {{ es_role }}
+  command: mktemp -d /tmp/openshift-logging-ansible-XXXXXX
+  register: mktemp
+  changed_when: False
+
+- name: set temp dir
+  set_fact:
+    tempdir: "{{ mktemp.stdout }}"
+
+- name: set legacy component
+  set_fact:
+    es_component: "{{ openshift_logging_elasticsearch_clustername  | regex_replace('^logging-','') }}"
+
+# This may not be necessary in this role
+- name: Create templates subdirectory
+  file:
+    state: directory
+    path: "{{ tempdir }}/templates"
+    mode: 0755
+  changed_when: False
+
+# we want to make sure we have all the necessary components here
+
+- name: Creating ES storage template
+  template:
+    src: pvc.j2
+    dest: "{{ tempdir }}/templates/logging-es-pvc.yml"
+  vars:
+    obj_name: "{{ openshift_logging_elasticsearch_pvc_name }}"
+    size: "{{ openshift_logging_elasticsearch_pvc_size }}"
+    access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
+    pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
+  when:
+  - node_storage_type == "pvc"
+  - not openshift_logging_elasticsearch_pvc_dynamic
+
+- name: Check to see if PVC already exists
+  oc_obj:
+    state: list
+    kind: pvc
+    name: "{{ openshift_logging_elasticsearch_pvc_name }}"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+  register: logging_elasticsearch_pvc
+
+# logging_elasticsearch_pvc.results.results | length > 0 returns a false positive
+# so we check for the presence of 'stderr' to determine if the obj exists or not
+# the RC for existing and not existing is both 0
+- when:
+    - logging_elasticsearch_pvc.results.stderr is defined
+    - node_storage_type == "pvc"
+  block:
+    # storageclasses are used by default but if static then disable
+    # storageclasses with the storageClassName set to "" in pvc.j2
+    - name: Creating ES storage template - static
+      template:
+        src: pvc.j2
+        dest: "{{ tempdir }}/templates/logging-es-pvc.yml"
+      vars:
+        obj_name: "{{ openshift_logging_elasticsearch_pvc_name }}"
+        size: "{{ openshift_logging_elasticsearch_pvc_size }}"
+        access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
+        pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
+        storage_class_name: "{{ openshift_logging_elasticsearch_pvc_storage_class_name | default('', true) }}"
+      when:
+        - not openshift_logging_elasticsearch_pvc_dynamic | bool
+
+    # Storageclasses are used by default if configured
+    - name: Creating ES storage template - dynamic
+      template:
+        src: pvc.j2
+        dest: "{{ tempdir }}/templates/logging-es-pvc.yml"
+      vars:
+        obj_name: "{{ openshift_logging_elasticsearch_pvc_name }}"
+        size: "{{ openshift_logging_elasticsearch_pvc_size }}"
+        access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
+        pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
+      when:
+        - openshift_logging_elasticsearch_pvc_dynamic | bool
+
+- name: Set ES data node storage
+  oc_obj:
+    state: present
+    kind: pvc
+    name: "{{ openshift_logging_elasticsearch_pvc_name }}"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    files:
+      - "{{ tempdir }}/templates/logging-es-pvc.yml"
+    delete_after: true
+  when:
+  - node_storage_type == "pvc"
+
+- name: Set deployment name
+  set_fact:
+    es_deploy_name: "{{ openshift_logging_elasticsearch_deployment_name }}"
+
+# Setup all configmaps and secrets
+- include: "{{ role_path }}/tasks/node_configuration.yaml"
+  vars:
+    node_configmap: "{{ es_deploy_name }}"
+    storage_type: "{{ node_storage_type }}"
+
+# DC
+- name: Set ES dc templates for role {{ es_role }}
+  template:
+    src: es.j2
+    dest: "{{ tempdir }}/templates/logging-es-dc.yml"
+  vars:
+    es_configmap: "{{ es_deploy_name }}"
+    es_cluster_name: "{{ openshift_logging_elasticsearch_clustername }}"
+    # TODO: add ability to add arbitrary label to ES deployments,
+    # remove mandatory logging_component
+    # TODO: component below needs to be changed
+    component: "{{ openshift_logging_elasticsearch_clustername }}"
+    es_component: "{{ es_component }}"
+    deploy_name: "{{ es_deploy_name }}"
+    storage_type: "{{ node_storage_type | default(emptydir) }}"
+    image: "{{ openshift_logging_elasticsearch_image_prefix }}{{ openshift_logging_elasticsearch_image_name }}:{{ openshift_logging_elasticsearch_image_version }}"
+    proxy_image: "{{ openshift_logging_elasticsearch_proxy_image_prefix }}oauth-proxy:{{ openshift_logging_elasticsearch_proxy_image_version }}"
+  changed_when: false
+
+- name: Set ES dc for role {{ es_role }}
+  oc_obj:
+    state: present
+    name: "{{ es_deploy_name }}"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    kind: dc
+    files:
+      - "{{ tempdir }}/templates/logging-es-dc.yml"
+    delete_after: true
+    kubeconfig: '{{ kubeconfig }}'
+
+# scale up
+- name: Start Elasticsearch for role {{ es_role }}
+  oc_scale:
+    kind: dc
+    name: "{{ es_deploy_name }}"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    replicas: "{{ replicas | default(1) }}"
+    kubeconfig: '{{ kubeconfig }}'
+
+## Placeholder for migration when necessary ##
+
+- name: Delete temp directory
+  file:
+    name: "{{ tempdir }}"
+    state: absent
+  changed_when: False

--- a/roles/openshift_logging_elasticsearch/tasks/service_accounts.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/service_accounts.yaml
@@ -120,11 +120,20 @@
 
 
 # Add hostmount SCC to the service account if required
-- name: Detect common lowest denominator for ES storage if hostaccess SCC is required
+- name: Detect common lowest denominator for ES storage if hostaccess SCC is required (for clientdata)
   set_fact:
     openshift_logging_elasticsearch_storage_type: "hostmount"
   when:
   - '"hostmount" in openshift_logging_elasticsearch_topology.node_topology.clientdata | map(attribute="node_storage_type")| list'
+  ignore_errors: yes
+
+- name: Detect common lowest denominator for ES storage if hostaccess SCC is required (for clientdatamaster)
+  set_fact:
+    openshift_logging_elasticsearch_storage_type: "hostmount"
+  when:
+  - '"hostmount" in openshift_logging_elasticsearch_topology.node_topology.clientdatamaster.node_storage_type'
+  ignore_errors: yes
+
 
 - name: Add hostaccess SCC to the service account in case nodes use hostmount
   oc_adm_policy_user:

--- a/roles/openshift_logging_elasticsearch/tasks/service_accounts.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/service_accounts.yaml
@@ -1,0 +1,145 @@
+---
+# service account
+- name: Create ES service account
+  oc_serviceaccount:
+    state: present
+    name: "{{ openshift_logging_elasticsearch_sa_name }}"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    image_pull_secrets: "{{ openshift_logging_elasticsearch_image_pull_secret }}"
+    kubeconfig: '{{ kubeconfig }}'
+  when: openshift_logging_elasticsearch_image_pull_secret != ''
+
+- name: Create ES service account
+  oc_serviceaccount:
+    state: present
+    name: "{{ openshift_logging_elasticsearch_sa_name }}"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    kubeconfig: '{{ kubeconfig }}'
+  when:
+    - openshift_logging_elasticsearch_image_pull_secret == ''
+
+# allow passing in a tempdir
+- name: Create temp directory for doing work in
+  command: mktemp -d /tmp/openshift-logging-ansible-XXXXXX
+  register: mktemp
+  changed_when: False
+
+- set_fact:
+    tempdir: "{{ mktemp.stdout }}"
+
+# This may not be necessary in this role
+- name: Create templates subdirectory
+  file:
+    state: directory
+    path: "{{ tempdir }}/templates"
+    mode: 0755
+  changed_when: False
+
+# rolebinding reader
+- copy:
+    src: rolebinding-reader.yml
+    dest: "{{ tempdir }}/rolebinding-reader.yml"
+  changed_when: no
+  when: openshift_logging_elasticsearch_clusterreader
+
+- name: Create rolebinding-reader role
+  oc_obj:
+    state: present
+    name: "rolebinding-reader"
+    kind: clusterrole
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    files:
+      - "{{ tempdir }}/rolebinding-reader.yml"
+    delete_after: true
+    kubeconfig: '{{ kubeconfig }}'
+  when: openshift_logging_elasticsearch_clusterreader
+
+
+# SA roles
+- name: Set rolebinding-reader permissions for ES
+  oc_adm_policy_user:
+    state: present
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    resource_kind: cluster-role
+    resource_name: rolebinding-reader
+    user: "system:serviceaccount:{{ openshift_logging_elasticsearch_namespace }}:{{ openshift_logging_elasticsearch_sa_name }}"
+    kubeconfig: '{{ kubeconfig }}'
+  when: openshift_logging_elasticsearch_clusterreader
+
+- oc_adm_policy_user:
+    state: present
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    resource_kind: cluster-role
+    resource_name: system:auth-delegator
+    user: "system:serviceaccount:{{ openshift_logging_elasticsearch_namespace}}:aggregated-logging-elasticsearch"
+
+# logging-metrics-reader role
+- template:
+    src: logging-metrics-role.j2
+    dest: "{{mktemp.stdout}}/templates/logging-metrics-role.yml"
+  vars:
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    role_namespace: "{{ openshift_logging_elasticsearch_prometheus_sa | serviceaccount_namespace(openshift_logging_elasticsearch_namespace) }}"
+    role_user: "{{ openshift_logging_elasticsearch_prometheus_sa | serviceaccount_name }}"
+
+- name: Create logging-metrics-reader-role
+  command: >
+    {{ openshift.common.client_binary }}
+    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    -n "{{ openshift_logging_elasticsearch_namespace }}"
+    create -f "{{mktemp.stdout}}/templates/logging-metrics-role.yml"
+  register: prometheus_out
+  check_mode: no
+  ignore_errors: yes
+
+- fail:
+    msg: "There was an error creating the logging-metrics-role and binding: {{prometheus_out}}"
+  when:
+    - "prometheus_out.stderr | length > 0"
+    - "'already exists' not in prometheus_out.stderr"
+
+# View role and binding
+- name: Generate logging-elasticsearch-view-role
+  template:
+    src: rolebinding.j2
+    dest: "{{mktemp.stdout}}/logging-elasticsearch-view-role.yaml"
+  vars:
+    obj_name: logging-elasticsearch-view-role
+    roleRef:
+      name: view
+    subjects:
+      - kind: ServiceAccount
+        name: "{{ openshift_logging_elasticsearch_sa_name }}"
+  changed_when: no
+
+- name: Set logging-elasticsearch-view-role role
+  oc_obj:
+    state: present
+    name: "logging-elasticsearch-view-role"
+    kind: rolebinding
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    files:
+      - "{{ tempdir }}/logging-elasticsearch-view-role.yaml"
+    delete_after: true
+
+
+# Add hostmount SCC to the service account if required
+- name: Detect common lowest denominator for ES storage if hostaccess SCC is required
+  set_fact:
+    openshift_logging_elasticsearch_storage_type: "hostmount"
+  when:
+  - '"hostmount" in openshift_logging_elasticsearch_node_topology.clientdata | map(attribute="node_storage_type")| list'
+    
+- name: Add hostaccess SCC to the service account in case nodes use hostmount
+  oc_adm_policy_user:
+    resource_kind: scc
+    resource_name: hostaccess
+    user: "system:serviceaccount:{{ openshift_logging_elasticsearch_namespace }}:{{ openshift_logging_elasticsearch_sa_name }}"
+    kubeconfig: '{{ kubeconfig }}'
+  when: openshift_logging_elasticsearch_storage_type == "hostmount"
+
+- name: Delete temp directory
+  file:
+    name: "{{ tempdir }}"
+    state: absent
+  changed_when: False

--- a/roles/openshift_logging_elasticsearch/tasks/service_accounts.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/service_accounts.yaml
@@ -104,8 +104,8 @@
     roleRef:
       name: view
     subjects:
-    - kind: ServiceAccount
-      name: "{{ openshift_logging_elasticsearch_sa_name }}"
+      - kind: ServiceAccount
+        name: "{{ openshift_logging_elasticsearch_sa_name }}"
   changed_when: no
 
 - name: Set logging-elasticsearch-view-role role
@@ -124,14 +124,14 @@
   set_fact:
     openshift_logging_elasticsearch_storage_type: "hostmount"
   when:
-  - '"hostmount" in openshift_logging_elasticsearch_topology.node_topology.clientdata | map(attribute="node_storage_type")| list'
+    - '"hostmount" in openshift_logging_elasticsearch_topology.node_topology.clientdata | map(attribute="node_storage_type")| list'
   ignore_errors: yes
 
 - name: Detect common lowest denominator for ES storage if hostaccess SCC is required (for clientdatamaster)
   set_fact:
     openshift_logging_elasticsearch_storage_type: "hostmount"
   when:
-  - '"hostmount" in openshift_logging_elasticsearch_topology.node_topology.clientdatamaster.node_storage_type'
+    - '"hostmount" in openshift_logging_elasticsearch_topology.node_topology.clientdatamaster.node_storage_type'
   ignore_errors: yes
 
 

--- a/roles/openshift_logging_elasticsearch/tasks/service_accounts.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/service_accounts.yaml
@@ -6,7 +6,6 @@
     name: "{{ openshift_logging_elasticsearch_sa_name }}"
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
     image_pull_secrets: "{{ openshift_logging_elasticsearch_image_pull_secret }}"
-    kubeconfig: '{{ kubeconfig }}'
   when: openshift_logging_elasticsearch_image_pull_secret != ''
 
 - name: Create ES service account
@@ -14,7 +13,6 @@
     state: present
     name: "{{ openshift_logging_elasticsearch_sa_name }}"
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    kubeconfig: '{{ kubeconfig }}'
   when:
     - openshift_logging_elasticsearch_image_pull_secret == ''
 
@@ -51,7 +49,6 @@
     files:
       - "{{ tempdir }}/rolebinding-reader.yml"
     delete_after: true
-    kubeconfig: '{{ kubeconfig }}'
   when: openshift_logging_elasticsearch_clusterreader
 
 
@@ -63,7 +60,6 @@
     resource_kind: cluster-role
     resource_name: rolebinding-reader
     user: "system:serviceaccount:{{ openshift_logging_elasticsearch_namespace }}:{{ openshift_logging_elasticsearch_sa_name }}"
-    kubeconfig: '{{ kubeconfig }}'
   when: openshift_logging_elasticsearch_clusterreader
 
 - oc_adm_policy_user:
@@ -108,8 +104,8 @@
     roleRef:
       name: view
     subjects:
-      - kind: ServiceAccount
-        name: "{{ openshift_logging_elasticsearch_sa_name }}"
+    - kind: ServiceAccount
+      name: "{{ openshift_logging_elasticsearch_sa_name }}"
   changed_when: no
 
 - name: Set logging-elasticsearch-view-role role
@@ -128,14 +124,13 @@
   set_fact:
     openshift_logging_elasticsearch_storage_type: "hostmount"
   when:
-  - '"hostmount" in openshift_logging_elasticsearch_node_topology.clientdata | map(attribute="node_storage_type")| list'
-    
+  - '"hostmount" in openshift_logging_elasticsearch_topology.node_topology.clientdata | map(attribute="node_storage_type")| list'
+
 - name: Add hostaccess SCC to the service account in case nodes use hostmount
   oc_adm_policy_user:
     resource_kind: scc
     resource_name: hostaccess
     user: "system:serviceaccount:{{ openshift_logging_elasticsearch_namespace }}:{{ openshift_logging_elasticsearch_sa_name }}"
-    kubeconfig: '{{ kubeconfig }}'
   when: openshift_logging_elasticsearch_storage_type == "hostmount"
 
 - name: Delete temp directory

--- a/roles/openshift_logging_elasticsearch/tasks/svcs_routes.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/svcs_routes.yaml
@@ -17,7 +17,7 @@
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
     selector:
       cluster-name: "{{ openshift_logging_elasticsearch_clustername }}"
-      es-node-role: "master"
+      es-node-master: "true"
     labels:
       logging-infra: 'support'
       cluster-name: "{{ openshift_logging_elasticsearch_clustername }}"
@@ -32,7 +32,7 @@
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
     selector:
       cluster-name: "{{ openshift_logging_elasticsearch_clustername }}"
-      elasticsearch-http: "true"
+      es-node-client: "true"
     labels:
       logging-infra: 'support'
       cluster-name: "{{ openshift_logging_elasticsearch_clustername }}"

--- a/roles/openshift_logging_elasticsearch/tasks/svcs_routes.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/svcs_routes.yaml
@@ -73,37 +73,37 @@
     src: "{{ generated_certs_dir }}/{{ item.file }}"
   register: key_pairs
   with_items:
-  - { name: "ca_file", file: "ca.crt" }
-  - { name: "es_key", file: "system.logging.es.key" }
-  - { name: "es_cert", file: "system.logging.es.crt" }
+    - { name: "ca_file", file: "ca.crt" }
+    - { name: "es_key", file: "system.logging.es.key" }
+    - { name: "es_cert", file: "system.logging.es.crt" }
   when: openshift_logging_elasticsearch_allow_external | bool
 
 - set_fact:
     es_key: "{{ lookup('file', openshift_logging_elasticsearch_key) | b64encode }}"
   when:
-  - openshift_logging_elasticsearch_key | trim | length > 0
-  - openshift_logging_elasticsearch_allow_external | bool
+    - openshift_logging_elasticsearch_key | trim | length > 0
+    - openshift_logging_elasticsearch_allow_external | bool
   changed_when: false
 
 - set_fact:
     es_cert: "{{ lookup('file', openshift_logging_elasticsearch_cert) | b64encode  }}"
   when:
-  - openshift_logging_elasticsearch_cert | trim | length > 0
-  - openshift_logging_elasticsearch_allow_external | bool
+    - openshift_logging_elasticsearch_cert | trim | length > 0
+    - openshift_logging_elasticsearch_allow_external | bool
   changed_when: false
 
 - set_fact:
     es_ca: "{{ lookup('file', openshift_logging_elasticsearch_ca_ext) | b64encode  }}"
   when:
-  - openshift_logging_elasticsearch_ca_ext | trim | length > 0
-  - openshift_logging_elasticsearch_allow_external | bool
+    - openshift_logging_elasticsearch_ca_ext | trim | length > 0
+    - openshift_logging_elasticsearch_allow_external | bool
   changed_when: false
 
 - set_fact:
     es_ca: "{{ key_pairs | entry_from_named_pair('ca_file') }}"
   when:
-  - es_ca is not defined
-  - openshift_logging_elasticsearch_allow_external | bool
+    - es_ca is not defined
+    - openshift_logging_elasticsearch_allow_external | bool
   changed_when: false
 
 - name: Generating Elasticsearch route template for the cluster {{ openshift_logging_elasticsearch_clustername }}

--- a/roles/openshift_logging_elasticsearch/tasks/svcs_routes.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/svcs_routes.yaml
@@ -1,0 +1,106 @@
+---
+# allow passing in a tempdir
+- name: Create temp directory for Elasticsearch services and routes
+  command: mktemp -d /tmp/openshift-logging-ansible-svcs-XXXXXX
+  register: mktemp
+  changed_when: False
+
+- name: set temp dir
+  set_fact:
+    tempdir: "{{ mktemp.stdout }}"
+
+# services
+- name: Create {{ openshift_logging_elasticsearch_clustername }}-cluster port 9300 service
+  oc_service:
+    state: present
+    name: "{{ openshift_logging_elasticsearch_clustername }}-cluster"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    selector:
+      cluster-name: "{{ openshift_logging_elasticsearch_clustername }}"
+      es-node-role: "master"
+    labels:
+      logging-infra: 'support'
+      cluster-name: "{{ openshift_logging_elasticsearch_clustername }}"
+    clusterip: None
+    ports:
+      - port: 9300
+
+- name: Set {{ openshift_logging_elasticsearch_clustername }} port 9200 service
+  oc_service:
+    state: present
+    name: "{{ openshift_logging_elasticsearch_clustername }}"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    selector:
+      cluster-name: "{{ openshift_logging_elasticsearch_clustername }}"
+      elasticsearch-http: "true"
+    labels:
+      logging-infra: 'support'
+      cluster-name: "{{ openshift_logging_elasticsearch_clustername }}"
+    ports:
+      - port: 9200
+        targetPort: "restapi"
+
+- name: Set {{ openshift_logging_elasticsearch_clustername }}-prometheus service
+  oc_service:
+    state: present
+    name: "{{ openshift_logging_elasticsearch_clustername }}-prometheus"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    labels:
+      cluster-name: '{{ openshift_logging_elasticsearch_clustername }}'
+      logging-infra: 'support'
+    ports:
+      - name: proxy
+        port: 443
+        targetPort: 4443
+    selector:
+      component: "{{ openshift_logging_elasticsearch_clustername }}-prometheus"
+      provider: openshift
+
+- oc_edit:
+    kind: service
+    name: "{{ openshift_logging_elasticsearch_clustername }}-prometheus"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    separator: '#'
+    content:
+      metadata#annotations#service.alpha.openshift.io/serving-cert-secret-name: "prometheus-tls"
+      metadata#annotations#prometheus.io/scrape: "true"
+      metadata#annotations#prometheus.io/scheme: "https"
+      metadata#annotations#prometheus.io/path: "_prometheus/metrics"
+
+- name: Generating Elasticsearch route template for the cluster {{ openshift_logging_elasticsearch_clustername }}
+  template:
+    src: route_reencrypt.j2
+    dest: "{{mktemp.stdout}}/{{ openshift_logging_elasticsearch_clustername }}-route.yaml"
+  vars:
+    obj_name: "{{ openshift_logging_elasticsearch_clustername }}"
+    route_host: "{{ openshift_logging_es_hostname }}"
+    service_name: "{{ openshift_logging_elasticsearch_clustername }}"
+    tls_key: "{{ es_key | default('') | b64decode }}"
+    tls_cert: "{{ es_cert | default('') | b64decode }}"
+    tls_ca_cert: "{{ es_ca | b64decode }}"
+    tls_dest_ca_cert: "{{ key_pairs | entry_from_named_pair('ca_file') | b64decode }}"
+    edge_term_policy: "{{ openshift_logging_es_edge_term_policy | default('') }}"
+    labels:
+      component: support
+      logging-infra: support
+      provider: openshift
+      cluster-name: "{{ openshift_logging_elasticsearch_clustername }}"
+  changed_when: no
+  when: openshift_logging_es_allow_external | bool
+
+# This currently has an issue if the host name changes
+- name: Setting Elasticsearch route for the cluster {{ openshift_logging_elasticsearch_clustername }}
+  oc_obj:
+    state: present
+    name: "{{ openshift_logging_elasticsearch_clustername }}"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    kind: route
+    files:
+      - "{{ tempdir }}/{{ openshift_logging_elasticsearch_clustername }}-route.yaml"
+  when: openshift_logging_es_allow_external | bool
+
+- name: Delete temp directory
+  file:
+    name: "{{ tempdir }}"
+    state: absent
+  changed_when: False

--- a/roles/openshift_logging_elasticsearch/tasks/svcs_routes.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/svcs_routes.yaml
@@ -67,26 +67,65 @@
       metadata#annotations#prometheus.io/scheme: "https"
       metadata#annotations#prometheus.io/path: "_prometheus/metrics"
 
+# External routes generation
+- name: Retrieving the cert to use when generating secrets for the {{ openshift_logging_elasticsearch_clustername }} cluster
+  slurp:
+    src: "{{ generated_certs_dir }}/{{ item.file }}"
+  register: key_pairs
+  with_items:
+  - { name: "ca_file", file: "ca.crt" }
+  - { name: "es_key", file: "system.logging.es.key" }
+  - { name: "es_cert", file: "system.logging.es.crt" }
+  when: openshift_logging_elasticsearch_allow_external | bool
+
+- set_fact:
+    es_key: "{{ lookup('file', openshift_logging_elasticsearch_key) | b64encode }}"
+  when:
+  - openshift_logging_elasticsearch_key | trim | length > 0
+  - openshift_logging_elasticsearch_allow_external | bool
+  changed_when: false
+
+- set_fact:
+    es_cert: "{{ lookup('file', openshift_logging_elasticsearch_cert) | b64encode  }}"
+  when:
+  - openshift_logging_elasticsearch_cert | trim | length > 0
+  - openshift_logging_elasticsearch_allow_external | bool
+  changed_when: false
+
+- set_fact:
+    es_ca: "{{ lookup('file', openshift_logging_elasticsearch_ca_ext) | b64encode  }}"
+  when:
+  - openshift_logging_elasticsearch_ca_ext | trim | length > 0
+  - openshift_logging_elasticsearch_allow_external | bool
+  changed_when: false
+
+- set_fact:
+    es_ca: "{{ key_pairs | entry_from_named_pair('ca_file') }}"
+  when:
+  - es_ca is not defined
+  - openshift_logging_elasticsearch_allow_external | bool
+  changed_when: false
+
 - name: Generating Elasticsearch route template for the cluster {{ openshift_logging_elasticsearch_clustername }}
   template:
     src: route_reencrypt.j2
     dest: "{{mktemp.stdout}}/{{ openshift_logging_elasticsearch_clustername }}-route.yaml"
   vars:
     obj_name: "{{ openshift_logging_elasticsearch_clustername }}"
-    route_host: "{{ openshift_logging_es_hostname }}"
+    route_host: "{{ openshift_logging_elasticsearch_hostname }}"
     service_name: "{{ openshift_logging_elasticsearch_clustername }}"
     tls_key: "{{ es_key | default('') | b64decode }}"
     tls_cert: "{{ es_cert | default('') | b64decode }}"
     tls_ca_cert: "{{ es_ca | b64decode }}"
     tls_dest_ca_cert: "{{ key_pairs | entry_from_named_pair('ca_file') | b64decode }}"
-    edge_term_policy: "{{ openshift_logging_es_edge_term_policy | default('') }}"
+    edge_term_policy: "{{ openshift_logging_elasticsearch_edge_term_policy | default('') }}"
     labels:
       component: support
       logging-infra: support
       provider: openshift
       cluster-name: "{{ openshift_logging_elasticsearch_clustername }}"
   changed_when: no
-  when: openshift_logging_es_allow_external | bool
+  when: openshift_logging_elasticsearch_allow_external | bool
 
 # This currently has an issue if the host name changes
 - name: Setting Elasticsearch route for the cluster {{ openshift_logging_elasticsearch_clustername }}
@@ -97,7 +136,7 @@
     kind: route
     files:
       - "{{ tempdir }}/{{ openshift_logging_elasticsearch_clustername }}-route.yaml"
-  when: openshift_logging_es_allow_external | bool
+  when: openshift_logging_elasticsearch_allow_external | bool
 
 - name: Delete temp directory
   file:

--- a/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
@@ -14,7 +14,7 @@ index:
     flush_threshold_period: 5m
 
 node:
-  name: ${DC_NAME}
+  name: ${NODE_NAME}
   master: ${IS_MASTER}
   data: ${HAS_DATA}
   max_local_storage_nodes: 1
@@ -65,7 +65,7 @@ path:
 searchguard:
   authcz.admin_dn:
   - CN=system.admin,OU=OpenShift,O=Logging
-  config_index_name: ".searchguard.${DC_NAME}"
+  config_index_name: ".searchguard.${NODE_NAME}"
   ssl:
     transport:
       enabled: true

--- a/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
@@ -24,19 +24,20 @@ network:
 
 cloud:
   kubernetes:
-    pod_label: ${POD_LABEL}
-    pod_port: 9300
+    service: ${SERVICE_DNS}
     namespace: ${NAMESPACE}
 
 discovery:
   type: kubernetes
   zen.ping.multicast.enabled: false
-  zen.minimum_master_nodes: ${NODE_QUORUM}
+  zen.minimum_master_nodes: {{es_masters_quorum | int}}
 
 gateway:
-  recover_after_nodes: ${NODE_QUORUM}
-  expected_nodes: ${RECOVER_EXPECTED_NODES}
-  recover_after_time: ${RECOVER_AFTER_TIME}
+  recover_after_nodes: {{ es_recover_after_nodes }}
+  expected_master_nodes: {{ es_masters_quorum | int }}
+  expected_nodes: {{ es_recover_expected_nodes }}
+  expected_data_nodes: {{ es_recover_expected_data_nodes }}
+  recover_after_time: "{{ openshift_elasticsearch_recover_after_time }}"
 
 io.fabric8.elasticsearch.authentication.users: ["system.logging.kibana", "system.logging.fluentd", "system.logging.curator", "system.admin"]
 io.fabric8.elasticsearch.kibana.mapping.app: /usr/share/elasticsearch/index_patterns/com.redhat.viaq-openshift.index-pattern.json

--- a/roles/openshift_logging_elasticsearch/templates/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/es.j2
@@ -154,21 +154,6 @@ spec:
               name: "HEAP_DUMP_LOCATION"
               value: "/elasticsearch/persistent/heapdump.hprof"
             -
-              name: "MASTERS_QUORUM"
-              value: "{{es_masters_quorum | int}}"
-            -
-              name: "RECOVER_AFTER_NODES"
-              value: "{{es_recover_after_nodes}}"
-            -
-              name: "RECOVER_EXPECTED_DATA_NODES"
-              value: "{{es_recover_expected_data_nodes}}"
-            -
-              name: "RECOVER_EXPECTED_NODES"
-              value: "{{es_recover_expected_nodes}}"
-            -
-              name: "RECOVER_AFTER_TIME"
-              value: "{{openshift_elasticsearch_recover_after_time}}"
-            -
               name: "READINESS_PROBE_TIMEOUT"
               value: "30"
             -

--- a/roles/openshift_logging_elasticsearch/templates/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/es.j2
@@ -4,14 +4,17 @@ metadata:
   name: "{{deploy_name}}"
   labels:
     provider: openshift
-    component: "{{component}}"
+    component: "{{es_component}}"
     deployment: "{{deploy_name}}"
+    cluster-name: "{{ es_cluster_name }}"
     logging-infra: "{{logging_component}}"
+    es-node-role: "{{ es_role }}"
+    elasticsearch-http: "{{ es_http_service }}"
 spec:
   replicas: {{es_replicas|default(1)}}
   selector:
     provider: openshift
-    component: "{{component}}"
+    component: "{{es_component}}"
     deployment: "{{deploy_name}}"
     logging-infra: "{{logging_component}}"
   strategy:
@@ -22,11 +25,14 @@ spec:
       labels:
         logging-infra: "{{logging_component}}"
         provider: openshift
-        component: "{{component}}"
+        component: "{{es_component}}"
         deployment: "{{deploy_name}}"
+        cluster-name: "{{ es_cluster_name }}"
+        es-node-role: "{{ es_role }}"
+        elasticsearch-http: "{{ es_http_service }}"
     spec:
       terminationGracePeriod: 600
-      serviceAccountName: aggregated-logging-elasticsearch
+      serviceAccountName: {{ openshift_logging_elasticsearch_sa_name }}
       securityContext:
         supplementalGroups:
 {% for group in es_storage_groups %}
@@ -78,15 +84,37 @@ spec:
           image: {{image}}
           imagePullPolicy: Always
           resources:
+{% if limits is defined %}
             limits:
-              memory: "{{es_memory_limit}}"
-{% if es_cpu_limit is defined and es_cpu_limit is not none %}
-              cpu: "{{es_cpu_limit}}"
+{% for key, value in limits.iteritems() %}
+              {{key}}: "{{value}}"
+{% endfor %}
 {% endif %}
+{% if requests is defined %}
             requests:
-              memory: "{{es_memory_limit}}"
+{% for key, value in requests.iteritems() %}
+              {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
 {% if es_container_security_context %}
           securityContext: {{ es_container_security_context | to_yaml }}
+{% endif %}
+          livenessProbe:
+            tcpSocket:
+              port: 9300
+            initialDelaySeconds: 480
+            periodSeconds: 5
+          readinessProbe:
+{% if es_role == "master" %}
+            tcpSocket:
+              port: 9300
+{% else %}
+            exec:
+              command:
+              - "/usr/share/java/elasticsearch/probe/readiness.sh"
+              initialDelaySeconds: 10
+              timeoutSeconds: 30
+              periodSeconds: 5
 {% endif %}
           ports:
             -
@@ -105,29 +133,41 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             -
-              name: "KUBERNETES_TRUST_CERT"
-              value: "true"
+              name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             -
               name: "SERVICE_DNS"
-              value: "logging-{{es_cluster_name}}-cluster"
+              value: "{{es_cluster_name}}-cluster"
             -
               name: "CLUSTER_NAME"
-              value: "logging-{{es_cluster_name}}"
+              value: "{{es_cluster_name}}"
             -
               name: "INSTANCE_RAM"
-              value: "{{openshift_logging_elasticsearch_memory_limit}}"
+{% if limits is defined and limits.memory is defined %}
+              value: "{{ limits.memory }}"
+{% else %}
+              value: "512m"
+{% endif %}
             -
               name: "HEAP_DUMP_LOCATION"
               value: "/elasticsearch/persistent/heapdump.hprof"
             -
-              name: "NODE_QUORUM"
-              value: "{{es_node_quorum | int}}"
+              name: "MASTERS_QUORUM"
+              value: "{{es_masters_quorum | int}}"
+            -
+              name: "RECOVER_AFTER_NODES"
+              value: "{{es_recover_after_nodes}}"
+            -
+              name: "RECOVER_EXPECTED_DATA_NODES"
+              value: "{{es_recover_expected_data_nodes}}"
             -
               name: "RECOVER_EXPECTED_NODES"
               value: "{{es_recover_expected_nodes}}"
             -
               name: "RECOVER_AFTER_TIME"
-              value: "{{openshift_logging_elasticsearch_recover_after_time}}"
+              value: "{{openshift_elasticsearch_recover_after_time}}"
             -
               name: "READINESS_PROBE_TIMEOUT"
               value: "30"
@@ -135,16 +175,14 @@ spec:
               name: "POD_LABEL"
               value: "component={{component}}"
             -
-              name: "IS_MASTER"
-              value: "{% if deploy_type in ['data-master', 'master'] %}true{% else %}false{% endif %}"
-
+              name: IS_MASTER
+              value: "{{ node_master }}"
             -
-              name: "HAS_DATA"
-              value: "{% if deploy_type in ['data-master', 'data-client'] %}true{% else %}false{% endif %}"
+              name: HAS_DATA
+              value: "{{ node_data }}"
             -
               name: "PROMETHEUS_USER"
               value: "{{openshift_logging_elasticsearch_prometheus_sa}}"
-
           volumeMounts:
             - name: elasticsearch
               mountPath: /etc/elasticsearch/secret
@@ -152,32 +190,33 @@ spec:
             - name: elasticsearch-config
               mountPath: /usr/share/java/elasticsearch/config
               readOnly: true
-            - name: elasticsearch-storage
-              mountPath: /elasticsearch/persistent
-          readinessProbe:
-            exec:
-              command:
-              - "/usr/share/java/elasticsearch/probe/readiness.sh"
-            initialDelaySeconds: 10
-            timeoutSeconds: 30
-            periodSeconds: 5
+{% if storage_type == 'hostmount' %}
+{% for item in hostmount_path %}
+            - name: elasticsearch-storage-{{ loop.index0 }}
+              mountPath: /elasticsearch/persistent/{{ loop.index0 }}
+{% endfor %}
+{% endif %}
       volumes:
         - name: proxy-tls
           secret:
             secretName: prometheus-tls
         - name: elasticsearch
           secret:
-            secretName: logging-elasticsearch
+            secretName: {{ es_cluster_name }}-certs
         - name: elasticsearch-config
           configMap:
-            name: logging-elasticsearch
+            name: {{ es_configmap }}
+{% if storage_type == 'pvc' %}
         - name: elasticsearch-storage
-{% if openshift_logging_elasticsearch_storage_type == 'pvc' %}
           persistentVolumeClaim:
             claimName: {{ openshift_logging_elasticsearch_pvc_name }}
-{% elif openshift_logging_elasticsearch_storage_type == 'hostmount' %}
+{% elif storage_type == 'hostmount' %}
+{% for item in hostmount_path %}
+        - name: elasticsearch-storage-{{ loop.index0 }}
           hostPath:
-            path: {{ openshift_logging_elasticsearch_hostmount_path }}
+            path: {{ item }}
+{% endfor %}
 {% else %}
+        - name: elasticsearch-storage
           emptydir: {}
 {% endif %}

--- a/roles/openshift_logging_elasticsearch/templates/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/es.j2
@@ -9,14 +9,21 @@ metadata:
     cluster-name: "{{ es_cluster_name }}"
     logging-infra: "{{logging_component}}"
     es-node-role: "{{ es_role }}"
-    elasticsearch-http: "{{ es_http_service }}"
+    es-node-client: "{{ es_http_service }}"
+    es-node-data: "{{ node_data }}"
+    es-node-master: "{{ node_master }}"
 spec:
   replicas: {{es_replicas|default(1)}}
   selector:
     provider: openshift
     component: "{{es_component}}"
     deployment: "{{deploy_name}}"
+    cluster-name: "{{ es_cluster_name }}"
     logging-infra: "{{logging_component}}"
+    es-node-role: "{{ es_role }}"
+    es-node-client: "{{ es_http_service }}"
+    es-node-data: "{{ node_data }}"
+    es-node-master: "{{ node_master }}"
   strategy:
     type: Recreate
   template:
@@ -29,7 +36,9 @@ spec:
         deployment: "{{deploy_name}}"
         cluster-name: "{{ es_cluster_name }}"
         es-node-role: "{{ es_role }}"
-        elasticsearch-http: "{{ es_http_service }}"
+        es-node-client: "{{ es_http_service }}"
+        es-node-data: "{{ node_data }}"
+        es-node-master: "{{ node_master }}"
     spec:
       terminationGracePeriod: 600
       serviceAccountName: {{ openshift_logging_elasticsearch_sa_name }}

--- a/roles/openshift_logging_elasticsearch/vars/main.yml
+++ b/roles/openshift_logging_elasticsearch/vars/main.yml
@@ -2,7 +2,7 @@
 __latest_es_version: "3_6"
 __allowed_es_versions: ["3_5", "3_6", "3_7"]
 __allowed_es_versions: ["3_5", "3_6"]
-__allowed_es_types: ["master", "clientdata"]
+__allowed_es_types: ["master", "clientdata", "clientdatamaster"]
 __es_log_appenders: ['file', 'console']
 __kibana_index_modes: ["unique", "shared_ops"]
 
@@ -11,6 +11,7 @@ openshift_master_config_dir: "{{ openshift.common.config_base }}/master"
 es_node_quorum: "{{ openshift_logging_elasticsearch_replica_count | int/2 + 1 }}"
 es_recover_after_nodes: "{{ openshift_logging_elasticsearch_replica_count | int }}"
 es_recover_expected_nodes: "{{ openshift_logging_elasticsearch_replica_count | int }}"
-es_masters_quorum: "{{ openshift_logging_elasticsearch_topology.node_topology.masters.replicas |int /2 + 1 }}"
-es_recover_expected_data_nodes: "{{ openshift_logging_elasticsearch_topology.node_topology.clientdata|length |default(1) }}"
 openshift_elasticsearch_recover_after_time: 5m
+
+#es_masters_quorum: "{{ es_node_topology.masters.replicas |int /2 + 1 }}"
+#es_recover_expected_data_nodes: "{{ es_node_topology.clientdata|length }}"

--- a/roles/openshift_logging_elasticsearch/vars/main.yml
+++ b/roles/openshift_logging_elasticsearch/vars/main.yml
@@ -1,7 +1,8 @@
 ---
 __latest_es_version: "3_6"
 __allowed_es_versions: ["3_5", "3_6", "3_7"]
-__allowed_es_types: ["data-master", "data-client", "master", "client"]
+__allowed_es_versions: ["3_5", "3_6"]
+__allowed_es_types: ["master", "clientdata"]
 __es_log_appenders: ['file', 'console']
 __kibana_index_modes: ["unique", "shared_ops"]
 
@@ -12,3 +13,6 @@ es_min_masters_default: "{{ (openshift_logging_elasticsearch_replica_count | int
 es_min_masters: "{{ (openshift_logging_elasticsearch_replica_count == 1) | ternary(1, es_min_masters_default) }}"
 es_recover_after_nodes: "{{ openshift_logging_elasticsearch_replica_count | int }}"
 es_recover_expected_nodes: "{{ openshift_logging_elasticsearch_replica_count | int }}"
+es_masters_quorum: "{{ openshift_logging_elasticsearch_node_topology.masters.replicas |int /2 + 1 }}"
+es_recover_expected_data_nodes: "{{ openshift_logging_elasticsearch_node_topology.clientdata|length }}"
+openshift_elasticsearch_recover_after_time: 5m

--- a/roles/openshift_logging_elasticsearch/vars/main.yml
+++ b/roles/openshift_logging_elasticsearch/vars/main.yml
@@ -1,7 +1,6 @@
 ---
 __latest_es_version: "3_6"
 __allowed_es_versions: ["3_5", "3_6", "3_7"]
-__allowed_es_versions: ["3_5", "3_6"]
 __allowed_es_types: ["master", "clientdata", "clientdatamaster"]
 __es_log_appenders: ['file', 'console']
 __kibana_index_modes: ["unique", "shared_ops"]

--- a/roles/openshift_logging_elasticsearch/vars/main.yml
+++ b/roles/openshift_logging_elasticsearch/vars/main.yml
@@ -9,10 +9,8 @@ __kibana_index_modes: ["unique", "shared_ops"]
 # TODO: integrate these
 openshift_master_config_dir: "{{ openshift.common.config_base }}/master"
 es_node_quorum: "{{ openshift_logging_elasticsearch_replica_count | int/2 + 1 }}"
-es_min_masters_default: "{{ (openshift_logging_elasticsearch_replica_count | int / 2 | round(0,'floor') + 1) | int }}"
-es_min_masters: "{{ (openshift_logging_elasticsearch_replica_count == 1) | ternary(1, es_min_masters_default) }}"
 es_recover_after_nodes: "{{ openshift_logging_elasticsearch_replica_count | int }}"
 es_recover_expected_nodes: "{{ openshift_logging_elasticsearch_replica_count | int }}"
-es_masters_quorum: "{{ openshift_logging_elasticsearch_node_topology.masters.replicas |int /2 + 1 }}"
-es_recover_expected_data_nodes: "{{ openshift_logging_elasticsearch_node_topology.clientdata|length }}"
+es_masters_quorum: "{{ openshift_logging_elasticsearch_topology.node_topology.masters.replicas |int /2 + 1 }}"
+es_recover_expected_data_nodes: "{{ openshift_logging_elasticsearch_topology.node_topology.clientdata|length |default(1) }}"
 openshift_elasticsearch_recover_after_time: 5m

--- a/roles/openshift_sanitize_inventory/tasks/__deprecations_logging.yml
+++ b/roles/openshift_sanitize_inventory/tasks/__deprecations_logging.yml
@@ -34,12 +34,12 @@
 
 
 - set_fact:
-    openshift_logging_elasticsearch_pvc_dynamic: "{{ 'true' if openshift_logging_storage_kind | default(none) == 'dynamic' else '' }}"
-    openshift_logging_elasticsearch_pvc_size: "{{ openshift_logging_storage_volume_size | default('10Gi') if openshift_logging_storage_kind | default(none) in ['dynamic','nfs'] else ''  }}"
-    openshift_logging_elasticsearch_pvc_prefix: "{{ 'logging-es' if openshift_logging_storage_kind | default(none) == 'dynamic' else '' }}"
-    openshift_logging_elasticsearch_ops_pvc_dynamic: "{{ 'true' if openshift_loggingops_storage_kind | default(none) == 'dynamic' else '' }}"
-    openshift_logging_elasticsearch_ops_pvc_size: "{{ openshift_loggingops_storage_volume_size | default('10Gi') if openshift_loggingops_storage_kind | default(none) in ['dynamic','nfs'] else ''  }}"
-    openshift_logging_elasticsearch_ops_pvc_prefix: "{{ 'logging-es-ops' if openshift_loggingops_storage_kind | default(none) == 'dynamic' else '' }}"
+    openshift_logging_legacy_es_pvc_dynamic: "{{ 'true' if openshift_logging_storage_kind | default(none) == 'dynamic' else '' }}"
+    openshift_logging_legacy_es_pvc_size: "{{ openshift_logging_storage_volume_size | default('10Gi') if openshift_logging_storage_kind | default(none) in ['dynamic','nfs'] else ''  }}"
+    openshift_logging_legacy_es_pvc_prefix: "{{ 'logging-es' if openshift_logging_storage_kind | default(none) == 'dynamic' else '' }}"
+    openshift_logging_legacy_es_ops_pvc_dynamic: "{{ 'true' if openshift_loggingops_storage_kind | default(none) == 'dynamic' else '' }}"
+    openshift_logging_legacy_es_ops_pvc_size: "{{ openshift_loggingops_storage_volume_size | default('10Gi') if openshift_loggingops_storage_kind | default(none) in ['dynamic','nfs'] else ''  }}"
+    openshift_logging_legacy_es_ops_pvc_prefix: "{{ 'logging-es-ops' if openshift_loggingops_storage_kind | default(none) == 'dynamic' else '' }}"
     openshift_logging_curator_nodeselector: "{{ openshift_hosted_logging_curator_nodeselector | default('') | map_from_pairs }}"
     openshift_logging_curator_ops_nodeselector: "{{ openshift_hosted_logging_curator_ops_nodeselector | default('') | map_from_pairs }}"
     openshift_logging_kibana_nodeselector: "{{ openshift_hosted_logging_kibana_nodeselector | default('') | map_from_pairs }}"


### PR DESCRIPTION
Elasticsearch 2.x topology is supported, 2 types of nodes are possible: master, clientdata.
Be default `logging-es` and `logging-es-ops` cluster deploy 1 master and 1 clientdata nodes
The role is launched from `openshift_logging` role.

cc @jcantrill @richm @portante @ewolinetz 