### PR TITLE
Changes necessary to support AMI building

### DIFF
--- a/playbooks/aws/openshift-cluster/build_ami.yml
+++ b/playbooks/aws/openshift-cluster/build_ami.yml
@@ -66,8 +66,14 @@
 - name: run the std_include
   include: ../../common/openshift-cluster/initialize_openshift_repos.yml
 
-- name: install node config
-  include: ../../common/openshift-node/config.yml
+- name: run node config setup
+  include: ../../common/openshift-node/setup.yml
+
+- name: run node config
+  include: ../../common/openshift-node/configure_nodes.yml
+
+- name: Re-enable excluders
+  include: ../../common/openshift-node/enable_excluders.yml
 
 - hosts: localhost
   connection: local

--- a/playbooks/aws/openshift-cluster/provision.yml
+++ b/playbooks/aws/openshift-cluster/provision.yml
@@ -11,7 +11,7 @@
     debug:
       msg: "openshift_aws_region={{ openshift_aws_region | default('us-east-1') }}"
 
-  - name: create default vpc
+  - name: provision cluster
     include_role:
       name: openshift_aws
       tasks_from: provision.yml

--- a/playbooks/common/openshift-node/additional_config.yml
+++ b/playbooks/common/openshift-node/additional_config.yml
@@ -1,0 +1,52 @@
+---
+- name: create additional node network plugin groups
+  hosts: "{{ openshift_node_scale_up_group | default('oo_nodes_to_config') }}"
+  tasks:
+  # Creating these node groups will prevent a ton of skipped tasks.
+  # Create group for flannel nodes
+  - group_by:
+      key: oo_nodes_use_{{ (openshift_use_flannel | default(False)) | ternary('flannel','nothing') }}
+    changed_when: False
+  # Create group for calico nodes
+  - group_by:
+      key: oo_nodes_use_{{ (openshift_use_calico | default(False)) | ternary('calico','nothing') }}
+    changed_when: False
+  # Create group for nuage nodes
+  - group_by:
+      key: oo_nodes_use_{{ (openshift_use_nuage | default(False)) | ternary('nuage','nothing') }}
+    changed_when: False
+  # Create group for contiv nodes
+  - group_by:
+      key: oo_nodes_use_{{ (openshift_use_contiv | default(False)) | ternary('contiv','nothing') }}
+    changed_when: False
+
+- include: etcd_client_config.yml
+  vars:
+    openshift_node_scale_up_group: "oo_nodes_use_flannel:oo_nodes_use_calico:oo_nodes_use_contiv"
+
+- name: Additional node config
+  hosts: oo_nodes_use_flannel
+  roles:
+  - role: flannel
+    etcd_urls: "{{ hostvars[groups.oo_first_master.0].openshift.master.etcd_urls }}"
+    embedded_etcd: "{{ hostvars[groups.oo_first_master.0].openshift.master.embedded_etcd }}"
+    when: openshift_use_flannel | default(false) | bool
+
+- name: Additional node config
+  hosts: oo_nodes_use_calico
+  roles:
+  - role: calico
+    when: openshift_use_calico | default(false) | bool
+
+- name: Additional node config
+  hosts: oo_nodes_use_nuage
+  roles:
+  - role: nuage_node
+    when: openshift_use_nuage | default(false) | bool
+
+- name: Additional node config
+  hosts: oo_nodes_use_contiv
+  roles:
+  - role: contiv
+    contiv_role: netplugin
+    when: openshift_use_contiv | default(false) | bool

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -10,106 +10,17 @@
         installer_phase_node: "In Progress"
       aggregate: false
 
-- name: Disable excluders
-  hosts: oo_nodes_to_config
-  gather_facts: no
-  roles:
-  - role: openshift_excluder
-    r_openshift_excluder_action: disable
-    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
+- include: setup.yml
 
-- name: Evaluate node groups
-  hosts: localhost
-  become: no
-  connection: local
-  tasks:
-  - name: Evaluate oo_containerized_master_nodes
-    add_host:
-      name: "{{ item }}"
-      groups: oo_containerized_master_nodes
-      ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
-      ansible_become: "{{ g_sudo | default(omit) }}"
-    with_items: "{{ groups.oo_nodes_to_config | default([]) }}"
-    when:
-    - hostvars[item].openshift is defined
-    - hostvars[item].openshift.common is defined
-    - hostvars[item].openshift.common.is_containerized | bool
-    - (item in groups.oo_nodes_to_config and item in groups.oo_masters_to_config)
-    changed_when: False
+- include: containerized_nodes.yml
 
-- name: Configure containerized nodes
-  hosts: oo_containerized_master_nodes
-  serial: 1
-  vars:
-    openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
-    openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
-    openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
-    openshift_no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']
-                                                    | union(groups['oo_masters_to_config'])
-                                                    | union(groups['oo_etcd_to_config'] | default([])))
-                                                | oo_collect('openshift.common.hostname') | default([]) | join (',')
-                                                }}"
+- include: configure_nodes.yml
 
-  roles:
-  - role: os_firewall
-  - role: openshift_node
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+- include: additional_config.yml
 
-- name: Configure nodes
-  hosts: oo_nodes_to_config:!oo_containerized_master_nodes
-  vars:
-    openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
-    openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
-    openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
-    openshift_no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']
-                                                    | union(groups['oo_masters_to_config'])
-                                                    | union(groups['oo_etcd_to_config'] | default([])))
-                                                | oo_collect('openshift.common.hostname') | default([]) | join (',')
-                                                }}"
-  roles:
-  - role: os_firewall
-  - role: openshift_node
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+- include: manage_node.yml
 
-- name: Additional node config
-  hosts: oo_nodes_to_config
-  vars:
-    openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
-  roles:
-  - role: openshift_facts
-  - role: openshift_etcd_facts
-  - role: openshift_etcd_client_certificates
-    etcd_cert_prefix: flannel.etcd-
-    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
-    etcd_cert_subdir: "openshift-node-{{ openshift.common.hostname }}"
-    etcd_cert_config_dir: "{{ openshift.common.config_base }}/node"
-  - role: flannel
-    etcd_urls: "{{ hostvars[groups.oo_first_master.0].openshift.master.etcd_urls }}"
-    embedded_etcd: "{{ hostvars[groups.oo_first_master.0].openshift.master.embedded_etcd }}"
-    when: openshift_use_flannel | default(false) | bool
-  - role: calico
-    when: openshift_use_calico | default(false) | bool
-  - role: nuage_node
-    when: openshift_use_nuage | default(false) | bool
-  - role: contiv
-    contiv_role: netplugin
-    when: openshift_use_contiv | default(false) | bool
-  - role: nickhammond.logrotate
-  - role: openshift_manage_node
-    openshift_master_host: "{{ groups.oo_first_master.0 }}"
-    when: not openshift_node_bootstrap | default(False)
-  tasks:
-  - name: Create group for deployment type
-    group_by: key=oo_nodes_deployment_type_{{ openshift.common.deployment_type }}
-    changed_when: False
-
-- name: Re-enable excluder if it was previously enabled
-  hosts: oo_nodes_to_config
-  gather_facts: no
-  roles:
-  - role: openshift_excluder
-    r_openshift_excluder_action: enable
-    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
+- include: enable_excluders.yml
 
 - name: Node Install Checkpoint End
   hosts: localhost

--- a/playbooks/common/openshift-node/configure_nodes.yml
+++ b/playbooks/common/openshift-node/configure_nodes.yml
@@ -1,0 +1,17 @@
+---
+- name: Configure nodes
+  hosts: oo_nodes_to_config:!oo_containerized_master_nodes
+  vars:
+    openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
+    openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
+    openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
+    openshift_no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']
+                                                    | union(groups['oo_masters_to_config'])
+                                                    | union(groups['oo_etcd_to_config'] | default([])))
+                                                | oo_collect('openshift.common.hostname') | default([]) | join (',')
+                                                }}"
+  roles:
+  - role: os_firewall
+  - role: openshift_node
+    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+  - role: nickhammond.logrotate

--- a/playbooks/common/openshift-node/containerized_nodes.yml
+++ b/playbooks/common/openshift-node/containerized_nodes.yml
@@ -1,0 +1,19 @@
+---
+- name: Configure containerized nodes
+  hosts: oo_containerized_master_nodes
+  serial: 1
+  vars:
+    openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
+    openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"
+    openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
+    openshift_no_proxy_internal_hostnames: "{{ hostvars | oo_select_keys(groups['oo_nodes_to_config']
+                                                    | union(groups['oo_masters_to_config'])
+                                                    | union(groups['oo_etcd_to_config'] | default([])))
+                                                | oo_collect('openshift.common.hostname') | default([]) | join (',')
+                                                }}"
+
+  roles:
+  - role: os_firewall
+  - role: openshift_node
+    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+  - role: nickhammond.logrotate

--- a/playbooks/common/openshift-node/enable_excluders.yml
+++ b/playbooks/common/openshift-node/enable_excluders.yml
@@ -1,0 +1,8 @@
+---
+- name: Re-enable excluder if it was previously enabled
+  hosts: oo_nodes_to_config
+  gather_facts: no
+  roles:
+  - role: openshift_excluder
+    r_openshift_excluder_action: enable
+    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"

--- a/playbooks/common/openshift-node/etcd_client_config.yml
+++ b/playbooks/common/openshift-node/etcd_client_config.yml
@@ -1,0 +1,11 @@
+---
+- name: etcd_client node config
+  hosts: "{{ openshift_node_scale_up_group | default('this_group_does_not_exist') }}"
+  roles:
+  - role: openshift_facts
+  - role: openshift_etcd_facts
+  - role: openshift_etcd_client_certificates
+    etcd_cert_prefix: flannel.etcd-
+    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
+    etcd_cert_subdir: "openshift-node-{{ openshift.common.hostname }}"
+    etcd_cert_config_dir: "{{ openshift.common.config_base }}/node"

--- a/playbooks/common/openshift-node/manage_node.yml
+++ b/playbooks/common/openshift-node/manage_node.yml
@@ -1,0 +1,12 @@
+---
+- name: Additional node config
+  hosts: "{{ openshift_node_scale_up_group | default('oo_nodes_to_config') }}"
+  vars:
+    openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
+  roles:
+  - role: openshift_manage_node
+    openshift_master_host: "{{ groups.oo_first_master.0 }}"
+  tasks:
+  - name: Create group for deployment type
+    group_by: key=oo_nodes_deployment_type_{{ openshift.common.deployment_type }}
+    changed_when: False

--- a/playbooks/common/openshift-node/setup.yml
+++ b/playbooks/common/openshift-node/setup.yml
@@ -1,0 +1,27 @@
+---
+- name: Disable excluders
+  hosts: oo_nodes_to_config
+  gather_facts: no
+  roles:
+  - role: openshift_excluder
+    r_openshift_excluder_action: disable
+    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
+
+- name: Evaluate node groups
+  hosts: localhost
+  become: no
+  connection: local
+  tasks:
+  - name: Evaluate oo_containerized_master_nodes
+    add_host:
+      name: "{{ item }}"
+      groups: oo_containerized_master_nodes
+      ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
+      ansible_become: "{{ g_sudo | default(omit) }}"
+    with_items: "{{ groups.oo_nodes_to_config | default([]) }}"
+    when:
+    - hostvars[item].openshift is defined
+    - hostvars[item].openshift.common is defined
+    - hostvars[item].openshift.common.is_containerized | bool
+    - (item in groups.oo_nodes_to_config and item in groups.oo_masters_to_config)
+    changed_when: False

--- a/roles/openshift_aws/tasks/iam_cert.yml
+++ b/roles/openshift_aws/tasks/iam_cert.yml
@@ -22,6 +22,11 @@
 - name: set_fact openshift_aws_elb_cert_arn
   set_fact:
     openshift_aws_elb_cert_arn: "{{ elb_cert_chain.arn }}"
+  when:
+  - openshift_aws_create_iam_cert | bool
+  - openshift_aws_iam_cert_path != ''
+  - openshift_aws_iam_cert_key_path != ''
+  - openshift_aws_elb_cert_arn == ''
 
 - name: wait for cert to propagate
   pause:

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -31,12 +31,9 @@ openshift_node_ami_prep_packages:
 - python-dbus
 - PyYAML
 - yum-utils
-- python2-boto
-- python2-boto3
 - cloud-utils-growpart
 # gluster
 - glusterfs-fuse
-- heketi-client
 # nfs
 - nfs-utils
 - flannel


### PR DESCRIPTION
Currently, AMI building does not work.

These changes implement the necessary steps to build
an AMI for usage as a 'golden node image'.