### PR TITLE
Import dnf only if importing yum fails

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/package_version.py
+++ b/roles/openshift_health_checker/openshift_checks/package_version.py
@@ -46,6 +46,7 @@ class PackageVersion(NotContainerizedMixin, OpenShiftCheck):
         check_multi_minor_release = deployment_type in ['openshift-enterprise']
 
         args = {
+            "package_mgr": self.get_var("ansible_pkg_mgr"),
             "package_list": [
                 {
                     "name": "openvswitch",

--- a/roles/openshift_health_checker/test/package_version_test.py
+++ b/roles/openshift_health_checker/test/package_version_test.py
@@ -5,6 +5,7 @@ from openshift_checks.package_version import PackageVersion, OpenShiftCheckExcep
 
 def task_vars_for(openshift_release, deployment_type):
     return dict(
+        ansible_pkg_mgr='yum',
         openshift=dict(common=dict(service_type=deployment_type)),
         openshift_release=openshift_release,
         openshift_image_tag='v' + openshift_release,
@@ -27,6 +28,7 @@ def test_openshift_version_not_supported():
 
 def test_invalid_openshift_release_format():
     task_vars = dict(
+        ansible_pkg_mgr='yum',
         openshift=dict(common=dict(service_type='origin')),
         openshift_image_tag='v0',
         openshift_deployment_type='origin',


### PR DESCRIPTION
We should try to import `dnf` only if importing `yum` fails. Part of the issue also was that importing `dnf` didn't failed even though dnf wasn't installed on the system.

Change is tested on [this job](https://ci.openshift.redhat.com/jenkins/view/All/job/test_pull_request_origin_extended_conformance_install_update/5393)

@mfojtik @sdodson @stevekuznetsov @jupierce fyi