### PR TITLE
Default groups.oo_new_etcd_to_config to an empty list

### DIFF
--- a/playbooks/common/openshift-etcd/scaleup.yml
+++ b/playbooks/common/openshift-etcd/scaleup.yml
@@ -71,7 +71,7 @@
     etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
     openshift_ca_host: "{{ groups.oo_first_master.0 }}"
     openshift_master_etcd_hosts: "{{ hostvars
-                                     | oo_select_keys(groups['oo_etcd_to_config'] | union(groups['oo_new_etcd_to_config']))
+                                     | oo_select_keys(groups['oo_etcd_to_config'] | union(groups['oo_new_etcd_to_config'] | default([]) ))
                                      | oo_collect('openshift.common.hostname')
                                      | default(none, true) }}"
     openshift_master_etcd_port: "{{ (etcd_client_port | default('2379')) if (groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config) else none }}"


### PR DESCRIPTION
In case there is zero etcd hosts to scale up. The scalup playbook is used as part of the etcd data v2->v3 migration. In case there is only one 1-node etcd cluster, the scale-up iterates over an empty list of etcd hosts.

This is a bug fix. We should skip the scaleup playbook when there is no etcd member to scaleup. However, no matter the way the scaleup playbook is run, it should not fail this way.