### PR TITLE
Glusterfs firewall updates.

### DIFF
--- a/playbooks/common/openshift-glusterfs/config.yml
+++ b/playbooks/common/openshift-glusterfs/config.yml
@@ -1,40 +1,26 @@
 ---
 - name: Open firewall ports for GlusterFS nodes
   hosts: glusterfs
-  vars:
-    os_firewall_allow:
-    - service: glusterfs_sshd
-      port: "2222/tcp"
-    - service: glusterfs_daemon
-      port: "24007/tcp"
-    - service: glusterfs_management
-      port: "24008/tcp"
-    - service: glusterfs_bricks
-      port: "49152-49251/tcp"
-  roles:
-  - role: os_firewall
+  tasks:
+  - include_role:
+      name: openshift_storage_glusterfs
+      tasks_from: firewall.yml
     when:
     - openshift_storage_glusterfs_is_native | default(True) | bool
 
 - name: Open firewall ports for GlusterFS registry nodes
   hosts: glusterfs_registry
-  vars:
-    os_firewall_allow:
-    - service: glusterfs_sshd
-      port: "2222/tcp"
-    - service: glusterfs_daemon
-      port: "24007/tcp"
-    - service: glusterfs_management
-      port: "24008/tcp"
-    - service: glusterfs_bricks
-      port: "49152-49251/tcp"
-  roles:
-  - role: os_firewall
+  tasks:
+  - include_role:
+      name: openshift_storage_glusterfs
+      tasks_from: firewall.yml
     when:
     - openshift_storage_glusterfs_registry_is_native | default(True) | bool
 
 - name: Configure GlusterFS
   hosts: oo_first_master
-  roles:
-  - role: openshift_storage_glusterfs
+  tasks:
+  - name: setup glusterfs
+    include_role:
+      name: openshift_storage_glusterfs
     when: groups.oo_glusterfs_to_config | default([]) | count > 0

--- a/roles/openshift_storage_glusterfs/defaults/main.yml
+++ b/roles/openshift_storage_glusterfs/defaults/main.yml
@@ -52,3 +52,15 @@ openshift_storage_glusterfs_registry_heketi_ssh_port: "{{ openshift_storage_glus
 openshift_storage_glusterfs_registry_heketi_ssh_user: "{{ openshift_storage_glusterfs_heketi_ssh_user }}"
 openshift_storage_glusterfs_registry_heketi_ssh_sudo: "{{ openshift_storage_glusterfs_heketi_ssh_sudo }}"
 openshift_storage_glusterfs_registry_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_heketi_ssh_keyfile | default(omit) }}"
+r_openshift_master_firewall_enabled: True
+r_openshift_master_use_firewalld: False
+r_openshift_storage_glusterfs_os_firewall_deny: []
+r_openshift_storage_glusterfs_os_firewall_allow:
+- service: glusterfs_sshd
+  port: "2222/tcp"
+- service: glusterfs_daemon
+  port: "24007/tcp"
+- service: glusterfs_management
+  port: "24008/tcp"
+- service: glusterfs_bricks
+  port: "49152-49251/tcp"

--- a/roles/openshift_storage_glusterfs/meta/main.yml
+++ b/roles/openshift_storage_glusterfs/meta/main.yml
@@ -13,3 +13,4 @@ dependencies:
 - role: openshift_hosted_facts
 - role: openshift_repos
 - role: lib_openshift
+- role: lib_os_firewall

--- a/roles/openshift_storage_glusterfs/tasks/firewall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/firewall.yml
@@ -1,0 +1,40 @@
+---
+- when: r_openshift_storage_glusterfs_firewall_enabled | bool and not r_openshift_storage_glusterfs_use_firewalld | bool
+  block:
+  - name: Add iptables allow rules
+    os_firewall_manage_iptables:
+      name: "{{ item.service }}"
+      action: add
+      protocol: "{{ item.port.split('/')[1] }}"
+      port: "{{ item.port.split('/')[0] }}"
+    when: item.cond | default(True)
+    with_items: "{{ r_openshift_storage_glusterfs_os_firewall_allow }}"
+
+  - name: Remove iptables rules
+    os_firewall_manage_iptables:
+      name: "{{ item.service }}"
+      action: remove
+      protocol: "{{ item.port.split('/')[1] }}"
+      port: "{{ item.port.split('/')[0] }}"
+    when: item.cond | default(True)
+    with_items: "{{ r_openshift_storage_glusterfs_os_firewall_deny }}"
+
+- when: r_openshift_storage_glusterfs_firewall_enabled | bool and r_openshift_storage_glusterfs_use_firewalld | bool
+  block:
+  - name: Add firewalld allow rules
+    firewalld:
+      port: "{{ item.port }}"
+      permanent: true
+      immediate: true
+      state: enabled
+    when: item.cond | default(True)
+    with_items: "{{ r_openshift_storage_glusterfs_os_firewall_allow }}"
+
+  - name: Remove firewalld allow rules
+    firewalld:
+      port: "{{ item.port }}"
+      permanent: true
+      immediate: true
+      state: disabled
+    when: item.cond | default(True)
+    with_items: "{{ r_openshift_storage_glusterfs_os_firewall_deny }}"


### PR DESCRIPTION
@jarrpa, with the landing of a recent firewall refactor I wanted to bring the glusterfs role inline with the new pattern.  I don't have a setup to test glusterfs but I believe these firewall changes would work.

The bulk of the PR encapsulates the firewall rules underneath the glusterfs role.  The openshift-glusterfs/config.yml script will then just apply those rules and call the glusterfs role.  The os_firewall role no longer applies the rules and only installs the proper firewall that is desired.