### PR TITLE
Bump ansible requirement to 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ you are not running a stable release.
     ***
 
     Requirements:
-    - Ansible >= 2.2.2.0
+    - Ansible >= 2.3.0.0
     - Jinja >= 2.7
     - pyOpenSSL
     - python-lxml

--- a/callback_plugins/aa_version_requirement.py
+++ b/callback_plugins/aa_version_requirement.py
@@ -29,7 +29,7 @@ else:
 
 
 # Set to minimum required Ansible version
-REQUIRED_VERSION = '2.2.2.0'
+REQUIRED_VERSION = '2.3.0.0'
 DESCRIPTION = "Supported versions: %s or newer" % REQUIRED_VERSION
 
 

--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -17,7 +17,7 @@ URL:            https://github.com/openshift/openshift-ansible
 Source0:        https://github.com/openshift/openshift-ansible/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-Requires:      ansible >= 2.2.2.0
+Requires:      ansible >= 2.3
 Requires:      python2
 Requires:      python-six
 Requires:      tar


### PR DESCRIPTION
We let some code slip into master that depends on naming blocks. We'd intended to start requiring ansible 2.3 anyway so may as well go for it.