### PR TITLE
remove experimental-cri flag from node config

### DIFF
--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -21,8 +21,6 @@ kubeletArguments: {{ openshift.node.kubelet_args | default(None) | to_padded_yam
   - remote
   container-runtime-endpoint:
   - /var/run/crio.sock
-  experimental-cri:
-  - 'true'
   image-service-endpoint:
   - /var/run/crio.sock
   node-labels:


### PR DESCRIPTION
`experimental-cri` is not a flag anymore in 3.6; replaced with `enable-cri`, which defaults to `true` so there is no need to explicitly enable it.

https://bugzilla.redhat.com/show_bug.cgi?id=1489014

@vikaslaad @sdodson @derekwaynecarr 