### PR TITLE
Add openshift_public_hostname length check

### DIFF
--- a/playbooks/common/openshift-cluster/sanity_checks.yml
+++ b/playbooks/common/openshift-cluster/sanity_checks.yml
@@ -45,3 +45,7 @@
   - fail:
       msg: openshift_hostname must be 63 characters or less
     when: openshift_hostname is defined and openshift_hostname | length > 63
+
+  - fail:
+      msg: openshift_public_hostname must be 63 characters or less
+    when: openshift_public_hostname is defined and openshift_public_hostname | length > 63


### PR DESCRIPTION
Currently, the variable openshift_hostname is checked to ensure it
is less than 63 characters.

The variable openshift_public_hostname should also be checked for
this length.

This commit checks the length of openshift_public_hostname to ensure
it is 63 characters or less.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1467790