### PR TITLE
Fix rpm version logic for hosts

### DIFF
--- a/playbooks/common/openshift-cluster/initialize_openshift_version.yml
+++ b/playbooks/common/openshift-cluster/initialize_openshift_version.yml
@@ -12,5 +12,10 @@
   hosts: oo_all_hosts:!oo_first_master
   vars:
     openshift_version: "{{ hostvars[groups.oo_first_master.0].openshift_version }}"
+  pre_tasks:
+  - set_fact:
+      openshift_pkg_version: -{{ openshift_version }}
+    when: openshift_pkg_version is not defined
+  - debug: msg="openshift_pkg_version set to {{ openshift_pkg_version }}"
   roles:
   - openshift_version


### PR DESCRIPTION
Currently, the variable openshift_pkg_version is defined
by the first master unless specified by the user.  The role
openshift_version attempts to set this value on all other
hosts after setting it on the first master.

During normal installation, openshift_pkg_version is not
initially defined, therefor each host will utilize the
most recent rpm available.  This creates a problem
during later operations of a cluster if a node is added
or replaced by a new node.

This commit ensures that the value for openshift_pkg_version
set by the first master is respected by subsequent hosts.

Fixes: #5341