### PR TITLE
1490268 Workaround Ansible Jinja2 delimiter warning

### DIFF
--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -5,8 +5,8 @@ r_openshift_hosted_router_use_firewalld: "{{ os_firewall_use_firewalld | default
 r_openshift_hosted_registry_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
 r_openshift_hosted_registry_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
-openshift_hosted_router_wait: "{{ not openshift_master_bootstrap_enabled | default(True) }}"
-openshift_hosted_registry_wait: "{{ not openshift_master_bootstrap_enabled | default(True) }}"
+openshift_hosted_router_wait: "{{ not (openshift_master_bootstrap_enabled | default(False)) }}"
+openshift_hosted_registry_wait: "{{ not (openshift_master_bootstrap_enabled | default(False)) }}"
 
 registry_volume_claim: 'registry-claim'
 

--- a/roles/openshift_hosted/tasks/registry/registry.yml
+++ b/roles/openshift_hosted/tasks/registry/registry.yml
@@ -137,7 +137,7 @@
     edits: "{{ openshift_hosted_registry_edits }}"
     force: "{{ True|bool in openshift_hosted_registry_force }}"
 
-- when: openshift_hosted_registry_wait
+- when: openshift_hosted_registry_wait == True
   block:
   - name: Ensure OpenShift registry correctly rolls out (best-effort today)
     command: |

--- a/roles/openshift_hosted/tasks/registry/registry.yml
+++ b/roles/openshift_hosted/tasks/registry/registry.yml
@@ -137,7 +137,7 @@
     edits: "{{ openshift_hosted_registry_edits }}"
     force: "{{ True|bool in openshift_hosted_registry_force }}"
 
-- when: openshift_hosted_registry_wait == True
+- when: openshift_hosted_registry_wait | bool
   block:
   - name: Ensure OpenShift registry correctly rolls out (best-effort today)
     command: |

--- a/roles/openshift_hosted/tasks/router/router.yml
+++ b/roles/openshift_hosted/tasks/router/router.yml
@@ -94,7 +94,7 @@
     stats_port: "{{ item.stats_port }}"
   with_items: "{{ openshift_hosted_routers }}"
 
-- when: openshift_hosted_router_wait == True
+- when: openshift_hosted_router_wait | bool
   block:
   - name: Ensure OpenShift router correctly rolls out (best-effort today)
     command: |

--- a/roles/openshift_hosted/tasks/router/router.yml
+++ b/roles/openshift_hosted/tasks/router/router.yml
@@ -94,7 +94,7 @@
     stats_port: "{{ item.stats_port }}"
   with_items: "{{ openshift_hosted_routers }}"
 
-- when: openshift_hosted_router_wait
+- when: openshift_hosted_router_wait == True
   block:
   - name: Ensure OpenShift router correctly rolls out (best-effort today)
     command: |


### PR DESCRIPTION
This workaround prevents the warnings on using Jinja2 templating delimiters in `when:` conditions in cases where a variable is used as the conditional.  This has been fixed in Ansible 2.4.
https://github.com/ansible/ansible/pull/25092

Fixes 1490268