### PR TITLE
Refactor openshift node role

### DIFF
--- a/filter_plugins/openshift_node.py
+++ b/filter_plugins/openshift_node.py
@@ -4,7 +4,7 @@
 Custom filters for use in openshift-node
 '''
 from ansible import errors
-
+from jinja2.runtime import Undefined
 
 class FilterModule(object):
     ''' Custom ansible filters for use by openshift_node role'''
@@ -23,7 +23,7 @@ class FilterModule(object):
             raise errors.AnsibleFilterError("|failed expects hostvars is a dict")
 
         # We always use what they've specified if they've specified a value
-        if openshift_dns_ip is not None:
+        if not isinstance(openshift_dns_ip, Undefined) and openshift_dns_ip is not None:
             return openshift_dns_ip
 
         if bool(hostvars['openshift']['common']['use_dnsmasq']):

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -30,10 +30,12 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-
-  roles:
-  - role: openshift_node
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+  tasks:
+  - include: refresh_node_facts.yml
+  - include_role:
+      name: openshift_node
+    vars:
+      openshift_ca_host: "{{ groups.oo_first_master.0 }}"
 
 - name: Configure nodes
   hosts: oo_nodes_to_config:!oo_containerized_master_nodes
@@ -46,9 +48,12 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-  roles:
-  - role: openshift_node
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+  tasks:
+  - include: refresh_node_facts.yml
+  - include_role:
+      name: openshift_node
+    vars:
+      openshift_ca_host: "{{ groups.oo_first_master.0 }}"
 
 - name: Additional node config
   hosts: oo_nodes_to_config

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -30,12 +30,11 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-  tasks:
-  - include: refresh_node_facts.yml
-  - include_role:
-      name: openshift_node
-    vars:
-      openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+  pre_tasks:
+  - include: pre_install_node.yml
+  roles:
+  - role: openshift_node
+    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
 
 - name: Configure nodes
   hosts: oo_nodes_to_config:!oo_containerized_master_nodes
@@ -48,12 +47,11 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-  tasks:
-  - include: refresh_node_facts.yml
-  - include_role:
-      name: openshift_node
-    vars:
-      openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+  pre_tasks:
+  - include: pre_install_node.yml
+  roles:
+  - role: openshift_node
+    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
 
 - name: Additional node config
   hosts: oo_nodes_to_config

--- a/playbooks/common/openshift-node/generate.json
+++ b/playbooks/common/openshift-node/generate.json
@@ -1,0 +1,24 @@
+{
+  "actions": [{
+    "action": "set_fact",
+    "target": "set_optional_node_facts_role_variables.yml",
+    "mapping": {
+      "r_openshift_node_facts_annotations": "openshift_node_annotations",
+      "r_openshift_node_facts_debug_level": "openshift_node_debug_level | default(openshift.common.debug_level)",
+      "r_openshift_node_facts_iptables_sync_period": "openshift_node_iptables_sync_period",
+      "r_openshift_node_facts_kubelet_args": "openshift_node_kubelet_args",
+      "r_openshift_node_facts_labels": "lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true)",
+      "r_openshift_node_facts_oreg_url": "oreg_url_node | default(oreg_url)",
+      "r_openshift_node_facts_schedulable": "openshift_schedulable | default(openshift_scheduleable)",
+      "r_openshift_node_facts_sdn_mtu": "openshift_node_sdn_mtu",
+      "r_openshift_node_facts_osn_storage_plugin_deps": "osn_storage_plugin_deps",
+      "r_openshift_node_facts_set_node_ip": "openshift_set_node_ip",
+      "r_openshift_node_facts_osn_image": "osn_image",
+      "r_openshift_node_facts_osn_ovs_image": "osn_ovs_image",
+      "r_openshift_node_facts_proxy_mode": "openshift_node_proxy_mode",
+      "r_openshift_node_facts_local_quota_per_fsgroup": "openshift_node_local_quota_per_fsgroup",
+      "r_openshift_node_facts_dns_ip": "openshift_dns_ip",
+      "r_openshift_node_facts_env_vars": "openshift_node_env_vars"
+    }
+  }]
+}

--- a/playbooks/common/openshift-node/generate.json
+++ b/playbooks/common/openshift-node/generate.json
@@ -20,5 +20,27 @@
       "r_openshift_node_facts_dns_ip": "openshift_dns_ip",
       "r_openshift_node_facts_env_vars": "openshift_node_env_vars"
     }
+  },{
+    "action": "set_fact",
+    "target": "set_optional_node_role_variables.yml",
+    "mapping": {
+      "r_openshift_node_dns_ip": "openshift.node.dns_ip",
+      "r_openshift_node_sdn_network_plugin_name": "openshift.common.sdn_network_plugin_name",
+      "r_openshift_node_ip": "openshift.common.ip",
+      "r_openshift_node_min_tls_version": "openshift_node_min_tls_version",
+      "r_openshift_node_cipher_suites": "openshift_node_cipher_suites",
+      "r_openshift_node_disable_swap": "openshift_disable_swap",
+      "r_openshift_node_cloudprovider_aws_access_key": "openshift_cloudprovider_aws_access_key",
+      "r_openshift_node_cloudprovider_aws_secret_key": "openshift_cloudprovider_aws_secret_key",
+      "r_openshift_node_cloudprovider_kind": "openshift_cloudprovider_kind",
+      "r_openshift_node_kubelet_args": "openshift_node_kubelet_args",
+      "r_openshift_node_no_proxy": "openshift.common.no_proxy",
+      "r_openshift_node_debug_level": "openshift.node.debug_level",
+      "r_openshift_node_https_proxy": "openshift.common.https_proxy",
+      "r_openshift_node_http_proxy": "openshift.common.http_proxy",
+      "r_openshift_node_system_images_registry": "openshift.common.system_images_registry",
+      "r_openshift_node_env_vars": "openshift.node.env_vars",
+      "r_openshift_node_docker_gte_1_10": "openshift.docker.gte_1_10"
+    }
   }]
 }

--- a/playbooks/common/openshift-node/pre_install_node.yml
+++ b/playbooks/common/openshift-node/pre_install_node.yml
@@ -1,0 +1,54 @@
+---
+# Set role variables that are optional and not defined
+- include: set_optional_node_facts_role_variables.yml
+
+- include_role:
+    name: openshift_node_facts
+
+# set required role variables and variables that are always defined
+# TODO(jchaloup): check all variables set in openshift_facts to see which are always set
+# and which are set only under certain circumstances. If a variable is always set, we can use it anytime.
+# If not, the variable needs to be checked if it exists
+# If possible, I would like to maximize a set of variables I can set right away and minimize
+# the set that is if-defined dependent.
+
+# set optional role variables
+- include: set_optional_node_role_variables.yml
+
+- set_fact:
+    r_openshift_node_deployment_type: "{{ deployment_type  }}"
+    r_openshift_node_service_type: "{{ openshift.common.service_type }}"
+    r_openshift_node_image_tag: "{{ openshift_image_tag }}"
+    r_openshift_node_config_base: "{{ openshift.common.config_base }}"
+    r_openshift_node_portal_net: "{{ openshift.common.portal_net }}"
+    r_openshift_node_dns_domain: "{{ openshift.common.dns_domain }}"
+    r_openshift_node_iptables_sync_period: "{{ openshift.node.iptables_sync_period }}"
+    r_openshift_node_registry_url: "{{ openshift.node.registry_url }}"
+    r_openshift_node_hostname: "{{ openshift.common.hostname }}"
+    r_openshift_node_sdn_mtu: "{{ openshift.node.sdn_mtu }}"
+    r_openshift_node_nodename: "{{ openshift.node.nodename }}"
+    r_openshift_node_data_dir: "{{ openshift.common.data_dir }}"
+    r_openshift_node_proxy_mode: "{{ openshift.node.proxy_mode }}"
+    r_openshift_node_local_quota_per_fsgroup: "{{ openshift.node.local_quota_per_fsgroup }}"
+    r_openshift_node_image: "{{ openshift.node.node_image }}"
+    r_openshift_node_system_image: "{{ openshift.node.node_system_image }}"
+    r_openshift_node_ovs_image: "{{ openshift.node.ovs_image }}"
+    r_openshift_node_ovs_system_image: "{{ openshift.node.ovs_system_image }}"
+    r_openshift_node_master_api_url: "{{ openshift_node_master_api_url }}"
+    r_openshift_node_master_sdn_cluster_network_cidr: "{{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }}"
+    r_openshift_node_storage_plugin_deps: "{{ openshift.node.storage_plugin_deps }}"
+    r_openshift_node_pkg_version: "{{ openshift_pkg_version  }}"
+    r_openshift_node_set_node_ip: "{{ openshift.node.set_node_ip }}"
+
+    r_openshift_node_is_containerized: "{{ openshift.common.is_containerized }}"
+    r_openshift_node_is_atomic: "{{ openshift.common.is_atomic }}"
+    r_openshift_node_is_node_system_container: "{{ openshift.common.is_node_system_container }}"
+    r_openshift_node_is_openvswitch_system_container: "{{ openshift.common.is_openvswitch_system_container }}"
+    r_openshift_node_use_openshift_sdn: "{{ openshift.common.use_openshift_sdn }}"
+    r_openshift_node_use_calico: "{{ openshift.common.use_calico }}"
+    r_openshift_node_use_dnsmasq: "{{ openshift.common.use_dnsmasq }}"
+    r_openshift_node_use_nuage: "{{ openshift.common.use_nuage }}"
+    r_openshift_node_use_contiv: "{{ openshift.common.use_contiv }}"
+    r_openshift_node_version_gte_3_3_or_1_3: "{{ openshift.common.version_gte_3_3_or_1_3 }}"
+    r_openshift_node_version_gte_3_6: "{{ openshift.common.version_gte_3_6 }}"
+    r_openshift_node_docker_service_name: "{{ openshift.docker.service_name  }}"

--- a/playbooks/common/openshift-node/refresh_node_facts.yml
+++ b/playbooks/common/openshift-node/refresh_node_facts.yml
@@ -1,0 +1,6 @@
+---
+# Set role variables that are optional and not defined
+- include: set_optional_node_facts_role_variables.yml
+
+- include_role:
+    name: openshift_node_facts

--- a/playbooks/common/openshift-node/refresh_node_facts.yml
+++ b/playbooks/common/openshift-node/refresh_node_facts.yml
@@ -1,6 +1,0 @@
----
-# Set role variables that are optional and not defined
-- include: set_optional_node_facts_role_variables.yml
-
-- include_role:
-    name: openshift_node_facts

--- a/playbooks/common/openshift-node/set_optional_node_facts_role_variables.yml
+++ b/playbooks/common/openshift-node/set_optional_node_facts_role_variables.yml
@@ -1,0 +1,65 @@
+---
+# This file is automatically generate. Do not edit it manually.
+- set_fact:
+    r_openshift_node_facts_osn_ovs_image: "{{ osn_ovs_image }}"
+  when: osn_ovs_image is defined
+
+- set_fact:
+    r_openshift_node_facts_dns_ip: "{{ openshift_dns_ip }}"
+  when: openshift_dns_ip is defined
+
+- set_fact:
+    r_openshift_node_facts_env_vars: "{{ openshift_node_env_vars }}"
+  when: openshift_node_env_vars is defined
+
+- set_fact:
+    r_openshift_node_facts_schedulable: "{{ openshift_schedulable | default(openshift_scheduleable) }}"
+  when: openshift_schedulable | default(openshift_scheduleable) is defined
+
+- set_fact:
+    r_openshift_node_facts_set_node_ip: "{{ openshift_set_node_ip }}"
+  when: openshift_set_node_ip is defined
+
+- set_fact:
+    r_openshift_node_facts_annotations: "{{ openshift_node_annotations }}"
+  when: openshift_node_annotations is defined
+
+- set_fact:
+    r_openshift_node_facts_kubelet_args: "{{ openshift_node_kubelet_args }}"
+  when: openshift_node_kubelet_args is defined
+
+- set_fact:
+    r_openshift_node_facts_osn_image: "{{ osn_image }}"
+  when: osn_image is defined
+
+- set_fact:
+    r_openshift_node_facts_sdn_mtu: "{{ openshift_node_sdn_mtu }}"
+  when: openshift_node_sdn_mtu is defined
+
+- set_fact:
+    r_openshift_node_facts_oreg_url: "{{ oreg_url_node | default(oreg_url) }}"
+  when: oreg_url_node | default(oreg_url) is defined
+
+- set_fact:
+    r_openshift_node_facts_proxy_mode: "{{ openshift_node_proxy_mode }}"
+  when: openshift_node_proxy_mode is defined
+
+- set_fact:
+    r_openshift_node_facts_osn_storage_plugin_deps: "{{ osn_storage_plugin_deps }}"
+  when: osn_storage_plugin_deps is defined
+
+- set_fact:
+    r_openshift_node_facts_iptables_sync_period: "{{ openshift_node_iptables_sync_period }}"
+  when: openshift_node_iptables_sync_period is defined
+
+- set_fact:
+    r_openshift_node_facts_labels: "{{ lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true) }}"
+  when: lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true) is defined
+
+- set_fact:
+    r_openshift_node_facts_local_quota_per_fsgroup: "{{ openshift_node_local_quota_per_fsgroup }}"
+  when: openshift_node_local_quota_per_fsgroup is defined
+
+- set_fact:
+    r_openshift_node_facts_debug_level: "{{ openshift_node_debug_level | default(openshift.common.debug_level) }}"
+  when: openshift_node_debug_level | default(openshift.common.debug_level) is defined

--- a/playbooks/common/openshift-node/set_optional_node_role_variables.yml
+++ b/playbooks/common/openshift-node/set_optional_node_role_variables.yml
@@ -1,0 +1,69 @@
+---
+# This file is automatically generate. Do not edit it manually.
+- set_fact:
+    r_openshift_node_docker_gte_1_10: "{{ openshift.docker.gte_1_10 }}"
+  when: openshift.docker.gte_1_10 is defined
+
+- set_fact:
+    r_openshift_node_http_proxy: "{{ openshift.common.http_proxy }}"
+  when: openshift.common.http_proxy is defined
+
+- set_fact:
+    r_openshift_node_debug_level: "{{ openshift.node.debug_level }}"
+  when: openshift.node.debug_level is defined
+
+- set_fact:
+    r_openshift_node_cipher_suites: "{{ openshift_node_cipher_suites }}"
+  when: openshift_node_cipher_suites is defined
+
+- set_fact:
+    r_openshift_node_min_tls_version: "{{ openshift_node_min_tls_version }}"
+  when: openshift_node_min_tls_version is defined
+
+- set_fact:
+    r_openshift_node_ip: "{{ openshift.common.ip }}"
+  when: openshift.common.ip is defined
+
+- set_fact:
+    r_openshift_node_cloudprovider_kind: "{{ openshift_cloudprovider_kind }}"
+  when: openshift_cloudprovider_kind is defined
+
+- set_fact:
+    r_openshift_node_dns_ip: "{{ openshift.node.dns_ip }}"
+  when: openshift.node.dns_ip is defined
+
+- set_fact:
+    r_openshift_node_cloudprovider_aws_access_key: "{{ openshift_cloudprovider_aws_access_key }}"
+  when: openshift_cloudprovider_aws_access_key is defined
+
+- set_fact:
+    r_openshift_node_kubelet_args: "{{ openshift_node_kubelet_args }}"
+  when: openshift_node_kubelet_args is defined
+
+- set_fact:
+    r_openshift_node_cloudprovider_aws_secret_key: "{{ openshift_cloudprovider_aws_secret_key }}"
+  when: openshift_cloudprovider_aws_secret_key is defined
+
+- set_fact:
+    r_openshift_node_https_proxy: "{{ openshift.common.https_proxy }}"
+  when: openshift.common.https_proxy is defined
+
+- set_fact:
+    r_openshift_node_disable_swap: "{{ openshift_disable_swap }}"
+  when: openshift_disable_swap is defined
+
+- set_fact:
+    r_openshift_node_system_images_registry: "{{ openshift.common.system_images_registry }}"
+  when: openshift.common.system_images_registry is defined
+
+- set_fact:
+    r_openshift_node_no_proxy: "{{ openshift.common.no_proxy }}"
+  when: openshift.common.no_proxy is defined
+
+- set_fact:
+    r_openshift_node_sdn_network_plugin_name: "{{ openshift.common.sdn_network_plugin_name }}"
+  when: openshift.common.sdn_network_plugin_name is defined
+
+- set_fact:
+    r_openshift_node_env_vars: "{{ openshift.node.env_vars }}"
+  when: openshift.node.env_vars is defined

--- a/roles/openshift_node/README.md
+++ b/roles/openshift_node/README.md
@@ -13,13 +13,67 @@ rhel-7-server-extras-rpms, and rhel-7-server-ose-3.0-rpms repos
 
 Role Variables
 --------------
-From this role:
 
-| Name                       | Default value         |                                                          |
-|----------------------------|-----------------------|----------------------------------------------------------|
-| openshift_node_debug_level | openshift_debug_level | Verbosity of the debug logs for node                     |
-| oreg_url                   | UNDEF (Optional)      | Default docker registry to use                           |
-| oreg_url_node              | UNDEF (Optional)      | Default docker registry to use, specifically on the node |
+| name                                             | description                                                     | default | required | choices                     |
+|--------------------------------------------------|-----------------------------------------------------------------|---------|----------|-----------------------------|
+| r_openshift_node_cipher_suites                   |                                                                 |         |          |                             |
+| r_openshift_node_cloudprovider_aws_access_key    | AWS access key                                                  | ''      |          |                             |
+| r_openshift_node_cloudprovider_aws_secret_key    | AWS secret key                                                  | ''      |          |                             |
+| r_openshift_node_cloudprovider_kind              | Cloud provider kind, e.g. aws                                   | ''      |          |                             |
+| r_openshift_node_config_base                     | Node configuration base directory, e.g. /etc/origin             |         | true     |                             |
+| r_openshift_node_data_dir                        |                                                                 |         | true     |                             |
+| r_openshift_node_debug_level                     | Set the default node debug level                                | 2       |          |                             |
+| r_openshift_node_deployment_type                 | Deployment type                                                 |         | true     | origin,openshift-enterprise |
+| r_openshift_node_disable_swap                    | Set to disable a swap to preserve quality of service guarantees | true    |          |                             |
+| r_openshift_node_dns_domain                      |                                                                 |         | true     |                             |
+| r_openshift_node_dns_ip                          |                                                                 |         |          |                             |
+| r_openshift_node_docker_gte_1_10                 |                                                                 | false   |          |                             |
+| r_openshift_node_docker_service_name             | Default docker service name, e.g. docker, container-engine      | docker  |          |                             |
+| r_openshift_node_env_vars                        | Set node environment variables                                  | {}      |          |                             |
+| r_openshift_node_firewall_enabled                |                                                                 | True    |          |                             |
+| r_openshift_node_hostname                        |                                                                 |         | true     |                             |
+| r_openshift_node_http_proxy                      | HTTP proxy URL address                                          | ''      |          |                             |
+| r_openshift_node_https_proxy                     | HTTPS proxy URL address                                         | ''      |          |                             |
+| r_openshift_node_image                           | Node image name to pull for containerized deployment            |         |          |                             |
+| r_openshift_node_image_tag                       | Node image tag to pull for containerized deployment             |         | true     |                             |
+| r_openshift_node_ip                              |                                                                 |         |          |                             |
+| r_openshift_node_iptables_sync_period            |                                                                 |         | true     |                             |
+| r_openshift_node_is_atomic                       | Set to deploy a node over AH                                    | false   |          |                             |
+| r_openshift_node_is_containerized                | Set to deploy containerized node                                | false   |          |                             |
+| r_openshift_node_is_node_system_container        | Set to deploy node system container                             | false   |          |                             |
+| r_openshift_node_is_openvswitch_system_container | Set to deploy OVS system container                              | false   |          |                             |
+| r_openshift_node_kubelet_args                    | Optionall Kubelet arguments                                     | None    |          |                             |
+| r_openshift_node_local_quota_per_fsgroup         |                                                                 |         | true     |                             |
+| r_openshift_node_master_api_url                  | Master API URL to query                                         |         | true     |                             |
+| r_openshift_node_master_sdn_cluster_network_cidr | SDN Cluster network CIDR set by the master component            |         |          |                             |
+| r_openshift_node_min_tls_version                 |                                                                 |         |          |                             |
+| r_openshift_node_no_proxy                        | No Proxy                                                        | []      |          |                             |
+| r_openshift_node_nodename                        |                                                                 |         | true     |                             |
+| r_openshift_node_os_firewall_allow               |                                                                 |         |          |                             |
+| r_openshift_node_os_firewall_deny                |                                                                 | []      |          |                             |
+| r_openshift_node_ovs_image                       | OVS image to pull for containerized deployment                  |         |          |                             |
+| r_openshift_node_ovs_system_image                | OVS system image to pull for containerized deployment           |         |          |                             |
+| r_openshift_node_pkg_version                     | Node package version to install for package based deployment    | ''      |          |                             |
+| r_openshift_node_port_range                      |                                                                 |         |          |                             |
+| r_openshift_node_portal_net                      | Portal net                                                      |         |          |                             |
+| r_openshift_node_proxy_mode                      |                                                                 |         | true     |                             |
+| r_openshift_node_registry_url                    |                                                                 |         | true     |                             |
+| r_openshift_node_sdn_mtu                         |                                                                 |         | true     |                             |
+| r_openshift_node_sdn_network_plugin_name         |                                                                 |         |          |                             |
+| r_openshift_node_service_type                    | System service type                                             |         | true     |                             |
+| r_openshift_node_set_node_ip                     |                                                                 | true    |          |                             |
+| r_openshift_node_storage_plugin_deps             | List if additional storage plugins to deploy                    | []      |          |                             |
+| r_openshift_node_system_image                    | Node system image to pull for system containers deployment      |         |          |                             |
+| r_openshift_node_system_images_registry          | System image registry to pull images from                       |         |          |                             |
+| r_openshift_node_use_calico                      |                                                                 | false   |          |                             |
+| r_openshift_node_use_contiv                      |                                                                 | false   |          |                             |
+| r_openshift_node_use_dnsmasq                     |                                                                 | false   |          |                             |
+| r_openshift_node_use_firewalld                   |                                                                 | False   |          |                             |
+| r_openshift_node_use_nuage                       |                                                                 | false   |          |                             |
+| r_openshift_node_use_openshift_sdn               | Set to use OpenShift SDN                                        | true    |          |                             |
+| r_openshift_node_version_gte_3_3_or_1_3          |                                                                 | true    |          |                             |
+| r_openshift_node_version_gte_3_6                 |                                                                 | true    |          |                             |
+
 
 From openshift_common:
 

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -1,4 +1,88 @@
 ---
+# The variables should be decomposed into the following groups (in the order)
+# - unconditionally used variables, i.e. required variable and variables used in conditions
+#   e.g. r_openshift_node_service_type, r_openshift_node_deployment_type, r_openshift_node_is_containerized
+# - variables used only when defined, e.g. {{ var if var is defined else '' }}
+# - conditionally used variables, i.e. variables that need to be defined only under certain condition(s)
+
+# List of required undefined variables:
+#: name=r_openshift_node_deployment_type, required=true, description="Deployment type", choices=['origin', 'openshift-enterprise']
+#: name=r_openshift_node_service_type, required=true, description="System service type"
+#: name=r_openshift_node_image_tag, required=true, description="Node image tag to pull for containerized deployment"
+#: name=r_openshift_node_config_base, required=true, description="Node configuration base directory, e.g. /etc/origin"
+#: name=r_openshift_node_dns_domain, required=true
+#: name=r_openshift_node_iptables_sync_period, required=true
+#: name=r_openshift_node_registry_url, required=true
+#: name=r_openshift_node_hostname, required=true
+#: name=r_openshift_node_sdn_mtu, required=true
+#: name=r_openshift_node_nodename, required=true
+#: name=r_openshift_node_data_dir, required=true
+#: name=r_openshift_node_proxy_mode, required=true
+#: name=r_openshift_node_local_quota_per_fsgroup, required=true
+#: name=r_openshift_node_image, description="Node image name to pull for containerized deployment"
+#: name=r_openshift_node_system_image, description="Node system image to pull for system containers deployment"
+#: name=r_openshift_node_ovs_image, description="OVS image to pull for containerized deployment"
+#: name=r_openshift_node_ovs_system_image, description="OVS system image to pull for containerized deployment"
+#: name=r_openshift_node_master_api_url, description="Master API URL to query", required=true
+
+# List of optional undefined variables
+#: name=r_openshift_node_system_images_registry, description="System image registry to pull images from", required_when=["r_openshift_node_is_containerized | bool", "r_openshift_node_is_node_system_container | bool"], required_when=["r_openshift_node_is_containerized | bool", "r_openshift_node_is_openvswitch_system_container | bool", "r_openshift_node_use_openshift_sdn | bool"]
+#: name=r_openshift_node_master_sdn_cluster_network_cidr, description="SDN Cluster network CIDR set by the master component", required_when=["r_openshift_node_http_proxy != ''"]
+#: name=r_openshift_node_portal_net, required_when=["r_openshift_node_http_proxy != ''"], description="Portal net"
+#: name=r_openshift_node_dns_ip
+#: name=r_openshift_node_sdn_network_plugin_name, required_when="r_openshift_node_use_openshift_sdn | bool or r_openshift_node_use_nuage | bool or r_openshift_node_use_contiv | bool"
+#: name=r_openshift_node_ip, required_when="r_openshift_node_set_node_ip | bool"
+#: name=r_openshift_node_min_tls_version
+#: name=r_openshift_node_cipher_suites
+#: name=r_openshift_node_port_range
+
+#: description="Set to deploy containerized node"
+r_openshift_node_is_containerized: false
+#: description="Set to deploy a node over AH"
+r_openshift_node_is_atomic: false
+#: description="Set to disable a swap to preserve quality of service guarantees"
+r_openshift_node_disable_swap: true
+#: description="Node package version to install for package based deployment"
+r_openshift_node_pkg_version: ''
+#: description="Default docker service name, e.g. docker, container-engine"
+r_openshift_node_docker_service_name: docker
+#: description="AWS access key"
+r_openshift_node_cloudprovider_aws_access_key: ''
+#: description="AWS secret key"
+r_openshift_node_cloudprovider_aws_secret_key: ''
+#: description="Cloud provider kind, e.g. aws"
+r_openshift_node_cloudprovider_kind: ''
+#: description="Optionall Kubelet arguments"
+r_openshift_node_kubelet_args: "{{ None }}"
+#: description="HTTP proxy URL address"
+r_openshift_node_http_proxy: ''
+#: description="HTTPS proxy URL address", required_when=["r_openshift_node_http_proxy != ''"]
+r_openshift_node_https_proxy: ''
+#: description="Set to deploy node system container"
+r_openshift_node_is_node_system_container: false
+#: description="Set to deploy OVS system container"
+r_openshift_node_is_openvswitch_system_container: false
+#: description="No Proxy", required_when=["r_openshift_node_http_proxy != ''"]
+r_openshift_node_no_proxy: []
+#: description="Set to use OpenShift SDN"
+r_openshift_node_use_openshift_sdn: true
+#: description="Set the default node debug level"
+r_openshift_node_debug_level: 2
+#: description="Set node environment variables"
+r_openshift_node_env_vars: {}
+#: description="List if additional storage plugins to deploy"
+r_openshift_node_storage_plugin_deps: []
+
+r_openshift_node_version_gte_3_6: true
+r_openshift_node_version_gte_3_3_or_1_3: true
+
+r_openshift_node_use_nuage: false
+r_openshift_node_use_contiv: false
+r_openshift_node_use_calico: false
+r_openshift_node_use_dnsmasq: false
+r_openshift_node_set_node_ip: true
+r_openshift_node_docker_gte_1_10: false
+
 r_openshift_node_firewall_enabled: True
 r_openshift_node_use_firewalld: False
 r_openshift_node_os_firewall_deny: []
@@ -11,13 +95,13 @@ r_openshift_node_os_firewall_allow:
   port: 443/tcp
 - service: OpenShift OVS sdn
   port: 4789/udp
-  cond: openshift.common.use_openshift_sdn | default(true) | bool
+  cond: "{{ r_openshift_node_use_openshift_sdn | bool }}"
 - service: Calico BGP Port
   port: 179/tcp
-  cond: "{{ openshift.common.use_calico | bool }}"
+  cond: "{{ r_openshift_node_use_calico | bool }}"
 - service: Kubernetes service NodePort TCP
-  port: "{{ openshift_node_port_range | default('') }}/tcp"
-  cond: "{{ openshift_node_port_range is defined }}"
+  port: "{{ r_openshift_node_port_range | default('') }}/tcp"
+  cond: "{{ r_openshift_node_port_range is defined }}"
 - service: Kubernetes service NodePort UDP
-  port: "{{ openshift_node_port_range | default('') }}/udp"
-  cond: "{{ openshift_node_port_range is defined }}"
+  port: "{{ r_openshift_node_port_range | default('') }}/udp"
+  cond: "{{ r_openshift_node_port_range is defined }}"

--- a/roles/openshift_node/generate.json
+++ b/roles/openshift_node/generate.json
@@ -1,0 +1,11 @@
+{
+  "actions": [{
+    "action": "role_var_checks",
+    "target": "tasks/pre_checks.yml",
+    "source": "defaults/main.yml"
+  },{
+    "action": "role_var_table",
+    "source": "defaults/main.yml",
+    "target": "README.md"
+    }]
+}

--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -3,7 +3,7 @@
   systemd:
     name: openvswitch
     state: restarted
-  when: (not skip_node_svc_handlers | default(False) | bool) and not (ovs_service_status_changed | default(false) | bool) and openshift.common.use_openshift_sdn | default(true) | bool
+  when: (not skip_node_svc_handlers | default(False) | bool) and not (ovs_service_status_changed | default(false) | bool) and r_openshift_node_use_openshift_sdn | bool
   register: l_openshift_node_stop_openvswitch_result
   until: not l_openshift_node_stop_openvswitch_result | failed
   retries: 3
@@ -14,11 +14,11 @@
 
 - name: restart openvswitch pause
   pause: seconds=15
-  when: (not skip_node_svc_handlers | default(False) | bool) and openshift.common.is_containerized | bool
+  when: (not skip_node_svc_handlers | default(False) | bool) and r_openshift_node_is_containerized | bool
 
 - name: restart node
   systemd:
-    name: "{{ openshift.common.service_type }}-node"
+    name: "{{ r_openshift_node_service_type }}-node"
     state: restarted
   register: l_openshift_node_restart_node_result
   until: not l_openshift_node_restart_node_result | failed

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -20,4 +20,4 @@ dependencies:
 - role: openshift_node_certificates
 - role: openshift_cloud_provider
 - role: openshift_node_dnsmasq
-  when: openshift.common.use_dnsmasq | bool
+  when: r_openshift_node_use_dnsmasq | bool

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -12,7 +12,6 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
-- role: openshift_node_facts
 - role: lib_openshift
 - role: lib_os_firewall
 - role: openshift_common

--- a/roles/openshift_node/tasks/config/configure-node-settings.yml
+++ b/roles/openshift_node/tasks/config/configure-node-settings.yml
@@ -1,16 +1,16 @@
 ---
 - name: Configure Node settings
   lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
+    dest: /etc/sysconfig/{{ r_openshift_node_service_type }}-node
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
     create: true
   with_items:
   - regex: '^OPTIONS='
-    line: "OPTIONS=--loglevel={{ openshift.node.debug_level | default(2) }}"
+    line: "OPTIONS=--loglevel={{ r_openshift_node_debug_level }}"
   - regex: '^CONFIG_FILE='
-    line: "CONFIG_FILE={{ openshift.common.config_base }}/node/node-config.yaml"
+    line: "CONFIG_FILE={{ r_openshift_node_config_base }}/node/node-config.yaml"
   - regex: '^IMAGE_VERSION='
-    line: "IMAGE_VERSION={{ openshift_image_tag }}"
+    line: "IMAGE_VERSION={{ r_openshift_node_image_tag }}"
   notify:
   - restart node

--- a/roles/openshift_node/tasks/config/configure-proxy-settings.yml
+++ b/roles/openshift_node/tasks/config/configure-proxy-settings.yml
@@ -1,17 +1,18 @@
 ---
 - name: Configure Proxy Settings
   lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
+    dest: /etc/sysconfig/{{ r_openshift_node_service_type }}-node
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
     create: true
   with_items:
   - regex: '^HTTP_PROXY='
-    line: "HTTP_PROXY={{ openshift.common.http_proxy | default('') }}"
+    line: "HTTP_PROXY={{  r_openshift_node_http_proxy }}"
   - regex: '^HTTPS_PROXY='
-    line: "HTTPS_PROXY={{ openshift.common.https_proxy | default('') }}"
+    line: "HTTPS_PROXY={{ r_openshift_node_https_proxy }}"
   - regex: '^NO_PROXY='
-    line: "NO_PROXY={{ openshift.common.no_proxy | default([]) }},{{ openshift.common.portal_net }},{{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }}"
-  when: ('http_proxy' in openshift.common and openshift.common.http_proxy != '')
+    line: "NO_PROXY={{ r_openshift_node_no_proxy }},{{ r_openshift_node_portal_net }},{{ r_openshift_node_master_sdn_cluster_network_cidr }}"
+  when:
+  - r_openshift_node_http_proxy != ''
   notify:
   - restart node

--- a/roles/openshift_node/tasks/config/install-node-deps-docker-service-file.yml
+++ b/roles/openshift_node/tasks/config/install-node-deps-docker-service-file.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install Node dependencies docker service file
   template:
-    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node-dep.service"
+    dest: "/etc/systemd/system/{{ r_openshift_node_service_type }}-node-dep.service"
     src: openshift.docker.node.dep.service
   notify:
   - reload systemd units

--- a/roles/openshift_node/tasks/config/install-node-docker-service-file.yml
+++ b/roles/openshift_node/tasks/config/install-node-docker-service-file.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install Node docker service file
   template:
-    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
+    dest: "/etc/systemd/system/{{ r_openshift_node_service_type }}-node.service"
     src: openshift.docker.node.service
   notify:
   - reload systemd units

--- a/roles/openshift_node/tasks/disable_swap.yml
+++ b/roles/openshift_node/tasks/disable_swap.yml
@@ -1,0 +1,30 @@
+---
+# https://docs.openshift.com/container-platform/3.4/admin_guide/overcommit.html#disabling-swap-memory
+- name: Check for swap usage
+  command: grep "^[^#].*swap" /etc/fstab
+  # grep: match any lines which don't begin with '#' and contain 'swap'
+  changed_when: false
+  failed_when: false
+  register: l_swap_result
+
+# Disable Swap Block
+- block:
+    - name: Disable swap
+      command: swapoff --all
+
+    - name: Remove swap entries from /etc/fstab
+      replace:
+        dest: /etc/fstab
+        regexp: '(^[^#].*swap.*)'
+        replace: '# \1'
+        backup: yes
+
+    - name: Add notice about disabling swap
+      lineinfile:
+        dest: /etc/fstab
+        line: '# OpenShift-Ansible Installer disabled swap per overcommit guidelines'
+        state: present
+  when:
+    - l_swap_result.stdout_lines | length > 0
+    - r_openshift_node_disable_swap | bool
+# End Disable Swap Block

--- a/roles/openshift_node/tasks/firewall.yml
+++ b/roles/openshift_node/tasks/firewall.yml
@@ -1,5 +1,7 @@
 ---
-- when: r_openshift_node_firewall_enabled | bool and not r_openshift_node_use_firewalld | bool
+- when:
+  - r_openshift_node_firewall_enabled | bool
+  - not r_openshift_node_use_firewalld | bool
   block:
   - name: Add iptables allow rules
     os_firewall_manage_iptables:
@@ -19,7 +21,9 @@
     when: item.cond | default(True)
     with_items: "{{ r_openshift_node_os_firewall_deny }}"
 
-- when: r_openshift_node_firewall_enabled | bool and r_openshift_node_use_firewalld | bool
+- when:
+  - r_openshift_node_firewall_enabled | bool
+  - r_openshift_node_use_firewalld | bool
   block:
   - name: Add firewalld allow rules
     firewalld:

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -1,82 +1,22 @@
 ---
+- include: pre_checks.yml
+
 # TODO: allow for overriding default ports where possible
 - fail:
     msg: "SELinux is disabled, This deployment type requires that SELinux is enabled."
   when:
-    - (not ansible_selinux or ansible_selinux.status != 'enabled') and deployment_type in ['enterprise', 'online', 'atomic-enterprise', 'openshift-enterprise']
+    - (not ansible_selinux or ansible_selinux.status != 'enabled') and r_openshift_node_deployment_type in ['enterprise', 'online', 'atomic-enterprise', 'openshift-enterprise']
     - not openshift_docker_use_crio | default(false)
 
-- name: setup firewall
-  include: firewall.yml
-  static: yes
-
-- name: Set node facts
-  openshift_facts:
-    role: "{{ item.role }}"
-    local_facts: "{{ item.local_facts }}"
-  with_items:
-    # Reset node labels to an empty dictionary.
-    - role: node
-      local_facts:
-        labels: {}
-    - role: node
-      local_facts:
-        annotations: "{{ openshift_node_annotations | default(none) }}"
-        debug_level: "{{ openshift_node_debug_level | default(openshift.common.debug_level) }}"
-        iptables_sync_period: "{{ openshift_node_iptables_sync_period | default(None) }}"
-        kubelet_args: "{{ openshift_node_kubelet_args | default(None) }}"
-        labels: "{{ lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true) }}"
-        registry_url: "{{ oreg_url_node | default(oreg_url) | default(None) }}"
-        schedulable: "{{ openshift_schedulable | default(openshift_scheduleable) | default(None) }}"
-        sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
-        storage_plugin_deps: "{{ osn_storage_plugin_deps | default(None) }}"
-        set_node_ip: "{{ openshift_set_node_ip | default(None) }}"
-        node_image: "{{ osn_image | default(None) }}"
-        ovs_image: "{{ osn_ovs_image | default(None) }}"
-        proxy_mode: "{{ openshift_node_proxy_mode | default('iptables') }}"
-        local_quota_per_fsgroup: "{{ openshift_node_local_quota_per_fsgroup | default(None) }}"
-        dns_ip: "{{ openshift_dns_ip | default(none) | get_dns_ip(hostvars[inventory_hostname])}}"
-        env_vars: "{{ openshift_node_env_vars | default(None) }}"
-
-# https://docs.openshift.com/container-platform/3.4/admin_guide/overcommit.html#disabling-swap-memory
-- name: Check for swap usage
-  command: grep "^[^#].*swap" /etc/fstab
-  # grep: match any lines which don't begin with '#' and contain 'swap'
-  changed_when: false
-  failed_when: false
-  register: swap_result
-
-# Disable Swap Block
-- block:
-
-    - name: Disable swap
-      command: swapoff --all
-
-    - name: Remove swap entries from /etc/fstab
-      replace:
-        dest: /etc/fstab
-        regexp: '(^[^#].*swap.*)'
-        replace: '# \1'
-        backup: yes
-
-    - name: Add notice about disabling swap
-      lineinfile:
-        dest: /etc/fstab
-        line: '# OpenShift-Ansible Installer disabled swap per overcommit guidelines'
-        state: present
-
-  when:
-    - swap_result.stdout_lines | length > 0
-    - openshift_disable_swap | default(true) | bool
-# End Disable Swap Block
+- include: disable_swap.yml
 
 # We have to add tuned-profiles in the same transaction otherwise we run into depsolving
 # problems because the rpms don't pin the version properly. This was fixed in 3.1 packaging.
 - name: Install Node package
   package:
-    name: "{{ openshift.common.service_type }}-node{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }},tuned-profiles-{{ openshift.common.service_type }}-node{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
+    name: "{{ r_openshift_node_service_type }}-node{{ r_openshift_node_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }},tuned-profiles-{{ r_openshift_node_service_type }}-node{{ r_openshift_node_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
     state: present
-  when: not openshift.common.is_containerized | bool
+  when: not r_openshift_node_is_containerized | bool
 
 - name: Check for tuned package
   command: rpm -q tuned
@@ -88,15 +28,15 @@
 
 - name: Set atomic-guest tuned profile
   command: "tuned-adm profile atomic-guest"
-  when: tuned_installed.rc == 0 and openshift.common.is_atomic | bool
+  when: tuned_installed.rc == 0 and r_openshift_node_is_atomic | bool
 
 - name: Install sdn-ovs package
   package:
-    name: "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version | oo_image_tag_to_rpm_version(include_dash=True) }}"
+    name: "{{ r_openshift_node_service_type }}-sdn-ovs{{ r_openshift_node_pkg_version | oo_image_tag_to_rpm_version(include_dash=True) }}"
     state: present
   when:
-    - openshift.common.use_openshift_sdn | default(true) | bool
-    - not openshift.common.is_containerized | bool
+    - r_openshift_node_use_openshift_sdn | bool
+    - not r_openshift_node_is_containerized | bool
 
 - name: Restart cri-o
   systemd:
@@ -109,7 +49,7 @@
   package:
     name: "conntrack-tools"
     state: present
-  when: not openshift.common.is_containerized | bool
+  when: not r_openshift_node_is_containerized | bool
 
 - name: Install the systemd units
   include: systemd_units.yml
@@ -133,8 +73,8 @@
     state: started
     daemon_reload: yes
   when:
-    - openshift.common.is_containerized | bool
-    - openshift.common.use_openshift_sdn | default(true) | bool
+    - r_openshift_node_is_containerized | bool
+    - r_openshift_node_use_openshift_sdn | bool
   register: ovs_start_result
   until: not ovs_start_result | failed
   retries: 3
@@ -144,14 +84,14 @@
     ovs_service_status_changed: "{{ ovs_start_result | changed }}"
 
 - file:
-    dest: "{{ (openshift_node_kubelet_args|default({'config':None})).config}}"
+    dest: "{{ r_openshift_node_kubelet_args.config }}"
     state: directory
-  when: openshift_node_kubelet_args is defined and 'config' in openshift_node_kubelet_args
+  when: r_openshift_node_kubelet_args is defined and 'config' in r_openshift_node_kubelet_args
 
 # TODO: add the validate parameter when there is a validation command to run
 - name: Create the Node config
   template:
-    dest: "{{ openshift.common.config_base }}/node/node-config.yaml"
+    dest: "{{ r_openshift_node_config_base }}/node/node-config.yaml"
     src: node.yaml.v1.j2
     backup: true
     owner: root
@@ -162,27 +102,27 @@
 
 - name: Configure AWS Cloud Provider Settings
   lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
+    dest: /etc/sysconfig/{{ r_openshift_node_service_type }}-node
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
     create: true
   with_items:
     - regex: '^AWS_ACCESS_KEY_ID='
-      line: "AWS_ACCESS_KEY_ID={{ openshift_cloudprovider_aws_access_key | default('') }}"
+      line: "AWS_ACCESS_KEY_ID={{ r_openshift_node_cloudprovider_aws_access_key | default('') }}"
     - regex: '^AWS_SECRET_ACCESS_KEY='
-      line: "AWS_SECRET_ACCESS_KEY={{ openshift_cloudprovider_aws_secret_key | default('') }}"
+      line: "AWS_SECRET_ACCESS_KEY={{ r_openshift_node_cloudprovider_aws_secret_key | default('') }}"
   no_log: True
-  when: openshift_cloudprovider_kind is defined and openshift_cloudprovider_kind == 'aws' and openshift_cloudprovider_aws_access_key is defined and openshift_cloudprovider_aws_secret_key is defined
+  when: r_openshift_node_cloudprovider_kind == 'aws' and r_openshift_node_cloudprovider_aws_access_key is defined and r_openshift_node_cloudprovider_aws_secret_key is defined
   notify:
     - restart node
 
 - name: Configure Node Environment Variables
   lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
+    dest: /etc/sysconfig/{{ r_openshift_node_service_type }}-node
     regexp: "^{{ item.key }}="
     line: "{{ item.key }}={{ item.value }}"
     create: true
-  with_dict: "{{ openshift.node.env_vars | default({}) }}"
+  with_dict: "{{ r_openshift_node_env_vars }}"
   notify:
     - restart node
 
@@ -193,15 +133,15 @@
 
 - name: GlusterFS storage plugin configuration
   include: storage_plugins/glusterfs.yml
-  when: "'glusterfs' in openshift.node.storage_plugin_deps"
+  when: "'glusterfs' in r_openshift_node_storage_plugin_deps"
 
 - name: Ceph storage plugin configuration
   include: storage_plugins/ceph.yml
-  when: "'ceph' in openshift.node.storage_plugin_deps"
+  when: "'ceph' in r_openshift_node_storage_plugin_deps"
 
 - name: iSCSI storage plugin configuration
   include: storage_plugins/iscsi.yml
-  when: "'iscsi' in openshift.node.storage_plugin_deps"
+  when: "'iscsi' in r_openshift_node_storage_plugin_deps"
 
 # Necessary because when you're on a node that's also a master the master will be
 # restarted after the node restarts docker and it will take up to 60 seconds for
@@ -210,8 +150,8 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent --tlsv1.2 --cacert {{ openshift.common.config_base }}/node/ca.crt
-    {{ openshift_node_master_api_url }}/healthz/ready
+    curl --silent --tlsv1.2 --cacert {{ r_openshift_node_config_base }}/node/ca.crt
+    {{ r_openshift_node_master_api_url }}/healthz/ready
   args:
     # Disables the following warning:
     # Consider using get_url or uri module rather than running curl
@@ -221,20 +161,20 @@
   retries: 120
   delay: 1
   changed_when: false
-  when: openshift.common.is_containerized | bool
+  when: r_openshift_node_is_containerized | bool
 
 - name: Start and enable node dep
   systemd:
     daemon_reload: yes
-    name: "{{ openshift.common.service_type }}-node-dep"
+    name: "{{ r_openshift_node_service_type }}-node-dep"
     enabled: yes
     state: started
-  when: openshift.common.is_containerized | bool
+  when: r_openshift_node_is_containerized | bool
 
 
 - name: Start and enable node
   systemd:
-    name: "{{ openshift.common.service_type }}-node"
+    name: "{{ r_openshift_node_service_type }}-node"
     enabled: yes
     state: started
     daemon_reload: yes
@@ -245,7 +185,7 @@
   ignore_errors: true
 
 - name: Dump logs from node service if it failed
-  command: journalctl --no-pager -n 100 -u {{ openshift.common.service_type }}-node
+  command: journalctl --no-pager -n 100 -u {{ r_openshift_node_service_type }}-node
   when: node_start_result | failed
 
 - name: Abort if node failed to start

--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -1,12 +1,12 @@
 ---
 - name: Pre-pull node system container image
   command: >
-    atomic pull --storage=ostree {{ 'docker:' if openshift.common.system_images_registry == 'docker' else openshift.common.system_images_registry + '/' }}{{ openshift.node.node_system_image }}:{{ openshift_image_tag }}
+    atomic pull --storage=ostree {{ 'docker:' if r_openshift_node_system_images_registry == 'docker' else r_openshift_node_system_images_registry + '/' }}{{ r_openshift_node_system_image }}:{{ r_openshift_node_image_tag }}
   register: pull_result
   changed_when: "'Pulling layer' in pull_result.stdout"
 
 - name: Install or Update node system container
   oc_atomic_container:
-    name: "{{ openshift.common.service_type }}-node"
-    image: "{{ 'docker:' if openshift.common.system_images_registry == 'docker' else openshift.common.system_images_registry + '/' }}{{ openshift.node.node_system_image }}:{{ openshift_image_tag }}"
+    name: "{{ r_openshift_node_service_type }}-node"
+    image: "{{ 'docker:' if r_openshift_node_system_images_registry == 'docker' else r_openshift_node_system_images_registry + '/' }}{{ r_openshift_node_system_image }}:{{ r_openshift_node_image_tag }}"
     state: latest

--- a/roles/openshift_node/tasks/openvswitch_system_container.yml
+++ b/roles/openshift_node/tasks/openvswitch_system_container.yml
@@ -12,14 +12,14 @@
 
 - name: Pre-pull OpenVSwitch system container image
   command: >
-    atomic pull --storage=ostree {{ 'docker:' if openshift.common.system_images_registry == 'docker' else openshift.common.system_images_registry + '/' }}{{ openshift.node.ovs_system_image }}:{{ openshift_image_tag }}
+    atomic pull --storage=ostree {{ 'docker:' if r_openshift_node_system_images_registry == 'docker' else r_openshift_node_system_images_registry + '/' }}{{ r_openshift_node_ovs_system_image }}:{{ r_openshift_node_image_tag }}
   register: pull_result
   changed_when: "'Pulling layer' in pull_result.stdout"
 
 - name: Install or Update OpenVSwitch system container
   oc_atomic_container:
     name: openvswitch
-    image: "{{ 'docker:' if openshift.common.system_images_registry == 'docker' else openshift.common.system_images_registry + '/' }}{{ openshift.node.ovs_system_image }}:{{ openshift_image_tag }}"
+    image: "{{ 'docker:' if r_openshift_node_system_images_registry == 'docker' else r_openshift_node_system_images_registry + '/' }}{{ r_openshift_node_ovs_system_image }}:{{ r_openshift_node_image_tag }}"
     state: latest
     values:
       - "DOCKER_SERVICE={{ l_service_name }}"

--- a/roles/openshift_node/tasks/pre_checks.yml
+++ b/roles/openshift_node/tasks/pre_checks.yml
@@ -1,0 +1,151 @@
+---
+# This file is automatically generate. Do not edit it manually.
+- name: "Fail if r_openshift_node_deployment_type is not defined"
+  fail:
+    msg: "r_openshift_node_deployment_type must be specified for this role"
+  when:
+  - r_openshift_node_deployment_type is not defined
+
+- name: Fail if invalid r_openshift_node_deployment_type provided
+  fail:
+    msg: "r_openshift_node_deployment_type can only be set to a single value from ['origin', 'openshift-enterprise']"
+  when:
+  - r_openshift_node_deployment_type is defined
+  - r_openshift_node_deployment_type not in ['origin', 'openshift-enterprise']
+
+- name: "Fail if r_openshift_node_service_type is not defined"
+  fail:
+    msg: "r_openshift_node_service_type must be specified for this role"
+  when:
+  - r_openshift_node_service_type is not defined
+
+- name: "Fail if r_openshift_node_image_tag is not defined"
+  fail:
+    msg: "r_openshift_node_image_tag must be specified for this role"
+  when:
+  - r_openshift_node_image_tag is not defined
+
+- name: "Fail if r_openshift_node_config_base is not defined"
+  fail:
+    msg: "r_openshift_node_config_base must be specified for this role"
+  when:
+  - r_openshift_node_config_base is not defined
+
+- name: "Fail if r_openshift_node_dns_domain is not defined"
+  fail:
+    msg: "r_openshift_node_dns_domain must be specified for this role"
+  when:
+  - r_openshift_node_dns_domain is not defined
+
+- name: "Fail if r_openshift_node_iptables_sync_period is not defined"
+  fail:
+    msg: "r_openshift_node_iptables_sync_period must be specified for this role"
+  when:
+  - r_openshift_node_iptables_sync_period is not defined
+
+- name: "Fail if r_openshift_node_registry_url is not defined"
+  fail:
+    msg: "r_openshift_node_registry_url must be specified for this role"
+  when:
+  - r_openshift_node_registry_url is not defined
+
+- name: "Fail if r_openshift_node_hostname is not defined"
+  fail:
+    msg: "r_openshift_node_hostname must be specified for this role"
+  when:
+  - r_openshift_node_hostname is not defined
+
+- name: "Fail if r_openshift_node_sdn_mtu is not defined"
+  fail:
+    msg: "r_openshift_node_sdn_mtu must be specified for this role"
+  when:
+  - r_openshift_node_sdn_mtu is not defined
+
+- name: "Fail if r_openshift_node_nodename is not defined"
+  fail:
+    msg: "r_openshift_node_nodename must be specified for this role"
+  when:
+  - r_openshift_node_nodename is not defined
+
+- name: "Fail if r_openshift_node_data_dir is not defined"
+  fail:
+    msg: "r_openshift_node_data_dir must be specified for this role"
+  when:
+  - r_openshift_node_data_dir is not defined
+
+- name: "Fail if r_openshift_node_proxy_mode is not defined"
+  fail:
+    msg: "r_openshift_node_proxy_mode must be specified for this role"
+  when:
+  - r_openshift_node_proxy_mode is not defined
+
+- name: "Fail if r_openshift_node_local_quota_per_fsgroup is not defined"
+  fail:
+    msg: "r_openshift_node_local_quota_per_fsgroup must be specified for this role"
+  when:
+  - r_openshift_node_local_quota_per_fsgroup is not defined
+
+- name: "Fail if r_openshift_node_master_api_url is not defined"
+  fail:
+    msg: "r_openshift_node_master_api_url must be specified for this role"
+  when:
+  - r_openshift_node_master_api_url is not defined
+
+- name: "Fail if r_openshift_node_system_images_registry is not defined"
+  fail:
+    msg: "r_openshift_node_system_images_registry must be specified for this role"
+  when:
+  - r_openshift_node_system_images_registry is not defined
+  - r_openshift_node_is_containerized | bool
+  - r_openshift_node_is_node_system_container | bool
+
+- name: "Fail if r_openshift_node_system_images_registry is not defined"
+  fail:
+    msg: "r_openshift_node_system_images_registry must be specified for this role"
+  when:
+  - r_openshift_node_system_images_registry is not defined
+  - r_openshift_node_is_containerized | bool
+  - r_openshift_node_is_openvswitch_system_container | bool
+  - r_openshift_node_use_openshift_sdn | bool
+
+- name: "Fail if r_openshift_node_master_sdn_cluster_network_cidr is not defined"
+  fail:
+    msg: "r_openshift_node_master_sdn_cluster_network_cidr must be specified for this role"
+  when:
+  - r_openshift_node_master_sdn_cluster_network_cidr is not defined
+  - r_openshift_node_http_proxy != ''
+
+- name: "Fail if r_openshift_node_portal_net is not defined"
+  fail:
+    msg: "r_openshift_node_portal_net must be specified for this role"
+  when:
+  - r_openshift_node_portal_net is not defined
+  - r_openshift_node_http_proxy != ''
+
+- name: "Fail if r_openshift_node_sdn_network_plugin_name is not defined"
+  fail:
+    msg: "r_openshift_node_sdn_network_plugin_name must be specified for this role"
+  when:
+  - r_openshift_node_sdn_network_plugin_name is not defined
+  - r_openshift_node_use_openshift_sdn | bool or r_openshift_node_use_nuage | bool or r_openshift_node_use_contiv | bool
+
+- name: "Fail if r_openshift_node_ip is not defined"
+  fail:
+    msg: "r_openshift_node_ip must be specified for this role"
+  when:
+  - r_openshift_node_ip is not defined
+  - r_openshift_node_set_node_ip | bool
+
+- name: "Fail if r_openshift_node_https_proxy is not defined"
+  fail:
+    msg: "r_openshift_node_https_proxy must be specified for this role"
+  when:
+  - r_openshift_node_https_proxy is not defined
+  - r_openshift_node_http_proxy != ''
+
+- name: "Fail if r_openshift_node_no_proxy is not defined"
+  fail:
+    msg: "r_openshift_node_no_proxy must be specified for this role"
+  when:
+  - r_openshift_node_no_proxy is not defined
+  - r_openshift_node_http_proxy != ''

--- a/roles/openshift_node/tasks/storage_plugins/ceph.yml
+++ b/roles/openshift_node/tasks/storage_plugins/ceph.yml
@@ -1,4 +1,4 @@
 ---
 - name: Install Ceph storage plugin dependencies
   package: name=ceph-common state=present
-  when: not openshift.common.is_atomic | bool
+  when: not r_openshift_node_is_atomic | bool

--- a/roles/openshift_node/tasks/storage_plugins/glusterfs.yml
+++ b/roles/openshift_node/tasks/storage_plugins/glusterfs.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install GlusterFS storage plugin dependencies
   package: name=glusterfs-fuse state=present
-  when: not openshift.common.is_atomic | bool
+  when: not r_openshift_node_is_atomic | bool
 
 - name: Check for existence of fusefs sebooleans
   command: getsebool {{ item }}

--- a/roles/openshift_node/tasks/storage_plugins/iscsi.yml
+++ b/roles/openshift_node/tasks/storage_plugins/iscsi.yml
@@ -1,4 +1,4 @@
 ---
 - name: Install iSCSI storage plugin dependencies
   package: name=iscsi-initiator-utils state=present
-  when: not openshift.common.is_atomic | bool
+  when: not r_openshift_node_is_atomic | bool

--- a/roles/openshift_node/tasks/storage_plugins/nfs.yml
+++ b/roles/openshift_node/tasks/storage_plugins/nfs.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install NFS storage plugin dependencies
   package: name=nfs-utils state=present
-  when: not openshift.common.is_atomic | bool
+  when: not r_openshift_node_is_atomic | bool
 
 - name: Check for existence of nfs sebooleans
   command: getsebool {{ item }}

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -3,60 +3,60 @@
 # playbooks.
 
 - include: config/install-node-deps-docker-service-file.yml
-  when: openshift.common.is_containerized | bool
+  when: r_openshift_node_is_containerized | bool
 
 - block:
   - name: Pre-pull node image
     command: >
-      docker pull {{ openshift.node.node_image }}:{{ openshift_image_tag }}
+      docker pull {{ r_openshift_node_image }}:{{ r_openshift_node_image_tag }}
     register: pull_result
     changed_when: "'Downloaded newer image' in pull_result.stdout"
 
   - include: config/install-node-docker-service-file.yml
   when:
-  - openshift.common.is_containerized | bool
-  - not openshift.common.is_node_system_container | bool
+  - r_openshift_node_is_containerized | bool
+  - not r_openshift_node_is_node_system_container | bool
 
 - name: Install Node service file
   template:
-    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
+    dest: "/etc/systemd/system/{{ r_openshift_node_service_type }}-node.service"
     src: "node.service.j2"
-  when: not openshift.common.is_containerized | bool
+  when: not r_openshift_node_is_containerized | bool
   notify:
   - reload systemd units
   - restart node
 
 - include: config/install-ovs-service-env-file.yml
-  when: openshift.common.is_containerized | bool
+  when: r_openshift_node_is_containerized | bool
 
 - name: Install Node system container
   include: node_system_container.yml
   when:
-  - openshift.common.is_containerized | bool
-  - openshift.common.is_node_system_container | bool
+  - r_openshift_node_is_containerized | bool
+  - r_openshift_node_is_node_system_container | bool
 
 - name: Install OpenvSwitch system containers
   include: openvswitch_system_container.yml
   when:
-  - openshift.common.use_openshift_sdn | default(true) | bool
-  - openshift.common.is_containerized | bool
-  - openshift.common.is_openvswitch_system_container | bool
+  - r_openshift_node_use_openshift_sdn | bool
+  - r_openshift_node_is_containerized | bool
+  - r_openshift_node_is_openvswitch_system_container | bool
 
 - include: config/workaround-bz1331590-ovs-oom-fix.yml
-  when: openshift.common.use_openshift_sdn | default(true) | bool
+  when: r_openshift_node_use_openshift_sdn | bool
 
 - block:
   - name: Pre-pull openvswitch image
     command: >
-      docker pull {{ openshift.node.ovs_image }}:{{ openshift_image_tag }}
+      docker pull {{ r_openshift_node_ovs_image }}:{{ r_openshift_node_image_tag }}
     register: pull_result
     changed_when: "'Downloaded newer image' in pull_result.stdout"
 
   - include: config/install-ovs-docker-service-file.yml
   when:
-  - openshift.common.is_containerized | bool
-  - openshift.common.use_openshift_sdn | default(true) | bool
-  - not openshift.common.is_openvswitch_system_container | bool
+  - r_openshift_node_is_containerized | bool
+  - r_openshift_node_use_openshift_sdn | bool
+  - not r_openshift_node_is_openvswitch_system_container | bool
 
 - include: config/configure-node-settings.yml
 - include: config/configure-proxy-settings.yml

--- a/roles/openshift_node/templates/node.service.j2
+++ b/roles/openshift_node/templates/node.service.j2
@@ -1,10 +1,10 @@
 [Unit]
 Description=OpenShift Node
-After={{ openshift.docker.service_name }}.service
+After={{ r_openshift_node_docker_service_name }}.service
 Wants=openvswitch.service
 After=ovsdb-server.service
 After=ovs-vswitchd.service
-Wants={{ openshift.docker.service_name }}.service
+Wants={{ r_openshift_node_docker_service_name }}.service
 Documentation=https://github.com/openshift/origin
 Requires=dnsmasq.service
 After=dnsmasq.service
@@ -12,17 +12,17 @@ After=dnsmasq.service
 
 [Service]
 Type=notify
-EnvironmentFile=/etc/sysconfig/{{ openshift.common.service_type }}-node
+EnvironmentFile=/etc/sysconfig/{{ r_openshift_node_service_type }}-node
 Environment=GOTRACEBACK=crash
 ExecStartPre=/usr/bin/cp /etc/origin/node/node-dnsmasq.conf /etc/dnsmasq.d/
-ExecStartPre=/usr/bin/dbus-send --system --dest=uk.org.thekelleys.dnsmasq /uk/org/thekelleys/dnsmasq uk.org.thekelleys.SetDomainServers array:string:/in-addr.arpa/127.0.0.1,/{{ openshift.common.dns_domain }}/127.0.0.1
+ExecStartPre=/usr/bin/dbus-send --system --dest=uk.org.thekelleys.dnsmasq /uk/org/thekelleys/dnsmasq uk.org.thekelleys.SetDomainServers array:string:/in-addr.arpa/127.0.0.1,/{{ r_openshift_node_dns_domain }}/127.0.0.1
 ExecStopPost=/usr/bin/rm /etc/dnsmasq.d/node-dnsmasq.conf
 ExecStopPost=/usr/bin/dbus-send --system --dest=uk.org.thekelleys.dnsmasq /uk/org/thekelleys/dnsmasq uk.org.thekelleys.SetDomainServers array:string:
 ExecStart=/usr/bin/openshift start node --config=${CONFIG_FILE} $OPTIONS
 LimitNOFILE=65536
 LimitCORE=infinity
 WorkingDirectory=/var/lib/origin/
-SyslogIdentifier={{ openshift.common.service_type }}-node
+SyslogIdentifier={{ r_openshift_node_service_type }}-node
 Restart=always
 RestartSec=5s
 TimeoutStartSec=300

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -1,21 +1,21 @@
 allowDisabledDocker: false
 apiVersion: v1
-{% if openshift.common.version_gte_3_6 %}
+{% if r_openshift_node_version_gte_3_6 %}
 dnsBindAddress: 127.0.0.1:53
 dnsRecursiveResolvConf: /etc/origin/node/resolv.conf
 {% endif %}
-dnsDomain: {{ openshift.common.dns_domain }}
-{% if 'dns_ip' in openshift.node %}
-dnsIP: {{ openshift.node.dns_ip }}
+dnsDomain: {{ r_openshift_node_dns_domain }}
+{% if r_openshift_node_dns_ip is defined %}
+dnsIP: {{ r_openshift_node_dns_ip }}
 {% endif %}
 dockerConfig:
   execHandlerName: ""
-iptablesSyncPeriod: "{{ openshift.node.iptables_sync_period }}"
+iptablesSyncPeriod: "{{ r_openshift_node_iptables_sync_period }}"
 imageConfig:
-  format: {{ openshift.node.registry_url }}
+  format: {{ r_openshift_node_registry_url }}
   latest: false
 kind: NodeConfig
-kubeletArguments: {{ openshift.node.kubelet_args | default(None) | to_padded_yaml(level=1) }}
+kubeletArguments: {{ r_openshift_node_kubelet_args | to_padded_yaml(level=1) }}
 {% if openshift.docker.use_crio | default(False) %}
   container-runtime:
   - remote
@@ -31,47 +31,47 @@ kubeletArguments: {{ openshift.node.kubelet_args | default(None) | to_padded_yam
   runtime-request-timeout:
   - 10m
 {% endif %}
-{% if openshift.common.version_gte_3_3_or_1_3 | bool %}
+{% if r_openshift_node_version_gte_3_3_or_1_3 | bool %}
 masterClientConnectionOverrides:
   acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
   contentType: application/vnd.kubernetes.protobuf
   burst: 200
   qps: 100
 {% endif %}
-masterKubeConfig: system:node:{{ openshift.common.hostname }}.kubeconfig
-{% if openshift.common.use_openshift_sdn | bool %}
-networkPluginName: {{ openshift.common.sdn_network_plugin_name }}
+masterKubeConfig: system:node:{{ r_openshift_node_hostname }}.kubeconfig
+{% if r_openshift_node_use_openshift_sdn | bool %}
+networkPluginName: {{ r_openshift_node_sdn_network_plugin_name }}
 {% endif %}
 # networkConfig struct introduced in origin 1.0.6 and OSE 3.0.2 which
 # deprecates networkPluginName above. The two should match.
 networkConfig:
-   mtu: {{ openshift.node.sdn_mtu }}
-{% if openshift.common.use_openshift_sdn | bool or openshift.common.use_nuage | bool or openshift.common.use_contiv | bool or openshift.common.sdn_network_plugin_name == 'cni' %}
-   networkPluginName: {{ openshift.common.sdn_network_plugin_name }}
+   mtu: {{ r_openshift_node_sdn_mtu }}
+{% if r_openshift_node_use_openshift_sdn | bool or r_openshift_node_use_nuage | bool or r_openshift_node_use_contiv | bool or r_openshift_node_sdn_network_plugin_name == 'cni' %}
+   networkPluginName: {{ r_openshift_node_sdn_network_plugin_name }}
 {% endif %}
-{% if openshift.node.set_node_ip | bool %}
-nodeIP: {{ openshift.common.ip }}
+{% if r_openshift_node_set_node_ip | bool %}
+nodeIP: {{ r_openshift_node_ip }}
 {% endif %}
-nodeName: {{ openshift.node.nodename }}
+nodeName: {{ r_openshift_node_nodename }}
 podManifestConfig:
 servingInfo:
   bindAddress: 0.0.0.0:10250
   certFile: server.crt
   clientCA: ca.crt
   keyFile: server.key
-{% if openshift_node_min_tls_version is defined %}
-  minTLSVersion: {{ openshift_node_min_tls_version }}
+{% if r_openshift_node_min_tls_version is defined %}
+  minTLSVersion: {{ r_openshift_node_min_tls_version }}
 {% endif %}
-{% if openshift_node_cipher_suites is defined %}
+{% if r_openshift_node_cipher_suites is defined %}
   cipherSuites:
-{% for cipher_suite in openshift_node_cipher_suites %}
+{% for cipher_suite in r_openshift_node_cipher_suites %}
   - {{ cipher_suite }}
 {% endfor %}
 {% endif %}
-volumeDirectory: {{ openshift.common.data_dir }}/openshift.local.volumes
+volumeDirectory: {{ r_openshift_node_data_dir }}/openshift.local.volumes
 proxyArguments:
   proxy-mode:
-     - {{ openshift.node.proxy_mode }}
+     - {{ r_openshift_node_proxy_mode }}
 volumeConfig:
   localQuota:
-    perFSGroup: {{ openshift.node.local_quota_per_fsgroup }}
+    perFSGroup: {{ r_openshift_node_local_quota_per_fsgroup }}

--- a/roles/openshift_node/templates/openshift.docker.node.dep.service
+++ b/roles/openshift_node/templates/openshift.docker.node.dep.service
@@ -1,11 +1,12 @@
 [Unit]
-Requires={{ openshift.docker.service_name }}.service
-After={{ openshift.docker.service_name }}.service
-PartOf={{ openshift.common.service_type }}-node.service
-Before={{ openshift.common.service_type }}-node.service
+Requires={{ r_openshift_node_docker_service_name }}.service
+After={{ r_openshift_node_docker_service_name }}.service
+PartOf={{ r_openshift_node_service_type }}-node.service
+Before={{ r_openshift_node_service_type }}-node.service
 {% if openshift.docker.use_crio %}Wants=cri-o.service{% endif %}
 
+
 [Service]
-ExecStart=/bin/bash -c "if [[ -f /usr/bin/docker-current ]]; then echo \"DOCKER_ADDTL_BIND_MOUNTS=--volume=/usr/bin/docker-current:/usr/bin/docker-current:ro --volume=/etc/sysconfig/docker:/etc/sysconfig/docker:ro\" > /etc/sysconfig/{{ openshift.common.service_type }}-node-dep; else echo \"#DOCKER_ADDTL_BIND_MOUNTS=\" > /etc/sysconfig/{{ openshift.common.service_type }}-node-dep; fi"
+ExecStart=/bin/bash -c "if [[ -f /usr/bin/docker-current ]]; then echo \"DOCKER_ADDTL_BIND_MOUNTS=--volume=/usr/bin/docker-current:/usr/bin/docker-current:ro --volume=/etc/sysconfig/docker:/etc/sysconfig/docker:ro\" > /etc/sysconfig/{{ r_openshift_node_service_type }}-node-dep; else echo \"#DOCKER_ADDTL_BIND_MOUNTS=\" > /etc/sysconfig/{{ r_openshift_node_service_type }}-node-dep; fi"
 ExecStop=
-SyslogIdentifier={{ openshift.common.service_type }}-node-dep
+SyslogIdentifier={{ r_openshift_node_service_type }}-node-dep

--- a/roles/openshift_node/templates/openshift.docker.node.service
+++ b/roles/openshift_node/templates/openshift.docker.node.service
@@ -1,34 +1,34 @@
 [Unit]
-After={{ openshift.common.service_type }}-master.service
-After={{ openshift.docker.service_name }}.service
+After={{ r_openshift_node_service_type }}-master.service
+After={{ r_openshift_node_docker_service_name }}.service
 After=openvswitch.service
-PartOf={{ openshift.docker.service_name }}.service
-Requires={{ openshift.docker.service_name }}.service
-{% if openshift.common.use_openshift_sdn %}
+PartOf={{ r_openshift_node_docker_service_name }}.service
+Requires={{ r_openshift_node_docker_service_name }}.service
+{% if r_openshift_node_use_openshift_sdn %}
 Wants=openvswitch.service
 After=ovsdb-server.service
 After=ovs-vswitchd.service
 {% endif %}
-Wants={{ openshift.common.service_type }}-master.service
-Requires={{ openshift.common.service_type }}-node-dep.service
-After={{ openshift.common.service_type }}-node-dep.service
+Wants={{ r_openshift_node_service_type }}-master.service
+Requires={{ r_openshift_node_service_type }}-node-dep.service
+After={{ r_openshift_node_service_type }}-node-dep.service
 Requires=dnsmasq.service
 After=dnsmasq.service
 
 [Service]
-EnvironmentFile=/etc/sysconfig/{{ openshift.common.service_type }}-node
-EnvironmentFile=/etc/sysconfig/{{ openshift.common.service_type }}-node-dep
-ExecStartPre=-/usr/bin/docker rm -f {{ openshift.common.service_type }}-node
+EnvironmentFile=/etc/sysconfig/{{ r_openshift_node_service_type }}-node
+EnvironmentFile=/etc/sysconfig/{{ r_openshift_node_service_type }}-node-dep
+ExecStartPre=-/usr/bin/docker rm -f {{ r_openshift_node_service_type }}-node
 ExecStartPre=/usr/bin/cp /etc/origin/node/node-dnsmasq.conf /etc/dnsmasq.d/
-ExecStartPre=/usr/bin/dbus-send --system --dest=uk.org.thekelleys.dnsmasq /uk/org/thekelleys/dnsmasq uk.org.thekelleys.SetDomainServers array:string:/in-addr.arpa/127.0.0.1,/{{ openshift.common.dns_domain }}/127.0.0.1
-ExecStart=/usr/bin/docker run --name {{ openshift.common.service_type }}-node --rm --privileged --net=host --pid=host --env-file=/etc/sysconfig/{{ openshift.common.service_type }}-node -v /:/rootfs:ro,rslave -e CONFIG_FILE=${CONFIG_FILE} -e OPTIONS=${OPTIONS} -e HOST=/rootfs -e HOST_ETC=/host-etc -v {{ openshift.common.data_dir }}:{{ openshift.common.data_dir }}{{ ':rslave' if openshift.docker.gte_1_10 | default(False) | bool else '' }} -v {{ openshift.common.config_base }}/node:{{ openshift.common.config_base }}/node {% if openshift_cloudprovider_kind | default('') != '' -%} -v {{ openshift.common.config_base }}/cloudprovider:{{ openshift.common.config_base}}/cloudprovider {% endif -%} -v /etc/localtime:/etc/localtime:ro -v /etc/machine-id:/etc/machine-id:ro -v /run:/run -v /sys:/sys:rw -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /usr/bin/docker:/usr/bin/docker:ro -v /var/lib/docker:/var/lib/docker -v /lib/modules:/lib/modules -v /etc/origin/openvswitch:/etc/openvswitch -v /etc/origin/sdn:/etc/openshift-sdn -v /var/lib/cni:/var/lib/cni -v /etc/systemd/system:/host-etc/systemd/system -v /var/log:/var/log -v /dev:/dev $DOCKER_ADDTL_BIND_MOUNTS -v /etc/pki:/etc/pki:ro {{ openshift.node.node_image }}:${IMAGE_VERSION}
+ExecStartPre=/usr/bin/dbus-send --system --dest=uk.org.thekelleys.dnsmasq /uk/org/thekelleys/dnsmasq uk.org.thekelleys.SetDomainServers array:string:/in-addr.arpa/127.0.0.1,/{{ r_openshift_node_dns_domain }}/127.0.0.1
+ExecStart=/usr/bin/docker run --name {{ r_openshift_node_service_type }}-node --rm --privileged --net=host --pid=host --env-file=/etc/sysconfig/{{ r_openshift_node_service_type }}-node -v /:/rootfs:ro,rslave -e CONFIG_FILE=${CONFIG_FILE} -e OPTIONS=${OPTIONS} -e HOST=/rootfs -e HOST_ETC=/host-etc -v {{ r_openshift_node_data_dir }}:{{ r_openshift_node_data_dir }}{{ ':rslave' if r_openshift_node_docker_gte_1_10 | bool else '' }} -v {{ r_openshift_node_config_base }}/node:{{ r_openshift_node_config_base }}/node {% if r_openshift_node_cloudprovider_kind != '' -%} -v {{ r_openshift_node_config_base }}/cloudprovider:{{ r_openshift_node_config_base}}/cloudprovider {% endif -%} -v /etc/localtime:/etc/localtime:ro -v /etc/machine-id:/etc/machine-id:ro -v /run:/run -v /sys:/sys:rw -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /usr/bin/docker:/usr/bin/docker:ro -v /var/lib/docker:/var/lib/docker -v /lib/modules:/lib/modules -v /etc/origin/openvswitch:/etc/openvswitch -v /etc/origin/sdn:/etc/openshift-sdn -v /var/lib/cni:/var/lib/cni -v /etc/systemd/system:/host-etc/systemd/system -v /var/log:/var/log -v /dev:/dev $DOCKER_ADDTL_BIND_MOUNTS -v /etc/pki:/etc/pki:ro {{ r_openshift_node_image }}:${IMAGE_VERSION}
 ExecStartPost=/usr/bin/sleep 10
-ExecStop=/usr/bin/docker stop {{ openshift.common.service_type }}-node
+ExecStop=/usr/bin/docker stop {{ r_openshift_node_service_type }}-node
 ExecStopPost=/usr/bin/rm /etc/dnsmasq.d/node-dnsmasq.conf
 ExecStopPost=/usr/bin/dbus-send --system --dest=uk.org.thekelleys.dnsmasq /uk/org/thekelleys/dnsmasq uk.org.thekelleys.SetDomainServers array:string:
-SyslogIdentifier={{ openshift.common.service_type }}-node
+SyslogIdentifier={{ r_openshift_node_service_type }}-node
 Restart=always
 RestartSec=5s
 
 [Install]
-WantedBy={{ openshift.docker.service_name }}.service
+WantedBy={{ r_openshift_node_docker_service_name }}.service

--- a/roles/openshift_node/templates/openvswitch.docker.service
+++ b/roles/openshift_node/templates/openvswitch.docker.service
@@ -1,12 +1,12 @@
 [Unit]
-After={{ openshift.docker.service_name }}.service
-Requires={{ openshift.docker.service_name }}.service
-PartOf={{ openshift.docker.service_name }}.service
+After={{ r_openshift_node_docker_service_name }}.service
+Requires={{ r_openshift_node_docker_service_name }}.service
+PartOf={{ r_openshift_node_docker_service_name }}.service
 
 [Service]
 EnvironmentFile=/etc/sysconfig/openvswitch
 ExecStartPre=-/usr/bin/docker rm -f openvswitch
-ExecStart=/usr/bin/docker run --name openvswitch --rm --privileged --net=host --pid=host -v /lib/modules:/lib/modules -v /run:/run -v /sys:/sys:ro -v /etc/origin/openvswitch:/etc/openvswitch {{ openshift.node.ovs_image }}:${IMAGE_VERSION}
+ExecStart=/usr/bin/docker run --name openvswitch --rm --privileged --net=host --pid=host -v /lib/modules:/lib/modules -v /run:/run -v /sys:/sys:ro -v /etc/origin/openvswitch:/etc/openvswitch {{ r_openshift_node_ovs_image }}:${IMAGE_VERSION}
 ExecStartPost=/usr/bin/sleep 5
 ExecStop=/usr/bin/docker stop openvswitch
 SyslogIdentifier=openvswitch
@@ -14,4 +14,4 @@ Restart=always
 RestartSec=5s
 
 [Install]
-WantedBy={{ openshift.docker.service_name }}.service
+WantedBy={{ r_openshift_node_docker_service_name }}.service

--- a/roles/openshift_node/templates/openvswitch.sysconfig.j2
+++ b/roles/openshift_node/templates/openvswitch.sysconfig.j2
@@ -1,1 +1,1 @@
-IMAGE_VERSION={{ openshift_image_tag }}
+IMAGE_VERSION={{ r_openshift_node_image_tag }}

--- a/roles/openshift_node_facts/README.md
+++ b/roles/openshift_node_facts/README.md
@@ -1,0 +1,55 @@
+OpenShift/Atomic Enterprise Node Facts
+================================
+
+Node facts collector
+
+Requirements
+------------
+
+* Ansible 2.2
+
+Role Variables
+--------------
+
+| name                                           | description                              | default  | required | choices |
+|------------------------------------------------|------------------------------------------|----------|----------|---------|
+| r_openshift_node_facts_annotations             | Node annotations                         | None     |          |         |
+| r_openshift_node_facts_debug_level             | Node debug lovel                         |          |          |         |
+| r_openshift_node_facts_dns_ip                  |                                          |          |          |         |
+| r_openshift_node_facts_env_vars                |                                          | None     |          |         |
+| r_openshift_node_facts_iptables_sync_period    |                                          | None     |          |         |
+| r_openshift_node_facts_kubelet_args            |                                          | None     |          |         |
+| r_openshift_node_facts_labels                  | Node labels                              | None     |          |         |
+| r_openshift_node_facts_local_quota_per_fsgroup |                                          | None     |          |         |
+| r_openshift_node_facts_oreg_url                |                                          | None     |          |         |
+| r_openshift_node_facts_osn_image               |                                          | None     |          |         |
+| r_openshift_node_facts_osn_ovs_image           |                                          | None     |          |         |
+| r_openshift_node_facts_osn_storage_plugin_deps | Store plugins to install on the node     | None     |          |         |
+| r_openshift_node_facts_proxy_mode              |                                          | iptables |          |         |
+| r_openshift_node_facts_schedulable             | If set pods can be scheduled on the node | None     |          |         |
+| r_openshift_node_facts_sdn_mtu                 |                                          | None     |          |         |
+| r_openshift_node_facts_set_node_ip             |                                          | None     |          |         |
+
+
+Dependencies
+------------
+
+openshift_facts
+
+Example Playbook
+----------------
+
+Notes
+-----
+
+TODO
+
+License
+-------
+
+Apache License, Version 2.0
+
+Author Information
+------------------
+
+TODO

--- a/roles/openshift_node_facts/defaults/main.yml
+++ b/roles/openshift_node_facts/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+#: name=r_openshift_node_facts_debug_level, description="Node debug lovel"
+#: description="Node annotations"
+r_openshift_node_facts_annotations: "{{ None }}"
+r_openshift_node_facts_iptables_sync_period: "{{ None }}"
+r_openshift_node_facts_kubelet_args: "{{ None }}"
+#: description="Node labels"
+r_openshift_node_facts_labels: "{{ None }}"
+r_openshift_node_facts_oreg_url: "{{ None }}"
+#: description="If set pods can be scheduled on the node"
+r_openshift_node_facts_schedulable: "{{ None }}"
+r_openshift_node_facts_sdn_mtu: "{{ None }}"
+#: description="Store plugins to install on the node"
+r_openshift_node_facts_osn_storage_plugin_deps: "{{ None }}"
+r_openshift_node_facts_set_node_ip: "{{ None }}"
+r_openshift_node_facts_osn_image: "{{ None }}"
+r_openshift_node_facts_osn_ovs_image: "{{ None }}"
+r_openshift_node_facts_proxy_mode: iptables
+r_openshift_node_facts_local_quota_per_fsgroup: "{{ None }}"
+#: name=r_openshift_node_facts_dns_ip
+r_openshift_node_facts_env_vars: "{{ None }}"

--- a/roles/openshift_node_facts/generate.json
+++ b/roles/openshift_node_facts/generate.json
@@ -1,0 +1,11 @@
+{
+  "actions": [{
+    "action": "role_var_checks",
+    "target": "tasks/pre_checks.yml",
+    "source": "defaults/main.yml"
+  },{
+    "action": "role_var_table",
+    "source": "defaults/main.yml",
+    "target": "README.md"
+    }]
+}

--- a/roles/openshift_node_facts/tasks/main.yml
+++ b/roles/openshift_node_facts/tasks/main.yml
@@ -1,8 +1,14 @@
 ---
+- name: Fail if r_openshift_node_facts_debug_level is not defined
+  fail:
+    msg: r_openshift_node_facts_debug_level must be specified for this role
+  when:
+  - r_openshift_node_facts_debug_level is not defined
+
 - set_fact:
     openshift_node_debug_level: "{{ lookup('oo_option', 'openshift_node_debug_level') }}"
   when:
-  - openshift_node_debug_level is not defined
+  - r_openshift_node_facts_debug_level is not defined
   - lookup('oo_option', 'openshift_node_debug_level') != ""
 
 - name: Set node facts
@@ -16,19 +22,20 @@
       labels: {}
   - role: node
     local_facts:
-      annotations: "{{ openshift_node_annotations | default(none) }}"
-      debug_level: "{{ openshift_node_debug_level | default(openshift.common.debug_level) }}"
-      iptables_sync_period: "{{ openshift_node_iptables_sync_period | default(None) }}"
-      kubelet_args: "{{ openshift_node_kubelet_args | default(None) }}"
-      labels: "{{ lookup('oo_option', 'openshift_node_labels') | default( openshift_node_labels | default(none), true) }}"
-      registry_url: "{{ oreg_url_node | default(oreg_url) | default(None) }}"
-      schedulable: "{{ openshift_schedulable | default(openshift_scheduleable) | default(None) }}"
-      sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
-      storage_plugin_deps: "{{ osn_storage_plugin_deps | default(None) }}"
-      set_node_ip: "{{ openshift_set_node_ip | default(None) }}"
-      node_image: "{{ osn_image | default(None) }}"
-      ovs_image: "{{ osn_ovs_image | default(None) }}"
-      proxy_mode: "{{ openshift_node_proxy_mode | default('iptables') }}"
-      local_quota_per_fsgroup: "{{ openshift_node_local_quota_per_fsgroup | default(None) }}"
-      dns_ip: "{{ openshift_dns_ip | default(none) | get_dns_ip(hostvars[inventory_hostname])}}"
-      env_vars: "{{ openshift_node_env_vars | default(None) }}"
+      annotations: "{{ r_openshift_node_facts_annotations }}"
+      debug_level: "{{ r_openshift_node_facts_debug_level }}"
+      iptables_sync_period: "{{ r_openshift_node_facts_iptables_sync_period }}"
+      kubelet_args: "{{ r_openshift_node_facts_kubelet_args }}"
+      labels: "{{ r_openshift_node_facts_labels }}"
+      registry_url: "{{ r_openshift_node_facts_oreg_url }}"
+      schedulable: "{{ r_openshift_node_facts_schedulable }}"
+      sdn_mtu: "{{ r_openshift_node_facts_sdn_mtu }}"
+      storage_plugin_deps: "{{ r_openshift_node_facts_osn_storage_plugin_deps }}"
+      set_node_ip: "{{ r_openshift_node_facts_set_node_ip }}"
+      node_image: "{{ r_openshift_node_facts_osn_image }}"
+      ovs_image: "{{ r_openshift_node_facts_osn_ovs_image }}"
+      proxy_mode: "{{ r_openshift_node_facts_proxy_mode }}"
+      local_quota_per_fsgroup: "{{ r_openshift_node_facts_local_quota_per_fsgroup }}"
+      # get_dns_ip is defined in filter_plugins/openshift_ndde.py
+      dns_ip: "{{ r_openshift_node_facts_dns_ip | get_dns_ip(hostvars[inventory_hostname])}}"
+      env_vars: "{{ r_openshift_node_facts_env_vars }}"

--- a/roles/openshift_node_upgrade/tasks/disable_swap.yml
+++ b/roles/openshift_node_upgrade/tasks/disable_swap.yml
@@ -1,0 +1,30 @@
+---
+# https://docs.openshift.com/container-platform/3.4/admin_guide/overcommit.html#disabling-swap-memory
+- name: Check for swap usage
+  command: grep "^[^#].*swap" /etc/fstab
+  # grep: match any lines which don't begin with '#' and contain 'swap'
+  changed_when: false
+  failed_when: false
+  register: l_swap_result
+
+# Disable Swap Block
+- block:
+    - name: Disable swap
+      command: swapoff --all
+
+    - name: Remove swap entries from /etc/fstab
+      replace:
+        dest: /etc/fstab
+        regexp: '(^[^#].*swap.*)'
+        replace: '# \1'
+        backup: yes
+
+    - name: Add notice about disabling swap
+      lineinfile:
+        dest: /etc/fstab
+        line: '# OpenShift-Ansible Installer disabled swap per overcommit guidelines'
+        state: present
+  when:
+    - l_swap_result.stdout_lines | length > 0
+    - openshift_disable_swap | default(true) | bool
+# End Disable Swap Block

--- a/roles/openshift_node_upgrade/tasks/main.yml
+++ b/roles/openshift_node_upgrade/tasks/main.yml
@@ -109,37 +109,7 @@
     value: "{{ oreg_url | default(oreg_url_node) }}"
   when: oreg_url is defined or oreg_url_node is defined
 
-# https://docs.openshift.com/container-platform/3.4/admin_guide/overcommit.html#disabling-swap-memory
-- name: Check for swap usage
-  command: grep "^[^#].*swap" /etc/fstab
-  # grep: match any lines which don't begin with '#' and contain 'swap'
-  changed_when: false
-  failed_when: false
-  register: swap_result
-
-  # Disable Swap Block
-- block:
-
-  - name: Disable swap
-    command: swapoff --all
-
-  - name: Remove swap entries from /etc/fstab
-    replace:
-      dest: /etc/fstab
-      regexp: '(^[^#].*swap.*)'
-      replace: '# \1'
-      backup: yes
-
-  - name: Add notice about disabling swap
-    lineinfile:
-      dest: /etc/fstab
-      line: '# OpenShift-Ansible Installer disabled swap per overcommit guidelines'
-      state: present
-
-  when:
-  - swap_result.stdout_lines | length > 0
-  - openshift_disable_swap | default(true) | bool
-  # End Disable Swap Block
+- include: disable_swap.yml
 
 - name: Reset selinux context
   command: restorecon -RF {{ openshift.common.data_dir }}/openshift.local.volumes


### PR DESCRIPTION
* move disable swap tasks into `disable_swap.yml`
* introduce `r_openshift_node_` prefixed variables and remove all free variables
* autogenerate table of role variables
* move node installation into its own file

Built on top of https://github.com/openshift/openshift-ansible/pull/5025. Once the underlying PR gets merged, I will rebase.

**In depth**
In a process of moving all global variables out of the `openshift_node` role I had to do the following:
1. For each global variable used inside the role create corresponding new variable prefixed with `r_openshift_node_`  string, e.g. for `openshift_node_sdn_mtu` create `r_openshift_node_facts_sdn_mtu`.
2. Given most of the variables has default value attach, I moved the default value of each role variable under `defaults/main.yml`. E.g. the `openshift.node.env_vars | default({})` resulted in `r_openshift_node_env_vars: {}` line.
3. Set all role variables to their corresponding global variables. By the nature of `openshift.node.env_vars | default({})` expression, one can use the following form:
   ```yaml
   include_role:
     name: openshift_node
   vars:
     r_openshift_node_env_vars: "{{ openshift.node.env_vars | default({}) }}"
   ```

   However, the default value (that is set inside `default/main.yml` gets duplicated). For that reason I decided to use the following form instead:

   ```yaml
   set_fact:
      r_openshift_node_env_vars: "{{ openshift.node.env_vars }}"
   when: openshift.node.env_vars is defined

   include_role:
     name: openshift_node
   ```
   It does not look good but the default value is specified only once. Plus, the `set_fact: ... when: ...` syntax is pretty generic, it can be automatically generated (see `playbooks/common/openshift-node/set_optional_node_facts_role_variables.yml`)
4. Verify role variables: a role has a list of role variables that needs to be defined, a list of variables that can be set to a restricted set of value or a list of variables that depends on other variables or their values. 
The checks can be automatically generated (see roles/openshift_node/tasks/pre_checks.yml).

As you can see in this PR there is about 50 role variables that are being set before the `openshift_node` role gets invoked. The fact may be a signal the role needs to be broken out into smaller roles. 
