### PR TITLE
Move sysctl.conf customizations to a separate file

### DIFF
--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -17,8 +17,5 @@
     state: restarted
   when: (not skip_node_svc_handlers | default(False) | bool) and not (node_service_status_changed | default(false) | bool)
 
-- name: reload sysctl.conf
-  command: /sbin/sysctl -p
-
 - name: reload systemd units
   command: systemctl daemon-reload

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -104,14 +104,11 @@
 # The atomic-openshift-node service will set this parameter on
 # startup, but if the network service is restarted this setting is
 # lost. Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1372388
-#
-# Use lineinfile w/ a handler for this task until
-# https://github.com/ansible/ansible/pull/24277 is included in an
-# ansible release and we can use the sysctl module.
-- name: Persist net.ipv4.ip_forward sysctl entry
-  lineinfile: dest=/etc/sysctl.conf regexp='^net.ipv4.ip_forward' line='net.ipv4.ip_forward=1'
-  notify:
-    - reload sysctl.conf
+- sysctl:
+    name: net.ipv4.ip_forward
+    value: 1
+    sysctl_file: "/etc/sysctl.d/99-openshift.conf"
+    reload: yes
 
 - name: Start and enable openvswitch service
   systemd:


### PR DESCRIPTION
Move them from /etc/sysctl.conf to /etc/sysctl.d/99-openshift.conf

This is a good idea becuase:
1- /etc/sysctl.conf is evaluated later, so it can easily be overwritten by previous customizations
2- It's likely that there is an agent like puppet monitoring this file
3- It's easier to know what's being changed by OpenShift