### PR TITLE
Fix openshift_master upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -91,10 +91,7 @@
 
   - include_vars: ../../../../roles/openshift_master/vars/main.yml
 
-  - name: Remove any legacy systemd units
-    include: ../../../../roles/openshift_master/tasks/clean_systemd_units.yml
-
-  - name: Update systemd units
+  - name: Remove any legacy systemd units and update systemd units
     include: ../../../../roles/openshift_master/tasks/systemd_units.yml
 
   - name: Check for ca-bundle.crt

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -177,9 +177,6 @@
     local_facts:
       no_proxy_etcd_host_ips: "{{ openshift_no_proxy_etcd_host_ips }}"
 
-- name: Remove the legacy master service if it exists
-  include: clean_systemd_units.yml
-
 - name: Install the systemd units
   include: systemd_units.yml
 

--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -3,6 +3,16 @@
 # playbooks.  For that reason the ha_svc variables are use set_fact instead of
 # the vars directory on the role.
 
+# This play may be consumed outside the role, we need to ensure that
+# openshift_master_config_dir is set.
+- name: Set openshift_master_config_dir if unset
+  set_fact:
+    openshift_master_config_dir: '/var/lib/origin'
+  when: openshift_master_config_dir is not defined
+
+- name: Remove the legacy master service if it exists
+  include: clean_systemd_units.yml
+
 - name: Init HA Service Info
   set_fact:
     containerized_svc_dir: "/usr/lib/systemd/system"


### PR DESCRIPTION
Currently, openshift_master upgrade play imports tasks directly
from the openshift_master role.  This method does not honor
role defaults.

This commit changes the method of inclusion to include_role
to properly consume the tasks.