### PR TITLE
Registry cert fix

### DIFF
--- a/playbooks/common/openshift-cluster/redeploy-certificates/registry.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/registry.yml
@@ -32,7 +32,7 @@
     set_fact:
       openshift_hosted_registry_env_vars: "{{ openshift_hosted_registry_env_vars | combine({'OPENSHIFT_DEFAULT_REGISTRY':'docker-registry.default.svc:5000'}) }}"
     when: openshift_push_via_dns | default(false) | bool
-  
+
   - name: Update registry proxy settings for dc/docker-registry
     set_fact:
       openshift_hosted_registry_env_vars: "{{ {'HTTPS_PROXY': (openshift.common.https_proxy | default('')),
@@ -55,7 +55,7 @@
 
   - name: Include openshift_hosted role secure routing
     include: roles/openshift_hosted/tasks/registry/secure.yml
- 
+
   - name: Redeploy docker registry
     command: |
       oc rollout latest {{ openshift_hosted_registry_name }} \

--- a/playbooks/common/openshift-cluster/redeploy-certificates/registry.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/registry.yml
@@ -4,99 +4,83 @@
   vars:
   roles:
   - lib_openshift
+  #we need facts as we are including other role tasks
+  - openshift_master_facts
   tasks:
-  - name: Create temp directory for kubeconfig
-    command: mktemp -d /tmp/openshift-ansible-XXXXXX
-    register: mktemp
-    changed_when: false
-
-  - name: Copy admin client config(s)
-    command: >
-      cp {{ openshift.common.config_base }}/master//admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
-    changed_when: false
-
-  - name: Determine if docker-registry exists
-    command: >
-      {{ openshift.common.client_binary }} get dc/docker-registry -o json
-      --config={{ mktemp.stdout }}/admin.kubeconfig
-      -n default
-    register: l_docker_registry_dc
-    failed_when: false
-    changed_when: false
 
   - set_fact:
-      docker_registry_env_vars: "{{ ((l_docker_registry_dc.stdout | from_json)['spec']['template']['spec']['containers'][0]['env']
-                                      | oo_collect('name'))
-                                      | default([]) }}"
-      docker_registry_secrets: "{{ ((l_docker_registry_dc.stdout | from_json)['spec']['template']['spec']['volumes']
-                                     | oo_collect('secret')
-                                     | oo_collect('secretName'))
-                                     | default([]) }}"
-    changed_when: false
-    when: l_docker_registry_dc.rc == 0
+      openshift_hosted_registry_namespace: "{{ openshift.hosted.registry.namespace | default('default') }}"
+      openshift_hosted_router_create_certificate: True
+      openshift_hosted_registry_cert_expire_days: 730
+      openshift_hosted_registry_name: docker-registry
+      openshift_hosted_registry_volumes: []
+      openshift_hosted_registry_env_vars: {}
+      openshift_hosted_registry_force:
+      - False
+      openshift_hosted_registry_edits:
+      # These edits are being specified only to prevent 'changed' on rerun
+      - key: spec.strategy.rollingParams
+        value:
+          intervalSeconds: 1
+          maxSurge: "25%"
+          maxUnavailable: "25%"
+          timeoutSeconds: 600
+          updatePeriodSeconds: 1
+        action: put
 
-  # Replace dc/docker-registry environment variable certificate data if set.
-  - name: Update docker-registry environment variables
-    shell: >
-      {{ openshift.common.client_binary }} env dc/docker-registry
-      OPENSHIFT_CA_DATA="$(cat /etc/origin/master/ca.crt)"
-      OPENSHIFT_CERT_DATA="$(cat /etc/origin/master/openshift-registry.crt)"
-      OPENSHIFT_KEY_DATA="$(cat /etc/origin/master/openshift-registry.key)"
-      --config={{ mktemp.stdout }}/admin.kubeconfig
-      -n default
-    when: l_docker_registry_dc.rc == 0 and 'OPENSHIFT_CA_DATA' in docker_registry_env_vars and 'OPENSHIFT_CERT_DATA' in docker_registry_env_vars and 'OPENSHIFT_KEY_DATA' in docker_registry_env_vars
+  - name: Update registry environment variables when pushing via dns
+    set_fact:
+      openshift_hosted_registry_env_vars: "{{ openshift_hosted_registry_env_vars | combine({'OPENSHIFT_DEFAULT_REGISTRY':'docker-registry.default.svc:5000'}) }}"
+    when: openshift_push_via_dns | default(false) | bool
+  
+  - name: Update registry proxy settings for dc/docker-registry
+    set_fact:
+      openshift_hosted_registry_env_vars: "{{ {'HTTPS_PROXY': (openshift.common.https_proxy | default('')),
+                                             'HTTP_PROXY':  (openshift.common.http_proxy  | default('')),
+                                             'NO_PROXY':    (openshift.common.no_proxy    | default(''))}
+                                           | combine(openshift_hosted_registry_env_vars) }}"
+    when: (openshift.common.https_proxy | default(False)) or (openshift.common.http_proxy | default('')) != ''
 
-  # Replace dc/docker-registry certificate secret contents if set.
-  - block:
-    - name: Retrieve registry service IP
-      oc_service:
-        namespace: default
-        name: docker-registry
-        state: list
-      register: docker_registry_service_ip
-      changed_when: false
+  - name: Update openshift_hosted facts for persistent volumes
+    set_fact:
+      openshift_hosted_registry_volumes: "{{ openshift_hosted_registry_volumes | union(pvc_volume_mounts) }}"
+    vars:
+      pvc_volume_mounts:
+      - name: registry-storage
+        type: persistentVolumeClaim
+        claim_name: "{{ openshift.hosted.registry.storage.volume.name }}-claim"
+    when:
+    - openshift.hosted.registry.storage.kind | default(none) in ['nfs', 'openstack', 'glusterfs']
 
-    - set_fact:
-        docker_registry_route_hostname: "{{ 'docker-registry-default.' ~ (openshift.master.default_subdomain | default('router.default.svc.cluster.local', true)) }}"
-      changed_when: false
 
-    - name: Generate registry certificate
-      command: >
-        {{ openshift.common.client_binary }} adm ca create-server-cert
-        --signer-cert={{ openshift.common.config_base }}/master/ca.crt
-        --signer-key={{ openshift.common.config_base }}/master/ca.key
-        --signer-serial={{ openshift.common.config_base }}/master/ca.serial.txt
-        --config={{ mktemp.stdout }}/admin.kubeconfig
-        --hostnames="{{ docker_registry_service_ip.results.clusterip }},docker-registry.default.svc,docker-registry.default.svc.cluster.local,{{ docker_registry_route_hostname }}"
-        --cert={{ openshift.common.config_base }}/master/registry.crt
-        --key={{ openshift.common.config_base }}/master/registry.key
-        {% if openshift_version | oo_version_gte_3_5_or_1_5(openshift.common.deployment_type) | bool %}
-        --expire-days={{ openshift_hosted_registry_cert_expire_days | default(730) }}
-        {% endif %}
-
-    - name: Update registry certificates secret
-      oc_secret:
-        kubeconfig: "{{ mktemp.stdout }}/admin.kubeconfig"
-        name: registry-certificates
-        namespace: default
-        state: present
-        files:
-        - name: registry.crt
-          path: "{{ openshift.common.config_base }}/master/registry.crt"
-        - name: registry.key
-          path: "{{ openshift.common.config_base }}/master/registry.key"
-      run_once: true
-    when: l_docker_registry_dc.rc == 0 and 'registry-certificates' in docker_registry_secrets and 'REGISTRY_HTTP_TLS_CERTIFICATE' in docker_registry_env_vars and 'REGISTRY_HTTP_TLS_KEY' in docker_registry_env_vars
-
+  - name: Include openshift_hosted role secure routing
+    include: roles/openshift_hosted/tasks/registry/secure.yml
+ 
   - name: Redeploy docker registry
-    command: >
-      {{ openshift.common.client_binary }} deploy dc/docker-registry
-      --latest
-      --config={{ mktemp.stdout }}/admin.kubeconfig
-      -n default
+    command: |
+      oc rollout latest {{ openshift_hosted_registry_name }} \
+                        --namespace {{ openshift_hosted_registry_namespace }} \
+                        --config {{ openshift.common.config_base }}/master/admin.kubeconfig
+    async: 600
+    poll: 15
+    failed_when: false
 
-  - name: Delete temp directory
-    file:
-      name: "{{ mktemp.stdout }}"
-      state: absent
-    changed_when: False
+  - name: Determine the latest version of the OpenShift registry deployment
+    command: |
+      {{ openshift.common.client_binary }} get deploymentconfig {{ openshift_hosted_registry_name }} \
+             --namespace {{ openshift_hosted_registry_namespace }} \
+             --config {{ openshift.common.config_base }}/master/admin.kubeconfig \
+             -o jsonpath='{ .status.latestVersion }'
+    register: openshift_hosted_registry_latest_version
+
+  - name: Sanity-check that the OpenShift registry rolled out correctly
+    command: |
+      {{ openshift.common.client_binary }} get replicationcontroller {{ openshift_hosted_registry_name }}-{{ openshift_hosted_registry_latest_version.stdout }} \
+             --namespace {{ openshift_hosted_registry_namespace }} \
+             --config {{ openshift.common.config_base }}/master/admin.kubeconfig \
+             -o jsonpath='{ .metadata.annotations.openshift\.io/deployment\.phase }'
+    register: openshift_hosted_registry_rc_phase
+    until: "'Running' not in openshift_hosted_registry_rc_phase.stdout"
+    delay: 15
+    retries: 40
+    failed_when: "'Failed' in openshift_hosted_registry_rc_phase.stdout"

--- a/roles/openshift_hosted/tasks/registry/secure.yml
+++ b/roles/openshift_hosted/tasks/registry/secure.yml
@@ -1,7 +1,9 @@
 ---
+
+#This play is being used in registry redeploy certificates play. If you changing anything here, make sure redeploy still works. Thanks.
 - name: Configure facts for docker-registry
   set_fact:
-    openshift_hosted_registry_routecertificates: "{{ ('routecertificates' in openshift.hosted.registry.keys()) | ternary(openshift.hosted.registry.routecertificates, {}) }}"
+    openshift_hosted_registry_routecertificates: "{{ ('routecertificates' in openshift.hosted.registry.keys()) | ternary(openshift_hosted_registry_routecertificates, {}) }}"
     openshift_hosted_registry_routehost: "{{ ('routehost' in openshift.hosted.registry.keys()) | ternary(openshift.hosted.registry.routehost, False) }}"
     openshift_hosted_registry_routetermination: "{{ ('routetermination' in openshift.hosted.registry.keys()) | ternary(openshift.hosted.registry.routetermination, 'passthrough') }}"
 

--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -112,7 +112,7 @@ EOF
       fi
       sed -e '/^nameserver.*$/d' /etc/resolv.conf >> ${NEW_RESOLV_CONF}
       echo "nameserver "${def_route_ip}"" >> ${NEW_RESOLV_CONF}
-      if ! grep -q 'search.*cluster.local' ${NEW_RESOLV_CONF}; then
+      if ! grep -q 'search.*/scluster.local' ${NEW_RESOLV_CONF}; then
         sed -i '/^search/ s/$/ cluster.local/' ${NEW_RESOLV_CONF}
       fi
       cp -Z ${NEW_RESOLV_CONF} /etc/resolv.conf

--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -112,7 +112,7 @@ EOF
       fi
       sed -e '/^nameserver.*$/d' /etc/resolv.conf >> ${NEW_RESOLV_CONF}
       echo "nameserver "${def_route_ip}"" >> ${NEW_RESOLV_CONF}
-      if ! grep -q 'search.*/scluster.local' ${NEW_RESOLV_CONF}; then
+      if ! grep -q 'search.*cluster.local' ${NEW_RESOLV_CONF}; then
         sed -i '/^search/ s/$/ cluster.local/' ${NEW_RESOLV_CONF}
       fi
       cp -Z ${NEW_RESOLV_CONF} /etc/resolv.conf


### PR DESCRIPTION
redeploy certificates does not work after main playbook refactor. 
Overall redeploy now hardly covers all use-cases as per new refactoring. 

It would be best to merge redeploy to main openshift_hosted playbook with parametrized actions as most of the actions are the same in the plays now.

This one is tactical fix, it makes redeploy work, but it includes secure.yml play into redeploy and mocks some of the facts settings which happen in the openshift_hosted play.

Any ideas how we would want to see this in the future, as I just checked registry cert re-deploy. dont know about others. + solution to include secure.yml looks hacky, but now we duplicating a lot of code.... 