### PR TITLE
remove openshift_upgrade_{pre,post}_storage_migration_enabled from failed_when

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -56,7 +56,6 @@
     register: l_pb_upgrade_control_plane_pre_upgrade_storage
     when: openshift_upgrade_pre_storage_migration_enabled | default(true) | bool
     failed_when:
-    - openshift_upgrade_pre_storage_migration_enabled | default(true) | bool
     - l_pb_upgrade_control_plane_pre_upgrade_storage.rc != 0
     - openshift_upgrade_pre_storage_migration_fatal | default(true) | bool
 
@@ -122,7 +121,6 @@
     - openshift_upgrade_post_storage_migration_enabled | default(true) | bool
     - openshift_version is version_compare('3.7','<')
     failed_when:
-    - openshift_upgrade_post_storage_migration_enabled | default(true) | bool
     - l_pb_upgrade_control_plane_post_upgrade_storage.rc != 0
     - openshift_upgrade_post_storage_migration_fatal | default(false) | bool
     run_once: true
@@ -258,7 +256,6 @@
     register: l_pb_upgrade_control_plane_post_upgrade_storage
     when: openshift_upgrade_post_storage_migration_enabled | default(true) | bool
     failed_when:
-    - openshift_upgrade_post_storage_migration_enabled | default(true) | bool
     - l_pb_upgrade_control_plane_post_upgrade_storage.rc != 0
     - openshift_upgrade_post_storage_migration_fatal | default(false) | bool
 


### PR DESCRIPTION
When `openshift_upgrade_{pre,post}_storage_migration_enabled` was
enabled, `oadm migrate storage` was called. After that, failed_when is
evaluated, so `openshift_upgrade_{pre,post}_storage_migration_enabled`
is always true and not necessary in the failed_when list. This patch
remove them from failed_when list.