### PR TITLE
papr: use F26 container for extended tests

### DIFF
--- a/.papr.sh
+++ b/.papr.sh
@@ -26,7 +26,8 @@ ansible-playbook -vvv -i .papr.inventory playbooks/byo/config.yml -e "openshift_
 # check the cluster NB: we run it on the master since we may
 # be in a different OSP network
 ssh ocp-master docker run --rm --net=host --privileged \
-  -v /etc/origin/master/admin.kubeconfig:/config fedora:25 sh -c \
+  -v /etc/origin/master/admin.kubeconfig:/config \
+  registry.fedoraproject.org/fedora:26 sh -c \
     '"dnf install -y origin-tests && \
       KUBECONFIG=/config /usr/libexec/origin/extended.test --ginkgo.v=1 \
         --ginkgo.noColor --ginkgo.focus=\"Services.*NodePort|EmptyDir\""'


### PR DESCRIPTION
Now that we updated the test nodes to F26, let's also update the
extended tests container to match.

/cc @ashcrow @sdodson 