### PR TITLE
Updating default tag for enterprise installation for ASB

### DIFF
--- a/roles/ansible_service_broker/vars/openshift-enterprise.yml
+++ b/roles/ansible_service_broker/vars/openshift-enterprise.yml
@@ -1,7 +1,7 @@
 ---
 
 __ansible_service_broker_image_prefix: registry.access.redhat.com/openshift3/ose-
-__ansible_service_broker_image_tag: latest
+__ansible_service_broker_image_tag: v3.6
 
 __ansible_service_broker_etcd_image_prefix: rhel7/
 __ansible_service_broker_etcd_image_tag: latest


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1479165
We should be setting the image tag for the ASB as a release rather than using `latest`