### PR TITLE
cri-o: Allow full image override

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -119,7 +119,7 @@ openshift_release=v3.6
 # will be built off of the deployment type and ansible_distribution. Only
 # use this option if you are sure you know what you are doing!
 #openshift_docker_systemcontainer_image_override="registry.example.com/container-engine:latest"
-#openshift_crio_systemcontainer_image_registry_override="registry.example.com"
+#openshift_crio_systemcontainer_image_override="registry.example.com/cri-o:latest"
 # Items added, as is, to end of /etc/sysconfig/docker OPTIONS
 # Default value: "--log-driver=journald"
 #openshift_docker_options="-l warn --ipv6=false"

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -119,7 +119,7 @@ openshift_release=v3.6
 # will be built off of the deployment type and ansible_distribution. Only
 # use this option if you are sure you know what you are doing!
 #openshift_docker_systemcontainer_image_override="registry.example.com/container-engine:latest"
-#openshift_crio_systemcontainer_image_registry_override="registry.example.com"
+#openshift_crio_systemcontainer_image_override="registry.example.com/cri-o:latest"
 # Items added, as is, to end of /etc/sysconfig/docker OPTIONS
 # Default value: "--log-driver=journald"
 #openshift_docker_options="-l warn --ipv6=false"

--- a/roles/docker/tasks/systemcontainer_crio.yml
+++ b/roles/docker/tasks/systemcontainer_crio.yml
@@ -108,17 +108,21 @@
         l_crio_image_name: "cri-o"
       when: ansible_distribution == "RedHat"
 
-    # For https://github.com/openshift/openshift-ansible/pull/4049#discussion_r114478504
-    - name: Use a testing registry if requested
-      set_fact:
-        l_crio_image_prepend: "{{ openshift_crio_systemcontainer_image_registry_override }}"
-      when:
-        - openshift_crio_systemcontainer_image_registry_override is defined
-        - openshift_crio_systemcontainer_image_registry_override != ""
-
     - name: Set the full image name
       set_fact:
         l_crio_image: "{{ l_crio_image_prepend }}/{{ l_crio_image_name }}:latest"
+
+    # For https://github.com/openshift/aos-cd-jobs/pull/624#pullrequestreview-61816548
+    - name: Use a specific image if requested
+      set_fact:
+        l_crio_image: "{{ openshift_crio_systemcontainer_image_override }}"
+      when:
+        - openshift_crio_systemcontainer_image_override is defined
+        - openshift_crio_systemcontainer_image_override != ""
+
+    # Be nice and let the user see the variable result
+    - debug:
+        var: l_crio_image
 
 # NOTE: no_proxy added as a workaround until https://github.com/projectatomic/atomic/pull/999 is released
 - name: Pre-pull CRI-O System Container image


### PR DESCRIPTION
``openshift_crio_systemcontainer_image_registry_override`` has been replaced
with ``openshift_crio_systemcontainer_image_override``. The difference is
``openshift_crio_systemcontainer_image_override`` takes a full image path
including the tag.

Example:

```
  openshift_crio_systemcontainer_image_override=gscrivano/cri-o-centos:latest
```