### PR TITLE
Standardize openshift-checks initialization patterns

### DIFF
--- a/playbooks/byo/openshift-checks/health.yml
+++ b/playbooks/byo/openshift-checks/health.yml
@@ -1,3 +1,6 @@
 ---
 - include: ../openshift-cluster/initialize_groups.yml
+
+- include: ../../common/openshift-cluster/std_include.yml
+
 - include: ../../common/openshift-checks/health.yml

--- a/playbooks/byo/openshift-checks/pre-install.yml
+++ b/playbooks/byo/openshift-checks/pre-install.yml
@@ -1,3 +1,6 @@
 ---
 - include: ../openshift-cluster/initialize_groups.yml
+
+- include: ../../common/openshift-cluster/std_include.yml
+
 - include: ../../common/openshift-checks/pre-install.yml

--- a/playbooks/common/openshift-checks/health.yml
+++ b/playbooks/common/openshift-checks/health.yml
@@ -1,10 +1,6 @@
 ---
-- include: ../openshift-cluster/std_include.yml
-  tags:
-  - always
-
 - name: Run OpenShift health checks
-  hosts: OSEv3
+  hosts: oo_all_hosts
   roles:
   - openshift_health_checker
   vars:

--- a/playbooks/common/openshift-checks/pre-install.yml
+++ b/playbooks/common/openshift-checks/pre-install.yml
@@ -1,10 +1,6 @@
 ---
-- include: ../openshift-cluster/std_include.yml
-  tags:
-  - always
-
-- hosts: OSEv3
-  name: run OpenShift pre-install checks
+- name: run OpenShift pre-install checks
+  hosts: oo_all_hosts
   roles:
   - openshift_health_checker
   vars:


### PR DESCRIPTION
Standardizing the pattern of starting entry point playbooks with:

```yaml
- include: ../openshift-cluster/initialize_groups.yml

- include: ../../common/openshift-cluster/std_include.yml
```
then including the necessary playbook from `common` to do the actual work.

`OSEv3` should not be used as a host group in `common` playbooks.