### PR TITLE
Update efs-provisioner default image prefix from nonexistent origin to openshift3/

### DIFF
--- a/roles/openshift_provisioners/README.md
+++ b/roles/openshift_provisioners/README.md
@@ -4,7 +4,7 @@
 * `openshift_provisioners_install_provisioners`: When `True` the openshift_provisioners role will install provisioners that have their "master" var (e.g. `openshift_provisioners_efs`) set `True`. When `False` will uninstall provisioners that have their var set `True`.
 
 ## Optional Vars
-* `openshift_provisioners_image_prefix`: The prefix for the provisioner images to use. Defaults to 'docker.io/openshift/origin-'.
+* `openshift_provisioners_image_prefix`: The prefix for the provisioner images to use. Defaults to 'registry.access.redhat.com/openshift3/'.
 * `openshift_provisioners_image_version`: The image version for the provisioner images to use. Defaults to 'latest'.
 * `openshift_provisioners_project`: The namespace that provisioners will be installed in. Defaults to 'openshift-infra'.
 

--- a/roles/openshift_provisioners/defaults/main.yaml
+++ b/roles/openshift_provisioners/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 openshift_provisioners_install_provisioners: True
-openshift_provisioners_image_prefix: docker.io/openshift/origin-
+openshift_provisioners_image_prefix: registry.access.redhat.com/openshift3/
 openshift_provisioners_image_version: latest
 
 openshift_provisioners_efs: False


### PR DESCRIPTION
fixes https://github.com/openshift/openshift-ansible/issues/5070 and https://bugzilla.redhat.com/show_bug.cgi?id=1486841

I need to fix openshift-docs as well.

I sent an email about how to get the image mirrored to `docker.io/openshift/origin-`, I think that would be ideal but this will suffice for now