### PR TITLE
Metrics won't start. It is missing --truststore_authorities param

### DIFF
--- a/roles/openshift_metrics/templates/hawkular_metrics_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_metrics_rc.j2
@@ -69,6 +69,8 @@ spec:
               fieldPath: metadata.namespace
         - name: MASTER_URL
           value: "{{ openshift_metrics_master_url }}"
+        - name: TRUSTSTORE_AUTHORITIES
+          value: "/hawkular-metrics-certs/tls.truststore.crt"
         - name: OPENSHIFT_KUBE_PING_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
oc -n openshift-infra log hawkular-metrics-mhg6p
2017-08-11 12:10:12 Starting Hawkular Metrics
The --truststore_authorities value is not specified. Aborting

Signed-off-by: jkaurredhat <jkaur@redhat.com>