### PR TITLE
Updating to always configure api aggregation with installation

### DIFF
--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -57,6 +57,17 @@
   tags:
   - hosted
 
+- name: Configure API Aggregation on masters
+  hosts: oo_masters
+  serial: 1
+  tasks:
+  - block:
+    - include_role:
+        name: openshift_service_catalog
+        tasks_from: wire_aggregator
+      vars:
+        first_master: "{{ groups.oo_first_master[0] }}"
+
 - include: service_catalog.yml
   when:
   - openshift_enable_service_catalog | default(false) | bool

--- a/playbooks/common/openshift-cluster/service_catalog.yml
+++ b/playbooks/common/openshift-cluster/service_catalog.yml
@@ -1,16 +1,4 @@
 ---
-
-- name: Update Master configs
-  hosts: oo_masters
-  serial: 1
-  tasks:
-  - block:
-    - include_role:
-        name: openshift_service_catalog
-        tasks_from: wire_aggregator
-      vars:
-        first_master: "{{ groups.oo_first_master[0] }}"
-
 - name: Service Catalog
   hosts: oo_first_master
   roles:

--- a/roles/openshift_service_catalog/tasks/install.yml
+++ b/roles/openshift_service_catalog/tasks/install.yml
@@ -6,8 +6,6 @@
   register: mktemp
   changed_when: False
 
-- include: wire_aggregator.yml
-
 - name: Set default image variables based on deployment_type
   include_vars: "{{ item }}"
   with_first_found:

--- a/roles/openshift_service_catalog/tasks/wire_aggregator.yml
+++ b/roles/openshift_service_catalog/tasks/wire_aggregator.yml
@@ -18,11 +18,10 @@
   changed_when: false
   delegate_to: "{{ first_master }}"
 
-
 # TODO: this currently has a bug where hostnames are required
 - name: Creating First Master Aggregator signer certs
   command: >
-    oc adm ca create-signer-cert
+    {{ hostvars[first_master].openshift.common.client_binary }} adm ca create-signer-cert
     --cert=/etc/origin/master/front-proxy-ca.crt
     --key=/etc/origin/master/front-proxy-ca.key
     --serial=/etc/origin/master/ca.serial.txt
@@ -79,7 +78,7 @@
 
 - name: Create first master api-client config for Aggregator
   command: >
-    oc adm create-api-client-config
+    {{ hostvars[first_master].openshift.common.client_binary }} adm create-api-client-config
     --certificate-authority=/etc/origin/master/front-proxy-ca.crt
     --signer-cert=/etc/origin/master/front-proxy-ca.crt
     --signer-key=/etc/origin/master/front-proxy-ca.key


### PR DESCRIPTION
This moves the wiring of the aggregator up into the config playbook as we want to enable this by default with an installation.

Resolves https://github.com/openshift/openshift-ansible/issues/5056