### PR TITLE
[3.6] Support setting annotations on Hawkular route

### DIFF
--- a/roles/openshift_metrics/README.md
+++ b/roles/openshift_metrics/README.md
@@ -39,6 +39,8 @@ For default values, see [`defaults/main.yaml`](defaults/main.yaml).
 
 - `openshift_metrics_hawkular_replicas:` The number of replicas for Hawkular metrics.
 
+- `openshift_metrics_hawkular_route_annotations`: Dictionary with annotations for the Hawkular route.
+
 - `openshift_metrics_cassandra_replicas`: The number of Cassandra nodes to deploy for the
   initial cluster.
 

--- a/roles/openshift_metrics/defaults/main.yaml
+++ b/roles/openshift_metrics/defaults/main.yaml
@@ -12,6 +12,7 @@ openshift_metrics_hawkular_cert: ""
 openshift_metrics_hawkular_key: ""
 openshift_metrics_hawkular_ca: ""
 openshift_metrics_hawkular_nodeselector: ""
+openshift_metrics_hawkular_route_annotations: {}
 
 openshift_metrics_cassandra_replicas: 1
 openshift_metrics_cassandra_storage_type: "{{ openshift_hosted_metrics_storage_kind | default('emptydir') }}"

--- a/roles/openshift_metrics/tasks/install_hawkular.yaml
+++ b/roles/openshift_metrics/tasks/install_hawkular.yaml
@@ -40,6 +40,7 @@
       dest: "{{ mktemp.stdout }}/templates/hawkular-metrics-route.yaml"
     vars:
       name: hawkular-metrics
+      annotations: "{{ openshift_metrics_hawkular_route_annotations }}"
       labels:
         metrics-infra: hawkular-metrics
       host: "{{ openshift_metrics_hawkular_hostname }}"

--- a/roles/openshift_metrics/templates/route.j2
+++ b/roles/openshift_metrics/templates/route.j2
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Route
 metadata:
   name: {{ name }}
+{% if annotations is defined %}
+  annotations: {{ annotations | to_yaml }}
+{% endif %}
 {% if labels is defined and labels %}
   labels:
 {% for k, v in labels.iteritems() %}


### PR DESCRIPTION
Cherry-pick changes from #5309 to the 3.6 branch.

Our setup uses annotations to request a separate component, namely the
ACME Controller[1], to request domain-validated certificates from the
Let's Encrypt CA. By setting the necessary annotation via Ansible rather
than manually the system will automatically retrieve a certificate.

[1] https://github.com/tnozicka/openshift-acme

(cherry picked from commit 028194f39eee85a44eb186dd5aab6f14268683a4)