### PR TITLE
cri-o: Split RHEL and CentOS images

### DIFF
--- a/roles/docker/tasks/systemcontainer_crio.yml
+++ b/roles/docker/tasks/systemcontainer_crio.yml
@@ -88,10 +88,16 @@
         l_crio_image_prepend: "docker.io/gscrivano"
         l_crio_image_name: "crio-o-fedora"
 
-    - name: Use Centos based image when distribution is Red Hat or CentOS
+    - name: Use Centos based image when distribution is CentOS
       set_fact:
         l_crio_image_name: "cri-o-centos"
-      when: ansible_distribution in ['RedHat', 'CentOS']
+      when: ansible_distribution == "CentOS"
+
+    - name: Use RHEL based image when distribution is Red Hat
+      set_fact:
+        l_crio_image_prepend: "registry.access.redhat.com"
+        l_crio_image_name: "cri-o"
+      when: ansible_distribution == "RedHat"
 
     # For https://github.com/openshift/openshift-ansible/pull/4049#discussion_r114478504
     - name: Use a testing registry if requested


### PR DESCRIPTION
Splitting out the container for official builds. We may want to wait a bit before merging but I wanted to get the PR available so it's easily and quickly able to merge.