### PR TITLE
Use openshift.node.dns_ip as listening address

### DIFF
--- a/roles/openshift_node_dnsmasq/templates/origin-dns.conf.j2
+++ b/roles/openshift_node_dnsmasq/templates/origin-dns.conf.j2
@@ -4,4 +4,4 @@ no-negcache
 max-cache-ttl=1
 enable-dbus
 bind-interfaces
-listen-address={{ ansible_default_ipv4.address }}
+listen-address={{ openshift.node.dns_ip }}


### PR DESCRIPTION
If someone has specified openshift_dns_ip address then we should use that when configuring dnsmasq so that it aligns with the dnsIP in the config file.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1481366