### PR TITLE
Add valid search when search does not exist on resolv.conf

### DIFF
--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -112,10 +112,10 @@ EOF
       fi
       sed -e '/^nameserver.*$/d' /etc/resolv.conf >> ${NEW_RESOLV_CONF}
       echo "nameserver "${def_route_ip}"" >> ${NEW_RESOLV_CONF}
-      if ! grep -q 'search.*cluster.local' ${NEW_RESOLV_CONF}; then
-        sed -i '/^search/ s/$/ cluster.local/' ${NEW_RESOLV_CONF}
-      elif ! grep -qw search ${NEW_RESOLV_CONF}; then
+      if ! grep -qw search ${NEW_RESOLV_CONF}; then
         echo 'search cluster.local' >> ${NEW_RESOLV_CONF}
+      elif ! grep -q 'search.*cluster.local' ${NEW_RESOLV_CONF}; then
+        sed -i '/^search/ s/$/ cluster.local/' ${NEW_RESOLV_CONF}
       fi
       cp -Z ${NEW_RESOLV_CONF} /etc/resolv.conf
     fi


### PR DESCRIPTION
Current fix https://github.com/openshift/openshift-ansible/pull/5433 still misses to add `search cluster.local`. The logic needs to be:

1. When `search` does not exist, adds `search cluster.local`.
2. When `search.*.cluster.local` does not exist, adds(sed) `cluster.local`.

in this order.

cc @sdodson @caruccio 
