### PR TITLE
Allow GCS object storage to be configured

### DIFF
--- a/roles/openshift_hosted/tasks/registry/storage/object_storage.yml
+++ b/roles/openshift_hosted/tasks/registry/storage/object_storage.yml
@@ -2,7 +2,7 @@
 - include: s3.yml
   when: openshift.hosted.registry.storage.provider == 's3'
 
-- name: Ensure the resgistry secret exists
+- name: Ensure the registry secret exists
   oc_secret:
     name: "{{ registry_config_secret_name }}"
     state: present
@@ -10,6 +10,19 @@
     - path: /tmp/config.yml
       data: "{{ lookup('template', 'registry_config.j2') }}"
   register: registry_config_out
+  when: openshift_hosted_registry_storage_gcs_keyfile is not defined
+
+- name: Ensure the registry secret exists for GCS
+  oc_secret:
+    name: "{{ registry_config_secret_name }}"
+    state: present
+    contents:
+    - path: /tmp/config.yml
+      data: "{{ lookup('template', 'registry_config.j2') }}"
+    - path: /tmp/gcs.json
+      data: "{{ lookup('file', openshift_hosted_registry_storage_gcs_keyfile) | string }}"
+  register: registry_config_out
+  when: openshift_hosted_registry_storage_gcs_keyfile is defined
 
 - name: Add secrets to registry service account
   oc_serviceaccount_secret:

--- a/roles/openshift_hosted/tasks/registry/storage/registry_config_secret.j2
+++ b/roles/openshift_hosted/tasks/registry/storage/registry_config_secret.j2
@@ -1,1 +1,0 @@
-../../../templates/registry_config_secret.j2

--- a/roles/openshift_hosted/templates/registry_config.j2
+++ b/roles/openshift_hosted/templates/registry_config.j2
@@ -60,7 +60,7 @@ storage:
   gcs:
     bucket: {{ openshift_hosted_registry_storage_gcs_bucket }}
 {%   if openshift_hosted_registry_storage_gcs_keyfile is defined %}
-    keyfile: {{ openshift_hosted_registry_storage_gcs_keyfile }}
+    keyfile: /etc/registry/gcs.json
 {%   endif -%}
 {%   if openshift_hosted_registry_storage_gcs_rootdirectory is defined %}
     rootdirectory: {{ openshift_hosted_registry_storage_gcs_rootdirectory }}

--- a/roles/openshift_hosted/templates/registry_config_secret.j2
+++ b/roles/openshift_hosted/templates/registry_config_secret.j2
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: registry-config
-  annotations:
-    provider: {{ openshift.hosted.registry.storage.provider }}
-data:
-  config.yml: {{ registry_config }}


### PR DESCRIPTION
Previously, setting the GCS registry object storage settings resulted in
an invalid configuration. This generates a registry-config secret that
has the correct file if the GCS config is set.