### PR TITLE
Remove ovsdb systemd dependencies

### DIFF
--- a/roles/openshift_node/templates/node.service.j2
+++ b/roles/openshift_node/templates/node.service.j2
@@ -1,9 +1,10 @@
 [Unit]
 Description=OpenShift Node
 After={{ openshift.docker.service_name }}.service
+{% if openshift.common.use_openshift_sdn %}
 Wants=openvswitch.service
-After=ovsdb-server.service
-After=ovs-vswitchd.service
+After=openvswitch.service
+{% endif %}
 Wants={{ openshift.docker.service_name }}.service
 Documentation=https://github.com/openshift/origin
 Requires=dnsmasq.service

--- a/roles/openshift_node/templates/openshift.docker.node.service
+++ b/roles/openshift_node/templates/openshift.docker.node.service
@@ -6,8 +6,7 @@ PartOf={{ openshift.docker.service_name }}.service
 Requires={{ openshift.docker.service_name }}.service
 {% if openshift.common.use_openshift_sdn %}
 Wants=openvswitch.service
-After=ovsdb-server.service
-After=ovs-vswitchd.service
+After=openvswitch.service
 {% endif %}
 Wants={{ openshift.common.service_type }}-master.service
 Requires={{ openshift.common.service_type }}-node-dep.service

--- a/roles/openshift_node_upgrade/templates/node.service.j2
+++ b/roles/openshift_node_upgrade/templates/node.service.j2
@@ -1,9 +1,10 @@
 [Unit]
 Description=OpenShift Node
 After={{ openshift.docker.service_name }}.service
+{% if openshift.common.use_openshift_sdn %}
 Wants=openvswitch.service
-After=ovsdb-server.service
-After=ovs-vswitchd.service
+After=openvswitch.service
+{% endif %}
 Wants={{ openshift.docker.service_name }}.service
 Documentation=https://github.com/openshift/origin
 Requires=dnsmasq.service

--- a/roles/openshift_node_upgrade/templates/openshift.docker.node.service
+++ b/roles/openshift_node_upgrade/templates/openshift.docker.node.service
@@ -6,8 +6,7 @@ PartOf={{ openshift.docker.service_name }}.service
 Requires={{ openshift.docker.service_name }}.service
 {% if openshift.common.use_openshift_sdn %}
 Wants=openvswitch.service
-After=ovsdb-server.service
-After=ovs-vswitchd.service
+After=openvswitch.service
 {% endif %}
 Wants={{ openshift.common.service_type }}-master.service
 Requires={{ openshift.common.service_type }}-node-dep.service


### PR DESCRIPTION
These were a workaround to an openvswitch bug. If the services that are
executed by openvswitch change in the future and these subservices were
removed we'd fail. So revert back to just depending on openvswitch.

Related https://bugzilla.redhat.com/show_bug.cgi?id=1439630