### PR TITLE
cri-o: add support for additional registries

### DIFF
--- a/roles/docker/tasks/systemcontainer_crio.yml
+++ b/roles/docker/tasks/systemcontainer_crio.yml
@@ -3,6 +3,15 @@
 - set_fact:
     l_insecure_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(openshift.docker.insecure_registries)) }}"
   when: openshift.docker.insecure_registries
+- set_fact:
+    l_crio_registries: "{{ openshift.docker.additional_registries + ['docker.io'] }}"
+  when: openshift.docker.additional_registries
+- set_fact:
+    l_crio_registries: "{{ ['docker.io'] }}"
+  when: not openshift.docker.additional_registries
+- set_fact:
+    l_additional_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l_crio_registries)) }}"
+  when: openshift.docker.additional_registries
 
 - name: Ensure container-selinux is installed
   package:

--- a/roles/docker/templates/crio.conf.j2
+++ b/roles/docker/templates/crio.conf.j2
@@ -120,6 +120,11 @@ insecure_registries = [
 {{ l_insecure_crio_registries|default("") }}
 ]
 
+# registries is used to specify a comma separated list of registries to be used
+# when pulling an unqualified image (e.g. fedora:rawhide).
+registries = [
+{{ l_additional_crio_registries|default("") }}
+]
 # The "crio.network" table contains settings pertaining to the
 # management of CNI plugins.
 [crio.network]


### PR DESCRIPTION
Support added to CRI-O with:
https://github.com/kubernetes-incubator/cri-o/commit/a35727c80bd2a26613aae21db00628045cb9be24

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>