### PR TITLE
[3.6] Backport master etcd v3 migration changes

### DIFF
--- a/playbooks/aws/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/aws/openshift-cluster/cluster_hosts.yml
@@ -4,6 +4,8 @@ g_all_hosts: "{{ groups['tag_clusterid_' ~ cluster_id] | default([])
 
 g_etcd_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type_etcd'] | default([])) }}"
 
+g_new_etcd_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type_new_etcd'] | default([])) }}"
+
 g_lb_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type_lb'] | default([])) }}"
 
 g_nfs_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type_nfs'] | default([])) }}"

--- a/playbooks/byo/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/byo/openshift-cluster/cluster_hosts.yml
@@ -1,6 +1,8 @@
 ---
 g_etcd_hosts: "{{ groups.etcd | default([]) }}"
 
+g_new_etcd_hosts: "{{ groups.new_etcd | default([]) }}"
+
 g_lb_hosts: "{{ groups.lb | default([]) }}"
 
 g_master_hosts: "{{ groups.masters | default([]) }}"
@@ -18,7 +20,7 @@ g_glusterfs_hosts: "{{ groups.glusterfs | default([]) }}"
 g_glusterfs_registry_hosts: "{{ groups.glusterfs_registry | default(g_glusterfs_hosts) }}"
 
 g_all_hosts: "{{ g_master_hosts | union(g_node_hosts) | union(g_etcd_hosts)
-                 | union(g_lb_hosts) | union(g_nfs_hosts)
+                 | union(g_new_etcd_hosts) | union(g_lb_hosts) | union(g_nfs_hosts)
                  | union(g_new_node_hosts)| union(g_new_master_hosts)
                  | union(g_glusterfs_hosts) | union(g_glusterfs_registry_hosts)
                  | default([]) }}"

--- a/playbooks/byo/openshift-etcd/scaleup.yml
+++ b/playbooks/byo/openshift-etcd/scaleup.yml
@@ -1,0 +1,22 @@
+---
+- hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+  - add_host:
+      name: "{{ item }}"
+      groups: l_oo_all_hosts
+    with_items: "{{ g_all_hosts }}"
+
+- hosts: l_oo_all_hosts
+  gather_facts: no
+  tasks:
+  - include_vars: ../../byo/openshift-cluster/cluster_hosts.yml
+
+- include: ../../common/openshift-cluster/evaluate_groups.yml
+- include: ../../common/openshift-etcd/scaleup.yml
+  vars:
+    openshift_cluster_id: "{{ cluster_id | default('default') }}"
+    openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/common/openshift-cluster/evaluate_groups.yml
+++ b/playbooks/common/openshift-cluster/evaluate_groups.yml
@@ -5,10 +5,10 @@
   become: no
   gather_facts: no
   tasks:
-  - name: Evaluate groups - g_etcd_hosts required
+  - name: Evaluate groups - g_etcd_hosts or g_new_etcd_hosts required
     fail:
-      msg: This playbook requires g_etcd_hosts to be set
-    when: g_etcd_hosts is not defined
+      msg: This playbook requires g_etcd_hosts or g_new_etcd_hosts to be set
+    when: "{{ g_etcd_hosts is not defined and g_new_etcd_hosts is not defined}}"
 
   - name: Evaluate groups - g_master_hosts or g_new_master_hosts required
     fail:
@@ -65,6 +65,15 @@
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_become: "{{ g_sudo | default(omit) }}"
     when: g_master_hosts|length > 0
+    changed_when: no
+
+  - name: Evaluate oo_new_etcd_to_config
+    add_host:
+      name: "{{ item }}"
+      groups: oo_new_etcd_to_config
+      ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
+      ansible_become: "{{ g_sudo | default(omit) }}"
+    with_items: "{{ g_new_etcd_hosts | default([]) }}"
     changed_when: no
 
   - name: Evaluate oo_masters_to_config

--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -17,6 +17,7 @@
   tags:
   - always
 
+# TODO: This will be different for release-3.6 branch
 - name: Prepare masters for etcd data migration
   hosts: oo_masters_to_config
   tasks:
@@ -67,8 +68,21 @@
     when:
     - etcd_backup_failed | length > 0
 
-- name: Migrate etcd data from v2 to v3
+- name: Stop etcd
   hosts: oo_etcd_to_migrate
+  gather_facts: no
+  tags:
+  - always
+  pre_tasks:
+  - set_fact:
+      l_etcd_service: "{{ 'etcd_container' if openshift.common.is_containerized else 'etcd' }}"
+  - name: Disable etcd members
+    service:
+      name: "{{ l_etcd_service }}"
+      state: stopped
+
+- name: Migrate data on first etcd
+  hosts: oo_etcd_to_migrate[0]
   gather_facts: no
   tags:
   - always
@@ -77,6 +91,36 @@
     r_etcd_migrate_action: migrate
     r_etcd_common_embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
     etcd_peer: "{{ ansible_default_ipv4.address }}"
+    etcd_url_scheme: "https"
+    etcd_peer_url_scheme: "https"
+
+- name: Clean data stores on remaining etcd hosts
+  hosts: oo_etcd_to_migrate[1:]
+  gather_facts: no
+  tags:
+  - always
+  roles:
+  - role: etcd_migrate
+    r_etcd_migrate_action: clean_data
+    r_etcd_common_embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
+    etcd_peer: "{{ ansible_default_ipv4.address }}"
+    etcd_url_scheme: "https"
+    etcd_peer_url_scheme: "https"
+  post_tasks:
+  - name: Add etcd hosts
+    delegate_to: localhost
+    add_host:
+      name: "{{ item }}"
+      groups: oo_new_etcd_to_config
+      ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
+      ansible_become: "{{ g_sudo | default(omit) }}"
+    with_items: "{{ groups.oo_etcd_to_migrate[1:] | default([]) }}"
+    changed_when: no
+  - name: Set success
+    set_fact:
+      r_etcd_migrate_success: true
+
+- include: ./scaleup.yml
 
 - name: Gate on etcd migration
   hosts: oo_masters_to_config
@@ -89,6 +133,16 @@
   - set_fact:
       etcd_migration_failed: "{{ groups.oo_etcd_to_migrate | difference(etcd_migration_completed) }}"
 
+- name: Add TTLs on the first master
+  hosts: oo_first_master[0]
+  roles:
+  - role: etcd_migrate
+    r_etcd_migrate_action: add_ttls
+    etcd_peer: "{{ hostvars[groups.oo_etcd_to_migrate.0].ansible_default_ipv4.address }}"
+    etcd_url_scheme: "https"
+    etcd_peer_url_scheme: "https"
+    when: etcd_migration_failed | length == 0
+
 - name: Configure masters if etcd data migration is succesfull
   hosts: oo_masters_to_config
   roles:
@@ -100,10 +154,6 @@
       msg: "Skipping master re-configuration since migration failed."
     when:
     - etcd_migration_failed | length > 0
-
-- name: Start masters after etcd data migration
-  hosts: oo_masters_to_config
-  tasks:
   - name: Start master services
     service:
       name: "{{ item }}"

--- a/playbooks/common/openshift-etcd/scaleup.yml
+++ b/playbooks/common/openshift-etcd/scaleup.yml
@@ -24,6 +24,9 @@
                        member add {{ etcd_hostname }} {{ etcd_peer_url_scheme }}://{{ etcd_ip }}:{{ etcd_peer_port }}
     delegate_to: "{{ etcd_ca_host }}"
     register: etcd_add_check
+    retries: 3
+    delay: 10
+    until: etcd_add_check.rc == 0
   roles:
   - role: openshift_etcd
     when: etcd_add_check.rc == 0
@@ -36,3 +39,13 @@
     r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
   - role: nickhammond.logrotate
     when: etcd_add_check.rc == 0
+  post_tasks:
+  - name: Verify cluster is stable
+    command: >
+      /usr/bin/etcdctl --cert-file {{ etcd_peer_cert_file }}
+                       --key-file {{ etcd_peer_key_file }}
+                       --ca-file {{ etcd_peer_ca_file }}
+                       -C {{ etcd_peer_url_scheme }}://{{ hostvars[etcd_ca_host].etcd_hostname }}:{{ etcd_client_port }}
+                       cluster-health
+    retries: 1
+    delay: 30

--- a/playbooks/common/openshift-etcd/scaleup.yml
+++ b/playbooks/common/openshift-etcd/scaleup.yml
@@ -1,0 +1,30 @@
+---
+- name: Configure etcd
+  hosts: oo_new_etcd_to_config
+  serial: 1
+  any_errors_fatal: true
+  vars:
+    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
+  pre_tasks:
+  - name: Add new etcd members to cluster
+    command: >
+      /usr/bin/etcdctl  --cert-file {{ etcd_peer_cert_file }}
+                        --key-file {{ etcd_peer_key_file }}
+                        --ca-file {{ etcd_peer_ca_file }}
+                        -C {{ etcd_peer_url_scheme }}://{{ etcd_ca_host }}:{{ etcd_client_port }}
+                        member add {{ inventory_hostname }} {{ etcd_peer_url_scheme }}://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ etcd_peer_port }}
+    delegate_to: "{{ etcd_ca_host }}"
+    register: etcd_add_check
+  roles:
+  - role: openshift_etcd
+    when: etcd_add_check.rc == 0
+    etcd_peers: "{{ groups.oo_etcd_to_config | union(groups.oo_new_etcd_to_config)| default([], true) }}"
+    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
+    etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"
+    etcd_initial_cluster_state: "existing"
+    initial_etcd_cluster: "{{ etcd_add_check.stdout_lines[3] | regex_replace('ETCD_INITIAL_CLUSTER=','') }}"
+    etcd_hostname: "{{ inventory_hostname }}"
+    etcd_ca_setup: False
+    r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
+  - role: nickhammond.logrotate
+    when: etcd_add_check.rc == 0

--- a/playbooks/common/openshift-etcd/scaleup.yml
+++ b/playbooks/common/openshift-etcd/scaleup.yml
@@ -1,4 +1,13 @@
 ---
+- name: Gather facts
+  hosts: oo_etcd_to_config:oo_new_etcd_to_config
+  roles:
+  - openshift_etcd_facts
+  post_tasks:
+  - set_fact:
+      etcd_hostname: "{{ etcd_hostname }}"
+      etcd_ip: "{{ etcd_ip }}"
+
 - name: Configure etcd
   hosts: oo_new_etcd_to_config
   serial: 1
@@ -8,11 +17,11 @@
   pre_tasks:
   - name: Add new etcd members to cluster
     command: >
-      /usr/bin/etcdctl  --cert-file {{ etcd_peer_cert_file }}
-                        --key-file {{ etcd_peer_key_file }}
-                        --ca-file {{ etcd_peer_ca_file }}
-                        -C {{ etcd_peer_url_scheme }}://{{ etcd_ca_host }}:{{ etcd_client_port }}
-                        member add {{ inventory_hostname }} {{ etcd_peer_url_scheme }}://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ etcd_peer_port }}
+      /usr/bin/etcdctl --cert-file {{ etcd_peer_cert_file }}
+                       --key-file {{ etcd_peer_key_file }}
+                       --ca-file {{ etcd_peer_ca_file }}
+                       -C {{ etcd_peer_url_scheme }}://{{ hostvars[etcd_ca_host].etcd_hostname }}:{{ etcd_client_port }}
+                       member add {{ etcd_hostname }} {{ etcd_peer_url_scheme }}://{{ etcd_ip }}:{{ etcd_peer_port }}
     delegate_to: "{{ etcd_ca_host }}"
     register: etcd_add_check
   roles:
@@ -23,7 +32,6 @@
     etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"
     etcd_initial_cluster_state: "existing"
     initial_etcd_cluster: "{{ etcd_add_check.stdout_lines[3] | regex_replace('ETCD_INITIAL_CLUSTER=','') }}"
-    etcd_hostname: "{{ inventory_hostname }}"
     etcd_ca_setup: False
     r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
   - role: nickhammond.logrotate

--- a/playbooks/gce/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/gce/openshift-cluster/cluster_hosts.yml
@@ -4,6 +4,8 @@ g_all_hosts: "{{ groups['tag_clusterid-' ~ cluster_id] | default([])
 
 g_etcd_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-etcd'] | default([])) }}"
 
+g_new_etcd_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-new_etcd'] | default([])) }}"
+
 g_lb_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-lb'] | default([])) }}"
 
 g_nfs_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-nfs'] | default([])) }}"

--- a/playbooks/libvirt/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/libvirt/openshift-cluster/cluster_hosts.yml
@@ -4,6 +4,8 @@ g_all_hosts: "{{ groups['tag_clusterid-' ~ cluster_id] | default([])
 
 g_etcd_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-etcd'] | default([])) }}"
 
+g_new_etcd_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-new_etcd'] | default([])) }}"
+
 g_lb_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-lb'] | default([])) }}"
 
 g_nfs_hosts: "{{ g_all_hosts | intersect(groups['tag_host-type-nfs'] | default([])) }}"

--- a/playbooks/openstack/openshift-cluster/cluster_hosts.yml
+++ b/playbooks/openstack/openshift-cluster/cluster_hosts.yml
@@ -4,6 +4,8 @@ g_all_hosts: "{{ groups['meta-clusterid_' ~ cluster_id] | default([])
 
 g_etcd_hosts: "{{ g_all_hosts | intersect(groups['meta-host-type_etcd'] | default([])) }}"
 
+g_new_etcd_hosts: "{{ g_all_hosts | intersect(groups['meta-host-type_new_etcd'] | default([])) }}"
+
 g_lb_hosts: "{{ g_all_hosts | intersect(groups['meta-host-type_lb'] | default([])) }}"
 
 g_nfs_hosts: "{{ g_all_hosts | intersect(groups['meta-host-type_nfs'] | default([])) }}"

--- a/roles/etcd/templates/etcd.conf.j2
+++ b/roles/etcd/templates/etcd.conf.j2
@@ -8,12 +8,8 @@
 {% endfor -%}
 {% endmacro -%}
 
-{% if (etcd_peers | default([]) | length > 1) or (etcd_is_thirdparty) %}
 ETCD_NAME={{ etcd_hostname }}
 ETCD_LISTEN_PEER_URLS={{ etcd_listen_peer_urls }}
-{% else %}
-ETCD_NAME=default
-{% endif %}
 ETCD_DATA_DIR={{ etcd_data_dir }}
 #ETCD_SNAPSHOT_COUNTER=10000
 ETCD_HEARTBEAT_INTERVAL=500
@@ -23,20 +19,20 @@ ETCD_LISTEN_CLIENT_URLS={{ etcd_listen_client_urls }}
 #ETCD_MAX_WALS=5
 #ETCD_CORS=
 
-{% if etcd_is_thirdparty %}
+
 #[cluster]
 ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_initial_advertise_peer_urls }}
-
+{% if etcd_is_thirdparty %}
 # TODO: This needs to be altered to support the correct etcd instances
 ETCD_INITIAL_CLUSTER={{ etcd_hostname}}={{ etcd_initial_advertise_peer_urls }}
 ETCD_INITIAL_CLUSTER_STATE={{ etcd_initial_cluster_state }}
 ETCD_INITIAL_CLUSTER_TOKEN=thirdparty-etcd-cluster-1
-{% endif %}
-
-{% if etcd_peers | default([]) | length > 1 %}
-#[cluster]
-ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_initial_advertise_peer_urls }}
+{% else %}
+{% if initial_etcd_cluster is defined and initial_etcd_cluster %}
+ETCD_INITIAL_CLUSTER={{ initial_etcd_cluster }}
+{% else %}
 ETCD_INITIAL_CLUSTER={{ initial_cluster() }}
+{% endif %}
 ETCD_INITIAL_CLUSTER_STATE={{ etcd_initial_cluster_state }}
 ETCD_INITIAL_CLUSTER_TOKEN={{ etcd_initial_cluster_token }}
 #ETCD_DISCOVERY=

--- a/roles/etcd_common/defaults/main.yml
+++ b/roles/etcd_common/defaults/main.yml
@@ -63,3 +63,13 @@ etcd_client_port: 2379
 etcd_peer_port: 2380
 etcd_url_scheme: http
 etcd_peer_url_scheme: http
+
+etcd_initial_cluster_state: new
+etcd_initial_cluster_token: etcd-cluster-1
+
+etcd_initial_advertise_peer_urls: "{{ etcd_peer_url_scheme }}://{{ etcd_ip }}:{{ etcd_peer_port }}"
+etcd_listen_peer_urls: "{{ etcd_peer_url_scheme }}://{{ etcd_ip }}:{{ etcd_peer_port }}"
+etcd_advertise_client_urls: "{{ etcd_url_scheme }}://{{ etcd_ip }}:{{ etcd_client_port }}"
+etcd_listen_client_urls: "{{ etcd_url_scheme }}://{{ etcd_ip }}:{{ etcd_client_port }}"
+
+etcd_systemd_dir: "/etc/systemd/system/{{ etcd_service }}.service.d"

--- a/roles/etcd_migrate/tasks/add_ttls.yml
+++ b/roles/etcd_migrate/tasks/add_ttls.yml
@@ -1,0 +1,33 @@
+---
+# To be executed on first master
+- slurp:
+    src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+  register: g_master_config_output
+
+- set_fact:
+    accessTokenMaxAgeSeconds: "{{ (g_master_config_output.content|b64decode|from_yaml).oauthConfig.tokenConfig.accessTokenMaxAgeSeconds | default(86400) }}"
+    authroizeTokenMaxAgeSeconds: "{{ (g_master_config_output.content|b64decode|from_yaml).oauthConfig.tokenConfig.authroizeTokenMaxAgeSeconds | default(500) }}"
+    controllerLeaseTTL: "{{ (g_master_config_output.content|b64decode|from_yaml).controllerLeaseTTL | default(30) }}"
+- name: Re-introduce leases (as a replacement for key TTLs)
+  command: >
+    oadm migrate etcd-ttl \
+    --cert {{ r_etcd_common_master_peer_cert_file }} \
+    --key {{ r_etcd_common_master_peer_key_file }} \
+    --cacert {{ r_etcd_common_master_peer_ca_file }} \
+    --etcd-address 'https://{{ etcd_peer }}:{{ etcd_client_port }}' \
+    --ttl-keys-prefix {{ item.keys }} \
+    --lease-duration {{ item.ttl }}
+  environment:
+    ETCDCTL_API: 3
+    PATH: "/usr/local/bin:/var/usrlocal/bin:{{ ansible_env.PATH }}"
+  with_items:
+    - keys: "/kubernetes.io/events"
+      ttl: "1h"
+    - keys: "/kubernetes.io/masterleases"
+      ttl: "10s"
+    - keys: "/openshift.io/oauth/accesstokens"
+      ttl: "{{ accessTokenMaxAgeSeconds }}s"
+    - keys: "/openshift.io/oauth/authorizetokens"
+      ttl: "{{ authroizeTokenMaxAgeSeconds }}s"
+    - keys: "/openshift.io/leases/controllers"
+      ttl: "{{ controllerLeaseTTL }}s"

--- a/roles/etcd_migrate/tasks/check.yml
+++ b/roles/etcd_migrate/tasks/check.yml
@@ -1,8 +1,4 @@
 ---
-- fail:
-    msg: "Currently etcd v3 migration is unsupported while we test it more thoroughly"
-  when: not openshift_enable_unsupported_configurations | default(false) | bool
-
 # Check the cluster is healthy
 - include: check_cluster_health.yml
 

--- a/roles/etcd_migrate/tasks/clean_data.yml
+++ b/roles/etcd_migrate/tasks/clean_data.yml
@@ -1,0 +1,5 @@
+---
+- name: Remove member data
+  file:
+    path: /var/lib/etcd/member
+    state: absent

--- a/roles/etcd_migrate/tasks/main.yml
+++ b/roles/etcd_migrate/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Fail if invalid r_etcd_migrate_action provided
   fail:
-    msg: "etcd_migrate role can only be called with 'check' or 'migrate' or 'configure'"
-  when: r_etcd_migrate_action not in ['check', 'migrate', 'configure']
+    msg: "etcd_migrate role can only be called with 'check', 'migrate', 'configure', 'add_ttls', or 'clean_data'"
+  when: r_etcd_migrate_action not in ['check', 'migrate', 'configure', 'add_ttls', 'clean_data']
 
 - name: Include main action task file
   include: "{{ r_etcd_migrate_action }}.yml"

--- a/roles/etcd_migrate/tasks/migrate.yml
+++ b/roles/etcd_migrate/tasks/migrate.yml
@@ -3,62 +3,45 @@
 - set_fact:
     l_etcd_service: "{{ 'etcd_container' if openshift.common.is_containerized else 'etcd' }}"
 
-- name: Disable etcd members
-  service:
-    name: "{{ l_etcd_service }}"
-    state: stopped
-
-# Should we skip all TTL keys? https://bugzilla.redhat.com/show_bug.cgi?id=1389773
 - name: Migrate etcd data
   command: >
     etcdctl migrate --data-dir={{ etcd_data_dir }}
   environment:
     ETCDCTL_API: 3
   register: l_etcdctl_migrate
-
 # TODO(jchaloup): If any of the members fails, we need to restore all members to v2 from the pre-migrate backup
 - name: Check the etcd v2 data are correctly migrated
   fail:
     msg: "Failed to migrate a member"
   when: "'finished transforming keys' not in l_etcdctl_migrate.stdout and 'no v2 keys to migrate' not in l_etcdctl_migrate.stdout"
-
 - name: Migration message
   debug:
     msg: "Etcd migration finished with: {{ l_etcdctl_migrate.stdout }}"
-
-- name: Enable etcd member
-  service:
+- name: Set ETCD_FORCE_NEW_CLUSTER=true on first etcd host
+  lineinfile:
+    line: "ETCD_FORCE_NEW_CLUSTER=true"
+    dest: /etc/etcd/etcd.conf
+- name: Start etcd
+  systemd:
     name: "{{ l_etcd_service }}"
     state: started
+- name: Unset ETCD_FORCE_NEW_CLUSTER=true on first etcd host
+  lineinfile:
+    line: "ETCD_FORCE_NEW_CLUSTER=true"
+    dest: /etc/etcd/etcd.conf
+    state: absent
+- name: Restart first etcd host
+  systemd:
+    name: "{{ l_etcd_service }}"
+    state: restarted
 
-- name: Wait for cluster to become healthy after migration
+- name: Wait for cluster to become healthy after bringing up first member
   command: >
     etcdctl --cert-file {{ etcd_peer_cert_file }} --key-file {{ etcd_peer_key_file }} --ca-file {{ etcd_peer_ca_file }} --endpoint https://{{ etcd_peer }}:{{ etcd_client_port }} cluster-health
   register: l_etcd_migrate_health
   until: l_etcd_migrate_health.rc == 0
   retries: 3
   delay: 30
-  run_once: true
-
-# NOTE: /usr/local/bin may be removed from the PATH by ansible hence why
-#       it's added to the environment in this task.
-- name: Re-introduce leases (as a replacement for key TTLs)
-  command: >
-    oadm migrate etcd-ttl \
-    --cert {{ r_etcd_common_master_peer_cert_file }} \
-    --key {{ r_etcd_common_master_peer_key_file }} \
-    --cacert {{ r_etcd_common_master_peer_ca_file }} \
-    --etcd-address 'https://{{ etcd_peer }}:{{ etcd_client_port }}' \
-    --ttl-keys-prefix {{ item }} \
-    --lease-duration 1h
-  environment:
-    ETCDCTL_API: 3
-    PATH: "/usr/local/bin:/var/usrlocal/bin:{{ ansible_env.PATH }}"
-  with_items:
-  - "/kubernetes.io/events"
-  - "/kubernetes.io/masterleases"
-  delegate_to: "{{ groups.oo_first_master[0] }}"
-  run_once: true
 
 - set_fact:
     r_etcd_migrate_success: true

--- a/roles/etcd_server_certificates/meta/main.yml
+++ b/roles/etcd_server_certificates/meta/main.yml
@@ -14,3 +14,4 @@ galaxy_info:
   - system
 dependencies:
 - role: etcd_ca
+  when: (etcd_ca_setup | default(True) | bool)

--- a/roles/openshift_etcd_ca/meta/main.yml
+++ b/roles/openshift_etcd_ca/meta/main.yml
@@ -15,3 +15,4 @@ galaxy_info:
 dependencies:
 - role: openshift_etcd_facts
 - role: etcd_ca
+  when: (etcd_ca_setup | default(True) | bool)


### PR DESCRIPTION
Backports #4980 with slight modification to the master services and Includes backports of #3043 and #4984 to pickup the etcd scaleup playbooks