### PR TITLE
fix whitespace for centos repos

### DIFF
--- a/roles/openshift_repos/templates/CentOS-OpenShift-Origin.repo.j2
+++ b/roles/openshift_repos/templates/CentOS-OpenShift-Origin.repo.j2
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 [centos-openshift-origin-testing]
 name=CentOS OpenShift Origin Testing
 baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin/
-enabled={% if openshift_repos_enable_testing %}1{% else %}0{% endif %}
+enabled={{ 1 if openshift_repos_enable_testing else 0 }}
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/openshift-ansible-CentOS-SIG-PaaS
 

--- a/roles/openshift_repos/templates/CentOS-OpenShift-Origin14.repo.j2
+++ b/roles/openshift_repos/templates/CentOS-OpenShift-Origin14.repo.j2
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 [centos-openshift-origin14-testing]
 name=CentOS OpenShift Origin Testing
 baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin14/
-enabled={% if openshift_repos_enable_testing %}1{% else %}0{% endif %}
+enabled={{ 1 if openshift_repos_enable_testing else 0 }}
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 

--- a/roles/openshift_repos/templates/CentOS-OpenShift-Origin15.repo.j2
+++ b/roles/openshift_repos/templates/CentOS-OpenShift-Origin15.repo.j2
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 [centos-openshift-origin15-testing]
 name=CentOS OpenShift Origin Testing
 baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin15/
-enabled={% if openshift_repos_enable_testing %}1{% else %}0{% endif %}
+enabled={{ 1 if openshift_repos_enable_testing else 0 }}
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 

--- a/roles/openshift_repos/templates/CentOS-OpenShift-Origin36.repo.j2
+++ b/roles/openshift_repos/templates/CentOS-OpenShift-Origin36.repo.j2
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 [centos-openshift-origin36-testing]
 name=CentOS OpenShift Origin Testing
 baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin36/
-enabled={% if openshift_repos_enable_testing %}1{% else %}0{% endif %}
+enabled={{ 1 if openshift_repos_enable_testing else 0 }}
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 


### PR DESCRIPTION
This addresses an issue where repo files were missing a newline between the enabled and gpgkey entries.

Current repo file content:
```
[centos-openshift-origin]
name=CentOS OpenShift Origin
baseurl=http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/
enabled=1
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS

[centos-openshift-origin-testing]
name=CentOS OpenShift Origin Testing
baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin/
enabled=0gpgcheck=0
gpgkey=file:///etc/pki/rpm-gpg/openshift-ansible-CentOS-SIG-PaaS

[centos-openshift-origin-debuginfo]
name=CentOS OpenShift Origin DebugInfo
baseurl=http://debuginfo.centos.org/centos/7/paas/x86_64/
enabled=0
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/openshift-ansible-CentOS-SIG-PaaS

[centos-openshift-origin-source]
name=CentOS OpenShift Origin Source
baseurl=http://vault.centos.org/centos/7/paas/Source/openshift-origin/
enabled=0
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/openshift-ansible-CentOS-SIG-PaaS
```
Expected content:
```
[centos-openshift-origin]
name=CentOS OpenShift Origin
baseurl=http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/
enabled=1
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS

[centos-openshift-origin-testing]
name=CentOS OpenShift Origin Testing
baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin/
enabled=0
gpgcheck=0
gpgkey=file:///etc/pki/rpm-gpg/openshift-ansible-CentOS-SIG-PaaS

[centos-openshift-origin-debuginfo]
name=CentOS OpenShift Origin DebugInfo
baseurl=http://debuginfo.centos.org/centos/7/paas/x86_64/
enabled=0
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/openshift-ansible-CentOS-SIG-PaaS

[centos-openshift-origin-source]
name=CentOS OpenShift Origin Source
baseurl=http://vault.centos.org/centos/7/paas/Source/openshift-origin/
enabled=0
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/openshift-ansible-CentOS-SIG-PaaS
```