### PR TITLE
Fix typo in drop_etcdctl.yml

### DIFF
--- a/roles/etcd/tasks/auxiliary/drop_etcdctl.yml
+++ b/roles/etcd/tasks/auxiliary/drop_etcdctl.yml
@@ -3,7 +3,7 @@
   package: name=etcd{{ '-' + etcd_version if etcd_version is defined else '' }} state=present
   when: not openshift.common.is_atomic | bool
 
-- name: Configure etcd profile.d alises
+- name: Configure etcd profile.d aliases
   template:
     dest: "/etc/profile.d/etcdctl.sh"
     src: etcdctl.sh.j2


### PR DESCRIPTION
`s/alises/aliases/` says everything.