### PR TITLE
add health checks 3_6,3_7 upgrade path

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
@@ -75,6 +75,10 @@
     # docker is configured and running.
     skip_docker_role: True
 
+- include: ../pre/verify_health_checks.yml
+  tags:
+  - pre_upgrade
+
 - include: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
@@ -68,6 +68,10 @@
     # docker is configured and running.
     skip_docker_role: True
 
+- include: ../pre/verify_health_checks.yml
+  tags:
+  - pre_upgrade
+
 - name: Verify masters are already upgraded
   hosts: oo_masters_to_config
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -75,6 +75,10 @@
     # docker is configured and running.
     skip_docker_role: True
 
+- include: ../pre/verify_health_checks.yml
+  tags:
+  - pre_upgrade
+
 - include: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_nodes.yml
@@ -68,6 +68,10 @@
     # docker is configured and running.
     skip_docker_role: True
 
+- include: ../pre/verify_health_checks.yml
+  tags:
+  - pre_upgrade
+
 - name: Verify masters are already upgraded
   hosts: oo_masters_to_config
   tags:


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1483931

Adds health checks to `upgrade_control_plane` and `upgrade_nodes` in 3_6 and 3_7.

cc @sosiouxme @rhcarvalho @brenton 