### PR TITLE
Do not reconcile in >= 3.7

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -189,8 +189,6 @@
   roles:
   - { role: openshift_cli }
   vars:
-    origin_reconcile_bindings: "{{ deployment_type == 'origin' and openshift_version | version_compare('1.0.6', '>') }}"
-    ent_reconcile_bindings: true
     openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
     # Another spot where we assume docker is running and do not want to accidentally trigger an unsafe
     # restart.
@@ -201,6 +199,7 @@
       {{ openshift.common.client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
       policy reconcile-cluster-roles --additive-only=true --confirm -o name
     register: reconcile_cluster_role_result
+    when: not openshift.common.version_gte_3_7 | bool
     changed_when:
     - reconcile_cluster_role_result.stdout != ''
     - reconcile_cluster_role_result.rc == 0
@@ -215,7 +214,7 @@
       --exclude-groups=system:unauthenticated
       --exclude-users=system:anonymous
       --additive-only=true --confirm -o name
-    when: origin_reconcile_bindings | bool or ent_reconcile_bindings | bool
+    when: not openshift.common.version_gte_3_7 | bool
     register: reconcile_bindings_result
     changed_when:
     - reconcile_bindings_result.stdout != ''
@@ -230,7 +229,7 @@
     changed_when:
     - reconcile_jenkins_role_binding_result.stdout != ''
     - reconcile_jenkins_role_binding_result.rc == 0
-    when: openshift.common.version_gte_3_4_or_1_4  | bool
+    when: (not openshift.common.version_gte_3_7 | bool) and (openshift.common.version_gte_3_4_or_1_4 | bool)
 
   - name: Reconcile Security Context Constraints
     command: >


### PR DESCRIPTION
Starting with 3.7 we use kube's RBAC which happens to do a forceful reconcile at server startup.
Explicit reconciles are not needed anymore.
