### PR TITLE
Fix hosted selector variable migration

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -707,11 +707,6 @@ def oo_openshift_env(hostvars):
         if regex.match(key):
             facts[key] = hostvars[key]
 
-    migrations = {'openshift_router_selector': 'openshift_hosted_router_selector',
-                  'openshift_registry_selector': 'openshift_hosted_registry_selector'}
-    for old_fact, new_fact in migrations.items():
-        if old_fact in facts and new_fact not in facts:
-            facts[new_fact] = facts[old_fact]
     return facts
 
 

--- a/roles/openshift_hosted_facts/tasks/main.yml
+++ b/roles/openshift_hosted_facts/tasks/main.yml
@@ -1,9 +1,11 @@
 ---
+# openshift_*_selector variables have been deprecated in favor of
+# openshift_hosted_*_selector variables.
 - set_fact:
-    openshift_hosted_router_selector: "{{ openshift_hosted_infra_selector }}"
+    openshift_hosted_router_selector: "{{ openshift_router_selector | default(openshift_hosted_infra_selector) }}"
   when: openshift_hosted_router_selector is not defined and openshift_hosted_infra_selector is defined
 - set_fact:
-    openshift_hosted_registry_selector: "{{ openshift_hosted_infra_selector }}"
+    openshift_hosted_registry_selector: "{{ openshift_registry_selector | default(openshift_hosted_infra_selector) }}"
   when: openshift_hosted_registry_selector is not defined and openshift_hosted_infra_selector is defined
 
 - name: Set hosted facts


### PR DESCRIPTION
Currently, if undefined, openshift_hosted_router_selector and
openshift_hosted_registry_selector as set to the value
of openshift_hosted_infra_selector.

The set_fact logic overrides variable migration inside of
oo_filters meant to utilize the deprecated variables
openshift_router_selector and openshift_registiry_selector,
respectively.

This commit corrects the set_fact logic and removes the
unused migration from oo_filters.

Fixes: https://github.com/openshift/openshift-ansible/issues/5615