### PR TITLE
Display "origin 3.6" as in previous installer 3.5

### DIFF
--- a/utils/src/ooinstall/variants.py
+++ b/utils/src/ooinstall/variants.py
@@ -61,7 +61,7 @@ LEGACY = Variant('openshift-enterprise', 'OpenShift Container Platform', [
 
 # Ordered list of variants we can install, first is the default.
 SUPPORTED_VARIANTS = (OSE, REG, origin, LEGACY)
-DISPLAY_VARIANTS = (OSE, REG,)
+DISPLAY_VARIANTS = (OSE, REG, origin)
 
 
 def find_variant(name, version=None):


### PR DESCRIPTION
Previous installer release v3.5 used to display the 3 variants.
I keep OSE as the default, but proposes to add back the "origin v3.6" variant, since it is supported anyway