### PR TITLE
[1.5] Ensure docker is restarted when iptables is restarted

### DIFF
--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -4,6 +4,7 @@
   systemd:
     name: docker
     state: restarted
+    daemon_reload: yes
   when: not docker_service_status_changed | default(false) | bool
 
 - name: restart udev

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -46,7 +46,9 @@
     template:
       dest: "{{ docker_systemd_dir }}/custom.conf"
       src: custom.conf.j2
-  when: not os_firewall_use_firewalld | default(False) | bool
+    notify:
+    - restart docker
+  when: not (os_firewall_use_firewalld | default(False)) | bool
 
 - include: udev_workaround.yml
   when: docker_udev_workaround | default(False) | bool


### PR DESCRIPTION
Currently, os_firewall role may run after docker role,
and iptables.service may be restarted.  When restarted,
this negatively impacts docker's iptables rules.

This commit ensures that if iptables is restarted,
docker is restarted as well (by systemd)

Fixes: https://github.com/openshift/origin/issues/16709
(cherry picked from commit 3d0ffb6edbd42d8b663bb268374101f44b6d2e36)

Backports: #5680