### PR TITLE
[1.5] Fix registry auth task ordering

### DIFF
--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -128,6 +128,8 @@
   when: openshift.master.request_header_ca is defined and item.kind == 'RequestHeaderIdentityProvider' and item.clientCA | default('') != ''
   with_items: "{{ openshift.master.identity_providers }}"
 
+- include: registry_auth.yml
+
 - name: Install the systemd units
   include: systemd_units.yml
 
@@ -163,8 +165,6 @@
     - restart master
     - restart master api
     - restart master controllers
-
-- include: registry_auth.yml
 
 - include: set_loopback_context.yml
   when: openshift.common.version_gte_3_2_or_1_2

--- a/roles/openshift_master/templates/master_docker/master.docker.service.j2
+++ b/roles/openshift_master/templates/master_docker/master.docker.service.j2
@@ -8,7 +8,7 @@ Wants=etcd_container.service
 [Service]
 EnvironmentFile=/etc/sysconfig/{{ openshift.common.service_type }}-master
 ExecStartPre=-/usr/bin/docker rm -f {{ openshift.common.service_type }}-master
-ExecStart=/usr/bin/docker run --rm --privileged --net=host --name {{ openshift.common.service_type }}-master --env-file=/etc/sysconfig/{{ openshift.common.service_type }}-master -v {{ openshift.common.data_dir }}:{{ openshift.common.data_dir }} -v /var/log:/var/log -v /var/run/docker.sock:/var/run/docker.sock -v {{ openshift.common.config_base }}:{{ openshift.common.config_base }} {% if openshift_cloudprovider_kind | default('') != '' -%} -v {{ openshift.common.config_base }}/cloudprovider:{{ openshift.common.config_base}}/cloudprovider {% endif -%} -v /etc/pki:/etc/pki:ro {{ openshift.master.master_image }}:${IMAGE_VERSION} start master --config=${CONFIG_FILE} $OPTIONS
+ExecStart=/usr/bin/docker run --rm --privileged --net=host --name {{ openshift.common.service_type }}-master --env-file=/etc/sysconfig/{{ openshift.common.service_type }}-master -v {{ openshift.common.data_dir }}:{{ openshift.common.data_dir }} -v /var/log:/var/log -v /var/run/docker.sock:/var/run/docker.sock -v {{ openshift.common.config_base }}:{{ openshift.common.config_base }} {% if openshift_cloudprovider_kind | default('') != '' -%} -v {{ openshift.common.config_base }}/cloudprovider:{{ openshift.common.config_base}}/cloudprovider {% endif -%} -v /etc/pki:/etc/pki:ro {% if l_bind_docker_reg_auth %} -v {{ oreg_auth_credentials_path }}:/root/.docker:ro{% endif %} {{ openshift.master.master_image }}:${IMAGE_VERSION} start master --config=${CONFIG_FILE} $OPTIONS
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop {{ openshift.common.service_type }}-master
 Restart=always

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -66,6 +66,8 @@
     state: present
   when: not openshift.common.is_containerized | bool
 
+- include: registry_auth.yml
+
 - name: Install the systemd units
   include: systemd_units.yml
 
@@ -108,8 +110,6 @@
     mode: 0600
   notify:
     - restart node
-
-- include: registry_auth.yml
 
 - name: Configure AWS Cloud Provider Settings
   lineinfile:


### PR DESCRIPTION
Currently, registry authentication credentials are not
produced until after docker systemd service files are
created.

This commit ensures the credentials are
created before the systemd service files to ensure
the proper boolean is set to include the read-only
mount of credentials inside containerized nodes and
masters.

This commit also ensures docker authentication credentials
are mounted into master containers in case of a single
master deployment.  This functionality was missing previously.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1316341
(cherry picked from commit a8a5245be646b0980b00cf6157d2162d4a07dafb)

Backports: #5441