### PR TITLE
Add independent registry auth support

### DIFF
--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -170,6 +170,14 @@ openshift_release=v3.6
 # modify image streams to point at that registry by setting the following to true
 #openshift_examples_modify_imagestreams=true
 
+# If oreg_url points to a registry requiring authentication, provide the following:
+#oreg_auth_user=some_user
+#oreg_auth_password='my-pass'
+# NOTE: oreg_url must be defined by the user for oreg_auth_* to have any affect.
+# oreg_auth_pass should be generated from running docker login.
+# To update registry auth credentials, uncomment the following:
+#oreg_auth_credentials_replace: True
+
 # OpenShift repository configuration
 #openshift_additional_repos=[{'id': 'ose-devel', 'name': 'ose-devel', 'baseurl': 'http://example.com/puddle/build/AtomicOpenShift/3.1/latest/RH7-RHOSE-3.0/$basearch/os', 'enabled': 1, 'gpgcheck': 0}]
 #openshift_repos_enable_testing=false

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -19,3 +19,8 @@ r_openshift_master_os_firewall_allow:
 - service: etcd embedded
   port: 4001/tcp
   cond: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
+
+oreg_url: ''
+oreg_host: "{{ oreg_url.split('/')[0] if '.' in oreg_url.split('/')[0] else '' }}"
+oreg_auth_credentials_path: "{{ openshift.common.data_dir }}/.docker"
+oreg_auth_credentials_replace: False

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -232,6 +232,22 @@
   - restart master controllers
   when: openshift_master_bootstrap_enabled | default(False)
 
+- name: Check for credentials file for registry auth
+  stat:
+    path: "{{oreg_auth_credentials_path }}"
+  when:
+  - oreg_auth_user is defined
+  register: master_oreg_auth_credentials_stat
+
+- name: Create credentials for registry auth
+  command: "docker --config={{ oreg_auth_credentials_path }} login -u {{ oreg_auth_user }} -p {{ oreg_auth_password }} {{ oreg_host }}"
+  when:
+  - oreg_auth_user is defined
+  - (not master_oreg_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
+  notify:
+  - restart master api
+  - restart master controllers
+
 - include: set_loopback_context.yml
   when:
   - openshift.common.version_gte_3_2_or_1_2

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -21,3 +21,8 @@ r_openshift_node_os_firewall_allow:
 - service: Kubernetes service NodePort UDP
   port: "{{ openshift_node_port_range | default('') }}/udp"
   cond: "{{ openshift_node_port_range is defined }}"
+
+oreg_url: ''
+oreg_host: "{{ oreg_url.split('/')[0] if '.' in oreg_url.split('/')[0] else '' }}"
+oreg_auth_credentials_path: "{{ openshift.common.data_dir }}/.docker"
+oreg_auth_credentials_replace: False

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -150,6 +150,21 @@
   notify:
     - restart node
 
+- name: Check for credentials file for registry auth
+  stat:
+    path: "{{oreg_auth_credentials_path }}"
+  when:
+    - oreg_auth_user is defined
+  register: node_oreg_auth_credentials_stat
+
+- name: Create credentials for registry auth
+  command: "docker --config={{ oreg_auth_credentials_path }} login -u {{ oreg_auth_user }} -p {{ oreg_auth_password }} {{ oreg_host }}"
+  when:
+    - oreg_auth_user is defined
+    - (not node_oreg_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
+  notify:
+    - restart node
+
 - name: Configure AWS Cloud Provider Settings
   lineinfile:
     dest: /etc/sysconfig/{{ openshift.common.service_type }}-node


### PR DESCRIPTION
Added the ability to support authentication for independent / 3rd party
registries. This commit will allow users to provide a `oreg_auth_user` and
`oreg_auth_password` to dynmically generate a docker config.json file.

The docker config.json file can be used by openshift to authenticate to
independent / 3rd party registries. `oreg_host` must supply endpoint connection
info in the form of 'hostname.com:port', with (optional) port 443 default.

To update the config.json on a later run, the user can specify
`oreg_auth_credentials_replace=False` to update the credentials.

These settings must be used in tandem with `oreg_url`

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1316341