### PR TITLE
openshift_facts: coerce docker_use_system_container to bool

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1680,7 +1680,9 @@ def set_container_facts_if_unset(facts):
     facts['common']['is_atomic'] = os.path.isfile('/run/ostree-booted')
     # If openshift_docker_use_system_container is set and is True ....
     if 'use_system_container' in list(facts['docker'].keys()):
-        if facts['docker']['use_system_container']:
+        # use safe_get_bool as the inventory variable may not be a
+        # valid boolean on it's own.
+        if safe_get_bool(facts['docker']['use_system_container']):
             # ... set the service name to container-engine
             facts['docker']['service_name'] = 'container-engine'
 


### PR DESCRIPTION
Use ``safe_get_bool()`` when reading ``docker_use_system_container`` to ensure
that ansible accepted inputs are turned into real boolean results.
    
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1496725

3.6 Backport: https://github.com/openshift/openshift-ansible/pull/5578