### PR TITLE
[wip] CA serial syncing BZ1469358

### DIFF
--- a/playbooks/common/openshift-cluster/redeploy-certificates/etcd-ca.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/etcd-ca.yml
@@ -125,8 +125,6 @@
 
 - name: Distribute etcd CA to masters
   hosts: oo_masters_to_config
-  vars:
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
   tasks:
   - name: Deploy etcd CA
     copy:

--- a/playbooks/common/openshift-cluster/redeploy-certificates/etcd.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/etcd.yml
@@ -51,7 +51,6 @@
       etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
       etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"
       etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"
-      openshift_ca_host: "{{ groups.oo_first_master.0 }}"
       r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
 
 - name: Redeploy etcd client certificates for masters
@@ -64,7 +63,5 @@
       etcd_cert_subdir: "openshift-master-{{ openshift.common.hostname }}"
       etcd_cert_config_dir: "{{ openshift.common.config_base }}/master"
       etcd_cert_prefix: "master.etcd-"
-      openshift_ca_host: "{{ groups.oo_first_master.0 }}"
-      openshift_master_count: "{{ openshift.master.master_count | default(groups.oo_masters | length) }}"
       r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
       when: groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config

--- a/playbooks/common/openshift-cluster/redeploy-certificates/masters.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/masters.yml
@@ -1,9 +1,13 @@
 ---
+- name: Determine openshift_ca_host
+  hosts: oo_masters_to_config
+  roles:
+  - role: openshift_ca_facts
+
 - name: Redeploy master certificates
   hosts: oo_masters_to_config
   any_errors_fatal: true
   vars:
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
     openshift_master_count: "{{ openshift.master.master_count | default(groups.oo_masters | length) }}"
   pre_tasks:
   - stat:

--- a/playbooks/common/openshift-cluster/redeploy-certificates/nodes.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/nodes.yml
@@ -25,5 +25,4 @@
   roles:
   - role: openshift_node_certificates
     openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
     openshift_certificates_redeploy: true

--- a/playbooks/common/openshift-cluster/redeploy-certificates/openshift-ca.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/openshift-ca.yml
@@ -119,7 +119,6 @@
     # will be created. We'll replace the existing CA with the CA
     # created in the temporary directory.
     openshift_ca_config_dir: "{{ g_new_openshift_ca_mktemp.stdout }}"
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
     openshift_master_hostnames: "{{ hostvars
                                     | oo_select_keys(groups['oo_masters_to_config'] | default([]))
                                     | oo_collect('openshift.common.all_hostnames')
@@ -138,8 +137,6 @@
 
 - name: Retrieve OpenShift CA
   hosts: oo_first_master
-  vars:
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
   tasks:
   - name: Retrieve CA certificate, key, bundle and serial
     fetch:
@@ -159,8 +156,6 @@
 
 - name: Distribute OpenShift CA to masters
   hosts: oo_masters_to_config
-  vars:
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
   tasks:
   - name: Deploy CA certificate, key, bundle and serial
     copy:
@@ -222,8 +217,6 @@
 
 - name: Distribute OpenShift CA certificate to nodes
   hosts: oo_nodes_to_config
-  vars:
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
   tasks:
   - copy:
       src: "{{ hostvars['localhost'].g_master_mktemp.stdout }}/ca-bundle.crt"

--- a/playbooks/common/openshift-cluster/upgrades/create_service_signer_cert.yml
+++ b/playbooks/common/openshift-cluster/upgrades/create_service_signer_cert.yml
@@ -29,7 +29,13 @@
       --serial="{{ remote_cert_create_tmpdir.stdout }}/"service-signer.serial.txt
     args:
       chdir: "{{ remote_cert_create_tmpdir.stdout }}/"
+    register: l_service_signer_cert_created
     when: not (hostvars[groups.oo_first_master.0].service_signer_cert_stat.stat.exists | bool)
+
+  - name: TODO - Call certificate sync handler
+    debug:
+      msg: We just created a cert for a node, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
+    when: not l_service_signer_cert_created.skipped
 
   - name: Retrieve service signer certificate
     fetch:

--- a/playbooks/common/openshift-cluster/upgrades/create_service_signer_cert.yml
+++ b/playbooks/common/openshift-cluster/upgrades/create_service_signer_cert.yml
@@ -35,7 +35,7 @@
   - name: TODO - Call certificate sync handler
     debug:
       msg: We just created a cert for a node, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
-    when: not l_service_signer_cert_created.skipped
+    when: not l_service_signer_cert_created.skipped | default(false) | bool
 
   - name: Retrieve service signer certificate
     fetch:

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -191,8 +191,6 @@
   roles:
   - role: os_firewall
   - role: openshift_master
-    # TODO: Use the value from openshift_ca_facts to set `openshift_ca_host`
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
     openshift_master_etcd_hosts: "{{ hostvars
                                      | oo_select_keys(groups['oo_etcd_to_config'] | default([]))
                                      | oo_collect('openshift.common.hostname')

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -26,6 +26,9 @@
     debug:
       var: g_openshift_master_is_scaleup
 
+  # TODO: This 'ca host detection' logic shouldn't be in this
+  # file. The logic needs to be called in several places. This needs
+  # to be moved somewhere that allows that.
   - name: Check for existance of ca.serial.txt on master
     stat:
       path: /etc/origin/master/ca.serial.txt

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -79,7 +79,6 @@
         api_port: "{{ openshift_master_api_port | default(None) }}"
         api_url: "{{ openshift_master_api_url | default(None) }}"
         api_use_ssl: "{{ openshift_master_api_use_ssl | default(None) }}"
-        ca_serial_number: "{{ openshift_master_ca_serial_number | default(0) }}"
         controllers_port: "{{ openshift_master_controllers_port | default(None) }}"
         public_api_url: "{{ openshift_master_public_api_url | default(None) }}"
         cluster_hostname: "{{ openshift_master_cluster_hostname | default(None) }}"
@@ -192,8 +191,7 @@
   roles:
   - role: os_firewall
   - role: openshift_master
-    # todo: sort the list of hosts and select the one which has the
-    # highest openshift.master.ca_serial_number value
+    # TODO: Use the value from openshift_ca_facts to set `openshift_ca_host`
     openshift_ca_host: "{{ groups.oo_first_master.0 }}"
     openshift_master_etcd_hosts: "{{ hostvars
                                      | oo_select_keys(groups['oo_etcd_to_config'] | default([]))

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -26,6 +26,17 @@
     debug:
       var: g_openshift_master_is_scaleup
 
+  - name: Check for existance of ca.serial.txt on master
+    stat:
+      path: /etc/origin/master/ca.serial.txt
+    register: l_ca_serial_exists
+
+  - name: Read value of CA serial number if it exists
+    slurp:
+      src: /etc/origin/master/ca.serial.txt
+    when: l_ca_serial_exists.stat.exists
+    register: l_ca_serial_number
+
   - name: Check for RPM generated config marker file .config_managed
     stat:
       path: /etc/origin/.config_managed
@@ -69,6 +80,10 @@
   - set_fact:
       openshift_hosted_metrics_resolution: "{{ lookup('oo_option', 'openshift_hosted_metrics_resolution') | default('10s', true) }}"
     when: openshift_hosted_metrics_resolution is not defined
+  - set_fact:
+      openshift_master_ca_serial_number: "{{ l_ca_serial_number | b64decode | int(base=16) }}"
+    when: l_ca_serial_number is defined
+
   roles:
   - openshift_facts
   post_tasks:
@@ -78,6 +93,7 @@
         api_port: "{{ openshift_master_api_port | default(None) }}"
         api_url: "{{ openshift_master_api_url | default(None) }}"
         api_use_ssl: "{{ openshift_master_api_use_ssl | default(None) }}"
+        ca_serial_number: "{{ openshift_master_ca_serial_number | default(0) }}"
         controllers_port: "{{ openshift_master_controllers_port | default(None) }}"
         public_api_url: "{{ openshift_master_public_api_url | default(None) }}"
         cluster_hostname: "{{ openshift_master_cluster_hostname | default(None) }}"
@@ -190,6 +206,8 @@
   roles:
   - role: os_firewall
   - role: openshift_master
+    # todo: sort the list of hosts and select the one which has the
+    # highest openshift.master.ca_serial_number value
     openshift_ca_host: "{{ groups.oo_first_master.0 }}"
     openshift_master_etcd_hosts: "{{ hostvars
                                      | oo_select_keys(groups['oo_etcd_to_config'] | default([]))

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -26,20 +26,6 @@
     debug:
       var: g_openshift_master_is_scaleup
 
-  # TODO: This 'ca host detection' logic shouldn't be in this
-  # file. The logic needs to be called in several places. This needs
-  # to be moved somewhere that allows that.
-  - name: Check for existance of ca.serial.txt on master
-    stat:
-      path: /etc/origin/master/ca.serial.txt
-    register: l_ca_serial_exists
-
-  - name: Read value of CA serial number if it exists
-    slurp:
-      src: /etc/origin/master/ca.serial.txt
-    when: l_ca_serial_exists.stat.exists
-    register: l_ca_serial_number
-
   - name: Check for RPM generated config marker file .config_managed
     stat:
       path: /etc/origin/.config_managed
@@ -83,9 +69,6 @@
   - set_fact:
       openshift_hosted_metrics_resolution: "{{ lookup('oo_option', 'openshift_hosted_metrics_resolution') | default('10s', true) }}"
     when: openshift_hosted_metrics_resolution is not defined
-  - set_fact:
-      openshift_master_ca_serial_number: "{{ l_ca_serial_number | b64decode | int(base=16) }}"
-    when: l_ca_serial_number is defined
 
   roles:
   - openshift_facts

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -42,7 +42,6 @@
   roles:
   - role: os_firewall
   - role: openshift_node
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
 
 - name: Configure nodes
   hosts: oo_nodes_to_config:!oo_containerized_master_nodes
@@ -58,7 +57,6 @@
   roles:
   - role: os_firewall
   - role: openshift_node
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
 
 - name: Additional node config
   hosts: oo_nodes_to_config

--- a/roles/openshift_ca/meta/main.yml
+++ b/roles/openshift_ca/meta/main.yml
@@ -15,3 +15,4 @@ galaxy_info:
 dependencies:
 - role: openshift_cli
 - role: openshift_named_certificates
+- role: openshift_ca_facts

--- a/roles/openshift_ca/tasks/sync_serial_file.yaml
+++ b/roles/openshift_ca/tasks/sync_serial_file.yaml
@@ -1,5 +1,9 @@
 ---
 # new in 2.3: http://docs.ansible.com/ansible/latest/tempfile_module.html
+
+# Note: We need to keep an eye on how many times we're doing this. We
+# don't want to be repeating this over and over unless there's no
+# other way around it.
 - name: Create local dir for saving serial file
   debug:
     msg: task to create local temp dir

--- a/roles/openshift_ca/tasks/sync_serial_file.yaml
+++ b/roles/openshift_ca/tasks/sync_serial_file.yaml
@@ -1,0 +1,21 @@
+---
+# new in 2.3: http://docs.ansible.com/ansible/latest/tempfile_module.html
+- name: Create local dir for saving serial file
+  debug:
+    msg: task to create local temp dir
+
+# http://docs.ansible.com/ansible/latest/fetch_module.html
+- name: Fetch serial file from canonical CA master
+  debug:
+    msg: task to grab /etc/origin/master/ca.serial.txt from CA host
+
+# http://docs.ansible.com/ansible/latest/copy_module.html#copy
+- name: Copy ca.serial.txt to other masters
+  debug:
+    msg: task to copy /tmp/tmp.xxxxxx/ca.serial.txt to other masters
+
+
+# http://docs.ansible.com/ansible/latest/file_module.html
+- name: Erase local dir for saving serial file
+  debug:
+    msg: task to erase local temp dir

--- a/roles/openshift_ca_facts/README.md
+++ b/roles/openshift_ca_facts/README.md
@@ -1,0 +1,4 @@
+# OpenShift CA Facts
+
+A role you must include as a dependency if you are creating
+certificates.

--- a/roles/openshift_ca_facts/meta/main.yml
+++ b/roles/openshift_ca_facts/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: Tim Bielawa
+  description: OpenShift CA Facts
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 2.3
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+  - system
+dependencies: []

--- a/roles/openshift_ca_facts/tasks/main.yml
+++ b/roles/openshift_ca_facts/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Determine canonical OpenShift CA host
+  hosts: oo_masters_to_config
+  tasks:
+  # TODO: This 'ca host detection' logic shouldn't be in this
+  # file. The logic needs to be called in several places. This needs
+  # to be moved somewhere that allows that.
+  - name: Check for existance of ca.serial.txt on master
+    stat:
+      path: /etc/origin/master/ca.serial.txt
+    register: l_ca_serial_exists
+
+  - name: Read value of CA serial number if it exists
+    slurp:
+      src: /etc/origin/master/ca.serial.txt
+    when: l_ca_serial_exists.stat.exists
+    register: l_ca_serial_number
+
+  - set_fact:
+      openshift_master_ca_serial_number: "{{ l_ca_serial_number | b64decode | int(base=16) }}"
+    when: l_ca_serial_number is defined

--- a/roles/openshift_ca_facts/tasks/main.yml
+++ b/roles/openshift_ca_facts/tasks/main.yml
@@ -19,3 +19,7 @@
   - set_fact:
       openshift_master_ca_serial_number: "{{ l_ca_serial_number | b64decode | int(base=16) }}"
     when: l_ca_serial_number is defined
+
+
+  # todo: sort the list of hosts and select the one which has the
+  # highest openshift.master.ca_serial_number value

--- a/roles/openshift_ca_facts/tasks/main.yml
+++ b/roles/openshift_ca_facts/tasks/main.yml
@@ -1,25 +1,47 @@
 ---
-- name: Determine canonical OpenShift CA host
-  hosts: oo_masters_to_config
-  tasks:
-  # TODO: This 'ca host detection' logic shouldn't be in this
-  # file. The logic needs to be called in several places. This needs
-  # to be moved somewhere that allows that.
-  - name: Check for existance of ca.serial.txt on master
-    stat:
-      path: /etc/origin/master/ca.serial.txt
-    register: l_ca_serial_exists
+- name: Check for existance of ca.serial.txt on master
+  stat:
+    path: /etc/origin/master/ca.serial.txt
+  register: l_ca_serial_exists
 
-  - name: Read value of CA serial number if it exists
-    slurp:
-      src: /etc/origin/master/ca.serial.txt
-    when: l_ca_serial_exists.stat.exists
-    register: l_ca_serial_number
+- name: Read value of CA serial number if it exists
+  slurp:
+    src: /etc/origin/master/ca.serial.txt
+  when:
+    - l_ca_serial_exists.stat.exists
+  register: l_ca_serial_number
 
-  - set_fact:
-      openshift_master_ca_serial_number: "{{ l_ca_serial_number | b64decode | int(base=16) }}"
-    when: l_ca_serial_number is defined
+######################################################################
+- name: what is the serial
+  debug:
+    msg: "{{ l_ca_serial_number }}"
+  when:
+    - l_ca_serial_exists.stat.exists
+
+- name: what is the serial
+  debug:
+    msg: "{{ l_ca_serial_number.content | b64decode}}"
+  when:
+    - l_ca_serial_exists.stat.exists
+
+######################################################################
+- name: Record the value of the ca serial number
+  set_fact:
+    ca_serial_number: "{{ l_ca_serial_number.content | b64decode | int(base=16) }}"
+  when:
+    - l_ca_serial_number is defined
+
+# The ca.serial.txt file does not exist on this master
+- name: Record the value of the ca serial number
+  set_fact:
+    ca_serial_number: "{{ None }}"
+  when:
+    - not l_ca_serial_number is defined
+
+######################################################################
+- debug:
+    var: ca_serial_number
 
 
-  # todo: sort the list of hosts and select the one which has the
-  # highest openshift.master.ca_serial_number value
+# todo: sort the list of hosts and select the one which has the
+# highest openshift.master.ca_serial_number value

--- a/roles/openshift_ca_facts/tasks/main.yml
+++ b/roles/openshift_ca_facts/tasks/main.yml
@@ -35,23 +35,13 @@
 - debug:
     var: ca_serial_number
 
-# ######################################################################
-# - name: what is the serial
-#   debug:
-#     msg: "{{ l_ca_serial_number }}"
-#   when:
-#     - l_ca_serial_exists.stat.exists
-
-# - name: what is the serial
-#   debug:
-#     msg: "{{ l_ca_serial_number.content | b64decode}}"
-#   when:
-#     - l_ca_serial_exists.stat.exists
-
 # sort the list of hosts and select the one which has the highest
 # ca_serial_number value
-- debug:
-    msg: "{{ (hostvars | oo_select_keys(ansible_play_hosts) | sort(attribute='ca_serial_number', reverse=True) | map(attribute='inventory_hostname') | list).0 }}"
-  run_once: true
+- name: Record which master is the openshift_ca_host
+  set_fact:
+    openshift_ca_host: "{{ (hostvars | oo_select_keys(ansible_play_hosts)
+                            | sort(attribute='ca_serial_number', reverse=True)
+                            | map(attribute='inventory_hostname')
+                            | list).0 }}"
 
-- fail:
+- debug: var=openshift_ca_host

--- a/roles/openshift_ca_facts/tasks/main.yml
+++ b/roles/openshift_ca_facts/tasks/main.yml
@@ -35,9 +35,6 @@
 - debug:
     var: ca_serial_number
 
-- fail:
-    msg: done
-
 # ######################################################################
 # - name: what is the serial
 #   debug:
@@ -51,5 +48,10 @@
 #   when:
 #     - l_ca_serial_exists.stat.exists
 
-# todo: sort the list of hosts and select the one which has the
-# highest openshift.master.ca_serial_number value
+# sort the list of hosts and select the one which has the highest
+# ca_serial_number value
+- debug:
+    msg: "{{ (hostvars | oo_select_keys(ansible_play_hosts) | sort(attribute='ca_serial_number', reverse=True) | map(attribute='inventory_hostname') | list).0 }}"
+  run_once: true
+
+- fail:

--- a/roles/openshift_ca_facts/tasks/main.yml
+++ b/roles/openshift_ca_facts/tasks/main.yml
@@ -16,15 +16,8 @@
   debug:
     msg: "{{ l_ca_serial_number }}"
   when:
-    - l_ca_serial_exists.stat.exists
+    - l_ca_serial_number is defined
 
-- name: what is the serial
-  debug:
-    msg: "{{ l_ca_serial_number.content | b64decode}}"
-  when:
-    - l_ca_serial_exists.stat.exists
-
-######################################################################
 - name: Record the value of the ca serial number
   set_fact:
     ca_serial_number: "{{ l_ca_serial_number.content | b64decode | int(base=16) }}"
@@ -32,7 +25,7 @@
     - l_ca_serial_number is defined
 
 # The ca.serial.txt file does not exist on this master
-- name: Record the value of the ca serial number
+- name: Record the empty value of the ca serial number
   set_fact:
     ca_serial_number: "{{ None }}"
   when:
@@ -42,6 +35,21 @@
 - debug:
     var: ca_serial_number
 
+- fail:
+    msg: done
+
+# ######################################################################
+# - name: what is the serial
+#   debug:
+#     msg: "{{ l_ca_serial_number }}"
+#   when:
+#     - l_ca_serial_exists.stat.exists
+
+# - name: what is the serial
+#   debug:
+#     msg: "{{ l_ca_serial_number.content | b64decode}}"
+#   when:
+#     - l_ca_serial_exists.stat.exists
 
 # todo: sort the list of hosts and select the one which has the
 # highest openshift.master.ca_serial_number value

--- a/roles/openshift_ca_facts/tasks/main.yml
+++ b/roles/openshift_ca_facts/tasks/main.yml
@@ -8,7 +8,7 @@
   slurp:
     src: /etc/origin/master/ca.serial.txt
   when:
-    - l_ca_serial_exists.stat.exists
+  - l_ca_serial_exists.stat.exists | bool
   register: l_ca_serial_number
 
 ######################################################################
@@ -16,20 +16,20 @@
   debug:
     msg: "{{ l_ca_serial_number }}"
   when:
-    - l_ca_serial_number is defined
+  - l_ca_serial_exists.stat.exists | bool
 
 - name: Record the value of the ca serial number
   set_fact:
     ca_serial_number: "{{ l_ca_serial_number.content | b64decode | int(base=16) }}"
   when:
-    - l_ca_serial_number is defined
+  - l_ca_serial_exists.stat.exists | bool
 
 # The ca.serial.txt file does not exist on this master
 - name: Record the empty value of the ca serial number
   set_fact:
     ca_serial_number: "{{ None }}"
   when:
-    - not l_ca_serial_number is defined
+  - not l_ca_serial_exists.stat.exists | bool
 
 ######################################################################
 - debug:

--- a/roles/openshift_handlers/README.md
+++ b/roles/openshift_handlers/README.md
@@ -1,5 +1,4 @@
-# OpenShift CA Handlers
+# OpenShift Handlers
 
 A role to *handle* various tasks related to certificate management in
 openshift.
-

--- a/roles/openshift_handlers/README.md
+++ b/roles/openshift_handlers/README.md
@@ -1,0 +1,5 @@
+# OpenShift CA Handlers
+
+A role to *handle* various tasks related to certificate management in
+openshift.
+

--- a/roles/openshift_handlers/handlers/main.yml
+++ b/roles/openshift_handlers/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Syncronize ca.serial.txt
+  debug:
+    # Probably will require some vars like masters_to_sync (which will
+    # be a new variable)
+    msg: Task that syncs the ca.serial.txt from openshift_ca_host to other masters

--- a/roles/openshift_handlers/meta/main.yml
+++ b/roles/openshift_handlers/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: Tim Bielawa
+  description: OpenShift CA Handlers
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 2.3
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+  - system
+dependencies: []

--- a/roles/openshift_hosted/meta/main.yml
+++ b/roles/openshift_hosted/meta/main.yml
@@ -16,3 +16,4 @@ dependencies:
 - role: openshift_hosted_facts
 - role: lib_openshift
 - role: lib_os_firewall
+- role: openshift_ca_facts

--- a/roles/openshift_hosted/tasks/registry/secure.yml
+++ b/roles/openshift_hosted/tasks/registry/secure.yml
@@ -46,7 +46,7 @@
   register: l_registry_self_cert_created
   when: docker_registry_self_signed
 
-- name: TODO: Call certificate sync handler
+- name: TODO - Call certificate sync handler
   debug:
     msg: We just created a cert for a master, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
   when: not l_registry_self_cert_created.skipped | default(false) | bool

--- a/roles/openshift_hosted/tasks/registry/secure.yml
+++ b/roles/openshift_hosted/tasks/registry/secure.yml
@@ -43,8 +43,13 @@
     cert: "{{ docker_registry_cert_path }}"
     key: "{{ docker_registry_key_path }}"
     expire_days: "{{ openshift_hosted_registry_cert_expire_days if openshift_version | oo_version_gte_3_5_or_1_5(openshift.common.deployment_type) | bool else omit }}"
-  register: registry_self_cert
+  register: l_registry_self_cert_created
   when: docker_registry_self_signed
+
+- name: TODO: Call certificate sync handler
+  debug:
+    msg: We just created a cert for a master, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
+  when: not l_registry_self_cert_created.skipped | default(false) | bool
 
 # Setting up REGISTRY_HTTP_TLS_CLIENTCAS as the cacert doesn't seem to work.
 # If we need to set up a cacert, bundle it with the cert.

--- a/roles/openshift_hosted/tasks/router/router.yml
+++ b/roles/openshift_hosted/tasks/router/router.yml
@@ -41,6 +41,12 @@
       cert: "{{ ('/etc/origin/master/' ~ (item.certificate.certfile | basename)) if 'certfile' in item.certificate else ((openshift_master_config_dir) ~ '/openshift-router.crt') }}"
       key: "{{ ('/etc/origin/master/' ~ (item.certificate.keyfile | basename)) if 'keyfile' in item.certificate else ((openshift_master_config_dir) ~ '/openshift-router.key') }}"
     with_items: "{{ openshift_hosted_routers }}"
+    register: l_router_cert_created
+
+  - name: TODO: Call certificate sync handler
+    debug:
+      msg: We just created a cert for a router, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
+    when: not l_router_cert_created.skipped
 
   - name: set the openshift_hosted_router_certificate
     set_fact:
@@ -48,6 +54,7 @@
         certfile: "{{ openshift_master_config_dir ~ '/openshift-router.crt' }}"
         keyfile: "{{ openshift_master_config_dir ~ '/openshift-router.key' }}"
         cafile: "{{ openshift_master_config_dir ~ '/ca.crt' }}"
+
 
   # End Block
   when: ( openshift_hosted_router_create_certificate | bool ) and openshift_hosted_router_certificate == {}

--- a/roles/openshift_hosted/tasks/router/router.yml
+++ b/roles/openshift_hosted/tasks/router/router.yml
@@ -43,7 +43,7 @@
     with_items: "{{ openshift_hosted_routers }}"
     register: l_router_cert_created
 
-  - name: TODO: Call certificate sync handler
+  - name: TODO - Call certificate sync handler
     debug:
       msg: We just created a cert for a router, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
     when: not l_router_cert_created.skipped

--- a/roles/openshift_hosted/tasks/router/router.yml
+++ b/roles/openshift_hosted/tasks/router/router.yml
@@ -46,7 +46,7 @@
   - name: TODO - Call certificate sync handler
     debug:
       msg: We just created a cert for a router, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
-    when: not l_router_cert_created.skipped
+    when: not l_router_cert_created.skipped | default(false) | bool
 
   - name: set the openshift_hosted_router_certificate
     set_fact:

--- a/roles/openshift_logging/meta/main.yaml
+++ b/roles/openshift_logging/meta/main.yaml
@@ -14,3 +14,4 @@ galaxy_info:
 dependencies:
 - role: lib_openshift
 - role: openshift_facts
+- role: openshift_ca_facts

--- a/roles/openshift_logging/tasks/generate_certs.yaml
+++ b/roles/openshift_logging/tasks/generate_certs.yaml
@@ -21,10 +21,16 @@
     --key={{generated_certs_dir}}/ca.key --cert={{generated_certs_dir}}/ca.crt
     --serial={{generated_certs_dir}}/ca.serial.txt --name=logging-signer-test
   check_mode: no
+  register: l_logging_cert_created
   when:
     - not ca_key_file.stat.exists
     - not ca_cert_file.stat.exists
     - not ca_serial_file.stat.exists
+
+- name: TODO: Call certificate sync handler
+  debug:
+    msg: We just created a cert for logging, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
+  when: not l_logging_cert_created.skipped
 
 - name: Checking for signing.conf
   stat: path="{{generated_certs_dir}}/signing.conf"

--- a/roles/openshift_logging/tasks/generate_certs.yaml
+++ b/roles/openshift_logging/tasks/generate_certs.yaml
@@ -27,7 +27,7 @@
     - not ca_cert_file.stat.exists
     - not ca_serial_file.stat.exists
 
-- name: TODO: Call certificate sync handler
+- name: TODO - Call certificate sync handler
   debug:
     msg: We just created a cert for logging, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
   when: not l_logging_cert_created.skipped

--- a/roles/openshift_logging/tasks/generate_certs.yaml
+++ b/roles/openshift_logging/tasks/generate_certs.yaml
@@ -30,7 +30,7 @@
 - name: TODO - Call certificate sync handler
   debug:
     msg: We just created a cert for logging, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
-  when: not l_logging_cert_created.skipped
+  when: not l_logging_cert_created.skipped | default(false) | bool
 
 - name: Checking for signing.conf
   stat: path="{{generated_certs_dir}}/signing.conf"

--- a/roles/openshift_master_certificates/meta/main.yml
+++ b/roles/openshift_master_certificates/meta/main.yml
@@ -15,4 +15,3 @@ galaxy_info:
 dependencies:
 - role: openshift_master_facts
 - role: openshift_ca
-- role: openshift_ca_facts

--- a/roles/openshift_master_certificates/meta/main.yml
+++ b/roles/openshift_master_certificates/meta/main.yml
@@ -15,3 +15,4 @@ galaxy_info:
 dependencies:
 - role: openshift_master_facts
 - role: openshift_ca
+- role: openshift_ca_facts

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -69,7 +69,13 @@
                   | oo_select_keys(groups['oo_masters_to_config'])
                   | oo_collect(attribute='inventory_hostname', filters={'master_certs_missing':True}) }}"
   delegate_to: "{{ openshift_ca_host }}"
+  register: l_master_cert_created
   run_once: true
+
+- name: TODO: Call certificate sync handler
+  debug:
+    msg: We just created a cert for a master, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
+  when: not l_master_cert_created.skipped
 
 - name: Generate the loopback master client config
   command: >

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -72,7 +72,7 @@
   register: l_master_cert_created
   run_once: true
 
-- name: TODO: Call certificate sync handler
+- name: TODO - Call certificate sync handler
   debug:
     msg: We just created a cert for a master, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
   when: not l_master_cert_created.skipped

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -75,7 +75,7 @@
 - name: TODO - Call certificate sync handler
   debug:
     msg: We just created a cert for a master, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
-  when: not l_master_cert_created.skipped
+  when: not l_master_cert_created.skipped | default(false) | bool
 
 - name: Generate the loopback master client config
   command: >

--- a/roles/openshift_metrics/meta/main.yaml
+++ b/roles/openshift_metrics/meta/main.yaml
@@ -15,5 +15,6 @@ galaxy_info:
   categories:
   - openshift
 dependencies:
-- { role: lib_openshift }
-- { role: openshift_facts }
+- role: lib_openshift
+- role: openshift_facts
+- role: openshift_ca_facts

--- a/roles/openshift_metrics/tasks/generate_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_certificates.yaml
@@ -8,4 +8,8 @@
     --serial='{{ mktemp.stdout }}/ca.serial.txt'
     --name="metrics-signer@{{lookup('pipe','date +%s')}}"
 
+- name: TODO: Call certificate sync handler
+  debug:
+    msg: We just created a cert for metrics, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
+
 - include: generate_hawkular_certificates.yaml

--- a/roles/openshift_node_certificates/meta/main.yml
+++ b/roles/openshift_node_certificates/meta/main.yml
@@ -14,3 +14,4 @@ galaxy_info:
   - system
 dependencies:
 - role: openshift_facts
+- role: openshift_ca_facts

--- a/roles/openshift_node_certificates/tasks/main.yml
+++ b/roles/openshift_node_certificates/tasks/main.yml
@@ -95,8 +95,14 @@
   with_items: "{{ hostvars
                   | oo_select_keys(groups['oo_nodes_to_config'])
                   | oo_collect(attribute='inventory_hostname', filters={'node_certs_missing':True}) }}"
+  register: l_node_cert_created
   delegate_to: "{{ openshift_ca_host }}"
   run_once: true
+
+- name: TODO: Call certificate sync handler
+  debug:
+    msg: We just created a cert for a node, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
+  when: not l_node_cert_created.skipped
 
 - name: Create local temp directory for syncing certs
   local_action: command mktemp -d /tmp/openshift-ansible-XXXXXXX

--- a/roles/openshift_node_certificates/tasks/main.yml
+++ b/roles/openshift_node_certificates/tasks/main.yml
@@ -102,7 +102,7 @@
 - name: TODO - Call certificate sync handler
   debug:
     msg: We just created a cert for a node, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
-  when: not l_node_cert_created.skipped
+  when: not l_node_cert_created.skipped | default(false) | bool
 
 - name: Create local temp directory for syncing certs
   local_action: command mktemp -d /tmp/openshift-ansible-XXXXXXX

--- a/roles/openshift_node_certificates/tasks/main.yml
+++ b/roles/openshift_node_certificates/tasks/main.yml
@@ -99,7 +99,7 @@
   delegate_to: "{{ openshift_ca_host }}"
   run_once: true
 
-- name: TODO: Call certificate sync handler
+- name: TODO - Call certificate sync handler
   debug:
     msg: We just created a cert for a node, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
   when: not l_node_cert_created.skipped

--- a/roles/openshift_service_catalog/meta/main.yml
+++ b/roles/openshift_service_catalog/meta/main.yml
@@ -15,3 +15,4 @@ dependencies:
 - role: lib_openshift
 - role: openshift_facts
 - role: lib_utils
+- role: openshift_ca_facts

--- a/roles/openshift_service_catalog/tasks/generate_certs.yml
+++ b/roles/openshift_service_catalog/tasks/generate_certs.yml
@@ -29,8 +29,7 @@
 - name: TODO - Call certificate sync handler
   debug:
     msg: We just created a cert for the service catalog, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
-  when: not l_service_catalog_cert_created.skipped
-
+  when: not l_service_catalog_cert_created.skipped | default(false) | bool
 
 - name: Create apiserver-ssl secret
   oc_secret:

--- a/roles/openshift_service_catalog/tasks/generate_certs.yml
+++ b/roles/openshift_service_catalog/tasks/generate_certs.yml
@@ -24,6 +24,13 @@
     signer_cert: "{{ generated_certs_dir }}/ca.crt"
     signer_key: "{{ generated_certs_dir }}/ca.key"
     signer_serial: "{{ generated_certs_dir }}/apiserver.serial.txt"
+  register: l_service_catalog_cert_created
+
+- name: TODO: Call certificate sync handler
+  debug:
+    msg: We just created a cert for the service catalog, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
+  when: not l_service_catalog_cert_created.skipped
+
 
 - name: Create apiserver-ssl secret
   oc_secret:

--- a/roles/openshift_service_catalog/tasks/generate_certs.yml
+++ b/roles/openshift_service_catalog/tasks/generate_certs.yml
@@ -26,7 +26,7 @@
     signer_serial: "{{ generated_certs_dir }}/apiserver.serial.txt"
   register: l_service_catalog_cert_created
 
-- name: TODO: Call certificate sync handler
+- name: TODO - Call certificate sync handler
   debug:
     msg: We just created a cert for the service catalog, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
   when: not l_service_catalog_cert_created.skipped

--- a/roles/openshift_service_catalog/tasks/wire_aggregator.yml
+++ b/roles/openshift_service_catalog/tasks/wire_aggregator.yml
@@ -32,7 +32,7 @@
   - not first_proxy_ca_crt.stat.exists
   - not first_proxy_ca_key.stat.exists
 
-- name: TODO: Call certificate sync handler
+- name: TODO - Call certificate sync handler
   debug:
     msg: We just created a cert for the master aggregator, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
   when: not l_master_aggregator_cert_created.skipped

--- a/roles/openshift_service_catalog/tasks/wire_aggregator.yml
+++ b/roles/openshift_service_catalog/tasks/wire_aggregator.yml
@@ -35,7 +35,7 @@
 - name: TODO - Call certificate sync handler
   debug:
     msg: We just created a cert for the master aggregator, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
-  when: not l_master_aggregator_cert_created.skipped
+  when: not l_master_aggregator_cert_created.skipped | default(false) | bool
 
 - name: Check for Aggregator Signer cert
   stat:

--- a/roles/openshift_service_catalog/tasks/wire_aggregator.yml
+++ b/roles/openshift_service_catalog/tasks/wire_aggregator.yml
@@ -27,9 +27,15 @@
     --key=/etc/origin/master/front-proxy-ca.key
     --serial=/etc/origin/master/ca.serial.txt
   delegate_to: "{{ first_master }}"
+  register: l_master_aggregator_cert_created
   when:
   - not first_proxy_ca_crt.stat.exists
   - not first_proxy_ca_key.stat.exists
+
+- name: TODO: Call certificate sync handler
+  debug:
+    msg: We just created a cert for the master aggregator, need to ensure serial file is synced. Delegate to openshift_ca_host, of course
+  when: not l_master_aggregator_cert_created.skipped
 
 - name: Check for Aggregator Signer cert
   stat:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1469358

```
/etc/origin/master/ca.serial.txt is only on the origin first master. When the first master
is broken or the sequence of masters is changed in inventory file, the node_certificates
may fail for there isn't /etc/origin/master/ca.serial.txt on the other masters.
```

work in progress