### PR TITLE
Allow examples management to be disabled

### DIFF
--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -60,7 +60,7 @@ openshift_release=v3.7
 # In either case, system_images_registry must be specified to be able to find the system images
 #system_images_registry="registry.access.redhat.com"
 
-# Install the openshift examples
+# Manage openshift example imagestreams and templates during install and upgrade
 #openshift_install_examples=true
 
 # Configure logoutURL in the master config for console customization

--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -90,10 +90,12 @@
   # openshift_examples from failing when trying to replace templates that do
   # not already exist. We could have potentially done a replace --force to
   # create and update in one step.
-  - openshift_examples
+  - role: openshift_examples
+    when: openshift_install_examples | default(true,true) | bool
   - openshift_hosted_templates
   # Update the existing templates
   - role: openshift_examples
+    when: openshift_install_examples | default(true,true) | bool
     registry_url: "{{ openshift.master.registry_url }}"
     openshift_examples_import_command: replace
   - role: openshift_hosted_templates

--- a/playbooks/common/openshift-master/additional_config.yml
+++ b/playbooks/common/openshift-master/additional_config.yml
@@ -10,8 +10,8 @@
   - role: openshift_master_cluster
     when: openshift_master_ha | bool and openshift.master.cluster_method == "pacemaker"
   - role: openshift_examples
+    when: openshift_install_examples | default(true, true) | bool
     registry_url: "{{ openshift.master.registry_url }}"
-    when: openshift_install_examples | default(True)
   - role: openshift_hosted_templates
     registry_url: "{{ openshift.master.registry_url }}"
   - role: openshift_manageiq


### PR DESCRIPTION
By setting openshift_install_examples=false the image stream and quick start templates will not be installed

https://trello.com/c/zLaSgxig/436-2-customers-need-a-way-to-opt-out-of-openshift-ansible-template-and-imagestream-mangement
Fixes #5061