### PR TITLE
system_container.yml: fix braces

### DIFF
--- a/roles/openshift_master/tasks/system_container.yml
+++ b/roles/openshift_master/tasks/system_container.yml
@@ -22,7 +22,7 @@
 - name: Install or Update HA controller master system container
   oc_atomic_container:
     name: "{{ openshift.common.service_type }}-master-controllers"
-    image: "{{{ 'docker:' if openshift.common.system_images_registry == 'docker' else openshift.common.system_images_registry + '/' }}{ openshift.master.master_system_image }}:{{ openshift_image_tag }}"
+    image: "{{ 'docker:' if openshift.common.system_images_registry == 'docker' else openshift.common.system_images_registry + '/' }}{{ openshift.master.master_system_image }}:{{ openshift_image_tag }}"
     state: latest
     values:
       - COMMAND=controllers


### PR DESCRIPTION
Fixes error from https://ci.openshift.redhat.com/jenkins/job/test_pull_request_openshift_ansible_extended_conformance_install_system_containers/52/consoleText

```
TASK [openshift_master : Install or Update HA controller master system container] ***
task path: /usr/share/ansible/openshift-ansible/roles/openshift_master/tasks/system_container.yml:22
fatal: [localhost]: FAILED! => {
    "failed": true, 
    "generated_timestamp": "2017-08-10 16:05:59.599931", 
    "msg": "template error while templating string: expected token ':', got '}'. String: {{{ 'docker:' if openshift.common.system_images_registry == 'docker' else openshift.common.system_images_registry + '/' }}{ openshift.master.master_system_image }}:{{ openshift_image_tag }}"
}
```