### PR TITLE
Add PartOf to docker systemd service unit.

### DIFF
--- a/roles/docker/templates/custom.conf.j2
+++ b/roles/docker/templates/custom.conf.j2
@@ -3,3 +3,9 @@
 [Unit]
 Wants=iptables.service
 After=iptables.service
+
+# The following line is a work-around to ensure docker is restarted whenever
+# iptables is restarted.  This ensures the proper iptables rules will be in
+# place for docker.
+# Note:  This will also cause docker to be stopped if iptables is stopped.
+PartOf=iptables.service


### PR DESCRIPTION
Currently, if iptables service is restarted,
existing iptables rules are removed.

Docker adds iptables rules dyanmically upon
startup and container creation.  Restarting
the iptables service results in a loss of these
needed iptables rules.

This commit ensures that if iptables service is
restarted by anisble or the user, docker is
also restarted.  This ensures the proper dynamic
iptables rules are in place for docker.

Fixes: openshift/origin#16709