### PR TITLE
Re-enabling new tuned profile hierarchy (PR5089)

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -2,17 +2,9 @@
 - name: Install the systemd units
   include: systemd_units.yml
 
-- name: Check for tuned package
-  command: rpm -q tuned
-  args:
-    warn: no
-  register: tuned_installed
-  changed_when: false
-  failed_when: false
-
-- name: Set atomic-guest tuned profile
-  command: "tuned-adm profile atomic-guest"
-  when: tuned_installed.rc == 0 and openshift.common.is_atomic | bool
+- name: Setup tuned
+  include: tuned.yml
+  static: yes
 
 - name: Start and enable openvswitch service
   systemd:

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -1,11 +1,9 @@
 ---
-# We have to add tuned-profiles in the same transaction otherwise we run into depsolving
-# problems because the rpms don't pin the version properly. This was fixed in 3.1 packaging.
 - when: not openshift.common.is_containerized | bool
   block:
   - name: Install Node package
     package:
-      name: "{{ openshift.common.service_type }}-node{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }},tuned-profiles-{{ openshift.common.service_type }}-node{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
+      name: "{{ openshift.common.service_type }}-node{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
       state: present
 
   - name: Install sdn-ovs package


### PR DESCRIPTION
This PR is to re-enable the new tuned profile hierarchy as outlined in #5089 and #5054.