### PR TITLE
disable adc reconciler sync for aws

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1131,6 +1131,7 @@ def build_controller_args(facts):
                 if facts['cloudprovider']['kind'] == 'aws':
                     controller_args['cloud-provider'] = ['aws']
                     controller_args['cloud-config'] = [cloud_cfg_path + '/aws.conf']
+                    controller_args['disable-attach-detach-reconcile-sync'] = 'true'
                 if facts['cloudprovider']['kind'] == 'openstack':
                     controller_args['cloud-provider'] = ['openstack']
                     controller_args['cloud-config'] = [cloud_cfg_path + '/openstack.conf']


### PR DESCRIPTION
This PR disables Attach detach controller reconciler sync introduced in https://github.com/kubernetes/kubernetes/pull/34859

The reason I am proposing to disable this sync is because originally code was written for cloudproviders like GCE where shutting down an instance automatically detaches volumes attached to it. But that is not the case with AWS. In AWS only terminating the node detaches the volumes.

But naturally terminating the node will also migrate the pods and hence we don't need to worry about attaching volumes to a terminated node. In a nutshell, I believe this sync is not necessary for AWS. I have tested this in smallish cluster, but I would like to make this as a default for Openshift.

Related Trello Card - https://trello.com/c/ycPNuBSb/567-remove-verifyvolumesareattached-feature-for-aws