### PR TITLE
Fix group conditional requirements in evaluate_groups.yml

### DIFF
--- a/playbooks/common/openshift-cluster/evaluate_groups.yml
+++ b/playbooks/common/openshift-cluster/evaluate_groups.yml
@@ -13,12 +13,12 @@
   - name: Evaluate groups - g_master_hosts or g_new_master_hosts required
     fail:
       msg: This playbook requires g_master_hosts or g_new_master_hosts to be set
-    when: g_master_hosts is not defined or g_new_master_hosts is not defined
+    when: g_master_hosts is not defined and g_new_master_hosts is not defined
 
   - name: Evaluate groups - g_node_hosts or g_new_node_hosts required
     fail:
       msg: This playbook requires g_node_hosts or g_new_node_hosts to be set
-    when: g_node_hosts is not defined or g_new_node_hosts is not defined
+    when: g_node_hosts is not defined and g_new_node_hosts is not defined
 
   - name: Evaluate groups - g_lb_hosts required
     fail:


### PR DESCRIPTION
The test should ensure that either one or the other group is defined, and if neither of them is defined, fail.

See discussion: https://github.com/openshift/openshift-ansible/pull/5215#discussion_r135797515