### PR TITLE
Standardize openshift_provisioners entry point

### DIFF
--- a/playbooks/byo/openshift-cluster/openshift-provisioners.yml
+++ b/playbooks/byo/openshift-cluster/openshift-provisioners.yml
@@ -1,0 +1,6 @@
+---
+- include: initialize_groups.yml
+
+- include: ../../common/openshift-cluster/std_include.yml
+
+- include: ../../common/openshift-cluster/openshift_provisioners.yml


### PR DESCRIPTION
Adding a `byo` entry point to standardize the playbook flow for openshift_provisioners.
