### PR TITLE
crio: rename openshift_docker_use_crio to openshift_use_crio

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -111,7 +111,7 @@ openshift_release=v3.6
 # Instead of using docker, replacec it with cri-o
 # NOTE: This uses openshift_docker_systemcontainer_image_registry_override as it's override
 # just as container-engine does.
-#openshift_docker_use_crio=False
+#openshift_use_crio=False
 # Force the registry to use for the docker/crio system container. By default the registry
 # will be built off of the deployment type and ansible_distribution. Only
 # use this option if you are sure you know what you are doing!

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -111,7 +111,7 @@ openshift_release=v3.6
 # Install and run cri-o along side docker
 # NOTE: This uses openshift_docker_systemcontainer_image_registry_override as it's override
 # just as container-engine does.
-#openshift_docker_use_crio=False
+#openshift_use_crio=False
 # Force the registry to use for the container-engine/crio system container. By default the registry
 # will be built off of the deployment type and ansible_distribution. Only
 # use this option if you are sure you know what you are doing!

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -7,8 +7,8 @@
 
 - set_fact:
     l_use_system_container: "{{ openshift.docker.use_system_container | default(False) }}"
-    l_use_crio: "{{ openshift.docker.use_crio | default(False) }}"
-    l_use_crio_only: "{{ openshift.docker.use_crio_only | default(False) }}"
+    l_use_crio: "{{ openshift_use_crio | default(False) }}"
+    l_use_crio_only: "{{ openshift_use_crio_only | default(False) }}"
 
 - name: Use Package Docker if Requested
   include: package_docker.yml

--- a/roles/docker/templates/crio.conf.j2
+++ b/roles/docker/templates/crio.conf.j2
@@ -43,7 +43,7 @@ stream_port = "10010"
 # This is a mandatory setting as this runtime will be the default one
 # and will also be used for untrusted container workloads if
 # runtime_untrusted_workload is not set.
-runtime = "/usr/libexec/crio/runc"
+runtime = "/usr/bin/runc"
 
 # runtime_untrusted_workload is the OCI compatible runtime used for untrusted
 # container workloads. This is an optional setting, except if

--- a/roles/openshift_cli/tasks/main.yml
+++ b/roles/openshift_cli/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - set_fact:
-    l_use_crio: "{{ openshift_docker_use_crio | default(false) }}"
+    l_use_crio: "{{ openshift_use_crio | default(false) }}"
 
 - name: Install clients
   package: name={{ openshift.common.service_type }}-clients state=present

--- a/roles/openshift_docker_facts/tasks/main.yml
+++ b/roles/openshift_docker_facts/tasks/main.yml
@@ -17,7 +17,7 @@
       hosted_registry_insecure: "{{ openshift_docker_hosted_registry_insecure | default(openshift.docker.hosted_registry_insecure | default(False)) }}"
       hosted_registry_network: "{{ openshift_docker_hosted_registry_network | default(None) }}"
       use_system_container: "{{ openshift_docker_use_system_container | default(False) }}"
-      use_crio: "{{ openshift_docker_use_crio | default(False) }}"
+      use_crio: "{{ openshift_use_crio | default(False) }}"
   - role: node
     local_facts:
       sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -4,7 +4,7 @@
     msg: "SELinux is disabled, This deployment type requires that SELinux is enabled."
   when:
     - (not ansible_selinux or ansible_selinux.status != 'enabled') and deployment_type in ['enterprise', 'online', 'atomic-enterprise', 'openshift-enterprise']
-    - not openshift_docker_use_crio | default(false)
+    - not openshift_use_crio | default(false)
 
 - name: setup firewall
   include: firewall.yml
@@ -103,7 +103,7 @@
     name: cri-o
     enabled: yes
     state: restarted
-  when: openshift_docker_use_crio | default(false)
+  when: openshift_use_crio | default(false)
 
 - name: Install conntrack-tools package
   package:

--- a/roles/openshift_node/tasks/openvswitch_system_container.yml
+++ b/roles/openshift_node/tasks/openvswitch_system_container.yml
@@ -1,6 +1,6 @@
 ---
 - set_fact:
-    l_use_crio: "{{ openshift_docker_use_crio | default(false) }}"
+    l_use_crio: "{{ openshift_use_crio | default(false) }}"
 
 - set_fact:
     l_service_name: "cri-o"

--- a/roles/openshift_node/templates/node.service.j2
+++ b/roles/openshift_node/templates/node.service.j2
@@ -8,7 +8,7 @@ Wants={{ openshift.docker.service_name }}.service
 Documentation=https://github.com/openshift/origin
 Requires=dnsmasq.service
 After=dnsmasq.service
-{% if openshift.docker.use_crio %}Wants=cri-o.service{% endif %}
+{% if openshift_use_crio|default(false) %}Wants=cri-o.service{% endif %}
 
 [Service]
 Type=notify

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -16,7 +16,7 @@ imageConfig:
   latest: false
 kind: NodeConfig
 kubeletArguments: {{ openshift.node.kubelet_args | default(None) | to_padded_yaml(level=1) }}
-{% if openshift.docker.use_crio | default(False) %}
+{% if openshift_use_crio | default(False) %}
   container-runtime:
   - remote
   container-runtime-endpoint:

--- a/roles/openshift_node/templates/openshift.docker.node.dep.service
+++ b/roles/openshift_node/templates/openshift.docker.node.dep.service
@@ -3,7 +3,7 @@ Requires={{ openshift.docker.service_name }}.service
 After={{ openshift.docker.service_name }}.service
 PartOf={{ openshift.common.service_type }}-node.service
 Before={{ openshift.common.service_type }}-node.service
-{% if openshift.docker.use_crio %}Wants=cri-o.service{% endif %}
+{% if openshift_use_crio|default(false) %}Wants=cri-o.service{% endif %}
 
 [Service]
 ExecStart=/bin/bash -c "if [[ -f /usr/bin/docker-current ]]; then echo \"DOCKER_ADDTL_BIND_MOUNTS=--volume=/usr/bin/docker-current:/usr/bin/docker-current:ro --volume=/etc/sysconfig/docker:/etc/sysconfig/docker:ro\" > /etc/sysconfig/{{ openshift.common.service_type }}-node-dep; else echo \"#DOCKER_ADDTL_BIND_MOUNTS=\" > /etc/sysconfig/{{ openshift.common.service_type }}-node-dep; fi"

--- a/roles/openshift_version/tasks/set_version_containerized.yml
+++ b/roles/openshift_version/tasks/set_version_containerized.yml
@@ -1,6 +1,6 @@
 ---
 - set_fact:
-    l_use_crio: "{{ openshift_docker_use_crio | default(false) }}"
+    l_use_crio: "{{ openshift_use_crio | default(false) }}"
 
 - name: Set containerized version to configure if openshift_image_tag specified
   set_fact:


### PR DESCRIPTION
It is confusing to have _docker_ in the name, since they are two
different backends.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>