### PR TITLE
Avoid undefined variable in master sysconfig template

### DIFF
--- a/roles/openshift_master/templates/atomic-openshift-master.j2
+++ b/roles/openshift_master/templates/atomic-openshift-master.j2
@@ -21,7 +21,7 @@ AWS_SECRET_ACCESS_KEY={{ openshift_cloudprovider_aws_secret_key }}
 {% endif %}
 
 {% if 'api_env_vars' in openshift.master or 'controllers_env_vars' in openshift.master -%}
-{% for key, value in openshift.master.api_env_vars.items() | default([]) | union(openshift.master.controllers_env_vars.items() | default([])) -%}
+{% for key, value in (openshift.master.api_env_vars | default({})).items() | union((openshift.master.controllers_env_vars | default({})).items()) -%}
 {{ key }}={{ value }}
 {% endfor -%}
 {% endif -%}


### PR DESCRIPTION
When "openshift_master_controllers_env_vars" is set, but
"openshift_master_api_env_vars" isn't, the template for the sysconfig
file of atomic-openshift-master fails:

  AnsibleUndefinedVariable: 'dict object' has no attribute 'api_env_vars'

Avoid this issue by applying "default({})" to the dict and always
calling ".items()".