### PR TITLE
Update hosts.origin.example

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -539,7 +539,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Defaults to https://hawkular-metrics.{{openshift_master_default_subdomain}}/hawkular/metrics
 # Currently, you may only alter the hostname portion of the url, alterting the
 # `/hawkular/metrics` path will break installation of metrics.
-#openshift_metrics_hawkular_hostname=https://hawkular-metrics.example.com/hawkular/metrics
+#openshift_metrics_hawkular_hostname=hawkular-metrics.example.com
 # Configure the prefix and version for the component images
 #openshift_metrics_image_prefix=docker.io/openshift/origin-
 #openshift_metrics_image_version=v3.7.0

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -547,7 +547,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Defaults to https://hawkular-metrics.{{openshift_master_default_subdomain}}/hawkular/metrics
 # Currently, you may only alter the hostname portion of the url, alterting the
 # `/hawkular/metrics` path will break installation of metrics.
-#openshift_metrics_hawkular_hostname=https://hawkular-metrics.example.com/hawkular/metrics
+#openshift_metrics_hawkular_hostname=hawkular-metrics.example.com
 # Configure the prefix and version for the component images
 #openshift_metrics_image_prefix=registry.example.com:8888/openshift3/
 #openshift_metrics_image_version=3.7.0


### PR DESCRIPTION
Changing sample config from:
#openshift_metrics_hawkular_hostname=https://hawkular-metrics.example.com/hawkular/metrics
To:
#openshift_metrics_hawkular_hostname=hawkular-metrics.example.com

Reason:
When i set my inventory with [openshift_metrics_hawkular_hostname=https://metrics.MYDOMAIN.com/hawkular/metrics/] the results is break of metrics url, like this: [https://https//metrics.cirrus.alterdata.com.br/hawkular/metrics/hawkular/metrics]