### PR TITLE
openshift_checks: ignore hidden files in checks dir

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/__init__.py
+++ b/roles/openshift_health_checker/openshift_checks/__init__.py
@@ -173,7 +173,7 @@ def load_checks(path=None, subpkg=""):
             modules = modules + load_checks(os.path.join(path, name), subpkg + "." + name)
             continue
 
-        if name.endswith(".py") and name not in LOADER_EXCLUDES:
+        if name.endswith(".py") and not name.startswith(".") and name not in LOADER_EXCLUDES:
             modules.append(import_module(__package__ + subpkg + "." + name[:-3]))
 
     return modules


### PR DESCRIPTION
`load_checks`: Ignore hidden files when scanning the directory for checks.

In particular, my editor had created a hidden temporary file under `roles/openshift_health_checker/openshift_checks/`, which caused openshift_health_check to fail with the following error: "ValueError: Empty module name".

---

openshift-bot, please [test]!