### PR TITLE
Use sdn_cluster_network_cidr as default calico pool

### DIFF
--- a/roles/calico/README.md
+++ b/roles/calico/README.md
@@ -32,7 +32,6 @@ Additional parameters that can be defined in the inventory are:
 
 | Environment | Description | Schema | Default |   
 |---------|----------------------|---------|---------|
-|CALICO_IPV4POOL_CIDR|	The IPv4 Pool to create if none exists at start up. It is invalid to define this variable and NO_DEFAULT_POOLS.	|IPv4 CIDR	| 192.168.0.0/16 |
 | CALICO_IPV4POOL_IPIP | IPIP Mode to use for the IPv4 POOL created at start up.	| off, always, cross-subnet	| always |
 | CALICO_LOG_DIR | Directory on the host machine where Calico Logs are written.| String	| /var/log/calico |
 

--- a/roles/calico/defaults/main.yaml
+++ b/roles/calico/defaults/main.yaml
@@ -9,7 +9,6 @@ calico_url_cni: "https://github.com/projectcalico/cni-plugin/releases/download/v
 calico_url_ipam: "https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico-ipam"
 
 calico_ipv4pool_ipip: "always"
-calico_ipv4pool_cidr: "192.168.0.0/16"
 
 calico_log_dir: "/var/log/calico"
 calico_node_image: "calico/node:v2.4.1"

--- a/roles/calico/meta/main.yml
+++ b/roles/calico/meta/main.yml
@@ -14,3 +14,4 @@ galaxy_info:
   - system
 dependencies:
 - role: openshift_facts
+- role: openshift_master_facts

--- a/roles/calico/templates/calico.service.j2
+++ b/roles/calico/templates/calico.service.j2
@@ -11,13 +11,14 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
  -e WAIT_FOR_DATASTORE=true \
  -e FELIX_DEFAULTENDPOINTTOHOSTACTION=ACCEPT \
  -e CALICO_IPV4POOL_IPIP={{ calico_ipv4pool_ipip }} \
- -e CALICO_IPV4POOL_CIDR={{ calico_ipv4pool_cidr }} \
+ -e CALICO_IPV4POOL_CIDR={{ openshift.master.sdn_cluster_network_cidr }} \
  -e FELIX_IPV6SUPPORT=false \
  -e ETCD_ENDPOINTS={{ calico_etcd_endpoints }} \
  -v {{ calico_etcd_cert_dir }}:{{ calico_etcd_cert_dir }}  \
  -e ETCD_CA_CERT_FILE={{ calico_etcd_ca_cert_file }} \
  -e ETCD_CERT_FILE={{ calico_etcd_cert_file }} \
  -e ETCD_KEY_FILE={{ calico_etcd_key_file }} \
+ -e CLUSTER_TYPE=origin,bgp \
  -e NODENAME={{ openshift.common.hostname }} \
  -v {{ calico_log_dir }}:/var/log/calico\
  -v /lib/modules:/lib/modules \

--- a/roles/calico_master/README.md
+++ b/roles/calico_master/README.md
@@ -29,7 +29,6 @@ Additional parameters that can be defined in the inventory are:
 
 | Environment | Description | Schema | Default |   
 |---------|----------------------|---------|---------|
-|CALICO_IPV4POOL_CIDR|	The IPv4 Pool to create if none exists at start up. It is invalid to define this variable and NO_DEFAULT_POOLS.	|IPv4 CIDR	| 192.168.0.0/16 |
 | CALICO_IPV4POOL_IPIP | IPIP Mode to use for the IPv4 POOL created at start up.	| off, always, cross-subnet	| always |
 | CALICO_LOG_DIR | Directory on the host machine where Calico Logs are written.| String	| /var/log/calico |
 


### PR DESCRIPTION
This PR removes `calico_ipv4pool_cidr` and uses the value of `osm_cluster_network_cidr` (which is actually stored as `openshift.master.sdn_cluster_network_cidr`) as the default pool for Calico.

Without this PR, the Calico pool and cluster-cidr can easily be mismatched, which causes some unexpected behavior with service IPs & kube-proxy.

This PR is follow up from @sdodson 's comment: https://github.com/openshift/openshift-ansible/pull/5037#discussion_r132076206 . His point was true - I confirmed that `osm_cluster_network_cidr` is undefined in ansible if undefined in inventory. I found that `openshift.master.sdn_cluster_network_cidr` does however have the correct value.