### PR TITLE
escape corsAllowedOrigins regexp strings and anchor them

### DIFF
--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -59,7 +59,7 @@ controllerConfig:
 controllers: '*'
 corsAllowedOrigins:
 {% for origin in ['127.0.0.1', 'localhost', openshift.common.ip, openshift.common.public_ip] | union(openshift.common.all_hostnames) | unique %}
-  - {{ origin }}
+  - (?i)\A{{ origin | regex_escape() }}\z
 {% endfor %}
 {% for custom_origin in openshift.master.custom_cors_origins | default("") %}
   - {{ custom_origin }}

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -59,7 +59,7 @@ controllerConfig:
 controllers: '*'
 corsAllowedOrigins:
 {% for origin in ['127.0.0.1', 'localhost', openshift.common.ip, openshift.common.public_ip] | union(openshift.common.all_hostnames) | unique %}
-  - (?i)\A{{ origin | regex_escape() }}\z
+  - (?i)\A{{ origin | regex_escape() }}\z {# anchor with start (\A) and end (\z) of the string, make the check case insensitive ((?i)) and escape hostname #}
 {% endfor %}
 {% for custom_origin in openshift.master.custom_cors_origins | default("") %}
   - {{ custom_origin }}

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -58,11 +58,12 @@ controllerConfig:
 {% endif %}
 controllers: '*'
 corsAllowedOrigins:
+  # anchor with start (\A) and end (\z) of the string, make the check case insensitive ((?i)) and escape hostname
 {% for origin in ['127.0.0.1', 'localhost', openshift.common.ip, openshift.common.public_ip] | union(openshift.common.all_hostnames) | unique %}
-  - (?i)\A{{ origin | regex_escape() }}\z {# anchor with start (\A) and end (\z) of the string, make the check case insensitive ((?i)) and escape hostname #}
+  - (?i)\A{{ origin | regex_escape() }}\z
 {% endfor %}
 {% for custom_origin in openshift.master.custom_cors_origins | default("") %}
-  - (?i)\A{{ custom_origin | regex_escape() }}\z {# anchor with start (\A) and end (\z) of the string, make the check case insensitive ((?i)) and escape hostname #}
+  - (?i)\A{{ custom_origin | regex_escape() }}\z
 {% endfor %}
 {% if 'disabled_features' in openshift.master %}
 disabledFeatures: {{ openshift.master.disabled_features | to_json }}

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -62,7 +62,7 @@ corsAllowedOrigins:
   - (?i)\A{{ origin | regex_escape() }}\z {# anchor with start (\A) and end (\z) of the string, make the check case insensitive ((?i)) and escape hostname #}
 {% endfor %}
 {% for custom_origin in openshift.master.custom_cors_origins | default("") %}
-  - {{ custom_origin }}
+  - (?i)\A{{ custom_origin | regex_escape() }}\z {# anchor with start (\A) and end (\z) of the string, make the check case insensitive ((?i)) and escape hostname #}
 {% endfor %}
 {% if 'disabled_features' in openshift.master %}
 disabledFeatures: {{ openshift.master.disabled_features | to_json }}


### PR DESCRIPTION
`corsAllowedOrigins` parameter got interpreted by OpenShift/Kubernetes as a regular expression (there is a bug about that: https://bugzilla.redhat.com/show_bug.cgi?id=1482903).
It leads to some vague behaviour, like for `127.0.0.1` value `127a0b0c1` will be matched as valid, as well as `localhost.example.com` for `localhost`.
I've added regexp escaping here, as well as value anchoring to the begin and end of the string.
I've also added case-insensitive flag `(?i)` to match values like `LocalHost` for `localhost`.