### PR TITLE
move health-checks and control-plane-verification before excluders

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
@@ -55,6 +55,10 @@
   tags:
   - pre_upgrade
 
+- include: ../pre/verify_control_plane_running.yml
+  tags:
+  - pre_upgrade
+
 - include: ../disable_master_excluders.yml
   tags:
   - pre_upgrade
@@ -74,10 +78,6 @@
     # docker restarts. At this early stage of upgrade we can assume
     # docker is configured and running.
     skip_docker_role: True
-
-- include: ../pre/verify_control_plane_running.yml
-  tags:
-  - pre_upgrade
 
 - include: ../../../openshift-master/validate_restart.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
@@ -55,6 +55,14 @@
   tags:
   - pre_upgrade
 
+- include: ../pre/verify_health_checks.yml
+  tags:
+  - pre_upgrade
+
+- include: ../pre/verify_control_plane_running.yml
+  tags:
+  - pre_upgrade
+
 - include: ../disable_master_excluders.yml
   tags:
   - pre_upgrade
@@ -74,14 +82,6 @@
     # docker restarts. At this early stage of upgrade we can assume
     # docker is configured and running.
     skip_docker_role: True
-
-- include: ../pre/verify_health_checks.yml
-  tags:
-  - pre_upgrade
-
-- include: ../pre/verify_control_plane_running.yml
-  tags:
-  - pre_upgrade
 
 - include: ../../../openshift-master/validate_restart.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
@@ -48,6 +48,10 @@
   tags:
   - pre_upgrade
 
+- include: ../pre/verify_health_checks.yml
+  tags:
+  - pre_upgrade
+
 - include: ../disable_node_excluders.yml
   tags:
   - pre_upgrade
@@ -67,10 +71,6 @@
     # docker restarts. At this early stage of upgrade we can assume
     # docker is configured and running.
     skip_docker_role: True
-
-- include: ../pre/verify_health_checks.yml
-  tags:
-  - pre_upgrade
 
 - name: Verify masters are already upgraded
   hosts: oo_masters_to_config

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -59,6 +59,14 @@
   tags:
   - pre_upgrade
 
+- include: ../pre/verify_health_checks.yml
+  tags:
+  - pre_upgrade
+
+- include: ../pre/verify_control_plane_running.yml
+  tags:
+  - pre_upgrade
+
 - include: ../disable_master_excluders.yml
   tags:
   - pre_upgrade
@@ -78,14 +86,6 @@
     # docker restarts. At this early stage of upgrade we can assume
     # docker is configured and running.
     skip_docker_role: True
-
-- include: ../pre/verify_health_checks.yml
-  tags:
-  - pre_upgrade
-
-- include: ../pre/verify_control_plane_running.yml
-  tags:
-  - pre_upgrade
 
 - include: ../../../openshift-master/validate_restart.yml
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_nodes.yml
@@ -48,6 +48,10 @@
   tags:
   - pre_upgrade
 
+- include: ../pre/verify_health_checks.yml
+  tags:
+  - pre_upgrade
+
 - include: ../disable_node_excluders.yml
   tags:
   - pre_upgrade
@@ -67,10 +71,6 @@
     # docker restarts. At this early stage of upgrade we can assume
     # docker is configured and running.
     skip_docker_role: True
-
-- include: ../pre/verify_health_checks.yml
-  tags:
-  - pre_upgrade
 
 - name: Verify masters are already upgraded
   hosts: oo_masters_to_config


### PR DESCRIPTION
Complements: https://github.com/openshift/openshift-ansible/pull/5413

Moving pre-checks sooner in the pure control-plane/node upgrade playbooks.