### PR TITLE
Skip failure dedup instead of crashing

### DIFF
--- a/roles/openshift_health_checker/test/zz_failure_summary_test.py
+++ b/roles/openshift_health_checker/test/zz_failure_summary_test.py
@@ -65,6 +65,21 @@ import pytest
             },
         ],
     ),
+    # if a failure contain an unhashable value, it will not be deduplicated
+    (
+        [
+            {
+                'host': 'master1',
+                'msg': {'unhashable': 'value'},
+            },
+        ],
+        [
+            {
+                'host': 'master1',
+                'msg': {'unhashable': 'value'},
+            },
+        ],
+    ),
 ])
 def test_deduplicate_failures(failures, deduplicated):
     assert deduplicate_failures(failures) == deduplicated


### PR DESCRIPTION
This makes the callback plugin behave better when dedup is not possible:
work with the original list of failures instead of raising an unhandled
exception and producing confusing output for users.

Fixes #5311.