### PR TITLE
update env in etcd.conf.j2 to reflect the latest naming

### DIFF
--- a/roles/etcd/templates/etcd.conf.j2
+++ b/roles/etcd/templates/etcd.conf.j2
@@ -11,7 +11,8 @@
 ETCD_NAME={{ etcd_hostname }}
 ETCD_LISTEN_PEER_URLS={{ etcd_listen_peer_urls }}
 ETCD_DATA_DIR={{ etcd_data_dir }}
-#ETCD_SNAPSHOT_COUNTER=10000
+#ETCD_WAL_DIR=""
+#ETCD_SNAPSHOT_COUNT=10000
 ETCD_HEARTBEAT_INTERVAL=500
 ETCD_ELECTION_TIMEOUT=2500
 ETCD_LISTEN_CLIENT_URLS={{ etcd_listen_client_urls }}
@@ -41,24 +42,43 @@ ETCD_INITIAL_CLUSTER_TOKEN={{ etcd_initial_cluster_token }}
 #ETCD_DISCOVERY_PROXY=
 {% endif %}
 ETCD_ADVERTISE_CLIENT_URLS={{ etcd_advertise_client_urls }}
+#ETCD_STRICT_RECONFIG_CHECK="false"
+#ETCD_AUTO_COMPACTION_RETENTION="0"
+#ETCD_ENABLE_V2="true"
 
 #[proxy]
 #ETCD_PROXY=off
+#ETCD_PROXY_FAILURE_WAIT="5000"
+#ETCD_PROXY_REFRESH_INTERVAL="30000"
+#ETCD_PROXY_DIAL_TIMEOUT="1000"
+#ETCD_PROXY_WRITE_TIMEOUT="5000"
+#ETCD_PROXY_READ_TIMEOUT="0"
 
 #[security]
 {% if etcd_url_scheme == 'https' -%}
-ETCD_CA_FILE={{ etcd_ca_file }}
+ETCD_TRUSTED_CA_FILE={{ etcd_ca_file }}
+ETCD_CLIENT_CERT_AUTH="true"
 ETCD_CERT_FILE={{ etcd_cert_file }}
 ETCD_KEY_FILE={{ etcd_key_file }}
 {% endif -%}
+#ETCD_AUTO_TLS="false"
 {% if etcd_peer_url_scheme == 'https' -%}
-ETCD_PEER_CA_FILE={{ etcd_peer_ca_file }}
+ETCD_PEER_TRUSTED_CA_FILE={{ etcd_peer_ca_file }}
+ETCD_PEER_CLIENT_CERT_AUTH="true"
 ETCD_PEER_CERT_FILE={{ etcd_peer_cert_file }}
 ETCD_PEER_KEY_FILE={{ etcd_peer_key_file }}
 {% endif -%}
+#ETCD_PEER_AUTO_TLS="false"
 
 #[logging]
 ETCD_DEBUG="{{ etcd_debug | default(false) | bool | string }}"
 {% if etcd_log_package_levels is defined %}
 ETCD_LOG_PACKAGE_LEVELS="{{ etcd_log_package_levels }}"
 {% endif %}
+
+#[profiling]
+#ETCD_ENABLE_PPROF="false"
+#ETCD_METRICS="basic"
+#
+#[auth]
+#ETCD_AUTH_TOKEN="simple"


### PR DESCRIPTION
Aligning envs in the `etcd.conf.j2` with the latest envs [1] based on `etcd-3.2.6` release.

Both `ETCD_CA_FILE`, resp. `ETCD_PEER_CA_FILE` are deprecated in favor of `ETCD_TRUSTED_CA_FILE` and `ETCD_CLIENT_CERT_AUTH`, resp. `ETCD_PEER_CA_FILE` and `ETCD_PEER_CLIENT_CERT_AUTH`.

[1] https://github.com/coreos/etcd/blob/9d43462d174c664f5edf313dec0de31e1ef4ed47/Documentation/op-guide/configuration.md

Fixes: 1473027