### PR TITLE
logging: fix kibana and kibana-ops defaults

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -32,7 +32,7 @@ openshift_logging_kibana_cpu_limit: null
 openshift_logging_kibana_memory_limit: 736Mi
 openshift_logging_kibana_proxy_debug: false
 openshift_logging_kibana_proxy_cpu_limit: null
-openshift_logging_kibana_proxy_memory_limit: 96Mi
+openshift_logging_kibana_proxy_memory_limit: 256Mi
 openshift_logging_kibana_replica_count: 1
 openshift_logging_kibana_edge_term_policy: Redirect
 
@@ -56,7 +56,7 @@ openshift_logging_kibana_ops_cpu_limit: null
 openshift_logging_kibana_ops_memory_limit: 736Mi
 openshift_logging_kibana_ops_proxy_debug: false
 openshift_logging_kibana_ops_proxy_cpu_limit: null
-openshift_logging_kibana_ops_proxy_memory_limit: 96Mi
+openshift_logging_kibana_ops_proxy_memory_limit: 256Mi
 openshift_logging_kibana_ops_replica_count: 1
 
 #The absolute path on the control node to the cert file to use


### PR DESCRIPTION
- move kibana-ops defaults to `openshift_logging_kibana` role
- set kibana-ops memory limit to 256Mi to match kibana memory limit

**additional steps:**
- [ ] backport to 3.6 
- [ ] backport to 3.5
- [x] wait for PR #5176 to merge and rebase

cc: @jcantrill 