### PR TITLE
Move all-in-one fail check to evaluate_groups.yml

### DIFF
--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -18,12 +18,6 @@
       - docker_image_availability
       - docker_storage
 
-- hosts: localhost
-  tasks:
-  - fail:
-      msg: No etcd hosts defined. Running an all-in-one master is deprecated and will no longer be supported in a future upgrade.
-    when: groups.oo_etcd_to_config | default([]) | length == 0 and not openshift_master_unsupported_all_in_one | default(False)
-
 - include: initialize_oo_option_facts.yml
   tags:
   - always

--- a/playbooks/common/openshift-cluster/evaluate_groups.yml
+++ b/playbooks/common/openshift-cluster/evaluate_groups.yml
@@ -33,12 +33,21 @@
   - name: Evaluate groups - g_nfs_hosts is single host
     fail:
       msg: The nfs group must be limited to one host
-    when: (groups[g_nfs_hosts] | default([])) | length > 1
+    when: g_nfs_hosts | default([]) | length > 1
 
   - name: Evaluate groups - g_glusterfs_hosts required
     fail:
       msg: This playbook requires g_glusterfs_hosts to be set
     when: g_glusterfs_hosts is not defined
+
+  - name: Evaluate groups - Fail if no etcd hosts group is defined
+    fail:
+      msg: >
+        No etcd hosts defined. Running an all-in-one master is deprecated and
+        will no longer be supported in a future upgrade.
+    when:
+    - g_etcd_hosts | default([]) | length == 0
+    - not openshift_master_unsupported_all_in_one | default(False)
 
   - name: Evaluate oo_all_hosts
     add_host:


### PR DESCRIPTION
Moving the new `fail` test for `etcd` group to evaluate groups where the rest of these tests reside.