### PR TITLE
Add booleans to prevent unwanted install of nuage roles.

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -219,7 +219,9 @@
     openshift_master_default_registry_value_api: "{{ hostvars[groups.oo_first_master.0].l_default_registry_value_api }}"
     openshift_master_default_registry_value_controllers: "{{ hostvars[groups.oo_first_master.0].l_default_registry_value_controllers }}"
   - role: nuage_ca
+    when: openshift_use_nuage | default(false) | bool
   - role: nuage_common
+    when: openshift_use_nuage | default(false) | bool
   - role: nuage_master
     when: openshift_use_nuage | default(false) | bool
   - role: calico_master


### PR DESCRIPTION
Recently, some role dependencies were removed from meta
depends into playbooks.  Particularly, the nuage role
requires several roles.  Currently, only the nuage_master
role requires openshift_use_nuage to be true.

This commit requires the other nuage roles to reference
the variable openshift_use_nuage before install.