### PR TITLE
Add switch to enable/disable container engine's audit log being stored in elasticsearch

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -69,6 +69,9 @@ When `openshift_logging_install_logging` is set to `False` the `openshift_loggin
 - `openshift_logging_fluentd_buffer_size_limit`: Buffer chunk limit for Fluentd. Defaults to 1m.
 - `openshift_logging_fluentd_file_buffer_limit`: Fluentd will set the value to the file buffer limit.  Defaults to '1Gi' per destination.
 
+- `openshift_logging_fluentd_audit_container_engine`: When `openshift_logging_fluentd_audit_container_engine` is set to `True`, the audit log of the container engine will be collected and stored in ES.
+- `openshift_logging_fluentd_audit_file`: Location of audit log file. The default is `/var/log/audit/audit.log`
+- `openshift_logging_fluentd_audit_pos_file`: Location of fluentd in_tail position file for the audit log file. The default is `/var/log/audit/audit.log.pos`
 
 - `openshift_logging_es_host`: The name of the ES service Fluentd should send logs to. Defaults to 'logging-es'.
 - `openshift_logging_es_port`: The port for the ES service Fluentd should sent its logs to. Defaults to '9200'.

--- a/roles/openshift_logging_fluentd/defaults/main.yml
+++ b/roles/openshift_logging_fluentd/defaults/main.yml
@@ -56,3 +56,7 @@ openshift_logging_fluentd_aggregating_passphrase: none
 #fluentd_secureforward_contents:
 
 openshift_logging_fluentd_file_buffer_limit: 1Gi
+
+# Configure fluentd to tail audit log file and filter out container engine's logs from there
+# These logs are then stored in ES operation index
+openshift_logging_fluentd_audit_container_engine: False

--- a/roles/openshift_logging_fluentd/tasks/main.yaml
+++ b/roles/openshift_logging_fluentd/tasks/main.yaml
@@ -108,7 +108,6 @@
     src: secure-forward.conf
     dest: "{{ tempdir }}/secure-forward.conf"
   when: fluentd_secureforward_contents is undefined
-
   changed_when: no
 
 - copy:
@@ -173,6 +172,9 @@
     ops_port: "{{ openshift_logging_fluentd_ops_port }}"
     fluentd_nodeselector_key: "{{ openshift_logging_fluentd_nodeselector.keys()[0] }}"
     fluentd_nodeselector_value: "{{ openshift_logging_fluentd_nodeselector.values()[0] }}"
+    audit_container_engine: "{{ openshift_logging_fluentd_audit_container_engine | default(False) | bool }}"
+    audit_log_file: "{{ openshift_logging_fluentd_audit_file | default() }}"
+    audit_pos_log_file: "{{ openshift_logging_fluentd_audit_pos_file | default() }}"
   check_mode: no
   changed_when: no
 

--- a/roles/openshift_logging_fluentd/templates/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/fluentd.j2
@@ -172,6 +172,28 @@ spec:
           value: "{{ openshift_logging_fluentd_remote_syslog_payload_key }}"
 {% endif %}
 
+{% if audit_container_engine %}
+        - name: "AUDIT_CONTAINER_ENGINE"
+          value: "{{ audit_container_engine | lower }}"
+{% endif %}
+
+{% if audit_container_engine %}
+        - name: "NODE_NAME"
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+{% endif %}
+
+{% if audit_log_file != '' %}
+        - name: AUDIT_FILE
+          value: "{{ audit_log_file }}"
+{% endif %}
+
+{% if audit_pos_log_file != '' %}
+        - name: AUDIT_POS_FILE
+          value: "{{ audit_pos_log_file }}"
+{% endif %}
+
       volumes:
       - name: runlogjournal
         hostPath:


### PR DESCRIPTION
If enabled, tho logs are stored in ES' operations index, accessible only by cluster admins.