### PR TITLE
Limit hosts that run openshift_version role

### DIFF
--- a/playbooks/common/openshift-cluster/initialize_openshift_version.yml
+++ b/playbooks/common/openshift-cluster/initialize_openshift_version.yml
@@ -16,8 +16,8 @@
 # NOTE: We set this even on etcd hosts as they may also later run as masters,
 # and we don't want to install wrong version of docker and have to downgrade
 # later.
-- name: Set openshift_version for all hosts
-  hosts: oo_all_hosts:!oo_first_master
+- name: Set openshift_version for etcd, node, and master hosts
+  hosts: oo_etcd_to_config:oo_nodes_to_config:oo_masters_to_config:!oo_first_master
   vars:
     openshift_version: "{{ hostvars[groups.oo_first_master.0].openshift_version }}"
   pre_tasks:


### PR DESCRIPTION
Currently, the openshift_version role is run against
the oo_all_hosts group.  This causes the dependencies,
such as openshift_docker and docker, to be run against
host groups that were not intended, such as nfs.

This commit explicitly limits the openshift_version
role to run only against masters, nodes, and etcd
host groups.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1497144