### PR TITLE
Remove logging ES_COPY feature

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -62,7 +62,6 @@ When `openshift_logging_install_logging` is set to `False` the `openshift_loggin
 - `openshift_logging_fluentd_nodeselector`: The node selector that the Fluentd daemonset uses to determine where to deploy to. Defaults to '"logging-infra-fluentd": "true"'.
 - `openshift_logging_fluentd_cpu_limit`: The CPU limit for Fluentd pods. Defaults to '100m'.
 - `openshift_logging_fluentd_memory_limit`: The memory limit for Fluentd pods. Defaults to '512Mi'.
-- `openshift_logging_fluentd_es_copy`: Whether or not to use the ES_COPY feature for Fluentd (DEPRECATED). Defaults to 'False'.
 - `openshift_logging_fluentd_use_journal`: *DEPRECATED - DO NOT USE* Fluentd will automatically detect whether or not Docker is using the journald log driver.
 - `openshift_logging_fluentd_journal_read_from_head`: If empty, Fluentd will use its internal default, which is false.
 - `openshift_logging_fluentd_hosts`: List of nodes that should be labeled for Fluentd to be deployed to. Defaults to ['--all'].

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -73,7 +73,6 @@ openshift_logging_kibana_ops_ca: ""
 openshift_logging_fluentd_nodeselector: {'logging-infra-fluentd': 'true'}
 openshift_logging_fluentd_cpu_limit: 100m
 openshift_logging_fluentd_memory_limit: 512Mi
-openshift_logging_fluentd_es_copy: false
 openshift_logging_fluentd_journal_source: ""
 openshift_logging_fluentd_journal_read_from_head: ""
 openshift_logging_fluentd_hosts: ['--all']

--- a/roles/openshift_logging_fluentd/defaults/main.yml
+++ b/roles/openshift_logging_fluentd/defaults/main.yml
@@ -50,8 +50,6 @@ openshift_logging_fluentd_aggregating_key_path: none
 openshift_logging_fluentd_aggregating_passphrase: none
 
 ### Deprecating in 3.6
-openshift_logging_fluentd_es_copy: false
-
 # following can be uncommented to provide values for configmaps -- take care when providing file contents as it may cause your cluster to not operate correctly
 #fluentd_config_contents:
 #fluentd_throttle_contents:

--- a/roles/openshift_logging_fluentd/tasks/main.yaml
+++ b/roles/openshift_logging_fluentd/tasks/main.yaml
@@ -1,5 +1,8 @@
 ---
 - fail:
+    msg: The ES_COPY feature is no longer supported. Please remove the variable from your inventory
+  when: openshift_logging_fluentd_es_copy is defined
+- fail:
     msg: Only one Fluentd nodeselector key pair should be provided
   when: openshift_logging_fluentd_nodeselector.keys() | count > 1
 

--- a/roles/openshift_logging_fluentd/templates/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/fluentd.j2
@@ -94,8 +94,6 @@ spec:
           value: "{{ openshift_logging_fluentd_ops_client_key }}"
         - name: "OPS_CA"
           value: "{{ openshift_logging_fluentd_ops_ca }}"
-        - name: "ES_COPY"
-          value: "false"
         - name: "JOURNAL_SOURCE"
           value: "{{ openshift_logging_fluentd_journal_source | default('') }}"
         - name: "JOURNAL_READ_FROM_HEAD"


### PR DESCRIPTION
This PR removes the ES_COPY feature that has been deprecated since 3.3