### PR TITLE
Add hostname/nodename length check

### DIFF
--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -40,8 +40,8 @@
   when: openshift_use_calico | default(false) | bool and openshift_use_contiv | default(false) | bool
 
 - fail:
-    msg: openshift_hostname must be 64 characters or less
-  when: openshift_hostname is defined and openshift_hostname | length > 64
+    msg: openshift_hostname must be 63 characters or less
+  when: openshift_hostname is defined and openshift_hostname | length > 63
 
 - name: Set common Cluster facts
   openshift_facts:

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -193,7 +193,9 @@ def hostname_valid(hostname):
     """
     if (not hostname or
             hostname.startswith('localhost') or
-            hostname.endswith('localdomain')):
+            hostname.endswith('localdomain') or
+            # OpenShift will not allow a node with more than 63 chars in name.
+            len(hostname) > 63):
         return False
 
     return True


### PR DESCRIPTION
OpenShift will not allow nodes to register if the nodename is > 63 chars.
This commit verifies that nodename is not set to a potential hostname
that is greater than 63 characters.  This commit also updates logic
to check `openshift_hostname` to check for > 63 chars.