### PR TITLE
use generic v3.4 and v3.3 tags for metrics and logging deployers

### DIFF
--- a/roles/openshift_hosted_templates/files/v1.3/enterprise/logging-deployer.yaml
+++ b/roles/openshift_hosted_templates/files/v1.3/enterprise/logging-deployer.yaml
@@ -204,7 +204,7 @@ items:
   -
     description: 'Specify version for logging components; e.g. for "registry.access.redhat.com/openshift3/logging-deployer:3.3.1", set version "3.3.1"'
     name: IMAGE_VERSION
-    value: "3.3.1"
+    value: "v3.3"
   -
     description: "(Deprecated) Specify the name of an existing pull secret to be used for pulling component images from an authenticated registry."
     name: IMAGE_PULL_SECRET

--- a/roles/openshift_hosted_templates/files/v1.3/enterprise/metrics-deployer.yaml
+++ b/roles/openshift_hosted_templates/files/v1.3/enterprise/metrics-deployer.yaml
@@ -101,7 +101,7 @@ parameters:
 -
   description: 'Specify version for metrics components; e.g. for "openshift/origin-metrics-deployer:latest", set version "latest"'
   name: IMAGE_VERSION
-  value: "3.3.1"
+  value: "v3.3"
 -
   description: "Internal URL for the master, for authentication retrieval"
   name: MASTER_URL

--- a/roles/openshift_hosted_templates/files/v1.4/enterprise/logging-deployer.yaml
+++ b/roles/openshift_hosted_templates/files/v1.4/enterprise/logging-deployer.yaml
@@ -223,7 +223,7 @@ items:
   -
     description: 'Specify version for logging components; e.g. for "registry.access.redhat.com/openshift3/logging-deployer:3.4.0", set version "3.4.0"'
     name: IMAGE_VERSION
-    value: "3.4.0"
+    value: "v3.4"
   -
     description: "(Deprecated) Specify the name of an existing pull secret to be used for pulling component images from an authenticated registry."
     name: IMAGE_PULL_SECRET

--- a/roles/openshift_hosted_templates/files/v1.4/enterprise/metrics-deployer.yaml
+++ b/roles/openshift_hosted_templates/files/v1.4/enterprise/metrics-deployer.yaml
@@ -105,7 +105,7 @@ parameters:
 -
   description: 'Specify version for metrics components; e.g. for "openshift/origin-metrics-deployer:latest", set version "latest"'
   name: IMAGE_VERSION
-  value: "3.4.0"
+  value: "v3.4"
 -
   description: "Internal URL for the master, for authentication retrieval"
   name: MASTER_URL
@@ -118,7 +118,7 @@ parameters:
   description: "Can be set to: 'preflight' to perform validation before a deployment; 'deploy' to perform an initial deployment; 'refresh' to delete and redeploy all components but to keep persisted data and routes; 'redeploy' to delete and redeploy everything (losing all data in the process); 'validate' to re-run validations after a deployment"
   name: MODE
   value: "deploy"
-- 
+-
   description: "Set to true to continue even if the deployer runs into an error."
   name: CONTINUE_ON_ERROR
   value: "false"


### PR DESCRIPTION
Users are having problems when upgrading using the deployer and having the x.x.0 version
 3.3.0 only gets upgraded to the latest 3.3.0-x version which is outdated. The same for 3.4