### PR TITLE
Start iptables on each master in serial

### DIFF
--- a/roles/os_firewall/tasks/firewall/iptables.yml
+++ b/roles/os_firewall/tasks/firewall/iptables.yml
@@ -29,6 +29,9 @@
     masked: no
     daemon_reload: yes
   register: result
+  delegate_to: "{{item}}"
+  run_once: true
+  with_items: "{{ ansible_play_hosts }}"
 
 - name: need to pause here, otherwise the iptables service starting can sometimes cause ssh to fail
   pause: seconds=10


### PR DESCRIPTION
This PR fixes the problem we are facing in #5050. The start/enable iptables task hangs when connecting to another master when running the playbook from a master without iptables already enabled.

This is one approach. The other approach is a separate task (and possibly a pause) to start/enable iptables first on the current host if the current host is also a master if that is preferred?