### PR TITLE
[WIP] Allow pods to reach dnsmasq ports from containers

### DIFF
--- a/playbooks/common/openshift-cluster/enable_dnsmasq.yml
+++ b/playbooks/common/openshift-cluster/enable_dnsmasq.yml
@@ -50,7 +50,14 @@
     - role: node
       local_facts:
         dns_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+  vars:
+    os_firewall_allow:
+    - service: dnsmasq tcp
+      port: 53/tcp
+    - service: dnsmasq udp
+      port: 53/udp
   roles:
+  - os_firewall
   - openshift_node_dnsmasq
   post_tasks:
   - modify_yaml:


### PR DESCRIPTION
For some cases, like Flannel SDN, pods can not reach the
dnsmasq's <listen-address:53>.
Fix iptables rules for nodes to allow tcp/udp for port 53.
Security issues should not be the case as there are no
bind servers running normally at the cluster nodes and local
dnsmasq instances' listen-addresses are effectively restricted
to openshift_node_facts's dns_ip values.

Related [bz bug](https://bugzilla.redhat.com/show_bug.cgi?id=1490820)