### PR TITLE
Fedora compat fixes for package version checks and dnf bug workaround

### DIFF
--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -1,7 +1,7 @@
 ---
 # TODO: refactor this into its own include
 # and pass a variable for ctx
-- name: Verify Install Requirements
+- name: Verify Requirements
   hosts: oo_all_hosts
   roles:
   - openshift_health_checker

--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -1,14 +1,17 @@
 ---
 # TODO: refactor this into its own include
 # and pass a variable for ctx
-- name: Verify Requirements
+- name: Verify Install Requirements
   hosts: oo_all_hosts
   roles:
   - openshift_health_checker
   vars:
   - r_openshift_health_checker_playbook_context: install
   post_tasks:
-  - action: openshift_health_check
+
+  - name: Verify Requirements - EL
+    when: ansible_distribution != "Fedora"
+    action: openshift_health_check
     args:
       checks:
       - disk_availability
@@ -17,6 +20,12 @@
       - package_version
       - docker_image_availability
       - docker_storage
+  - name: Verify Requirements - Fedora
+    when: ansible_distribution == "Fedora"
+    action: openshift_health_check
+    args:
+      checks:
+      - docker_image_availability
 
 - include: ../openshift-etcd/config.yml
 

--- a/roles/openshift_excluder/tasks/install.yml
+++ b/roles/openshift_excluder/tasks/install.yml
@@ -6,19 +6,46 @@
 
   block:
 
-  - name: Install docker excluder
+  - name: Install docker excluder - yum
     package:
       name: "{{ r_openshift_excluder_service_type }}-docker-excluder{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) +  '*' }}"
       state: "{{ r_openshift_excluder_docker_package_state }}"
     when:
     - r_openshift_excluder_enable_docker_excluder | bool
+    - ansible_pkg_mgr == "yum"
 
-  - name: Install openshift excluder
+
+  # For DNF we do not need the "*" and if we add it, it causes an error because
+  # it's not a valid pkg_spec
+  #
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1199432
+  - name: Install docker excluder - dnf
+    package:
+      name: "{{ r_openshift_excluder_service_type }}-docker-excluder{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
+      state: "{{ r_openshift_excluder_docker_package_state }}"
+    when:
+    - r_openshift_excluder_enable_docker_excluder | bool
+    - ansible_pkg_mgr == "dnf"
+
+  - name: Install openshift excluder - yum
     package:
       name: "{{ r_openshift_excluder_service_type }}-excluder{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) + '*' }}"
       state: "{{ r_openshift_excluder_package_state }}"
     when:
     - r_openshift_excluder_enable_openshift_excluder | bool
+    - ansible_pkg_mgr == "yum"
+
+  # For DNF we do not need the "*" and if we add it, it causes an error because
+  # it's not a valid pkg_spec
+  #
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1199432
+  - name: Install openshift excluder - dnf
+    package:
+      name: "{{ r_openshift_excluder_service_type }}-excluder{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
+      state: "{{ r_openshift_excluder_package_state }}"
+    when:
+    - r_openshift_excluder_enable_openshift_excluder | bool
+    - ansible_pkg_mgr == "dnf"
 
   - set_fact:
       r_openshift_excluder_install_ran: True


### PR DESCRIPTION
Fix a couple things that don't work with Fedora:
- Don't attempt to version check components, they aren't going to match the hard coded RHEL package versions.
- Work around a [bug in dnf](https://bugzilla.redhat.com/show_bug.cgi?id=1199432)'s python API that throws an error when a package spec has a `*` character in the Release field

Once we're done with review, I'll squash commits.