### PR TITLE
Adding meta/main.yml to allow for Galaxy use of this repo

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies:


### PR DESCRIPTION
In order to reference `openshift/openshift-ansible` from an Ansible Galaxy [requirements file \[1\]](http://docs.ansible.com/ansible/latest/galaxy.html#installing-multiple-roles-from-a-file), the meta/main.yml file needs to exist at the top level of the repo. This PR is to introduce this dir/file so we can reference `openshift/openshift-ansible` from our automation jobs using ansible galaxy to pull in the dependencies. 

\[1\]: http://docs.ansible.com/ansible/latest/galaxy.html#installing-multiple-roles-from-a-file