### PR TITLE
container-engine: Allow full image override

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -118,7 +118,7 @@ openshift_release=v3.6
 # Force the registry to use for the docker/crio system container. By default the registry
 # will be built off of the deployment type and ansible_distribution. Only
 # use this option if you are sure you know what you are doing!
-#openshift_docker_systemcontainer_image_registry_override="registry.example.com"
+#openshift_docker_systemcontainer_image_override="registry.example.com/container-engine:latest"
 #openshift_crio_systemcontainer_image_registry_override="registry.example.com"
 # Items added, as is, to end of /etc/sysconfig/docker OPTIONS
 # Default value: "--log-driver=journald"

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -118,7 +118,7 @@ openshift_release=v3.6
 # Force the registry to use for the container-engine/crio system container. By default the registry
 # will be built off of the deployment type and ansible_distribution. Only
 # use this option if you are sure you know what you are doing!
-#openshift_docker_systemcontainer_image_registry_override="registry.example.com"
+#openshift_docker_systemcontainer_image_override="registry.example.com/container-engine:latest"
 #openshift_crio_systemcontainer_image_registry_override="registry.example.com"
 # Items added, as is, to end of /etc/sysconfig/docker OPTIONS
 # Default value: "--log-driver=journald"

--- a/roles/docker/tasks/systemcontainer_docker.yml
+++ b/roles/docker/tasks/systemcontainer_docker.yml
@@ -100,17 +100,21 @@
         l_docker_image_prepend: "registry.fedoraproject.org/f25"
       when: ansible_distribution == 'Fedora'
 
-    # For https://github.com/openshift/openshift-ansible/pull/4049#discussion_r114478504
-    - name: Use a testing registry if requested
-      set_fact:
-        l_docker_image_prepend: "{{ openshift_docker_systemcontainer_image_registry_override }}"
-      when:
-        - openshift_docker_systemcontainer_image_registry_override is defined
-        - openshift_docker_systemcontainer_image_registry_override != ""
-
     - name: Set the full image name
       set_fact:
         l_docker_image: "{{ l_docker_image_prepend }}/{{ openshift.docker.service_name }}:latest"
+
+    # For https://github.com/openshift/openshift-ansible/pull/5354#issuecomment-328552959
+    - name: Use a specific image if requested
+      set_fact:
+        l_docker_image: "{{ openshift_docker_systemcontainer_image_override }}"
+      when:
+        - openshift_docker_systemcontainer_image_override is defined
+        - openshift_docker_systemcontainer_image_override != ""
+
+    # Be nice and let the user see the variable result
+    - debug:
+        var: l_docker_image
 
 # NOTE: no_proxy added as a workaround until https://github.com/projectatomic/atomic/pull/999 is released
 - name: Pre-pull Container Engine System Container image


### PR DESCRIPTION
``openshift_docker_systemcontainer_image_registry_override`` has been replaced
with ``openshift_docker_systemcontainer_image_override``. The difference is
``openshift_docker_systemcontainer_image_override`` takes a full image path
including the tag.

Example:

```
  openshift_docker_systemcontainer_image_override=gscrivano/container-engine:latest
```