### PR TITLE
copy etcd client certificates for nuage openshift monitor

### DIFF
--- a/roles/nuage_master/tasks/etcd_certificates.yml
+++ b/roles/nuage_master/tasks/etcd_certificates.yml
@@ -1,0 +1,21 @@
+---
+- name: Generate openshift etcd certs
+  become: yes
+  include_role:
+    name: etcd
+    tasks_from: client_certificates
+  vars:
+    etcd_cert_prefix: nuageEtcd-
+    etcd_cert_config_dir: "{{ cert_output_dir }}"
+    embedded_etcd: "{{ hostvars[groups.oo_first_master.0].openshift.master.embedded_etcd }}"
+    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
+    etcd_cert_subdir: "openshift-nuage-{{ openshift.common.hostname }}"
+
+
+- name: Error if etcd certs are not copied
+  stat:
+    path: "{{ item }}"
+  with_items:
+  - "{{ cert_output_dir }}/nuageEtcd-ca.crt"
+  - "{{ cert_output_dir }}/nuageEtcd-client.crt"
+  - "{{ cert_output_dir }}/nuageEtcd-client.key"

--- a/roles/nuage_master/tasks/main.yaml
+++ b/roles/nuage_master/tasks/main.yaml
@@ -81,6 +81,7 @@
     - nuage.key
     - nuage.kubeconfig
 
+- include_tasks: etcd_certificates.yml
 - include_tasks: certificates.yml
 
 - name: Install Nuage VSD user certificate
@@ -99,7 +100,16 @@
   become: yes
   template: src=nuage-node-config-daemonset.j2 dest=/etc/nuage-node-config-daemonset.yaml owner=root mode=0644
 
-- name: Add the service account to the privileged scc to have root permissions
+- name: Create Nuage Infra Pod daemon set yaml file
+  become: yes
+  template: src=nuage-infra-pod-config-daemonset.j2 dest=/etc/nuage-infra-pod-config-daemonset.yaml owner=root mode=0644
+
+- name: Add the service account to the privileged scc to have root permissions for kube-system
+  shell: oc adm policy add-scc-to-user privileged system:serviceaccount:kube-system:daemon-set-controller
+  ignore_errors: true
+  when: inventory_hostname == groups.oo_first_master.0
+
+- name: Add the service account to the privileged scc to have root permissions for openshift-infra
   shell: oc adm policy add-scc-to-user privileged system:serviceaccount:openshift-infra:daemonset-controller
   ignore_errors: true
   when: inventory_hostname == groups.oo_first_master.0
@@ -111,6 +121,11 @@
 
 - name: Spawn Nuage CNI daemon sets pod
   shell: oc create -f /etc/nuage-node-config-daemonset.yaml
+  ignore_errors: true
+  when: inventory_hostname == groups.oo_first_master.0
+
+- name: Spawn Nuage Infra daemon sets pod
+  shell: oc create -f /etc/nuage-infra-pod-config-daemonset.yaml
   ignore_errors: true
   when: inventory_hostname == groups.oo_first_master.0
 

--- a/roles/nuage_master/templates/nuage-infra-pod-config-daemonset.j2
+++ b/roles/nuage_master/templates/nuage-infra-pod-config-daemonset.j2
@@ -1,0 +1,39 @@
+# This manifest installs Nuage Infra pod on
+# each worker node in an Openshift cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: nuage-infra-ds
+  namespace: kube-system
+  labels:
+    k8s-app: nuage-infra-ds
+spec:
+  selector:
+    matchLabels:
+      k8s-app: nuage-infra-ds
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s-app: nuage-infra-ds
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+          operator: Exists
+      containers:
+        # This container spawns a Nuage Infra pod
+        # on each worker node
+        - name: install-nuage-infra
+          image: nuage/infra:{{ nuage_infra_container_image_version }}
+          command: ["/install-nuage-infra-pod.sh"]
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /var/log
+              name: log-dir
+      volumes:
+        - name: log-dir
+          hostPath:
+            path: /var/log

--- a/roles/nuage_master/templates/nuage-master-config-daemonset.j2
+++ b/roles/nuage_master/templates/nuage-master-config-daemonset.j2
@@ -37,11 +37,14 @@ data:
       nuageMonServer:
           URL: 0.0.0.0:9443
           certificateDirectory: {{ nuage_master_crt_dir }}
+          clientCA: ""
+          serverCertificate: ""
+          serverKey: ""
       # etcd config required for HA
       etcdClientConfig:
-          ca: {{ nuage_master_crt_dir }}/nuageMonCA.crt
-          certFile: {{ nuage_master_crt_dir }}/nuageMonServer.crt
-          keyFile: {{ nuage_master_crt_dir }}/master.etcd-client.key
+          ca: {{ nuage_master_crt_dir }}/nuageEtcd-ca.crt
+          certFile: {{ nuage_master_crt_dir }}/nuageEtcd-client.crt
+          keyFile: {{ nuage_master_crt_dir }}/nuageEtcd-client.key
           urls:
       {% for etcd_url in openshift.master.etcd_urls %}
               - {{ etcd_url }}

--- a/roles/nuage_master/templates/nuage-node-config-daemonset.j2
+++ b/roles/nuage_master/templates/nuage-node-config-daemonset.j2
@@ -61,6 +61,8 @@ spec:
   selector:
     matchLabels:
       k8s-app: nuage-cni-ds
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -104,6 +106,8 @@ spec:
             - mountPath: /var/log
               name: cni-log-dir
             - mountPath: {{ nuage_node_config_dsets_mount_dir }}
+              name: var-usr-share-dir
+            - mountPath: /usr/share/
               name: usr-share-dir
       volumes:
         - name: cni-bin-dir
@@ -121,9 +125,12 @@ spec:
         - name: cni-log-dir
           hostPath:
             path: /var/log
-        - name: usr-share-dir
+        - name: var-usr-share-dir
           hostPath:
             path: {{ nuage_node_config_dsets_mount_dir }}
+        - name: usr-share-dir
+          hostPath:
+            path: /usr/share/
 
 ---
 
@@ -164,7 +171,7 @@ spec:
             - name: NUAGE_PLATFORM
               value: '"kvm, k8s"'
             - name: NUAGE_K8S_SERVICE_IPV4_SUBNET
-              value: '192.168.0.0\/16'
+              value: '172.30.0.0\/16'
             - name: NUAGE_NETWORK_UPLINK_INTF
               value: "eth0"
           volumeMounts:

--- a/roles/nuage_master/vars/main.yaml
+++ b/roles/nuage_master/vars/main.yaml
@@ -26,9 +26,10 @@ nuage_master_config_dsets_mount_dir: /usr/share/
 nuage_node_config_dsets_mount_dir: /usr/share/
 nuage_cni_bin_dsets_mount_dir: /opt/cni/bin
 nuage_cni_netconf_dsets_mount_dir: /etc/cni/net.d
-nuage_monitor_container_image_version: "{{ nuage_monitor_image_version | default('v5.1.1') }}"
-nuage_vrs_container_image_version: "{{ nuage_vrs_image_version | default('v5.1.1') }}"
-nuage_cni_container_image_version: "{{ nuage_cni_image_version | default('v5.1.1') }}"
+nuage_monitor_container_image_version: "{{ nuage_monitor_image_version | default('v5.2.1') }}"
+nuage_vrs_container_image_version: "{{ nuage_vrs_image_version | default('v5.2.1') }}"
+nuage_cni_container_image_version: "{{ nuage_cni_image_version | default('v5.2.1') }}"
+nuage_infra_container_image_version: "{{ nuage_infra_image_version | default('v5.2.1') }}"
 api_server_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
 nuage_vport_mtu: "{{ nuage_interface_mtu | default('1460') }}"
 master_host_type: "{{ master_base_host_type | default('is_rhel_server') }}"


### PR DESCRIPTION
Nuage OpenShift Monitor requires etcd client certificates to talk to etcd. This PR helps in copying the certificates to the node where monitor is running and configures the input parameters accordingly.