### PR TITLE
upgrade: Verify required network items are set

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -613,6 +613,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # WORKAROUND : If you must use an overlapping subnet, you can configure a non conflicting
 # docker0 CIDR range by adding '--bip=192.168.2.1/24' to DOCKER_NETWORK_OPTIONS
 # environment variable located in /etc/sysconfig/docker-network.
+# When upgrading these must be specificed!
 #osm_cluster_network_cidr=10.128.0.0/14
 #openshift_portal_net=172.30.0.0/16
 
@@ -634,6 +635,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 
 # Configure number of bits to allocate to each host’s subnet e.g. 9
 # would mean a /23 network on the host.
+# When upgrading this must be specificed!
 #osm_host_subnet_length=9
 
 # Configure master API and console ports.

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -621,6 +621,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # WORKAROUND : If you must use an overlapping subnet, you can configure a non conflicting
 # docker0 CIDR range by adding '--bip=192.168.2.1/24' to DOCKER_NETWORK_OPTIONS
 # environment variable located in /etc/sysconfig/docker-network.
+# When upgrading these must be specificed!
 #osm_cluster_network_cidr=10.128.0.0/14
 #openshift_portal_net=172.30.0.0/16
 
@@ -642,6 +643,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 
 # Configure number of bits to allocate to each host’s subnet e.g. 9
 # would mean a /23 network on the host.
+# When upgrading this must be specificed!
 #osm_host_subnet_length=9
 
 # Configure master API and console ports.

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_inventory_vars.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_inventory_vars.yml
@@ -9,6 +9,21 @@
         deployment types
     when: deployment_type not in ['origin','openshift-enterprise', 'online']
 
+  # osm_cluster_network_cidr, osm_host_subnet_length and openshift_portal_net are
+  # required when upgrading to avoid changes that may occur between releases
+  # Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1451023
+  - assert:
+      that:
+      - "osm_cluster_network_cidr is defined"
+      - "osm_host_subnet_length is defined"
+      - "openshift_portal_net is defined"
+      msg: >
+        osm_cluster_network_cidr, osm_host_subnet_length, and openshift_portal_net are required inventory
+        variables when upgrading. These variables should match what is currently used in the cluster. If
+        you don't remember what these values are you can find them in /etc/origin/master/master-config.yaml
+        on a master with the names clusterNetworkCIDR (osm_cluster_network_cidr),
+        osm_host_subnet_length (hostSubnetLength), and openshift_portal_net (hostSubnetLength).
+
   # Error out in situations where the user has older versions specified in their
   # inventory in any of the openshift_release, openshift_image_tag, and
   # openshift_pkg_version variables. These must be removed or updated to proceed


### PR DESCRIPTION
When upgrading ``osm_cluster_network_cidr``, ``osm_host_subnet_length``, and
``openshift_portal_net`` must be set to avoid SDN initialization errors.
This was found when the default parameters were changed between Openshift
versions. This meant users who upgraded and did not specify either
mentioned variable at install/upgrade time ended up getting SDN errors
post upgrade.

When ``osm_cluster_network_cidr``, ``osm_host_subnet_length``, and
``openshift_portal_net`` are not set the upgrade will fail telling the user
that the variables must be set and how to find the current values in the
current install.
    
References: https://github.com/openshift/openshift-ansible/commit/b50b4ea0b03feb9431abd7294fe4fb6b549ddfc0
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1451023
