### PR TITLE
Scaffold out the entire build defaults hash

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1602,11 +1602,13 @@ def set_builddefaults_facts(facts):
             builddefaults['git_no_proxy'] = builddefaults['no_proxy']
         # If we're actually defining a builddefaults config then create admission_plugin_config
         # then merge builddefaults[config] structure into admission_plugin_config
+
+        # 'config' is the 'openshift_builddefaults_json' inventory variable
         if 'config' in builddefaults:
             if 'admission_plugin_config' not in facts['master']:
-                facts['master']['admission_plugin_config'] = dict()
+                # Scaffold out the full expected datastructure
+                facts['master']['admission_plugin_config'] = {'BuildDefaults': {'configuration': {'env': {}}}}
             facts['master']['admission_plugin_config'].update(builddefaults['config'])
-            # if the user didn't actually provide proxy values, delete the proxy env variable defaults.
             delete_empty_keys(facts['master']['admission_plugin_config']['BuildDefaults']['configuration']['env'])
 
     return facts


### PR DESCRIPTION
Some functions called later may expect sub-keys to exist which will
not with the current default empty-dict.

Forwardports https://github.com/openshift/openshift-ansible/pull/5375
