### PR TITLE
logging set memory request to limit

### DIFF
--- a/roles/openshift_logging_curator/templates/curator.j2
+++ b/roles/openshift_logging_curator/templates/curator.j2
@@ -44,6 +44,8 @@ spec:
               cpu: "{{curator_cpu_limit}}"
 {% if curator_memory_limit is defined and curator_memory_limit is not none and curator_memory_limit != "" %}
               memory: "{{curator_memory_limit}}"
+            requests:
+              memory: "{{curator_memory_limit}}"
 {% endif %}
           env:
             -

--- a/roles/openshift_logging_elasticsearch/templates/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/es.j2
@@ -48,7 +48,7 @@ spec:
               cpu: "{{es_cpu_limit}}"
 {% endif %}
             requests:
-              memory: "512Mi"
+              memory: "{{es_memory_limit}}"
           ports:
             -
               containerPort: 9200

--- a/roles/openshift_logging_fluentd/templates/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/fluentd.j2
@@ -36,6 +36,8 @@ spec:
           limits:
             cpu: {{ openshift_logging_fluentd_cpu_limit }}
             memory: {{ openshift_logging_fluentd_memory_limit }}
+          requests:
+            memory: {{ openshift_logging_fluentd_memory_limit }}
         volumeMounts:
         - name: runlogjournal
           mountPath: /run/log/journal

--- a/roles/openshift_logging_kibana/templates/kibana.j2
+++ b/roles/openshift_logging_kibana/templates/kibana.j2
@@ -46,6 +46,8 @@ spec:
 {% endif %}
 {% if kibana_memory_limit is not none and kibana_memory_limit != "" %}
               memory: "{{ kibana_memory_limit }}"
+            requests:
+              memory: "{{ kibana_memory_limit }}"
 {% endif %}
 {% endif %}
           env:
@@ -81,6 +83,8 @@ spec:
               cpu: "{{ kibana_proxy_cpu_limit }}"
 {% endif %}
 {% if kibana_proxy_memory_limit is not none and kibana_proxy_memory_limit != "" %}
+              memory: "{{ kibana_proxy_memory_limit }}"
+            requests:
               memory: "{{ kibana_proxy_memory_limit }}"
 {% endif %}
 {% endif %}

--- a/roles/openshift_logging_mux/templates/mux.j2
+++ b/roles/openshift_logging_mux/templates/mux.j2
@@ -45,6 +45,8 @@ spec:
 {% endif %}
 {% if mux_memory_limit is not none %}
             memory: "{{mux_memory_limit}}"
+          requests:
+            memory: "{{mux_memory_limit}}"
 {% endif %}
 {% endif %}
         ports:


### PR DESCRIPTION
Per conversation with @portante this PR sets the requests to the limit for memory of logging components so they do not get OOM killed.