### PR TITLE
[3.6] Ensure docker restarts with iptables bp 3.6

### DIFF
--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -4,6 +4,7 @@
   systemd:
     name: "{{ openshift.docker.service_name }}"
     state: restarted
+    daemon_reload: yes
   register: r_docker_restart_docker_result
   until: not r_docker_restart_docker_result | failed
   retries: 3

--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -46,7 +46,9 @@
     template:
       dest: "{{ docker_systemd_dir }}/custom.conf"
       src: custom.conf.j2
-  when: not os_firewall_use_firewalld | default(False) | bool
+    notify:
+    - restart docker
+  when: not (os_firewall_use_firewalld | default(False)) | bool
 
 - stat: path=/etc/sysconfig/docker
   register: docker_check


### PR DESCRIPTION
Currently, os_firewall role may run after docker role,
and iptables.service may be restarted.  When restarted,
this negatively impacts docker's iptables rules.

This commit ensures that if iptables is restarted,
docker is restarted as well (by systemd)

Fixes: https://github.com/openshift/origin/issues/16709
(cherry picked from commit 3d0ffb6edbd42d8b663bb268374101f44b6d2e36)

Backports: https://github.com/openshift/openshift-ansible/pull/5680