### PR TITLE
[3.6 backport] Update master config with new client urls during etcd scaleup.

### DIFF
--- a/playbooks/common/openshift-etcd/scaleup.yml
+++ b/playbooks/common/openshift-etcd/scaleup.yml
@@ -23,6 +23,9 @@
                        -C {{ etcd_peer_url_scheme }}://{{ hostvars[etcd_ca_host].etcd_hostname }}:{{ etcd_client_port }}
                        member add {{ etcd_hostname }} {{ etcd_peer_url_scheme }}://{{ etcd_ip }}:{{ etcd_peer_port }}
     delegate_to: "{{ etcd_ca_host }}"
+    failed_when:
+    - etcd_add_check.rc == 1
+    - ("peerURL exists" not in etcd_add_check.stderr)
     register: etcd_add_check
     retries: 3
     delay: 10
@@ -51,3 +54,19 @@
     retries: 3
     delay: 30
     until: scaleup_health.rc == 0
+
+- name: Update master etcd client urls
+  hosts: oo_masters_to_config
+  serial: 1
+  tasks:
+  - include_role:
+      name: openshift_master
+      tasks_from: update_etcd_client_urls
+    vars:
+      etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
+      openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+      openshift_master_etcd_hosts: "{{ hostvars
+                                       | oo_select_keys(groups['oo_etcd_to_config'] | union(groups['oo_new_etcd_to_config']))
+                                       | oo_collect('openshift.common.hostname')
+                                       | default(none, true) }}"
+      openshift_master_etcd_port: "{{ (etcd_client_port | default('2379')) if (groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config) else none }}"

--- a/roles/openshift_master/tasks/update_etcd_client_urls.yml
+++ b/roles/openshift_master/tasks/update_etcd_client_urls.yml
@@ -1,0 +1,8 @@
+---
+- yedit:
+    src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+    key: 'etcdClientInfo.urls'
+    value: "{{ openshift.master.etcd_urls }}"
+  notify:
+  - restart master api
+  - restart master controllers


### PR DESCRIPTION
Backporting https://github.com/openshift/openshift-ansible/pull/5367