### PR TITLE
fixes for scaleup master 0 and nodes

### DIFF
--- a/playbooks/openshift-etcd/private/scaleup.yml
+++ b/playbooks/openshift-etcd/private/scaleup.yml
@@ -70,9 +70,11 @@
                                      | lib_utils_oo_collect('openshift.common.hostname')
                                      | default(none, true) }}"
     openshift_master_etcd_port: "{{ (etcd_client_port | default('2379')) if (groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config) else none }}"
+  handlers:
+  - include: ../../../roles/openshift_master/handlers/main.yml
+    static: yes
   roles:
   - role: openshift_master_facts
   post_tasks:
-  - import_role:
-      name: openshift_master
-      tasks_from: update_etcd_client_urls.yml
+  - include: ../../../roles/openshift_master/tasks/update_etcd_client_urls.yml
+    static: yes


### PR DESCRIPTION
- adding ca.serial.txt fixes scaling up when we loose first master. 
- ensuring node directories and tarballs are removed from generated_config fixes scaleup nodes coming back with same names and diffrent ip, in this case, if we dont clean generated_config, node certificate will be wrong. This is the case for preemptible vms on gce
