### PR TITLE
Fix registry auth task ordering

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -177,6 +177,8 @@
     local_facts:
       no_proxy_etcd_host_ips: "{{ openshift_no_proxy_etcd_host_ips }}"
 
+- include: registry_auth.yml
+
 - name: Install the systemd units
   include: systemd_units.yml
 
@@ -228,8 +230,6 @@
   notify:
   - restart master controllers
   when: openshift_master_bootstrap_enabled | default(False)
-
-- include: registry_auth.yml
 
 - include: set_loopback_context.yml
   when:

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -69,11 +69,11 @@
   include: bootstrap.yml
   when: openshift_node_bootstrap
 
+- include: registry_auth.yml
+
 - name: include standard node config
   include: config.yml
   when: not openshift_node_bootstrap
-
-- include: registry_auth.yml
 
 - name: Configure AWS Cloud Provider Settings
   lineinfile:


### PR DESCRIPTION
Currently, registry authentication credentials are not
produced until after docker systemd service files are
created.

This commit ensures the credentials are
created before the systemd service files to ensure
the proper boolean is set to include the read-only
mount of credentials inside containerized nodes and
masters.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1316341