### PR TITLE
Only assert that CIDR values must be set on scaleup

### DIFF
--- a/roles/openshift_sanitize_inventory/tasks/main.yml
+++ b/roles/openshift_sanitize_inventory/tasks/main.yml
@@ -20,6 +20,7 @@
 # Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1451023
 - when:
     - not testing_skip_some_requirements|default(False)|bool
+    - groups['new_masters'] | default([]) | length > 0
   assert:
     that:
       - "osm_cluster_network_cidr is defined"


### PR DESCRIPTION
Quick fix for https://bugzilla.redhat.com/show_bug.cgi?id=1493268

This makes it so that those variables are only required on scaleup operations. A more long term fix would be to read the values from existing masters and use those when scaling up.