### PR TITLE
Upgrade check for OpenShift authorization objects

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_7/validator.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/validator.yml
@@ -7,6 +7,16 @@
   hosts: oo_first_master
   roles:
   - { role: lib_openshift }
+
   tasks:
   - name: Check for invalid namespaces and SDN errors
     oc_objectvalidator:
+
+  - name: Confirm OpenShift authorization objects are in sync
+    command: >
+      {{ openshift.common.client_binary }} adm migrate authorization
+    changed_when: false
+    register: l_oc_result
+    until: l_oc_result.rc == 0
+    retries: 4
+    delay: 15


### PR DESCRIPTION
Adds task to run `oc adm migrate authorization` to ensure OpenShift authorization objects are in sync.

Fixes #5021