### PR TITLE
AMI Build process calls openshift-node/config.yml.

### DIFF
--- a/playbooks/aws/README.md
+++ b/playbooks/aws/README.md
@@ -43,6 +43,8 @@ The current expected work flow should be to provide an AMI with access to Opensh
 
 ```yaml
 ---
+# when creating an AMI set this to True
+# when installing a cluster set this to False
 openshift_node_bootstrap: True
 
 # specify a clusterid
@@ -96,6 +98,11 @@ etcd
 ################################################################################
 # openshift_deployment_type is required for installation
 openshift_deployment_type=origin
+
+# required when building an AMI.  This will
+# be dependent on the version provided by the yum repository
+openshift_pkg_version=-3.6.0
+
 openshift_master_bootstrap_enabled=True
 
 openshift_hosted_router_wait=False

--- a/playbooks/aws/openshift-cluster/build_ami.yml
+++ b/playbooks/aws/openshift-cluster/build_ami.yml
@@ -63,15 +63,8 @@
 - name: run the std_include
   include: ../../common/openshift-cluster/initialize_openshift_repos.yml
 
-- hosts: nodes
-  remote_user: root
-  tasks:
-  - set_fact:
-      openshift_node_bootstrap: True
-
-  - name: run openshift image preparation
-    include_role:
-      name: openshift_node
+- name: install node config
+  include: ../../common/openshift-node/config.yml
 
 - hosts: localhost
   connection: local

--- a/playbooks/aws/openshift-cluster/provisioning_vars.example.yml
+++ b/playbooks/aws/openshift-cluster/provisioning_vars.example.yml
@@ -1,4 +1,6 @@
 ---
+# when creating an AMI set this option to True
+# when installing the cluster, set this to False
 openshift_node_bootstrap: True
 
 # specify a clusterid

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -82,6 +82,7 @@
   - role: nickhammond.logrotate
   - role: openshift_manage_node
     openshift_master_host: "{{ groups.oo_first_master.0 }}"
+    when: not openshift_node_bootstrap | default(False)
   tasks:
   - name: Create group for deployment type
     group_by: key=oo_nodes_deployment_type_{{ openshift.common.deployment_type }}


### PR DESCRIPTION
These are settings that allow the `openshift-cluster/config.yml` to be called when building an AMI.