### PR TITLE
Backport 3.6 - logging: honor openshift_logging_es_cpu_limit

### DIFF
--- a/roles/openshift_logging_elasticsearch/defaults/main.yml
+++ b/roles/openshift_logging_elasticsearch/defaults/main.yml
@@ -6,7 +6,7 @@ openshift_logging_elasticsearch_image_pull_secret: "{{ openshift_hosted_logging_
 openshift_logging_elasticsearch_namespace: logging
 
 openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_nodeselector | default('') }}"
-openshift_logging_elasticsearch_cpu_limit: 1000m
+openshift_logging_elasticsearch_cpu_limit: "{{ openshift_logging_es_cpu_limit | default('1000m') }}"
 openshift_logging_elasticsearch_memory_limit: "{{ openshift_logging_es_memory_limit | default('1Gi') }}"
 openshift_logging_elasticsearch_recover_after_time: "{{ openshift_logging_es_recover_after_time | default('5m') }}"
 


### PR DESCRIPTION
Backport of https://github.com/openshift/openshift-ansible/pull/5616 to 3.6

PR https://github.com/openshift/openshift-ansible/pull/3509 has removed any usage of `openshift_logging_es_cpu_limit`.

Currently, the `openshift_logging_elasticsearch_cpu_limit` is either default '1000m' or derived from `openshift_logging_es_ops_cpu_limit` but if user sets the `openshift_logging_es_cpu_limit` in the inventory as documented, its value is ignored.

This PR fixes the issue by trying to set openshift_logging_elasticsearch_cpu_limit=openshift_logging_es_cpu_limit

And including the role as -ops overrides this setting.