### PR TITLE
Fixed file reference issue when path includes spaces.

### DIFF
--- a/roles/openshift_metrics/tasks/import_jks_certs.yaml
+++ b/roles/openshift_metrics/tasks/import_jks_certs.yaml
@@ -41,7 +41,7 @@
     - hawkular-cassandra.crt
     - ca.crt
 
-  - local_action: command {{role_path}}/files/import_jks_certs.sh
+  - local_action: command "{{role_path}}/files/import_jks_certs.sh"
     environment:
       CERT_DIR: "{{local_tmp.stdout}}"
       METRICS_KEYSTORE_PASSWD: "{{metrics_keystore_password.content}}"


### PR DESCRIPTION
Quotes are added for the value provided in local_action parameter to solve file reference problem when it contains spaces.