### PR TITLE
Change default CFME namespace to use reserved openshift- prefix

### DIFF
--- a/roles/openshift_cfme/defaults/main.yml
+++ b/roles/openshift_cfme/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
-# Namespace for the CFME project
-openshift_cfme_project: cfme
+# Namespace for the CFME project (Note: changed post-3.6 to use
+# reserved 'openshift-' namespace prefix)
+openshift_cfme_project: openshift-cfme
 # Namespace/project description
 openshift_cfme_project_description: ManageIQ - CloudForms Management Engine
 # Basic user assigned the `admin` role for the project


### PR DESCRIPTION
As of OCP 3.6 we are advised to prefix reserved namespaces with an
'openshift-' prefix.

Fixes #5049

----

**Note:** I don't think this should be backported into the `release-3.6` branch. It could produce unexpected results and confuse people on an existing 3.6 install if they suddenly re-ran the playbook and all projects and resources were created in a new namespace.