### PR TITLE
Calico v3.6 patches

### DIFF
--- a/roles/calico/README.md
+++ b/roles/calico/README.md
@@ -6,12 +6,6 @@ Configure Calico components for the Master host.
 
 * Ansible 2.2
 
-## Warning: This Calico Integration is in Alpha
-
-Calico shares the etcd instance used by OpenShift, and distributes client etcd certificates to each node.
-For this reason, **we do not (yet) recommend running Calico on any production-like
-cluster, or using it for any purpose besides early access testing.**
-
 ## Installation
 
 To install, set the following inventory configuration parameters:
@@ -20,7 +14,19 @@ To install, set the following inventory configuration parameters:
 * `openshift_use_openshift_sdn=False`
 * `os_sdn_network_plugin_name='cni'`
 
-## Additional Calico/Node and Felix Configuration Options
+For more information, see [Calico's official OpenShift Installation Documentation](https://docs.projectcalico.org/latest/getting-started/openshift/installation#bring-your-own-etcd)
+
+## Improving security with BYO-etcd
+
+By default, Calico uses the etcd set up by OpenShift. To accomplish this, it generates and distributes client etcd certificates to each node.
+Distributing these certs across the cluster in this way weakens the overall security,
+so Calico should not be deployed in production in this mode.
+
+Instead, Calico can be installed in BYO-etcd mode, where it connects to an externally
+set up etcd. For information on deploying Calico in BYO-etcd mode, see 
+[Calico's official OpenShift Installation Documentation](https://docs.projectcalico.org/latest/getting-started/openshift/installation#bring-your-own-etcd)
+
+## Calico Configuration Options
 
 Additional parameters that can be defined in the inventory are:
 

--- a/roles/calico/README.md
+++ b/roles/calico/README.md
@@ -26,7 +26,6 @@ Additional parameters that can be defined in the inventory are:
 
 | Environment | Description | Schema | Default |   
 |---------|----------------------|---------|---------|
-|CALICO_IPV4POOL_CIDR|	The IPv4 Pool to create if none exists at start up. It is invalid to define this variable and NO_DEFAULT_POOLS.	|IPv4 CIDR	| 192.168.0.0/16 |
 | CALICO_IPV4POOL_IPIP | IPIP Mode to use for the IPv4 POOL created at start up.	| off, always, cross-subnet	| always |
 | CALICO_LOG_DIR | Directory on the host machine where Calico Logs are written.| String	| /var/log/calico |
 

--- a/roles/calico/defaults/main.yaml
+++ b/roles/calico/defaults/main.yaml
@@ -11,4 +11,4 @@ calico_url_ipam: "https://github.com/projectcalico/cni-plugin/releases/download/
 calico_ipv4pool_ipip: "always"
 
 calico_log_dir: "/var/log/calico"
-calico_node_image: "calico/node:v2.4.1"
+calico_node_image: "calico/node:v2.5.0"

--- a/roles/calico/defaults/main.yaml
+++ b/roles/calico/defaults/main.yaml
@@ -9,7 +9,6 @@ calico_url_cni: "https://github.com/projectcalico/cni-plugin/releases/download/v
 calico_url_ipam: "https://github.com/projectcalico/cni-plugin/releases/download/v1.8.3/calico-ipam"
 
 calico_ipv4pool_ipip: "always"
-calico_ipv4pool_cidr: "192.168.0.0/16"
 
 calico_log_dir: "/var/log/calico"
 calico_node_image: "calico/node:v1.2.1"

--- a/roles/calico/defaults/main.yaml
+++ b/roles/calico/defaults/main.yaml
@@ -5,10 +5,10 @@ cni_conf_dir: "/etc/cni/net.d/"
 cni_bin_dir: "/opt/cni/bin/"
 cni_url: "https://github.com/containernetworking/cni/releases/download/v0.5.2/cni-amd64-v0.5.2.tgz"
 
-calico_url_cni: "https://github.com/projectcalico/cni-plugin/releases/download/v1.8.3/calico"
-calico_url_ipam: "https://github.com/projectcalico/cni-plugin/releases/download/v1.8.3/calico-ipam"
+calico_url_cni: "https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico"
+calico_url_ipam: "https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico-ipam"
 
 calico_ipv4pool_ipip: "always"
 
 calico_log_dir: "/var/log/calico"
-calico_node_image: "calico/node:v1.2.1"
+calico_node_image: "calico/node:v2.4.1"

--- a/roles/calico/defaults/main.yaml
+++ b/roles/calico/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-kubeconfig: "{{openshift.common.config_base}}/node/{{ 'system:node:' +  openshift.common.hostname }}.kubeconfig"
+kubeconfig: "{{  openshift.common.config_base }}/node/{{ 'system:node:' +  openshift.common.hostname }}.kubeconfig"
 
 cni_conf_dir: "/etc/cni/net.d/"
 cni_bin_dir: "/opt/cni/bin/"

--- a/roles/calico/meta/main.yml
+++ b/roles/calico/meta/main.yml
@@ -14,3 +14,4 @@ galaxy_info:
   - system
 dependencies:
 - role: openshift_facts
+- role: openshift_master_facts

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -38,7 +38,7 @@
     path: "{{ item }}"
   with_items:
     - "{{ calico_etcd_ca_cert_file }}"
-    - "{{ calico_etcd_cert_file}}"
+    - "{{ calico_etcd_cert_file }}"
     - "{{ calico_etcd_key_file }}"
 
 - name: Calico Node | Configure Calico service unit file

--- a/roles/calico/templates/calico.service.j2
+++ b/roles/calico/templates/calico.service.j2
@@ -11,13 +11,14 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
  -e WAIT_FOR_DATASTORE=true \
  -e FELIX_DEFAULTENDPOINTTOHOSTACTION=ACCEPT \
  -e CALICO_IPV4POOL_IPIP={{ calico_ipv4pool_ipip }} \
- -e CALICO_IPV4POOL_CIDR={{ calico_ipv4pool_cidr }} \
+ -e CALICO_IPV4POOL_CIDR={{ openshift.master.sdn_cluster_network_cidr }} \
  -e FELIX_IPV6SUPPORT=false \
  -e ETCD_ENDPOINTS={{ calico_etcd_endpoints }} \
  -v {{ calico_etcd_cert_dir }}:{{ calico_etcd_cert_dir }}  \
  -e ETCD_CA_CERT_FILE={{ calico_etcd_ca_cert_file }} \
  -e ETCD_CERT_FILE={{ calico_etcd_cert_file }} \
  -e ETCD_KEY_FILE={{ calico_etcd_key_file }} \
+ -e CLUSTER_TYPE=origin,bgp \
  -e NODENAME={{ openshift.common.hostname }} \
  -v {{ calico_log_dir }}:/var/log/calico\
  -v /lib/modules:/lib/modules \

--- a/roles/calico_master/README.md
+++ b/roles/calico_master/README.md
@@ -29,7 +29,6 @@ Additional parameters that can be defined in the inventory are:
 
 | Environment | Description | Schema | Default |   
 |---------|----------------------|---------|---------|
-|CALICO_IPV4POOL_CIDR|	The IPv4 Pool to create if none exists at start up. It is invalid to define this variable and NO_DEFAULT_POOLS.	|IPv4 CIDR	| 192.168.0.0/16 |
 | CALICO_IPV4POOL_IPIP | IPIP Mode to use for the IPv4 POOL created at start up.	| off, always, cross-subnet	| always |
 | CALICO_LOG_DIR | Directory on the host machine where Calico Logs are written.| String	| /var/log/calico |
 

--- a/roles/calico_master/defaults/main.yaml
+++ b/roles/calico_master/defaults/main.yaml
@@ -3,5 +3,5 @@ kubeconfig: "{{ openshift.common.config_base }}/master/openshift-master.kubeconf
 
 calicoctl_bin_dir: "/usr/local/bin/"
 
-calico_url_calicoctl: "https://github.com/projectcalico/calicoctl/releases/download/v1.4.0/calicoctl"
+calico_url_calicoctl: "https://github.com/projectcalico/calicoctl/releases/download/v1.5.0/calicoctl"
 calico_url_policy_controller: "quay.io/calico/kube-policy-controller:v0.7.0"

--- a/roles/calico_master/defaults/main.yaml
+++ b/roles/calico_master/defaults/main.yaml
@@ -3,5 +3,5 @@ kubeconfig: "{{ openshift.common.config_base }}/master/openshift-master.kubeconf
 
 calicoctl_bin_dir: "/usr/local/bin/"
 
-calico_url_calicoctl: "https://github.com/projectcalico/calicoctl/releases/download/v1.1.3/calicoctl"
-calico_url_policy_controller: "quay.io/calico/kube-policy-controller:v0.5.4"
+calico_url_calicoctl: "https://github.com/projectcalico/calicoctl/releases/download/v1.4.0/calicoctl"
+calico_url_policy_controller: "quay.io/calico/kube-policy-controller:v0.7.0"

--- a/roles/calico_master/tasks/main.yml
+++ b/roles/calico_master/tasks/main.yml
@@ -4,7 +4,7 @@
     path: "{{ item }}"
   with_items:
   - "{{ calico_etcd_ca_cert_file }}"
-  - "{{ calico_etcd_cert_file}}"
+  - "{{ calico_etcd_cert_file }}"
   - "{{ calico_etcd_key_file }}"
 
 - name: Calico Master | Create temp directory for policy controller definition


### PR DESCRIPTION
Besides some spacing and readme changes, this PR brings primarily two changes:

1. Bump Calico to latest release (v2.5.0)
2. Sync Calico Pool cidr with OCP Cluster cidr