### PR TITLE
Removing setting of pod presets

### DIFF
--- a/roles/openshift_service_catalog/files/openshift-ansible-catalog-console.js
+++ b/roles/openshift_service_catalog/files/openshift-ansible-catalog-console.js
@@ -1,2 +1,1 @@
 window.OPENSHIFT_CONSTANTS.ENABLE_TECH_PREVIEW_FEATURE.service_catalog_landing_page = true;
-window.OPENSHIFT_CONSTANTS.ENABLE_TECH_PREVIEW_FEATURE.pod_presets = true;


### PR DESCRIPTION
Pod presets are not supported in 3.7.
When we are enabling the service catalog we should not be enabling pod presets.

Resolves https://github.com/openshift/openshift-ansible/issues/5403