### PR TITLE
Restart all controllers to force reconfiguration during upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
@@ -119,7 +119,23 @@
   tasks:
   - include: ../cleanup_unused_images.yml
 
+#TODO: Why doesn't this compose using ./upgrade_control_plane rather than
+# ../upgrade_control_plane?
 - include: ../upgrade_control_plane.yml
+
+# All controllers must be stopped at the same time then restarted
+- name: Cycle all controller services to force new leader election mode
+  hosts: oo_etcd_to_config
+  gather_facts: no
+  tasks:
+  - name: Stop {{ openshift.common.service_type }}-master-controllers
+    systemd:
+      name: "{{ openshift.common.service_type }}-master-controllers"
+      state: stopped
+  - name: Start {{ openshift.common.service_type }}-master-controllers
+    systemd:
+      name: "{{ openshift.common.service_type }}-master-controllers"
+      state: started
 
 - include: ../upgrade_nodes.yml
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -128,4 +128,18 @@
   vars:
     master_config_hook: "v3_7/master_config_upgrade.yml"
 
+# All controllers must be stopped at the same time then restarted
+- name: Cycle all controller services to force new leader election mode
+  hosts: oo_etcd_to_config
+  gather_facts: no
+  tasks:
+  - name: Stop {{ openshift.common.service_type }}-master-controllers
+    systemd:
+      name: "{{ openshift.common.service_type }}-master-controllers"
+      state: stopped
+  - name: Start {{ openshift.common.service_type }}-master-controllers
+    systemd:
+      name: "{{ openshift.common.service_type }}-master-controllers"
+      state: started
+
 - include: ../post_control_plane.yml


### PR DESCRIPTION
When switching from old style leader election to new style you must ensure that all controllers are stopped at the same time before being restarted. Normal restarts happen only on one master at a time because we upgrade them in a serial manners. So after the rest of the control plane upgrade is complete stop them and start them again during 3.7 upgrade.

Partial fix for https://github.com/openshift/openshift-ansible/issues/4979