### PR TITLE
Allow checkpoint status to work across all groups

### DIFF
--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -1,7 +1,6 @@
 ---
 - name: Hosted Install Checkpoint Start
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set Hosted install 'In Progress'
@@ -26,8 +25,7 @@
   when: openshift_hosted_prometheus_deploy | default(False) | bool
 
 - name: Hosted Install Checkpoint End
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set Hosted install 'Complete'

--- a/playbooks/common/openshift-cluster/openshift_logging.yml
+++ b/playbooks/common/openshift-cluster/openshift_logging.yml
@@ -1,7 +1,6 @@
 ---
 - name: Logging Install Checkpoint Start
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set Logging install 'In Progress'
@@ -24,8 +23,7 @@
         tasks_from: update_master_config
 
 - name: Logging Install Checkpoint End
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set Logging install 'Complete'

--- a/playbooks/common/openshift-cluster/openshift_metrics.yml
+++ b/playbooks/common/openshift-cluster/openshift_metrics.yml
@@ -1,7 +1,6 @@
 ---
 - name: Metrics Install Checkpoint Start
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set Metrics install 'In Progress'
@@ -25,8 +24,7 @@
       tasks_from: update_master_config.yaml
 
 - name: Metrics Install Checkpoint End
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set Metrics install 'Complete'

--- a/playbooks/common/openshift-cluster/service_catalog.yml
+++ b/playbooks/common/openshift-cluster/service_catalog.yml
@@ -1,7 +1,6 @@
 ---
 - name: Service Catalog Install Checkpoint Start
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set Service Catalog install 'In Progress'
@@ -20,8 +19,7 @@
     first_master: "{{ groups.oo_first_master[0] }}"
 
 - name: Service Catalog Install Checkpoint End
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set Service Catalog install 'Complete'

--- a/playbooks/common/openshift-cluster/std_include.yml
+++ b/playbooks/common/openshift-cluster/std_include.yml
@@ -1,7 +1,6 @@
 ---
 - name: Initialization Checkpoint Start
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   roles:
   - installer_checkpoint
@@ -37,8 +36,7 @@
   - always
 
 - name: Initialization Checkpoint End
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set install initialization 'Complete'

--- a/playbooks/common/openshift-etcd/config.yml
+++ b/playbooks/common/openshift-etcd/config.yml
@@ -1,7 +1,6 @@
 ---
 - name: etcd Install Checkpoint Start
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set etcd install 'In Progress'
@@ -23,8 +22,7 @@
   - role: nickhammond.logrotate
 
 - name: etcd Install Checkpoint End
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set etcd install 'Complete'

--- a/playbooks/common/openshift-glusterfs/config.yml
+++ b/playbooks/common/openshift-glusterfs/config.yml
@@ -1,7 +1,6 @@
 ---
 - name: GlusterFS Install Checkpoint Start
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set GlusterFS install 'In Progress'
@@ -37,8 +36,7 @@
     when: groups.oo_glusterfs_to_config | default([]) | count > 0
 
 - name: GlusterFS Install Checkpoint End
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set GlusterFS install 'Complete'

--- a/playbooks/common/openshift-loadbalancer/config.yml
+++ b/playbooks/common/openshift-loadbalancer/config.yml
@@ -1,7 +1,6 @@
 ---
 - name: Load Balancer Install Checkpoint Start
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set load balancer install 'In Progress'
@@ -29,8 +28,7 @@
   - role: openshift_loadbalancer
 
 - name: Load Balancer Install Checkpoint End
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set load balancer install 'Complete'

--- a/playbooks/common/openshift-master/additional_config.yml
+++ b/playbooks/common/openshift-master/additional_config.yml
@@ -1,7 +1,6 @@
 ---
 - name: Master Additional Install Checkpoint Start
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set Master Additional install 'In Progress'
@@ -37,8 +36,7 @@
     when: openshift_use_flannel | default(false) | bool
 
 - name: Master Additional Install Checkpoint End
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set Master Additional install 'Complete'

--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -1,7 +1,6 @@
 ---
 - name: Master Install Checkpoint Start
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set Master install 'In Progress'
@@ -224,8 +223,7 @@
     r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
 
 - name: Master Install Checkpoint End
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set Master install 'Complete'

--- a/playbooks/common/openshift-nfs/config.yml
+++ b/playbooks/common/openshift-nfs/config.yml
@@ -1,7 +1,6 @@
 ---
 - name: NFS Install Checkpoint Start
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set NFS install 'In Progress'
@@ -17,8 +16,7 @@
   - role: openshift_storage_nfs
 
 - name: NFS Install Checkpoint End
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set NFS install 'Complete'

--- a/playbooks/common/openshift-node/config.yml
+++ b/playbooks/common/openshift-node/config.yml
@@ -1,7 +1,6 @@
 ---
 - name: Node Install Checkpoint Start
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set Node install 'In Progress'
@@ -23,8 +22,7 @@
 - include: enable_excluders.yml
 
 - name: Node Install Checkpoint End
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   tasks:
   - name: Set Node install 'Complete'

--- a/roles/installer_checkpoint/README.md
+++ b/roles/installer_checkpoint/README.md
@@ -92,8 +92,7 @@ phase/component and then a final play for setting `installer_hase_initialize` to
 # common/openshift-cluster/std_include.yml
 ---
 - name: Initialization Checkpoint Start
-  hosts: localhost
-  connection: local
+  hosts: oo_all_hosts
   gather_facts: false
   roles:
   - installer_checkpoint


### PR DESCRIPTION
Conditionals placed in inventories were not being applied to localhost causing the checkpoint status to not be updated properly.  Moving to the `oo_all_hosts` group will correctly pick up the conditional and apply regardless of which group (or host) may have that conditional set.