### PR TITLE
Add enclosing <store> tags to sample secure-forward.conf files

### DIFF
--- a/roles/openshift_logging_fluentd/files/secure-forward.conf
+++ b/roles/openshift_logging_fluentd/files/secure-forward.conf
@@ -1,3 +1,4 @@
+# <store>
 # @type secure_forward
 
 # self_hostname ${HOSTNAME}
@@ -22,3 +23,4 @@
   # specify hostlabel for FQDN verification if ipaddress is used for host
 #   hostlabel server.fqdn.example.com
 # </server>
+# </store>

--- a/roles/openshift_logging_mux/files/secure-forward.conf
+++ b/roles/openshift_logging_mux/files/secure-forward.conf
@@ -1,3 +1,4 @@
+# <store>
 # @type secure_forward
 
 # self_hostname ${HOSTNAME}
@@ -22,3 +23,4 @@
   # specify hostlabel for FQDN verification if ipaddress is used for host
 #   hostlabel server.fqdn.example.com
 # </server>
+# </store>


### PR DESCRIPTION
This fixes [BZ#1498398](https://bugzilla.redhat.com/show_bug.cgi?id=1498398)
The examples provided in the documentation to configure the secure forward mention the configuration must be enclosed between the <store> tag. For that I think the examples should include it as well.

See [3.6 Documentation](https://docs.openshift.com/container-platform/3.6/install_config/aggregate_logging.html#aggregated-fluentd)
~~~
<store>
@type secure_forward
self_hostname pod-${HOSTNAME}
shared_key thisisasharedkey
secure yes
enable_strict_verification yes
ca_cert_path /etc/fluent/keys/your_ca_cert
ca_private_key_path /etc/fluent/keys/your_private_key
ca_private_key_passphrase passphrase
<server>
  host ose1.example.com
  port 24284
</server>
<server>
  host ose2.example.com
  port 24284
  standby
</server>
<server>
  host ose3.example.com
  port 24284
  standby
</server>
</store>
~~~