### PR TITLE
Initial Kuryr support

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -206,6 +206,12 @@
     when: openshift_use_nuage | default(false) | bool
   - role: calico_master
     when: openshift_use_calico | default(false) | bool
+  tasks:
+  - include_role:
+      name: kuryr
+      tasks_from: master
+    when: openshift_use_kuryr | default(false) | bool
+
   post_tasks:
   - name: Create group for deployment type
     group_by: key=oo_masters_deployment_type_{{ openshift.common.deployment_type }}

--- a/playbooks/common/openshift-node/additional_config.yml
+++ b/playbooks/common/openshift-node/additional_config.yml
@@ -19,10 +19,14 @@
   - group_by:
       key: oo_nodes_use_{{ (openshift_use_contiv | default(False)) | ternary('contiv','nothing') }}
     changed_when: False
+  # Create group for kuryr nodes
+  - group_by:
+      key: oo_nodes_use_{{ (openshift_use_kuryr | default(False)) | ternary('kuryr','nothing') }}
+    changed_when: False
 
 - include: etcd_client_config.yml
   vars:
-    openshift_node_scale_up_group: "oo_nodes_use_flannel:oo_nodes_use_calico:oo_nodes_use_contiv"
+    openshift_node_scale_up_group: "oo_nodes_use_flannel:oo_nodes_use_calico:oo_nodes_use_contiv:oo_nodes_use_kuryr"
 
 - name: Additional node config
   hosts: oo_nodes_use_flannel
@@ -50,3 +54,11 @@
   - role: contiv
     contiv_role: netplugin
     when: openshift_use_contiv | default(false) | bool
+
+- name: Configure Kuryr node
+  hosts: oo_nodes_use_kuryr
+  tasks:
+  - include_role:
+      name: kuryr
+      tasks_from: node
+    when: openshift_use_kuryr | default(false) | bool

--- a/roles/kuryr/README.md
+++ b/roles/kuryr/README.md
@@ -1,0 +1,38 @@
+## OpenStack Kuryr
+
+Install Kuryr CNI components (kuryr-controller, kuryr-cni) on Master and worker
+nodes. Kuryr uses OpenStack Networking service (Neutron) to provide network for
+pods. This allows to have interconnectivity between pods and OpenStack VMs.
+
+## Requirements
+
+* Ansible 2.2+
+* Centos/ RHEL 7.3+
+
+## Current Kuryr restrictions when used with OpenShift
+
+* Openshift Origin only
+* OpenShift on OpenStack Newton or newer (only with Trunk ports)
+
+## Key Ansible inventory Kuryr master configuration parameters
+
+* ``openshift_use_kuryr=True``
+* ``openshift_use_openshift_sdn=False``
+* ``openshift_sdn_network_plugin_name='cni'``
+* ``kuryr_cni_link_interface=eth0``
+* ``kuryr_openstack_auth_url=keystone_url``
+* ``kuryr_openstack_user_domain_name=Default``
+* ``kuryr_openstack_user_project_name=Default``
+* ``kuryr_openstack_project_id=project_uuid``
+* ``kuryr_openstack_username=kuryr``
+* ``kuryr_openstack_password=kuryr_pass``
+* ``kuryr_openstack_pod_sg_id=pod_security_group_uuid``
+* ``kuryr_openstack_pod_subnet_id=pod_subnet_uuid``
+* ``kuryr_openstack_pod_service_id=service_subnet_uuid``
+* ``kuryr_openstack_pod_project_id=pod_project_uuid``
+* ``kuryr_openstack_worker_nodes_subnet_id=worker_nodes_subnet_uuid``
+
+## Kuryr resources
+
+* [Kuryr documentation](https://docs.openstack.org/kuryr-kubernetes/latest/)
+* [Installing Kuryr containerized](https://docs.openstack.org/kuryr-kubernetes/latest/installation/containerized.html)

--- a/roles/kuryr/defaults/main.yaml
+++ b/roles/kuryr/defaults/main.yaml
@@ -1,0 +1,72 @@
+---
+# Kuryr conf directory
+kuryr_config_dir: /etc/kuryr
+
+# Kuryr username
+kuryr_openstack_username: kuryr
+
+# Kuryr username domain
+kuryr_openstack_user_domain_name: default
+
+# Kuryr username domain
+kuryr_openstack_project_domain_name: default
+
+# Kuryr OpenShift namespace
+kuryr_namespace: kube-system
+
+# Whether to run the cni plugin in debug mode
+kuryr_cni_debug: "false"
+
+# The version of cni binaries
+cni_version: v0.5.2
+
+# Path to bin dir (where kuryr execs get installed)
+bin_dir: /usr/bin
+
+# Path to the cni binaries
+cni_bin_dir: /opt/cni/bin
+
+# URL for cni binaries
+cni_bin_url_base: "https://github.com/containernetworking/cni/releases/download/"
+cni_bin_url: "{{ cni_bin_url_base }}/{{ cni_version }}/cni-{{ cni_version }}.tgz"
+cni_bin_checksum: "71f411080245aa14d0cc06f6824e8039607dd9e9"
+
+# Kuryr ClusterRole definiton
+kuryr_clusterrole:
+  name: kuryrctl
+  state: present
+  rules:
+    - apiGroups:
+        - ""
+      attributeRestrictions: null
+      verbs:
+        - get
+        - list
+        - watch
+      resources:
+        - daemonsets
+        - deployments
+        - deploymentconfigs
+        - endpoints
+        - ingress
+        - nodes
+        - namespaces
+        - pods
+        - projects
+        - routes
+        - services
+    - apiGroups:
+        - ""
+      attributeRestrictions: null
+      verbs:
+        - update
+        - patch
+      resources:
+        - endpoints
+        - ingress
+        - pods
+        - namespaces
+        - nodes
+        - services
+        - services/status
+        - routes

--- a/roles/kuryr/meta/main.yml
+++ b/roles/kuryr/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: Red Hat
+  description: Kuryr networking
+  company: Red Hat
+  license: Apache License, Version 2.0
+  min_ansible_version: 2.2
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+  - system
+dependencies:
+- { role: lib_openshift }
+- { role: openshift_facts }

--- a/roles/kuryr/tasks/master.yaml
+++ b/roles/kuryr/tasks/master.yaml
@@ -1,0 +1,52 @@
+---
+- name: Perform OpenShit ServiceAccount config
+  include: serviceaccount.yaml
+
+- name: Create kuryr manifests tempdir
+  command: mktemp -d
+  register: manifests_tmpdir
+
+- name: Create kuryr ConfigMap manifest
+  become: yes
+  template:
+    src: configmap.yaml.j2
+    dest: "{{ manifests_tmpdir.stdout }}/configmap.yaml"
+
+- name: Create kuryr-controller Deployment manifest
+  become: yes
+  template:
+    src: controller-deployment.yaml.j2
+    dest: "{{ manifests_tmpdir.stdout }}/controller-deployment.yaml"
+
+- name: Create kuryr-cni DaemonSet manifest
+  become: yes
+  template:
+    src: cni-daemonset.yaml.j2
+    dest: "{{ manifests_tmpdir.stdout }}/cni-daemonset.yaml"
+
+- name: Apply ConfigMap manifest
+  oc_obj:
+    state: present
+    kind: ConfigMap
+    name: "kuryr-config"
+    namespace: "{{ kuryr_namespace }}"
+    files:
+    - "{{ manifests_tmpdir.stdout }}/configmap.yaml"
+
+- name: Apply Controller Deployment manifest
+  oc_obj:
+    state: present
+    kind: Deployment
+    name: "kuryr-controller"
+    namespace: "{{ kuryr_namespace }}"
+    files:
+    - "{{ manifests_tmpdir.stdout }}/controller-deployment.yaml"
+
+- name: Apply kuryr-cni DaemonSet manifest
+  oc_obj:
+    state: present
+    kind: DaemonSet
+    name: "kuryr-cni-ds"
+    namespace: "{{ kuryr_namespace }}"
+    files:
+    - "{{ manifests_tmpdir.stdout }}/cni-daemonset.yaml"

--- a/roles/kuryr/tasks/node.yaml
+++ b/roles/kuryr/tasks/node.yaml
@@ -1,0 +1,48 @@
+---
+- name: Create CNI bin directory
+  file:
+    state: directory
+    path: "{{ cni_bin_dir }}"
+    mode: 0755
+    owner: root
+    group: root
+    recurse: yes
+
+- name: Create CNI extraction tempdir
+  command: mktemp -d
+  register: cni_tmpdir
+
+- name: Download CNI
+  get_url:
+    url: "{{ cni_bin_url }}"
+    checksum: "sha1:{{ cni_bin_checksum }}"
+    mode: 0644
+    dest: "{{ cni_tmpdir.stdout }}"
+  register: downloaded_tarball
+
+- name: Extract CNI
+  become: yes
+  unarchive:
+    remote_src: True
+    src: "{{ downloaded_tarball.dest }}"
+    dest: "{{ cni_bin_dir }}"
+  when: downloaded_tarball.changed
+
+- name: Ensure CNI net.d exists
+  file:
+    path: /etc/cni/net.d
+    recurse: yes
+    state: directory
+
+- name: Configure OpenShift node with disabled service proxy
+  lineinfile:
+    dest: "/etc/sysconfig/{{ openshift.common.service_type }}-node"
+    regexp: '^OPTIONS="?(.*?)"?$'
+    backrefs: yes
+    backup: yes
+    line: 'OPTIONS="\1 --disable dns,proxy,plugins"'
+
+- name: force node restart to disable the proxy
+  service:
+    name: "{{ openshift.common.service_type }}-node"
+    state: restarted

--- a/roles/kuryr/tasks/serviceaccount.yaml
+++ b/roles/kuryr/tasks/serviceaccount.yaml
@@ -1,0 +1,31 @@
+---
+- name: Create Controller service account
+  oc_serviceaccount:
+    name: kuryr-controller
+    namespace: "{{ kuryr_namespace }}"
+  register: saout
+
+- name: Create a role for the Kuryr
+  oc_clusterrole: "{{ kuryr_clusterrole }}"
+
+- name: Fetch the created Kuryr controller cluster role
+  oc_clusterrole:
+    name: kuryrctl
+    state: list
+  register: crout
+
+- name: Grant Kuryr the privileged security context constraints
+  oc_adm_policy_user:
+    user: "system:serviceaccount:{{ kuryr_namespace }}:{{ saout.results.results.0.metadata.name }}"
+    namespace: "{{ kuryr_namespace }}"
+    resource_kind: scc
+    resource_name: privileged
+    state: present
+
+- name: Assign role to Kuryr service account
+  oc_adm_policy_user:
+    user: "system:serviceaccount:{{ kuryr_namespace }}:{{ saout.results.results.0.metadata.name }}"
+    namespace: "{{ kuryr_namespace }}"
+    resource_kind: cluster-role
+    resource_name: "{{ crout.results.results.metadata.name }}"
+    state: present

--- a/roles/kuryr/templates/cni-daemonset.yaml.j2
+++ b/roles/kuryr/templates/cni-daemonset.yaml.j2
@@ -1,0 +1,53 @@
+# More info about the template: https://docs.openstack.org/kuryr-kubernetes/latest/installation/containerized.html#generating-kuryr-resource-definitions-for-kubernetes
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kuryr-cni-ds
+  namespace: {{ kuryr_namespace }}
+  labels:
+    tier: node
+    app: kuryr
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: kuryr
+    spec:
+      hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: kuryr-controller
+      containers:
+      - name: kuryr-cni
+        image: kuryr/cni:latest
+        imagePullPolicy: IfNotPresent
+        command: [ "cni_ds_init" ]
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: bin
+          mountPath: /opt/cni/bin
+        - name: net-conf
+          mountPath: /etc/cni/net.d
+        - name: config-volume
+          mountPath: /tmp/kuryr/kuryr.conf
+          subPath: kuryr-cni.conf
+        - name: etc
+          mountPath: /etc
+      volumes:
+        - name: bin
+          hostPath:
+            path: {{ cni_bin_dir }}
+        - name: net-conf
+          hostPath:
+            path: /etc/cni/net.d
+        - name: config-volume
+          configMap:
+            name: kuryr-config
+        - name: etc
+          hostPath:
+            path: /etc

--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -1,0 +1,343 @@
+# More info about the template: https://docs.openstack.org/kuryr-kubernetes/latest/installation/containerized.html#generating-kuryr-resource-definitions-for-kubernetes
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kuryr-config
+  namespace: {{ kuryr_namespace }}
+data:
+  kuryr.conf: |+
+    [DEFAULT]
+
+    #
+    # From kuryr_kubernetes
+    #
+
+    # Directory for Kuryr vif binding executables. (string value)
+    #bindir = /usr/libexec/kuryr
+
+    # If set to true, the logging level will be set to DEBUG instead of the default
+    # INFO level. (boolean value)
+    # Note: This option can be changed without restarting.
+    #debug = false
+
+    # DEPRECATED: If set to false, the logging level will be set to WARNING instead
+    # of the default INFO level. (boolean value)
+    # This option is deprecated for removal.
+    # Its value may be silently ignored in the future.
+    #verbose = true
+
+    # The name of a logging configuration file. This file is appended to any
+    # existing logging configuration files. For details about logging configuration
+    # files, see the Python logging module documentation. Note that when logging
+    # configuration files are used then all logging configuration is set in the
+    # configuration file and other logging configuration options are ignored (for
+    # example, logging_context_format_string). (string value)
+    # Note: This option can be changed without restarting.
+    # Deprecated group/name - [DEFAULT]/log_config
+    #log_config_append = <None>
+
+    # Defines the format string for %%(asctime)s in log records. Default:
+    # %(default)s . This option is ignored if log_config_append is set. (string
+    # value)
+    #log_date_format = %Y-%m-%d %H:%M:%S
+
+    # (Optional) Name of log file to send logging output to. If no default is set,
+    # logging will go to stderr as defined by use_stderr. This option is ignored if
+    # log_config_append is set. (string value)
+    # Deprecated group/name - [DEFAULT]/logfile
+    #log_file = /var/log/kuryr/kuryr-controller.log
+
+    # (Optional) The base directory used for relative log_file  paths. This option
+    # is ignored if log_config_append is set. (string value)
+    # Deprecated group/name - [DEFAULT]/logdir
+    #log_dir = <None>
+
+    # Uses logging handler designed to watch file system. When log file is moved or
+    # removed this handler will open a new log file with specified path
+    # instantaneously. It makes sense only if log_file option is specified and
+    # Linux platform is used. This option is ignored if log_config_append is set.
+    # (boolean value)
+    #watch_log_file = false
+
+    # Use syslog for logging. Existing syslog format is DEPRECATED and will be
+    # changed later to honor RFC5424. This option is ignored if log_config_append
+    # is set. (boolean value)
+    #use_syslog = false
+
+    # Syslog facility to receive log lines. This option is ignored if
+    # log_config_append is set. (string value)
+    #syslog_log_facility = LOG_USER
+
+    # Log output to standard error. This option is ignored if log_config_append is
+    # set. (boolean value)
+    #use_stderr = true
+
+    # Format string to use for log messages with context. (string value)
+    #logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+    # Format string to use for log messages when context is undefined. (string
+    # value)
+    #logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+    # Additional data to append to log message when logging level for the message
+    # is DEBUG. (string value)
+    #logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+    # Prefix each line of exception output with this format. (string value)
+    #logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+    # Defines the format string for %(user_identity)s that is used in
+    # logging_context_format_string. (string value)
+    #logging_user_identity_format = %(user)s %(tenant)s %(domain)s %(user_domain)s %(project_domain)s
+
+    # List of package logging levels in logger=LEVEL pairs. This option is ignored
+    # if log_config_append is set. (list value)
+    #default_log_levels = amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,dogpile.core.dogpile=INFO
+
+    # Enables or disables publication of error events. (boolean value)
+    #publish_errors = false
+
+    # The format for an instance that is passed with the log message. (string
+    # value)
+    #instance_format = "[instance: %(uuid)s] "
+
+    # The format for an instance UUID that is passed with the log message. (string
+    # value)
+    #instance_uuid_format = "[instance: %(uuid)s] "
+
+    # Enables or disables fatal status of deprecations. (boolean value)
+    #fatal_deprecations = false
+
+
+    [binding]
+
+    driver = kuryr.lib.binding.drivers.vlan
+    link_iface = eth0
+
+    [kubernetes]
+
+    #
+    # From kuryr_kubernetes
+    #
+
+    # The root URL of the Kubernetes API (string value)
+    api_root = {{ openshift.master.api_url }}
+
+    # Absolute path to client cert to connect to HTTPS K8S_API (string value)
+    # ssl_client_crt_file = /etc/kuryr/controller.crt
+
+    # Absolute path client key file to connect to HTTPS K8S_API (string value)
+    # ssl_client_key_file = /etc/kuryr/controller.key
+
+    # Absolute path to ca cert file to connect to HTTPS K8S_API (string value)
+    ssl_ca_crt_file = /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+    # The token to talk to the k8s API
+    token_file = /var/run/secrets/kubernetes.io/serviceaccount/token
+
+    # HTTPS K8S_API server identity verification (boolean value)
+    # TODO (apuimedo): Make configurable
+    ssl_verify_server_crt = True
+
+    # The driver to determine OpenStack project for pod ports (string value)
+    pod_project_driver = default
+
+    # The driver to determine OpenStack project for services (string value)
+    service_project_driver = default
+
+    # The driver to determine Neutron subnets for pod ports (string value)
+    pod_subnets_driver = default
+
+    # The driver to determine Neutron subnets for services (string value)
+    service_subnets_driver = default
+
+    # The driver to determine Neutron security groups for pods (string value)
+    pod_security_groups_driver = default
+
+    # The driver to determine Neutron security groups for services (string value)
+    service_security_groups_driver = default
+
+    # The driver that provides VIFs for Kubernetes Pods. (string value)
+    pod_vif_driver = nested-vlan
+
+
+    [neutron]
+    # Configuration options for OpenStack Neutron
+
+    #
+    # From kuryr_kubernetes
+    #
+
+    # Authentication URL (string value)
+    auth_url = {{ kuryr_openstack_auth_url }}
+
+    # Authentication type to load (string value)
+    # Deprecated group/name - [neutron]/auth_plugin
+    auth_type = password
+
+    # Domain ID to scope to (string value)
+    user_domain_name = {{ kuryr_openstack_user_domain_name }}
+
+    # User's password (string value)
+    password = {{ kuryr_openstack_password }}
+
+    # Domain name containing project (string value)
+    project_domain_name = {{ kuryr_openstack_project_domain_name }}
+
+    # Project ID to scope to (string value)
+    # Deprecated group/name - [neutron]/tenant-id
+    project_id = {{ kuryr_openstack_project_id }}
+
+    # Token (string value)
+    #token = <None>
+
+    # Trust ID (string value)
+    #trust_id = <None>
+
+    # User's domain id (string value)
+    #user_domain_id = <None>
+
+    # User id (string value)
+    #user_id = <None>
+
+    # Username (string value)
+    # Deprecated group/name - [neutron]/user-name
+    username = {{kuryr_openstack_username }}
+
+    # Whether a plugging operation is failed if the port to plug does not become
+    # active (boolean value)
+    #vif_plugging_is_fatal = false
+
+    # Seconds to wait for port to become active (integer value)
+    #vif_plugging_timeout = 0
+
+    [neutron_defaults]
+
+    pod_security_groups = {{ kuryr_openstack_pod_sg_id }}
+    pod_subnet = {{ kuryr_openstack_pod_subnet_id }}
+    service_subnet = {{ kuryr_openstack_service_subnet_id }}
+    project = {{ kuryr_openstack_pod_project_id }}
+    # TODO (apuimedo): Remove the duplicated line just after this one once the
+    # RDO packaging contains the upstream patch
+    worker_nodes_subnet = {{ kuryr_openstack_worker_nodes_subnet_id }}
+
+    [pod_vif_nested]
+    worker_nodes_subnet = {{ kuryr_openstack_worker_nodes_subnet_id }}
+  kuryr-cni.conf: |+
+    [DEFAULT]
+
+    #
+    # From kuryr_kubernetes
+    #
+    # If set to true, the logging level will be set to DEBUG instead of the default
+    # INFO level. (boolean value)
+    # Note: This option can be changed without restarting.
+    #debug = false
+
+    # The name of a logging configuration file. This file is appended to any
+    # existing logging configuration files. For details about logging configuration
+    # files, see the Python logging module documentation. Note that when logging
+    # configuration files are used then all logging configuration is set in the
+    # configuration file and other logging configuration options are ignored (for
+    # example, logging_context_format_string). (string value)
+    # Note: This option can be changed without restarting.
+    # Deprecated group/name - [DEFAULT]/log_config
+    #log_config_append = <None>
+
+    # Defines the format string for %%(asctime)s in log records. Default:
+    # %(default)s . This option is ignored if log_config_append is set. (string
+    # value)
+    #log_date_format = %Y-%m-%d %H:%M:%S
+
+    # (Optional) Name of log file to send logging output to. If no default is set,
+    # logging will go to stderr as defined by use_stderr. This option is ignored if
+    # log_config_append is set. (string value)
+    # Deprecated group/name - [DEFAULT]/logfile
+    #log_file = /var/log/kuryr/cni.log
+
+    # (Optional) The base directory used for relative log_file  paths. This option
+    # is ignored if log_config_append is set. (string value)
+    # Deprecated group/name - [DEFAULT]/logdir
+    #log_dir = <None>
+
+    # Uses logging handler designed to watch file system. When log file is moved or
+    # removed this handler will open a new log file with specified path
+    # instantaneously. It makes sense only if log_file option is specified and
+    # Linux platform is used. This option is ignored if log_config_append is set.
+    # (boolean value)
+    #watch_log_file = false
+
+    # Use syslog for logging. Existing syslog format is DEPRECATED and will be
+    # changed later to honor RFC5424. This option is ignored if log_config_append
+    # is set. (boolean value)
+    #use_syslog = false
+
+    # Syslog facility to receive log lines. This option is ignored if
+    # log_config_append is set. (string value)
+    #syslog_log_facility = LOG_USER
+
+    # Log output to standard error. This option is ignored if log_config_append is
+    # set. (boolean value)
+    use_stderr = true
+
+    # Format string to use for log messages with context. (string value)
+    #logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+    # Format string to use for log messages when context is undefined. (string
+    # value)
+    #logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+    # Additional data to append to log message when logging level for the message
+    # is DEBUG. (string value)
+    #logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+    # Prefix each line of exception output with this format. (string value)
+    #logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+    # Defines the format string for %(user_identity)s that is used in
+    # logging_context_format_string. (string value)
+    #logging_user_identity_format = %(user)s %(tenant)s %(domain)s %(user_domain)s %(project_domain)s
+
+    # List of package logging levels in logger=LEVEL pairs. This option is ignored
+    # if log_config_append is set. (list value)
+    #default_log_levels = amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,dogpile.core.dogpile=INFO
+
+    # Enables or disables publication of error events. (boolean value)
+    #publish_errors = false
+
+    # The format for an instance that is passed with the log message. (string
+    # value)
+    #instance_format = "[instance: %(uuid)s] "
+
+    # The format for an instance UUID that is passed with the log message. (string
+    # value)
+    #instance_uuid_format = "[instance: %(uuid)s] "
+
+    # Enables or disables fatal status of deprecations. (boolean value)
+    #fatal_deprecations = false
+
+
+    [binding]
+
+    driver = kuryr.lib.binding.drivers.vlan
+    link_iface = {{ kuryr_cni_link_interface }}
+
+    [kubernetes]
+
+    #
+    # From kuryr_kubernetes
+    #
+
+    # The root URL of the Kubernetes API (string value)
+    api_root = {{ openshift.master.api_url }}
+
+    # The token to talk to the k8s API
+    token_file = /etc/kuryr/token
+
+    # Absolute path to ca cert file to connect to HTTPS K8S_API (string value)
+    ssl_ca_crt_file = /etc/kuryr/ca.crt
+
+    # HTTPS K8S_API server identity verification (boolean value)
+    # TODO (apuimedo): Make configurable
+    ssl_verify_server_crt = True

--- a/roles/kuryr/templates/controller-deployment.yaml.j2
+++ b/roles/kuryr/templates/controller-deployment.yaml.j2
@@ -1,0 +1,40 @@
+# More info about the template: https://docs.openstack.org/kuryr-kubernetes/latest/installation/containerized.html#generating-kuryr-resource-definitions-for-kubernetes
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    name: kuryr-controller
+  name: kuryr-controller
+  namespace: {{ kuryr_namespace }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: kuryr-controller
+      name: kuryr-controller
+    spec:
+      serviceAccountName: kuryr-controller
+      automountServiceAccountToken: true
+      hostNetwork: true
+      containers:
+      - image: kuryr/controller:latest
+        imagePullPolicy: IfNotPresent
+        name: controller
+        terminationMessagePath: "/dev/termination-log"
+        # FIXME(dulek): This shouldn't be required, but without it selinux is
+        #               complaining about access to kuryr.conf.
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        volumeMounts:
+        - name: config-volume
+          mountPath: "/etc/kuryr/kuryr.conf"
+          subPath: kuryr.conf
+      volumes:
+      - name: config-volume
+        configMap:
+          name: kuryr-config
+          defaultMode: 0666
+      restartPolicy: Always

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -46,6 +46,9 @@ r_openshift_master_use_nuage: "{{ r_openshift_master_use_nuage_default }}"
 r_openshift_master_use_contiv_default: "{{ openshift_use_contiv | default(False) }}"
 r_openshift_master_use_contiv: "{{ r_openshift_master_use_contiv_default }}"
 
+r_openshift_master_use_kuryr_default: "{{ openshift_use_kuryr | default(False) }}"
+r_openshift_master_use_kuryr: "{{ r_openshift_master_use_kuryr_default }}"
+
 r_openshift_master_data_dir_default: "{{ openshift_data_dir | default('/var/lib/origin') }}"
 r_openshift_master_data_dir: "{{ r_openshift_master_data_dir_default }}"
 

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -179,7 +179,7 @@ masterPublicURL: {{ openshift.master.public_api_url }}
 networkConfig:
   clusterNetworkCIDR: {{ openshift.master.sdn_cluster_network_cidr }}
   hostSubnetLength: {{ openshift.master.sdn_host_subnet_length }}
-{% if r_openshift_master_use_openshift_sdn or r_openshift_master_use_nuage or r_openshift_master_use_contiv or r_openshift_master_sdn_network_plugin_name == 'cni' %}
+{% if r_openshift_master_use_openshift_sdn or r_openshift_master_use_nuage or r_openshift_master_use_contiv or r_openshift_master_use_kuryr or r_openshift_master_sdn_network_plugin_name == 'cni' %}
   networkPluginName: {{ r_openshift_master_sdn_network_plugin_name_default }}
 {% endif %}
 # serviceNetworkCIDR must match kubernetesMasterConfig.servicesSubnet

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -104,6 +104,9 @@ openshift_node_use_nuage: "{{ openshift_node_use_nuage_default }}"
 openshift_node_use_contiv_default: "{{ openshift_use_contiv | default(False) }}"
 openshift_node_use_contiv: "{{ openshift_node_use_contiv_default }}"
 
+openshift_node_use_kuryr_default: "{{ openshift_use_kuryr | default(False) }}"
+openshift_node_use_kuryr: "{{ openshift_node_use_kuryr_default }}"
+
 openshift_node_data_dir_default: "{{ openshift_data_dir | default('/var/lib/origin') }}"
 openshift_node_data_dir: "{{ openshift_node_data_dir_default }}"
 

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -44,7 +44,7 @@ networkPluginName: {{ openshift_node_sdn_network_plugin_name }}
 # deprecates networkPluginName above. The two should match.
 networkConfig:
    mtu: {{ openshift.node.sdn_mtu }}
-{% if openshift_node_use_openshift_sdn | bool or openshift_node_use_nuage | bool or openshift_node_use_contiv | bool or openshift_node_sdn_network_plugin_name == 'cni' %}
+{% if openshift_node_use_openshift_sdn | bool or openshift_node_use_nuage | bool or openshift_node_use_contiv | bool or openshift_node_use_kuryr | bool or openshift_node_sdn_network_plugin_name == 'cni' %}
    networkPluginName: {{ openshift_node_sdn_network_plugin_name }}
 {% endif %}
 {% if openshift.node.set_node_ip | bool %}
@@ -67,9 +67,11 @@ servingInfo:
 {% endfor %}
 {% endif %}
 volumeDirectory: {{ openshift_node_data_dir }}/openshift.local.volumes
+{% if not (openshift_node_use_kuryr | default(False)) | bool %}
 proxyArguments:
   proxy-mode:
      - {{ openshift.node.proxy_mode }}
+{% endif %}
 volumeConfig:
   localQuota:
     perFSGroup: {{ openshift.node.local_quota_per_fsgroup }}


### PR DESCRIPTION
This commit enables deploying Kuryr networking on top of OpenShift in
containers.  kuryr-controller is a Deployment and kuryr-cni is deployed
as DaemonSet (container will drop all CNI configuration files).

Co-Authored-By: Antoni Segura Puimedon <celebdor@gmail.com>