### PR TITLE
Fix new_master or new_node fail check during scaleup

### DIFF
--- a/playbooks/byo/openshift-master/scaleup.yml
+++ b/playbooks/byo/openshift-master/scaleup.yml
@@ -1,7 +1,7 @@
 ---
 - include: ../openshift-cluster/initialize_groups.yml
 
-- name: Ensure there are new_masters
+- name: Ensure there are new_masters or new_nodes
   hosts: localhost
   connection: local
   become: no
@@ -13,7 +13,7 @@
         add hosts to the new_masters and new_nodes host groups to add
         masters.
     when:
-    - (g_new_master_hosts | default([]) | length == 0) or (g_new_node_hosts | default([]) | length == 0)
+    - (g_new_master_hosts | default([]) | length == 0) and (g_new_node_hosts | default([]) | length == 0)
 
 - include: ../../common/openshift-cluster/std_include.yml
 


### PR DESCRIPTION
The current check would incorrectly trigger a fail if there are new_masters but no new_nodes or vice versa. We only want to fail if there are hosts in neither group.