### PR TITLE
[3.6] Fix registry auth variable

### DIFF
--- a/roles/openshift_node/tasks/registry_auth.yml
+++ b/roles/openshift_node/tasks/registry_auth.yml
@@ -21,4 +21,4 @@
   when:
     - openshift.common.is_containerized | bool
     - oreg_auth_user is defined
-    - (node_oreg_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace or oreg_auth_credentials_replace.changed) | bool
+    - (node_oreg_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace or node_oreg_auth_credentials_create.changed) | bool

--- a/roles/openshift_node_upgrade/tasks/registry_auth.yml
+++ b/roles/openshift_node_upgrade/tasks/registry_auth.yml
@@ -21,4 +21,4 @@
   when:
     - openshift.common.is_containerized | bool
     - oreg_auth_user is defined
-    - (node_oreg_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace or oreg_auth_credentials_replace.changed) | bool
+    - (node_oreg_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace or node_oreg_auth_credentials_create.changed) | bool


### PR DESCRIPTION
There is currently a bug in registry auth
credential creation logic for openshift_node
and openshift_node_upgrade

This commit fixes the logic.

(cherry picked from commit 823d4c4e18d33cbb6dcffb122b8cc80b8766b7dd)

Backports: https://github.com/openshift/openshift-ansible/pull/5595