### PR TITLE
[3.6] Add variable to control whether NetworkManager hook is installed

### DIFF
--- a/roles/openshift_node_dnsmasq/README.md
+++ b/roles/openshift_node_dnsmasq/README.md
@@ -1,0 +1,27 @@
+OpenShift Node DNS resolver
+===========================
+
+Configure dnsmasq to act as a DNS resolver for an OpenShift node.
+
+Requirements
+------------
+
+Role Variables
+--------------
+
+From this role:
+
+| Name                                                | Default value | Description                                                                       |
+|-----------------------------------------------------|---------------|-----------------------------------------------------------------------------------|
+| openshift_node_dnsmasq_install_network_manager_hook | true          | Install NetworkManager hook updating /etc/resolv.conf with local dnsmasq instance |
+
+Dependencies
+------------
+
+* openshift_common
+* openshift_node_facts
+
+License
+-------
+
+Apache License Version 2.0

--- a/roles/openshift_node_dnsmasq/defaults/main.yml
+++ b/roles/openshift_node_dnsmasq/defaults/main.yml
@@ -1,1 +1,2 @@
 ---
+openshift_node_dnsmasq_install_network_manager_hook: true

--- a/roles/openshift_node_dnsmasq/tasks/network-manager.yml
+++ b/roles/openshift_node_dnsmasq/tasks/network-manager.yml
@@ -5,5 +5,6 @@
     dest: /etc/NetworkManager/dispatcher.d/
     mode: 0755
   notify: restart NetworkManager
+  when: openshift_node_dnsmasq_install_network_manager_hook | bool
 
 - meta: flush_handlers


### PR DESCRIPTION
We control /etc/resolv.conf and parts of the dnsmasq configuration via
Puppet in our environment. The hook ends up overwriting the managed
configuration.