### PR TITLE
[3.5] - Only empty 'env' builddefaults keys if the 'env' key exists

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1674,11 +1674,22 @@ def set_builddefaults_facts(facts):
             builddefaults['git_no_proxy'] = builddefaults['no_proxy']
         # If we're actually defining a builddefaults config then create admission_plugin_config
         # then merge builddefaults[config] structure into admission_plugin_config
+
+        # 'config' is the 'openshift_builddefaults_json' inventory variable
         if 'config' in builddefaults:
             if 'admission_plugin_config' not in facts['master']:
-                facts['master']['admission_plugin_config'] = dict()
+                # Scaffold out the full expected datastructure
+                facts['master']['admission_plugin_config'] = {
+                    'BuildDefaults': {
+                        'configuration': {
+                            'env': {
+                            }
+                        }
+                    }
+                }
+            # admission_plugin_config gets defaults from the inventory
+            # 'openshift_builddefaults_json' variable
             facts['master']['admission_plugin_config'].update(builddefaults['config'])
-            # if the user didn't actually provide proxy values, delete the proxy env variable defaults.
             delete_empty_keys(facts['master']['admission_plugin_config']['BuildDefaults']['configuration']['env'])
 
     return facts

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1679,16 +1679,7 @@ def set_builddefaults_facts(facts):
         if 'config' in builddefaults:
             if 'admission_plugin_config' not in facts['master']:
                 # Scaffold out the full expected datastructure
-                facts['master']['admission_plugin_config'] = {
-                    'BuildDefaults': {
-                        'configuration': {
-                            'env': {
-                            }
-                        }
-                    }
-                }
-            # admission_plugin_config gets defaults from the inventory
-            # 'openshift_builddefaults_json' variable
+                facts['master']['admission_plugin_config'] = {'BuildDefaults': {'configuration': {'env': {}}}}
             facts['master']['admission_plugin_config'].update(builddefaults['config'])
             delete_empty_keys(facts['master']['admission_plugin_config']['BuildDefaults']['configuration']['env'])
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1469387

Customer using the `release-1.5` upgrade playbook to go from 3.4 to 3.5 is encountering an error when the builddefault facts are set. An attempt is made to reference a key which does not exist

```
2017-06-29 11:55:50,474 p=45692 u=ocpauto |  TASK [openshift_facts : Gather Cluster facts and set is_containerized if needed] ***
2017-06-29 11:55:52,467 p=45692 u=ocpauto |  ok: [atom0010.]
2017-06-29 11:55:52,475 p=45692 u=ocpauto |  ok: [atom0008.]
2017-06-29 11:55:52,482 p=45692 u=ocpauto |  fatal: [atom0001.]: FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Shared connection to atom0001. closed.\r\n",
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_CHxjyW/ansible_module_openshift_facts.py\", line 2495, in <module>\r\n    main()\r\n  File \"/tmp/ansible_CHxjyW/ansible_module_openshift_facts.py\", line 2482, in main\r\n    protected_facts_to_overwrite)\r\n  File \"/tmp/ansible_CHxjyW/ansible_module_openshift_facts.py\", line 1913, in __init__\r\n    protected_facts_to_overwrite)\r\n  File \"/tmp/ansible_CHxjyW/ansible_module_openshift_facts.py\", line 1979, in generate_facts\r\n    facts = set_builddefaults_facts(facts)\r\n  File \"/tmp/ansible_CHxjyW/ansible_module_openshift_facts.py\", line 1686, in set_builddefaults_facts\r\n    delete_empty_keys(facts['master']['admission_plugin_config']['BuildDefaults']['configuration']['env'])\r\nKeyError: 'env'\r\n"
}

MSG:

MODULE FAILURE
```

PR checks to see if the key exists before attempting to pass it through the `delete_empty_keys` function.