### PR TITLE
Used inline form of jinja if statement.

### DIFF
--- a/roles/openshift_repos/templates/CentOS-OpenShift-Origin.repo.j2
+++ b/roles/openshift_repos/templates/CentOS-OpenShift-Origin.repo.j2
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 [centos-openshift-origin-testing]
 name=CentOS OpenShift Origin Testing
 baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin/
-enabled={% if openshift_repos_enable_testing %}1{% else %}0{% endif %}
+enabled={{ 1 if openshift_repos_enable_testing else 0 }}
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/openshift-ansible-CentOS-SIG-PaaS
 

--- a/roles/openshift_repos/templates/CentOS-OpenShift-Origin14.repo.j2
+++ b/roles/openshift_repos/templates/CentOS-OpenShift-Origin14.repo.j2
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 [centos-openshift-origin14-testing]
 name=CentOS OpenShift Origin Testing
 baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin14/
-enabled={% if openshift_repos_enable_testing %}1{% else %}0{% endif %}
+enabled={{ 1 if openshift_repos_enable_testing else 0 }}
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 

--- a/roles/openshift_repos/templates/CentOS-OpenShift-Origin15.repo.j2
+++ b/roles/openshift_repos/templates/CentOS-OpenShift-Origin15.repo.j2
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 [centos-openshift-origin15-testing]
 name=CentOS OpenShift Origin Testing
 baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin15/
-enabled={% if openshift_repos_enable_testing %}1{% else %}0{% endif %}
+enabled={{ 1 if openshift_repos_enable_testing else 0 }}
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 

--- a/roles/openshift_repos/templates/CentOS-OpenShift-Origin36.repo.j2
+++ b/roles/openshift_repos/templates/CentOS-OpenShift-Origin36.repo.j2
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 [centos-openshift-origin36-testing]
 name=CentOS OpenShift Origin Testing
 baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin36/
-enabled={% if openshift_repos_enable_testing %}1{% else %}0{% endif %}
+enabled={{ 1 if openshift_repos_enable_testing else 0 }}
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
 


### PR DESCRIPTION
- This fixes the problem where the `enabled` and `gpgcheck` params are joined
  on the same line: `enabled=0gpgcheck=0`

To force the new line, an alternative could also be:

enabled={% if openshift_repos_enable_testing %}1
{% else %}0
{% endif %}