### PR TITLE
Fix Heketi Deployment without external registry access

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/heketi_deploy_part2.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_deploy_part2.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create heketi DB volume
-  command: "{{ glusterfs_heketi_client }} setup-openshift-heketi-storage --listfile /tmp/heketi-storage.json"
+  command: "{{ glusterfs_heketi_client }} setup-openshift-heketi-storage --image {{ glusterfs_heketi_image}}:{{ glusterfs_heketi_version }} --listfile /tmp/heketi-storage.json"
   register: setup_storage
 
 - name: Copy heketi-storage list


### PR DESCRIPTION
#5550
Updated task to use the --image flag.
The Image will now be set to:
{{ glusterfs_heketi_image}}:{{ glusterfs_heketi_version }}

This means that the user can specify an internal registry if needed.

Created ticket with heketi:

heketi/heketi#870