### PR TITLE
[3.6] Force reconciliation of role for 3.6

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/files/shared_resource_viewer_role.yaml
+++ b/playbooks/common/openshift-cluster/upgrades/files/shared_resource_viewer_role.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: Role
+metadata:
+  name: shared-resource-viewer
+  namespace: openshift
+rules:
+- apiGroups:
+  - ""
+  - template.openshift.io
+  attributeRestrictions: null
+  resources:
+  - templates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - image.openshift.io
+  attributeRestrictions: null
+  resources:
+  - imagestreamimages
+  - imagestreams
+  - imagestreamtags
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - image.openshift.io
+  attributeRestrictions: null
+  resources:
+  - imagestreams/layers
+  verbs:
+  - get

--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -101,9 +101,16 @@
     openshift_hosted_templates_import_command: replace
 
 # Check for warnings to be printed at the end of the upgrade:
-- name: Check for warnings
+- name: Clean up and display warnings
   hosts: oo_masters_to_config
-  tasks:
+  tags:
+  - always
+  gather_facts: no
+  roles:
+  - role: openshift_excluder
+    r_openshift_excluder_action: enable
+    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
+  post_tasks:
   # Check if any masters are using pluginOrderOverride and warn if so, only for 1.3/3.3 and beyond:
   - name: grep pluginOrderOverride
     command: grep pluginOrderOverride {{ openshift.common.config_base }}/master/master-config.yaml
@@ -119,12 +126,8 @@
     - not grep_plugin_order_override | skipped
     - grep_plugin_order_override.rc == 0
 
-- name: Re-enable excluder if it was previously enabled
-  hosts: oo_masters_to_config
-  tags:
-  - always
-  gather_facts: no
-  roles:
-  - role: openshift_excluder
-    r_openshift_excluder_action: enable
-    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
+  - name: Warn if shared-resource-viewer could not be updated
+    debug:
+      msg: "WARNING the shared-resource-viewer role could not be upgraded to 3.6 spec because it's marked protected, please see https://bugzilla.redhat.com/show_bug.cgi?id=1493213"
+    when:
+    - __shared_resource_viewer_protected | default(false)

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -195,6 +195,7 @@
     # Another spot where we assume docker is running and do not want to accidentally trigger an unsafe
     # restart.
     skip_docker_role: True
+    __master_shared_resource_viewer_file: "shared_resource_viewer_role.yaml"
   tasks:
   - name: Reconcile Cluster Roles
     command: >
@@ -231,6 +232,44 @@
     - reconcile_jenkins_role_binding_result.stdout != ''
     - reconcile_jenkins_role_binding_result.rc == 0
     when: openshift.common.version_gte_3_4_or_1_4  | bool
+
+  - when: (openshift.common.version_gte_3_6 | bool) and (not openshift.common.version_gte_3_7 | bool)
+    block:
+    - name: Retrieve shared-resource-viewer
+      oc_obj:
+        state: list
+        kind: role
+        name: "shared-resource-viewer"
+        namespace: "openshift"
+      register: objout
+
+    - name: Determine if shared-resource-viewer is protected
+      set_fact:
+        __shared_resource_viewer_protected: true
+      when:
+      - "'results' in objout"
+      - "'results' in objout['results']"
+      - "'annotations' in objout['results']['results'][0]['metadata']"
+      - "'openshift.io/reconcile-protect' in objout['results']['results'][0]['metadata']['annotations']"
+      - "objout['results']['results'][0]['metadata']['annotations']['openshift.io/reconcile-protect'] == 'true'"
+
+    - copy:
+        src: "{{ item }}"
+        dest: "/tmp/{{ item }}"
+      with_items:
+      - "{{ __master_shared_resource_viewer_file }}"
+      when: __shared_resource_viewer_protected is not defined
+
+    - name: Fixup shared-resource-viewer role
+      oc_obj:
+        state: present
+        kind: role
+        name: "shared-resource-viewer"
+        namespace: "openshift"
+        files:
+        - "/tmp/{{ __master_shared_resource_viewer_file }}"
+        delete_after: true
+      when: __shared_resource_viewer_protected is not defined
 
   - name: Reconcile Security Context Constraints
     command: >

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -915,6 +915,7 @@ def set_version_facts_if_unset(facts):
                 version_gte_3_4_or_1_4 = version >= LooseVersion('1.4')
                 version_gte_3_5_or_1_5 = version >= LooseVersion('1.5')
                 version_gte_3_6 = version >= LooseVersion('3.6')
+                version_gte_3_7 = version >= LooseVersion('3.7')
             else:
                 version_gte_3_1_or_1_1 = version >= LooseVersion('3.0.2.905')
                 version_gte_3_1_1_or_1_1_1 = version >= LooseVersion('3.1.1')
@@ -923,6 +924,7 @@ def set_version_facts_if_unset(facts):
                 version_gte_3_4_or_1_4 = version >= LooseVersion('3.4')
                 version_gte_3_5_or_1_5 = version >= LooseVersion('3.5')
                 version_gte_3_6 = version >= LooseVersion('3.6')
+                version_gte_3_7 = version >= LooseVersion('3.7')
         else:
             # 'Latest' version is set to True, 'Next' versions set to False
             version_gte_3_1_or_1_1 = True
@@ -932,6 +934,7 @@ def set_version_facts_if_unset(facts):
             version_gte_3_4_or_1_4 = True
             version_gte_3_5_or_1_5 = True
             version_gte_3_6 = True
+            version_gte_3_7 = False
         facts['common']['version_gte_3_1_or_1_1'] = version_gte_3_1_or_1_1
         facts['common']['version_gte_3_1_1_or_1_1_1'] = version_gte_3_1_1_or_1_1_1
         facts['common']['version_gte_3_2_or_1_2'] = version_gte_3_2_or_1_2
@@ -939,8 +942,11 @@ def set_version_facts_if_unset(facts):
         facts['common']['version_gte_3_4_or_1_4'] = version_gte_3_4_or_1_4
         facts['common']['version_gte_3_5_or_1_5'] = version_gte_3_5_or_1_5
         facts['common']['version_gte_3_6'] = version_gte_3_6
+        facts['common']['version_gte_3_7'] = version_gte_3_7
 
-        if version_gte_3_6:
+        if version_gte_3_7:
+            examples_content_version = 'v3.7'
+        elif version_gte_3_6:
             examples_content_version = 'v3.6'
         elif version_gte_3_5_or_1_5:
             examples_content_version = 'v1.5'


### PR DESCRIPTION
This is needed because in 3.6 we cannot reconcile non-cluster roles in the
bootstrap reconciliation code.  In 3.7 this is taken care of in code.

Adds version_gte_3_7 facts and Backports https://github.com/openshift/openshift-ansible/pull/5617