### PR TITLE
Setup tuned after the node has been restarted.

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -2,10 +2,6 @@
 - name: Install the systemd units
   include: systemd_units.yml
 
-- name: Setup tuned
-  include: tuned.yml
-  static: yes
-
 - name: Start and enable openvswitch service
   systemd:
     name: openvswitch.service
@@ -98,6 +94,10 @@
   fail:
     msg: Node failed to start please inspect the logs and try again
   when: node_start_result | failed
+
+- name: Setup tuned
+  include: tuned.yml
+  static: yes
 
 - set_fact:
     node_service_status_changed: "{{ node_start_result | changed }}"


### PR DESCRIPTION
Tuned OpenShift recommend.conf takes values from node-config.yaml,  This file is updated after node restart.  Without this PR, OpenShift control plane currently gets the correct profile during install, but not regular worker nodes.
