### PR TITLE
Roles will default to global setting when set.

### DIFF
--- a/roles/cockpit/defaults/main.yml
+++ b/roles/cockpit/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-r_cockpit_firewall_enabled: True
-r_cockpit_use_firewalld: False
+r_cockpit_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
+r_cockpit_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
 r_cockpit_os_firewall_deny: []
 r_cockpit_os_firewall_allow:

--- a/roles/nuage_master/defaults/main.yml
+++ b/roles/nuage_master/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-r_nuage_master_firewall_enabled: True
-r_nuage_master_use_firewalld: False
+r_nuage_master_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
+r_nuage_master_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
 nuage_mon_rest_server_port: '9443'
 

--- a/roles/nuage_node/defaults/main.yml
+++ b/roles/nuage_node/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-r_nuage_node_firewall_enabled: True
-r_nuage_node_use_firewalld: False
+r_nuage_node_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
+r_nuage_node_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
 nuage_mon_rest_server_port: '9443'
 

--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
-r_openshift_hosted_router_firewall_enabled: True
-r_openshift_hosted_router_use_firewalld: False
+r_openshift_hosted_router_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
+r_openshift_hosted_router_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
-r_openshift_hosted_registry_firewall_enabled: True
-r_openshift_hosted_registry_use_firewalld: False
+r_openshift_hosted_registry_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
+r_openshift_hosted_registry_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
 openshift_hosted_router_wait: True
 openshift_hosted_registry_wait: True

--- a/roles/openshift_loadbalancer/defaults/main.yml
+++ b/roles/openshift_loadbalancer/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-r_openshift_loadbalancer_firewall_enabled: True
-r_openshift_loadbalancer_use_firewalld: False
+r_openshift_loadbalancer_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
+r_openshift_loadbalancer_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
 haproxy_frontends:
 - name: main

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-r_openshift_master_firewall_enabled: True
-r_openshift_master_use_firewalld: False
+r_openshift_master_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
+r_openshift_master_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
 openshift_node_ips: []
 r_openshift_master_clean_install: false

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-r_openshift_node_firewall_enabled: True
-r_openshift_node_use_firewalld: False
+r_openshift_node_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
+r_openshift_node_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 r_openshift_node_os_firewall_deny: []
 r_openshift_node_os_firewall_allow:
 - service: Kubernetes kubelet

--- a/roles/openshift_storage_glusterfs/defaults/main.yml
+++ b/roles/openshift_storage_glusterfs/defaults/main.yml
@@ -52,8 +52,8 @@ openshift_storage_glusterfs_registry_heketi_ssh_port: "{{ openshift_storage_glus
 openshift_storage_glusterfs_registry_heketi_ssh_user: "{{ openshift_storage_glusterfs_heketi_ssh_user }}"
 openshift_storage_glusterfs_registry_heketi_ssh_sudo: "{{ openshift_storage_glusterfs_heketi_ssh_sudo }}"
 openshift_storage_glusterfs_registry_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_heketi_ssh_keyfile | default(omit) }}"
-r_openshift_master_firewall_enabled: True
-r_openshift_master_use_firewalld: False
+r_openshift_master_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
+r_openshift_master_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 r_openshift_storage_glusterfs_os_firewall_deny: []
 r_openshift_storage_glusterfs_os_firewall_allow:
 - service: glusterfs_sshd

--- a/roles/openshift_storage_nfs/defaults/main.yml
+++ b/roles/openshift_storage_nfs/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-r_openshift_storage_nfs_firewall_enabled: True
-r_openshift_storage_nfs_use_firewalld: False
+r_openshift_storage_nfs_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
+r_openshift_storage_nfs_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
 r_openshift_storage_nfs_os_firewall_deny: []
 r_openshift_storage_nfs_os_firewall_allow:

--- a/roles/os_firewall/defaults/main.yml
+++ b/roles/os_firewall/defaults/main.yml
@@ -2,4 +2,4 @@
 os_firewall_enabled: True
 # firewalld is not supported on Atomic Host
 # https://bugzilla.redhat.com/show_bug.cgi?id=1403331
-os_firewall_use_firewalld: "{{ False }}"
+os_firewall_use_firewalld: False


### PR DESCRIPTION
During the firewall refactor there were a few steps that were left out.  This code enables the default to refer back to a single setting from the inventory.  This was overlooked on the first pass.