### PR TITLE
Fix some provisioning variables

### DIFF
--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -17,7 +17,6 @@ openshift_aws_build_ami_group: "{{ openshift_aws_clusterid }}"
 
 openshift_aws_iam_cert_name: "{{ openshift_aws_clusterid }}-master-external"
 openshift_aws_iam_cert_path: ''
-openshift_aws_iam_cert_chain_path: ''
 openshift_aws_iam_cert_key_path: ''
 openshift_aws_scale_group_name: "{{ openshift_aws_clusterid }} openshift {{ openshift_aws_node_group_type }}"
 

--- a/roles/openshift_aws/tasks/elb.yml
+++ b/roles/openshift_aws/tasks/elb.yml
@@ -29,9 +29,9 @@
                    if 'master' in openshift_aws_node_group_type or 'infra' in openshift_aws_node_group_type
                    else openshift_aws_elb_listeners }}"
 
-- name: "Create ELB {{ openshift_aws_elb_name }}"
+- name: "Create ELB {{ l_openshift_aws_elb_name }}"
   ec2_elb_lb:
-    name: "{{ openshift_aws_elb_name }}"
+    name: "{{ l_openshift_aws_elb_name }}"
     state: present
     security_group_names: "{{ openshift_aws_elb_security_groups }}"
     idle_timeout: "{{ openshift_aws_elb_idle_timout }}"
@@ -49,10 +49,10 @@
 
 # It is necessary to ignore_errors here because the instances are not in 'ready'
 #  state when first added to ELB
-- name: "Add instances to ELB {{ openshift_aws_elb_name }}"
+- name: "Add instances to ELB {{ l_openshift_aws_elb_name }}"
   ec2_elb:
     instance_id: "{{ item.id }}"
-    ec2_elbs: "{{ openshift_aws_elb_name }}"
+    ec2_elbs: "{{ l_openshift_aws_elb_name }}"
     state: present
     region: "{{ openshift_aws_region }}"
     wait: False

--- a/roles/openshift_aws/tasks/iam_cert.yml
+++ b/roles/openshift_aws/tasks/iam_cert.yml
@@ -11,13 +11,14 @@
   - "'failed' in elb_cert_chain"
   - elb_cert_chain.failed
   - "'msg' in elb_cert_chain"
-  - "'already exists and has a different certificate body' in elb_cert_chain.msg"
-  - "'BotoServerError' in elb_cert_chain.msg"
+  - "'already exists and has a different certificate body' in elb_cert_chain.msg or 'BotoServerError' in elb_cert_chain.msg or 'Traceback' in elb_cert_chain.msg.module_stderr"
   when:
   - openshift_aws_create_iam_cert | bool
   - openshift_aws_iam_cert_path != ''
   - openshift_aws_iam_cert_key_path != ''
   - openshift_aws_elb_cert_arn == ''
+
+- debug: msg="{{ elb_cert_chain }}"
 
 - name: set_fact openshift_aws_elb_cert_arn
   set_fact:

--- a/roles/openshift_aws/tasks/provision.yml
+++ b/roles/openshift_aws/tasks/provision.yml
@@ -34,14 +34,14 @@
   include: elb.yml
   vars:
     openshift_aws_elb_direction: internal
-    openshift_aws_elb_name: "{{ openshift_aws_clusterid }}-{{openshift_aws_node_group_type }}-internal"
+    l_openshift_aws_elb_name: "{{ openshift_aws_elb_name }}-internal"
     openshift_aws_elb_scheme: internal
 
 - name: create our master external load balancers
   include: elb.yml
   vars:
     openshift_aws_elb_direction: external
-    openshift_aws_elb_name: "{{ openshift_aws_clusterid }}-{{openshift_aws_node_group_type }}-external"
+    l_openshift_aws_elb_name: "{{ openshift_aws_elb_name }}-external"
     openshift_aws_elb_scheme: internet-facing
 
 - name: wait for ssh to become available


### PR DESCRIPTION
This commit fixes some provisioning variables.

It also adjusts a failure condition for an
ec2 call, which may fail silently without having
the necessary permissions, which creates an
unrelated error message later in the run.