### PR TITLE
Fix origin metrics and logging container version

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -571,7 +571,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_hosted_metrics_public_url=https://hawkular-metrics.example.com/hawkular/metrics
 # Configure the prefix and version for the component images
 #openshift_hosted_metrics_deployer_prefix=docker.io/openshift/origin-
-#openshift_hosted_metrics_deployer_version=3.6.0
+#openshift_hosted_metrics_deployer_version=v3.6.0
 #
 # StorageClass
 # openshift_storageclass_name=gp2
@@ -626,7 +626,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_hosted_logging_elasticsearch_cluster_size=1
 # Configure the prefix and version for the component images
 #openshift_hosted_logging_deployer_prefix=docker.io/openshift/origin-
-#openshift_hosted_logging_deployer_version=3.6.0
+#openshift_hosted_logging_deployer_version=v3.6.0
 
 # Configure the multi-tenant SDN plugin (default is 'redhat/openshift-ovs-subnet')
 # os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'


### PR DESCRIPTION
The docker image version for the metric and logging containers are prefixed with a "v".  Not having adding the "v" fails to deploy the logging and metrics containers.