### PR TITLE
[3.6] Ensure valid search on resolv.conf

### DIFF
--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -104,6 +104,8 @@ EOF
 
       if ! grep -q 'search.*cluster.local' ${NEW_RESOLV_CONF}; then
         sed -i '/^search/ s/$/ cluster.local/' ${NEW_RESOLV_CONF}
+      elif ! grep -qw search ${NEW_RESOLV_CONF}; then
+        echo 'search cluster.local' >> ${NEW_RESOLV_CONF}
       fi
       cp -Z ${NEW_RESOLV_CONF} /etc/resolv.conf
     fi


### PR DESCRIPTION
On cluster without internal name resolution there will be no `search XXX` on /etc/resolv.conf at all, thus this script will fail to add an entry for `cluster.local`.