### PR TITLE
Setup tuned profiles in /etc/tuned

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -70,25 +70,15 @@
     - openshift_disable_swap | default(true) | bool
 # End Disable Swap Block
 
-# We have to add tuned-profiles in the same transaction otherwise we run into depsolving
-# problems because the rpms don't pin the version properly. This was fixed in 3.1 packaging.
 - name: Install Node package
   package:
-    name: "{{ openshift.common.service_type }}-node{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }},tuned-profiles-{{ openshift.common.service_type }}-node{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
+    name: "{{ openshift.common.service_type }}-node{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
     state: present
   when: not openshift.common.is_containerized | bool
 
-- name: Check for tuned package
-  command: rpm -q tuned
-  args:
-    warn: no
-  register: tuned_installed
-  changed_when: false
-  failed_when: false
-
-- name: Set atomic-guest tuned profile
-  command: "tuned-adm profile atomic-guest"
-  when: tuned_installed.rc == 0 and openshift.common.is_atomic | bool
+- name: setup tuned
+  include: tuned.yml
+  static: yes
 
 - name: Install sdn-ovs package
   package:

--- a/roles/openshift_node/tasks/tuned.yml
+++ b/roles/openshift_node/tasks/tuned.yml
@@ -1,0 +1,41 @@
+---
+- name: Check for tuned package
+  command: rpm -q tuned
+  args:
+    warn: no
+  register: tuned_installed
+  changed_when: false
+  failed_when: false
+
+- name: Tuned service setup
+  block:
+  - name: Set tuned OpenShift variables
+    set_fact:
+      openshift_tuned_guest_profile: "{{ 'atomic-guest' if openshift.common.is_atomic else 'virtual-guest' }}"
+      tuned_etc_directory: '/etc/tuned'
+      tuned_templates_source: '../templates/tuned'
+
+  - name: Ensure directory structure exists
+    file:
+      state: directory
+      dest: '{{ tuned_etc_directory }}/{{ item.path }}'
+    with_filetree: '{{ tuned_templates_source }}'
+    when: item.state == 'directory'
+
+  - name: Ensure files are populated from templates
+    template:
+      src: '{{ item.src }}'
+      dest: '{{ tuned_etc_directory }}/{{ item.path }}'
+    with_filetree: '{{ tuned_templates_source }}'
+    when: item.state == 'file'
+
+  - name: Make tuned use the recommended tuned profile on restart
+    file: path=/etc/tuned/active_profile state=absent
+
+  - name: Restart tuned service
+    systemd:
+      state: restarted
+      daemon_reload: yes
+      name: tuned
+
+  when: tuned_installed.rc == 0 | bool


### PR DESCRIPTION
This PR is to instantiate the new tuned profile hierarchy outlined in https://github.com/openshift/openshift-ansible/pull/5054.  