### PR TITLE
Default values for CFME container images are invalid

### DIFF
--- a/roles/openshift_cfme/defaults/main.yml
+++ b/roles/openshift_cfme/defaults/main.yml
@@ -35,9 +35,9 @@ openshift_cfme_nfs_server: "{{ groups.nfs.0 }}"
 # --template=manageiq). If False everything UP TO 'new-app' is ran.
 openshift_cfme_install_app: False
 # Docker image to pull
-openshift_cfme_application_img_name: "{{ 'registry.access.redhat.com/cloudforms45/cfme-openshift-app' if openshift_deployment_type == 'openshift-enterprise' else 'docker.io/manageiq/manageiq-pods:app-latest-fine' }}"
-openshift_cfme_postgresql_img_name: "{{ 'registry.access.redhat.com/cloudforms45/cfme-openshift-postgresql' if openshift_deployment_type == 'openshift-enterprise' else 'docker.io/manageiq/manageiq-pods:app-latest-fine' }}"
-openshift_cfme_memcached_img_name: "{{ 'registry.access.redhat.com/cloudforms45/cfme-openshift-memcached' if openshift_deployment_type == 'openshift-enterprise' else 'docker.io/manageiq/manageiq-pods:app-latest-fine' }}"
+openshift_cfme_application_img_name: "{{ 'registry.access.redhat.com/cloudforms45/cfme-openshift-app' if openshift_deployment_type == 'openshift-enterprise' else 'docker.io/manageiq/manageiq-pods' }}"
+openshift_cfme_postgresql_img_name: "{{ 'registry.access.redhat.com/cloudforms45/cfme-openshift-postgresql' if openshift_deployment_type == 'openshift-enterprise' else 'docker.io/manageiq/manageiq-pods' }}"
+openshift_cfme_memcached_img_name: "{{ 'registry.access.redhat.com/cloudforms45/cfme-openshift-memcached' if openshift_deployment_type == 'openshift-enterprise' else 'docker.io/manageiq/manageiq-pods' }}"
 openshift_cfme_application_img_tag: "{{ 'latest' if openshift_deployment_type == 'openshift-enterprise' else 'app-latest-fine' }}"
 openshift_cfme_memcached_img_tag: "{{ 'latest' if openshift_deployment_type == 'openshift-enterprise' else 'memcached-latest-fine' }}"
 openshift_cfme_postgresql_img_tag: "{{ 'latest' if openshift_deployment_type == 'openshift-enterprise' else 'postgresql-latest-fine' }}"


### PR DESCRIPTION
openshift_cfme_application_img_name, openshift_cfme_postgresql_img_name and  openshift_cfme_memcached_img_name are incorrect.

It will fail with below error :

The ImageStream \"miq-app\" is invalid: spec.dockerImageRepository: Invalid value: \"docker.io/manageiq/manageiq-pods:app-latest-fine\": the repository name may not contain a tag
The ImageStream \"miq-postgresql\" is invalid: spec.dockerImageRepository: Invalid value: \"docker.io/manageiq/manageiq-pods:app-latest-fine\": the repository name may not contain a tag
The ImageStream \"miq-memcached\" is invalid: spec.dockerImageRepository: Invalid value: \"docker.io/manageiq/manageiq-pods:app-latest-fine\": the repository name may not contain a tag

Signed-off-by: jkaurredhat <jkaur@redhat.com>