### PR TITLE
upgrade: Ensure clients are upgraded when containerized

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -8,6 +8,11 @@
 - name: Pre master upgrade - Upgrade all storage
   hosts: oo_first_master
   tasks:
+  # Ensure we have the right client tools before running
+  - include_role:
+      name: openshift_cli
+    when: openshift.common.is_containerized | bool
+
   - name: Upgrade all storage
     command: >
       {{ openshift.common.client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
@@ -81,6 +86,11 @@
 
   - include: rpm_upgrade.yml component=master
     when: not openshift.common.is_containerized | bool
+
+  # Ensure the latest cli tools
+  - include_role:
+      name: openshift_cli
+    when: openshift.common.is_containerized | bool
 
   - include_vars: ../../../../roles/openshift_master_facts/vars/main.yml
 


### PR DESCRIPTION
The openshift cli tools remained previous versions during upgrades. This
change pulls down the proper cli (master) container, copies the clients
to the system, reloads facts and then returns to the normal upgrade
flow. This should ensure that the version of the cli tools match the
server version.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1489781