### PR TITLE
Use etcd_ip when communicating with the cluster as a peer in etcd scaleup.

### DIFF
--- a/playbooks/common/openshift-etcd/scaleup.yml
+++ b/playbooks/common/openshift-etcd/scaleup.yml
@@ -20,7 +20,7 @@
       /usr/bin/etcdctl --cert-file {{ etcd_peer_cert_file }}
                        --key-file {{ etcd_peer_key_file }}
                        --ca-file {{ etcd_peer_ca_file }}
-                       -C {{ etcd_peer_url_scheme }}://{{ hostvars[etcd_ca_host].etcd_hostname }}:{{ etcd_client_port }}
+                       -C {{ etcd_peer_url_scheme }}://{{ hostvars[etcd_ca_host].etcd_ip }}:{{ etcd_client_port }}
                        member add {{ etcd_hostname }} {{ etcd_peer_url_scheme }}://{{ etcd_ip }}:{{ etcd_peer_port }}
     delegate_to: "{{ etcd_ca_host }}"
     failed_when:


### PR DESCRIPTION
We can't communicate with the hostname here since etcd will be [configured to listen to its IP address](https://github.com/openshift/openshift-ansible/blob/ead22bb1c3b6d6366502b14b97b7aae5605f8a58/roles/etcd/defaults/main.yaml#L69).

Fixes https://github.com/openshift/openshift-ansible/issues/5620