### PR TITLE
Set master facts prior to adding new etcd client urls to master config.

### DIFF
--- a/playbooks/common/openshift-etcd/scaleup.yml
+++ b/playbooks/common/openshift-etcd/scaleup.yml
@@ -60,15 +60,17 @@
 - name: Update master etcd client urls
   hosts: oo_masters_to_config
   serial: 1
-  tasks:
+  vars:
+    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
+    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+    openshift_master_etcd_hosts: "{{ hostvars
+                                     | oo_select_keys(groups['oo_etcd_to_config'] | union(groups['oo_new_etcd_to_config']))
+                                     | oo_collect('openshift.common.hostname')
+                                     | default(none, true) }}"
+    openshift_master_etcd_port: "{{ (etcd_client_port | default('2379')) if (groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config) else none }}"
+  roles:
+  - role: openshift_master_facts
+  post_tasks:
   - include_role:
       name: openshift_master
       tasks_from: update_etcd_client_urls
-    vars:
-      etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
-      openshift_ca_host: "{{ groups.oo_first_master.0 }}"
-      openshift_master_etcd_hosts: "{{ hostvars
-                                       | oo_select_keys(groups['oo_etcd_to_config'] | union(groups['oo_new_etcd_to_config']))
-                                       | oo_collect('openshift.common.hostname')
-                                       | default(none, true) }}"
-      openshift_master_etcd_port: "{{ (etcd_client_port | default('2379')) if (groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config) else none }}"


### PR DESCRIPTION
`openshift_master` role dependencies were moved out of the role in https://github.com/openshift/openshift-ansible/pull/5392 so we need to call `openshift_master_facts` prior to patching the master config in etcd scaleup.

https://bugzilla.redhat.com/show_bug.cgi?id=1490304