### PR TITLE
[3.6] Miscellaneous fixes

### DIFF
--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -37,9 +37,9 @@
   stat:
     path: "{{ item }}"
   with_items:
-    - "{{ calico_etcd_ca_cert_file }}"
-    - "{{ calico_etcd_cert_file }}"
-    - "{{ calico_etcd_key_file }}"
+    - "{{ calico_etcd_ca_cert_file | default('') }}"
+    - "{{ calico_etcd_cert_file | default('') }}"
+    - "{{ calico_etcd_key_file | default('') }}"
 
 - name: Calico Node | Configure Calico service unit file
   template:

--- a/roles/calico_master/tasks/main.yml
+++ b/roles/calico_master/tasks/main.yml
@@ -3,9 +3,9 @@
   stat:
     path: "{{ item }}"
   with_items:
-  - "{{ calico_etcd_ca_cert_file }}"
-  - "{{ calico_etcd_cert_file }}"
-  - "{{ calico_etcd_key_file }}"
+  - "{{ calico_etcd_ca_cert_file | default('') }}"
+  - "{{ calico_etcd_cert_file | default('') }}"
+  - "{{ calico_etcd_key_file | default('') }}"
 
 - name: Calico Master | Create temp directory for policy controller definition
   command: mktemp -d /tmp/openshift-ansible-XXXXXXX

--- a/roles/contiv/tasks/netmaster.yml
+++ b/roles/contiv/tasks/netmaster.yml
@@ -23,7 +23,7 @@
     line: "{{ hostvars[item]['ansible_' + netmaster_interface].ipv4.address }} netmaster"
     state: present
   when: hostvars[item]['ansible_' + netmaster_interface].ipv4.address is defined
-  with_items: "{{ groups['masters'] }}"
+  with_items: "{{ groups['oo_masters'] }}"
 
 - name: Netmaster | Create netmaster symlinks
   file:


### PR DESCRIPTION
Attempt to create an OCP 3.6 cluster with the `release-3.6` branch, with neither Contiv, nor Calico produced the following errors:

```
TASK [contiv : Netmaster | Create hosts file if it is not present] *************
skipping: [lenaic-master-86621]

TASK [contiv : Netmaster | Build hosts file] ***********************************
fatal: [lenaic-master-86621]: FAILED! => {"failed": true, "msg": "'dict object' has no attribute 'masters'"}
```

```
TASK [calico : Calico Node | Error if no certs set.] ***************************
skipping: [lenaic-master-86621] => (item=calico_etcd_ca_cert_file)
skipping: [lenaic-master-86621] => (item=calico_etcd_cert_file)
skipping: [lenaic-master-86621] => (item=calico_etcd_key_file)
skipping: [lenaic-master-86621] => (item=calico_etcd_endpoints)

TASK [calico : Calico Node | Assure the calico certs are present] **************
fatal: [lenaic-master-86621]: FAILED! => {"failed": true, "msg": "'calico_etcd_ca_cert_file' is undefined"}
```

```
TASK [calico : Calico Node | Set calicoctl.cfg] ********************************
skipping: [lenaic-master-86621]

TASK [calico_master : Calico Master | Assure the calico certs have been generated] ***
fatal: [lenaic-master-86621]: FAILED! => {"failed": true, "msg": "'calico_etcd_ca_cert_file' is undefined"}
```

Those errors are caused by the fact that Ansible requires variables inside Jinja template snippets to be resolvable even if the whole task is skipped.

So, I added some default values to avoid having skipped roles preventing the playbook to complete.