### PR TITLE
docker_image_availability: timeout skopeo inspect

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -168,7 +168,10 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
             registries = [registry]
 
         for registry in registries:
-            args = {"_raw_params": "skopeo inspect --tls-verify=false docker://{}/{}".format(registry, image)}
+            args = {
+                "_raw_params": "timeout 10 skopeo inspect --tls-verify=false "
+                               "docker://{}/{}".format(registry, image)
+            }
             result = self.execute_module("command", args)
             if result.get("rc", 0) == 0 and not result.get("failed"):
                 return True


### PR DESCRIPTION
Set a 10 second timeout when using skopeo to inspect remote registries,
so that it does not wait for a tcp timeout to fail if they are unreachable.

(I am hesitant to set it any lower although most of the time this should return in a couple seconds... but I do not want to add more opportunities for network flakiness to break things.)

Aimed at improving UX for disconnected installs, per https://bugzilla.redhat.com/show_bug.cgi?id=1480195