### PR TITLE
Add python3-PyYAML for Fedora installs

### DIFF
--- a/playbooks/common/openshift-cluster/initialize_facts.yml
+++ b/playbooks/common/openshift-cluster/initialize_facts.yml
@@ -94,7 +94,7 @@
       with_items:
       - iproute
       - "{{ 'python3-dbus' if ansible_distribution == 'Fedora' else 'python-dbus' }}"
-      - PyYAML
+      - "{{ 'python3-PyYAML' if ansible_distribution == 'Fedora' else 'PyYAML' }}"
       - yum-utils
 
     - name: Ensure various deps for running system containers are installed


### PR DESCRIPTION
Fedora installs currently fail because nodes require
the usage of python3.  python3-PyYAML must be installed
in order to support usage of python3.

This commit adds the rpm python3-PyYAML to fedora
nodes.

Fixes: https://github.com/openshift/openshift-ansible/issues/5469