### PR TITLE
Adding deprecation checks to ansible_syntax

### DIFF
--- a/roles/openshift_logging/tasks/annotate_ops_projects.yaml
+++ b/roles/openshift_logging/tasks/annotate_ops_projects.yaml
@@ -14,4 +14,4 @@
     content:
       metadata#annotations#openshift.io/logging.ui.hostname: "{{ openshift_logging_kibana_ops_hostname }}"
   with_items: "{{ __logging_ops_projects.results }}"
-  when: "{{ item.results.stderr is not defined }}"
+  when: item.results.stderr is not defined


### PR DESCRIPTION
Added a check to the ansible_syntax check to identify yaml files which are using Jinja2 templating delimiters in `when` conditions.  This functionality was deprecated in Ansible 2.3 and should no longer be used.  Future Ansible deprecations can be added to these checks.

We've had way too many bugs and PRs on fixing `DEPRECATION WARNING` messages in ansible.log.