### PR TITLE
Only attempt to start iptables on hosts in the current batch

### DIFF
--- a/roles/os_firewall/tasks/iptables.yml
+++ b/roles/os_firewall/tasks/iptables.yml
@@ -33,7 +33,7 @@
   register: result
   delegate_to: "{{item}}"
   run_once: true
-  with_items: "{{ ansible_play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
 
 - name: need to pause here, otherwise the iptables service starting can sometimes cause ssh to fail
   pause:


### PR DESCRIPTION
If os_firewall role is called from within a play that uses serial then
it was attempting to start iptables on hosts that may not have had
iptables installed on them yet. So limit the hosts to the current batch.
According to the ansible docs on plays where serial is unused this is
the same as ansible_play_hosts.

See http://docs.ansible.com/ansible/latest/playbooks_variables.html

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1490739