### PR TITLE
Ensuring that kube-service-catalog project has empty node-selector

### DIFF
--- a/roles/openshift_service_catalog/tasks/install.yml
+++ b/roles/openshift_service_catalog/tasks/install.yml
@@ -25,6 +25,15 @@
     name: "kube-service-catalog"
     node_selector: ""
 
+- name: Set Service Catalog namespace nodeSelector annotation
+  oc_edit:
+    state: present
+    kind: project
+    name: kube-service-catalog
+    separator: '#'
+    content:
+      metadata#annotations#openshift.io/node-selector: ""
+
 - name: Make kube-service-catalog project network global
   command: >
     oc adm pod-network make-projects-global kube-service-catalog


### PR DESCRIPTION
This doesn't appear to be an issue in 3.7, but for 3.6 the default node selector of "" isn't being set with the `oc_project module` which prevents the kube-service-catalog pods from being able to deploy to master in cases where the `osm_default_node_selector` doesn't match any labels on the master node.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1483787