### PR TITLE
 Bug 1490647 - logging-fluentd deployed with openshift_logging_use_mux=false fails to start due to missing

### DIFF
--- a/roles/openshift_logging_fluentd/templates/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/fluentd.j2
@@ -66,7 +66,9 @@ spec:
           readOnly: true
         - name: filebufferstorage
           mountPath: /var/lib/fluentd
-{% if openshift_logging_mux_client_mode is defined %}
+{% if openshift_logging_mux_client_mode is defined and
+     ((openshift_logging_mux_allow_external is defined and openshift_logging_mux_allow_external | bool) or
+      (openshift_logging_use_mux is defined and openshift_logging_use_mux | bool)) %}
         - name: muxcerts
           mountPath: /etc/fluent/muxkeys
           readOnly: true
@@ -114,7 +116,9 @@ spec:
               resource: limits.memory
         - name: "FILE_BUFFER_LIMIT"
           value: "{{ openshift_logging_fluentd_file_buffer_limit | default('1Gi') }}"
-{% if openshift_logging_mux_client_mode is defined %}
+{% if openshift_logging_mux_client_mode is defined and
+     ((openshift_logging_mux_allow_external is defined and openshift_logging_mux_allow_external | bool) or
+      (openshift_logging_use_mux is defined and openshift_logging_use_mux | bool)) %}
         - name: "MUX_CLIENT_MODE"
           value: "{{ openshift_logging_mux_client_mode }}"
 {% endif %}
@@ -196,7 +200,9 @@ spec:
       - name: dockerdaemoncfg
         hostPath:
           path: /etc/docker
-{% if openshift_logging_mux_client_mode is defined %}
+{% if openshift_logging_mux_client_mode is defined and
+     ((openshift_logging_mux_allow_external is defined and openshift_logging_mux_allow_external | bool) or
+      (openshift_logging_use_mux is defined and openshift_logging_use_mux | bool)) %}
       - name: muxcerts
         secret:
           secretName: logging-mux


### PR DESCRIPTION
If openshift_logging_use_mux=False and openshift_logging_mux_allow_external=False,
then all other mux related parameters should be set to False (if boolean) or
removed (e.g. openshift_logging_mux_client_mode should be undefined).