### PR TITLE
Reverting using uninstall variables for logging and metrics

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -8,7 +8,6 @@ openshift_logging_labels: {}
 openshift_logging_label_key: ""
 openshift_logging_label_value: ""
 openshift_logging_install_logging: False
-openshift_logging_uninstall_logging: False
 
 openshift_logging_purge_logging: False
 openshift_logging_image_pull_secret: ""

--- a/roles/openshift_logging/tasks/main.yaml
+++ b/roles/openshift_logging/tasks/main.yaml
@@ -36,7 +36,7 @@
 
 - include: delete_logging.yaml
   when:
-    - openshift_logging_uninstall_logging | default(false) | bool
+    - not openshift_logging_install_logging | default(false) | bool
 
 - name: Cleaning up local temp dir
   local_action: file path="{{local_tmp.stdout}}" state=absent

--- a/roles/openshift_metrics/defaults/main.yaml
+++ b/roles/openshift_metrics/defaults/main.yaml
@@ -1,7 +1,6 @@
 ---
 openshift_metrics_start_cluster: True
 openshift_metrics_install_metrics: False
-openshift_metrics_uninstall_metrics: False
 openshift_metrics_startup_timeout: 500
 
 openshift_metrics_hawkular_replicas: 1

--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -49,7 +49,7 @@
 
 - include: uninstall_metrics.yaml
   when:
-    - openshift_metrics_uninstall_metrics | bool
+    - not openshift_metrics_install_metrics | bool
 
 - include: uninstall_hosa.yaml
   when: not openshift_metrics_install_hawkular_agent | bool


### PR DESCRIPTION
Reverting using `uninstall` variables for logging and metrics.

Addresses bug and comments in https://bugzilla.redhat.com/show_bug.cgi?id=1496352