### PR TITLE
bug: container_binary_sync no longer moves upon symlinks

### DIFF
--- a/roles/openshift_cli/library/openshift_container_binary_sync.py
+++ b/roles/openshift_cli/library/openshift_container_binary_sync.py
@@ -102,6 +102,11 @@ class BinarySyncer(object):
         dest_path = os.path.join(self.bin_dir, binary_name)
         incoming_checksum = self.module.run_command(['sha256sum', src_path])[1]
         if not os.path.exists(dest_path) or self.module.run_command(['sha256sum', dest_path])[1] != incoming_checksum:
+
+            # See: https://github.com/openshift/openshift-ansible/issues/4965
+            if os.path.islink(dest_path):
+                os.unlink(dest_path)
+                self.output.append('Removed old symlink {} before copying binary.'.format(dest_path))
             shutil.move(src_path, dest_path)
             self.output.append("Moved %s to %s." % (src_path, dest_path))
             self.changed = True


### PR DESCRIPTION
Backport of https://github.com/openshift/openshift-ansible/pull/5098

With origin 1.5, /usr/local/bin/oc was a symlink to
/usr/local/bin/openshift. During the container_binary_sync updated
versions of both binaries are copied to the host. First openshift is
copied to /usr/local/bin/openshift followed by copying oc to
/usr/local/bin/oc. Since oc is a symlink back to
/usr/local/bin/openshift the end result was everything linked to oc.

This change adds a check before copying a binary. If the destination is
a symlink then said symlink is removed before copying the new binary
over.

Fixed #4965

Reference: https://github.com/openshift/openshift-ansible/issues/4965