### PR TITLE
Tuned profiles are no longer installed by rpms.

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -124,8 +124,6 @@
         - origin-clients
         - origin-node
         - origin-sdn-ovs
-        - tuned-profiles-openshift-node
-        - tuned-profiles-origin-node
 
       - name: Remove flannel package
         package: name=flannel state=absent

--- a/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
@@ -17,7 +17,6 @@
       - "{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
       - "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version }}"
       - "{{ openshift.common.service_type }}-clients{{ openshift_pkg_version }}"
-      - "tuned-profiles-{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
       - PyYAML
   when:
     - component == "master"

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1718,8 +1718,7 @@ def set_installed_variant_rpm_facts(facts):
     for base_rpm in ['openshift', 'atomic-openshift', 'origin']:
         optional_rpms = ['master', 'node', 'clients', 'sdn-ovs']
         variant_rpms = [base_rpm] + \
-                       ['{0}-{1}'.format(base_rpm, r) for r in optional_rpms] + \
-                       ['tuned-profiles-%s-node' % base_rpm]
+                       ['{0}-{1}'.format(base_rpm, r) for r in optional_rpms]
         for rpm in variant_rpms:
             exit_code, _, _ = module.run_command(['rpm', '-q', rpm])  # noqa: F405
             if exit_code == 0:


### PR DESCRIPTION
A cleanup PR in support of openshift/origin/pull/16442.