### PR TITLE
1499254 Ensure host was reached for proper conditional validation

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
@@ -30,6 +30,7 @@
         ansible_become: "{{ g_sudo | default(omit) }}"
       with_items: " {{ groups['oo_nodes_to_config'] }}"
       when:
+      - hostvars[item].openshift is defined
       - hostvars[item].openshift.common.hostname in nodes_to_upgrade.results.results[0]['items'] | map(attribute='metadata.name') | list
       changed_when: false
 


### PR DESCRIPTION
If a host was unreachable during module setup, facts will not be
initialized properly and will result in later failures when stepping
through host groups.  Verification that 'openshift' is defined will skip
any hosts which were previously unreachable and did not have facts
initialized.

Fixes 1499254

https://bugzilla.redhat.com/show_bug.cgi?id=1499254