### PR TITLE
Backport 3.6 - Bug 1496271 - Perserve SCC for ES local persistent storage

### DIFF
--- a/roles/openshift_logging/library/openshift_logging_facts.py
+++ b/roles/openshift_logging/library/openshift_logging_facts.py
@@ -182,16 +182,14 @@ class OpenshiftLoggingFacts(OCBaseCommand):
                     facts["nodeSelector"] = spec["nodeSelector"]
                 if "supplementalGroups" in spec["securityContext"]:
                     facts["storageGroups"] = spec["securityContext"]["supplementalGroups"]
+                facts["spec"] = spec
                 if "volumes" in spec:
                     for vol in spec["volumes"]:
                         clone = copy.deepcopy(vol)
                         clone.pop("name", None)
                         facts["volumes"][vol["name"]] = clone
                 for container in spec["containers"]:
-                    facts["containers"][container["name"]] = dict(
-                        image=container["image"],
-                        resources=container["resources"],
-                    )
+                    facts["containers"][container["name"]] = container
                 self.add_facts_for(comp, "deploymentconfigs", name, facts)
 
     def facts_for_services(self, namespace):

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -79,6 +79,7 @@
     openshift_logging_elasticsearch_pvc_pv_selector: "{{ openshift_logging_es_pv_selector }}"
     openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_nodeselector if item.0.nodeSelector | default(None) is none else item.0.nodeSelector }}"
     openshift_logging_elasticsearch_storage_group: "{{ [openshift_logging_es_storage_group] if item.0.storageGroups | default([]) | length == 0 else item.0.storageGroups }}"
+    _es_containers: "{{item.0.containers}}"
 
   with_together:
   - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs.values() }}"
@@ -144,6 +145,7 @@
     openshift_logging_es_hostname: "{{ openshift_logging_es_ops_hostname }}"
     openshift_logging_es_edge_term_policy: "{{ openshift_logging_es_ops_edge_term_policy | default('') }}"
     openshift_logging_es_allow_external: "{{ openshift_logging_es_ops_allow_external }}"
+    _es_containers: "{{item.0.containers}}"
 
   with_together:
   - "{{ openshift_logging_facts.elasticsearch_ops.deploymentconfigs.values() }}"

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -276,6 +276,7 @@
     es_memory_limit: "{{ openshift_logging_elasticsearch_memory_limit }}"
     es_node_selector: "{{ openshift_logging_elasticsearch_nodeselector | default({}) }}"
     es_storage_groups: "{{ openshift_logging_elasticsearch_storage_group | default([]) }}"
+    es_container_security_context: "{{ _es_containers.elasticsearch.securityContext if _es_containers is defined and 'elasticsearch' in _es_containers and 'securityContext' in _es_containers.elasticsearch else None }}"
     deploy_type: "{{ openshift_logging_elasticsearch_deployment_type }}"
     es_replicas: 1
 

--- a/roles/openshift_logging_elasticsearch/templates/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/es.j2
@@ -51,6 +51,9 @@ spec:
 {% endif %}
             requests:
               memory: "{{es_memory_limit}}"
+{% if es_container_security_context %}
+          securityContext: {{ es_container_security_context | to_yaml }} 
+{% endif %}
           ports:
             -
               containerPort: 9200


### PR DESCRIPTION
Backport of https://github.com/openshift/openshift-ansible/pull/5637 to 3.6

ES can be modified to use node local persistent storage. This requires changing SCC and is described in docs:

https://docs.openshift.com/container-platform/3.6/install_config/aggregate_logging.html

During an upgrade, SCC defined by the user is ignored. This fix fetches SCC user defined as a fact and adds it to the ES DC which is later used.

Also includes cherrypicked fix for - Bug 1482661 - Preserve ES dc nodeSelector and supplementalGroups

cc @jcantrill 