### PR TITLE
Change memory requests and limits units

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -739,9 +739,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_builddefaults_nodeselectors={'nodelabel1':'nodelabelvalue1'}
 #openshift_builddefaults_annotations={'annotationkey1':'annotationvalue1'}
 #openshift_builddefaults_resources_requests_cpu=100m
-#openshift_builddefaults_resources_requests_memory=256m
+#openshift_builddefaults_resources_requests_memory=256Mi
 #openshift_builddefaults_resources_limits_cpu=1000m
-#openshift_builddefaults_resources_limits_memory=512m
+#openshift_builddefaults_resources_limits_memory=512Mi
 
 # Or you may optionally define your own build defaults configuration serialized as json
 #openshift_builddefaults_json='{"BuildDefaults":{"configuration":{"apiVersion":"v1","env":[{"name":"HTTP_PROXY","value":"http://proxy.example.com.redhat.com:3128"},{"name":"NO_PROXY","value":"ose3-master.example.com"}],"gitHTTPProxy":"http://proxy.example.com:3128","gitNoProxy":"ose3-master.example.com","kind":"BuildDefaultsConfig"}}}'

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -739,9 +739,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_builddefaults_nodeselectors={'nodelabel1':'nodelabelvalue1'}
 #openshift_builddefaults_annotations={'annotationkey1':'annotationvalue1'}
 #openshift_builddefaults_resources_requests_cpu=100m
-#openshift_builddefaults_resources_requests_memory=256m
+#openshift_builddefaults_resources_requests_memory=256Mi
 #openshift_builddefaults_resources_limits_cpu=1000m
-#openshift_builddefaults_resources_limits_memory=512m
+#openshift_builddefaults_resources_limits_memory=512Mi
 
 # Or you may optionally define your own build defaults configuration serialized as json
 #openshift_builddefaults_json='{"BuildDefaults":{"configuration":{"apiVersion":"v1","env":[{"name":"HTTP_PROXY","value":"http://proxy.example.com.redhat.com:3128"},{"name":"NO_PROXY","value":"ose3-master.example.com"}],"gitHTTPProxy":"http://proxy.example.com:3128","gitNoProxy":"ose3-master.example.com","kind":"BuildDefaultsConfig"}}}'


### PR DESCRIPTION
Using the example inventory in OCP v3.6 will cause Builds to fail due to an incorrect unit assigned to both requests and limits in memory.

This PR basically changes those units from 'm' to 'Mi' in order to solve this issue.

The following errors can be seen during any build with the existing values:

```docker_sandbox.go:263] NetworkPlugin cni failed on the status hook for pod "xxxxxxxxxx": Unexpected command output nsenter: cannot open : No such file or directory```
 