### PR TITLE
1484324 Ensure upgrade playbook exits on health check failures

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_health_checks.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_health_checks.yml
@@ -1,12 +1,14 @@
 ---
-- name: Verify Host Requirements
+- name: OpenShift Health Checks
   hosts: oo_all_hosts
+  any_errors_fatal: true
   roles:
   - openshift_health_checker
   vars:
   - r_openshift_health_checker_playbook_context: upgrade
   post_tasks:
-  - action: openshift_health_check
+  - name: Run health checks (upgrade)
+    action: openshift_health_check
     args:
       checks:
       - disk_availability


### PR DESCRIPTION
Adds `any_errors_fatal: true`

https://bugzilla.redhat.com/show_bug.cgi?id=1484324