### PR TITLE
Standardize etcd entry point playbooks

### DIFF
--- a/playbooks/byo/openshift-etcd/config.yml
+++ b/playbooks/byo/openshift-etcd/config.yml
@@ -1,14 +1,6 @@
 ---
 - include: ../openshift-cluster/initialize_groups.yml
-  tags:
-  - always
 
 - include: ../../common/openshift-cluster/std_include.yml
-  tags:
-  - always
 
 - include: ../../common/openshift-etcd/config.yml
-  vars:
-    openshift_cluster_id: "{{ cluster_id | default('default') }}"
-    openshift_debug_level: "{{ debug_level | default(2) }}"
-    openshift_deployment_subtype: "{{ deployment_subtype | default(none) }}"

--- a/playbooks/byo/openshift-etcd/migrate.yml
+++ b/playbooks/byo/openshift-etcd/migrate.yml
@@ -1,8 +1,6 @@
 ---
 - include: ../openshift-cluster/initialize_groups.yml
-  tags:
-  - always
+
+- include: ../../common/openshift-cluster/std_include.yml
 
 - include: ../../common/openshift-etcd/migrate.yml
-  tags:
-  - always

--- a/playbooks/byo/openshift-etcd/restart.yml
+++ b/playbooks/byo/openshift-etcd/restart.yml
@@ -1,10 +1,6 @@
 ---
 - include: ../openshift-cluster/initialize_groups.yml
-  tags:
-  - always
 
 - include: ../../common/openshift-cluster/std_include.yml
-  tags:
-  - always
 
 - include: ../../common/openshift-etcd/restart.yml

--- a/playbooks/byo/openshift-etcd/scaleup.yml
+++ b/playbooks/byo/openshift-etcd/scaleup.yml
@@ -1,8 +1,6 @@
 ---
 - include: ../openshift-cluster/initialize_groups.yml
 
-- include: ../../common/openshift-cluster/evaluate_groups.yml
+- include: ../../common/openshift-cluster/std_include.yml
+
 - include: ../../common/openshift-etcd/scaleup.yml
-  vars:
-    openshift_cluster_id: "{{ cluster_id | default('default') }}"
-    openshift_deployment_type: "{{ deployment_type }}"

--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -23,8 +23,6 @@
   - always
 
 - include: ../openshift-etcd/config.yml
-  tags:
-  - etcd
 
 - include: ../openshift-nfs/config.yml
   tags:

--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -1,21 +1,11 @@
 ---
-- include: ../openshift-cluster/evaluate_groups.yml
-  tags:
-  - always
-
 - name: Run pre-checks
   hosts: oo_etcd_to_migrate
-  tags:
-  - always
   roles:
   - role: etcd_migrate
     r_etcd_migrate_action: check
     r_etcd_common_embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
     etcd_peer: "{{ ansible_default_ipv4.address }}"
-
-- include: ../openshift-cluster/initialize_facts.yml
-  tags:
-  - always
 
 # TODO: This will be different for release-3.6 branch
 - name: Prepare masters for etcd data migration
@@ -36,8 +26,6 @@
 - name: Backup v2 data
   hosts: oo_etcd_to_migrate
   gather_facts: no
-  tags:
-  - always
   roles:
   - role: openshift_facts
   - role: etcd_common
@@ -66,8 +54,6 @@
 - name: Stop etcd
   hosts: oo_etcd_to_migrate
   gather_facts: no
-  tags:
-  - always
   pre_tasks:
   - set_fact:
       l_etcd_service: "{{ 'etcd_container' if openshift.common.is_containerized else 'etcd' }}"
@@ -79,8 +65,6 @@
 - name: Migrate data on first etcd
   hosts: oo_etcd_to_migrate[0]
   gather_facts: no
-  tags:
-  - always
   roles:
   - role: etcd_migrate
     r_etcd_migrate_action: migrate
@@ -92,8 +76,6 @@
 - name: Clean data stores on remaining etcd hosts
   hosts: oo_etcd_to_migrate[1:]
   gather_facts: no
-  tags:
-  - always
   roles:
   - role: etcd_migrate
     r_etcd_migrate_action: clean_data


### PR DESCRIPTION
Updated byo/openshift-etcd playbooks to follow the common initialization pattern.  Playbooks already existed for performing etcd config.

Related:
https://trello.com/c/9py0X3Dl