### PR TITLE
docker, CRI-O: openshift_image_tag defaults to openshift_release

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -10,14 +10,6 @@
     l_use_crio: "{{ openshift_use_crio | default(False) }}"
     l_use_crio_only: "{{ openshift_use_crio_only | default(False) }}"
 
-- when:
-    - openshift_deployment_type == 'openshift-enterprise'
-  assert:
-    that:
-      - "openshift_image_tag is defined"
-    msg: >
-      openshift_image_tag is a required inventory variable when installing openshift-enterprise
-
 - name: Use Package Docker if Requested
   include: package_docker.yml
   when:

--- a/roles/docker/tasks/systemcontainer_crio.yml
+++ b/roles/docker/tasks/systemcontainer_crio.yml
@@ -14,6 +14,22 @@
     l_additional_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l_crio_registries)) }}"
   when: l2_docker_additional_registries
 
+- set_fact:
+    l_openshift_image_tag: "{{ openshift_image_tag | string }}"
+  when: openshift_image_tag is defined
+
+- set_fact:
+    l_openshift_image_tag: "latest"
+  when:
+    - openshift_image_tag is not defined
+    - openshift_release == "latest"
+
+- set_fact:
+    l_openshift_image_tag: "v{{ openshift_release | string }}"
+  when:
+    - openshift_image_tag is not defined
+    - openshift_release != "latest"
+
 - name: Ensure container-selinux is installed
   package:
     name: container-selinux
@@ -106,10 +122,9 @@
 
     - name: Set CRI-O image tag
       set_fact:
-        l_crio_image_tag: "{{ openshift_image_tag }}"
+        l_crio_image_tag: "{{ l_openshift_image_tag }}"
       when:
         - openshift_deployment_type == 'openshift-enterprise'
-        - openshift_image_tag is defined
 
     - name: Use RHEL based image when distribution is Red Hat
       set_fact:

--- a/roles/docker/tasks/systemcontainer_crio.yml
+++ b/roles/docker/tasks/systemcontainer_crio.yml
@@ -147,7 +147,7 @@
     image: "{{ l_crio_image }}"
     state: latest
 
-- name: Remove CRI-o default configuration files
+- name: Remove CRI-O default configuration files
   file:
     path: "{{ item }}"
     state: absent

--- a/roles/docker/tasks/systemcontainer_docker.yml
+++ b/roles/docker/tasks/systemcontainer_docker.yml
@@ -1,5 +1,21 @@
 ---
 
+- set_fact:
+    l_openshift_image_tag: "{{ openshift_image_tag | string }}"
+  when: openshift_image_tag is defined
+
+- set_fact:
+    l_openshift_image_tag: "latest"
+  when:
+    - openshift_image_tag is not defined
+    - openshift_release == "latest"
+
+- set_fact:
+    l_openshift_image_tag: "v{{ openshift_release | string }}"
+  when:
+    - openshift_image_tag is not defined
+    - openshift_release != "latest"
+
 # If docker_options are provided we should fail. We should not install docker and ignore
 # the users configuration. NOTE: docker_options == inventory:openshift_docker_options
 - name: Fail quickly if openshift_docker_options are set
@@ -94,10 +110,9 @@
 
     - name: Set container engine image tag
       set_fact:
-        l_docker_image_tag: "{{ openshift_image_tag }}"
+        l_docker_image_tag: "{{ l_openshift_image_tag }}"
       when:
         - openshift_deployment_type == 'openshift-enterprise'
-        - openshift_image_tag is defined
 
     - name: Use Red Hat Registry for image when distribution is Red Hat
       set_fact:


### PR DESCRIPTION
Replace:

commit c2c4ba7ec62d4dfd87d746d20991e10f2bd1bddf
Author: Giuseppe Scrivano <gscrivan@redhat.com>
Date:   Tue Sep 26 09:01:59 2017 +0200

    Require openshift_image_tag in the inventory with openshift-enterprise
    
    Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

with using openshift_release for openshift_image_tag so we don't require users to include both in their inventory.  Probably it is only a temporary solution until the openshift_image_tag vs openshift_release when using Docker/CRI-O is sorted out.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1493376