### PR TITLE
Support installation of NetworkManager for provisioned nodes

### DIFF
--- a/roles/openshift_node_dnsmasq/handlers/main.yml
+++ b/roles/openshift_node_dnsmasq/handlers/main.yml
@@ -3,6 +3,7 @@
   systemd:
     name: NetworkManager
     state: restarted
+    enabled: True
 
 - name: restart dnsmasq
   systemd:

--- a/roles/openshift_node_dnsmasq/tasks/no-network-manager.yml
+++ b/roles/openshift_node_dnsmasq/tasks/no-network-manager.yml
@@ -1,2 +1,11 @@
 ---
 - fail: msg="Currently, NetworkManager must be installed and enabled prior to installation."
+  when: not openshift_node_bootstrap | bool
+
+- name: Install NetworkManager during node_bootstrap provisioning
+  package:
+    name: NetworkManager
+    state: present
+  notify: restart NetworkManager
+
+- include: ./network-manager.yml


### PR DESCRIPTION
Currently, automated AWS provisionging fails when provisioning
with images that don't already have NetworkManager installed
and activated.

This commit adds NetworkManager to the build_ami provisioning
process, if not already installed.