### PR TITLE
(3.6 backport of #5693) Bug 1490647 - logging-fluentd deployed with openshift_logging_use_mux=false fails to start due to missing

### DIFF
--- a/roles/openshift_logging_fluentd/templates/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/fluentd.j2
@@ -66,7 +66,9 @@ spec:
           readOnly: true
         - name: filebufferstorage
           mountPath: /var/lib/fluentd
-{% if openshift_logging_mux_client_mode is defined %}
+{% if openshift_logging_mux_client_mode is defined and
+     ((openshift_logging_mux_allow_external is defined and openshift_logging_mux_allow_external | bool) or
+      (openshift_logging_use_mux is defined and openshift_logging_use_mux | bool)) %}
         - name: muxcerts
           mountPath: /etc/fluent/muxkeys
           readOnly: true
@@ -116,7 +118,9 @@ spec:
               resource: limits.memory
         - name: "FILE_BUFFER_LIMIT"
           value: "{{ openshift_logging_fluentd_file_buffer_limit | default('1Gi') }}"
-{% if openshift_logging_mux_client_mode is defined %}
+{% if openshift_logging_mux_client_mode is defined and
+     ((openshift_logging_mux_allow_external is defined and openshift_logging_mux_allow_external | bool) or
+      (openshift_logging_use_mux is defined and openshift_logging_use_mux | bool)) %}
         - name: "MUX_CLIENT_MODE"
           value: "{{ openshift_logging_mux_client_mode }}"
 {% endif %}
@@ -148,7 +152,9 @@ spec:
       - name: dockerdaemoncfg
         hostPath:
           path: /etc/docker
-{% if openshift_logging_mux_client_mode is defined %}
+{% if openshift_logging_mux_client_mode is defined and
+     ((openshift_logging_mux_allow_external is defined and openshift_logging_mux_allow_external | bool) or
+      (openshift_logging_use_mux is defined and openshift_logging_use_mux | bool)) %}
       - name: muxcerts
         secret:
           secretName: logging-mux


### PR DESCRIPTION
(3.6 backport of #5693)

If openshift_logging_use_mux=False and openshift_logging_mux_allow_external=False,
then all other mux related parameters should be set to False (if boolean) or
removed (e.g. openshift_logging_mux_client_mode should be undefined).

(cherry picked from commit 554a9281265e0234af6a1de4142c67f5f8061de1)