### PR TITLE
Add ability to set node and master imageConfig to latest

### DIFF
--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -51,3 +51,6 @@ r_openshift_master_data_dir: "{{ r_openshift_master_data_dir_default }}"
 
 r_openshift_master_sdn_network_plugin_name_default: "{{ os_sdn_network_plugin_name | default('redhat/openshift-ovs-subnet') }}"
 r_openshift_master_sdn_network_plugin_name: "{{ r_openshift_master_sdn_network_plugin_name_default }}"
+
+openshift_master_image_config_latest_default: "{{ openshift_image_config_latest | default(False) }}"
+openshift_master_image_config_latest: "{{ openshift_master_image_config_latest_default }}"

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -115,7 +115,7 @@ etcdStorageConfig:
   openShiftStorageVersion: v1
 imageConfig:
   format: {{ openshift.master.registry_url }}
-  latest: false
+  latest: {{ openshift_master_image_config_latest }}
 {% if 'image_policy_config' in openshift.master %}
 imagePolicyConfig:{{ openshift.master.image_policy_config | to_padded_yaml(level=1) }}
 {% endif %}

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -107,3 +107,6 @@ openshift_node_use_contiv: "{{ openshift_node_use_contiv_default }}"
 
 openshift_node_data_dir_default: "{{ openshift_data_dir | default('/var/lib/origin') }}"
 openshift_node_data_dir: "{{ openshift_node_data_dir_default }}"
+
+openshift_node_image_config_latest_default: "{{ openshift_image_config_latest | default(False) }}"
+openshift_node_image_config_latest: "{{ openshift_node_image_config_latest_default }}"

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -13,7 +13,7 @@ dockerConfig:
 iptablesSyncPeriod: "{{ openshift.node.iptables_sync_period }}"
 imageConfig:
   format: {{ openshift.node.registry_url }}
-  latest: false
+  latest: {{ openshift_node_image_config_latest }}
 kind: NodeConfig
 kubeletArguments: {{ openshift.node.kubelet_args | default(None) | to_padded_yaml(level=1) }}
 {% if openshift_use_crio | default(False) %}


### PR DESCRIPTION
Currently, imageConfig.latest is hard-coded to false.

This commit adds an appropriate boolean to enable
setting to true.

Fixes: https://github.com/openshift/openshift-ansible/issues/1422