### PR TITLE
resolve #5428: python-dbus not found

### DIFF
--- a/playbooks/common/openshift-cluster/initialize_facts.yml
+++ b/playbooks/common/openshift-cluster/initialize_facts.yml
@@ -93,7 +93,7 @@
         state: present
       with_items:
       - iproute
-      - "{{ 'python3-dbus' if ansible_distribution == 'Fedora' else 'python-dbus' }}"
+      - "{{ 'python3-dbus' if ansible_distribution == 'Fedora' else 'dbus-python' }}"
       - "{{ 'python3-PyYAML' if ansible_distribution == 'Fedora' else 'PyYAML' }}"
       - yum-utils
 


### PR DESCRIPTION
`python-dbus` is not available in centos standard repos, but:

>  It appears python-dbus is just a reference to dbus-python

and `dbus-python` is.