### PR TITLE
crio, docker: expect openshift_release to have 'v'

### DIFF
--- a/roles/docker/tasks/systemcontainer_crio.yml
+++ b/roles/docker/tasks/systemcontainer_crio.yml
@@ -25,7 +25,7 @@
     - openshift_release == "latest"
 
 - set_fact:
-    l_openshift_image_tag: "v{{ openshift_release | string }}"
+    l_openshift_image_tag: "{{ openshift_release | string }}"
   when:
     - openshift_image_tag is not defined
     - openshift_release != "latest"

--- a/roles/docker/tasks/systemcontainer_docker.yml
+++ b/roles/docker/tasks/systemcontainer_docker.yml
@@ -11,7 +11,7 @@
     - openshift_release == "latest"
 
 - set_fact:
-    l_openshift_image_tag: "v{{ openshift_release | string }}"
+    l_openshift_image_tag: "{{ openshift_release | string }}"
   when:
     - openshift_image_tag is not defined
     - openshift_release != "latest"


### PR DESCRIPTION
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1493376

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>