### PR TITLE
Fix include path for docker upgrade tasks

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/tasks/verify_docker_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/tasks/verify_docker_upgrade_targets.yml
@@ -1,8 +1,10 @@
 ---
 # Only check if docker upgrade is required if docker_upgrade is not
 # already set to False.
-- include: ../docker/upgrade_check.yml
-  when: docker_upgrade is not defined or docker_upgrade | bool and not openshift.common.is_atomic | bool
+- include: ../../docker/upgrade_check.yml
+  when:
+  - docker_upgrade is not defined or (docker_upgrade | bool)
+  - not (openshift.common.is_atomic | bool)
 
 # Additional checks for Atomic hosts:
 


### PR DESCRIPTION
* Minor fix for include path due to recent refactoring
* `when:` condition converted to `list` style

Note: This task include error was not caught by the standard Ansible `--syntax-check` checks in CI.  The error was discovered when using the ansible-repo-grapher tool.