### PR TITLE
[1.4] Remove default value for oreg_url

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 docker_cli_auth_config_path: '/root/.docker'
 
-oreg_url: ''
-oreg_host: "{{ oreg_url.split('/')[0] if '.' in oreg_url.split('/')[0] else '' }}"
+# oreg_url is defined by user input.
+oreg_host: "{{ oreg_url.split('/')[0] if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"
 oreg_auth_credentials_replace: False

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -3,8 +3,8 @@ openshift_node_ips: []
 # TODO: update setting these values based on the facts
 #openshift_version: "{{ openshift_pkg_version | default(openshift_image_tag | default(openshift.docker.openshift_image_tag | default(''))) }}"
 
-oreg_url: ''
-oreg_host: "{{ oreg_url.split('/')[0] if '.' in oreg_url.split('/')[0] else '' }}"
+# oreg_url is defined by user input
+oreg_host: "{{ oreg_url.split('/')[0] if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"
 oreg_auth_credentials_path: "{{ openshift.common.data_dir }}/.docker"
 oreg_auth_credentials_replace: False
 

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -14,8 +14,8 @@ os_firewall_allow:
   port: 4789/udp
   when: openshift.node.use_openshift_sdn | bool
 
-oreg_url: ''
-oreg_host: "{{ oreg_url.split('/')[0] if '.' in oreg_url.split('/')[0] else '' }}"
+# oreg_url is defined by user input
+oreg_host: "{{ oreg_url.split('/')[0] if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"
 oreg_auth_credentials_path: "{{ openshift.common.data_dir }}/.docker"
 oreg_auth_credentials_replace: False
 


### PR DESCRIPTION
Due to some plays importing variables from roles
directly, oreg_url was being set to a default
value when it otherwise shouldn't be.

This commit removes the default values for oreg_url
to ensure existing logic works as desired.

Fixes: https://github.com/openshift/openshift-ansible/issues/5455
(cherry picked from commit e67a0b25ecbfc0c30343fd895a5a491e6b7e67ed)

Backports: #5477