### PR TITLE
update system container cwd

### DIFF
--- a/images/installer/root/exports/config.json.template
+++ b/images/installer/root/exports/config.json.template
@@ -24,7 +24,7 @@
             "PLAYBOOK_FILE=$PLAYBOOK_FILE",
             "ANSIBLE_CONFIG=$ANSIBLE_CONFIG"
         ],
-        "cwd": "/opt/app-root/src/",
+        "cwd": "/usr/share/ansible/openshift-ansible",
         "rlimits": [
             {
                 "type": "RLIMIT_NOFILE",

--- a/images/installer/root/usr/local/bin/run
+++ b/images/installer/root/usr/local/bin/run
@@ -39,7 +39,7 @@ if [[ "$ALLOW_ANSIBLE_CONNECTION_LOCAL" = false ]]; then
 fi
 
 if [[ -v VAULT_PASS ]]; then
-  VAULT_PASS_FILE=.vaultpass
+  VAULT_PASS_FILE="$(mktemp)"
   echo ${VAULT_PASS} > ${VAULT_PASS_FILE}
   VAULT_PASS_ARG="--vault-password-file ${VAULT_PASS_FILE}"
 fi


### PR DESCRIPTION
This changes the cwd for the system container to be the base of the openshift-ansible content. This way the playbook can be specified as a relative path, and in the future when we drop the symlinks for various plugins and rely on cwd to find them, this will still work.

Looking through the Dockerfile side of things I noticed that the run script changes directories to WORK_DIR which is the content base, so this change brings the two methods closer together. I was looking for anything that actually wrote to the current directory (which is $HOME at the beginning of the run script) and found one, the vault password. It seemed slightly more robust to write that to a temporary location instead so I tacked on a commit to do that as well.