### PR TITLE
Update broker configuration to track current broker

### DIFF
--- a/roles/ansible_service_broker/defaults/main.yml
+++ b/roles/ansible_service_broker/defaults/main.yml
@@ -6,6 +6,14 @@ ansible_service_broker_log_level: info
 ansible_service_broker_output_request: false
 ansible_service_broker_recovery: true
 ansible_service_broker_bootstrap_on_startup: true
-# Recommended you do not enable this for now
 ansible_service_broker_dev_broker: false
+ansible_service_broker_refresh_interval: 600s
+# Recommended you do not enable this for now
 ansible_service_broker_launch_apb_on_bind: false
+
+ansible_service_broker_image_pull_policy: IfNotPresent
+ansible_service_broker_sandbox_role: edit
+ansible_service_broker_auto_escalate: true
+ansible_service_broker_registry_tag: latest
+ansible_service_broker_registry_whitelist:
+  - '.*-apb$'

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -17,15 +17,23 @@
     ansible_service_broker_etcd_image_etcd_path: "{{ ansible_service_broker_etcd_image_etcd_path | default(__ansible_service_broker_etcd_image_etcd_path) }}"
 
     ansible_service_broker_registry_type: "{{ ansible_service_broker_registry_type | default(__ansible_service_broker_registry_type) }}"
+    ansible_service_broker_registry_name: "{{ ansible_service_broker_registry_name | default(__ansible_service_broker_registry_name) }}"
     ansible_service_broker_registry_url: "{{ ansible_service_broker_registry_url | default(__ansible_service_broker_registry_url) }}"
     ansible_service_broker_registry_user: "{{ ansible_service_broker_registry_user | default(__ansible_service_broker_registry_user) }}"
     ansible_service_broker_registry_password: "{{ ansible_service_broker_registry_password | default(__ansible_service_broker_registry_password) }}"
     ansible_service_broker_registry_organization: "{{ ansible_service_broker_registry_organization | default(__ansible_service_broker_registry_organization) }}"
 
+    ansible_service_broker_certs_dir: "{{ openshift.common.config_base }}/service-catalog"
+
 - name: set ansible-service-broker image facts using set prefix and tag
   set_fact:
     ansible_service_broker_image: "{{ ansible_service_broker_image_prefix }}ansible-service-broker:{{ ansible_service_broker_image_tag }}"
     ansible_service_broker_etcd_image: "{{ ansible_service_broker_etcd_image_prefix }}etcd:{{ ansible_service_broker_etcd_image_tag }}"
+
+- slurp:
+    src: "{{ ansible_service_broker_certs_dir }}/ca.crt"
+  register: catalog_ca
+
 
 - include: validate_facts.yml
 
@@ -42,53 +50,119 @@
     namespace: openshift-ansible-service-broker
     state: present
 
-- name: Set SA cluster-role
+- name: create ansible-service-broker client serviceaccount
+  oc_serviceaccount:
+    name: asb-client
+    namespace: openshift-ansible-service-broker
+    state: present
+
+- name: Create asb-auth cluster role
+  oc_clusterrole:
+    state: present
+    name: asb-auth
+    rules:
+      - apiGroups: [""]
+        resources: ["namespaces"]
+        verbs: ["create", "delete"]
+      - apiGroups: ["authorization.openshift.io"]
+        resources: ["subjectrulesreview"]
+        verbs: ["create"]
+      - apiGroups: ["authorization.k8s.io"]
+        resources: ["subjectaccessreviews"]
+        verbs: ["create"]
+      - apiGroups: ["authentication.k8s.io"]
+        resources: ["tokenreviews"]
+        verbs: ["create"]
+
+- name: Create asb-access cluster role
+  oc_clusterrole:
+    state: present
+    name: asb-access
+    rules:
+      - nonResourceURLs: ["/ansible-service-broker", "ansible-service-broker/*"]
+        verbs: ["get", "post", "put", "patch", "delete"]
+
+- name: Bind admin cluster-role to asb serviceaccount
   oc_adm_policy_user:
     state: present
-    namespace: "openshift-ansible-service-broker"
+    namespace: openshift-ansible-service-broker
     resource_kind: cluster-role
     resource_name: admin
     user: "system:serviceaccount:openshift-ansible-service-broker:asb"
 
+- name: Bind auth cluster role to asb service account
+  oc_adm_policy_user:
+    state: present
+    namespace: openshift-ansible-service-broker
+    resource_kind: cluster-role
+    resource_name: asb-auth
+    user: "system:serviceaccount:openshift-ansible-service-broker:asb"
+
+- name: Bind asb-access role to asb-client service account
+  oc_adm_policy_user:
+    state: present
+    namespace: openshift-ansible-service-broker
+    resource_kind: cluster-role
+    resource_name: asb-access
+    user: "system:serviceaccount:openshift-ansible-service-broker:asb-client"
+
+- name: create asb-client token secret
+  oc_obj:
+    name: asb-client
+    state: present
+    kind: Secret
+    content:
+      path: /tmp/asbclientsecretout
+      data:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: asb-client
+          annotations:
+            kubernetes.io/service-account.name: asb-client
+        type: kubernetes.io/service-account-token
+
+# Using oc_obj because oc_service doesn't seem to allow annotations
+# TODO: Extend oc_service to allow annotations
 - name: create ansible-service-broker service
-  oc_service:
+  oc_obj:
     name: asb
     namespace: openshift-ansible-service-broker
     state: present
-    labels:
-      app: openshift-ansible-service-broker
-      service: asb
-    ports:
-      - name: port-1338
-        port: 1338
-    selector:
-      app: openshift-ansible-service-broker
-      service: asb
-
-- name: create etcd service
-  oc_service:
-    name: etcd
-    namespace: openshift-ansible-service-broker
-    state: present
-    ports:
-      - name: etcd-advertise
-        port: 2379
-    selector:
-      app: openshift-ansible-service-broker
-      service: etcd
+    kind: Service
+    content:
+      path: /tmp/asbsvcout
+      data:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: asb
+          labels:
+            app: openshift-ansible-service-broker
+            service: asb
+          annotations:
+            service.alpha.openshift.io/serving-cert-secret-name: asb-tls
+        spec:
+          ports:
+            - name: port-1338
+              port: 1338
+              targetPort: 1338
+              protocol: TCP
+          selector:
+            app: openshift-ansible-service-broker
+            service: asb
 
 - name: create route for ansible-service-broker service
   oc_route:
     name: asb-1338
     namespace: openshift-ansible-service-broker
     state: present
+    labels:
+      app: openshift-ansible-service-broker
+      service: asb
     service_name: asb
     port: 1338
-  register: asb_route_out
-
-- name: get ansible-service-broker route name
-  set_fact:
-    ansible_service_broker_route: "{{ asb_route_out.results.results[0].spec.host }}"
+    tls_termination: Reencrypt
 
 - name: create persistent volume claim for etcd
   oc_obj:
@@ -97,7 +171,7 @@
     state: present
     kind: PersistentVolumeClaim
     content:
-      path: /tmp/dcout
+      path: /tmp/pvcout
       data:
         apiVersion: v1
         kind: PersistentVolumeClaim
@@ -111,50 +185,61 @@
             requests:
               storage: 1Gi
 
-- name: create etcd deployment
+- name: Create Ansible Service Broker deployment config
   oc_obj:
-    name: etcd
+    name: asb
     namespace: openshift-ansible-service-broker
     state: present
-    kind: Deployment
+    kind: DeploymentConfig
     content:
       path: /tmp/dcout
       data:
-        apiVersion: extensions/v1beta1
-        kind: Deployment
+        apiVersion: v1
+        kind: DeploymentConfig
         metadata:
-          name: etcd
-          namespace: openshift-ansible-service-broker
+          name: asb
           labels:
             app: openshift-ansible-service-broker
-            service: etcd
+            service: asb
         spec:
-          selector:
-            matchLabels:
-              app: openshift-ansible-service-broker
-              service: etcd
-          strategy:
-            type: RollingUpdate
-            rollingUpdate:
-              maxSurge: 1
-              maxUnavailable: 1
           replicas: 1
+          selector:
+            app: openshift-ansible-service-broker
+          strategy:
+            type: Rolling
           template:
             metadata:
               labels:
                 app: openshift-ansible-service-broker
-                service: etcd
+                service: asb
             spec:
-              restartPolicy: Always
+              serviceAccount: asb
               containers:
+                - image: "{{ ansible_service_broker_image }}"
+                  name: asb
+                  imagePullPolicy: IfNotPresent
+                  volumeMounts:
+                    - name: config-volume
+                      mountPath: /etc/ansible-service-broker
+                    - name: asb-tls
+                      mountPath: /etc/tls/private
+                  ports:
+                    - containerPort: 1338
+                      protocol: TCP
+                  env:
+                    - name: BROKER_CONFIG
+                      value: /etc/ansible-service-broker/config.yaml
+                  resources: {}
+                  terminationMessagePath: /tmp/termination-log
+
                 - image: "{{ ansible_service_broker_etcd_image }}"
                   name: etcd
                   imagePullPolicy: IfNotPresent
                   terminationMessagePath: /tmp/termination-log
                   workingDir: /etcd
                   args:
-                    - '{{ ansible_service_broker_etcd_image_etcd_path }}'
-                    - --data-dir=/data
+                    - "{{ ansible_service_broker_etcd_image_etcd_path }}"
+                    - "--data-dir=/data"
                     - "--listen-client-urls=http://0.0.0.0:2379"
                     - "--advertise-client-urls=http://0.0.0.0:2379"
                   ports:
@@ -170,57 +255,15 @@
                 - name: etcd
                   persistentVolumeClaim:
                     claimName: etcd
-
-- name: create ansible-service-broker deployment
-  oc_obj:
-    name: asb
-    namespace: openshift-ansible-service-broker
-    state: present
-    kind: Deployment
-    content:
-      path: /tmp/dcout
-      data:
-        apiVersion: extensions/v1beta1
-        kind: Deployment
-        metadata:
-          name: asb
-          namespace: openshift-ansible-service-broker
-          labels:
-            app: openshift-ansible-service-broker
-            service: asb
-        spec:
-          strategy:
-            type: Recreate
-          replicas: 1
-          template:
-            metadata:
-              labels:
-                app: openshift-ansible-service-broker
-                service: asb
-            spec:
-              serviceAccount: asb
-              restartPolicy: Always
-              containers:
-                - image: "{{ ansible_service_broker_image }}"
-                  name: asb
-                  imagePullPolicy: IfNotPresent
-                  volumeMounts:
-                    - name: config-volume
-                      mountPath: /etc/ansible-service-broker
-                  ports:
-                    - containerPort: 1338
-                      protocol: TCP
-                  env:
-                    - name: BROKER_CONFIG
-                      value: /etc/ansible-service-broker/config.yaml
-                  terminationMessagePath: /tmp/termination-log
-              volumes:
                 - name: config-volume
                   configMap:
                     name: broker-config
                     items:
                       - key: broker-config
                         path: config.yaml
+                - name: asb-tls
+                  secret:
+                    secretName: asb-tls
 
 
 # TODO: saw a oc_configmap in the library, but didn't understand how to get it to do the following:
@@ -239,42 +282,65 @@
           name: broker-config
           namespace: openshift-ansible-service-broker
           labels:
-            app: ansible-service-broker
+            app: openshift-ansible-service-broker
         data:
           broker-config: |
             registry:
-              name: "{{ ansible_service_broker_registry_type }}"
-              url:  "{{ ansible_service_broker_registry_url }}"
-              user: "{{ ansible_service_broker_registry_user }}"
-              pass: "{{ ansible_service_broker_registry_password }}"
-              org:  "{{ ansible_service_broker_registry_organization }}"
+              - type: {{ ansible_service_broker_registry_type }}
+                name: {{ ansible_service_broker_registry_name }}
+                url:  {{ ansible_service_broker_registry_url }}
+                user: {{ ansible_service_broker_registry_user }}
+                pass: {{ ansible_service_broker_registry_password }}
+                org:  {{ ansible_service_broker_registry_organization }}
+                tag:  {{ ansible_service_broker_registry_tag }}
+                white_list: {{ ansible_service_broker_registry_whitelist }}
             dao:
-              etcd_host: etcd
+              etcd_host: 0.0.0.0
               etcd_port: 2379
             log:
               logfile: /var/log/ansible-service-broker/asb.log
               stdout: true
-              level: "{{ ansible_service_broker_log_level }}"
+              level: {{ ansible_service_broker_log_level }}
               color: true
-            openshift: {}
+            openshift:
+              host: ""
+              ca_file: ""
+              bearer_token_file: ""
+              sandbox_role: {{ ansible_service_broker_sandbox_role }}
+              image_pull_policy: {{ ansible_service_broker_image_pull_policy }}
             broker:
               dev_broker: {{ ansible_service_broker_dev_broker | bool | lower }}
-              launch_apb_on_bind: {{ ansible_service_broker_launch_apb_on_bind | bool | lower }}
-              recovery: {{ ansible_service_broker_recovery | bool | lower }}
-              output_request: {{ ansible_service_broker_output_request | bool | lower }}
               bootstrap_on_startup: {{ ansible_service_broker_bootstrap_on_startup | bool | lower }}
+              refresh_interval: {{ ansible_service_broker_refresh_interval }}
+              launch_apb_on_bind: {{ ansible_service_broker_launch_apb_on_bind | bool | lower }}
+              output_request: {{ ansible_service_broker_output_request | bool | lower }}
+              recovery: {{ ansible_service_broker_recovery | bool | lower }}
+              ssl_cert_key: /etc/tls/private/tls.key
+              ssl_cert: /etc/tls/private/tls.crt
+              auto_escalate: {{ ansible_service_broker_auto_escalate }}
+              auth:
+                - type: basic
+                  enabled: false
+
 
 - name: Create the Broker resource in the catalog
   oc_obj:
     name: ansible-service-broker
     state: present
-    kind: Broker
+    kind: ServiceBroker
     content:
       path: /tmp/brokerout
       data:
         apiVersion: servicecatalog.k8s.io/v1alpha1
-        kind: Broker
+        kind: ServiceBroker
         metadata:
           name: ansible-service-broker
         spec:
-          url: http://asb.openshift-ansible-service-broker.svc:1338
+          url: http://asb.openshift-ansible-service-broker.svc:1338/ansible-service-broker
+          authInfo:
+            bearer:
+              secretRef:
+                name: asb-client
+                namespace: openshift-ansible-service-broker
+                kind: Secret
+          caBundle: "{{ catalog_ca.content }}"

--- a/roles/ansible_service_broker/tasks/remove.yml
+++ b/roles/ansible_service_broker/tasks/remove.yml
@@ -1,15 +1,56 @@
 ---
 
-- name: remove openshift-ansible-service-broker project
-  oc_project:
-    name: openshift-ansible-service-broker
-    state: absent
-
 - name: remove ansible-service-broker serviceaccount
   oc_serviceaccount:
     name: asb
     namespace: openshift-ansible-service-broker
     state: absent
+
+- name: remove ansible-service-broker client serviceaccount
+  oc_serviceaccount:
+    name: asb-client
+    namespace: openshift-ansible-service-broker
+    state: absent
+
+- name: remove asb-auth cluster role
+  oc_clusterrole:
+    state: absent
+    name: asb-auth
+
+- name: remove asb-access cluster role
+  oc_clusterrole:
+    state: absent
+    name: asb-access
+
+- name: Unbind admin cluster-role to asb serviceaccount
+  oc_adm_policy_user:
+    state: absent
+    namespace: openshift-ansible-service-broker
+    resource_kind: cluster-role
+    resource_name: admin
+    user: "system:serviceaccount:openshift-ansible-service-broker:asb"
+
+- name: Unbind auth cluster role to asb service account
+  oc_adm_policy_user:
+    state: absent
+    namespace: openshift-ansible-service-broker
+    resource_kind: cluster-role
+    resource_name: asb-auth
+    user: "system:serviceaccount:openshift-ansible-service-broker:asb"
+
+- name: Unbind asb-access role to asb-client service account
+  oc_adm_policy_user:
+    state: absent
+    namespace: openshift-ansible-service-broker
+    resource_kind: cluster-role
+    resource_name: asb-access
+    user: "system:serviceaccount:openshift-ansible-service-broker:asb-client"
+
+- name: remove asb-client token secret
+  oc_secret:
+    state: absent
+    name: asb-client
+    namespace: openshift-ansible-service-broker
 
 - name: remove ansible-service-broker service
   oc_service:
@@ -35,19 +76,19 @@
     namespace: openshift-ansible-service-broker
     state: absent
 
-- name: remove etcd deployment
-  oc_obj:
-    name: etcd
-    namespace: openshift-ansible-service-broker
-    state: absent
-    kind: Deployment
-
-- name: remove ansible-service-broker deployment
+- name: remove Ansible Service Broker deployment config
   oc_obj:
     name: asb
     namespace: openshift-ansible-service-broker
+    kind: DeploymentConfig
     state: absent
-    kind: Deployment
+
+- name: remove secret for broker auth
+  oc_obj:
+    name: asb-auth-secret
+    namespace: openshift-ansible-service-broker
+    kind: Broker
+    state: absent
 
 # TODO: saw a oc_configmap in the library, but didn't understand how to get it to do the following:
 - name: remove config map for ansible-service-broker
@@ -62,4 +103,9 @@
   oc_obj:
     name: ansible-service-broker
     state: absent
-    kind: Broker
+    kind: ServiceBroker
+
+- name: remove openshift-ansible-service-broker project
+  oc_project:
+    name: openshift-ansible-service-broker
+    state: absent

--- a/roles/ansible_service_broker/vars/default_images.yml
+++ b/roles/ansible_service_broker/vars/default_images.yml
@@ -8,6 +8,7 @@ __ansible_service_broker_etcd_image_tag: latest
 __ansible_service_broker_etcd_image_etcd_path: /usr/local/bin/etcd
 
 __ansible_service_broker_registry_type: dockerhub
+__ansible_service_broker_registry_name: dh
 __ansible_service_broker_registry_url: null
 __ansible_service_broker_registry_user: null
 __ansible_service_broker_registry_password: null

--- a/roles/ansible_service_broker/vars/openshift-enterprise.yml
+++ b/roles/ansible_service_broker/vars/openshift-enterprise.yml
@@ -7,7 +7,9 @@ __ansible_service_broker_etcd_image_prefix: rhel7/
 __ansible_service_broker_etcd_image_tag: latest
 __ansible_service_broker_etcd_image_etcd_path: /bin/etcd
 
+
 __ansible_service_broker_registry_type: rhcc
+__ansible_service_broker_registry_name: rh
 __ansible_service_broker_registry_url: "https://registry.access.redhat.com"
 __ansible_service_broker_registry_user: null
 __ansible_service_broker_registry_password: null

--- a/roles/lib_openshift/library/oc_adm_registry.py
+++ b/roles/lib_openshift/library/oc_adm_registry.py
@@ -1886,13 +1886,15 @@ class SecretConfig(object):
                  namespace,
                  kubeconfig,
                  secrets=None,
-                 stype=None):
+                 stype=None,
+                 annotations=None):
         ''' constructor for handling secret options '''
         self.kubeconfig = kubeconfig
         self.name = sname
         self.type = stype
         self.namespace = namespace
         self.secrets = secrets
+        self.annotations = annotations
         self.data = {}
 
         self.create_dict()
@@ -1909,6 +1911,8 @@ class SecretConfig(object):
         if self.secrets:
             for key, value in self.secrets.items():
                 self.data['data'][key] = value
+        if self.annotations:
+            self.data['metadata']['annotations'] = self.annotations
 
 # pylint: disable=too-many-instance-attributes
 class Secret(Yedit):

--- a/roles/lib_openshift/library/oc_adm_router.py
+++ b/roles/lib_openshift/library/oc_adm_router.py
@@ -2230,13 +2230,15 @@ class SecretConfig(object):
                  namespace,
                  kubeconfig,
                  secrets=None,
-                 stype=None):
+                 stype=None,
+                 annotations=None):
         ''' constructor for handling secret options '''
         self.kubeconfig = kubeconfig
         self.name = sname
         self.type = stype
         self.namespace = namespace
         self.secrets = secrets
+        self.annotations = annotations
         self.data = {}
 
         self.create_dict()
@@ -2253,6 +2255,8 @@ class SecretConfig(object):
         if self.secrets:
             for key, value in self.secrets.items():
                 self.data['data'][key] = value
+        if self.annotations:
+            self.data['metadata']['annotations'] = self.annotations
 
 # pylint: disable=too-many-instance-attributes
 class Secret(Yedit):

--- a/roles/lib_openshift/library/oc_route.py
+++ b/roles/lib_openshift/library/oc_route.py
@@ -90,6 +90,12 @@ options:
     required: false
     default: str
     aliases: []
+  labels:
+    description:
+    - The labels to apply on the route
+    required: false
+    default: None
+    aliases: []
   tls_termination:
     description:
     - The options for termination. e.g. reencrypt
@@ -1469,6 +1475,7 @@ class RouteConfig(object):
                  sname,
                  namespace,
                  kubeconfig,
+                 labels=None,
                  destcacert=None,
                  cacert=None,
                  cert=None,
@@ -1483,6 +1490,7 @@ class RouteConfig(object):
         self.kubeconfig = kubeconfig
         self.name = sname
         self.namespace = namespace
+        self.labels = labels
         self.host = host
         self.tls_termination = tls_termination
         self.destcacert = destcacert
@@ -1508,6 +1516,8 @@ class RouteConfig(object):
         self.data['metadata'] = {}
         self.data['metadata']['name'] = self.name
         self.data['metadata']['namespace'] = self.namespace
+        if self.labels:
+            self.data['metadata']['labels'] = self.labels
         self.data['spec'] = {}
 
         self.data['spec']['host'] = self.host
@@ -1715,6 +1725,7 @@ class OCRoute(OpenShiftCLI):
         rconfig = RouteConfig(params['name'],
                               params['namespace'],
                               params['kubeconfig'],
+                              params['labels'],
                               files['destcacert']['value'],
                               files['cacert']['value'],
                               files['cert']['value'],
@@ -1819,6 +1830,7 @@ def main():
             state=dict(default='present', type='str',
                        choices=['present', 'absent', 'list']),
             debug=dict(default=False, type='bool'),
+            labels=dict(default=None, type='dict'),
             name=dict(default=None, required=True, type='str'),
             namespace=dict(default=None, required=True, type='str'),
             tls_termination=dict(default=None, type='str'),

--- a/roles/lib_openshift/library/oc_secret.py
+++ b/roles/lib_openshift/library/oc_secret.py
@@ -90,6 +90,12 @@ options:
     required: false
     default: default
     aliases: []
+  annotations:
+    description:
+    - Annotations to apply to the object
+    required: false
+    default: None
+    aliases: []
   files:
     description:
     - A list of files provided for secrets
@@ -1464,13 +1470,15 @@ class SecretConfig(object):
                  namespace,
                  kubeconfig,
                  secrets=None,
-                 stype=None):
+                 stype=None,
+                 annotations=None):
         ''' constructor for handling secret options '''
         self.kubeconfig = kubeconfig
         self.name = sname
         self.type = stype
         self.namespace = namespace
         self.secrets = secrets
+        self.annotations = annotations
         self.data = {}
 
         self.create_dict()
@@ -1487,6 +1495,8 @@ class SecretConfig(object):
         if self.secrets:
             for key, value in self.secrets.items():
                 self.data['data'][key] = value
+        if self.annotations:
+            self.data['metadata']['annotations'] = self.annotations
 
 # pylint: disable=too-many-instance-attributes
 class Secret(Yedit):
@@ -1698,8 +1708,7 @@ class OCSecret(OpenShiftCLI):
             elif params['contents']:
                 files = Utils.create_tmp_files_from_contents(params['contents'])
             else:
-                return {'failed': True,
-                        'msg': 'Either specify files or contents.'}
+                files = [{'name': 'null', 'path': os.devnull}]
 
             ########
             # Create
@@ -1783,6 +1792,7 @@ def main():
             debug=dict(default=False, type='bool'),
             namespace=dict(default='default', type='str'),
             name=dict(default=None, type='str'),
+            annotations=dict(default=None, type='dict'),
             type=dict(default=None, type='str'),
             files=dict(default=None, type='list'),
             delete_after=dict(default=False, type='bool'),

--- a/roles/lib_openshift/src/ansible/oc_route.py
+++ b/roles/lib_openshift/src/ansible/oc_route.py
@@ -13,6 +13,7 @@ def main():
             state=dict(default='present', type='str',
                        choices=['present', 'absent', 'list']),
             debug=dict(default=False, type='bool'),
+            labels=dict(default=None, type='dict'),
             name=dict(default=None, required=True, type='str'),
             namespace=dict(default=None, required=True, type='str'),
             tls_termination=dict(default=None, type='str'),

--- a/roles/lib_openshift/src/ansible/oc_secret.py
+++ b/roles/lib_openshift/src/ansible/oc_secret.py
@@ -15,6 +15,7 @@ def main():
             debug=dict(default=False, type='bool'),
             namespace=dict(default='default', type='str'),
             name=dict(default=None, type='str'),
+            annotations=dict(default=None, type='dict'),
             type=dict(default=None, type='str'),
             files=dict(default=None, type='list'),
             delete_after=dict(default=False, type='bool'),

--- a/roles/lib_openshift/src/class/oc_route.py
+++ b/roles/lib_openshift/src/class/oc_route.py
@@ -118,6 +118,7 @@ class OCRoute(OpenShiftCLI):
         rconfig = RouteConfig(params['name'],
                               params['namespace'],
                               params['kubeconfig'],
+                              params['labels'],
                               files['destcacert']['value'],
                               files['cacert']['value'],
                               files['cert']['value'],

--- a/roles/lib_openshift/src/class/oc_secret.py
+++ b/roles/lib_openshift/src/class/oc_secret.py
@@ -142,8 +142,7 @@ class OCSecret(OpenShiftCLI):
             elif params['contents']:
                 files = Utils.create_tmp_files_from_contents(params['contents'])
             else:
-                return {'failed': True,
-                        'msg': 'Either specify files or contents.'}
+                files = [{'name': 'null', 'path': os.devnull}]
 
             ########
             # Create

--- a/roles/lib_openshift/src/doc/route
+++ b/roles/lib_openshift/src/doc/route
@@ -39,6 +39,12 @@ options:
     required: false
     default: str
     aliases: []
+  labels:
+    description:
+    - The labels to apply on the route
+    required: false
+    default: None
+    aliases: []
   tls_termination:
     description:
     - The options for termination. e.g. reencrypt

--- a/roles/lib_openshift/src/doc/secret
+++ b/roles/lib_openshift/src/doc/secret
@@ -39,6 +39,12 @@ options:
     required: false
     default: default
     aliases: []
+  annotations:
+    description:
+    - Annotations to apply to the object
+    required: false
+    default: None
+    aliases: []
   files:
     description:
     - A list of files provided for secrets

--- a/roles/lib_openshift/src/lib/route.py
+++ b/roles/lib_openshift/src/lib/route.py
@@ -11,6 +11,7 @@ class RouteConfig(object):
                  sname,
                  namespace,
                  kubeconfig,
+                 labels=None,
                  destcacert=None,
                  cacert=None,
                  cert=None,
@@ -25,6 +26,7 @@ class RouteConfig(object):
         self.kubeconfig = kubeconfig
         self.name = sname
         self.namespace = namespace
+        self.labels = labels
         self.host = host
         self.tls_termination = tls_termination
         self.destcacert = destcacert
@@ -50,6 +52,8 @@ class RouteConfig(object):
         self.data['metadata'] = {}
         self.data['metadata']['name'] = self.name
         self.data['metadata']['namespace'] = self.namespace
+        if self.labels:
+            self.data['metadata']['labels'] = self.labels
         self.data['spec'] = {}
 
         self.data['spec']['host'] = self.host

--- a/roles/lib_openshift/src/lib/secret.py
+++ b/roles/lib_openshift/src/lib/secret.py
@@ -10,13 +10,15 @@ class SecretConfig(object):
                  namespace,
                  kubeconfig,
                  secrets=None,
-                 stype=None):
+                 stype=None,
+                 annotations=None):
         ''' constructor for handling secret options '''
         self.kubeconfig = kubeconfig
         self.name = sname
         self.type = stype
         self.namespace = namespace
         self.secrets = secrets
+        self.annotations = annotations
         self.data = {}
 
         self.create_dict()
@@ -33,6 +35,8 @@ class SecretConfig(object):
         if self.secrets:
             for key, value in self.secrets.items():
                 self.data['data'][key] = value
+        if self.annotations:
+            self.data['metadata']['annotations'] = self.annotations
 
 # pylint: disable=too-many-instance-attributes
 class Secret(Yedit):

--- a/roles/lib_openshift/src/test/unit/test_oc_route.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_route.py
@@ -39,6 +39,7 @@ class OCRouteTest(unittest.TestCase):
             'debug': False,
             'name': 'test',
             'namespace': 'default',
+            'labels': {'route': 'route'},
             'tls_termination': 'passthrough',
             'dest_cacert_path': None,
             'cacert_path': None,
@@ -64,7 +65,10 @@ class OCRouteTest(unittest.TestCase):
                 "selfLink": "/oapi/v1/namespaces/default/routes/test",
                 "uid": "1b127c67-ecd9-11e6-96eb-0e0d9bdacd26",
                 "resourceVersion": "439182",
-                "creationTimestamp": "2017-02-07T01:59:48Z"
+                "creationTimestamp": "2017-02-07T01:59:48Z",
+                "labels": {
+                    "route": "route"
+                }
             },
             "spec": {
                 "host": "test.example",
@@ -141,6 +145,7 @@ class OCRouteTest(unittest.TestCase):
             'debug': False,
             'name': 'test',
             'namespace': 'default',
+            'labels': {'route': 'route'},
             'tls_termination': 'edge',
             'dest_cacert_path': None,
             'cacert_path': None,
@@ -166,7 +171,8 @@ class OCRouteTest(unittest.TestCase):
                     "namespace": "default",
                     "resourceVersion": "517745",
                     "selfLink": "/oapi/v1/namespaces/default/routes/test",
-                    "uid": "b6f25898-ed77-11e6-9755-0e737db1e63a"
+                    "uid": "b6f25898-ed77-11e6-9755-0e737db1e63a",
+                    "labels": {"route": "route"}
                 },
                 "spec": {
                     "host": "test.openshift.com",
@@ -250,6 +256,7 @@ metadata:
         self.assertTrue(results['changed'])
         self.assertEqual(results['state'], 'present')
         self.assertEqual(results['results']['results'][0]['metadata']['name'], 'test')
+        self.assertEqual(results['results']['results'][0]['metadata']['labels']['route'], 'route')
 
         # Making sure our mock was called as we expected
         mock_cmd.assert_has_calls([


### PR DESCRIPTION
Broker configuration has been drifting from this installer, updated configuration and deployment methods a bit to make it work with the new upstream broker. 

Note: This will not work well when deploying openshift-enterprise, to deploy openshift-enterprise you will need to use an older checkout of openshift-ansible, or specify the upstream broker + catalog and use a registry other than the RHCC. This is because the configuration for the current upstream broker is incompatible with the downstream broker.