### PR TITLE
Fix openshift_master_config_dir

### DIFF
--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -7,7 +7,7 @@
 # openshift_master_config_dir is set.
 - name: Set openshift_master_config_dir if unset
   set_fact:
-    openshift_master_config_dir: '/etc/origin'
+    openshift_master_config_dir: '/etc/origin/master'
   when: openshift_master_config_dir is not defined
 
 - name: Remove the legacy master service if it exists


### PR DESCRIPTION
The problem is masked by the fact that the variable is defined in openshift_master_facts today.