### PR TITLE
allow logging to set a passwd to scrape ES prometheus endpoint

### DIFF
--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -159,6 +159,7 @@
     openshift_logging_elasticsearch_pvc_name: "{{ openshift_logging_es_ops_pvc_prefix }}-{{ item | int + openshift_logging_facts.elasticsearch_ops.deploymentconfigs | count - 1 }}"
     openshift_logging_elasticsearch_ops_deployment: true
     openshift_logging_elasticsearch_replica_count: "{{ openshift_logging_es_ops_cluster_size | int }}"
+    openshift_logging_elasticsearch_prometheus_passwd: "{{openshift_logging_elasticsearch_ops_prometheus_passwd | default(8 | oo_random_word) }}"
 
     openshift_logging_elasticsearch_storage_type: "{{ elasticsearch_storage_type }}"
     openshift_logging_elasticsearch_pvc_size: "{{ openshift_logging_es_ops_pvc_size }}"

--- a/roles/openshift_logging_elasticsearch/defaults/main.yml
+++ b/roles/openshift_logging_elasticsearch/defaults/main.yml
@@ -37,6 +37,10 @@ openshift_logging_elasticsearch_storage_group: '65534'
 
 openshift_logging_es_pvc_prefix: "{{ openshift_hosted_logging_elasticsearch_pvc_prefix | default('logging-es') }}"
 
+# The password to use for scraping the prometheus endpoint which is a bcrypt value
+# Temporary until we are able to make the oauth-proxy work with bearer tokens
+# openshift_logging_elasticsearch_prometheus_passwd: none
+
 # config the es plugin to write kibana index based on the index mode
 openshift_logging_elasticsearch_kibana_index_mode: 'unique'
 

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -153,6 +153,9 @@
       elasticsearch.yml: "{{ tempdir }}/elasticsearch.yml"
       logging.yml: "{{ tempdir }}/elasticsearch-logging.yml"
 
+- copy:
+    content: "{{openshift_logging_elasticsearch_prometheus_passwd | default(8 | oo_random_word) }}"
+    dest: "{{generated_certs_dir}}/prometheus.passwd"
 
 # secret
 - name: Set ES secret
@@ -177,6 +180,8 @@
       path: "{{ generated_certs_dir }}/ca.crt"
     - name: admin.jks
       path: "{{ generated_certs_dir }}/system.admin.jks"
+    - name: prometheus.passwd
+      path: "{{ generated_certs_dir }}/prometheus.passwd"
 
 # services
 - name: Set logging-{{ es_component }}-cluster service


### PR DESCRIPTION
This PR allows users to set the password to use for scraping the prom endpoint of es