### PR TITLE
Fix Prometheus byo entry point

### DIFF
--- a/playbooks/byo/openshift-cluster/openshift-prometheus.yml
+++ b/playbooks/byo/openshift-cluster/openshift-prometheus.yml
@@ -1,4 +1,6 @@
 ---
 - include: initialize_groups.yml
 
+- include: ../../common/openshift-cluster/std_include.yml
+
 - include: ../../common/openshift-cluster/openshift_prometheus.yml

--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -23,6 +23,7 @@
 - include: cockpit-ui.yml
 
 - include: openshift_prometheus.yml
+  when: openshift_hosted_prometheus_deploy | default(False) | bool
 
 - name: Hosted Install Checkpoint End
   hosts: localhost

--- a/playbooks/common/openshift-cluster/openshift_prometheus.yml
+++ b/playbooks/common/openshift-cluster/openshift_prometheus.yml
@@ -3,4 +3,3 @@
   hosts: oo_first_master
   roles:
   - role: openshift_prometheus
-    when: openshift_hosted_prometheus_deploy | default(False) | bool


### PR DESCRIPTION
Adds the std_include.yml playbook to the byo entrypoint and moves the conditional install to the openshift_hosted.yml portion of an install.