### PR TITLE
openshift_node: Set DOCKER_SERVICE for system container

### DIFF
--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -11,4 +11,5 @@
     image: "{{ 'docker:' if openshift.common.system_images_registry == 'docker' else openshift.common.system_images_registry + '/' }}{{ openshift.node.node_system_image }}:{{ openshift_image_tag }}"
     values:
     - "DNS_DOMAIN={{ openshift.common.dns_domain }}"
+    - "DOCKER_SERVICE={{ openshift.docker.service_name }}.service"
     state: latest

--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -12,4 +12,5 @@
     values:
     - "DNS_DOMAIN={{ openshift.common.dns_domain }}"
     - "DOCKER_SERVICE={{ openshift.docker.service_name }}.service"
+    - "MASTER_SERVICE={{ openshift.common.service_type }}.service"
     state: latest


### PR DESCRIPTION
The node system container was being installed with the ```DOCKER_SERVICE```
holding to it's ```manifest.json``` default of docker.service. This chage
adds the ```DOCKER_SERVICE``` parameter on node system container install
so that it uses the same value from the installer stored in
```openshift.docker.service_name```.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1496707