### PR TITLE
Bug 1493276: Setting servingInfo.clientCA to ca-bundle.crt can cause unwanted client cert popups in browser when hitting console

### DIFF
--- a/playbooks/common/openshift-cluster/redeploy-certificates/openshift-ca.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/openshift-ca.yml
@@ -44,8 +44,8 @@
   - modify_yaml:
       dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
       yaml_key: servingInfo.clientCA
-      yaml_value: ca-bundle.crt
-    when: (g_master_config_output.content|b64decode|from_yaml).servingInfo.clientCA != 'ca-bundle.crt'
+      yaml_value: ca.crt
+    when: (g_master_config_output.content|b64decode|from_yaml).servingInfo.clientCA != 'ca.crt'
   - modify_yaml:
       dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
       yaml_key: etcdClientInfo.ca

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -251,11 +251,7 @@ servingInfo:
   bindAddress: {{ openshift.master.bind_addr }}:{{ openshift.master.api_port }}
   bindNetwork: tcp4
   certFile: master.server.crt
-{% if openshift.common.version_gte_3_2_or_1_2 | bool %}
-  clientCA: ca-bundle.crt
-{% else %}
   clientCA: ca.crt
-{% endif %}
   keyFile: master.server.key
   maxRequestsInFlight: {{ openshift.master.max_requests_inflight }}
   requestTimeoutSeconds: 3600


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1493276