### PR TITLE
[1.5] Ensure docker service status actually changes

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -122,6 +122,13 @@
   notify:
   - restart docker
 
+# The following task is needed as the systemd module may report a change in
+# state even though docker is already running.
+- name: Detect if docker is already started
+  command: "systemctl show docker -p ActiveState"
+  changed_when: False
+  register: r_docker_already_running_result
+
 - name: Start the Docker service
   systemd:
     name: docker
@@ -131,7 +138,7 @@
   register: start_result
 
 - set_fact:
-    docker_service_status_changed: start_result | changed
+    docker_service_status_changed: "{{ (start_result | changed) and (r_docker_already_running_result.stdout != 'ActiveState=active' ) }}"
 
 - name: Check for credentials file for registry auth
   stat:


### PR DESCRIPTION
Currently, docker is started during the docker role. If
docker is started during the run of the role, the
handler to restart docker is not triggered to prevent
excess restarts of the docker service.

The systemd docker that starts the docker service may
report the result of the task as 'changed' even though
docker is already running and the state of the service
itself does not change.

This commit checks the status of the docker service
before starting it to ensure that docker was not in
an 'active' state according to systemd. If the
docker service is already in the 'active' state,
the restart handler will trigger and restart
docker at the end of the run of the role.

Fixes: https://github.com/openshift/origin/issues/16709
(cherry picked from commit 090ba0dbd9bd31be49b66d996a61b936773d65f1)

Backports: https://github.com/openshift/openshift-ansible/pull/5721