### PR TITLE
Only install base openshift package on masters and nodes

### DIFF
--- a/playbooks/common/openshift-cluster/initialize_openshift_version.yml
+++ b/playbooks/common/openshift-cluster/initialize_openshift_version.yml
@@ -1,4 +1,12 @@
 ---
+- name: Set version_install_base_package true on masters and nodes
+  hosts: oo_masters_to_config:oo_nodes_to_config
+  tasks:
+  - name: Set version_install_base_package true
+    set_fact:
+      version_install_base_package: True
+    when: version_install_base_package is not defined
+
 # NOTE: requires openshift_facts be run
 - name: Determine openshift_version to configure on first master
   hosts: oo_first_master

--- a/roles/openshift_version/defaults/main.yml
+++ b/roles/openshift_version/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 openshift_protect_installed_version: True
+version_install_base_package: False

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -5,11 +5,15 @@
     is_containerized: "{{ openshift.common.is_containerized | default(False) | bool }}"
     is_atomic: "{{ openshift.common.is_atomic | default(False) | bool }}"
 
+# This is only needed on masters and nodes; version_install_base_package
+# should be set by a play externally.
 - name: Install the base package for versioning
   package:
     name: "{{ openshift.common.service_type }}{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
     state: present
-  when: not is_containerized | bool
+  when:
+  - not is_containerized | bool
+  - version_install_base_package | bool
 
 # Block attempts to install origin without specifying some kind of version information.
 # This is because the latest tags for origin are usually alpha builds, which should not


### PR DESCRIPTION
Recent refactoring to remove openshift_common resulted
in base openshift rpm's being installed on more hosts
than previous.  This situation results in hosts that
would otherwise not need access to openshift repositories
to require them.

This patch set results in only openshift_masters and
openshift_nodes to have the openshift base package installed.