### PR TITLE
Fix origin repo deployment

### DIFF
--- a/roles/openshift_repos/tasks/centos_repos.yml
+++ b/roles/openshift_repos/tasks/centos_repos.yml
@@ -1,0 +1,25 @@
+---
+# Note: OpenShift repositories under CentOS may be shipped through the
+# "centos-release-openshift-origin" package which configures the repository.
+# This task matches the file names provided by the package so that they are
+# not installed twice in different files and remains idempotent.
+
+- name: Configure origin gpg keys
+  copy:
+    src: "origin/gpg_keys/openshift-ansible-CentOS-SIG-PaaS"
+    dest: "/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS"
+  notify: refresh cache
+
+# openshift_release is formatted to a standard string in openshift_version role.
+# openshift_release is expected to be in format 'x.y.z...' here.
+# Here, we drop the '.' characters and try to match the correct repo template
+# for our corresponding openshift_release.
+- name: Configure correct origin release repository
+  template:
+    src: "{{ item }}"
+    dest: "/etc/yum.repos.d/{{ (item | basename | splitext)[0] }}"
+  with_first_found:
+    - "CentOS-OpenShift-Origin{{ (openshift_release | default('')).split('.') | join('') }}.repo.j2"
+    - "CentOS-OpenShift-Origin{{ ((openshift_release | default('')).split('.') | join(''))[0:2] }}.repo.j2"
+    - "CentOS-OpenShift-Origin.repo.j2"
+  notify: refresh cache

--- a/roles/openshift_repos/tasks/main.yaml
+++ b/roles/openshift_repos/tasks/main.yaml
@@ -30,29 +30,12 @@
   - when: r_openshift_repos_has_run is not defined
     block:
 
-    # Note: OpenShift repositories under CentOS may be shipped through the
-    # "centos-release-openshift-origin" package which configures the repository.
-    # This task matches the file names provided by the package so that they are
-    # not installed twice in different files and remains idempotent.
-    - name: Configure origin repositories and gpg keys if needed
-      copy:
-        src: "{{ item.src }}"
-        dest: "{{ item.dest }}"
-      with_items:
-      - src: origin/gpg_keys/openshift-ansible-CentOS-SIG-PaaS
-        dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
-      - src: origin/repos/openshift-ansible-centos-paas-sig.repo
-        dest: /etc/yum.repos.d/CentOS-OpenShift-Origin.repo
-      notify: refresh cache
+    - include: centos_repos.yml
       when:
       - ansible_os_family == "RedHat"
       - ansible_distribution != "Fedora"
       - openshift_deployment_type == 'origin'
       - openshift_enable_origin_repo | default(true) | bool
-
-    - name: Enable centos-openshift-origin-testing repository
-      command: yum-config-manager --enable centos-openshift-origin-testing
-      when: openshift_repos_enable_testing | bool
 
     - name: Ensure clean repo cache in the event repos have been changed manually
       debug:

--- a/roles/openshift_repos/templates/CentOS-OpenShift-Origin.repo.j2
+++ b/roles/openshift_repos/templates/CentOS-OpenShift-Origin.repo.j2
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 [centos-openshift-origin-testing]
 name=CentOS OpenShift Origin Testing
 baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin/
-enabled=0
+enabled={% if openshift_repos_enable_testing %}1{% else %}0{% endif %}
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/openshift-ansible-CentOS-SIG-PaaS
 

--- a/roles/openshift_repos/templates/CentOS-OpenShift-Origin14.repo.j2
+++ b/roles/openshift_repos/templates/CentOS-OpenShift-Origin14.repo.j2
@@ -1,0 +1,27 @@
+[centos-openshift-origin14]
+name=CentOS OpenShift Origin
+baseurl=http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin14/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
+
+[centos-openshift-origin14-testing]
+name=CentOS OpenShift Origin Testing
+baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin14/
+enabled={% if openshift_repos_enable_testing %}1{% else %}0{% endif %}
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
+
+[centos-openshift-origin14-debuginfo]
+name=CentOS OpenShift Origin DebugInfo
+baseurl=http://debuginfo.centos.org/centos/7/paas/x86_64/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
+
+[centos-openshift-origin14-source]
+name=CentOS OpenShift Origin Source
+baseurl=http://vault.centos.org/centos/7/paas/Source/openshift-origin14/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS

--- a/roles/openshift_repos/templates/CentOS-OpenShift-Origin15.repo.j2
+++ b/roles/openshift_repos/templates/CentOS-OpenShift-Origin15.repo.j2
@@ -1,0 +1,27 @@
+[centos-openshift-origin15]
+name=CentOS OpenShift Origin
+baseurl=http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin15/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
+
+[centos-openshift-origin15-testing]
+name=CentOS OpenShift Origin Testing
+baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin15/
+enabled={% if openshift_repos_enable_testing %}1{% else %}0{% endif %}
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
+
+[centos-openshift-origin15-debuginfo]
+name=CentOS OpenShift Origin DebugInfo
+baseurl=http://debuginfo.centos.org/centos/7/paas/x86_64/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
+
+[centos-openshift-origin15-source]
+name=CentOS OpenShift Origin Source
+baseurl=http://vault.centos.org/centos/7/paas/Source/openshift-origin15/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS

--- a/roles/openshift_repos/templates/CentOS-OpenShift-Origin36.repo.j2
+++ b/roles/openshift_repos/templates/CentOS-OpenShift-Origin36.repo.j2
@@ -1,0 +1,27 @@
+[centos-openshift-origin36]
+name=CentOS OpenShift Origin
+baseurl=http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin36/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
+
+[centos-openshift-origin36-testing]
+name=CentOS OpenShift Origin Testing
+baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin36/
+enabled={% if openshift_repos_enable_testing %}1{% else %}0{% endif %}
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
+
+[centos-openshift-origin36-debuginfo]
+name=CentOS OpenShift Origin DebugInfo
+baseurl=http://debuginfo.centos.org/centos/7/paas/x86_64/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
+
+[centos-openshift-origin36-source]
+name=CentOS OpenShift Origin Source
+baseurl=http://vault.centos.org/centos/7/paas/Source/openshift-origin36/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS


### PR DESCRIPTION
Currently, origin deployments place a repo on nodes and
masters named centos-openshift-origin. At some point,
the maintainers of centos-openshift-origin migrated
previous releases of openshift to their own respective
repositories.

This commit provides the correct repositories for
centos-openshift-origin based on the variable openshift_release,
defaulting to the latest release reposititory (unversioned).

Fixes: https://github.com/openshift/openshift-ansible/issues/5404