### PR TITLE
openshift-checks: have playbooks invoke std_include

### DIFF
--- a/playbooks/common/openshift-checks/health.yml
+++ b/playbooks/common/openshift-checks/health.yml
@@ -1,5 +1,7 @@
 ---
-- include: ../openshift-cluster/evaluate_groups.yml
+- include: ../openshift-cluster/std_include.yml
+  tags:
+  - always
 
 - name: Run OpenShift health checks
   hosts: OSEv3

--- a/playbooks/common/openshift-checks/pre-install.yml
+++ b/playbooks/common/openshift-checks/pre-install.yml
@@ -1,5 +1,7 @@
 ---
-- include: ../openshift-cluster/evaluate_groups.yml
+- include: ../openshift-cluster/std_include.yml
+  tags:
+  - always
 
 - hosts: OSEv3
   name: run OpenShift pre-install checks

--- a/roles/openshift_health_checker/openshift_checks/etcd_traffic.py
+++ b/roles/openshift_health_checker/openshift_checks/etcd_traffic.py
@@ -14,8 +14,8 @@ class EtcdTraffic(OpenShiftCheck):
         group_names = self.get_var("group_names", default=[])
         valid_group_names = "etcd" in group_names
 
-        version = self.get_var("openshift", "common", "short_version")
-        valid_version = version in ("3.4", "3.5", "1.4", "1.5")
+        version = self.get_major_minor_version(self.get_var("openshift_image_tag"))
+        valid_version = version in ((3, 4), (3, 5))
 
         return super(EtcdTraffic, self).is_active() and valid_group_names and valid_version
 

--- a/roles/openshift_health_checker/test/etcd_traffic_test.py
+++ b/roles/openshift_health_checker/test/etcd_traffic_test.py
@@ -8,7 +8,7 @@ from openshift_checks.etcd_traffic import EtcdTraffic
     (['masters'], "3.6", False),
     (['nodes'], "3.4", False),
     (['etcd'], "3.4", True),
-    (['etcd'], "3.5", True),
+    (['etcd'], "1.5", True),
     (['etcd'], "3.1", False),
     (['masters', 'nodes'], "3.5", False),
     (['masters', 'etcd'], "3.5", True),
@@ -17,9 +17,7 @@ from openshift_checks.etcd_traffic import EtcdTraffic
 def test_is_active(group_names, version, is_active):
     task_vars = dict(
         group_names=group_names,
-        openshift=dict(
-            common=dict(short_version=version),
-        ),
+        openshift_image_tag=version,
     )
     assert EtcdTraffic(task_vars=task_vars).is_active() == is_active
 


### PR DESCRIPTION
@sdodson @kwoodson with fixing [the refactor](https://github.com/openshift/openshift-ansible/pull/4739) integration tests last night I was sloppy and didn't test what happens with the actual check playbooks. CI doesn't test either. They broke, of course. Here's a quick commit to start fixing that. However the `health.yml` checks still report:

    OpenShiftCheckException: 'openshift.common.short_version' is undefined

... so did something change about setting that fact?

@rhcarvalho the adhoc playbook will of course need similar alteration. And to get the instant informational failure you'll have to move the first conditional invocation before the std_include.