### PR TITLE
Move some pre-checks before excluders are disabled

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade.yml
@@ -47,6 +47,10 @@
   tags:
   - pre_upgrade
 
+- include: ../pre/verify_control_plane_running.yml
+  tags:
+  - pre_upgrade
+
 - include: ../disable_master_excluders.yml
   tags:
   - pre_upgrade
@@ -70,10 +74,6 @@
     # docker restarts. At this early stage of upgrade we can assume
     # docker is configured and running.
     skip_docker_role: True
-
-- include: ../pre/verify_control_plane_running.yml
-  tags:
-  - pre_upgrade
 
 - include: ../../../openshift-master/validate_restart.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
@@ -47,6 +47,14 @@
   tags:
   - pre_upgrade
 
+- include: ../pre/verify_health_checks.yml
+  tags:
+  - pre_upgrade
+
+- include: ../pre/verify_control_plane_running.yml
+  tags:
+  - pre_upgrade
+
 - include: ../disable_master_excluders.yml
   tags:
   - pre_upgrade
@@ -70,14 +78,6 @@
     # docker restarts. At this early stage of upgrade we can assume
     # docker is configured and running.
     skip_docker_role: True
-
-- include: ../pre/verify_health_checks.yml
-  tags:
-  - pre_upgrade
-
-- include: ../pre/verify_control_plane_running.yml
-  tags:
-  - pre_upgrade
 
 - include: ../../../openshift-master/validate_restart.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
@@ -47,6 +47,14 @@
   tags:
   - pre_upgrade
 
+- include: ../pre/verify_health_checks.yml
+  tags:
+  - pre_upgrade
+
+- include: ../pre/verify_control_plane_running.yml
+  tags:
+  - pre_upgrade
+
 - include: ../disable_master_excluders.yml
   tags:
   - pre_upgrade
@@ -70,14 +78,6 @@
     # docker restarts. At this early stage of upgrade we can assume
     # docker is configured and running.
     skip_docker_role: True
-
-- include: ../pre/verify_health_checks.yml
-  tags:
-  - pre_upgrade
-
-- include: ../pre/verify_control_plane_running.yml
-  tags:
-  - pre_upgrade
 
 - include: ../../../openshift-master/validate_restart.yml
   tags:


### PR DESCRIPTION
Some pre-checks needs an OCP version which is detected by a set of tasks that need the excluders to be disabled. So at the best I can move some pre-checks before the excluders are disabled. However, there will be still some checks that can fail with excluders updated to the newer version.

Bug: 1484304