### PR TITLE
Default openshift_pkg_version to full version-release during upgrades

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -27,13 +27,17 @@
 
   - name: Set fact avail_openshift_version
     set_fact:
-      avail_openshift_version: "{{ repoquery_out.results.versions.available_versions.0 }}"
+      avail_openshift_version: "{{ repoquery_out.results.versions.available_versions_full.0 }}"
+  - name: Set openshift_pkg_version when not specified
+    set_fact:
+      openshift_pkg_version: "-{{ repoquery_out.results.versions.available_versions_full.0 }}"
+    when: openshift_pkg_version | default('') == ''
 
   - name: Verify OpenShift RPMs are available for upgrade
     fail:
       msg: "OpenShift {{ avail_openshift_version }} is available, but {{ openshift_upgrade_target }} or greater is required"
     when:
-    - avail_openshift_version | default('0.0', True) | version_compare(openshift_release, '<')
+    - openshift_pkg_version | default('0.0', True) | version_compare(openshift_release, '<')
 
 - name: Fail when openshift version does not meet minium requirement for Origin upgrade
   fail:

--- a/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
@@ -8,7 +8,9 @@
 
 # TODO: If the sdn package isn't already installed this will install it, we
 # should fix that
-
+- debug: var=avail_openshift_version
+- debug: var=openshift_pkg_version
+- pause:
 - name: Upgrade master packages
   package: name={{ master_pkgs | join(',') }} state=present
   vars:
@@ -16,7 +18,7 @@
       - "{{ openshift.common.service_type }}{{ openshift_pkg_version }}"
       - "{{ openshift.common.service_type }}-master{{ openshift_pkg_version }}"
       - "{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
-      - "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version}}"
+      - "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version }}"
       - "{{ openshift.common.service_type }}-clients{{ openshift_pkg_version }}"
       - "tuned-profiles-{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
       - PyYAML

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -166,7 +166,9 @@
     - set_fact:
         openshift_pkg_version: -{{ openshift_version }}
 
-    when: openshift_pkg_version is not defined
+    when:
+    - openshift_pkg_version is not defined
+    - openshift_upgrade_target is not defined
 
   - fail:
       msg: openshift_version role was unable to set openshift_version
@@ -181,7 +183,10 @@
   - fail:
       msg: openshift_version role was unable to set openshift_pkg_version
     name: Abort if openshift_pkg_version was not set
-    when: openshift_pkg_version is not defined
+    when:
+    - openshift_pkg_version is not defined
+    - openshift_upgrade_target is not defined
+
 
   - fail:
       msg: "No OpenShift version available; please ensure your systems are fully registered and have access to appropriate yum repositories."


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1490677

The versioning scheme for 3.7 pre-releases has changed and now all
versions are 3.7.0 and the release is incremented on builds, ie:
3.7.0-0.124.0 upgraded to 3.7.0-0.125.0. If we know we're an upgrade and
they haven't requested a specific package version defer the defaulting
of openshift_pkg_version until the upgrade playbooks and there set it to
the available version including the release.