### PR TITLE
[1.5] Ensure docker service started prior to credentials

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -120,6 +120,17 @@
   notify:
   - restart docker
 
+- name: Start the Docker service
+  systemd:
+    name: docker
+    enabled: yes
+    state: started
+    daemon_reload: yes
+  register: start_result
+
+- set_fact:
+    docker_service_status_changed: start_result | changed
+
 - name: Check for credentials file for registry auth
   stat:
     path: "{{ docker_cli_auth_config_path }}/config.json"
@@ -131,16 +142,5 @@
   when:
   - oreg_auth_user is defined
   - (not docker_cli_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
-
-- name: Start the Docker service
-  systemd:
-    name: docker
-    enabled: yes
-    state: started
-    daemon_reload: yes
-  register: start_result
-
-- set_fact:
-    docker_service_status_changed: start_result | changed
 
 - meta: flush_handlers


### PR DESCRIPTION
Currently, authenticated registry credentials
are requested before docker might be started in
the docker role.

This commit moves the relevant registry credential
tasks to after docker is started.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1316341
(cherry picked from commit 9bd849c32d87c8e92b9808087e7017934449ef64)

Backports: https://github.com/openshift/openshift-ansible/pull/5647