### PR TITLE
New tuned profile hierarchy.

### DIFF
--- a/roles/openshift_node/templates/tuned/openshift-control-plane/tuned.conf
+++ b/roles/openshift_node/templates/tuned/openshift-control-plane/tuned.conf
@@ -1,0 +1,25 @@
+#
+# tuned configuration
+#
+
+[main]
+summary=Optimize systems running OpenShift control plane
+include=openshift
+
+[sysctl]
+# ktune sysctl settings, maximizing i/o throughput
+#
+# Minimal preemption granularity for CPU-bound tasks:
+# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
+kernel.sched_min_granularity_ns=10000000
+
+# The total time the scheduler will consider a migrated process
+# "cache hot" and thus less likely to be re-migrated
+# (system default is 500000, i.e. 0.5 ms)
+kernel.sched_migration_cost_ns=5000000
+
+# SCHED_OTHER wake-up granularity.
+#
+# Preemption granularity when tasks wake up.  Lower the value to improve 
+# wake-up latency and throughput for latency critical tasks.
+kernel.sched_wakeup_granularity_ns = 4000000

--- a/roles/openshift_node/templates/tuned/openshift-node/tuned.conf
+++ b/roles/openshift_node/templates/tuned/openshift-node/tuned.conf
@@ -1,0 +1,10 @@
+#
+# tuned configuration
+#
+
+[main]
+summary=Optimize systems running OpenShift nodes
+include=openshift
+
+[sysctl]
+net.ipv4.tcp_fastopen=3

--- a/roles/openshift_node/templates/tuned/openshift/tuned.conf
+++ b/roles/openshift_node/templates/tuned/openshift/tuned.conf
@@ -1,0 +1,24 @@
+#
+# tuned configuration
+#
+
+[main]
+summary=Optimize systems running OpenShift (parent profile)
+include=${f:virt_check:{{ openshift_tuned_guest_profile }}:throughput-performance}
+
+[selinux]
+avc_cache_threshold=65536
+
+[net]
+nf_conntrack_hashsize=131072
+
+[sysctl]
+kernel.pid_max=131072
+net.netfilter.nf_conntrack_max=1048576
+fs.inotify.max_user_watches=65536
+net.ipv4.neigh.default.gc_thresh1=8192
+net.ipv4.neigh.default.gc_thresh2=32768
+net.ipv4.neigh.default.gc_thresh3=65536
+net.ipv6.neigh.default.gc_thresh1=8192
+net.ipv6.neigh.default.gc_thresh2=32768
+net.ipv6.neigh.default.gc_thresh3=65536

--- a/roles/openshift_node/templates/tuned/recommend.conf
+++ b/roles/openshift_node/templates/tuned/recommend.conf
@@ -1,0 +1,8 @@
+[openshift-node]
+/etc/origin/node/node-config.yaml=.*region=primary
+
+[openshift-control-plane,master]
+/etc/origin/master/master-config.yaml=.*
+
+[openshift-control-plane,node]
+/etc/origin/node/node-config.yaml=.*region=infra


### PR DESCRIPTION
This PR aims to restructure the current tuned profile hierarchy and also address RH BZ1459146 and BZ1477518.

Old tuned hierarchy:

                              throughput-performance
                                 /        /\     \______________
       _________________________/        /  \                   \
      |                                 /    \            virtual-guest
      |                 _______________/      \       __________/
      |                /     \                 \     /
      |      virtual-{host,guest}     atomic-{host,guest}
      |                      \                 |   |
      |                       \              BZ1477518: tuned-profiles-atomic-openshift-node is not installed on atomic host
      |                        \
      +_____________________    \
                            \    \
    atomic-openshift-node-{host,guest}
    
Proposed tuned hierarchy.    
    
                          throughput-performance
                             /       /\     \______________
       _____________________/       /  \                   \
      |                            /    \            virtual-guest
      |            _______________/      \       __________/
      |           /     \                 \     /
      |  virtual-{host,guest}     atomic-{host,guest}
      +______________  /______________________/
                     \//
                 openshift (all the existing tunings)
                     |
            ---------+---------------
           |                         |
           |                         |
    openshift-node     openshift-control-plane (sched_migration_cost, kernel.sched_wakeup_granularity_ns=4000000, ...)

I'm placing this under "templates" as the "virtual" in openshift profile will need to be parametrized based on the installation environment.  For Atomic Host, it will be "atomic", for anything else "virtual".

Instatiation of the profiles can be done by placing the tuned profiles into /etc/tuned and running:

    tuned-adm profile `tuned-adm recommend`

once the /etc/origin/node/node-config.yaml file is populated with the region key-value pair.  Ansible code for the actual profile instantiation will be provided by a separate PR.