### PR TITLE
[3.6] Add independent registry auth support

### DIFF
--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -155,6 +155,14 @@ openshift_release=v3.6
 # modify image streams to point at that registry by setting the following to true
 #openshift_examples_modify_imagestreams=true
 
+# If oreg_url points to a registry requiring authentication, provide the following:
+#oreg_auth_user=some_user
+#oreg_auth_password='my-pass'
+# NOTE: oreg_url must be defined by the user for oreg_auth_* to have any affect.
+# oreg_auth_pass should be generated from running docker login.
+# To update registry auth credentials, uncomment the following:
+#oreg_auth_credentials_replace: True
+
 # Additional yum repos to install
 #openshift_additional_repos=[{'id': 'ose-devel', 'name': 'ose-devel', 'baseurl': 'http://example.com/puddle/build/AtomicOpenShift/3.1/latest/RH7-RHOSE-3.0/$basearch/os', 'enabled': 1, 'gpgcheck': 0}]
 

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -2,3 +2,8 @@
 openshift_node_ips: []
 r_openshift_master_clean_install: false
 r_openshift_master_etcd3_storage: false
+
+oreg_url: ''
+oreg_host: "{{ oreg_url.split('/')[0] if '.' in oreg_url.split('/')[0] else '' }}"
+oreg_auth_credentials_path: "{{ openshift.common.data_dir }}/.docker"
+oreg_auth_credentials_replace: False

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -182,6 +182,23 @@
     - restart master api
     - restart master controllers
 
+- name: Check for credentials file for registry auth
+  stat:
+    path: "{{oreg_auth_credentials_path }}"
+  when:
+    - oreg_auth_user is defined
+  register: master_oreg_auth_credentials_stat
+
+- name: Create credentials for registry auth
+  command: "docker --config={{ oreg_auth_credentials_path }} login -u {{ oreg_auth_user }} -p {{ oreg_auth_password }} {{ oreg_host }}"
+  when:
+    - oreg_auth_user is defined
+    - (not master_oreg_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
+  notify:
+    - restart master
+    - restart master api
+    - restart master controllers
+
 - include: set_loopback_context.yml
   when: openshift.common.version_gte_3_2_or_1_2
 

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -12,3 +12,8 @@ os_firewall_allow:
 - service: Calico BGP Port
   port: 179/tcp
   when: openshift.common.use_calico | bool
+
+oreg_url: ''
+oreg_host: "{{ oreg_url.split('/')[0] if '.' in oreg_url.split('/')[0] else '' }}"
+oreg_auth_credentials_path: "{{ openshift.common.data_dir }}/.docker"
+oreg_auth_credentials_replace: False

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -145,6 +145,21 @@
   notify:
     - restart node
 
+- name: Check for credentials file for registry auth
+  stat:
+    path: "{{oreg_auth_credentials_path }}"
+  when:
+    - oreg_auth_user is defined
+  register: node_oreg_auth_credentials_stat
+
+- name: Create credentials for registry auth
+  command: "docker --config={{ oreg_auth_credentials_path }} login -u {{ oreg_auth_user }} -p {{ oreg_auth_password }} {{ oreg_host }}"
+  when:
+    - oreg_auth_user is defined
+    - (not node_oreg_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
+  notify:
+    - restart node
+
 - name: Configure AWS Cloud Provider Settings
   lineinfile:
     dest: /etc/sysconfig/{{ openshift.common.service_type }}-node


### PR DESCRIPTION
Added the ability to support authentication for independent / 3rd party
registries. This commit will allow users to provide a `oreg_auth_user` and
`oreg_auth_password` to dynmically generate a docker config.json file.

The docker config.json file can be used by openshift to authenticate to
independent / 3rd party registries. `oreg_host` must supply endpoint connection
info in the form of 'hostname.com:port', with (optional) port 443 default.

To update the config.json on a later run, the user can specify
`oreg_auth_credentials_replace=False` to update the credentials.

These settings must be used in tandem with `oreg_url`

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1316341
(cherry picked from commit 5815311c8fbad15fe23691e010ce7e4a132f6e7c)