### PR TITLE
Fixed AnsibleUnsafeText by converting to int

### DIFF
--- a/roles/flannel_register/defaults/main.yaml
+++ b/roles/flannel_register/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 flannel_network: "{{ openshift.master.sdn_cluster_network_cidr }}"
-flannel_subnet_len: "{{ 32 - openshift.master.sdn_host_subnet_length }}"
+flannel_subnet_len: "{{ 32 - (openshift.master.sdn_host_subnet_length | int) }}"
 flannel_etcd_key: /openshift.com/network
 etcd_hosts: "{{ etcd_urls }}"
 etcd_conf_dir: "{{ openshift.common.config_base }}/master"


### PR DESCRIPTION
Related to https://github.com/openshift/openshift-ansible/pull/5067

I've tested with custom values and it failed. This fixes the issue in my tests.

```
[cloud-user@bastion ~]$ grep -E 'osm|portal' /etc/ansible/hosts
osm_default_node_selector="role=app"
osm_use_cockpit=true
osm_cluster_network_cidr=10.130.0.0/14
osm_host_subnet_length=8
openshift_portal_net=10.111.0.0/16
```
After the installation:
```
[root@master-0 ~]# alias oetcdctl='etcdctl --cert-file=/etc/etcd/peer.crt --key-file=/etc/etcd/peer.key --ca-file=/etc/etcd/ca.crt --peers="https://master-0.edu.flannel.com:2379,https://master-1.edu.flannel.com:2379,https://master-2.edu.flannel.com:2379"'
[root@master-0 ~]# oetcdctl get /openshift.com/network/config
{
    "Network": "10.130.0.0/14",
    "SubnetLen": 24,
    "Backend": {
        "Type": "host-gw"
     }
}
```

But, the subnets assigned to the nodes are on different subnet:

```
[root@master-0 ~]# oetcdctl ls /openshift.com/network/subnets
/openshift.com/network/subnets/10.128.83.0-24
/openshift.com/network/subnets/10.128.18.0-24
/openshift.com/network/subnets/10.128.77.0-24
/openshift.com/network/subnets/10.128.101.0-24
/openshift.com/network/subnets/10.128.20.0-24
/openshift.com/network/subnets/10.128.92.0-24
/openshift.com/network/subnets/10.128.58.0-24
/openshift.com/network/subnets/10.128.48.0-24
```