### PR TITLE
Introduce r_openshift_node_facts prefixed role variables

### DIFF
--- a/filter_plugins/openshift_node.py
+++ b/filter_plugins/openshift_node.py
@@ -4,7 +4,7 @@
 Custom filters for use in openshift-node
 '''
 from ansible import errors
-
+from jinja2.runtime import Undefined
 
 class FilterModule(object):
     ''' Custom ansible filters for use by openshift_node role'''
@@ -23,7 +23,7 @@ class FilterModule(object):
             raise errors.AnsibleFilterError("|failed expects hostvars is a dict")
 
         # We always use what they've specified if they've specified a value
-        if openshift_dns_ip is not None:
+        if not isinstance(openshift_dns_ip, Undefined) and openshift_dns_ip is not None:
             return openshift_dns_ip
 
         if bool(hostvars['openshift']['common']['use_dnsmasq']):

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -30,10 +30,12 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-
-  roles:
-  - role: openshift_node
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+  tasks:
+  - include: refresh_node_facts.yml
+  - include_role:
+      name: openshift_node
+    vars:
+      openshift_ca_host: "{{ groups.oo_first_master.0 }}"
 
 - name: Configure nodes
   hosts: oo_nodes_to_config:!oo_containerized_master_nodes
@@ -46,9 +48,12 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-  roles:
-  - role: openshift_node
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+  tasks:
+  - include: refresh_node_facts.yml
+  - include_role:
+      name: openshift_node
+    vars:
+      openshift_ca_host: "{{ groups.oo_first_master.0 }}"
 
 - name: Additional node config
   hosts: oo_nodes_to_config

--- a/playbooks/common/openshift-node/generate.json
+++ b/playbooks/common/openshift-node/generate.json
@@ -1,0 +1,24 @@
+{
+  "actions": [{
+    "action": "set_fact",
+    "target": "set_optional_node_facts_role_variables.yml",
+    "mapping": {
+      "r_openshift_node_facts_annotations": "openshift_node_annotations",
+      "r_openshift_node_facts_debug_level": "openshift_node_debug_level | default(openshift.common.debug_level)",
+      "r_openshift_node_facts_iptables_sync_period": "openshift_node_iptables_sync_period",
+      "r_openshift_node_facts_kubelet_args": "openshift_node_kubelet_args",
+      "r_openshift_node_facts_labels": "lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true)",
+      "r_openshift_node_facts_oreg_url": "oreg_url_node | default(oreg_url)",
+      "r_openshift_node_facts_schedulable": "openshift_schedulable | default(openshift_scheduleable)",
+      "r_openshift_node_facts_sdn_mtu": "openshift_node_sdn_mtu",
+      "r_openshift_node_facts_osn_storage_plugin_deps": "osn_storage_plugin_deps",
+      "r_openshift_node_facts_set_node_ip": "openshift_set_node_ip",
+      "r_openshift_node_facts_osn_image": "osn_image",
+      "r_openshift_node_facts_osn_ovs_image": "osn_ovs_image",
+      "r_openshift_node_facts_proxy_mode": "openshift_node_proxy_mode",
+      "r_openshift_node_facts_local_quota_per_fsgroup": "openshift_node_local_quota_per_fsgroup",
+      "r_openshift_node_facts_dns_ip": "openshift_dns_ip",
+      "r_openshift_node_facts_env_vars": "openshift_node_env_vars"
+    }
+  }]
+}

--- a/playbooks/common/openshift-node/refresh_node_facts.yml
+++ b/playbooks/common/openshift-node/refresh_node_facts.yml
@@ -1,0 +1,6 @@
+---
+# Set role variables that are optional and not defined
+- include: set_optional_node_facts_role_variables.yml
+
+- include_role:
+    name: openshift_node_facts

--- a/playbooks/common/openshift-node/set_optional_node_facts_role_variables.yml
+++ b/playbooks/common/openshift-node/set_optional_node_facts_role_variables.yml
@@ -1,0 +1,65 @@
+---
+# This file is automatically generate. Do not edit it manually.
+- set_fact:
+    r_openshift_node_facts_osn_ovs_image: "{{ osn_ovs_image }}"
+  when: osn_ovs_image is defined
+
+- set_fact:
+    r_openshift_node_facts_dns_ip: "{{ openshift_dns_ip }}"
+  when: openshift_dns_ip is defined
+
+- set_fact:
+    r_openshift_node_facts_env_vars: "{{ openshift_node_env_vars }}"
+  when: openshift_node_env_vars is defined
+
+- set_fact:
+    r_openshift_node_facts_schedulable: "{{ openshift_schedulable | default(openshift_scheduleable) }}"
+  when: openshift_schedulable | default(openshift_scheduleable) is defined
+
+- set_fact:
+    r_openshift_node_facts_set_node_ip: "{{ openshift_set_node_ip }}"
+  when: openshift_set_node_ip is defined
+
+- set_fact:
+    r_openshift_node_facts_annotations: "{{ openshift_node_annotations }}"
+  when: openshift_node_annotations is defined
+
+- set_fact:
+    r_openshift_node_facts_kubelet_args: "{{ openshift_node_kubelet_args }}"
+  when: openshift_node_kubelet_args is defined
+
+- set_fact:
+    r_openshift_node_facts_osn_image: "{{ osn_image }}"
+  when: osn_image is defined
+
+- set_fact:
+    r_openshift_node_facts_sdn_mtu: "{{ openshift_node_sdn_mtu }}"
+  when: openshift_node_sdn_mtu is defined
+
+- set_fact:
+    r_openshift_node_facts_oreg_url: "{{ oreg_url_node | default(oreg_url) }}"
+  when: oreg_url_node | default(oreg_url) is defined
+
+- set_fact:
+    r_openshift_node_facts_proxy_mode: "{{ openshift_node_proxy_mode }}"
+  when: openshift_node_proxy_mode is defined
+
+- set_fact:
+    r_openshift_node_facts_osn_storage_plugin_deps: "{{ osn_storage_plugin_deps }}"
+  when: osn_storage_plugin_deps is defined
+
+- set_fact:
+    r_openshift_node_facts_iptables_sync_period: "{{ openshift_node_iptables_sync_period }}"
+  when: openshift_node_iptables_sync_period is defined
+
+- set_fact:
+    r_openshift_node_facts_labels: "{{ lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true) }}"
+  when: lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true) is defined
+
+- set_fact:
+    r_openshift_node_facts_local_quota_per_fsgroup: "{{ openshift_node_local_quota_per_fsgroup }}"
+  when: openshift_node_local_quota_per_fsgroup is defined
+
+- set_fact:
+    r_openshift_node_facts_debug_level: "{{ openshift_node_debug_level | default(openshift.common.debug_level) }}"
+  when: openshift_node_debug_level | default(openshift.common.debug_level) is defined

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -12,7 +12,6 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
-- role: openshift_node_facts
 - role: lib_openshift
 - role: openshift_common
 - role: openshift_clock

--- a/roles/openshift_node_facts/README.md
+++ b/roles/openshift_node_facts/README.md
@@ -1,0 +1,55 @@
+OpenShift/Atomic Enterprise Node Facts
+================================
+
+Node facts collector
+
+Requirements
+------------
+
+* Ansible 2.2
+
+Role Variables
+--------------
+
+| name                                           | description                              | default  | required | choices |
+|------------------------------------------------|------------------------------------------|----------|----------|---------|
+| r_openshift_node_facts_annotations             | Node annotations                         | None     |          |         |
+| r_openshift_node_facts_debug_level             | Node debug lovel                         |          |          |         |
+| r_openshift_node_facts_dns_ip                  |                                          |          |          |         |
+| r_openshift_node_facts_env_vars                |                                          | None     |          |         |
+| r_openshift_node_facts_iptables_sync_period    |                                          | None     |          |         |
+| r_openshift_node_facts_kubelet_args            |                                          | None     |          |         |
+| r_openshift_node_facts_labels                  | Node labels                              | None     |          |         |
+| r_openshift_node_facts_local_quota_per_fsgroup |                                          | None     |          |         |
+| r_openshift_node_facts_oreg_url                |                                          | None     |          |         |
+| r_openshift_node_facts_osn_image               |                                          | None     |          |         |
+| r_openshift_node_facts_osn_ovs_image           |                                          | None     |          |         |
+| r_openshift_node_facts_osn_storage_plugin_deps | Store plugins to install on the node     | None     |          |         |
+| r_openshift_node_facts_proxy_mode              |                                          | iptables |          |         |
+| r_openshift_node_facts_schedulable             | If set pods can be scheduled on the node | None     |          |         |
+| r_openshift_node_facts_sdn_mtu                 |                                          | None     |          |         |
+| r_openshift_node_facts_set_node_ip             |                                          | None     |          |         |
+
+
+Dependencies
+------------
+
+openshift_facts
+
+Example Playbook
+----------------
+
+Notes
+-----
+
+TODO
+
+License
+-------
+
+Apache License, Version 2.0
+
+Author Information
+------------------
+
+TODO

--- a/roles/openshift_node_facts/defaults/main.yml
+++ b/roles/openshift_node_facts/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+#: name=r_openshift_node_facts_debug_level, description="Node debug lovel"
+#: description="Node annotations"
+r_openshift_node_facts_annotations: "{{ None }}"
+r_openshift_node_facts_iptables_sync_period: "{{ None }}"
+r_openshift_node_facts_kubelet_args: "{{ None }}"
+#: description="Node labels"
+r_openshift_node_facts_labels: "{{ None }}"
+r_openshift_node_facts_oreg_url: "{{ None }}"
+#: description="If set pods can be scheduled on the node"
+r_openshift_node_facts_schedulable: "{{ None }}"
+r_openshift_node_facts_sdn_mtu: "{{ None }}"
+#: description="Store plugins to install on the node"
+r_openshift_node_facts_osn_storage_plugin_deps: "{{ None }}"
+r_openshift_node_facts_set_node_ip: "{{ None }}"
+r_openshift_node_facts_osn_image: "{{ None }}"
+r_openshift_node_facts_osn_ovs_image: "{{ None }}"
+r_openshift_node_facts_proxy_mode: iptables
+r_openshift_node_facts_local_quota_per_fsgroup: "{{ None }}"
+#: name=r_openshift_node_facts_dns_ip
+r_openshift_node_facts_env_vars: "{{ None }}"

--- a/roles/openshift_node_facts/generate.json
+++ b/roles/openshift_node_facts/generate.json
@@ -1,0 +1,11 @@
+{
+  "actions": [{
+    "action": "role_var_checks",
+    "target": "tasks/pre_checks.yml",
+    "source": "defaults/main.yml"
+  },{
+    "action": "role_var_table",
+    "source": "defaults/main.yml",
+    "target": "README.md"
+    }]
+}

--- a/roles/openshift_node_facts/tasks/main.yml
+++ b/roles/openshift_node_facts/tasks/main.yml
@@ -1,8 +1,14 @@
 ---
+- name: Fail if r_openshift_node_facts_debug_level is not defined
+  fail:
+    msg: r_openshift_node_facts_debug_level must be specified for this role
+  when:
+  - r_openshift_node_facts_debug_level is not defined
+
 - set_fact:
     openshift_node_debug_level: "{{ lookup('oo_option', 'openshift_node_debug_level') }}"
   when:
-  - openshift_node_debug_level is not defined
+  - r_openshift_node_facts_debug_level is not defined
   - lookup('oo_option', 'openshift_node_debug_level') != ""
 
 - name: Set node facts
@@ -16,19 +22,20 @@
       labels: {}
   - role: node
     local_facts:
-      annotations: "{{ openshift_node_annotations | default(none) }}"
-      debug_level: "{{ openshift_node_debug_level | default(openshift.common.debug_level) }}"
-      iptables_sync_period: "{{ openshift_node_iptables_sync_period | default(None) }}"
-      kubelet_args: "{{ openshift_node_kubelet_args | default(None) }}"
-      labels: "{{ lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true) }}"
-      registry_url: "{{ oreg_url_node | default(oreg_url) | default(None) }}"
-      schedulable: "{{ openshift_schedulable | default(openshift_scheduleable) | default(None) }}"
-      sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
-      storage_plugin_deps: "{{ osn_storage_plugin_deps | default(None) }}"
-      set_node_ip: "{{ openshift_set_node_ip | default(None) }}"
-      node_image: "{{ osn_image | default(None) }}"
-      ovs_image: "{{ osn_ovs_image | default(None) }}"
-      proxy_mode: "{{ openshift_node_proxy_mode | default('iptables') }}"
-      local_quota_per_fsgroup: "{{ openshift_node_local_quota_per_fsgroup | default(None) }}"
-      dns_ip: "{{ openshift_dns_ip | default(none) | get_dns_ip(hostvars[inventory_hostname])}}"
-      env_vars: "{{ openshift_node_env_vars | default(None) }}"
+      annotations: "{{ r_openshift_node_facts_annotations }}"
+      debug_level: "{{ r_openshift_node_facts_debug_level }}"
+      iptables_sync_period: "{{ r_openshift_node_facts_iptables_sync_period }}"
+      kubelet_args: "{{ r_openshift_node_facts_kubelet_args }}"
+      labels: "{{ r_openshift_node_facts_labels }}"
+      registry_url: "{{ r_openshift_node_facts_oreg_url }}"
+      schedulable: "{{ r_openshift_node_facts_schedulable }}"
+      sdn_mtu: "{{ r_openshift_node_facts_sdn_mtu }}"
+      storage_plugin_deps: "{{ r_openshift_node_facts_osn_storage_plugin_deps }}"
+      set_node_ip: "{{ r_openshift_node_facts_set_node_ip }}"
+      node_image: "{{ r_openshift_node_facts_osn_image }}"
+      ovs_image: "{{ r_openshift_node_facts_osn_ovs_image }}"
+      proxy_mode: "{{ r_openshift_node_facts_proxy_mode }}"
+      local_quota_per_fsgroup: "{{ r_openshift_node_facts_local_quota_per_fsgroup }}"
+      # get_dns_ip is defined in filter_plugins/openshift_ndde.py
+      dns_ip: "{{ r_openshift_node_facts_dns_ip | get_dns_ip(hostvars[inventory_hostname])}}"
+      env_vars: "{{ r_openshift_node_facts_env_vars }}"


### PR DESCRIPTION
Removing all free variables from the role, replacing all of then with r_openshift_node_facts prefixed variables.

Given the openshift_node consumes all node facts either via openshift.node or free variables, the openshift_node_facts does not need to be openshift_node's dependency as long as we make sure proper node facts are collected before the openshift_node role is run. I am not removing the dependency on the assumption the node facts role gets run ahead, but on the assumption the node facts can change over time and the facts needs to be collected only once and not each time the openshift_node role gets run. At the same time the node facts are set to default values so the openshift_node role should work on its own. Plus, removing the dependency will allow us to set custom node facts during testing to cover more combinations of the node facts.

The `generate.json` file is read by new generators from [1]. it generates the role variable table in `README.md` and the `set_optional_node_facts_role_variables.yml`.

**In depth**
In a process of moving all global variables out of the `openshift_node_facts` role I had to do the following:
1. For each global variable used inside the role create corresponding new variable prefixed with `r_openshift_node_facts_`  string, e.g. for `openshift_node_debug_level` create `r_openshift_node_facts_debug_level`.
2. Given most of the variables has default value attach, I moved the default value of each role variable under `defaults/main.yml`. E.g. the `openshift_node_proxy_mode | default('iptables')` resulted in `r_openshift_node_facts_proxy_mode: iptables` line.
3. Set all role variables to their corresponding global variables. By the nature of `openshift_node_proxy_mode | default('iptables')` expression, one can use the following form:
   ```yaml
   include_role:
     name: openshift_node_facts
   vars:
     r_openshift_node_facts_proxy_mode: "{{ openshift_node_proxy_mode | default('iptables') }}"
   ```

   However, the default value (that is set inside `default/main.yml` gets duplicated). For that reason I decided to use the following form instead:

   ```yaml
   set_fact:
      r_openshift_node_facts_proxy_mode: "{{ openshift_node_proxy_mode }}"
   when: openshift_node_proxy_mode is defined

   include_role:
     name: openshift_node_facts
   ```
   It does not look good but the default value is specified only once. Plus, the `set_fact: ... when: ...` syntax is pretty generic, it can be automatically generated (see `playbooks/common/openshift-node/set_optional_node_facts_role_variables.yml`)
4. Verify role variables: a role has a list of role variables that needs to be defined, a list of variables that can be set to a restricted set of value or a list of variables that depends on other variables or their values. 
This role has only one check (see top of `roles/openshift_node_facts/tasks/main.yml`). For more checks see https://github.com/openshift/openshift-ansible/pull/5027/files#diff-ca0eb3d2f4b4907fcf15212649d257e9

[1] https://github.com/openshift/openshift-ansible/pull/4998