### PR TITLE
Fix duplicate evaluate_groups.yml call during install

### DIFF
--- a/playbooks/byo/openshift-cluster/service-catalog.yml
+++ b/playbooks/byo/openshift-cluster/service-catalog.yml
@@ -5,6 +5,12 @@
 # currently supported method.
 #
 - include: initialize_groups.yml
+  tags:
+  - always
+
+- include: ../../common/openshift-cluster/std_include.yml
+  tags:
+  - always
 
 - include: ../../common/openshift-cluster/service_catalog.yml
   vars:

--- a/playbooks/common/openshift-cluster/service_catalog.yml
+++ b/playbooks/common/openshift-cluster/service_catalog.yml
@@ -1,5 +1,4 @@
 ---
-- include: evaluate_groups.yml
 
 - name: Update Master configs
   hosts: oo_masters


### PR DESCRIPTION
The way the service_catalog.yml playbook calls evaluate_groups.yml
causes the evaluation to happen twice during a standard byo/config.yml
installation.  Refactoring the service_catalog.yml playbooks to remove
this duplicate.