### PR TITLE
Add `openshift_node_open_ports` to allow arbitrary firewall exposure

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -60,7 +60,7 @@ openshift_deployment_type: origin
 openshift_node_bootstrap: False
 
 r_openshift_node_os_firewall_deny: []
-r_openshift_node_os_firewall_allow:
+default_r_openshift_node_os_firewall_allow:
 - service: Kubernetes kubelet
   port: 10250/tcp
 - service: http
@@ -79,6 +79,8 @@ r_openshift_node_os_firewall_allow:
 - service: Kubernetes service NodePort UDP
   port: "{{ openshift_node_port_range | default('') }}/udp"
   cond: "{{ openshift_node_port_range is defined }}"
+# Allow multiple port ranges to be added to the role
+r_openshift_node_os_firewall_allow: "{{ default_r_openshift_node_os_firewall_allow | union(openshift_node_open_ports | default([])) }}"
 
 oreg_url: ''
 oreg_host: "{{ oreg_url.split('/')[0] if '.' in oreg_url.split('/')[0] else '' }}"


### PR DESCRIPTION
It should be possible for an admin to define an arbitrary set of ports
to be exposed on each node that will relate to the cluster function.
This adds a new global variable for the node that supports

    Array(Object{'service':<name>,'port':<port_spec>,'cond':<boolean>})

which is the same format accepted by the firewall role.

@sdodson as discussed, open to alternatives. I used this from origin-gce with

    openshift_node_open_ports:
    - service: Router stats
      port: 1936/tcp
    - service: Open node ports
      port: 9000-10000/tcp
    - service: Open node ports
      port: 9000-10000/udp

Which then allows me to set firewall rules appropriately.

Alternatives considered:
* Simpler external format (have to parse inputs)
* Additional parameter to role - felt ugly