### PR TITLE
Add docker_storage_to_overlay2 role

### DIFF
--- a/roles/docker_storage_driver/README.md
+++ b/roles/docker_storage_driver/README.md
@@ -1,0 +1,40 @@
+Docker Storage Driver
+=====================
+
+Returns the current Docker storage driver according to `docker info`.
+
+Requirements
+------------
+
+* Ansible 2.2
+* Docker
+
+Role Variables
+--------------
+
+`docker_storage_driver` (out)
+
+* Name of the current storage driver (`devicemapper`, `overlay2`, etc)
+
+Example Playbook
+----------------
+
+```
+- hosts: nodes
+  gather_facts: no
+  roles:
+  - role: docker_storage_driver
+  tasks:
+  - debug:
+      msg: "Storage Driver: {{ docker_storage_driver }}"
+```
+
+License
+-------
+
+Apache License, Version 2.0
+
+Author Information
+------------------
+
+Matthew Barnes <mbarnes@redhat.com>

--- a/roles/docker_storage_driver/meta/main.yml
+++ b/roles/docker_storage_driver/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+- openshift_facts

--- a/roles/docker_storage_driver/tasks/main.yml
+++ b/roles/docker_storage_driver/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Start container service
+  service:
+    name: "{{ openshift.docker.service_name }}"
+    state: started
+
+- name: Capture output of "docker info"
+  command: docker info
+  register: docker_info_output
+  changed_when: False
+
+- name: Isolate storage driver
+  set_fact:
+    match_list: "{{ docker_info_output.stdout | regex_search('(?<=Storage Driver:)\\s*(\\w+)', '\\1', ignorecase=True, multiline=True) }}"
+
+- name: Set output variable
+  set_fact:
+    docker_storage_driver: "{{ match_list[0] }}"

--- a/roles/docker_storage_to_overlay2/README.md
+++ b/roles/docker_storage_to_overlay2/README.md
@@ -1,0 +1,87 @@
+Docker Storage to Overlay2
+==========================
+
+Changes the Docker storage driver to overlay2.
+
+## WARNING
+
+This makes no attempt to migrate existing containers/images.  It
+momentarily stops docker.service and uses `atomic storage reset`
+to wipe all local Docker storage.
+
+## NOTE
+
+If the existing storage configuration includes a `dm.basesize` option,
+it will be replaced with an `overlay2.size` option with the same value.
+
+The `overlay2.size` option, however, requires overlay2 storage driver
+features beyond Docker 1.12.  See:
+
+   https://github.com/moby/moby/pull/24771
+
+   and
+
+   https://github.com/moby/moby/pull/32977
+
+These features have been backported to RHEL and package version checks
+will be made before adding the `overlay2.size` option.
+
+Requirements
+------------
+
+* Ansible 2.3
+* RHEL 7.4 host
+* `atomic` >= 1.19.1-3
+* `docker` (>= 1.12.6-58 if using `overlay2.size`)
+* `container-storage-setup` (>= 0.7.0 if using `overlay2.size`)
+
+Role Variables
+--------------
+
+`docker_storage_to_overlay2_lvname` (default: `"docker-root-lv"`)
+
+* Container storage logical volume name
+
+`docker_storage_to_overlay2_lvsize` (default: `"100%FREE"`)
+
+* Container storage logical volume size
+
+`docker_storage_to_overlay2_reboot` (default: `True`)
+
+* Reboot host after changing Docker storage to overlay2.  This will
+  verify that `docker-storage-setup.service` can successfully mount
+  the reconfigured logical volume during boot. 
+
+Dependencies
+------------
+
+* `setup` (for `ansible_distribution` fact)
+* `lib_utils` (for `repoquery` module)
+
+Example Playbook
+----------------
+
+```
+- hosts: nodes
+  gather_facts: yes
+  roles:
+  - role: docker_storage_to_overlay2
+```
+
+See Also
+--------
+
+`docker_storage_driver` role
+
+* Sets `docker_storage_driver` fact, which could be useful in writing an
+  idempotent playbook around this role.
+
+License
+-------
+
+Apache License, Version 2.0
+
+Author Information
+------------------
+
+Matthew Barnes <mbarnes@redhat.com>

--- a/roles/docker_storage_to_overlay2/defaults/main.yml
+++ b/roles/docker_storage_to_overlay2/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+docker_storage_to_overlay2_lvname: "docker-root-lv"
+docker_storage_to_overlay2_lvsize: "100%FREE"
+docker_storage_to_overlay2_reboot: True

--- a/roles/docker_storage_to_overlay2/meta/main.yml
+++ b/roles/docker_storage_to_overlay2/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+- lib_utils
+- openshift_facts

--- a/roles/docker_storage_to_overlay2/tasks/main.yml
+++ b/roles/docker_storage_to_overlay2/tasks/main.yml
@@ -1,0 +1,166 @@
+---
+
+# As of 7.4, SELinux security labels are now supported
+# on the OverlayFS file system (see RHEL release notes).
+- name: Check if distribution supports overlayfs (RHEL/CentOS)
+  when: ansible_distribution in ["RedHat", "CentOS"]
+  assert:
+    that: ansible_distribution_version | version_compare("7.4", "ge")
+    msg: "The OverlayFS file system only works with SELinux in {{ ansible_distribution }} 7.4 or later."
+
+- name: Install or update required packages
+  package:
+    name: "{{ item.key }}"
+    state: latest
+  with_dict: "{{ docker_storage_to_overlay2_package_requirements }}"
+
+- name: Capture storage setup configuration
+  slurp:
+    src: "{{ docker_storage_to_overlay2_storage_setup_path }}"
+  register: storage_setup
+
+- name: Isolate disk quota from dm.basesize, if present
+  set_fact:
+    disk_quota: "{{ storage_setup['content'] | b64decode | regex_search('(?<=dm.basesize=)(\\w+)', '\\1', multiline=True) }}"
+
+- name: Check package versions for overlay2 disk quota support
+  when: disk_quota|length > 0
+  block:
+
+  - name: "Get {{ item.key }} version"
+    repoquery:
+      name: "{{ item.key }}"
+      query_type: installed
+    register: package_version
+    with_dict: "{{ docker_storage_to_overlay2_package_requirements }}"
+
+  - name: "Ensure {{ item.item.key }} >= {{ item.item.value.minimum }}"
+    assert:
+      that: item.results.versions.latest_full | version_compare(item.item.value.minimum, "ge")
+      msg: "{{ item.item.key }} >= {{ item.item.value.minimum }} required for {{ item.item.value.reason }}"
+    with_items: "{{ package_version.results }}"
+
+- name: Check which optional services are available
+  command: systemctl status {{ item }}
+  register: service_available
+  ignore_errors: yes
+  changed_when: False
+  with_items: "{{ docker_storage_to_overlay2_optional_service_names }}"
+
+- name: Add available optional services to service list
+  when: item.rc == 0
+  set_fact:
+    docker_storage_to_overlay2_service_names: "{{ [item.item] + docker_storage_to_overlay2_service_names }}"
+  with_items: "{{ service_available.results }}"
+
+# Limit the recursion depth. If an immutable flag is present, it's
+# most likely on /var/lib/docker or an immediate child directory.
+#
+# XXX The find module lacks a "maxdepth" option, and both the find
+#     module and GNU command lack a way to search for an immutable
+#     file attribute. So we have to break this into multiple tasks.
+- name: Find directories under /var/lib/docker
+  command: find /var/lib/docker -maxdepth 1 -type d
+  register: directories
+  changed_when: False
+
+- name: Lookup extended attributes on directories
+  stat:
+    path: "{{ item }}"
+    get_attributes: yes
+  register: directory_attributes
+  with_items: "{{ directories.stdout_lines }}"
+
+- name: Initialize list for directories
+  set_fact:
+    immutable_directories: []
+
+- name: Filter immutable directories
+  when: "'immutable' in item.stat.attributes"
+  set_fact:
+    immutable_directories: "{{ immutable_directories + [item.item] }}"
+  with_items: "{{ directory_attributes.results }}"
+
+- name: Stop services
+  service:
+    name: "{{ item }}"
+    state: stopped
+  with_items: "{{ docker_storage_to_overlay2_service_names }}"
+
+# XXX The file module can set these attributes, but you have to set them all
+#     at once.  chattr is still better at manipulating individual attributes.
+- name: Remove immutable flag on immutable directories
+  command: chattr -i "{{ item }}"
+  with_items: "{{ immutable_directories }}"
+
+# This step is highly destructive!
+- name: Remove Docker storage
+  command: atomic storage reset
+
+# Based on list_devicemapper_params() in container-storage-setup.
+- name: Remove any devicemapper-specific config keys
+  lineinfile:
+    path: "{{ docker_storage_to_overlay2_storage_setup_path }}"
+    regexp: "^{{ item }}="
+    state: absent
+  with_items:
+  - "AUTO_EXTEND_POOL"
+  - "CONTAINER_THINPOOL"
+  - "DEVICE_WAIT_TIMEOUT"
+
+- name: Remove any extra storage options for old driver
+  lineinfile:
+    path: "{{ docker_storage_to_overlay2_storage_setup_path }}"
+    regexp: "^{{ item }}="
+    state: absent
+  with_items:
+  - "EXTRA_STORAGE_OPTIONS"
+  - "EXTRA_DOCKER_STORAGE_OPTIONS"  # Deprecated
+
+- name: Change storage driver to overlay2
+  command: >
+    atomic storage modify --driver=overlay2
+    --rootfs=/var/lib/docker
+    --lvname={{ docker_storage_to_overlay2_lvname }}
+    --lvsize={{ docker_storage_to_overlay2_lvsize }}
+
+- name: Apply previous disk quota for overlay2
+  lineinfile:
+    path: "{{ docker_storage_to_overlay2_storage_setup_path }}"
+    line: EXTRA_STORAGE_OPTIONS="--storage-opt overlay2.size={{ disk_quota[0] }}"
+    state: present
+  when: disk_quota|length > 0
+
+- name: Recreate previously immutable directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items: "{{ immutable_directories }}"
+
+# XXX The file module can set these attributes, but you have to set them all
+#     at once.  chattr is still better at manipulating individual attributes.
+- name: Restore immutable flag to previously immutable directories
+  command: chattr +i "{{ item }}"
+  with_items: "{{ immutable_directories }}"
+
+- name: Start services
+  service:
+    name: "{{ item }}"
+    state: started
+  with_items: "{{ docker_storage_to_overlay2_service_names }}"
+
+- name: Reboot
+  command: systemctl reboot
+  async: 1
+  poll: 0
+  when: docker_storage_to_overlay2_reboot
+
+- name: Wait for SSH service
+  local_action:
+    module: wait_for
+      host={{ ansible_ssh_host }}
+      port=22
+      delay=3
+      timeout=600
+  sudo: False
+  when: docker_storage_to_overlay2_reboot

--- a/roles/docker_storage_to_overlay2/vars/main.yml
+++ b/roles/docker_storage_to_overlay2/vars/main.yml
@@ -1,0 +1,29 @@
+---
+docker_storage_to_overlay2_storage_setup_path: "/etc/sysconfig/docker-storage-setup"
+
+# List of services to stop and restart.  Any available services
+# in optional_service_names get appended to this list beforehand.
+docker_storage_to_overlay2_service_names:
+- "{{ openshift.docker.service_name }}"
+
+docker_storage_to_overlay2_optional_service_names:
+- "{{ openshift.common.service_type }}-node.service"
+
+docker_storage_to_overlay2_package_requirements:
+
+  # Ensure we have a fix for the --lvsize option; previously it would
+  # try to call into /usr/lib/docker-storage-setup/libdss.sh, instead
+  # of /usr/share/container-storage-setup/libcss.sh.
+  atomic:
+    minimum: 1.19.1-3
+    reason: "a 'storage modify' bugfix"
+
+  # Ensure XFS volumes are mounted with the pquota option.
+  container-storage-setup:
+    minimum: 0.7.0-1
+    reason: "pquota mount option"
+
+  # Ensure we have the backported overlay2.size storage option.
+  docker:
+    minimum: 1.12.6-58
+    reason: "overlay2.size storage option"


### PR DESCRIPTION
This adds an adhoc playbook to change the Docker storage driver to overlay2.

Note, this makes no attempt to migrate existing containers/images.  It momentarily stops `docker.service` and uses `atomic storage reset` to wipe all local Docker storage.

Tested on:

 - RHEL 7.4 (works)
 - CentOS 7.3 (always fails)
 - Fedora 26 (works)

Some necessary changes for OverlayFS to support SELinux security labels [landed in RHEL 7.4](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/7.4_Release_Notes/new_features_file_systems.html), so I had the playbook do a version check for `RedHat`/`CentOS` distributions.  Presumably this will work on CentOS 7.4 once it's released.