### PR TITLE
Fix syntax for when statement

### DIFF
--- a/playbooks/common/openshift-cluster/evaluate_groups.yml
+++ b/playbooks/common/openshift-cluster/evaluate_groups.yml
@@ -8,7 +8,7 @@
   - name: Evaluate groups - g_etcd_hosts or g_new_etcd_hosts required
     fail:
       msg: This playbook requires g_etcd_hosts or g_new_etcd_hosts to be set
-    when: "{{ g_etcd_hosts is not defined and g_new_etcd_hosts is not defined}}"
+    when: g_etcd_hosts is not defined and g_new_etcd_hosts is not defined
 
   - name: Evaluate groups - g_master_hosts or g_new_master_hosts required
     fail:

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_scheduler.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_scheduler.yml
@@ -74,18 +74,21 @@
   - block:
     - debug:
         msg: "WARNING: existing scheduler config does not match previous known defaults automated upgrade of scheduler config is disabled.\nexisting scheduler predicates: {{ openshift_master_scheduler_current_predicates }}\ncurrent scheduler default predicates are: {{ openshift_master_scheduler_default_predicates }}"
-      when: "{{ openshift_master_scheduler_current_predicates != openshift_master_scheduler_default_predicates and
-                openshift_master_scheduler_current_predicates not in older_predicates + [prev_predicates] }}"
+      when:
+      - openshift_master_scheduler_current_predicates != openshift_master_scheduler_default_predicates
+      - openshift_master_scheduler_current_predicates not in older_predicates + [prev_predicates]
 
     - set_fact:
         openshift_upgrade_scheduler_predicates: "{{ openshift_master_scheduler_default_predicates }}"
-      when: "{{ openshift_master_scheduler_current_predicates != openshift_master_scheduler_default_predicates and
-                openshift_master_scheduler_current_predicates in older_predicates + [prev_predicates] }}"
+      when:
+      - openshift_master_scheduler_current_predicates != openshift_master_scheduler_default_predicates
+      - openshift_master_scheduler_current_predicates in older_predicates + [prev_predicates]
 
     - set_fact:
         openshift_upgrade_scheduler_predicates: "{{ default_predicates_no_region }}"
-      when: "{{ openshift_master_scheduler_current_predicates != default_predicates_no_region and
-                openshift_master_scheduler_current_predicates in older_predicates_no_region + [prev_predicates_no_region] }}"
+      when:
+      - openshift_master_scheduler_current_predicates != default_predicates_no_region
+      - openshift_master_scheduler_current_predicates in older_predicates_no_region + [prev_predicates_no_region]
 
     when: openshift_master_scheduler_predicates | default(none) is none
 
@@ -131,18 +134,21 @@
   - block:
     - debug:
         msg: "WARNING: existing scheduler config does not match previous known defaults automated upgrade of scheduler config is disabled.\nexisting scheduler priorities: {{ openshift_master_scheduler_current_priorities }}\ncurrent scheduler default priorities are: {{ openshift_master_scheduler_default_priorities }}"
-      when: "{{ openshift_master_scheduler_current_priorities != openshift_master_scheduler_default_priorities and
-                openshift_master_scheduler_current_priorities not in older_priorities + [prev_priorities] }}"
+      when:
+      - openshift_master_scheduler_current_priorities != openshift_master_scheduler_default_priorities
+      - openshift_master_scheduler_current_priorities not in older_priorities + [prev_priorities]
 
     - set_fact:
         openshift_upgrade_scheduler_priorities: "{{ openshift_master_scheduler_default_priorities }}"
-      when: "{{ openshift_master_scheduler_current_priorities != openshift_master_scheduler_default_priorities and
-                openshift_master_scheduler_current_priorities in older_priorities + [prev_priorities] }}"
+      when:
+      - openshift_master_scheduler_current_priorities != openshift_master_scheduler_default_priorities
+      - openshift_master_scheduler_current_priorities in older_priorities + [prev_priorities]
 
     - set_fact:
         openshift_upgrade_scheduler_priorities: "{{ default_priorities_no_zone }}"
-      when: "{{ openshift_master_scheduler_current_priorities != default_priorities_no_zone and
-                openshift_master_scheduler_current_priorities in older_priorities_no_zone + [prev_priorities_no_zone] }}"
+      when:
+      - openshift_master_scheduler_current_priorities != default_priorities_no_zone
+      - openshift_master_scheduler_current_priorities in older_priorities_no_zone + [prev_priorities_no_zone]
 
     when: openshift_master_scheduler_priorities | default(none) is none
 
@@ -162,5 +168,6 @@
       content: "{{ scheduler_config | to_nice_json }}"
       dest: "{{ openshift_master_scheduler_conf }}"
       backup: true
-  when: "{{ openshift_upgrade_scheduler_predicates is defined or
-            openshift_upgrade_scheduler_priorities is defined }}"
+  when: >
+    openshift_upgrade_scheduler_predicates is defined or
+    openshift_upgrade_scheduler_priorities is defined

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade.yml
@@ -39,8 +39,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
@@ -47,8 +47,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_nodes.yml
@@ -40,8 +40,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade.yml
@@ -39,8 +39,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
@@ -47,8 +47,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_nodes.yml
@@ -40,8 +40,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade.yml
@@ -39,8 +39,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
@@ -47,8 +47,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_nodes.yml
@@ -40,8 +40,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
@@ -39,8 +39,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
@@ -47,8 +47,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
@@ -40,8 +40,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
@@ -39,8 +39,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -47,8 +47,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_nodes.yml
@@ -40,8 +40,9 @@
                                                     | union(groups['oo_etcd_to_config'] | default([])))
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
-    when: "{{ (openshift_http_proxy is defined or openshift_https_proxy is defined) and
-            openshift_generate_no_proxy_hosts | default(True) | bool }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
 
 - include: ../pre/verify_inventory_vars.yml
   tags:

--- a/roles/openshift_logging_fluentd/tasks/main.yaml
+++ b/roles/openshift_logging_fluentd/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - fail:
     msg: Only one Fluentd nodeselector key pair should be provided
-  when: "{{ openshift_logging_fluentd_nodeselector.keys() | count }} > 1"
+  when: openshift_logging_fluentd_nodeselector.keys() | count > 1
 
 - fail:
     msg: Application logs destination is required

--- a/roles/openshift_logging_kibana/tasks/main.yaml
+++ b/roles/openshift_logging_kibana/tasks/main.yaml
@@ -99,17 +99,17 @@
 # TODO: set up these certs differently?
 - set_fact:
     kibana_key: "{{ lookup('file', openshift_logging_kibana_key) | b64encode }}"
-  when: "{{ openshift_logging_kibana_key | trim | length > 0 }}"
+  when: openshift_logging_kibana_key | trim | length > 0
   changed_when: false
 
 - set_fact:
     kibana_cert: "{{ lookup('file', openshift_logging_kibana_cert) | b64encode }}"
-  when: "{{ openshift_logging_kibana_cert | trim | length > 0 }}"
+  when: openshift_logging_kibana_cert | trim | length > 0
   changed_when: false
 
 - set_fact:
     kibana_ca: "{{ lookup('file', openshift_logging_kibana_ca) | b64encode }}"
-  when: "{{ openshift_logging_kibana_ca | trim | length > 0 }}"
+  when: openshift_logging_kibana_ca | trim | length > 0
   changed_when: false
 
 - set_fact:

--- a/roles/openshift_provisioners/tasks/install_efs.yaml
+++ b/roles/openshift_provisioners/tasks/install_efs.yaml
@@ -67,4 +67,4 @@
   register: efs_output
   failed_when: efs_output.rc == 1 and 'exists' not in efs_output.stderr
   check_mode: no
-  when: efs_anyuid.stdout.find("system:serviceaccount:{{openshift_provisioners_project}}:provisioners-efs") == -1
+  when: efs_anyuid.stdout.find("system:serviceaccount:" + openshift_provisioners_project + ":provisioners-efs") == -1


### PR DESCRIPTION
Without that, playbook runs print warnings such as this:

```
 [WARNING]: when statements should not include jinja2 templating
 delimiters such as {{ }} or {% %}. Found: {{ g_etcd_hosts is not
 defined and g_new_etcd_hosts is not
 defined}}
```

Note: many of the changes are essentially the same fix in the several copies of the upgrade playbooks (for the different versions).