### PR TITLE
[WIP] Bug 1488367: Create registry certificates fails when openshift_hosted_routers have a ca called ca.crt 

### DIFF
--- a/roles/openshift_hosted/tasks/router.yml
+++ b/roles/openshift_hosted/tasks/router.yml
@@ -26,7 +26,6 @@
   command: mktemp -d /tmp/openshift-ansible-XXXXXXX
   register: l_openshift_hosted_router_tempdir
   changed_when: False
-  when: ( not openshift_hosted_router_create_certificate | bool ) or openshift_hosted_router_certificate != {}
 
 - name: Get the certificate contents for router
   copy:
@@ -48,8 +47,8 @@
       hostnames:
       - "{{ openshift_master_default_subdomain | default('router.default.svc.cluster.local') }}"
       - "*.{{ openshift_master_default_subdomain | default('router.default.svc.cluster.local') }}"
-      cert: "{{ ((l_openshift_hosted_router_tempdir.stdout ~ '/') ~ (item.certificate.certfile | basename)) if 'certfile' in item.certificate else ((openshift_master_config_dir) ~ '/openshift-router.crt') }}"
-      key: "{{ ((l_openshift_hosted_router_tempdir.stdout ~ '/')~ (item.certificate.keyfile | basename)) if 'keyfile' in item.certificate else ((openshift_master_config_dir) ~ '/openshift-router.key') }}"
+      cert: "{{ l_openshift_hosted_router_tempdir.stdout ~ '/openshift-router.crt' }}"
+      key: "{{ l_openshift_hosted_router_tempdir.stdout ~ '/openshift-router.key' }}"
     with_items: "{{ openshift_hosted_routers }}"
 
   - name: set the openshift_hosted_router_certificate

--- a/roles/openshift_hosted/tasks/router.yml
+++ b/roles/openshift_hosted/tasks/router.yml
@@ -22,10 +22,16 @@
     openshift_hosted_router_selector: "{{ openshift.hosted.router.selector | default(None) }}"
     openshift_hosted_router_image: "{{ openshift.hosted.router.registryurl }}"
 
+- name: Create temporary directory for router artifacts
+  command: mktemp -d /tmp/openshift-ansible-XXXXXXX
+  register: l_openshift_hosted_router_tempdir
+  changed_when: False
+  when: ( not openshift_hosted_router_create_certificate | bool ) or openshift_hosted_router_certificate != {}
+
 - name: Get the certificate contents for router
   copy:
     backup: True
-    dest: "/etc/origin/master/{{ item | basename }}"
+    dest: "{{ l_openshift_hosted_router_tempdir.stdout }}/{{ item | basename }}"
     src: "{{ item }}"
   with_items: "{{ openshift_hosted_routers | oo_collect(attribute='certificate') |
                   oo_select_keys_from_list(['keyfile', 'certfile', 'cafile']) }}"
@@ -42,8 +48,8 @@
       hostnames:
       - "{{ openshift_master_default_subdomain | default('router.default.svc.cluster.local') }}"
       - "*.{{ openshift_master_default_subdomain | default('router.default.svc.cluster.local') }}"
-      cert: "{{ ('/etc/origin/master/' ~ (item.certificate.certfile | basename)) if 'certfile' in item.certificate else ((openshift_master_config_dir) ~ '/openshift-router.crt') }}"
-      key: "{{ ('/etc/origin/master/' ~ (item.certificate.keyfile | basename)) if 'keyfile' in item.certificate else ((openshift_master_config_dir) ~ '/openshift-router.key') }}"
+      cert: "{{ ((l_openshift_hosted_router_tempdir.stdout ~ '/') ~ (item.certificate.certfile | basename)) if 'certfile' in item.certificate else ((openshift_master_config_dir) ~ '/openshift-router.crt') }}"
+      key: "{{ ((l_openshift_hosted_router_tempdir.stdout ~ '/')~ (item.certificate.keyfile | basename)) if 'keyfile' in item.certificate else ((openshift_master_config_dir) ~ '/openshift-router.key') }}"
     with_items: "{{ openshift_hosted_routers }}"
 
   - name: set the openshift_hosted_router_certificate
@@ -90,9 +96,9 @@
     service_account: "{{ item.serviceaccount | default('router') }}"
     selector: "{{ item.selector | default(none) }}"
     images: "{{ item.images | default(omit) }}"
-    cert_file: "{{ ('/etc/origin/master/' ~ (item.certificate.certfile | basename)) if 'certfile' in item.certificate else omit }}"
-    key_file: "{{ ('/etc/origin/master/' ~ (item.certificate.keyfile | basename)) if 'keyfile' in item.certificate else omit }}"
-    cacert_file: "{{ ('/etc/origin/master/' ~ (item.certificate.cafile | basename)) if 'cafile' in item.certificate else omit }}"
+    cert_file: "{{ ((l_openshift_hosted_router_tempdir.stdout ~ '/') ~ (item.certificate.certfile | basename)) if 'certfile' in item.certificate else omit }}"
+    key_file: "{{ ((l_openshift_hosted_router_tempdir.stdout ~ '/') ~ (item.certificate.keyfile | basename)) if 'keyfile' in item.certificate else omit }}"
+    cacert_file: "{{ ((l_openshift_hosted_router_tempdir.stdout ~ '/') ~ (item.certificate.cafile | basename)) if 'cafile' in item.certificate else omit }}"
     edits: "{{ openshift_hosted_router_edits | union(item.edits)  }}"
     ports: "{{ item.ports }}"
     stats_port: "{{ item.stats_port }}"
@@ -103,3 +109,9 @@
   vars:
     l_openshift_hosted_wait_for_pod: "{{ openshift_hosted_router_wait }}"
     l_openshift_hosted_wfp_items: "{{ openshift_hosted_routers }}"
+
+- name: Delete temporary directory
+  file:
+    path: "{{ l_openshift_hosted_router_tempdir.stdout }}"
+    state: absent
+  changed_when: False


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1488367