### PR TITLE
Registry glusterfs fix

### DIFF
--- a/roles/openshift_hosted/tasks/registry/registry.yml
+++ b/roles/openshift_hosted/tasks/registry/registry.yml
@@ -44,7 +44,6 @@
     openshift_hosted_registry_volumes: []
     openshift_hosted_registry_env_vars: {}
     openshift_hosted_registry_edits:
-    glusterfs_nodes: "{{ groups.glusterfs }}"
     # These edits are being specified only to prevent 'changed' on rerun
     - key: spec.strategy.rollingParams
       value:
@@ -56,6 +55,8 @@
       action: put
     openshift_hosted_registry_force:
     - False
+    glusterfs_nodes: "{{ groups.glusterfs | default([]) }}"
+    glusterfs_name: "{{ openshift_storage_glusterfs_name | default ('registry') }}"
 
 - name: Update registry environment variables when pushing via dns
   set_fact:
@@ -125,6 +126,61 @@
   when:
   - openshift.hosted.registry.storage.kind | default(none) in ['nfs', 'openstack', 'glusterfs']
 
+#Create EP if we dont have gluster nodes in the cluster (no group defined) but e want to use glusterfs as backend
+- name: Create temp mount directory
+  command: mktemp -d /tmp/openshift-glusterfs-registry-XXXXXX
+  register: mktemp
+  changed_when: False
+  check_mode: no
+
+- name: Generate GlusterFS registry endpoints
+  template:
+    src: "glusterfs-registry-endpoints.yml.j2"
+    dest: "{{ mktemp.stdout }}/glusterfs-registry-endpoints.yml"
+  when:
+  - "glusterfs_nodes | count == 0"
+  - openshift_hosted_registry_glusterfs_endpoints is defined
+
+- name: Copy GlusterFS registry service
+  template:
+    src: "glusterfs-registry-service.yml.j2"
+    dest: "{{ mktemp.stdout }}/glusterfs-registry-service.yml"
+  when:
+  - "glusterfs_nodes | count == 0"
+  - openshift_hosted_registry_glusterfs_endpoints is defined
+
+
+- name: Create GlusterFS registry endpoints
+  oc_obj:
+    namespace: "{{ openshift.hosted.registry.namespace | default('default') }}"
+    state: present
+    kind: endpoints
+    name: "glusterfs-{{ glusterfs_name }}-endpoints"
+    files:
+    - "{{ mktemp.stdout }}/glusterfs-registry-endpoints.yml"
+  when:
+  - "glusterfs_nodes | count == 0"
+  - openshift_hosted_registry_glusterfs_endpoints is defined
+
+- name: Create GlusterFS registry service
+  oc_obj:
+    namespace: "{{ openshift.hosted.registry.namespace | default('default') }}"
+    state: present
+    kind: service
+    name: "glusterfs-{{ glusterfs_name }}-endpoints"
+    files:
+    - "{{ mktemp.stdout }}/glusterfs-registry-service.yml"
+  when:
+  - "glusterfs_nodes | count == 0"
+  - openshift_hosted_registry_glusterfs_endpoints is defined
+
+- name: Delete temp mount directory
+  file:
+    dest: "{{ mktemp.stdout }}"
+    state: absent
+  changed_when: False
+  check_mode: no
+
 - name: Create OpenShift registry
   oc_adm_registry:
     name: "{{ openshift_hosted_registry_name }}"
@@ -172,3 +228,4 @@
 - include: storage/glusterfs.yml
   when:
   - openshift.hosted.registry.storage.kind | default(none) == 'glusterfs' or openshift.hosted.registry.storage.glusterfs.swap
+  - "glusterfs_nodes | count >= 1"

--- a/roles/openshift_hosted/tasks/registry/registry.yml
+++ b/roles/openshift_hosted/tasks/registry/registry.yml
@@ -44,6 +44,7 @@
     openshift_hosted_registry_volumes: []
     openshift_hosted_registry_env_vars: {}
     openshift_hosted_registry_edits:
+    glusterfs_nodes: "{{ groups.glusterfs }}"
     # These edits are being specified only to prevent 'changed' on rerun
     - key: spec.strategy.rollingParams
       value:

--- a/roles/openshift_hosted/tasks/registry/storage/glusterfs.yml
+++ b/roles/openshift_hosted/tasks/registry/storage/glusterfs.yml
@@ -46,6 +46,48 @@
     mode: "2775"
     recurse: True
 
+#Create EP if we dont have gluster nodes in the cluster (no group defined) but e want to use glusterfs as backend
+- name: Generate GlusterFS registry endpoints
+  template:
+    src: "glusterfs-registry-endpoints.yml.j2"
+    dest: "{{ mktemp.stdout }}/glusterfs-registry-endpoints.yml"
+  when:
+   - "glusterfs_nodes | count == 0"
+   - openshift_hosted_registry_glusterfs_endpoints is defined
+
+- name: Copy GlusterFS registry service
+  template:
+    src: "glusterfs-registry-service.yml.j2"
+    dest: "{{ mktemp.stdout }}/glusterfs-registry-service.yml"
+  when:
+   - "glusterfs_nodes | count == 0"
+   - openshift_hosted_registry_glusterfs_endpoints is defined
+
+
+- name: Create GlusterFS registry endpoints
+  oc_obj:
+    namespace: "{{ openshift.hosted.registry.namespace | default('default') }}"
+    state: present
+    kind: endpoints
+    name: "glusterfs-{{ glusterfs_name }}-endpoints"
+    files:
+    - "{{ mktemp.stdout }}/glusterfs-registry-endpoints.yml"
+  when:
+   - "glusterfs_nodes | count == 0"
+   - openshift_hosted_registry_glusterfs_endpoints is defined
+
+- name: Create GlusterFS registry service
+  oc_obj:
+    namespace: "{{ openshift.hosted.registry.namespace | default('default') }}"
+    state: present
+    kind: service
+    name: "glusterfs-{{ glusterfs_name }}-endpoints"
+    files:
+    - "{{ mktemp.stdout }}/glusterfs-registry-service.yml"
+  when:
+   - "glusterfs_nodes | count == 0"
+   - openshift_hosted_registry_glusterfs_endpoints is defined
+
 - block:
   - name: Activate registry maintenance mode
     oc_env:

--- a/roles/openshift_hosted/tasks/registry/storage/glusterfs.yml
+++ b/roles/openshift_hosted/tasks/registry/storage/glusterfs.yml
@@ -46,48 +46,6 @@
     mode: "2775"
     recurse: True
 
-#Create EP if we dont have gluster nodes in the cluster (no group defined) but e want to use glusterfs as backend
-- name: Generate GlusterFS registry endpoints
-  template:
-    src: "glusterfs-registry-endpoints.yml.j2"
-    dest: "{{ mktemp.stdout }}/glusterfs-registry-endpoints.yml"
-  when:
-   - "glusterfs_nodes | count == 0"
-   - openshift_hosted_registry_glusterfs_endpoints is defined
-
-- name: Copy GlusterFS registry service
-  template:
-    src: "glusterfs-registry-service.yml.j2"
-    dest: "{{ mktemp.stdout }}/glusterfs-registry-service.yml"
-  when:
-   - "glusterfs_nodes | count == 0"
-   - openshift_hosted_registry_glusterfs_endpoints is defined
-
-
-- name: Create GlusterFS registry endpoints
-  oc_obj:
-    namespace: "{{ openshift.hosted.registry.namespace | default('default') }}"
-    state: present
-    kind: endpoints
-    name: "glusterfs-{{ glusterfs_name }}-endpoints"
-    files:
-    - "{{ mktemp.stdout }}/glusterfs-registry-endpoints.yml"
-  when:
-   - "glusterfs_nodes | count == 0"
-   - openshift_hosted_registry_glusterfs_endpoints is defined
-
-- name: Create GlusterFS registry service
-  oc_obj:
-    namespace: "{{ openshift.hosted.registry.namespace | default('default') }}"
-    state: present
-    kind: service
-    name: "glusterfs-{{ glusterfs_name }}-endpoints"
-    files:
-    - "{{ mktemp.stdout }}/glusterfs-registry-service.yml"
-  when:
-   - "glusterfs_nodes | count == 0"
-   - openshift_hosted_registry_glusterfs_endpoints is defined
-
 - block:
   - name: Activate registry maintenance mode
     oc_env:

--- a/roles/openshift_hosted/templates/glusterfs-registry-endpoints.yml.j2
+++ b/roles/openshift_hosted/templates/glusterfs-registry-endpoints.yml.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: glusterfs-{{ glusterfs_name }}-endpoints
+subsets:
+- addresses:
+{% for ep in openshift_hosted_registry_glusterfs_endpoints %}
+  - ip: ep }}
+{% endfor %}
+  ports:
+  - port: 1

--- a/roles/openshift_hosted/templates/glusterfs-registry-endpoints.yml.j2
+++ b/roles/openshift_hosted/templates/glusterfs-registry-endpoints.yml.j2
@@ -6,7 +6,7 @@ metadata:
 subsets:
 - addresses:
 {% for ep in openshift_hosted_registry_glusterfs_endpoints %}
-  - ip: ep }}
+  - ip: {{ ep }}
 {% endfor %}
   ports:
   - port: 1

--- a/roles/openshift_hosted/templates/glusterfs-registry-service.yml.j2
+++ b/roles/openshift_hosted/templates/glusterfs-registry-service.yml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: glusterfs-{{ glusterfs_name }}-endpoints
+spec:
+  ports:
+  - port: 1
+status:
+  loadBalancer: {}


### PR DESCRIPTION
1. If you have external Gluster cluster deployed and you want to use it as backing storage for registry it does not work.
2. We support only internal running gluster at this point with gluster playbooks. 
3. gluster playbooks itself are not idempotent (https://access.redhat.com/support/cases/#/case/01934446) so now if you run it each and every time we do `--skip-tags glusterfs` as it fails on each second run. (this does not address this one).

did a small review of glusterfs plays but they need much more refactoring, pre-flights checks, testing.

This one splits EP creation from glusterfs playbook and checks if playbooks will run (by node count)
This piece of code should be in gluster.yml but we cant put it because it fails as we deploy registry before it and configure PV before, which is causing a failure. 

This is tactical fix for this and we should raise backlog story to "change glusterfs" role to be more resilient and move EP.SVC creation to glusterfs.yaml and move this file to the top of the registry file to fix some order. 

