### PR TITLE
Add authentication credentials to skopeo for image check

### DIFF
--- a/roles/openshift_health_checker/test/action_plugin_test.py
+++ b/roles/openshift_health_checker/test/action_plugin_test.py
@@ -94,6 +94,7 @@ def skipped(result):
     {},
 ])
 def test_action_plugin_missing_openshift_facts(plugin, task_vars, monkeypatch):
+    monkeypatch.setattr(plugin, 'load_known_checks', lambda *_: {})
     monkeypatch.setattr('openshift_health_check.resolve_checks', lambda *args: ['fake_check'])
     result = plugin.run(tmp=None, task_vars=task_vars)
 


### PR DESCRIPTION
Currently, docker_image_availability health_check
does not support authenticated registries.

This commit adds the '--creds=' option to skopeo
if needed to support authentication credentials.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1316341