### PR TITLE
Glusterfs variable naming fix.

### DIFF
--- a/roles/openshift_storage_glusterfs/defaults/main.yml
+++ b/roles/openshift_storage_glusterfs/defaults/main.yml
@@ -52,8 +52,8 @@ openshift_storage_glusterfs_registry_heketi_ssh_port: "{{ openshift_storage_glus
 openshift_storage_glusterfs_registry_heketi_ssh_user: "{{ openshift_storage_glusterfs_heketi_ssh_user }}"
 openshift_storage_glusterfs_registry_heketi_ssh_sudo: "{{ openshift_storage_glusterfs_heketi_ssh_sudo }}"
 openshift_storage_glusterfs_registry_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_heketi_ssh_keyfile | default(omit) }}"
-r_openshift_master_firewall_enabled: True
-r_openshift_master_use_firewalld: False
+r_openshift_storage_glusterfs_firewall_enabled: True
+r_openshift_storage_glusterfs_use_firewalld: False
 r_openshift_storage_glusterfs_os_firewall_deny: []
 r_openshift_storage_glusterfs_os_firewall_allow:
 - service: glusterfs_sshd


### PR DESCRIPTION
This pull request changes the role variables for firewall to the correct role name.  This is the result of a copy and paste error.