### PR TITLE
Fluentd: one output tag, one output plugin (origin-aggregated-logging; release-3.6)

### DIFF
--- a/roles/openshift_logging_fluentd/templates/fluent.conf.j2
+++ b/roles/openshift_logging_fluentd/templates/fluent.conf.j2
@@ -49,7 +49,9 @@
   @include configs.d/openshift/filter-viaq-data-model.conf
   @include configs.d/openshift/filter-post-*.conf
 ##
+</label>
 
+<label @OUTPUT>
 ## matches
   @include configs.d/openshift/output-pre-*.conf
   @include configs.d/openshift/output-operations.conf

--- a/roles/openshift_logging_mux/files/fluent.conf
+++ b/roles/openshift_logging_mux/files/fluent.conf
@@ -25,7 +25,9 @@
   @include configs.d/openshift/filter-viaq-data-model.conf
   @include configs.d/openshift/filter-post-*.conf
 ##
+</label>
 
+<label @OUTPUT>
 ## matches
   @include configs.d/openshift/output-pre-*.conf
   @include configs.d/openshift/output-operations.conf


### PR DESCRIPTION
Adding <label @OUTPUT> to fluent.conf.

(cherry picked from commit 09997d4efeab2af94694969eb7d371f1a585b2e6)