### PR TITLE
Move docker install to std_include

### DIFF
--- a/playbooks/aws/openshift-cluster/build_ami.yml
+++ b/playbooks/aws/openshift-cluster/build_ami.yml
@@ -62,9 +62,13 @@
 
 - name: run the std_include
   include: ../../common/openshift-cluster/initialize_facts.yml
+  vars:
+    openshift_setup_docker: True
 
-- name: run the std_include
+- name: run the openshift_repos
   include: ../../common/openshift-cluster/initialize_openshift_repos.yml
+
+- include: ../../common/openshift-cluster/setup_docker.yml
 
 - name: run node config setup
   include: ../../common/openshift-node/setup.yml

--- a/playbooks/byo/openshift-cluster/config.yml
+++ b/playbooks/byo/openshift-cluster/config.yml
@@ -1,11 +1,9 @@
 ---
 - include: initialize_groups.yml
-  tags:
-  - always
 
 - include: ../../common/openshift-cluster/std_include.yml
-  tags:
-  - always
+  vars:
+    openshift_setup_docker: True
 
 - include: ../../common/openshift-cluster/config.yml
   vars:

--- a/playbooks/common/openshift-cluster/initialize_docker_facts.yml
+++ b/playbooks/common/openshift-cluster/initialize_docker_facts.yml
@@ -1,0 +1,14 @@
+---
+- name: Setup Docker - Masters and Nodes
+  hosts: oo_masters_to_config:oo_nodes_to_config
+  roles:
+  - role: openshift_docker_facts
+
+- name: Setup Docker - etcd hosts
+  hosts: oo_etcd_to_config
+  roles:
+  - role: openshift_docker_facts
+    when:
+    - openshift.common.is_containerized | default(False) | bool
+    - "'oo_masters_to_config' not in group_names"
+    - "'oo_nodes_to_config' not in group_names"

--- a/playbooks/common/openshift-cluster/initialize_facts.yml
+++ b/playbooks/common/openshift-cluster/initialize_facts.yml
@@ -154,3 +154,8 @@
   - name: initialize_facts set_fact on openshift_docker_hosted_registry_network
     set_fact:
       openshift_docker_hosted_registry_network: "{{ '' if 'oo_first_master' not in groups else hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
+
+# If we don't run setup_docker, we need to ensure we gather some facts
+# for other roles and plays.
+- include: initialize_docker_facts.yml
+  when: (not openshift_setup_docker | default(False) | bool) or (skip_docker_role | default(False) | bool)

--- a/playbooks/common/openshift-cluster/setup_docker.yml
+++ b/playbooks/common/openshift-cluster/setup_docker.yml
@@ -1,0 +1,21 @@
+---
+- name: Setup Docker - Masters and Nodes
+  hosts: oo_masters_to_config:oo_nodes_to_config
+  roles:
+  - role: openshift_docker
+    when: not skip_docker_role | default(False) | bool
+
+- name: Setup Docker - etcd hosts
+  hosts: oo_etcd_to_config
+  roles:
+  - role: openshift_docker_facts
+    when:
+    - not skip_docker_role | default(False) | bool
+    - "'oo_masters_to_config' not in group_names"
+    - "'oo_nodes_to_config' not in group_names"
+  - role: docker
+    when:
+    - not skip_docker_role | default(False) | bool
+    - openshift.common.is_containerized | default(False) | bool
+    - "'oo_masters_to_config' not in group_names"
+    - "'oo_nodes_to_config' not in group_names"

--- a/playbooks/common/openshift-cluster/std_include.yml
+++ b/playbooks/common/openshift-cluster/std_include.yml
@@ -13,28 +13,22 @@
       aggregate: false
 
 - include: evaluate_groups.yml
-  tags:
-  - always
 
 - include: initialize_facts.yml
-  tags:
-  - always
 
 - include: sanity_checks.yml
-  tags:
-  - always
 
 - include: validate_hostnames.yml
-  tags:
-  - node
 
 - include: initialize_openshift_repos.yml
-  tags:
-  - always
+
+# openshift_setup_docker should be set a include task's variable.
+# We only need to run setup_docker on first cluster install.
+# We set openshift_setup_docker to True in playbooks/byo/openshift-cluster/config.yml
+- include: setup_docker.yml
+  when: openshift_setup_docker | default(False) | bool
 
 - include: initialize_openshift_version.yml
-  tags:
-  - always
 
 - name: Initialization Checkpoint End
   hosts: localhost

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -190,9 +190,6 @@
   - { role: openshift_cli }
   vars:
     openshift_docker_hosted_registry_network: "{{ hostvars[groups.oo_first_master.0].openshift.common.portal_net }}"
-    # Another spot where we assume docker is running and do not want to accidentally trigger an unsafe
-    # restart.
-    skip_docker_role: True
   tasks:
   - name: Reconcile Cluster Roles
     command: >

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade.yml
@@ -65,12 +65,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - include: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
@@ -69,12 +69,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - include: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_nodes.yml
@@ -62,12 +62,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - name: Verify masters are already upgraded
   hosts: oo_masters_to_config
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade.yml
@@ -65,12 +65,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - include: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
@@ -69,12 +69,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - include: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_nodes.yml
@@ -62,12 +62,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - name: Verify masters are already upgraded
   hosts: oo_masters_to_config
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade.yml
@@ -69,12 +69,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - include: ../../../openshift-master/validate_restart.yml
   tags:
   - pre_upgrade

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
@@ -73,12 +73,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - include: ../../../openshift-master/validate_restart.yml
   tags:
   - pre_upgrade

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_nodes.yml
@@ -62,12 +62,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - name: Verify masters are already upgraded
   hosts: oo_masters_to_config
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
@@ -73,12 +73,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - include: ../../../openshift-master/validate_restart.yml
   tags:
   - pre_upgrade

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
@@ -77,12 +77,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - include: ../../../openshift-master/validate_restart.yml
   tags:
   - pre_upgrade

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
@@ -66,12 +66,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - name: Verify masters are already upgraded
   hosts: oo_masters_to_config
   tags:

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
@@ -77,12 +77,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - include: ../../../openshift-master/validate_restart.yml
   tags:
   - pre_upgrade

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -81,12 +81,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - include: ../../../openshift-master/validate_restart.yml
   tags:
   - pre_upgrade

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_nodes.yml
@@ -66,12 +66,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-    # We skip the docker role at this point in upgrade to prevent
-    # unintended package, container, or config upgrades which trigger
-    # docker restarts. At this early stage of upgrade we can assume
-    # docker is configured and running.
-    skip_docker_role: True
-
 - name: Verify masters are already upgraded
   hosts: oo_masters_to_config
   tags:

--- a/roles/openshift_cli/meta/main.yml
+++ b/roles/openshift_cli/meta/main.yml
@@ -12,6 +12,4 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
-- role: openshift_docker
-  when: not skip_docker_role | default(False) | bool
 - role: openshift_facts

--- a/roles/openshift_etcd/meta/main.yml
+++ b/roles/openshift_etcd/meta/main.yml
@@ -14,6 +14,4 @@ galaxy_info:
 dependencies:
 - role: openshift_etcd_facts
 - role: openshift_clock
-- role: openshift_docker
-  when: openshift.common.is_containerized | bool
 - role: etcd

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -16,6 +16,5 @@ dependencies:
 - role: lib_openshift
 - role: lib_os_firewall
 - role: openshift_clock
-- role: openshift_docker
 - role: openshift_cloud_provider
 - role: openshift_node_dnsmasq

--- a/roles/openshift_version/meta/main.yml
+++ b/roles/openshift_version/meta/main.yml
@@ -12,7 +12,4 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
-- role: openshift_docker_facts
-- role: docker
-  when: openshift.common.is_containerized | default(False) | bool and not skip_docker_role | default(False) | bool
 - role: lib_utils


### PR DESCRIPTION
Currently, docker is potentially installed as a dependency
of various roles or plays.

This commit ensures configured only once during a
cluster installation.  On subsequent runs of different
plays (such as configuring logging), the docker role
will not be run by default.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1488833