### PR TITLE
Updating tuned recommend.conf based on OpenShift docs.

### DIFF
--- a/roles/openshift_node/templates/tuned/recommend.conf
+++ b/roles/openshift_node/templates/tuned/recommend.conf
@@ -1,8 +1,11 @@
-[openshift-node]
-/etc/origin/node/node-config.yaml=.*region=primary
-
 [openshift-control-plane,master]
 /etc/origin/master/master-config.yaml=.*
 
 [openshift-control-plane,node]
 /etc/origin/node/node-config.yaml=.*region=infra
+
+[openshift-control-plane,lb]
+/etc/haproxy/haproxy.cfg=.*
+
+[openshift-node]
+/etc/origin/node/node-config.yaml=.*


### PR DESCRIPTION
OpenShift docs doesn't mandate use of  `region=primary' for non-infrastructure nodes.