### PR TITLE
Fix Restore Master AWS Options

### DIFF
--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -70,7 +70,7 @@
   with_items: "{{ master_api_proxy.stdout_lines | default([]) }}"
 
 - name: Restore Master API AWS Options
-  when: bool and openshift.master.cluster_method == "native"
+  when: openshift.master.cluster_method == "native"
       and master_api_aws.rc == 0 and
       not (openshift_cloudprovider_kind is defined and openshift_cloudprovider_kind == 'aws' and openshift_cloudprovider_aws_access_key is defined and openshift_cloudprovider_aws_secret_key is defined)
   lineinfile:


### PR DESCRIPTION
When you specify AWS as the provider and provide the AWS ACCESS and SECRET keys, the install fails with an error 'undefined bool'.
When the scripts were last modified, the bool part should have been removed with the previous content.