### PR TITLE
Update glusterfs docs for working array definition

### DIFF
--- a/roles/openshift_storage_glusterfs/README.md
+++ b/roles/openshift_storage_glusterfs/README.md
@@ -55,7 +55,7 @@ defined:
 
 | Name              | Default value | Description                             |
 |-------------------|---------------|-----------------------------------------|
-| glusterfs_devices | None          | A list of block devices that will be completely managed as part of a GlusterFS cluster. There must be at least one device listed. Each device must be bare, e.g. no partitions or LVM PVs. **Example:** '[ "/dev/sdb" ]'
+| glusterfs_devices | None          | A list of block devices that will be completely managed as part of a GlusterFS cluster. There must be at least one device listed. Each device must be bare, e.g. no partitions or LVM PVs. **Example:** `glusterfs_devices=[ "/dev/sdb" ]`
 
 In addition, each host may specify the following variables to further control
 their configuration as GlusterFS nodes:


### PR DESCRIPTION
This updates the glusterfs docs to show an example for the `glusterfs_devices` array.

Due to some dynamic creation of variables within loops in jinja2 templates, the array cannot be specified in an inventory (or as playbook `--extra-vars`) as  `'[ "/dev/sdb" ]'` it must be specified without the single quotes, e.g. `[ "/dev/sdb" ]`. 

Previously if used in the fashion shown in the documents, the array would be interpreted as a string literally with the template resulting in "an array of characters", like this:

```
"devices": ["["," ",""","/","d","e","v","/","v","d","c","""," ","]"]
```
This PR enhances the example to show a working specification of the array.
