### PR TITLE
[3.6] Fail within scaleup playbooks when new_{nodes,masters} host groups are empty.

### DIFF
--- a/playbooks/byo/openshift-master/scaleup.yml
+++ b/playbooks/byo/openshift-master/scaleup.yml
@@ -1,6 +1,20 @@
 ---
 - include: ../openshift-cluster/initialize_groups.yml
 
+- name: Ensure there are new_masters
+  hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tasks:
+  - fail:
+      msg: >
+        Detected no new_masters or no new_nodes in inventory. Please
+        add hosts to the new_masters and new_nodes host groups to add
+        masters.
+    when:
+    - (g_new_master_hosts | default([]) | length == 0) or (g_new_node_hosts | default([]) | length == 0)
+
 - include: ../../common/openshift-master/scaleup.yml
   vars:
     openshift_cluster_id: "{{ cluster_id | default('default') }}"

--- a/playbooks/byo/openshift-node/scaleup.yml
+++ b/playbooks/byo/openshift-node/scaleup.yml
@@ -1,6 +1,19 @@
 ---
 - include: ../openshift-cluster/initialize_groups.yml
 
+- name: Ensure there are new_nodes
+  hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tasks:
+  - fail:
+      msg: >
+        Detected no new_nodes in inventory. Please add hosts to the
+        new_nodes host group to add nodes.
+    when:
+    - g_new_node_hosts | default([]) | length == 0
+
 - include: ../../common/openshift-node/scaleup.yml
   vars:
     openshift_cluster_id: "{{ cluster_id | default('default') }}"


### PR DESCRIPTION
Backports #4784