### PR TITLE
Remove unused registry_volume_claim variable

### DIFF
--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -69,7 +69,6 @@ r_openshift_hosted_registry_use_firewalld: "{{ os_firewall_use_firewalld | defau
 
 openshift_hosted_registry_name: docker-registry
 openshift_hosted_registry_wait: "{{ not (openshift_master_bootstrap_enabled | default(False)) }}"
-registry_volume_claim: 'registry-claim'
 openshift_hosted_registry_cert_expire_days: 730
 
 r_openshift_hosted_registry_os_firewall_deny: []


### PR DESCRIPTION
The "registry_volume_claim" variable has not been used since at least
commit 7cf5cc1 (February 21, 2017) and this commit removes the last
mention.