### PR TITLE
Bug 1477515 - [3.5] Data loss of logs can occur if fluentd pod is terminated/restarted when Elasticsearch is unavailable

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -83,6 +83,8 @@ openshift_logging_fluentd_use_journal: "{{ openshift_hosted_logging_use_journal 
 openshift_logging_fluentd_journal_source: "{{ openshift_hosted_logging_journal_source | default('') }}"
 openshift_logging_fluentd_journal_read_from_head: "{{ openshift_hosted_logging_journal_read_from_head | default('') }}"
 openshift_logging_fluentd_hosts: ['--all']
+openshift_logging_fluentd_buffer_queue_limit: 1024
+openshift_logging_fluentd_buffer_size_limit: 1m
 
 openshift_logging_es_host: logging-es
 openshift_logging_es_port: 9200

--- a/roles/openshift_logging/templates/fluentd.j2
+++ b/roles/openshift_logging/templates/fluentd.j2
@@ -59,6 +59,8 @@ spec:
         - name: dockercfg
           mountPath: /etc/sysconfig/docker
           readOnly: true
+        - name: filebufferstorage
+          mountPath: /var/lib/fluentd
         env:
         - name: "K8S_HOST_URL"
           value: "{{openshift_logging_master_url}}"
@@ -122,6 +124,20 @@ spec:
           value: "{{openshift_logging_fluentd_journal_source | default('')}}"
         - name: "JOURNAL_READ_FROM_HEAD"
           value: "{{openshift_logging_fluentd_journal_read_from_head|lower}}"
+        - name: "BUFFER_QUEUE_LIMIT"
+          value: "{{openshift_logging_fluentd_buffer_queue_limit}}"
+        - name: "BUFFER_SIZE_LIMIT"
+          value: "{{openshift_logging_fluentd_buffer_size_limit}}"
+        - name: "FLUENTD_CPU_LIMIT"
+          valueFrom:
+            resourceFieldRef:
+              containerName: "{{ daemonset_container_name }}"
+              resource: limits.cpu
+        - name: "FLUENTD_MEMORY_LIMIT"
+          valueFrom:
+            resourceFieldRef:
+              containerName: "{{ daemonset_container_name }}"
+              resource: limits.memory
       volumes:
       - name: runlogjournal
         hostPath:
@@ -147,3 +163,7 @@ spec:
       - name: dockercfg
         hostPath:
           path: /etc/sysconfig/docker
+      - name: filebufferstorage
+        hostPath:
+          path: /var/lib/fluentd
+


### PR DESCRIPTION
openshift_logging - fluentd
- adding filebufferstorage
- adding environment variables:
  BUFFER_QUEUE_LIMIT, BUFFER_SIZE_LIMIT, FLUENTD_CPU_LIMIT & FLUENTD_MEMORY_LIMIT