### PR TITLE
More variables in AWS provisioning plays

### DIFF
--- a/playbooks/aws/openshift-cluster/build_ami.yml
+++ b/playbooks/aws/openshift-cluster/build_ami.yml
@@ -47,9 +47,12 @@
       groups: nodes
       name: "{{ instancesout.instances[0].public_dns_name }}"
 
+- hosts: nodes
+  gather_facts: False
+  tasks:
   - name: set the user to perform installation
     set_fact:
-      ansible_ssh_user: root
+      ansible_ssh_user: "{{ openshift_aws_build_ami_ssh_user | default(root) }}"
 
 - name: normalize groups
   include: ../../byo/openshift-cluster/initialize_groups.yml

--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -13,6 +13,7 @@ openshift_aws_wait_for_ssh: True
 openshift_aws_clusterid: default
 openshift_aws_region: us-east-1
 openshift_aws_vpc_name: "{{ openshift_aws_clusterid }}"
+openshift_aws_build_ami_group: "{{ openshift_aws_clusterid }}"
 
 openshift_aws_iam_cert_name: "{{ openshift_aws_clusterid }}-master-external"
 openshift_aws_iam_cert_path: ''

--- a/roles/openshift_aws/tasks/build_ami.yml
+++ b/roles/openshift_aws/tasks/build_ami.yml
@@ -31,7 +31,7 @@
     assign_public_ip: yes
     region: "{{ openshift_aws_region }}"
     key_name: "{{ openshift_aws_ssh_key_name }}"
-    group: "{{ openshift_aws_clusterid }}"
+    group: "{{ openshift_aws_build_ami_group }}"
     instance_type: m4.xlarge
     vpc_subnet_id: "{{ subnetout.subnets[0].id }}"
     image: "{{ openshift_aws_base_ami }}"


### PR DESCRIPTION
This commit adds more optional variables to provision
hosts in AWS environments.

These changes allow provisioning instances that utilize
an ssh_user other than root.