### PR TITLE
Adding proxy env vars for dc/docker-registry

### DIFF
--- a/roles/openshift_hosted/tasks/registry/registry.yml
+++ b/roles/openshift_hosted/tasks/registry/registry.yml
@@ -61,6 +61,14 @@
     openshift_hosted_registry_env_vars: "{{ openshift_hosted_registry_env_vars | combine({'OPENSHIFT_DEFAULT_REGISTRY':'docker-registry.default.svc:5000'}) }}"
   when: openshift_push_via_dns | default(false) | bool
 
+- name: Update registry proxy settings for dc/docker-registry
+  set_fact:
+    openshift_hosted_registry_env_vars: "{{ {'HTTPS_PROXY': (openshift.common.https_proxy | default('')),
+                                             'HTTP_PROXY':  (openshift.common.http_proxy  | default('')),
+                                             'NO_PROXY':    (openshift.common.no_proxy    | default(''))}
+                                           | combine(openshift_hosted_registry_env_vars) }}"
+  when: (openshift.common.https_proxy | default(False)) or (openshift.common.http_proxy | default('')) != ''
+
 - name: Create the registry service account
   oc_serviceaccount:
     name: "{{ openshift_hosted_registry_serviceaccount }}"


### PR DESCRIPTION
Port back registry proxy settings to release-3.6
