### PR TITLE
annotate the infra projects for logging to fix bz1480988

### DIFF
--- a/roles/openshift_logging/tasks/annotate_ops_projects.yaml
+++ b/roles/openshift_logging/tasks/annotate_ops_projects.yaml
@@ -1,0 +1,17 @@
+---
+- oc_obj:
+    state: list
+    kind: project
+    name: "{{ item }}"
+  with_items: "{{ __default_logging_ops_projects }}"
+  register: __logging_ops_projects
+
+- name: Annotate Operations Projects
+  oc_edit:
+    kind: ns
+    name: "{{ item.item }}"
+    separator: '#'
+    content:
+      metadata#annotations#openshift.io/logging.ui.hostname: "{{ openshift_logging_kibana_ops_hostname }}"
+  with_items: "{{ __logging_ops_projects.results }}"
+  when: "{{ item.results.stderr is not defined }}"

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -220,6 +220,7 @@
   when:
   - openshift_logging_use_ops | bool
 
+- include: annotate_ops_projects.yaml
 
 ## Curator
 - include_role:

--- a/roles/openshift_logging/vars/main.yaml
+++ b/roles/openshift_logging/vars/main.yaml
@@ -6,3 +6,5 @@ es_ops_node_quorum: "{{ (openshift_logging_es_ops_cluster_size | int/2 | round(0
 es_ops_recover_expected_nodes: "{{openshift_logging_es_ops_cluster_size | int}}"
 
 es_log_appenders: ['file', 'console']
+
+__default_logging_ops_projects: ['default', 'openshift', 'openshift-infra', 'kube-system']


### PR DESCRIPTION
This PR annotates 'operations' projects to include the kibana ops url so the web console may consume that information to address BZ1480988 where one is directed to the wrong instance of kibana