### PR TITLE
Improve searching `when:` conditions for Jinja2 delimiters

### DIFF
--- a/roles/openshift_metrics/tasks/pre_install.yaml
+++ b/roles/openshift_metrics/tasks/pre_install.yaml
@@ -10,7 +10,7 @@
       is invalid, must be one of: emptydir, pv, dynamic
   when:
   - openshift_metrics_cassandra_storage_type not in openshift_metrics_cassandra_storage_types
-  - "not {{ openshift_metrics_heapster_standalone | bool }}"
+  - not (openshift_metrics_heapster_standalone | bool)
 
 - name: list existing secrets
   command: >


### PR DESCRIPTION
Refactoring the hunt for Jinja2 templating delimiters in `when:` conditions, even when `when:` is a list!