### PR TITLE
only evaluate openshift_cfme_nfs_server if using nfs

### DIFF
--- a/roles/openshift_cfme/defaults/main.yml
+++ b/roles/openshift_cfme/defaults/main.yml
@@ -27,9 +27,6 @@ openshift_cfme_pv_data:
 
 # Tuning parameter to use more than 5 images at once from an ImageStream
 openshift_cfme_maxImagesBulkImportedPerRepository: 100
-# Hostname/IP of the NFS server. Currently defaults to first master
-openshift_cfme_nfs_server: "{{ groups.nfs.0 }}"
-openshift_cfme_nfs_directory: "/exports"
 # TODO: Refactor '_install_app' variable. This is just for testing but
 # maybe in the future it should control the entire yes/no for CFME.
 #

--- a/roles/openshift_cfme/tasks/nfs.yml
+++ b/roles/openshift_cfme/tasks/nfs.yml
@@ -1,6 +1,13 @@
 ---
 # Tasks to statically provision NFS volumes
 # Include if not using dynamic volume provisioning
+
+- name: Set openshift_cfme_nfs_server fact
+  when: openshift_cfme_nfs_server is not defined
+  set_fact:
+    # Hostname/IP of the NFS server. Currently defaults to first master
+    openshift_cfme_nfs_server: "{{ oo_nfs_to_config.0 }}"
+
 - name: Ensure the /exports/ directory exists
   file:
     path: /exports/


### PR DESCRIPTION
Currently if no nfs groups are defined, `openshift_cfme_nfs_server` is being evaluated in openshift-cfme role's `defaults.yml`

This variable is not needed if we are not using NFS for deployment, and can cause error if the host's inventory file does not contain an `nfs` hosts section.

This change modifies `openshift_cfme_nfs_server` to be set via `set_fact` rather than as a  default variable, running only as a part of the `nfs.yml` tasks (and onyl when `openshift_cfme_nfs_server` has not been set by the user)