### PR TITLE
[3.6] Ensure docker service started prior to credentials

### DIFF
--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -117,18 +117,6 @@
   notify:
   - restart docker
 
-- name: Check for credentials file for registry auth
-  stat:
-    path: "{{ docker_cli_auth_config_path }}/config.json"
-  when: oreg_auth_user is defined
-  register: docker_cli_auth_credentials_stat
-
-- name: Create credentials for docker cli registry auth
-  command: "docker --config={{ docker_cli_auth_config_path }} login -u {{ oreg_auth_user }} -p {{ oreg_auth_password }} {{ oreg_host }}"
-  when:
-  - oreg_auth_user is defined
-  - (not docker_cli_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
-
 - name: Start the Docker service
   systemd:
     name: docker
@@ -142,5 +130,17 @@
 
 - set_fact:
     docker_service_status_changed: "{{ r_docker_package_docker_start_result | changed }}"
+
+- name: Check for credentials file for registry auth
+  stat:
+    path: "{{ docker_cli_auth_config_path }}/config.json"
+  when: oreg_auth_user is defined
+  register: docker_cli_auth_credentials_stat
+
+- name: Create credentials for docker cli registry auth
+  command: "docker --config={{ docker_cli_auth_config_path }} login -u {{ oreg_auth_user }} -p {{ oreg_auth_password }} {{ oreg_host }}"
+  when:
+  - oreg_auth_user is defined
+  - (not docker_cli_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
 
 - meta: flush_handlers


### PR DESCRIPTION
Currently, authenticated registry credentials
are requested before docker might be started in
the docker role.

This commit moves the relevant registry credential
tasks to after docker is started.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1316341
(cherry picked from commit 9bd849c32d87c8e92b9808087e7017934449ef64)

Backports: https://github.com/openshift/openshift-ansible/pull/5647