### PR TITLE
Install latest iptables packages

### DIFF
--- a/roles/os_firewall/tasks/iptables.yml
+++ b/roles/os_firewall/tasks/iptables.yml
@@ -17,7 +17,7 @@
 - name: Install iptables packages
   package:
     name: "{{ item }}"
-    state: present
+    state: latest
   with_items:
     - iptables
     - iptables-services


### PR DESCRIPTION
Install the latest versions of the iptables and iptables-service packages in order to avoid depsolve failures in the package manager's transition check.

Because the task was only asserting the packages' presence, it would try to install a newer iptables-services package with an older iptables package if the latter were already present, and because the iptables and iptables-services packages are version-locked, installing a newer iptables-services package with an older iptables package fails.

For example, if iptables 1.4.21-18 were installed and iptables-services-1.4.21-21 were available, Yum would fail with the following error message:

    iptables = 1.4.21-21.el7 is needed by iptables-services-1.4.21-21.el7.x86_64

This change will avoid the problem by asserting both packages are at the latest version, on the assumption that the latest version of each package is the same.

---

An alternative approach would be to rely on the user to update all packages before running the installer, in which case I would propose adding a pre-install check that would fail if packages were not up to date.