### PR TITLE
Add 3.7 scheduler predicates

### DIFF
--- a/roles/openshift_master_facts/lookup_plugins/openshift_master_facts_default_predicates.py
+++ b/roles/openshift_master_facts/lookup_plugins/openshift_master_facts_default_predicates.py
@@ -101,7 +101,7 @@ class LookupModule(LookupBase):
                 {'name': 'MatchInterPodAffinity'}
             ])
 
-        if short_version in ['3.5', '3.6', '3.7']:
+        if short_version in ['3.5', '3.6']:
             predicates.extend([
                 {'name': 'NoVolumeZoneConflict'},
                 {'name': 'MaxEBSVolumeCount'},
@@ -112,6 +112,21 @@ class LookupModule(LookupBase):
                 {'name': 'PodToleratesNodeTaints'},
                 {'name': 'CheckNodeMemoryPressure'},
                 {'name': 'CheckNodeDiskPressure'},
+            ])
+
+        if short_version in ['3.7']:
+            predicates.extend([
+                {'name': 'NoVolumeZoneConflict'},
+                {'name': 'MaxEBSVolumeCount'},
+                {'name': 'MaxGCEPDVolumeCount'},
+                {'name': 'MaxAzureDiskVolumeCount'},
+                {'name': 'MatchInterPodAffinity'},
+                {'name': 'NoDiskConflict'},
+                {'name': 'GeneralPredicates'},
+                {'name': 'PodToleratesNodeTaints'},
+                {'name': 'CheckNodeMemoryPressure'},
+                {'name': 'CheckNodeDiskPressure'},
+                {'name': 'NoVolumeNodeConflict'},
             ])
 
         if regions_enabled:

--- a/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/openshift_master_facts/test/openshift_master_facts_default_predicates_tests.py
@@ -57,6 +57,20 @@ DEFAULT_PREDICATES_1_5 = [
 
 DEFAULT_PREDICATES_3_6 = DEFAULT_PREDICATES_1_5
 
+DEFAULT_PREDICATES_3_7 = [
+    {'name': 'NoVolumeZoneConflict'},
+    {'name': 'MaxEBSVolumeCount'},
+    {'name': 'MaxGCEPDVolumeCount'},
+    {'name': 'MaxAzureDiskVolumeCount'},
+    {'name': 'MatchInterPodAffinity'},
+    {'name': 'NoDiskConflict'},
+    {'name': 'GeneralPredicates'},
+    {'name': 'PodToleratesNodeTaints'},
+    {'name': 'CheckNodeMemoryPressure'},
+    {'name': 'CheckNodeDiskPressure'},
+    {'name': 'NoVolumeNodeConflict'},
+]
+
 REGION_PREDICATE = {
     'name': 'Region',
     'argument': {
@@ -79,6 +93,8 @@ TEST_VARS = [
     ('3.5', 'openshift-enterprise', DEFAULT_PREDICATES_1_5),
     ('3.6', 'origin', DEFAULT_PREDICATES_3_6),
     ('3.6', 'openshift-enterprise', DEFAULT_PREDICATES_3_6),
+    ('3.7', 'origin', DEFAULT_PREDICATES_3_7),
+    ('3.7', 'openshift-enterprise', DEFAULT_PREDICATES_3_7),
 ]
 
 


### PR DESCRIPTION
In 3.7 we added NoVolumeNodeConflict and  MaxAzureDiskVolumeCount predicate that needs to be installed.

Check carefully, I tested it on my virtual machine, but I did not manage to run the test.