### PR TITLE
Add OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,12 @@
+# approval == this is a good idea /approve
+approvers:
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/docs/openshift_components.md
+++ b/docs/openshift_components.md
@@ -7,6 +7,7 @@
 Components in OpenShift-Ansible consist of two main parts:
 * Entry point playbook(s)
 * Ansible role
+* OWNERS files in both the playbooks and roles associated with the component
 
 When writing playbooks and roles, follow these basic guidelines to ensure
 success and maintainability. 
@@ -48,6 +49,7 @@ playbooks/openshift-component_name
 ├── private
 │   ├── config.yml                      Included by the Cluster Installer
 │   └── roles -> ../../roles            Don't forget to create this symlink
+├── OWNERS                              Assign 2-3 approvers and reviewers
 └── README.md                           Tell us what this component does
 ```
 
@@ -108,6 +110,7 @@ roles/openshift_component_name
 │   └── main.yml
 ├── meta
 │   └── main.yml
+├── OWNERS                              Assign 2-3 approvers and reviewers
 ├── README.md
 ├── tasks
 │   └── main.yml                        Default playbook used when calling the role

--- a/playbooks/aws/OWNERS
+++ b/playbooks/aws/OWNERS
@@ -1,0 +1,16 @@
+# approval == this is a good idea /approve
+approvers:
+  - kwoodson
+  - abutcher
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - kwoodson
+  - abutcher
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/playbooks/cluster-operator/OWNERS
+++ b/playbooks/cluster-operator/OWNERS
@@ -1,0 +1,10 @@
+# approval == this is a good idea /approve
+approvers:
+  - abutcher
+  - dgoodwin
+  - csrwng
+# review == this code is good /lgtm
+reviewers:
+  - abutcher
+  - dgoodwin
+  - csrwng

--- a/playbooks/gcp/OWNERS
+++ b/playbooks/gcp/OWNERS
@@ -1,0 +1,14 @@
+# approval == this is a good idea /approve
+approvers:
+  - smarterclayton
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - smarterclayton
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/playbooks/openshift-checks/OWNERS
+++ b/playbooks/openshift-checks/OWNERS
@@ -1,0 +1,14 @@
+# approval == this is a good idea /approve
+approvers:
+  - sosiouxme
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - sosiouxme
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/playbooks/openshift-descheduler/OWNERS
+++ b/playbooks/openshift-descheduler/OWNERS
@@ -1,0 +1,10 @@
+# approval == this is a good idea /approve
+approvers:
+  - aveshagarwal
+  - ingvagabund
+  - ravisantoshgudimetla
+# review == this code is good /lgtm
+reviewers:
+  - aveshagarwal
+  - ingvagabund
+  - ravisantoshgudimetla

--- a/playbooks/openshift-glusterfs/OWNERS
+++ b/playbooks/openshift-glusterfs/OWNERS
@@ -1,0 +1,14 @@
+# approval == this is a good idea /approve
+approvers:
+  - jarrpa
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - jarrpa
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/playbooks/openshift-logging/OWNERS
+++ b/playbooks/openshift-logging/OWNERS
@@ -1,0 +1,12 @@
+# approval == this is a good idea /approve
+approvers:
+  - jcantrill
+  - ewolinetz
+  - richm
+  - wozniakjan
+# review == this code is good /lgtm
+reviewers:
+  - jcantrill
+  - ewolinetz
+  - richm
+  - wozniakjan

--- a/playbooks/openshift-metrics/OWNERS
+++ b/playbooks/openshift-metrics/OWNERS
@@ -1,0 +1,16 @@
+# approval == this is a good idea /approve
+approvers:
+  - ewolinetz
+  - jcantrill
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - ewolinetz
+  - jcantrill
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/playbooks/openshift-monitoring/OWNERS
+++ b/playbooks/openshift-monitoring/OWNERS
@@ -1,0 +1,12 @@
+# approval == this is a good idea /approve
+approvers:
+  - ironcladlou
+  - elad661
+  - mxinden
+  - brancz
+# review == this code is good /lgtm
+reviewers:
+  - ironcladlou
+  - elad661
+  - mxinden
+  - brancz

--- a/playbooks/openshift-node-problem-detector/OWNERS
+++ b/playbooks/openshift-node-problem-detector/OWNERS
@@ -1,0 +1,10 @@
+# approval == this is a good idea /approve
+approvers:
+  - ironcladlou
+  - joelsmith
+  - ingvagabund
+# review == this code is good /lgtm
+reviewers:
+  - ironcladlou
+  - joelsmith
+  - ingvagabund

--- a/playbooks/openshift-prometheus/OWNERS
+++ b/playbooks/openshift-prometheus/OWNERS
@@ -1,0 +1,16 @@
+# approval == this is a good idea /approve
+approvers:
+  - zgalor
+  - pgier
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - zgalor
+  - pgier
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/playbooks/openshift-service-catalog/OWNERS
+++ b/playbooks/openshift-service-catalog/OWNERS
@@ -1,0 +1,16 @@
+# approval == this is a good idea /approve
+approvers:
+  - jpeeler
+  - jboyd01
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - jpeeler
+  - jboyd01
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/playbooks/openshift-web-console/OWNERS
+++ b/playbooks/openshift-web-console/OWNERS
@@ -1,0 +1,14 @@
+# approval == this is a good idea /approve
+approvers:
+  - spadgett
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - spadgett
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/playbooks/openstack/OWNERS
+++ b/playbooks/openstack/OWNERS
@@ -1,0 +1,8 @@
+# approval == this is a good idea /approve
+approvers:
+  - tomassedovic
+  - tzumainn
+# review == this code is good /lgtm
+reviewers:
+  - tomassedovic
+  - tzumainn

--- a/roles/ansible_service_broker/OWNERS
+++ b/roles/ansible_service_broker/OWNERS
@@ -1,0 +1,18 @@
+# approval == this is a good idea /approve
+approvers:
+  - fabianvf
+  - dymurray
+  - shawn-hurley
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - fabianvf
+  - dymurray
+  - shawn-hurley
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/roles/kuryr/OWNERS
+++ b/roles/kuryr/OWNERS
@@ -1,0 +1,8 @@
+# approval == this is a good idea /approve
+approvers:
+  - tomassedovic
+  - tzumainn
+# review == this code is good /lgtm
+reviewers:
+  - tomassedovic
+  - tzumainn

--- a/roles/openshift_aws/OWNERS
+++ b/roles/openshift_aws/OWNERS
@@ -1,0 +1,16 @@
+# approval == this is a good idea /approve
+approvers:
+  - kwoodson
+  - abutcher
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - kwoodson
+  - abutcher
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/roles/openshift_builddefaults/OWNERS
+++ b/roles/openshift_builddefaults/OWNERS
@@ -1,0 +1,14 @@
+# approval == this is a good idea /approve
+approvers:
+  - bparees
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - bparees
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/roles/openshift_buildoverrides/OWNERS
+++ b/roles/openshift_buildoverrides/OWNERS
@@ -1,0 +1,14 @@
+# approval == this is a good idea /approve
+approvers:
+  - bparees
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - bparees
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/roles/openshift_ca/OWNERS
+++ b/roles/openshift_ca/OWNERS
@@ -1,0 +1,14 @@
+# approval == this is a good idea /approve
+approvers:
+  - abutcher
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - abutcher
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/roles/openshift_certificate_expiry/OWNERS
+++ b/roles/openshift_certificate_expiry/OWNERS
@@ -1,0 +1,14 @@
+# approval == this is a good idea /approve
+approvers:
+  - abutcher
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - abutcher
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/roles/openshift_cfme/OWNERS
+++ b/roles/openshift_cfme/OWNERS
@@ -1,0 +1,12 @@
+# approval == this is a good idea /approve
+approvers:
+  - jcantrill
+  - ewolinetz
+  - sdodson
+# review == this code is good /lgtm
+reviewers:
+  - jcantrill
+  - ewolinetz
+  - richm
+  - wozniakjan
+  - zgalor

--- a/roles/openshift_cluster_monitoring_operator/OWNERS
+++ b/roles/openshift_cluster_monitoring_operator/OWNERS
@@ -1,0 +1,12 @@
+# approval == this is a good idea /approve
+approvers:
+  - ironcladlou
+  - elad661
+  - mxinden
+  - brancz
+# review == this code is good /lgtm
+reviewers:
+  - ironcladlou
+  - elad661
+  - mxinden
+  - brancz

--- a/roles/openshift_daemonset_config/OWNERS
+++ b/roles/openshift_daemonset_config/OWNERS
@@ -1,0 +1,16 @@
+# approval == this is a good idea /approve
+approvers:
+  - kwoodson
+  - abutcher
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - kwoodson
+  - abutcher
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/roles/openshift_descheduler/OWNERS
+++ b/roles/openshift_descheduler/OWNERS
@@ -1,0 +1,10 @@
+# approval == this is a good idea /approve
+approvers:
+  - aveshagarwal
+  - ingvagabund
+  - ravisantoshgudimetla
+# review == this code is good /lgtm
+reviewers:
+  - aveshagarwal
+  - ingvagabund
+  - ravisantoshgudimetla

--- a/roles/openshift_docker_gc/OWNERS
+++ b/roles/openshift_docker_gc/OWNERS
@@ -1,0 +1,10 @@
+# approval == this is a good idea /approve
+approvers:
+  - ashcrow
+  - kwoodson
+  - mrunalp
+# review == this code is good /lgtm
+reviewers:
+  - ashcrow
+  - kwoodson
+  - mrunalp

--- a/roles/openshift_gcp/OWNERS
+++ b/roles/openshift_gcp/OWNERS
@@ -1,0 +1,14 @@
+# approval == this is a good idea /approve
+approvers:
+  - smarterclayton
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - smarterclayton
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/roles/openshift_health_checker/OWNERS
+++ b/roles/openshift_health_checker/OWNERS
@@ -1,0 +1,14 @@
+# approval == this is a good idea /approve
+approvers:
+  - sosiouxme
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - sosiouxme
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/roles/openshift_logging/OWNERS
+++ b/roles/openshift_logging/OWNERS
@@ -1,0 +1,12 @@
+# approval == this is a good idea /approve
+approvers:
+  - jcantrill
+  - ewolinetz
+  - richm
+  - wozniakjan
+# review == this code is good /lgtm
+reviewers:
+  - jcantrill
+  - ewolinetz
+  - richm
+  - wozniakjan

--- a/roles/openshift_logging_curator/OWNERS
+++ b/roles/openshift_logging_curator/OWNERS
@@ -1,0 +1,11 @@
+# approval == this is a good idea /approve
+approvers:
+  - jcantrill
+  - ewolinetz
+  - sdodson
+# review == this code is good /lgtm
+reviewers:
+  - jcantrill
+  - ewolinetz
+  - richm
+  - wozniakjan

--- a/roles/openshift_logging_elasticsearch/OWNERS
+++ b/roles/openshift_logging_elasticsearch/OWNERS
@@ -1,0 +1,11 @@
+# approval == this is a good idea /approve
+approvers:
+  - jcantrill
+  - ewolinetz
+  - sdodson
+# review == this code is good /lgtm
+reviewers:
+  - jcantrill
+  - ewolinetz
+  - richm
+  - wozniakjan

--- a/roles/openshift_logging_eventrouter/OWNERS
+++ b/roles/openshift_logging_eventrouter/OWNERS
@@ -1,0 +1,11 @@
+# approval == this is a good idea /approve
+approvers:
+  - jcantrill
+  - ewolinetz
+  - sdodson
+# review == this code is good /lgtm
+reviewers:
+  - jcantrill
+  - ewolinetz
+  - richm
+  - wozniakjan

--- a/roles/openshift_logging_fluentd/OWNERS
+++ b/roles/openshift_logging_fluentd/OWNERS
@@ -1,0 +1,11 @@
+# approval == this is a good idea /approve
+approvers:
+  - jcantrill
+  - ewolinetz
+  - sdodson
+# review == this code is good /lgtm
+reviewers:
+  - jcantrill
+  - ewolinetz
+  - richm
+  - wozniakjan

--- a/roles/openshift_logging_kibana/OWNERS
+++ b/roles/openshift_logging_kibana/OWNERS
@@ -1,0 +1,11 @@
+# approval == this is a good idea /approve
+approvers:
+  - jcantrill
+  - ewolinetz
+  - sdodson
+# review == this code is good /lgtm
+reviewers:
+  - jcantrill
+  - ewolinetz
+  - richm
+  - wozniakjan

--- a/roles/openshift_logging_mux/OWNERS
+++ b/roles/openshift_logging_mux/OWNERS
@@ -1,0 +1,12 @@
+# approval == this is a good idea /approve
+approvers:
+  - jcantrill
+  - ewolinetz
+  - richm
+  - wozniakjan
+# review == this code is good /lgtm
+reviewers:
+  - jcantrill
+  - ewolinetz
+  - richm
+  - wozniakjan

--- a/roles/openshift_metrics/OWNERS
+++ b/roles/openshift_metrics/OWNERS
@@ -1,0 +1,10 @@
+# approval == this is a good idea /approve
+approvers:
+  - jcantrill
+  - ewolinetz
+  - jsanda
+# review == this code is good /lgtm
+reviewers:
+  - jcantrill
+  - ewolinetz
+  - jsanda

--- a/roles/openshift_named_certificates/OWNERS
+++ b/roles/openshift_named_certificates/OWNERS
@@ -1,0 +1,14 @@
+# approval == this is a good idea /approve
+approvers:
+  - abutcher
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - abutcher
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/roles/openshift_node_certificates/OWNERS
+++ b/roles/openshift_node_certificates/OWNERS
@@ -1,0 +1,14 @@
+# approval == this is a good idea /approve
+approvers:
+  - abutcher
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - abutcher
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/roles/openshift_node_problem_detector/OWNERS
+++ b/roles/openshift_node_problem_detector/OWNERS
@@ -1,0 +1,10 @@
+# approval == this is a good idea /approve
+approvers:
+  - ironcladlou
+  - joelsmith
+  - ingvagabund
+# review == this code is good /lgtm
+reviewers:
+  - ironcladlou
+  - joelsmith
+  - ingvagabund

--- a/roles/openshift_openstack/OWNERS
+++ b/roles/openshift_openstack/OWNERS
@@ -1,0 +1,8 @@
+# approval == this is a good idea /approve
+approvers:
+  - tomassedovic
+  - tzumainn
+# review == this code is good /lgtm
+reviewers:
+  - tomassedovic
+  - tzumainn

--- a/roles/openshift_prometheus/OWNERS
+++ b/roles/openshift_prometheus/OWNERS
@@ -1,0 +1,8 @@
+# approval == this is a good idea /approve
+approvers:
+  - pgier
+  - zgalor
+# review == this code is good /lgtm
+reviewers:
+  - pgier
+  - zgalor

--- a/roles/openshift_service_catalog/OWNERS
+++ b/roles/openshift_service_catalog/OWNERS
@@ -1,0 +1,16 @@
+# approval == this is a good idea /approve
+approvers:
+  - jpeeler
+  - jboyd01
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs
+# review == this code is good /lgtm
+reviewers:
+  - jpeeler
+  - jboyd01
+  - michaelgugino
+  - mtnbikenc
+  - sdodson
+  - vrutkovs

--- a/roles/openshift_storage_glusterfs/OWNERS
+++ b/roles/openshift_storage_glusterfs/OWNERS
@@ -1,0 +1,10 @@
+# approval == this is a good idea /approve
+approvers:
+  - jarrpa
+  - abutcher
+  - sdodson
+# review == this code is good /lgtm
+reviewers:
+  - jarrpa
+  - abutcher
+  - sdodson

--- a/roles/openshift_web_console/OWNERS
+++ b/roles/openshift_web_console/OWNERS
@@ -1,0 +1,10 @@
+# approval == this is a good idea /approve
+approvers:
+  - spadgett
+  - jwforres
+  - sdodson
+# review == this code is good /lgtm
+reviewers:
+  - spadgett
+  - jwforres
+  - sdodson

--- a/roles/tuned/OWNERS
+++ b/roles/tuned/OWNERS
@@ -1,0 +1,8 @@
+# approval == this is a good idea /approve
+approvers:
+  - jmencak
+  - jeremyeder
+# review == this code is good /lgtm
+reviewers:
+  - jmencak
+  - jeremyeder


### PR DESCRIPTION
Attempt to give component owners autonomy and ensure that PRs
automatically receive assigned reviewers.

Just a first pass, open to changes in the future

See https://github.com/kubernetes/test-infra/tree/master/mungegithub/mungers/approvers for description of approvers and reviewers process