### PR TITLE
[3.6 backport] Set the openshift_version from the openshift.common.version in case it is empty

### DIFF
--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -81,7 +81,7 @@
     openshift_version: "{{ openshift.common.version }}"
   when:
   - openshift.common.version is defined
-  - openshift_version is not defined
+  - openshift_version is not defined or openshift_version == ""
   - openshift_protect_installed_version | bool
 
 # The rest of these tasks should only execute on


### PR DESCRIPTION
It can happen the openshift_version is set to an empty string.
Which results in openshift_pkg_version set to "-".
Thus, failing installation of base and excluder packages.
For more info see https://bugzilla.redhat.com/show_bug.cgi?id=1474871