### PR TITLE
Adding support for cluster-autoscaler.

### DIFF
--- a/roles/lib_openshift/library/oc_adm_policy_user.py
+++ b/roles/lib_openshift/library/oc_adm_policy_user.py
@@ -71,6 +71,12 @@ options:
     required: false
     default: None
     aliases: []
+  role_namespace:
+    description:
+    - The namespace where to find the role
+    required: false
+    default: None
+    aliases: []
   debug:
     description:
     - Turn on debug output.
@@ -122,6 +128,14 @@ EXAMPLES = '''
     resource_kind: cluster-role
     resource_name: system:build-strategy-docker
     state: present
+
+- name: oc adm policy add-role-to-user system:build-strategy-docker ausername --role-namespace foo
+  oc_adm_policy_user:
+    user: ausername
+    resource_kind: cluster-role
+    resource_name: system:build-strategy-docker
+    state: present
+    role_namespace: foo
 '''
 
 # -*- -*- -*- End included fragment: doc/policy_user -*- -*- -*-
@@ -2065,6 +2079,9 @@ class PolicyUser(OpenShiftCLI):
                self.config.config_options['name']['value'],
                self.config.config_options['user']['value']]
 
+        if self.config.config_options['role_namespace']['value'] is not None:
+            cmd.extend(['--role-namespace', self.config.config_options['role_namespace']['value']])
+
         return self.openshift_cmd(cmd, oadm=True)
 
     @staticmethod
@@ -2085,6 +2102,7 @@ class PolicyUser(OpenShiftCLI):
                                     'user': {'value': params['user'], 'include': False},
                                     'resource_kind': {'value': params['resource_kind'], 'include': False},
                                     'name': {'value': params['resource_name'], 'include': False},
+                                    'role_namespace': {'value': params['role_namespace'], 'include': False},
                                    })
 
         policyuser = PolicyUser(nconfig, params['debug'])
@@ -2149,6 +2167,7 @@ def main():
             debug=dict(default=False, type='bool'),
             resource_name=dict(required=True, type='str'),
             namespace=dict(default='default', type='str'),
+            role_namespace=dict(default=None, type='str'),
             kubeconfig=dict(default='/etc/origin/master/admin.kubeconfig', type='str'),
 
             user=dict(required=True, type='str'),

--- a/roles/lib_openshift/src/ansible/oc_adm_policy_user.py
+++ b/roles/lib_openshift/src/ansible/oc_adm_policy_user.py
@@ -14,6 +14,7 @@ def main():
             debug=dict(default=False, type='bool'),
             resource_name=dict(required=True, type='str'),
             namespace=dict(default='default', type='str'),
+            role_namespace=dict(default=None, type='str'),
             kubeconfig=dict(default='/etc/origin/master/admin.kubeconfig', type='str'),
 
             user=dict(required=True, type='str'),

--- a/roles/lib_openshift/src/class/oc_adm_policy_user.py
+++ b/roles/lib_openshift/src/class/oc_adm_policy_user.py
@@ -148,6 +148,9 @@ class PolicyUser(OpenShiftCLI):
                self.config.config_options['name']['value'],
                self.config.config_options['user']['value']]
 
+        if self.config.config_options['role_namespace']['value'] is not None:
+            cmd.extend(['--role-namespace', self.config.config_options['role_namespace']['value']])
+
         return self.openshift_cmd(cmd, oadm=True)
 
     @staticmethod
@@ -168,6 +171,7 @@ class PolicyUser(OpenShiftCLI):
                                     'user': {'value': params['user'], 'include': False},
                                     'resource_kind': {'value': params['resource_kind'], 'include': False},
                                     'name': {'value': params['resource_name'], 'include': False},
+                                    'role_namespace': {'value': params['role_namespace'], 'include': False},
                                    })
 
         policyuser = PolicyUser(nconfig, params['debug'])

--- a/roles/lib_openshift/src/doc/policy_user
+++ b/roles/lib_openshift/src/doc/policy_user
@@ -20,6 +20,12 @@ options:
     required: false
     default: None
     aliases: []
+  role_namespace:
+    description:
+    - The namespace where to find the role
+    required: false
+    default: None
+    aliases: []
   debug:
     description:
     - Turn on debug output.
@@ -71,4 +77,12 @@ EXAMPLES = '''
     resource_kind: cluster-role
     resource_name: system:build-strategy-docker
     state: present
+
+- name: oc adm policy add-role-to-user system:build-strategy-docker ausername --role-namespace foo
+  oc_adm_policy_user:
+    user: ausername
+    resource_kind: cluster-role
+    resource_name: system:build-strategy-docker
+    state: present
+    role_namespace: foo
 '''

--- a/roles/openshift_cluster_autoscaler/README.md
+++ b/roles/openshift_cluster_autoscaler/README.md
@@ -1,0 +1,58 @@
+Openshift cluster autoscaler
+================================
+
+Install the cluster autoscaler
+
+Requirements
+------------
+
+* One or more Master servers
+* A cloud provider that supports the cluster-autoscaler
+
+Role Variables
+--------------
+Check defaults/main.yml
+
+Dependencies
+------------
+
+
+Example Playbook
+----------------
+
+#!/usr/bin/ansible-playbook
+```
+---
+- hosts: masters
+  gather_facts: no
+  remote_user: root
+  tasks:
+  - name: include role autoscaler
+    include_role:
+      name: openshift_cluster_autoscaler
+    vars:
+      openshift_clusterid: opstest
+      openshift_cluster_autoscaler_aws_key: <aws_key>
+      openshift_cluster_autoscaler_aws_secret_key: <aws_secret_key>
+```
+
+
+Notes
+-----
+
+This is currently experimental software.  This role allows users to install the cluster-autoscaler and the necessary authorization pieces that allow the autoscaler to function.
+
+
+This feature requires cloud provider credentials or a serviceaccount that has access to scale up/down nodes within the scaling groups.
+
+https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+
+License
+-------
+
+Apache License, Version 2.0
+
+Author Information
+------------------
+
+Openshift

--- a/roles/openshift_cluster_autoscaler/defaults/main.yml
+++ b/roles/openshift_cluster_autoscaler/defaults/main.yml
@@ -1,0 +1,40 @@
+---
+openshift_cluster_autoscaler_name: cluster-autoscaler
+openshift_cluster_autoscaler_version: 4
+
+openshift_cluster_autoscaler_template_location: /tmp
+openshift_cluster_autoscaler_template_name: "{{ openshift_cluster_autoscaler_name }}"
+
+openshift_cluster_autoscaler_node_selector:
+  type: infra
+
+openshift_cluster_autoscaler_state: present
+openshift_cluster_autoscaler_namespace: openshift-infra
+openshift_cluster_autoscaler_delete_config: True
+openshift_cluster_autoscaler_skip_nodes_local_storage: False
+openshift_cluster_autoscaler_serviceaccount: cluster-autoscaler
+openshift_cluster_autoscaler_region: us-east-1
+
+openshift_cluster_autoscaler_image: docker.io/openshift/kubernetes-autoscaler:v0.6.1
+
+openshift_cluster_autoscaler_cloud_provider: aws
+
+# AWS specific variables here
+openshift_cluster_autoscaler_aws_creds_name: aws-creds
+openshift_cluster_autoscaler_aws_secret_name: autoscaler-credentials
+openshift_cluster_autoscaler_aws_creds_path: "/var/run/secrets/{{ openshift_cluster_autoscaler_aws_creds_name }}/creds"
+openshift_cluster_autoscaler_aws_env_vars:
+- name: AWS_REGION
+  value: "{{ openshift_cluster_autoscaler_region }}"
+- name: AWS_SHARED_CREDENTIALS_FILE
+  value: "{{ openshift_cluster_autoscaler_aws_creds_path }}"
+
+## End AWS vars ##
+
+openshift_cluster_autoscaler_env_vars: []
+
+
+openshift_cluster_autoscaler_node_groups:
+- min: 3
+  max: 10
+  name: "{{ openshift_cluster_autoscaler_node_group_name | default(openshift_clusterid ~ ' openshift compute') }}"

--- a/roles/openshift_cluster_autoscaler/files/clusterrole.yml
+++ b/roles/openshift_cluster_autoscaler/files/clusterrole.yml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  name: system:cluster-autoscaler
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  attributeRestrictions: null
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  attributeRestrictions: null
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+  attributeRestrictions: null

--- a/roles/openshift_cluster_autoscaler/files/role.yml
+++ b/roles/openshift_cluster_autoscaler/files/role.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Role
+metadata:
+  name: cluster-autoscaler
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - cluster-autoscaler
+  - cluster-autoscaler-status
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+  attributeRestrictions: null
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  attributeRestrictions: null
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  attributeRestrictions: null

--- a/roles/openshift_cluster_autoscaler/meta/main.yml
+++ b/roles/openshift_cluster_autoscaler/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+- lib_openshift

--- a/roles/openshift_cluster_autoscaler/tasks/aws.yml
+++ b/roles/openshift_cluster_autoscaler/tasks/aws.yml
@@ -1,0 +1,17 @@
+---
+- when: openshift_cluster_autoscaler_cloud_provider == 'aws'
+  block:
+  - name: laydown the aws-credentials
+    template:
+      src: aws-creds.j2
+      dest: "{{ openshift_cluster_autoscaler_template_location }}/{{ openshift_cluster_autoscaler_aws_creds_name }}"
+    when: openshift_cluster_autoscaler_state == 'present'
+
+  - name: create the aws creds secret
+    oc_secret:
+      state: "{{ openshift_cluster_autoscaler_state }}"
+      name: "{{ openshift_cluster_autoscaler_aws_secret_name }}"
+      namespace: "{{ openshift_cluster_autoscaler_namespace }}"
+      files:
+      - name: creds
+        path: "{{ openshift_cluster_autoscaler_template_location }}/{{ openshift_cluster_autoscaler_aws_creds_name }}"

--- a/roles/openshift_cluster_autoscaler/tasks/main.yml
+++ b/roles/openshift_cluster_autoscaler/tasks/main.yml
@@ -1,0 +1,72 @@
+---
+- name: create the cluster-autoscaler serviceaccount
+  oc_serviceaccount:
+    name: "{{ openshift_cluster_autoscaler_serviceaccount }}"
+    namespace: "{{ openshift_cluster_autoscaler_namespace }}"
+    state: "{{ openshift_cluster_autoscaler_state }}"
+
+- name: copy the cluster-autoscaler files
+  copy:
+    src: "{{ item }}"
+    dest: "{{ openshift_cluster_autoscaler_template_location }}/{{ item }}"
+  with_items:
+  - clusterrole.yml
+  - role.yml
+  when: openshift_cluster_autoscaler_state == 'present'
+
+- name: "Ensure the cluster-autoscaler roles are {{ openshift_cluster_autoscaler_state }}"
+  oc_obj:
+    namespace: "{{ openshift_cluster_autoscaler_namespace }}"
+    state: "{{ openshift_cluster_autoscaler_state }}"
+    kind: "{{ item.type }}"
+    name: "{{ item.name }}"
+    delete_after: "{{ openshift_cluster_autoscaler_delete_config }}"
+    files:
+    - "{{ openshift_cluster_autoscaler_template_location }}/{{ item.fname }}"
+  with_items:
+  - fname: clusterrole.yml
+    type: clusterrole
+    name: "system:{{ openshift_cluster_autoscaler_name }}"
+  - fname: role.yml
+    type: role
+    name: "{{ openshift_cluster_autoscaler_name }}"
+
+- include: aws.yml
+  when: openshift_cluster_autoscaler_cloud_provider == 'aws'
+
+- name: create the policies
+  oc_adm_policy_user:
+    state: "{{ openshift_cluster_autoscaler_state }}"
+    user: "system:serviceaccount:openshift-infra:{{ openshift_cluster_autoscaler_serviceaccount }}"
+    namespace: "{{ openshift_cluster_autoscaler_namespace }}"
+    resource_kind: "{{ item.name }}"
+    resource_name: cluster-autoscaler
+    role_namespace: "{{ item.role_namespace | default(omit) }}"
+  with_items:
+  - name: cluster-role
+  - name: role
+    role_namespace: "{{ openshift_cluster_autoscaler_namespace }}"
+
+- name: "grant cluster-reader to {{ openshift_cluster_autoscaler_serviceaccount }}"
+  oc_adm_policy_user:
+    state: "{{ openshift_cluster_autoscaler_state }}"
+    user: "system:serviceaccount:{{ openshift_cluster_autoscaler_namespace }}:{{ openshift_cluster_autoscaler_serviceaccount }}"
+    namespace: "{{ openshift_cluster_autoscaler_namespace }}"
+    resource_name: cluster-reader
+    resource_kind: cluster-role
+
+- name: laydown the deployment file for cluster-autoscaler
+  template:
+    src: cluster-autoscaler.j2
+    dest: "{{ openshift_cluster_autoscaler_template_location }}/{{ openshift_cluster_autoscaler_template_name }}"
+  when: openshift_cluster_autoscaler_state == 'present'
+
+- name: "Ensure the cluster-autoscaler is {{ openshift_cluster_autoscaler_state }}"
+  oc_obj:
+    namespace: "{{ openshift_cluster_autoscaler_namespace }}"
+    state: "{{ openshift_cluster_autoscaler_state }}"
+    kind: deployment
+    name: "{{ openshift_cluster_autoscaler_name }}"
+    delete_after: "{{ openshift_cluster_autoscaler_delete_config }}"
+    files:
+    - "{{ openshift_cluster_autoscaler_template_location }}/{{ openshift_cluster_autoscaler_template_name }}"

--- a/roles/openshift_cluster_autoscaler/templates/aws-creds.j2
+++ b/roles/openshift_cluster_autoscaler/templates/aws-creds.j2
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id = {{ openshift_cluster_autoscaler_aws_key }}
+aws_secret_access_key = {{ openshift_cluster_autoscaler_aws_secret_key }}

--- a/roles/openshift_cluster_autoscaler/templates/cluster-autoscaler.j2
+++ b/roles/openshift_cluster_autoscaler/templates/cluster-autoscaler.j2
@@ -1,0 +1,58 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ openshift_cluster_autoscaler_name }}
+  name: {{ openshift_cluster_autoscaler_name }}
+  namespace: {{ openshift_cluster_autoscaler_namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ openshift_cluster_autoscaler_name }}
+      role: infra
+  template:
+    metadata:
+      labels:
+        app: {{ openshift_cluster_autoscaler_name }}
+        role: infra
+    spec:
+      containers:
+      - args:
+        - --alsologtostderr
+        - --v={{ openshift_cluster_autoscaler_version }}
+        - --skip-nodes-with-local-storage={{ openshift_cluster_autoscaler_skip_nodes_local_storage }}
+        - --leader-elect-resource-lock=configmaps
+        - --namespace={{ openshift_cluster_autoscaler_namespace }}
+{% if openshift_cluster_autoscaler_scale_down_delay is defined %}
+        - --scale-down-delay={{ openshift_cluster_autoscaler_scale_down_delay }}
+{% endif %}
+        - --cloud-provider={{ openshift_cluster_autoscaler_cloud_provider }}
+{% for group in openshift_cluster_autoscaler_node_groups %}
+        - --nodes={{ group.min }}:{{ group.max }}:{{ group.name }}
+{% endfor %}
+{% if openshift_cluster_autoscaler_cloud_provider == 'aws' %}
+        env: {{ openshift_cluster_autoscaler_aws_env_vars | union(openshift_cluster_autoscaler_env_vars) | to_json }}
+{% else %}
+        env: {{ openshift_cluster_autoscaler_env_vars }}
+{% endif %}
+        image: {{ openshift_cluster_autoscaler_image }}
+        name: autoscaler
+{% if openshift_cluster_autoscaler_cloud_provider == 'aws' %}
+        volumeMounts:
+        - mountPath: {{ openshift_cluster_autoscaler_aws_creds_path | dirname }}
+          name: {{ openshift_cluster_autoscaler_aws_creds_name }}
+          readOnly: true
+{% endif %}
+      nodeSelector: {{ openshift_cluster_autoscaler_node_selector | to_json }}
+      dnsPolicy: ClusterFirst
+      serviceAccountName: {{ openshift_cluster_autoscaler_serviceaccount }}
+      terminationGracePeriodSeconds: 30
+{% if openshift_cluster_autoscaler_cloud_provider == 'aws' %}
+      volumes:
+      - name: {{ openshift_cluster_autoscaler_aws_creds_name }}
+        secret:
+          defaultMode: 420
+          secretName: {{ openshift_cluster_autoscaler_aws_secret_name }}
+{% endif %}


### PR DESCRIPTION
This is the kubernetes cluster-autoscaler role.

Features:
- Updated lib_openshift to handle --role-namespace when modifying/creating rolebindings for specific namespaced role objects
- openshift_cluster_autoscaler role to deploy the autoscaler