### PR TITLE
Add loadbalancer config entry point

### DIFF
--- a/playbooks/byo/openshift-loadbalancer/config.yml
+++ b/playbooks/byo/openshift-loadbalancer/config.yml
@@ -1,0 +1,6 @@
+---
+- include: ../openshift-cluster/initialize_groups.yml
+
+- include: ../../common/openshift-cluster/std_include.yml
+
+- include: ../../common/openshift-loadbalancer/config.yml


### PR DESCRIPTION
Since the master config playbook has been broken out as an independent component, the loadbalancer config step was not being processed for HA installs.  This adds an entry point to run the loadbalancer config so that a user can configure the loadbalancer if they do not have one already configured.

See: https://trello.com/c/tKzi4PUA