### PR TITLE
Restore registires to /etc/sysconfig/docker

### DIFF
--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -61,15 +61,25 @@
 - stat: path=/etc/sysconfig/docker
   register: docker_check
 
-- name: Comment old registry params in /etc/sysconfig/docker
+- name: Set registry params
   lineinfile:
     dest: /etc/sysconfig/docker
     regexp: '^{{ item.reg_conf_var }}=.*$'
-    line: "#{{ item.reg_conf_var }}=''# Moved to {{ containers_registries_conf_path }}"
+    line: "{{ item.reg_conf_var }}='{{ item.reg_fact_val | oo_prepend_strings_in_list(item.reg_flag ~ ' ') | join(' ') }}'"
+  when:
+  - item.reg_fact_val != []
+  - docker_check.stat.isreg is defined
+  - docker_check.stat.isreg
   with_items:
   - reg_conf_var: ADD_REGISTRY
+    reg_fact_val: "{{ l2_docker_additional_registries }}"
+    reg_flag: --add-registry
   - reg_conf_var: BLOCK_REGISTRY
+    reg_fact_val: "{{ l2_docker_blocked_registries }}"
+    reg_flag: --block-registry
   - reg_conf_var: INSECURE_REGISTRY
+    reg_fact_val: "{{ l2_docker_insecure_registries }}"
+    reg_flag: --insecure-registry
   notify:
   - restart docker
 


### PR DESCRIPTION
Previously, a commit was added to migrate registires
from /etc/sysconfig/docker to /etc/containers/registries.conf

We are not currently enforcing a minimum version of docker
to consume from this new file, thus some installations
are not utilizing the correct repositories.

This commit duplicates the registires in both locations
to ensure additional/blocked/insecure registries are
honored.