### PR TITLE
elasticsearch: reintroduce readiness probe

### DIFF
--- a/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
@@ -24,7 +24,8 @@ network:
 
 cloud:
   kubernetes:
-    service: ${SERVICE_DNS}
+    pod_label: ${POD_LABEL}
+    pod_port: 9300
     namespace: ${NAMESPACE}
 
 discovery:

--- a/roles/openshift_logging_elasticsearch/templates/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/es.j2
@@ -90,6 +90,12 @@ spec:
               name: "RECOVER_AFTER_TIME"
               value: "{{openshift_logging_elasticsearch_recover_after_time}}"
             -
+              name: "READINESS_PROBE_TIMEOUT"
+              value: "30"
+            -
+              name: "POD_LABEL"
+              value: "component={{component}}" 
+            -
               name: "IS_MASTER"
               value: "{% if deploy_type in ['data-master', 'master'] %}true{% else %}false{% endif %}"
 
@@ -106,6 +112,13 @@ spec:
               readOnly: true
             - name: elasticsearch-storage
               mountPath: /elasticsearch/persistent
+          readinessProbe:
+            exec:
+              command:
+              - "/usr/share/java/elasticsearch/probe/readiness.sh"
+            initialDelaySeconds: 10
+            timeoutSeconds: 30
+            periodSeconds: 5
       volumes:
         - name: elasticsearch
           secret:


### PR DESCRIPTION
Interim readiness probe until multi-role Elasticsearch topology from https://github.com/openshift/openshift-ansible/pull/5001 is introduced.

**Depends on these PR:**
https://github.com/fabric8io/elasticsearch-cloud-kubernetes/pull/98
https://github.com/openshift/origin-aggregated-logging/pull/609

cc: @lukas-vlcek , @jcantrill , @t0ffel , @richm , @portante 