### PR TITLE
Playbook to deploy keepalived on master nodes for native HA

### DIFF
--- a/playbooks/byo/master_keepalived.yml
+++ b/playbooks/byo/master_keepalived.yml
@@ -1,0 +1,128 @@
+### Playbook to provision keepalived on master nodes for native HA
+#
+# To configure create group keepalived in inventory file with next labels:
+# keepalived_name: <name of vip>
+# keepalived_vip: <virtual ip>
+# keepalived_nic: <interface to listen on>
+# keepalived_router_id: <id>
+# keepalived_pass: <password>
+#
+# E.g.
+#
+# [keepalived]
+# gls-master-1b1b8.example.com keepalived_nic=eth0 keepalived_router_id=42 keepalived_vip=192.168.55.3 keepalived_name=VIP_0 keepalived_pass=sea8soKe
+# gls-master-f4ac1.example.com keepalived_nic=eth0 keepalived_router_id=43 keepalived_vip=192.168.55.4 keepalived_name=VIP_1 keepalived_pass=Ya1mohxo
+# gls-master-cc3cf.example.com keepalived_nic=eth0 keepalived_router_id=44 keepalived_vip=192.168.55.5 keepalived_name=VIP_2 keepalived_pass=lae4ShuV
+#
+# And add round-robin DNS entry on all VIPs:
+# $ host master.example.com
+# master.example.com has address 192.168.55.5
+# master.example.com has address 192.168.55.3
+# master.example.com has address 192.168.55.4
+#
+# This playbook will generate 3 different virtual routers for 3 different VIPs
+# to enable load balancing based on round-robin DNS
+# 
+# Excerpt from /etc/keepalived/keepalived.conf
+#
+# vrrp_instance VIP_1 {
+#   interface eth0
+#   state BACKUP
+#   virtual_router_id 43
+#   priority 50
+#   authentication {
+#     auth_type PASS
+#     auth_pass Ya1mohxo
+#   }
+#   virtual_ipaddress {
+#     192.168.55.4 dev eth0
+#   }
+# 
+# 
+# }
+# vrrp_instance VIP_0 {
+#   interface eth0
+#   state BACKUP
+#   virtual_router_id 42
+#   priority 50
+#   authentication {
+#     auth_type PASS
+#     auth_pass sea8soKe
+#   }
+#   virtual_ipaddress {
+#     192.168.55.3 dev eth0
+#   }
+# 
+# 
+# }
+# vrrp_instance VIP_2 {
+#   interface eth0
+#   state MASTER
+#   virtual_router_id 44
+#   priority 100
+#   authentication {
+#     auth_type PASS
+#     auth_pass lae4ShuV
+#   }
+#   virtual_ipaddress {
+#     192.168.55.5 dev eth0
+#   }
+# }
+# 
+
+
+---
+- name: Generate vars
+  hosts: keepalived
+  gather_facts: False
+  tasks:
+    - name: Populate
+      set_fact:
+        keepalived_instances: >
+            {{ keepalived_instances | default({}) | combine({
+                  hostvars[item].keepalived_name: {
+                    'interface': hostvars[inventory_hostname].keepalived_nic,
+                    'virtual_router_id': hostvars[item].keepalived_router_id,
+                    'state': ((inventory_hostname == item) | ternary('MASTER','BACKUP')),
+                    'priority': ((inventory_hostname == item) | ternary('100','50')),
+                    'authentication_password': hostvars[item].keepalived_pass,
+                    'vips': [
+                      hostvars[item].keepalived_vip + ' dev ' + hostvars[inventory_hostname].keepalived_nic
+                    ]
+                  }
+             }) }}
+        
+      with_items: "{{ groups.keepalived }}"
+    
+- name: Enable IPTables
+  hosts: keepalived
+  tasks:
+    - iptables:
+        action: insert
+        chain: INPUT
+        in_interface: "{{ hostvars[inventory_hostname].keepalived_nic }}"
+        destination: 224.0.0.0/8
+        protocol: vrrp
+        jump: ACCEPT
+      become: yes
+    - iptables:
+        action: insert
+        chain: OUTPUT
+        out_interface: "{{ hostvars[inventory_hostname].keepalived_nic }}"
+        destination: 224.0.0.0/8
+        protocol: vrrp
+        jump: ACCEPT
+      become: yes
+
+- name: Install KeepAliveD
+  hosts: keepalived
+  vars:
+    keepalived_instances: "{{ hostvars[inventory_hostname].keepalived_instances }}"
+    
+  tasks:
+    - debug:
+        msg: "{{ keepalived_instances }}"
+
+  roles:
+    - role: ansible_keepalived
+

--- a/playbooks/byo/master_keepalived.yml
+++ b/playbooks/byo/master_keepalived.yml
@@ -93,6 +93,11 @@
              }) }}
         
       with_items: "{{ groups.keepalived }}"
+
+- name: Install os_firewall to prevent IPTables rules wiping
+  hosts: keepalived
+  roles:
+    - role: os_firewall
     
 - name: Enable IPTables
   hosts: keepalived

--- a/roles/ansible_keepalived/.gitignore
+++ b/roles/ansible_keepalived/.gitignore
@@ -1,0 +1,3 @@
+*.retry
+*.log
+.vagrant/

--- a/roles/ansible_keepalived/LICENSE
+++ b/roles/ansible_keepalived/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/roles/ansible_keepalived/README.md
+++ b/roles/ansible_keepalived/README.md
@@ -1,0 +1,74 @@
+Keepalived
+=========
+
+This role installs keepalived and configures it according to the variables you'll pass to the role.
+
+Requirements
+------------
+
+No fancy requirements. Only package and file management in the role.
+
+Role Variables
+--------------
+
+By default, this role doesn't configure keepalived, it barely installs it. This way keepalived is fully flexible based on what you give as input.
+Examples are given in the vars folder. Don't try them immediately, they won't work! (You need to define VIPs, passwords, etc.). The examples are only a source of inspiration.
+
+The main variables are:
+
+* keepalived_instances: This is a mandatory dict. It gathers information about the vips, the prefered state (master/backup), the VRRIP IDs and priorities, the password used for authentication... This is where things like nopreempt are configured. nopreempt allows to stay in backup state (instead of preempting to configured master) on a master return of availability, after its failure. Please check the template for additional settings support, and original keepalived documentation for their configuration.
+* keepalived_sync_groups: This is a mandatory dict. It groups items defined in keepalived_instances, and (if desired) allow the configuration of notifications scripts per group of keepalived_instances. Notification scripts are triggered on keepalived's state change and are facultative.
+* keepalived_virtual_servers: This is an optional dict. It sets up a virtual server + port and balances traffic over real_servers given in a sub dict. Checkout the _example.yaml files in vars/ to see a sample on how to use this dict. The official documentation for keepalived's virtual_server can be found [here](https://github.com/acassen/keepalived/blob/master/doc/keepalived.conf.SYNOPSIS#L393).
+* keepalived_scripts: This is an optional dict where you could have checking scripts that can trigger the notifications scripts.
+* keepalived_bind_on_non_local: This variable (defaulted to "False") determines whether the system that host keepalived will allow its apps to bind on non-local addresses. If you set it to true, this allows apps to bind (and start) even if they don't currently have the VIP for example.
+
+Please check the examples for more explanations on how these dicts must be configured.
+
+Other editable variables are listed in the defaults/main.yml. Please read the explanation there if you want to override them.
+An example of a notification script is also given, in the files folder.
+
+Antoher good source of informations is the official keepalived [GIT repo](https://github.com/acassen/keepalived) where you can find a fully commented [keepalived.conf](https://github.com/acassen/keepalived/blob/master/doc/keepalived.conf.SYNOPSIS). Also various official samples are [provided](https://github.com/acassen/keepalived/tree/master/doc/samples).
+
+Dependencies
+------------
+
+No dependency
+
+Example Playbook
+----------------
+
+Here is how you could use the role:
+
+    - hosts: keepalived_hosts[0]
+      vars_files:
+        - roles/keepalived/tests/keepalived_haproxy_master_example.yml
+      roles:
+         - keepalived
+    - hosts: keepalived_hosts:!keepalived_hosts[0]
+      vars_files:
+        - roles/keepalived/tests/keepalived_haproxy_backup_example.yml
+      roles:
+         - keepalived
+
+Or more simply:
+
+    - hosts: keepalived_hosts
+      vars_files:
+        - roles/keepalived/tests/keepalived_haproxy_combined_example.yml
+      roles:
+         - keepalived
+
+You could also replace the vars_files by proper group_vars, host_vars.
+
+License
+-------
+
+Apache2
+
+Author Information
+------------------
+
+Jean-Philippe Evrard
+
+
+Forked from https://github.com/evrardjp/ansible-keepalived

--- a/roles/ansible_keepalived/UPGRADE.md
+++ b/roles/ansible_keepalived/UPGRADE.md
@@ -1,0 +1,2 @@
+- Starting from 2.0, you must use keepalived_use_external_repo instead of keepalived_use_latest_stable_ppa in order to use an external repository
+- Starting from 2.0, the external repo is hard set for the user.

--- a/roles/ansible_keepalived/Vagrantfile
+++ b/roles/ansible_keepalived/Vagrantfile
@@ -1,0 +1,66 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Ansible provisioner for multimachine
+ANSIBLE_RAW_SSH_ARGS = []
+boxes = [
+    {
+        :name => "keepalived1",
+        :eth1 => "192.168.33.10",
+        :image => "ubuntu/trusty64",
+    },
+    {
+        :name => "keepalived2",
+        :eth1 => "192.168.33.11",
+        :image => "ubuntu/xenial64",
+    },
+    {
+        :name => "keepalived3",
+        :eth1 => "192.168.33.12",
+        :image => "centos/7",
+    }
+]
+
+# Gather all the keys for the ssh connections
+boxes.each do |boxopts|
+  ANSIBLE_RAW_SSH_ARGS << "-o IdentityFile=.vagrant/machines/#{boxopts[:name]}/virtualbox/private_key"
+end
+
+Vagrant.configure(2) do |config|
+
+  config.vm.provider "virtualbox" do |v|
+    v.customize ["modifyvm", :id, "--memory", 256]
+    v.customize ["modifyvm", :id, "--cpus", 1]
+  end
+
+  # Optional vagrant cache
+  #if Vagrant.has_plugin?("vagrant-cachier")
+  #  # http://fgrehm.viewdocs.io/vagrant-cachier/usage/
+  #  config.cache.scope = :box
+  #  #config.cache.synced_folder_opts = {
+  #  #  type: :nfs,
+  #  #  mount_options: ['rw', 'vers=3', 'tcp', 'nolock']
+  #  #}
+  #end
+
+  boxes.each do |boxopts|
+    config.vm.define boxopts[:name] do |config|
+      config.vm.box = boxopts[:image]
+      config.vm.hostname = boxopts[:name]
+      config.vm.network :private_network, ip: boxopts[:eth1]
+      # Vagrant works serially and provision machines
+      # serially. Each of them is unaware of the others.
+      # Therefore, we should start provisioning only on last machine
+      if boxopts[:name] == "keepalived3"
+        config.vm.provision :ansible do |ansible|
+          ansible.playbook = "tests/deploy.yml"
+          ansible.extra_vars = "tests/keepalived_haproxy_combined_example.yml"
+          ansible.limit = 'all'
+          #ansible.inventory_path = "tests/inventory"
+          ansible.verbose = "-v"
+          ansible.raw_ssh_args = ANSIBLE_RAW_SSH_ARGS
+        end
+      end
+    end
+  end
+end

--- a/roles/ansible_keepalived/defaults/main.yml
+++ b/roles/ansible_keepalived/defaults/main.yml
@@ -1,0 +1,50 @@
+---
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# keepalived_ubuntu_src should be either "uca", "ppa" or "native":
+# "ppa" will ensure that keepalived ppa source is installed (recommended)
+# "uca" will ensure that the Ubuntu Cloud Archive is installed (good enough)
+# "native" will not ensure any external repository is set
+#  and use what's available (not recommended, unless you defined one of the
+#  above on your hosts)
+# Please see vars/ for information about these repositories
+# TODO(evrardjp), 2017-11:to remove the conditional
+# Remove the deprecation conditional and provide a good unconditional
+# default:
+#keepalived_ubuntu_src: "uca"
+keepalived_ubuntu_src: "{{ (keepalived_uca_enable is defined and (keepalived_uca_enable | bool)) | ternary('uca','ppa') }}"
+
+# If using UCA, you may want to point with your local mirror of UCA.
+keepalived_uca_apt_repo_url: "http://ubuntu-cloud.archive.canonical.com/ubuntu"
+
+# If running keepalived with SELinux, you could need to compile your
+# rules. Please override this list with path to files to compile.
+keepalived_selinux_compile_rules:
+  - keepalived_ping
+
+# TODO(evrardjp), 2017-11:
+# Remove the deprecation conditional and provide a good unconditional
+# default:
+#keepalived_package_state: "latest"
+keepalived_package_state: "{{ ( (keepalived_use_latest_stable | default(true)) | bool) | ternary('latest','present') }}"
+
+#This is the expiration time of your package manager cache.
+#When expired, this role will require to update the package manger cache.
+#This variable will be removed when the ansible upstream bugs will be fixed.
+cache_timeout: 600
+
+keepalived_instances: []
+keepalived_sync_groups: {}
+keepalived_bind_on_non_local: False

--- a/roles/ansible_keepalived/files/keepalived_haproxy_pid_file.te
+++ b/roles/ansible_keepalived/files/keepalived_haproxy_pid_file.te
@@ -1,0 +1,23 @@
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+module keepalived_haproxy_pid_file 1.0;
+
+require {
+    type haproxy_var_run_t;
+    type keepalived_t;
+    class file { getattr open read };
+}
+
+#============= keepalived_t ==============
+allow keepalived_t haproxy_var_run_t:file { getattr open read };

--- a/roles/ansible_keepalived/files/keepalived_notifications.sh
+++ b/roles/ansible_keepalived/files/keepalived_notifications.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TYPE=$1
+NAME=$2
+NOW=`date "+%Y-%m-%d %H:%M:%S"`
+NEWSTATE=$3
+OLDSTATE=$(cat /var/run/keepalived.state)
+
+echo "$NEWSTATE" > /var/run/keepalived.state
+
+case $NEWSTATE in
+        "FAULT") echo "$NOW Trying to restart haproxy to get out"\
+                  "of faulty state" >> /var/log/keepalived-notifications.log
+                 /etc/init.d/haproxy stop
+                 /etc/init.d/haproxy start
+                 exit 0
+                 ;;
+        *) echo "$NOW Unknown state" >> /var/log/keepalived-notifications.log
+           exit 1
+           ;;
+
+esac

--- a/roles/ansible_keepalived/files/keepalived_ping.te
+++ b/roles/ansible_keepalived/files/keepalived_ping.te
@@ -1,0 +1,26 @@
+# Copyright 2017, Major Hayden <major@mhtx.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module keepalived_ping 1.0;
+
+require {
+    type ping_exec_t;
+    type keepalived_t;
+    class process setcap;
+    class file { execute execute_no_trans getattr open read };
+}
+
+#============= keepalived_t ==============
+allow keepalived_t ping_exec_t:file { execute execute_no_trans getattr open read };
+allow keepalived_t self:process setcap;

--- a/roles/ansible_keepalived/handlers/main.yml
+++ b/roles/ansible_keepalived/handlers/main.yml
@@ -1,0 +1,19 @@
+---
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: restart keepalived
+  service:
+    name: "{{ keepalived_service_name }}"
+    state: restarted

--- a/roles/ansible_keepalived/meta/main.yml
+++ b/roles/ansible_keepalived/meta/main.yml
@@ -1,0 +1,34 @@
+---
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+galaxy_info:
+  author: Jean-Philippe Evrard
+  description:  This role installs and configure keepalived based on a variable file
+  license: Apache
+  min_ansible_version: 2.3
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  - name: Ubuntu
+    versions:
+    - trusty
+    - xenial
+  - name: opensuse
+    versions:
+    - all
+  categories:
+  - clustering
+dependencies: []

--- a/roles/ansible_keepalived/tasks/keepalived_install.yml
+++ b/roles/ansible_keepalived/tasks/keepalived_install.yml
@@ -1,0 +1,83 @@
+---
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Add the keepalived through ppa
+  apt_key:
+    id: "{{ keepalived_ppa_keyid }}"
+    keyserver: "{{ keepalived_ppa_keyserver }}"
+    state: present
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - keepalived_ubuntu_src == "ppa"
+  tags:
+    - keepalived-apt-keys
+
+- name: Add Ubuntu Cloud Archive keyring
+  apt:
+    pkg: ubuntu-cloud-keyring
+    state: "{{ keepalived_package_state }}"
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - keepalived_ubuntu_src == "uca"
+  tags:
+    - keepalived-apt-keys
+
+- name: Add the keepalived apt repository
+  apt_repository:
+    repo: "{{ (keepalived_ubuntu_src == 'ppa') | ternary(keepalived_ppa_repo, keepalived_uca_repo) }}"
+    update_cache: True
+    state: present
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - keepalived_ubuntu_src != "native"
+  tags:
+    - keepalived-repo
+
+- name: Check if keepalived is already installed
+  package:
+    name: "{{ keepalived_package_name }}"
+    state: present
+  register: check_if_present
+  check_mode: yes
+
+- name: Prevent keepalived from starting on install
+  copy:
+    dest: "{{ prevent_start_file }}"
+    content: "{{ prevent_start_file_content }}"
+  when:
+    - ansible_os_family | lower == 'debian'
+    - check_if_present | changed
+  tags:
+    - keepalived-prevent-start
+
+- name: install keepalived
+  package:
+    name: "{{ keepalived_package_name }}"
+    state: "{{ keepalived_package_state }}"
+    update_cache: "{{ (ansible_pkg_mgr == 'apt') | ternary('yes', omit) }}"
+    cache_valid_time: "{{ (ansible_pkg_mgr == 'apt') | ternary(cache_timeout, omit) }}"
+  tags:
+    - keepalived-apt-packages
+
+- name: Revert keepalived start prevention
+  file:
+    dest: "{{ prevent_start_file }}"
+    state: absent
+  when:
+    - ansible_os_family | lower == 'debian'
+    - check_if_present | changed
+  tags:
+    - keepalived-config
+    - keepalived-prevent-start

--- a/roles/ansible_keepalived/tasks/keepalived_selinux.yml
+++ b/roles/ansible_keepalived/tasks/keepalived_selinux.yml
@@ -1,0 +1,36 @@
+---
+# Copyright 2017, Major Hayden <major@mhtx.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Get list of SELinux modules loaded
+  command: semodule -l
+  changed_when: False
+  register: selinux_modules
+
+- name: Ensure SELinux packages are installed
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - libselinux
+    - libselinux-devel
+    - checkpolicy
+    - policycoreutils-python
+  when:
+    - '"keepalived_ping" not in selinux_modules.stdout'
+
+- include: keepalived_selinux_compile.yml
+  with_items: "{{ keepalived_selinux_compile_rules }}"
+  loop_control:
+    loop_var: selinux_policy_name

--- a/roles/ansible_keepalived/tasks/keepalived_selinux_compile.yml
+++ b/roles/ansible_keepalived/tasks/keepalived_selinux_compile.yml
@@ -1,0 +1,51 @@
+---
+# Copyright 2017, Major Hayden <major@mhtx.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Create directory for compiling SELinux role
+  file:
+    path: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}"
+    state: directory
+    mode: '0755'
+  when:
+    - selinux_policy_name not in selinux_modules.stdout
+
+- name: Deploy SELinux policy source file
+  copy:
+    src: "{{ selinux_policy_name }}.te"
+    dest: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}/{{ selinux_policy_name }}.te"
+    owner: root
+    group: root
+    mode: "0755"
+  when:
+    - selinux_policy_name not in selinux_modules.stdout
+
+- name: Compile and load SELinux module
+  command: "{{ item }}"
+  args:
+    creates: "/etc/selinux/targeted/active/modules/400/{{ selinux_policy_name }}/cil"
+    chdir: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}"
+  with_items:
+    - checkmodule -M -m -o {{ selinux_policy_name }}.mod {{ selinux_policy_name }}.te
+    - semodule_package -o {{ selinux_policy_name }}.pp -m {{ selinux_policy_name }}.mod
+    - semodule -i {{ selinux_policy_name }}.pp
+  when:
+    - selinux_policy_name not in selinux_modules.stdout
+
+- name: Remove temporary directory
+  file:
+    path: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}"
+    state: absent
+  when:
+    - selinux_policy_name not in selinux_modules.stdout

--- a/roles/ansible_keepalived/tasks/main.yml
+++ b/roles/ansible_keepalived/tasks/main.yml
@@ -1,0 +1,180 @@
+---
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Gather variables for each operating system
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
+    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
+    - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
+    - "{{ ansible_distribution | lower }}.yml"
+    - "{{ ansible_os_family | lower }}.yml"
+  tags:
+    - always
+
+- include: keepalived_install.yml
+  tags:
+    - keepalived-install
+
+- include: keepalived_selinux.yml
+  when:
+    - ansible_selinux.status is defined
+    - ansible_selinux.status == "enabled"
+  tags:
+    - keepalived-config
+
+- name: Allow consuming apps to bind on non local addresses
+  sysctl:
+    name: net.ipv4.ip_nonlocal_bind
+    value: 1
+    sysctl_set: yes
+    state: present
+  when: keepalived_bind_on_non_local | bool
+  tags:
+    - keepalived-install
+
+- name: configure keepalived
+  template:
+    src: keepalived.conf.j2
+    dest: "{{ keepalived_config_file_path }}"
+  tags:
+    - keepalived-config
+  notify:
+    - restart keepalived
+
+- name: Dropping the tracking scripts
+  copy:
+    src: "{{ item.value.src_check_script }}"
+    dest: "{{ item.value.check_script }}"
+    mode: "0755"
+  with_dict: "{{ keepalived_scripts | default('{}') }}"
+  when: item.value.src_check_script is defined
+  tags:
+    - keepalived-config
+  notify:
+    - restart keepalived
+
+- name: Dropping the general notification scripts
+  copy:
+    src: "{{ item.value.src_notify_script }}"
+    dest: "{{ item.value.notify_script }}"
+    mode: "0755"
+  with_dict: "{{ keepalived_sync_groups }}"
+  when: item.value.src_notify_script is defined
+  tags:
+    - keepalived-config
+  notify:
+    - restart keepalived
+
+- name: Dropping the notification scripts for switching to master
+  copy:
+    src: "{{ item.value.src_notify_master }}"
+    dest: "{{ item.value.notify_master }}"
+    mode: "0755"
+  with_dict: "{{ keepalived_sync_groups }}"
+  when: item.value.src_notify_master is defined
+  tags:
+    - keepalived-config
+  notify:
+    - restart keepalived
+
+- name: Dropping the notification scripts for switching to backup
+  copy:
+    src: "{{ item.value.src_notify_backup }}"
+    dest: "{{ item.value.notify_backup }}"
+    mode: "0755"
+  with_dict: "{{ keepalived_sync_groups }}"
+  when: item.value.src_notify_backup is defined
+  tags:
+    - keepalived-config
+  notify:
+    - restart keepalived
+
+- name: Dropping the notification scripts for failures
+  copy:
+    src: "{{ item.value.src_notify_fault }}"
+    dest: "{{ item.value.notify_fault }}"
+    mode: "0755"
+  with_dict: "{{ keepalived_sync_groups }}"
+  when: item.value.src_notify_fault is defined
+  tags:
+    - keepalived-config
+  notify:
+    - restart keepalived
+
+- name: Dropping the general notification scripts (instances)
+  copy:
+    src: "{{ item.value.src_notify_script }}"
+    dest: "{{ item.value.notify_script }}"
+    mode: "0755"
+  with_dict: "{{ keepalived_instances }}"
+  when: item.value.src_notify_script is defined
+  tags:
+    - keepalived-config
+  notify:
+    - restart keepalived
+
+- name: Dropping the notification scripts for switching to master (instances)
+  copy:
+    src: "{{ item.value.src_notify_master }}"
+    dest: "{{ item.value.notify_master }}"
+    mode: "0755"
+  with_dict: "{{ keepalived_instances }}"
+  when: item.value.src_notify_master is defined
+  tags:
+    - keepalived-config
+  notify:
+    - restart keepalived
+
+- name: Dropping the notification scripts for switching to backup (instances)
+  copy:
+    src: "{{ item.value.src_notify_backup }}"
+    dest: "{{ item.value.notify_backup }}"
+    mode: "0755"
+  with_dict: "{{ keepalived_instances }}"
+  when: item.value.src_notify_backup is defined
+  tags:
+    - keepalived-config
+  notify:
+    - restart keepalived
+
+- name: Dropping the notification scripts for stopping vrrp (instances)
+  copy:
+    src: "{{ item.value.src_notify_stop }}"
+    dest: "{{ item.value.notify_stop }}"
+    mode: "0755"
+  with_dict: "{{ keepalived_instances }}"
+  when: item.value.src_notify_stop is defined
+  tags:
+    - keepalived-config
+  notify:
+    - restart keepalived
+
+- name: Dropping the notification scripts for failures (instances)
+  copy:
+    src: "{{ item.value.src_notify_fault }}"
+    dest: "{{ item.value.notify_fault }}"
+    mode: "0755"
+  with_dict: "{{ keepalived_instances }}"
+  when: item.value.src_notify_fault is defined
+  tags:
+    - keepalived-config
+  notify:
+    - restart keepalived
+
+- name: Ensuring keepalived is enabled
+  service:
+    name: "{{ keepalived_service_name }}"
+    enabled: "yes"

--- a/roles/ansible_keepalived/templates/keepalived.conf.j2
+++ b/roles/ansible_keepalived/templates/keepalived.conf.j2
@@ -1,0 +1,159 @@
+#jinja2: lstrip_blocks: True
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{% for name, sync_group in keepalived_sync_groups.items() %}
+vrrp_sync_group {{ name }} {
+  group {
+    {% for instance in sync_group.instances %}
+    {{ instance }}
+    {% endfor %}
+  }
+  {% if sync_group.notify_script is defined %}
+  notify "{{ sync_group.notify_script }}"
+  {% endif %}
+  {% if sync_group.notify_master is defined %}
+  notify_master "{{ sync_group.notify_master }}"
+  {% endif %}
+  {% if sync_group.notify_backup is defined %}
+  notify_backup "{{ sync_group.notify_backup }}"
+  {% endif %}
+  {% if sync_group.notify_fault is defined %}
+  notify_fault "{{ sync_group.notify_fault }}"
+  {% endif %}
+}
+{% endfor %}
+
+{% if keepalived_scripts is defined %}
+{% for name, details in keepalived_scripts.items() %}
+vrrp_script {{ name }} {
+  script "{{ details.check_script }}"
+  interval {{ details.interval | default(5) }}   # checking every {{ details.interval | default(5) }} seconds (default: 5 seconds)
+  fall {{ details.fall | default(3) }}           # require {{ details.fall | default(3) }} failures for KO (default: 3)
+  rise {{ details.rise | default(6) }}           # require {{ details.rise | default(6) }} successes for OK (default: 6)
+  {% if details.timeout is defined %}
+  timeout {{ details.timeout }}                  # allow scripts like ping to succeed, before timing out
+  {% endif %}
+}
+{% endfor %}
+{% endif %}
+
+{% for name, instance in keepalived_instances.items() %}
+vrrp_instance {{ name }} {
+  interface {{ instance.interface }}
+  state {{ instance.state }}
+  virtual_router_id {{ instance.virtual_router_id }}
+  priority {{ instance.priority }}
+  {% if instance.nopreempt is defined and instance.nopreempt | bool %}
+  nopreempt                                        # Override VRRP RFC preemption default
+  {% endif %}
+  {% if instance.preempt_delay is defined %}
+  preempt_delay {{ instance.preempt_delay }}       # Seconds after startup until preemption. 0 (default) to 1,000.
+  {% endif %}
+  {% if instance.authentication_password is defined %}
+  authentication {
+    auth_type PASS
+    auth_pass {{instance.authentication_password}}
+  }
+  {% endif %}
+  {% if instance.unicast_src_ip is defined and instance.unicast_peers|length > 0 %}
+  unicast_src_ip {{ instance.unicast_src_ip }}
+  unicast_peer {
+  {% for peer in instance.unicast_peers %}
+    {{ peer }}
+  {% endfor %}
+  }
+  {% endif %}
+  virtual_ipaddress {
+    {% for vip in instance.vips %}
+    {{ vip }}
+    {% endfor %}
+  }
+  {% if instance.virtual_routes is defined %}
+  virtual_routes {
+  {% for route in instance.virtual_routes %}
+    {{ route }}
+  {% endfor %}
+  }
+  {% endif %}
+  {% if instance.track_scripts is defined %}
+  track_script {
+    {% for track_script in instance.track_scripts %}
+    {{ track_script }}
+    {% endfor %}
+  }
+  {% endif %}
+
+  {% if instance.track_interfaces is defined %}
+  track_interface {
+    {% for track_interface in instance.track_interfaces %}
+    {{ track_interface }}
+    {% endfor %}
+  }
+  {% endif %}
+
+  {% if instance.notify_script is defined %}
+  notify "{{ instance.notify_script }}"
+  {% endif %}
+  {% if instance.notify_master is defined %}
+  notify_master "{{ instance.notify_master }}"
+  {% endif %}
+  {% if instance.notify_backup is defined %}
+  notify_backup "{{ instance.notify_backup }}"
+  {% endif %}
+  {% if instance.notify_fault is defined %}
+  notify_fault "{{ instance.notify_fault }}"
+  {% endif %}
+  {% if instance.notify_stop is defined %}
+  notify_stop "{{ instance.notify_stop }}"
+  {% endif %}
+}
+{% endfor %}
+
+{% if keepalived_virtual_servers is defined %}
+{% for vserver in keepalived_virtual_servers %}
+virtual_server {{ vserver.ip }} {{ vserver.port }} {
+  ip_family {{ vserver.ip_family | default('inet') }}
+  {% if vserver.delay_loop is defined %}
+  delay_loop {{ vserver.delay_loop }}
+  {% endif %}
+  lvs_sched {{ vserver.lvs_sched | default ('rr') }}
+  lvs_method {{ vserver.lvs_method | default ('DR') }}
+  protocol {{ vserver.protocol | default ('TCP') }}
+  {% if vserver.ha_suspend is defined and vserver.ha_suspend %}
+  ha_suspend
+  {% endif %}
+
+  {% for rserver in vserver.real_servers %}
+  real_server {{ rserver.ip }} {{ rserver.port }} {
+    {% if rserver.misc_check is defined %}
+    {% for mcheck in rserver.misc_check %}
+    MISC_CHECK {
+      misc_path "{{ mcheck.misc_path }}"
+      misc_timeout {{ mcheck.misc_timeout | default('3') }}
+      {% if mcheck.warmup is defined and mcheck.warmup %}
+      warmup {{ mcheck.warmup }}
+      {% endif %}
+      {% if mcheck.misc_dynamic is defined and mcheck.misc_dynamic %}
+      misc_dynamic
+      {% endif %}
+    }
+    {% endfor %}
+    {% endif %}
+  }
+  {% endfor %}
+
+}
+{% endfor %}
+{% endif %}

--- a/roles/ansible_keepalived/tests/deploy.yml
+++ b/roles/ansible_keepalived/tests/deploy.yml
@@ -1,0 +1,53 @@
+---
+- hosts: keepalived2
+  gather_facts: no
+  tasks:
+    - raw: sudo apt-get install -y python
+
+- hosts: all
+  gather_facts: yes
+  become: true
+  become_method: sudo
+  pre_tasks:
+    - name: Ensure the vrrp nics are up
+      shell: ip link set dev {{ vrrp_nic }} up || true
+      changed_when: false
+    - name: Display the configuration
+      debug:
+        var: keepalived_instances
+  roles:
+    - ../ansible-keepalived
+
+- name: Check if first node is master
+  hosts: keepalived1
+  gather_facts: yes
+  become: true
+  become_method: sudo
+  tasks:
+    - assert:
+        that:
+          - "'ipv4_secondaries' in ansible_eth1"
+          - "ansible_eth1['ipv4_secondaries'][0]['address'] == '192.168.33.2'"
+
+- name: Check if failover works
+  hosts: all
+  gather_facts: yes
+  become: true
+  become_method: sudo
+  tasks:
+    - shell: ifconfig {{ vrrp_nic }} down || true
+      changed_when: false
+      when: inventory_hostname != ansible_play_hosts[2]
+    - name: The VRRP state needs to adapt the topo change
+      wait_for:
+        timeout: 12
+    - setup:
+        gather_subset: network
+    - debug:
+        var: ansible_all_ipv4_addresses
+    - assert:
+        that:
+          - "'192.168.33.2' in ansible_all_ipv4_addresses"
+      when: inventory_hostname == ansible_play_hosts[2]
+    #- shell: ifconfig {{ vrrp_nic }} up || true
+    #  changed_when: false

--- a/roles/ansible_keepalived/tests/group_vars/all.yml
+++ b/roles/ansible_keepalived/tests/group_vars/all.yml
@@ -1,0 +1,2 @@
+---
+vrrp_nic: eth1

--- a/roles/ansible_keepalived/tests/host_vars/keepalived2.yml
+++ b/roles/ansible_keepalived/tests/host_vars/keepalived2.yml
@@ -1,0 +1,2 @@
+---
+vrrp_nic: "{{ ansible_interfaces | reject('equalto','lo') | sort | last }}"

--- a/roles/ansible_keepalived/tests/keepalived_haproxy_backup_example.yml
+++ b/roles/ansible_keepalived/tests/keepalived_haproxy_backup_example.yml
@@ -1,0 +1,131 @@
+---
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+keepalived_sync_groups:
+  # You can have multiple sync groups. Here is an example of just one.
+  haproxy:
+    # Each group can have muliple instances
+    instances:
+      - external
+      - internal
+    # Uncomment this to have a notification script, triggered on state change.
+    # all the *_scripts can be a direct command, or a path to a script
+    # For the latter, you MUST define a script that will be used a source in
+    # src_*_script (available on the deployment host).
+    # The src_*_script will be uploaded to your destination host at the _script
+    # location
+    #notify_script: /etc/keepalived/haproxy_notify.sh
+    #src_notify_script: <path to source script if notify_script is not a command>
+    # If instead of one notification script handling all types of events, you
+    # want to define script per type of notification, please uncomment this.
+    # They will act before the general notification script.
+    # Their deployment and configuration are like the notify_script
+    #notify_master:
+    #src_notify_master:
+    #notify_backup:
+    #src_notify_backup:
+    #notify_fault:
+    #src_notify_fault:
+
+# Uncomment this to have keepalived status checking. They will run on all the hosts
+# whether it's master or backup. You can have multiple scripts.
+#keepalived_scripts:
+  #haproxy_check_script:
+    # Here is an example with a command instead of a script.
+    # Add src_check_script if you want to run a script instead of a command
+    # and upload it from your deploy host
+    #check_script: "killall -0 haproxy"
+  #pingable_check_script:
+    #check_script: "ping -c 1 193.0.14.129 1>&2"
+    # Interval is the time in seconds between each check
+    #interval: 10
+    # Fall is the time to mark the keepalived status as not ok
+    #fall: 2
+    # Rise is the time to mark the keepalived status as back to ok
+    #rise: 4
+    # Allow the check script to complete within a timeout
+    #timeout: 2
+
+
+keepalived_instances:
+  #This dict name is the same as the one above, in keepalived_sync_groups.
+  external:
+    #remember you can use ansible variables here.
+    interface: eth0
+    state: BACKUP
+    virtual_router_id: 10
+    priority: 20
+    # Please set this if you want to use authentication in your VRRP
+    # instance. If more than 8 characters, it will be truncated.
+    # The password must be the same per router_id (so backup and
+    # master should have the same password).
+    #authentication_password: "your_password"
+    vips:
+      - "{{ keepalived_external_vip_cidr | default('127.0.2.1') }} dev {{ keepalived_external_interface | default('eth0') }}"
+    # Optional Scripts for tracking the current status of the keepalived instance
+    #track_scripts:
+    #  - haproxy_check_script
+    #  - pingable_check_script
+    # Optional Interfaces for tracking the link status of the interfaces listed
+    #track_interfaces:
+    #  - eth1
+    #  - eth2
+  internal:
+    interface: eth1
+    state: BACKUP
+    virtual_router_id: 11
+    priority: 20
+    # Please set this if you want to use authentication in your VRRP
+    # instance. If more than 8 characters, it will be truncated.
+    # The password must be the same per router_id (so backup and
+    # master should have the same password).
+    #authentication_password: "your_password"
+    # Optional Scripts for tracking the current status of the keepalived instance
+    #track_scripts:
+    #  - haproxy_check_script
+    #  - pingable_check_script
+    # Optional Interfaces for tracking the link status of the interfaces listed
+    #track_interfaces:
+    #  - eth1
+    #  - eth2
+    vips:
+      - "{{ keepalived_internal_vip_cidr | default('127.0.3.1') }} dev {{ keepalived_internal_interface | default('eth1') }} "
+
+# Uncomment and adjust to make use of keepalived's virtual_server functions.
+#keepalived_virtual_servers:
+#  # Example with recycled {{ keepalived_internal_vip_cidr }}
+#  - ip: "{{ keepalived_internal_vip_cidr | ipaddr('address') }}"
+#    port: '53'
+#    protocol: 'UDP'
+#    lvs_method: 'NAT'
+#    # Optional, set false or omit to not use it.
+#    ha_suspend: true
+#    real_servers:
+#      - ip: '8.8.8.8'
+#        port: '53'
+#        # Currently on MISC_CHECK is supported. Section is optional.
+#        misc_check:
+#            - misc_path: '/usr/bin/host -W 1 github.com 8.8.8.8'
+#              # Role default is 3
+#              misc_timeout: '2'
+#      - ip: '8.8.4.4'
+#        port: '53'
+#        misc_check:
+#            - misc_path: '/usr/bin/host -W 1 github.com 8.8.4.4'
+#              misc_timeout: '10'
+#              # Optinal, set false or omit to not use it.
+#              warmup: true
+#              # Optinal, set false or omit to not use it.
+#              misc_dynamic: true

--- a/roles/ansible_keepalived/tests/keepalived_haproxy_combined_example.yml
+++ b/roles/ansible_keepalived/tests/keepalived_haproxy_combined_example.yml
@@ -1,0 +1,27 @@
+---
+# Copyright 2017, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+keepalived_sync_groups:
+  haproxy:
+    instances:
+      - internal
+keepalived_instances:
+  internal:
+    interface: "{{ vrrp_nic }}"
+    state: "{{ (play_hosts.index(inventory_hostname) == 0) | ternary('MASTER','BACKUP') }}"
+    virtual_router_id: 42
+    priority: "{{ (play_hosts.index(inventory_hostname) == 0) | ternary('100','50') }}"
+    vips:
+      - "192.168.33.2/24 dev {{ vrrp_nic }}"

--- a/roles/ansible_keepalived/tests/keepalived_haproxy_master_example.yml
+++ b/roles/ansible_keepalived/tests/keepalived_haproxy_master_example.yml
@@ -1,0 +1,130 @@
+---
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+keepalived_sync_groups:
+  # You can have multiple sync groups. Here is an example of just one.
+  haproxy:
+    # Each group can have muliple instances
+    instances:
+      - external
+      - internal
+    # Uncomment this to have a notification script, triggered on state change.
+    # all the *_scripts can be a direct command, or a path to a script
+    # For the latter, you MUST define a script that will be used a source in
+    # src_*_script (available on the deployment host).
+    # The src_*_script will be uploaded to your destination host at the _script
+    # location
+    #notify_script: /etc/keepalived/haproxy_notify.sh
+    #src_notify_script: <path to source script if notify_script is not a command>
+    # If instead of one notification script handling all types of events, you
+    # want to define script per type of notification, please uncomment this.
+    # They will act before the general notification script.
+    # Their deployment and configuration are like the notify_script
+    #notify_master:
+    #src_notify_master:
+    #notify_backup:
+    #src_notify_backup:
+    #notify_fault:
+    #src_notify_fault:
+
+# Uncomment this to have keepalived status checking. They will run on all the hosts
+# whether it's master or backup. You can have multiple scripts.
+#keepalived_scripts:
+  #haproxy_check_script:
+    # Here is an example with a command instead of a script.
+    # Add src_check_script if you want to run a script instead of a command
+    # and upload it from your deploy host
+    #check_script: "killall -0 haproxy"
+  #pingable_check_script:
+    #check_script: "ping -c 1 193.0.14.129 1>&2"
+    # Interval is the time in seconds between each check
+    #interval: 10
+    # Fall is the time to mark the keepalived status as not ok
+    #fall: 2
+    # Rise is the time to mark the keepalived status as back to ok
+    #rise: 4
+    # Allow the check script to complete within a timeout
+    #timeout: 2
+
+keepalived_instances:
+  #This dict name is the same as the one above, in keepalived_sync_groups.
+  external:
+    #remember you can use ansible variables here.
+    interface: eth0
+    state: MASTER
+    virtual_router_id: 10
+    priority: 100
+    # Please set this if you want to use authentication in your VRRP
+    # instance. If more than 8 characters, it will be truncated.
+    # The password must be the same per router_id (so backup and
+    # master should have the same password).
+    #authentication_password: "your_password"
+    vips:
+      - "{{keepalived_external_vip_cidr}} dev eth0"
+    # Optional Scripts for tracking the current status of the keepalived instance
+    #track_scripts:
+    #  - haproxy_check_script
+    #  - pingable_check_script
+    # Optional Interfaces for tracking the link status of the interfaces listed
+    #track_interfaces:
+    #  - eth1
+    #  - eth2
+  internal:
+    interface: eth1
+    state: MASTER
+    virtual_router_id: 11
+    priority: 100
+    # Please set this if you want to use authentication in your VRRP
+    # instance. If more than 8 characters, it will be truncated.
+    # The password must be the same per router_id (so backup and
+    # master should have the same password).
+    #authentication_password: "your_password"
+    # Optional Scripts for tracking the current status of the keepalived instance
+    #track_scripts:
+    #  - haproxy_check_script
+    #  - pingable_check_script
+    # Optional Interfaces for tracking the link status of the interfaces listed
+    #track_interfaces:
+    #  - eth1
+    #  - eth2
+    vips:
+      - "{{keepalived_internal_vip_cidr}} dev eth1"
+
+# Uncomment and adjust to make use of keepalived's virtual_server functions.
+#keepalived_virtual_servers:
+#  # Example with recycled {{ keepalived_internal_vip_cidr }}
+#  - ip: "{{ keepalived_internal_vip_cidr | ipaddr('address') }}"
+#    port: '53'
+#    protocol: 'UDP'
+#    lvs_method: 'NAT'
+#    # Optional, set false or omit to not use it.
+#    ha_suspend: true
+#    real_servers:
+#      - ip: '8.8.8.8'
+#        port: '53'
+#        # Currently on MISC_CHECK is supported. Section is optional.
+#        misc_check:
+#            - misc_path: '/usr/bin/host -W 1 github.com 8.8.8.8'
+#              # Role default is 3
+#              misc_timeout: '2'
+#      - ip: '8.8.4.4'
+#        port: '53'
+#        misc_check:
+#            - misc_path: '/usr/bin/host -W 1 github.com 8.8.4.4'
+#              misc_timeout: '10'
+#              # Optinal, set false or omit to not use it.
+#              warmup: true
+#              # Optinal, set false or omit to not use it.
+#              misc_dynamic: true

--- a/roles/ansible_keepalived/vars/main.yml
+++ b/roles/ansible_keepalived/vars/main.yml
@@ -1,0 +1,14 @@
+---
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/roles/ansible_keepalived/vars/redhat.yml
+++ b/roles/ansible_keepalived/vars/redhat.yml
@@ -1,0 +1,19 @@
+---
+# Copyright 2017, Major Hayden <major@mhtx.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard names and paths for CentOS 7
+keepalived_package_name: "keepalived"
+keepalived_service_name: "keepalived"
+keepalived_config_file_path: "/etc/keepalived/keepalived.conf"

--- a/roles/ansible_keepalived/vars/suse.yml
+++ b/roles/ansible_keepalived/vars/suse.yml
@@ -1,0 +1,18 @@
+---
+# Copyright 2017, SUSE LINUX GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+keepalived_package_name: "keepalived"
+keepalived_service_name: "keepalived"
+keepalived_config_file_path: "/etc/keepalived/keepalived.conf"

--- a/roles/ansible_keepalived/vars/ubuntu-14.04.yml
+++ b/roles/ansible_keepalived/vars/ubuntu-14.04.yml
@@ -1,0 +1,33 @@
+---
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#Standard names and paths for ubuntu 14.04
+keepalived_package_name: "keepalived"
+keepalived_service_name: "keepalived"
+keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+
+## Repo details for keepalived ppa
+keepalived_ppa_repo: "ppa:keepalived/stable"
+keepalived_ppa_keyid: "7C33BDC6"
+keepalived_ppa_keyserver: "keyserver.ubuntu.com"
+
+## Repo details for keepalived uca
+keepalived_uca_repo: "deb {{ keepalived_uca_apt_repo_url }} {{ keepalived_uca_repo_dist }} main"
+keepalived_uca_repo_dist: "{{ ansible_lsb.codename }}-updates/{{ keepalived_uca_openstack_release }}"
+keepalived_uca_openstack_release: mitaka
+
+## Prevent start on install
+prevent_start_file: "/etc/init/keepalived.override"
+prevent_start_file_content: "manual"

--- a/roles/ansible_keepalived/vars/ubuntu-16.04.yml
+++ b/roles/ansible_keepalived/vars/ubuntu-16.04.yml
@@ -1,0 +1,33 @@
+---
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#Standard names and paths for ubuntu 16.04
+keepalived_package_name: "keepalived"
+keepalived_service_name: "keepalived.service"
+keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+
+## Repo details for keepalived ppa
+keepalived_ppa_repo: "ppa:keepalived/stable"
+keepalived_ppa_keyid: "7C33BDC6"
+keepalived_ppa_keyserver: "keyserver.ubuntu.com"
+
+## Repo details for uca
+keepalived_uca_repo: "deb {{ keepalived_uca_apt_repo_url }} {{ keepalived_uca_repo_dist }} main"
+keepalived_uca_repo_dist: "{{ ansible_lsb.codename }}-updates/{{ keepalived_uca_openstack_release }}"
+keepalived_uca_openstack_release: ocata
+
+## Prevent start on install
+prevent_start_file: "/usr/sbin/policy-rc.d"
+prevent_start_file_content: "exit 101"

--- a/roles/openshift_storage_glusterfs/defaults/main.yml
+++ b/roles/openshift_storage_glusterfs/defaults/main.yml
@@ -52,8 +52,8 @@ openshift_storage_glusterfs_registry_heketi_ssh_port: "{{ openshift_storage_glus
 openshift_storage_glusterfs_registry_heketi_ssh_user: "{{ openshift_storage_glusterfs_heketi_ssh_user }}"
 openshift_storage_glusterfs_registry_heketi_ssh_sudo: "{{ openshift_storage_glusterfs_heketi_ssh_sudo }}"
 openshift_storage_glusterfs_registry_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_heketi_ssh_keyfile | default(omit) }}"
-r_openshift_master_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
-r_openshift_master_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
+r_openshift_storage_glusterfs_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
+r_openshift_storage_glusterfs_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 r_openshift_storage_glusterfs_os_firewall_deny: []
 r_openshift_storage_glusterfs_os_firewall_allow:
 - service: glusterfs_sshd


### PR DESCRIPTION
Just simple playbook to deploy keepalived on master node for HA clustering without external LoadBlanacer with round-robin DNS only.

Uses ansible-keepalived role from evrardjp/ansible-keepalived to deploy keepalived and couple of iptables rules to enable VRRP traffic.