### PR TITLE
Fix: set openshift_master_config_dir to the correct value.

### DIFF
--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -7,7 +7,7 @@
 # openshift_master_config_dir is set.
 - name: Set openshift_master_config_dir if unset
   set_fact:
-    openshift_master_config_dir: '/var/lib/origin'
+    openshift_master_config_dir: '/etc/origin'
   when: openshift_master_config_dir is not defined
 
 - name: Remove the legacy master service if it exists


### PR DESCRIPTION
Previous commit set 'openshift_master_config_dir' to
'/var/lib/origin' if undefined during upgrades.

This commit sets value to the proper directory '/etc/origin'