### PR TITLE
Limit base-package install during master upgrades

### DIFF
--- a/playbooks/common/openshift-cluster/initialize_openshift_version.yml
+++ b/playbooks/common/openshift-cluster/initialize_openshift_version.yml
@@ -1,6 +1,9 @@
 ---
+# openshift_install_base_package_group may be set in a play variable to limit
+# the host groups the base package is installed on.  This is currently used
+# for master/control-plane upgrades.
 - name: Set version_install_base_package true on masters and nodes
-  hosts: oo_masters_to_config:oo_nodes_to_config
+  hosts: "{{ openshift_install_base_package_group | default('oo_masters_to_config:oo_nodes_to_config') }}"
   tasks:
   - name: Set version_install_base_package true
     set_fact:

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
@@ -68,6 +68,7 @@
     # defined, and overriding the normal behavior of protecting the installed version
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
+    openshift_install_base_package_group: "oo_masters_to_config"
 
     # We skip the docker role at this point in upgrade to prevent
     # unintended package, container, or config upgrades which trigger

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
@@ -68,6 +68,7 @@
     # defined, and overriding the normal behavior of protecting the installed version
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
+    openshift_install_base_package_group: "oo_masters_to_config"
 
     # We skip the docker role at this point in upgrade to prevent
     # unintended package, container, or config upgrades which trigger

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
@@ -72,6 +72,7 @@
     # defined, and overriding the normal behavior of protecting the installed version
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
+    openshift_install_base_package_group: "oo_masters_to_config"
 
     # We skip the docker role at this point in upgrade to prevent
     # unintended package, container, or config upgrades which trigger

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
@@ -76,6 +76,7 @@
     # defined, and overriding the normal behavior of protecting the installed version
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
+    openshift_install_base_package_group: "oo_masters_to_config"
 
     # We skip the docker role at this point in upgrade to prevent
     # unintended package, container, or config upgrades which trigger

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -80,6 +80,7 @@
     # defined, and overriding the normal behavior of protecting the installed version
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
+    openshift_install_base_package_group: "oo_masters_to_config"
 
     # We skip the docker role at this point in upgrade to prevent
     # unintended package, container, or config upgrades which trigger


### PR DESCRIPTION
Currently, openshift_version installs RPM packages
on all nodes and masters to aid in determining and
setting the proper version across the cluster.

This commit limits the host groups to only
masters during upgrade_control_plane plays.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1495107