### PR TITLE
Fix containerized node service unit placement order

### DIFF
--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -1,4 +1,7 @@
 ---
+# systemd_units.yml is included both in the openshift_master role and in the upgrade
+# playbooks.
+
 - include: upgrade_facts.yml
   when: openshift_master_defaults_in_use is not defined
 

--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -29,7 +29,7 @@
     line: "{% raw %}ExecStart=/usr/bin/openshift start node --bootstrap --kubeconfig=${KUBECONFIG} $OPTIONS{% endraw %}"
     regexp: "^ExecStart=.*"
 
-- name: "systemctl enable {{ openshift_service_type }}-node"
+- name: "disable {{ openshift_service_type }}-node and {{ openshift_service_type }}-master services"
   systemd:
     name: "{{ item }}"
     enabled: no

--- a/roles/openshift_node/tasks/config/install-node-docker-service-file.yml
+++ b/roles/openshift_node/tasks/config/install-node-docker-service-file.yml
@@ -1,8 +1,0 @@
----
-- name: Install Node docker service file
-  template:
-    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
-    src: openshift.docker.node.service
-  notify:
-  - reload systemd units
-  - restart node

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -27,5 +27,3 @@
       docker pull {{ openshift.node.node_image }}:{{ openshift_image_tag }}
     register: pull_result
     changed_when: "'Downloaded newer image' in pull_result.stdout"
-
-  - include: config/install-node-docker-service-file.yml

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -1,11 +1,9 @@
 ---
-# This file is included both in the openshift_master role and in the upgrade
-# playbooks.
 - name: Install Node service file
   template:
     dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
-    src: "node.service.j2"
-  when: not openshift.common.is_containerized | bool
+    src: "{{ openshift.common.is_containerized | bool | ternary('openshift.docker.node.service', 'node.service.j2') }}"
+  when: not openshift.common.is_node_system_container | bool
   notify:
   - reload systemd units
   - restart node


### PR DESCRIPTION
Currently, non-containerized nodes have systemd
service unit files created after registry auth
credentials are created.  Containerized nodes
place service unit files prior to creation of
these credentials.

This commit ensures systemd service units
are created at the correct time for both
containerized and non-containerized nodes.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1500642