### PR TITLE
Switch to configmap leader election on 3.7 upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_7/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/master_config_upgrade.yml
@@ -14,3 +14,8 @@
     dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
     yaml_key: 'kubernetesMasterConfig.admissionConfig'
     yaml_value:
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'controllerConfig.election.lockName'
+    yaml_value: 'openshift-master-controllers'


### PR DESCRIPTION
This change sets the controllerConfig.election.lockName to openshift-master-controllers on a 3.7 upgrade.

This is the default in a new 3.7 cluster.  Important excerpt from the docs inside the origin codebase (slightly modified):

There are two modes for lease operation - a legacy mode that directly connects to etcd, and the preferred mode which coordinates on a configmap or endpoint in the kube-system namespace. Because legacy mode and the new mode do not coordinate on the same key, an upgrade must stop all controllers before changing the configuration and starting controllers with the new config.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/assign @smarterclayton @jupierce
/kind bug