### PR TITLE
bug 1482661. Preserve ES dc nodeSelector and supplementalGroups

### DIFF
--- a/roles/openshift_logging/library/openshift_logging_facts.py
+++ b/roles/openshift_logging/library/openshift_logging_facts.py
@@ -171,12 +171,17 @@ class OpenshiftLoggingFacts(OCBaseCommand):
             if comp is not None:
                 spec = dc_item["spec"]["template"]["spec"]
                 facts = dict(
+                    name=name,
                     selector=dc_item["spec"]["selector"],
                     replicas=dc_item["spec"]["replicas"],
                     serviceAccount=spec["serviceAccount"],
                     containers=dict(),
                     volumes=dict()
                 )
+                if "nodeSelector" in spec:
+                    facts["nodeSelector"] = spec["nodeSelector"]
+                if "supplementalGroups" in spec["securityContext"]:
+                    facts["storageGroups"] = spec["securityContext"]["supplementalGroups"]
                 if "volumes" in spec:
                     for vol in spec["volumes"]:
                         clone = copy.deepcopy(vol)

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -69,7 +69,7 @@
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
-    openshift_logging_elasticsearch_deployment_name: "{{ item.0 }}"
+    openshift_logging_elasticsearch_deployment_name: "{{ item.0.name }}"
     openshift_logging_elasticsearch_pvc_name: "{{ openshift_logging_es_pvc_prefix ~ '-' ~ item.2 if item.1 is none else item.1 }}"
     openshift_logging_elasticsearch_replica_count: "{{ openshift_logging_es_cluster_size | int }}"
 
@@ -77,9 +77,11 @@
     openshift_logging_elasticsearch_pvc_size: "{{ openshift_logging_es_pvc_size }}"
     openshift_logging_elasticsearch_pvc_dynamic: "{{ openshift_logging_es_pvc_dynamic }}"
     openshift_logging_elasticsearch_pvc_pv_selector: "{{ openshift_logging_es_pv_selector }}"
+    openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_nodeselector if item.0.nodeSelector | default(None) is none else item.0.nodeSelector }}"
+    openshift_logging_elasticsearch_storage_group: "{{ [openshift_logging_es_storage_group] if item.0.storageGroups | default([]) | length == 0 else item.0.storageGroups }}"
 
   with_together:
-  - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs }}"
+  - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs.values() }}"
   - "{{ openshift_logging_facts.elasticsearch.pvcs }}"
   - "{{ es_indices }}"
   when:
@@ -123,7 +125,7 @@
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
-    openshift_logging_elasticsearch_deployment_name: "{{ item.0 }}"
+    openshift_logging_elasticsearch_deployment_name: "{{ item.0.name }}"
     openshift_logging_elasticsearch_pvc_name: "{{ openshift_logging_es_ops_pvc_prefix ~ '-' ~ item.2 if item.1 is none else item.1 }}"
     openshift_logging_elasticsearch_ops_deployment: true
     openshift_logging_elasticsearch_replica_count: "{{ openshift_logging_es_ops_cluster_size | int }}"
@@ -134,6 +136,8 @@
     openshift_logging_elasticsearch_pvc_pv_selector: "{{ openshift_logging_es_ops_pv_selector }}"
     openshift_logging_elasticsearch_memory_limit: "{{ openshift_logging_es_ops_memory_limit }}"
     openshift_logging_elasticsearch_cpu_limit: "{{ openshift_logging_es_ops_cpu_limit }}"
+    openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_ops_nodeselector if item.0.nodeSelector | default(None) is none else item.0.nodeSelector }}"
+    openshift_logging_elasticsearch_storage_group: "{{ [openshift_logging_es_ops_storage_group] if item.0.storageGroups | default([]) | length == 0 else item.0.storageGroups }}"
     openshift_logging_es_key: "{{ openshift_logging_es_ops_key }}"
     openshift_logging_es_cert: "{{ openshift_logging_es_ops_cert }}"
     openshift_logging_es_ca_ext: "{{ openshift_logging_es_ops_ca_ext }}"
@@ -142,7 +146,7 @@
     openshift_logging_es_allow_external: "{{ openshift_logging_es_ops_allow_external }}"
 
   with_together:
-  - "{{ openshift_logging_facts.elasticsearch_ops.deploymentconfigs }}"
+  - "{{ openshift_logging_facts.elasticsearch_ops.deploymentconfigs.values() }}"
   - "{{ openshift_logging_facts.elasticsearch_ops.pvcs }}"
   - "{{ es_ops_indices }}"
   when:

--- a/roles/openshift_logging_elasticsearch/defaults/main.yml
+++ b/roles/openshift_logging_elasticsearch/defaults/main.yml
@@ -33,7 +33,7 @@ openshift_logging_elasticsearch_pvc_size: ""
 openshift_logging_elasticsearch_pvc_dynamic: false
 openshift_logging_elasticsearch_pvc_pv_selector: {}
 openshift_logging_elasticsearch_pvc_access_modes: ['ReadWriteOnce']
-openshift_logging_elasticsearch_storage_group: '65534'
+openshift_logging_elasticsearch_storage_group: ['65534']
 
 openshift_logging_es_pvc_prefix: "{{ openshift_hosted_logging_elasticsearch_pvc_prefix | default('logging-es') }}"
 

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -275,6 +275,7 @@
     es_cpu_limit: "{{ openshift_logging_elasticsearch_cpu_limit }}"
     es_memory_limit: "{{ openshift_logging_elasticsearch_memory_limit }}"
     es_node_selector: "{{ openshift_logging_elasticsearch_nodeselector | default({}) }}"
+    es_storage_groups: "{{ openshift_logging_elasticsearch_storage_group | default([]) }}"
     deploy_type: "{{ openshift_logging_elasticsearch_deployment_type }}"
     es_replicas: 1
 

--- a/roles/openshift_logging_elasticsearch/templates/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/es.j2
@@ -29,7 +29,9 @@ spec:
       serviceAccountName: aggregated-logging-elasticsearch
       securityContext:
         supplementalGroups:
-        - {{openshift_logging_elasticsearch_storage_group}}
+{% for group in es_storage_groups %}
+        - {{group}}
+{% endfor %}
 {% if es_node_selector is iterable and es_node_selector | length > 0 %}
       nodeSelector:
 {% for key, value in es_node_selector.iteritems() %}


### PR DESCRIPTION
After discussion with the logging team, we decided preserving nodeSelectors and supplementalGroups is in the same spirit of preserving hostMount volumes if a user made edits.  This PR:

* Preserves ES nodeSelector if found in the facts
* Preserves ES supplementalGroup if found in the facts

@anton similar changes are required in 3.7 but I would ask you to make the necessary changes in the role refactoring you are doing 