### PR TITLE
Backport to 1.5 - bug 1468987: kibana_proxy OOM

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -25,7 +25,7 @@ openshift_logging_kibana_cpu_limit: null
 openshift_logging_kibana_memory_limit: 736Mi
 openshift_logging_kibana_proxy_debug: false
 openshift_logging_kibana_proxy_cpu_limit: null
-openshift_logging_kibana_proxy_memory_limit: 96Mi
+openshift_logging_kibana_proxy_memory_limit: 256Mi
 openshift_logging_kibana_replica_count: 1
 openshift_logging_kibana_edge_term_policy: Redirect
 


### PR DESCRIPTION
Backporting https://github.com/openshift/openshift-ansible/pull/4761 to 1.5

We currently set the memory allocated to the kibana-proxy container to be the same as `max_old_space_size` for nodejs. But in V8, the heap consists of multiple spaces.

The old space has only memory ready to be GC and measuring the used heap by kibana-proxy code, there is at least additional 32MB needed in the code space when `max_old_space_size` peaks.

Setting the default memory limit to 256MB here and also changing the default calculation of `max_old_space_size` in the image repository to be only half of what the container receives to allow some heap for other `spaces`.