### PR TITLE
Correct include path to not follow symlink

### DIFF
--- a/playbooks/common/openshift-master/restart.yml
+++ b/playbooks/common/openshift-master/restart.yml
@@ -7,7 +7,7 @@
     openshift_master_ha: "{{ groups.oo_masters_to_config | length > 1 }}"
   serial: 1
   handlers:
-  - include: roles/openshift_master/handlers/main.yml
+  - include: ../../../roles/openshift_master/handlers/main.yml
     static: yes
   roles:
   - openshift_facts


### PR DESCRIPTION
The include path is being corrected to not follow the local symlink for `roles`.  This will be important when we remove symlinks in the future.