### PR TITLE
Move master additional config out of base

### DIFF
--- a/playbooks/byo/openshift-master/additional_config.yml
+++ b/playbooks/byo/openshift-master/additional_config.yml
@@ -1,0 +1,6 @@
+---
+- include: ../openshift-cluster/initialize_groups.yml
+
+- include: ../../common/openshift-cluster/std_include.yml
+
+- include: ../../common/openshift-master/additional_config.yml

--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -34,6 +34,8 @@
 
 - include: ../openshift-master/config.yml
 
+- include: ../openshift-master/additional_config.yml
+
 - include: ../openshift-node/config.yml
   tags:
   - node

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -217,9 +217,6 @@
     group_by: key=oo_masters_deployment_type_{{ openshift.common.deployment_type }}
     changed_when: False
 
-- include: additional_config.yml
-  when: not g_openshift_master_is_scaleup
-
 - name: Re-enable excluder if it was previously enabled
   hosts: oo_masters_to_config
   gather_facts: no


### PR DESCRIPTION
An issue was discovered with the master scaleup playbook where the conditional using `g_openshift_master_is_scaleup` would fail.  This PR moves the `additional_config.yml` out of the regular master config code path.