### PR TITLE
Returning actual results of yedit query.  Empty list was returning empty dict.

### DIFF
--- a/roles/lib_openshift/library/oc_adm_ca_server_cert.py
+++ b/roles/lib_openshift/library/oc_adm_ca_server_cert.py
@@ -745,7 +745,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_adm_csr.py
+++ b/roles/lib_openshift/library/oc_adm_csr.py
@@ -723,7 +723,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_adm_manage_node.py
+++ b/roles/lib_openshift/library/oc_adm_manage_node.py
@@ -731,7 +731,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_adm_policy_group.py
+++ b/roles/lib_openshift/library/oc_adm_policy_group.py
@@ -717,7 +717,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_adm_policy_user.py
+++ b/roles/lib_openshift/library/oc_adm_policy_user.py
@@ -717,7 +717,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_adm_registry.py
+++ b/roles/lib_openshift/library/oc_adm_registry.py
@@ -835,7 +835,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_adm_router.py
+++ b/roles/lib_openshift/library/oc_adm_router.py
@@ -860,7 +860,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_clusterrole.py
+++ b/roles/lib_openshift/library/oc_clusterrole.py
@@ -709,7 +709,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_configmap.py
+++ b/roles/lib_openshift/library/oc_configmap.py
@@ -715,7 +715,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_edit.py
+++ b/roles/lib_openshift/library/oc_edit.py
@@ -759,7 +759,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_env.py
+++ b/roles/lib_openshift/library/oc_env.py
@@ -726,7 +726,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_group.py
+++ b/roles/lib_openshift/library/oc_group.py
@@ -699,7 +699,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_image.py
+++ b/roles/lib_openshift/library/oc_image.py
@@ -718,7 +718,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_label.py
+++ b/roles/lib_openshift/library/oc_label.py
@@ -735,7 +735,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_obj.py
+++ b/roles/lib_openshift/library/oc_obj.py
@@ -738,7 +738,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_objectvalidator.py
+++ b/roles/lib_openshift/library/oc_objectvalidator.py
@@ -670,7 +670,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_process.py
+++ b/roles/lib_openshift/library/oc_process.py
@@ -727,7 +727,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_project.py
+++ b/roles/lib_openshift/library/oc_project.py
@@ -724,7 +724,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_pvc.py
+++ b/roles/lib_openshift/library/oc_pvc.py
@@ -731,7 +731,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_route.py
+++ b/roles/lib_openshift/library/oc_route.py
@@ -769,7 +769,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_scale.py
+++ b/roles/lib_openshift/library/oc_scale.py
@@ -713,7 +713,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_secret.py
+++ b/roles/lib_openshift/library/oc_secret.py
@@ -765,7 +765,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_service.py
+++ b/roles/lib_openshift/library/oc_service.py
@@ -772,7 +772,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_serviceaccount.py
+++ b/roles/lib_openshift/library/oc_serviceaccount.py
@@ -711,7 +711,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_serviceaccount_secret.py
+++ b/roles/lib_openshift/library/oc_serviceaccount_secret.py
@@ -711,7 +711,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_storageclass.py
+++ b/roles/lib_openshift/library/oc_storageclass.py
@@ -729,7 +729,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_user.py
+++ b/roles/lib_openshift/library/oc_user.py
@@ -771,7 +771,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_version.py
+++ b/roles/lib_openshift/library/oc_version.py
@@ -683,7 +683,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_openshift/library/oc_volume.py
+++ b/roles/lib_openshift/library/oc_volume.py
@@ -760,7 +760,7 @@ class Yedit(object):  # pragma: no cover
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_utils/library/yedit.py
+++ b/roles/lib_utils/library/yedit.py
@@ -793,7 +793,7 @@ class Yedit(object):
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 

--- a/roles/lib_utils/src/class/yedit.py
+++ b/roles/lib_utils/src/class/yedit.py
@@ -590,7 +590,7 @@ class Yedit(object):
                 yamlfile.yaml_dict = content
 
             if params['key']:
-                rval = yamlfile.get(params['key']) or {}
+                rval = yamlfile.get(params['key'])
 
             return {'changed': False, 'result': rval, 'state': state}
 


### PR DESCRIPTION
This is a simple change but since code generation happens it affects lots of files.

The only change that is happening here is the following:
```
-                rval = yamlfile.get(params['key']) or {}		￼
+               rval = yamlfile.get(params['key'])
```
When something returned as 0, [], or None the query would return {}.  This was unintended.  