### PR TITLE
block 3.6->3.7 upgrade if storage backend is not set to etcd3

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
@@ -21,6 +21,10 @@
   tags:
   - pre_upgrade
 
+- include: ../pre/verify_etcd3_backend.yml
+  tags:
+  - pre_upgrade
+
 - name: Update repos and initialize facts on all hosts
   hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config:oo_lb_to_config
   tags:


### PR DESCRIPTION
Bug: 1497168

Complementing https://github.com/openshift/openshift-ansible/pull/5520