### PR TITLE
Bug 1467265 - logging: add 'purge' option with uninstall

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -15,12 +15,11 @@ to the list of persisted [node labels](https://docs.openshift.org/latest/install
 ###Required vars:
 
 - `openshift_logging_install_logging`: When `True` the `openshift_logging` role will install Aggregated Logging.
-- `openshift_logging_upgrade_logging`:  When `True` the `openshift_logging` role will upgrade Aggregated Logging.
 
-When both `openshift_logging_install_logging` and `openshift_logging_upgrade_logging` are `False` the `openshift_logging` role will uninstall Aggregated Logging.
+When `openshift_logging_install_logging` is set to `False` the `openshift_logging` role will uninstall Aggregated Logging.
 
 ###Optional vars:
-
+- `openshift_logging_purge_logging`: When `openshift_logging_install_logging` is set to 'False' to trigger uninstalation and `openshift_logging_purge_logging` is set to 'True', it will completely and irreversibly remove all logging persistent data including PVC. Defaults to 'False'.
 - `openshift_logging_image_prefix`: The prefix for the logging images to use. Defaults to 'docker.io/openshift/origin-'.
 - `openshift_logging_image_version`: The image version for the logging images to use. Defaults to 'latest'.
 - `openshift_logging_use_ops`: If 'True', set up a second ES and Kibana cluster for infrastructure logs. Defaults to 'False'.

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -8,6 +8,7 @@ openshift_logging_labels: {}
 openshift_logging_label_key: ""
 openshift_logging_label_value: ""
 openshift_logging_install_logging: True
+openshift_logging_purge_logging: False
 openshift_logging_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"
 
 openshift_logging_curator_default_days: 30

--- a/roles/openshift_logging/tasks/delete_logging.yaml
+++ b/roles/openshift_logging/tasks/delete_logging.yaml
@@ -14,6 +14,16 @@
     - templates
     - ds
 
+# return all persistent volume claims as well if purge is set
+- name: delete logging pvc objects
+  oc_obj:
+    state: absent
+    kind: pvc
+    namespace: "{{ openshift_logging_namespace }}"
+    selector: "logging-infra"
+  when:
+    - openshift_logging_purge_logging | default(false) | bool
+
 # delete the oauthclient
 - name: delete oauthclient kibana-proxy
   oc_obj:


### PR DESCRIPTION
The common uninstall would keep PVC around to prevent unwanted data loss during reinstalls. There is a scenario where the user may want complete removal of EFK stack including PVC.

This change adds an optional `openshift_logging_purge_logging` variable to completely remove the EFK stack. By default, this is set to 'False' and only works if user sets `openshift_logging_install_logging` to 'False' to initiate the uninstallation process.

cc: @jcantrill , @richm 

https://bugzilla.redhat.com/show_bug.cgi?id=1467265