### PR TITLE
Fix the prometheus byo playbook

### DIFF
--- a/playbooks/byo/openshift-cluster/openshift-prometheus.yml
+++ b/playbooks/byo/openshift-cluster/openshift-prometheus.yml
@@ -1,4 +1,11 @@
 ---
 - include: initialize_groups.yml
 
-- include: ../../common/openshift-cluster/openshift_prometheus.yml
+- include: ../../common/openshift-cluster/std_include.yml
+
+- name: OpenShift Prometheus
+  hosts: oo_first_master
+  roles:
+  - openshift_prometheus
+  vars:
+    openshift_prometheus_state: present


### PR DESCRIPTION
Recently the include of common/openshift-cluester/std_include.yml has been removed from openshift_prometheus.yml and moved to openshift_hosted.yml. (commit 82d61ae9e23c2ae1f722ed3b458a6e39721e71fd)

This caused openshift-prometheus.yml byo playbook that uses common/openshift-cluster/poenshift_prometheus.yml not to work.
I also want this playbook to always install prometheus, and not base on a variable that is false by default.
Not sure this is the best practice fix, but it works.