### PR TITLE
use .svc.cluster.local dns, not .svc

### DIFF
--- a/roles/openshift_service_catalog/tasks/start_api_server.yml
+++ b/roles/openshift_service_catalog/tasks/start_api_server.yml
@@ -10,7 +10,7 @@
 # wait to see that the apiserver is available
 - name: wait for api server to be ready
   command: >
-    curl -k https://apiserver.kube-service-catalog.svc/healthz
+    curl -k https://apiserver.kube-service-catalog.svc.cluster.local/healthz
   args:
     # Disables the following warning:
     # Consider using get_url or uri module rather than running curl

--- a/roles/template_service_broker/tasks/install.yml
+++ b/roles/template_service_broker/tasks/install.yml
@@ -46,7 +46,7 @@
 # Check that the TSB is running
 - name: Verify that TSB is running
   command: >
-    curl -k https://apiserver.openshift-template-service-broker.svc/healthz
+    curl -k https://apiserver.openshift-template-service-broker.svc.cluster.local/healthz
   args:
     # Disables the following warning:
     # Consider using get_url or uri module rather than running curl


### PR DESCRIPTION
without this patch, on F26 I get:

```
fatal: [192.168.121.118]: FAILED! => {"attempts": 120, "changed": false, "cmd": ["curl", "-k", "https://apiserver.kube-service-catalog.svc/healthz"], "delta": "0:00:00.012332", "end": "2017-10-06 13:08:15.014424", "failed": true, "msg": "non-zero return code", "rc": 6, "start": "2017-10-06 13:08:15.002092", "stderr": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: apiserver.kube-service-catalog.svc", "stderr_lines": ["  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: apiserver.kube-service-catalog.svc"], "stdout": "", "stdout_lines": []}
```