### PR TITLE
Backport to 3.6 - Bug 1468987: kibana_proxy OOM

### DIFF
--- a/roles/openshift_logging_kibana/defaults/main.yml
+++ b/roles/openshift_logging_kibana/defaults/main.yml
@@ -26,7 +26,7 @@ openshift_logging_kibana_ops_deployment: false
 # Proxy settings
 openshift_logging_kibana_proxy_debug: false
 openshift_logging_kibana_proxy_cpu_limit: null
-openshift_logging_kibana_proxy_memory_limit: 96Mi
+openshift_logging_kibana_proxy_memory_limit: 256Mi
 
 #The absolute path on the control node to the cert file to use
 #for the public facing kibana certs


### PR DESCRIPTION
Backporting https://github.com/openshift/openshift-ansible/pull/4761 to 3.6

We currently set the memory allocated to the kibana-proxy container to be the same as `max_old_space_size` for nodejs. But in V8, the heap consists of multiple spaces.

The old space has only memory ready to be GC and measuring the used heap by kibana-proxy code, there is at least additional 32MB needed in the code space when `max_old_space_size` peaks.

Setting the default memory limit to 256MB here and also changing the default calculation of `max_old_space_size` in the image repository to be only half of what the container receives to allow some heap for other `spaces`.