### PR TITLE
move (and rename) get_dns_ip filter into openshift_node_facts

### DIFF
--- a/roles/openshift_node_facts/filter_plugins/filters.py
+++ b/roles/openshift_node_facts/filter_plugins/filters.py
@@ -7,10 +7,10 @@ from ansible import errors
 
 
 class FilterModule(object):
-    ''' Custom ansible filters for use by openshift_node role'''
+    ''' Custom ansible filters for use by openshift_node_facts role'''
 
     @staticmethod
-    def get_dns_ip(openshift_dns_ip, hostvars):
+    def node_get_dns_ip(openshift_dns_ip, hostvars):
         ''' Navigates the complicated logic of when to set dnsIP
 
             In all situations if they've set openshift_dns_ip use that
@@ -29,4 +29,4 @@ class FilterModule(object):
 
     def filters(self):
         ''' returns a mapping of filters to methods '''
-        return {'get_dns_ip': self.get_dns_ip}
+        return {'node_get_dns_ip': self.node_get_dns_ip}

--- a/roles/openshift_node_facts/tasks/main.yml
+++ b/roles/openshift_node_facts/tasks/main.yml
@@ -30,5 +30,5 @@
       ovs_image: "{{ osn_ovs_image | default(None) }}"
       proxy_mode: "{{ openshift_node_proxy_mode | default('iptables') }}"
       local_quota_per_fsgroup: "{{ openshift_node_local_quota_per_fsgroup | default(None) }}"
-      dns_ip: "{{ openshift_dns_ip | default(none) | get_dns_ip(hostvars[inventory_hostname])}}"
+      dns_ip: "{{ openshift_dns_ip | default(none) | node_get_dns_ip(hostvars[inventory_hostname])}}"
       env_vars: "{{ openshift_node_env_vars | default(None) }}"


### PR DESCRIPTION
Due to recent changes to filter_plugins/openshift_node.py, when trying to run a current version of the openshift_node_facts role on a system with an older version of the openshift-ansible-filter-plugins RPM, the new role will fail.
```
  File "/usr/share/ansible_plugins/filter_plugins/openshift_node.py", line 30, in get_dns_ip
    if bool(hostvars['openshift']['common']['use_dnsmasq']):
KeyError: 'use_dnsmasq'
```
It's not possible for us to have our current RPM version (presently openshift-ansible-filter-plugins-3.5.120-1.git.0.c60f69a.el7.noarch) and a newer RPM installed and run both current openshift-ansible code and older checked-out/vendored releases (for older clusters/releases).

Since only the openshift_node_facts role uses the get_dns_ip filter, move the functionality into a role-specific filter plugin.

In addition, rename the filter plugin to 'node_get_dns_ip' because Ansible is preffering the get_dns_ip from the RPM (ie /usr/share/ansible_plugins/filter_plugins/openshift_node.py) over the role-specific filter plugin of the same name. Ansile prefers the filter plugins in /usr/share/ansible_plugins/filter_plugins/* even when /etc/ansible/ansible.cfg is set to something like:

filter_plugins     = filter_plugins:/usr/share/ansible_plugins/filter_plugins:filter_plugins   <--- yes, 'filter_plugins' before and after /usr/share/ansible_plugins/filter_plugins (ansible 2.3.1.0) (perhaps this is because the /usr/share/ansible/plugins/filter symlink to /usr/share/ansible_plugins/filter_plugins takes precedence over everything???)

Renaming the filter plugin function ensures that versions of the openshift_node_facts role that depend on the old implementation can continue to use it through what the older RPM provides, and the new role can use it's role-specific filter plugin without any variable namespace collisions.

Lastly, remove filter_plugins/openshift_node.py since it is now self-contained in roles/openshift_node_facts.

https://bugzilla.redhat.com/show_bug.cgi?id=1494312