### PR TITLE
[release-3.6] openshift_checks: allow OVS 2.7 on OCP 3.5 and 3.6

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/ovs_version.py
+++ b/roles/openshift_health_checker/openshift_checks/ovs_version.py
@@ -16,8 +16,8 @@ class OvsVersion(NotContainerizedMixin, OpenShiftCheck):
     tags = ["health"]
 
     openshift_to_ovs_version = {
-        "3.6": "2.6",
-        "3.5": "2.6",
+        "3.6": ["2.6", "2.7"],
+        "3.5": ["2.6", "2.7"],
         "3.4": "2.4",
     }
 

--- a/roles/openshift_health_checker/test/ovs_version_test.py
+++ b/roles/openshift_health_checker/test/ovs_version_test.py
@@ -38,8 +38,8 @@ def test_invalid_openshift_release_format():
 
 
 @pytest.mark.parametrize('openshift_release,expected_ovs_version', [
-    ("3.5", "2.6"),
-    ("3.6", "2.6"),
+    ("3.5", ["2.6", "2.7"]),
+    ("3.6", ["2.6", "2.7"]),
     ("3.4", "2.4"),
     ("3.3", "2.4"),
     ("1.0", "2.4"),

--- a/roles/openshift_health_checker/test/rpm_version_test.py
+++ b/roles/openshift_health_checker/test/rpm_version_test.py
@@ -49,7 +49,7 @@ def test_check_pkg_found(pkgs, expect_not_found):
         },
         {
             "eggs": {
-                "required_version": "3.2",
+                "required_versions": ["3.2"],
                 "found_versions": ["3.3"],
             }
         },  # not the right version
@@ -61,11 +61,11 @@ def test_check_pkg_found(pkgs, expect_not_found):
         },
         {
             "eggs": {
-                "required_version": "3.2",
+                "required_versions": ["3.2"],
                 "found_versions": ["3.3", "1.2"],
             },
             "spam": {
-                "required_version": "3.2",
+                "required_versions": ["3.2"],
                 "found_versions": ["3.1", "3.3"],
             }
         },  # not the right version


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/openshift-ansible/pull/5036
Fixes bug https://bugzilla.redhat.com/show_bug.cgi?id=1481721

rpm_version: Allow package_list items to specify a list value for version.
If a list value is provided for a package, pass the check if any version in
that list is found.

ovs_version: Specify both 2.6 and 2.7 as allowed versions of OVS for
OpenShift versions 3.5 and 3.6.