### PR TITLE
double the required disk space for etcd backup

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/etcd/backup.yml
+++ b/playbooks/common/openshift-cluster/upgrades/etcd/backup.yml
@@ -2,7 +2,7 @@
 - name: Backup etcd
   hosts: oo_etcd_hosts_to_backup
   roles:
-  - role: openshift_facts
+  - role: openshift_etcd_facts
   - role: etcd_common
     r_etcd_common_action: backup
     r_etcd_common_backup_tag: etcd_backup_tag

--- a/roles/etcd_common/defaults/main.yml
+++ b/roles/etcd_common/defaults/main.yml
@@ -56,7 +56,7 @@ etcd_is_containerized: False
 etcd_is_thirdparty: False
 
 # etcd dir vars
-etcd_data_dir: "{{ '/var/lib/origin/openshift.local.etcd' if r_etcd_common_embedded_etcd | bool else '/var/lib/etcd/' if openshift.common.etcd_runtime != 'runc' else '/var/lib/etcd/etcd.etcd/' }}"
+etcd_data_dir: "{{ '/var/lib/origin/openshift.local.etcd' if r_etcd_common_embedded_etcd | bool else '/var/lib/etcd/' if r_etcd_common_etcd_runtime != 'runc' else '/var/lib/etcd/etcd.etcd/' }}"
 
 # etcd ports and protocols
 etcd_client_port: 2379

--- a/roles/etcd_common/tasks/backup.yml
+++ b/roles/etcd_common/tasks/backup.yml
@@ -29,7 +29,6 @@
 - name: Check current etcd disk usage
   shell: du --exclude='*openshift-backup*' -k {{ l_etcd_data_dir }} | tail -n 1 | cut -f1
   register: l_etcd_disk_usage
-  when: r_etcd_common_embedded_etcd | bool
   # AUDIT:changed_when: `false` because we are only inspecting
   # state, not manipulating anything
   changed_when: false
@@ -39,7 +38,7 @@
     msg: >
       {{ l_etcd_disk_usage.stdout }} Kb disk space required for etcd backup,
       {{ l_avail_disk.stdout }} Kb available.
-  when: (r_etcd_common_embedded_etcd | bool) and (l_etcd_disk_usage.stdout|int > l_avail_disk.stdout|int)
+  when: l_etcd_disk_usage.stdout|int*2 > l_avail_disk.stdout|int
 
 # For non containerized and non embedded we should have the correct version of
 # etcd installed already. So don't do anything.


### PR DESCRIPTION
Double the disk space required for backup so one can migrate the etcd storage after the upgrade with still sufficient disk space.

Bug: 1489182