### PR TITLE
[3.6] Remove default value for oreg_url

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 docker_cli_auth_config_path: '/root/.docker'
 
-oreg_url: ''
-oreg_host: "{{ oreg_url.split('/')[0] if '.' in oreg_url.split('/')[0] else '' }}"
+# oreg_url is defined by user input.
+oreg_host: "{{ oreg_url.split('/')[0] if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"
 oreg_auth_credentials_replace: False

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -3,8 +3,8 @@ openshift_node_ips: []
 r_openshift_master_clean_install: false
 r_openshift_master_etcd3_storage: false
 
-oreg_url: ''
-oreg_host: "{{ oreg_url.split('/')[0] if '.' in oreg_url.split('/')[0] else '' }}"
+# oreg_url is defined by user input
+oreg_host: "{{ oreg_url.split('/')[0] if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"
 oreg_auth_credentials_path: "{{ openshift.common.data_dir }}/.docker"
 oreg_auth_credentials_replace: False
 

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -13,8 +13,8 @@ os_firewall_allow:
   port: 179/tcp
   when: openshift.common.use_calico | bool
 
-oreg_url: ''
-oreg_host: "{{ oreg_url.split('/')[0] if '.' in oreg_url.split('/')[0] else '' }}"
+# oreg_url is defined by user input
+oreg_host: "{{ oreg_url.split('/')[0] if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"
 oreg_auth_credentials_path: "{{ openshift.common.data_dir }}/.docker"
 oreg_auth_credentials_replace: False
 


### PR DESCRIPTION
Due to some plays importing variables from roles
directly, oreg_url was being set to a default
value when it otherwise shouldn't be.

This commit removes the default values for oreg_url
to ensure existing logic works as desired.

Fixes: https://github.com/openshift/openshift-ansible/issues/5455
(cherry picked from commit 0fee9f4e194101cfbd094d140b59d1b262b9b6a6)

Backports: #5477