### PR TITLE
Adding support for an inventory directory/hybrid inventory

### DIFF
--- a/images/installer/README_CONTAINER_IMAGE.md
+++ b/images/installer/README_CONTAINER_IMAGE.md
@@ -46,3 +46,5 @@ These options may be set via the ``atomic`` ``--set`` flag. For defaults see ``r
 * ANSIBLE_CONFIG - Full path for the ansible configuration file to use inside the container
 
 * INVENTORY_FILE - Full path for the inventory to use from the host
+
+* INVENTORY_DIR - Full path for the inventory directory to use (e.g. for use with a hybrid dynamic/static inventory)

--- a/images/installer/root/usr/local/bin/run
+++ b/images/installer/root/usr/local/bin/run
@@ -19,6 +19,9 @@ if [[ -v INVENTORY_FILE ]]; then
   # Make a copy so that ALLOW_ANSIBLE_CONNECTION_LOCAL below
   # does not attempt to modify the original
   cp -a ${INVENTORY_FILE} ${INVENTORY}
+elif [[ -v INVENTORY_DIR ]]; then
+  INVENTORY="$(mktemp -d)"
+  cp -R ${INVENTORY_DIR}/* ${INVENTORY}
 elif [[ -v INVENTORY_URL ]]; then
   curl -o ${INVENTORY} ${INVENTORY_URL}
 elif [[ -v DYNAMIC_SCRIPT_URL ]]; then
@@ -29,7 +32,7 @@ elif [[ -v GENERATE_INVENTORY ]]; then
   /usr/local/bin/generate ${INVENTORY}
 else
   echo
-  echo "One of INVENTORY_FILE, INVENTORY_URL, GENERATE_INVENTORY, or DYNAMIC_SCRIPT_URL must be provided."
+  echo "One of INVENTORY_FILE, INVENTORY_DIR, INVENTORY_URL, GENERATE_INVENTORY, or DYNAMIC_SCRIPT_URL must be provided."
   exec /usr/local/bin/usage
 fi
 INVENTORY_ARG="-i ${INVENTORY}"


### PR DESCRIPTION
We often support more advanced installations that require the use of a directory as inventory rather than just a single `hosts` file. This run script addition supports this.

@sdodson @oybed 