### PR TITLE
Cleanup old deployment types

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -877,10 +877,8 @@ def oo_pods_match_component(pods, deployment_type, component):
         raise errors.AnsibleFilterError("failed expects component to be a string")
 
     image_prefix = 'openshift/origin-'
-    if deployment_type in ['enterprise', 'online', 'openshift-enterprise']:
+    if deployment_type == 'openshift-enterprise':
         image_prefix = 'openshift3/ose-'
-    elif deployment_type == 'atomic-enterprise':
-        image_prefix = 'aep3_beta/aep-'
 
     matching_pods = []
     image_regex = image_prefix + component + r'.*'

--- a/filter_plugins/openshift_version.py
+++ b/filter_plugins/openshift_version.py
@@ -33,10 +33,10 @@ def legacy_gte_function_builder(name, versions):
             returns True/False
         """
         version_gte = False
-        if 'enterprise' in deployment_type:
+        if deployment_type == 'openshift-enterprise':
             if str(version) >= LooseVersion(enterprise_version):
                 version_gte = True
-        elif 'origin' in deployment_type:
+        else:
             if str(version) >= LooseVersion(origin_version):
                 version_gte = True
         return version_gte

--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -8,9 +8,9 @@
   hosts: OSEv3
   roles:
   - role: rhel_subscribe
-    when: deployment_type in ['atomic-enterprise', 'enterprise', 'openshift-enterprise'] and
-          ansible_distribution == "RedHat" and
-          lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) |
-          default('no', True) | lower in ['no', 'false']
-  - openshift_repos
-  - os_update_latest
+    when:
+    - deployment_type == 'openshift-enterprise'
+    - ansible_distribution == "RedHat"
+    - lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) | default('no', True) | lower in ['no', 'false']
+  - role: openshift_repos
+  - role: os_update_latest

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_inventory_vars.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_inventory_vars.yml
@@ -5,9 +5,9 @@
   tasks:
   - fail:
       msg: >
-        This upgrade is only supported for origin, openshift-enterprise, and online
+        This upgrade is only supported for origin and openshift-enterprise
         deployment types
-    when: deployment_type not in ['origin','openshift-enterprise', 'online']
+    when: deployment_type not in ['origin','openshift-enterprise']
 
   # Error out in situations where the user has older versions specified in their
   # inventory in any of the openshift_release, openshift_image_tag, and

--- a/playbooks/common/openshift-master/additional_config.yml
+++ b/playbooks/common/openshift-master/additional_config.yml
@@ -17,7 +17,10 @@
   - role: openshift_manageiq
     when: openshift_use_manageiq | default(false) | bool
   - role: cockpit
-    when: not openshift.common.is_atomic and ( deployment_type in ['atomic-enterprise','openshift-enterprise'] ) and
-      (osm_use_cockpit | bool or osm_use_cockpit is undefined ) and ( openshift.common.deployment_subtype != 'registry' )
+    when:
+    - openshift.common.is_atomic
+    - deployment_type == 'openshift-enterprise'
+    - osm_use_cockpit is undefined or osm_use_cockpit | bool
+    - openshift.common.deployment_subtype != 'registry'
   - role: flannel_register
     when: openshift_use_flannel | default(false) | bool

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -35,7 +35,9 @@
     file:
       path: "/etc/origin/{{ item }}"
       state: absent
-    when: rpmgenerated_config.stat.exists == true and deployment_type in ['openshift-enterprise', 'atomic-enterprise']
+    when:
+    - rpmgenerated_config.stat.exists == true
+    - deployment_type == 'openshift-enterprise'
     with_items:
     - master
     - node

--- a/roles/lib_openshift/src/test/integration/oc_configmap.yml
+++ b/roles/lib_openshift/src/test/integration/oc_configmap.yml
@@ -55,7 +55,7 @@
         config: "{{ filename }}"
       from_literal:
         foo: notbar
-        deployment_type: online
+        deployment_type: openshift-enterprise
 
   - name: fetch the updated configmap
     oc_configmap:
@@ -70,7 +70,7 @@
     assert:
       that:
       - cmout.results.results[0].metadata.name == 'configmaptest'
-      - cmout.results.results[0].data.deployment_type == 'online'
+      - cmout.results.results[0].data.deployment_type == 'openshift-enterprise'
       - cmout.results.results[0].data.foo == 'notbar'
   ###### end update test ###########
 

--- a/roles/lib_openshift/src/test/unit/test_oc_configmap.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_configmap.py
@@ -79,7 +79,7 @@ class OCConfigMapTest(unittest.TestCase):
         ''' Testing a configmap create '''
         params = copy.deepcopy(OCConfigMapTest.params)
         params['from_file'] = {'test': '/root/file'}
-        params['from_literal'] = {'foo': 'bar', 'deployment_type': 'online'}
+        params['from_literal'] = {'foo': 'bar', 'deployment_type': 'openshift-enterprise'}
 
         configmap = '''{
                 "apiVersion": "v1",
@@ -100,7 +100,7 @@ class OCConfigMapTest(unittest.TestCase):
                 "apiVersion": "v1",
                 "data": {
                     "foo": "bar",
-                    "deployment_type": "online",
+                    "deployment_type": "openshift-enterprise",
                     "test": "this is a file\\n"
                 },
                 "kind": "ConfigMap",
@@ -128,7 +128,7 @@ class OCConfigMapTest(unittest.TestCase):
 
         self.assertTrue(results['changed'])
         self.assertEqual(results['results']['results'][0]['metadata']['name'], 'configmap')
-        self.assertEqual(results['results']['results'][0]['data']['deployment_type'], 'online')
+        self.assertEqual(results['results']['results'][0]['data']['deployment_type'], 'openshift-enterprise')
 
     @unittest.skipIf(six.PY3, 'py2 test only')
     @mock.patch('os.path.exists')

--- a/roles/openshift_examples/README.md
+++ b/roles/openshift_examples/README.md
@@ -21,13 +21,13 @@ Facts
 Role Variables
 --------------
 
-| Name                                | Default value                                       |                                          |
-|-------------------------------------|-----------------------------------------------------|------------------------------------------|
-| openshift_examples_load_centos      | true when openshift_deployment_typenot 'enterprise' | Load centos image streams                |
-| openshift_examples_load_rhel        | true if openshift_deployment_type is 'enterprise'   | Load rhel image streams                  |
-| openshift_examples_load_db_templates| true                                                | Loads database templates                 |
-| openshift_examples_load_quickstarts | true                                                | Loads quickstarts ie: nodejs, rails, etc |
-| openshift_examples_load_xpaas       | false                                               | Loads xpass streams and templates        |
+| Name                                | Default value                                                  |                                          |
+|-------------------------------------|----------------------------------------------------------------|------------------------------------------|
+| openshift_examples_load_centos      | true when openshift_deployment_type not 'openshift-enterprise' | Load centos image streams                |
+| openshift_examples_load_rhel        | true if openshift_deployment_type is 'openshift-enterprise'    | Load rhel image streams                  |
+| openshift_examples_load_db_templates| true                                                           | Loads database templates                 |
+| openshift_examples_load_quickstarts | true                                                           | Loads quickstarts ie: nodejs, rails, etc |
+| openshift_examples_load_xpaas       | false                                                          | Loads xpass streams and templates        |
 
 
 Dependencies

--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -109,8 +109,6 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
         # containerized etcd may not have openshift_image_tag, see bz 1466622
         image_tag = self.get_var("openshift_image_tag", default="latest")
         image_info = DEPLOYMENT_IMAGE_INFO[deployment_type]
-        if not image_info:
-            return required
 
         # template for images that run on top of OpenShift
         image_url = "{}/{}-{}:{}".format(image_info["namespace"], image_info["name"], "${component}", "${version}")
@@ -160,7 +158,7 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
         deployment_type = self.get_var("openshift_deployment_type")
         if deployment_type == "origin" and "docker.io" not in regs:
             regs.append("docker.io")
-        elif "enterprise" in deployment_type and "registry.access.redhat.com" not in regs:
+        elif deployment_type == 'openshift-enterprise' and "registry.access.redhat.com" not in regs:
             regs.append("registry.access.redhat.com")
 
         return regs

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -224,7 +224,7 @@
   - restart master api
 
 - set_fact:
-    translated_identity_providers: "{{ openshift.master.identity_providers | translate_idps('v1', openshift.common.version, openshift.common.deployment_type) }}"
+    translated_identity_providers: "{{ openshift.master.identity_providers | translate_idps('v1') }}"
 
 # TODO: add the validate parameter when there is a validation command to run
 - name: Create master config

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -2,7 +2,8 @@
 - fail:
     msg: "SELinux is disabled, This deployment type requires that SELinux is enabled."
   when:
-    - (not ansible_selinux or ansible_selinux.status != 'enabled') and deployment_type in ['enterprise', 'online', 'atomic-enterprise', 'openshift-enterprise']
+    - (not ansible_selinux or ansible_selinux.status != 'enabled')
+    - deployment_type == 'openshift-enterprise'
     - not openshift_use_crio | default(false)
 
 - name: setup firewall

--- a/roles/openshift_repos/README.md
+++ b/roles/openshift_repos/README.md
@@ -1,4 +1,4 @@
-OpenShift Repos 
+OpenShift Repos
 ================
 
 Configures repositories for an OpenShift installation
@@ -12,10 +12,10 @@ rhel-7-server-extra-rpms, and rhel-7-server-ose-3.0-rpms repos.
 Role Variables
 --------------
 
-| Name                          | Default value |                                    |
-|-------------------------------|---------------|------------------------------------|
-| openshift_deployment_type     | None          | Possible values enterprise, origin |
-| openshift_additional_repos    | {}            | TODO                               |
+| Name                          | Default value |                                              |
+|-------------------------------|---------------|----------------------------------------------|
+| openshift_deployment_type     | None          | Possible values openshift-enterprise, origin |
+| openshift_additional_repos    | {}            | TODO                                         |
 
 Dependencies
 ------------

--- a/roles/openshift_sanitize_inventory/vars/main.yml
+++ b/roles/openshift_sanitize_inventory/vars/main.yml
@@ -1,7 +1,4 @@
 ---
 # origin uses community packages named 'origin'
-# online currently uses 'openshift' packages
-# enterprise is used for OSE 3.0 < 3.1 which uses packages named 'openshift'
-# atomic-enterprise uses Red Hat packages named 'atomic-openshift'
-# openshift-enterprise uses Red Hat packages named 'atomic-openshift' starting with OSE 3.1
-known_openshift_deployment_types: ['origin', 'online', 'enterprise', 'atomic-enterprise', 'openshift-enterprise']
+# openshift-enterprise uses Red Hat packages named 'atomic-openshift'
+known_openshift_deployment_types: ['origin', 'openshift-enterprise']

--- a/roles/rhel_subscribe/tasks/enterprise.yml
+++ b/roles/rhel_subscribe/tasks/enterprise.yml
@@ -3,20 +3,17 @@
   command: subscription-manager repos --disable="*"
 
 - set_fact:
-    default_ose_version: '3.0'
-  when: deployment_type == 'enterprise'
-
-- set_fact:
     default_ose_version: '3.6'
-  when: deployment_type in ['atomic-enterprise', 'openshift-enterprise']
+  when: deployment_type == 'openshift-enterprise'
 
 - set_fact:
     ose_version: "{{ lookup('oo_option', 'ose_version') | default(default_ose_version, True) }}"
 
 - fail:
     msg: "{{ ose_version }} is not a valid version for {{ deployment_type }} deployment type"
-  when: ( deployment_type == 'enterprise' and ose_version not in ['3.0'] ) or
-        ( deployment_type in ['atomic-enterprise', 'openshift-enterprise'] and ose_version not in ['3.1', '3.2', '3.3', '3.4', '3.5', '3.6'] )
+  when:
+    - deployment_type == 'openshift-enterprise'
+    - ose_version not in ['3.1', '3.2', '3.3', '3.4', '3.5', '3.6'] )
 
 - name: Enable RHEL repositories
   command: subscription-manager repos \

--- a/roles/rhel_subscribe/tasks/main.yml
+++ b/roles/rhel_subscribe/tasks/main.yml
@@ -69,5 +69,5 @@
 
 - include: enterprise.yml
   when:
-  - deployment_type in [ 'enterprise', 'atomic-enterprise', 'openshift-enterprise' ]
+  - deployment_type == 'openshift-enterprise'
   - not ostree_booted.stat.exists | bool

--- a/test/openshift_version_tests.py
+++ b/test/openshift_version_tests.py
@@ -17,39 +17,39 @@ class OpenShiftVersionTests(unittest.TestCase):
 
     # Static tests for legacy filters.
     legacy_gte_tests = [{'name': 'oo_version_gte_3_1_or_1_1',
-                         'positive_enterprise_version': '3.2.0',
-                         'negative_enterprise_version': '3.0.0',
+                         'positive_openshift-enterprise_version': '3.2.0',
+                         'negative_openshift-enterprise_version': '3.0.0',
                          'positive_origin_version': '1.2.0',
                          'negative_origin_version': '1.0.0'},
                         {'name': 'oo_version_gte_3_1_1_or_1_1_1',
-                         'positive_enterprise_version': '3.2.0',
-                         'negative_enterprise_version': '3.1.0',
+                         'positive_openshift-enterprise_version': '3.2.0',
+                         'negative_openshift-enterprise_version': '3.1.0',
                          'positive_origin_version': '1.2.0',
                          'negative_origin_version': '1.1.0'},
                         {'name': 'oo_version_gte_3_2_or_1_2',
-                         'positive_enterprise_version': '3.3.0',
-                         'negative_enterprise_version': '3.1.0',
+                         'positive_openshift-enterprise_version': '3.3.0',
+                         'negative_openshift-enterprise_version': '3.1.0',
                          'positive_origin_version': '1.3.0',
                          'negative_origin_version': '1.1.0'},
                         {'name': 'oo_version_gte_3_3_or_1_3',
-                         'positive_enterprise_version': '3.4.0',
-                         'negative_enterprise_version': '3.2.0',
+                         'positive_openshift-enterprise_version': '3.4.0',
+                         'negative_openshift-enterprise_version': '3.2.0',
                          'positive_origin_version': '1.4.0',
                          'negative_origin_version': '1.2.0'},
                         {'name': 'oo_version_gte_3_4_or_1_4',
-                         'positive_enterprise_version': '3.5.0',
-                         'negative_enterprise_version': '3.3.0',
+                         'positive_openshift-enterprise_version': '3.5.0',
+                         'negative_openshift-enterprise_version': '3.3.0',
                          'positive_origin_version': '1.5.0',
                          'negative_origin_version': '1.3.0'},
                         {'name': 'oo_version_gte_3_5_or_1_5',
-                         'positive_enterprise_version': '3.6.0',
-                         'negative_enterprise_version': '3.4.0',
+                         'positive_openshift-enterprise_version': '3.6.0',
+                         'negative_openshift-enterprise_version': '3.4.0',
                          'positive_origin_version': '3.6.0',
                          'negative_origin_version': '1.4.0'}]
 
     def test_legacy_gte_filters(self):
         for test in self.legacy_gte_tests:
-            for deployment_type in ['enterprise', 'origin']:
+            for deployment_type in ['openshift-enterprise', 'origin']:
                 # Test negative case per deployment_type
                 self.assertFalse(
                     self.openshift_version_filters._filters[test['name']](
@@ -70,3 +70,7 @@ class OpenShiftVersionTests(unittest.TestCase):
                 self.assertFalse(
                     self.openshift_version_filters._filters["oo_version_gte_{}_{}".format(major, minor)](
                         "{}.{}".format(major, minor)))
+
+    def test_get_filters(self):
+        self.assertTrue(
+            self.openshift_version_filters.filters() == self.openshift_version_filters._filters)

--- a/utils/docs/config.md
+++ b/utils/docs/config.md
@@ -52,7 +52,6 @@ Indicates the version of configuration this file was written with. Current imple
 The OpenShift variant to install. Currently valid options are:
 
  * openshift-enterprise
- * atomic-enterprise
 
 ### variant_version (optional)
 


### PR DESCRIPTION
Previously, openshift-ansible supported various
types of deployments using the variable "openshift_deployment_type"

Currently, openshift-ansible only supports two deployment types,
"origin" and "openshift-enterprise".

This commit removes all logic and references to deprecated
deployment types.