### PR TITLE
1464025 Fix issue with etcd_common when using pre_upgrade tag

### DIFF
--- a/roles/etcd_common/tasks/main.yml
+++ b/roles/etcd_common/tasks/main.yml
@@ -6,4 +6,4 @@
 
 - name: Include main action task file
   include: "{{ r_etcd_common_action }}.yml"
-  when: '"noop" not in r_etcd_common_action'
+  when: r_etcd_common_action != "noop"

--- a/roles/etcd_common/tasks/noop.yml
+++ b/roles/etcd_common/tasks/noop.yml
@@ -1,0 +1,4 @@
+---
+# This is file is here because the usage of tags, specifically `pre_upgrade`
+# breaks the functionality of this role.
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1464025


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1464025

Resorting to adding an empty `noop.yml` file because the usage of Ansible tags breaks the functionality of this role.  No change in logic at the task level addresses this problem.