### PR TITLE
Update service catalog playbook for service-catalog rc1

### DIFF
--- a/files/origin-components/template-service-broker-registration.yaml
+++ b/files/origin-components/template-service-broker-registration.yaml
@@ -10,7 +10,7 @@ parameters:
 objects:
 # register the tsb with the service catalog
 - apiVersion: servicecatalog.k8s.io/v1beta1
-  kind: ServiceBroker
+  kind: ClusterServiceBroker
   metadata:
     name: template-service-broker
   spec:

--- a/files/origin-components/template-service-broker-registration.yaml
+++ b/files/origin-components/template-service-broker-registration.yaml
@@ -9,7 +9,7 @@ parameters:
   required: true
 objects:
 # register the tsb with the service catalog
-- apiVersion: servicecatalog.k8s.io/v1alpha1
+- apiVersion: servicecatalog.k8s.io/v1beta1
   kind: ServiceBroker
   metadata:
     name: template-service-broker

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -327,12 +327,12 @@
   oc_obj:
     name: ansible-service-broker
     state: present
-    kind: ServiceBroker
+    kind: ClusterServiceBroker
     content:
       path: /tmp/brokerout
       data:
         apiVersion: servicecatalog.k8s.io/v1beta1
-        kind: ServiceBroker
+        kind: ClusterServiceBroker
         metadata:
           name: ansible-service-broker
         spec:

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -30,8 +30,12 @@
     ansible_service_broker_image: "{{ ansible_service_broker_image_prefix }}ansible-service-broker:{{ ansible_service_broker_image_tag }}"
     ansible_service_broker_etcd_image: "{{ ansible_service_broker_etcd_image_prefix }}etcd:{{ ansible_service_broker_etcd_image_tag }}"
 
+- set_fact:
+    openshift_master_config_dir: "{{ openshift.common.config_base }}/master"
+  when: openshift_master_config_dir is undefined
+
 - slurp:
-    src: "{{ ansible_service_broker_certs_dir }}/ca.crt"
+    src: "{{ openshift_master_config_dir }}/service-signer.crt"
   register: catalog_ca
 
 

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -331,7 +331,7 @@
     content:
       path: /tmp/brokerout
       data:
-        apiVersion: servicecatalog.k8s.io/v1alpha1
+        apiVersion: servicecatalog.k8s.io/v1beta1
         kind: ServiceBroker
         metadata:
           name: ansible-service-broker

--- a/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
+++ b/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
@@ -206,19 +206,6 @@ objects:
     name: service-catalog-controller
 
 - apiVersion: authorization.openshift.io/v1
-  kind: RoleBinding
-  metadata:
-    name: extension-apiserver-authentication-reader-binding
-    namespace: ${KUBE_SYSTEM_NAMESPACE}
-  roleRef:
-    name: extension-apiserver-authentication-reader
-    namespace: ${KUBE_SYSTEM_NAMESPACE}
-  subjects:
-  - kind: ServiceAccount
-    name: service-catalog-apiserver
-    namespace: kube-service-catalog
-
-- apiVersion: authorization.openshift.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: system:auth-delegator-binding

--- a/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
+++ b/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
@@ -4,22 +4,23 @@ metadata:
   name: service-catalog
 objects:
 
-- kind: ClusterRole
-  apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRole
   metadata:
     name: servicecatalog-serviceclass-viewer
   rules:
   - apiGroups:
     - servicecatalog.k8s.io
     resources:
-    - serviceclasses
+    - clusterserviceclasses
+    - clusterserviceplans
     verbs:
     - list
     - watch
     - get
 
-- kind: ClusterRoleBinding
-  apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRoleBinding
   metadata:
     name: servicecatalog-serviceclass-viewer-binding
   roleRef:
@@ -37,8 +38,8 @@ objects:
   metadata:
     name: service-catalog-apiserver
 
-- kind: ClusterRole
-  apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRole
   metadata:
     name: sar-creator
   rules:
@@ -49,17 +50,19 @@ objects:
     verbs:
     - create
 
-- kind: ClusterRoleBinding
-  apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRoleBinding
   metadata:
     name: service-catalog-sar-creator-binding
   roleRef:
     name: sar-creator
-  userNames:
-    - system:serviceaccount:kube-service-catalog:service-catalog-apiserver
+  subjects:
+  - kind: ServiceAccount
+    name: service-catalog-apiserver
+    namespace: kube-service-catalog
 
-- kind: ClusterRole
-  apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRole
   metadata:
     name: namespace-viewer
   rules:
@@ -72,26 +75,30 @@ objects:
     - watch
     - get
 
-- kind: ClusterRoleBinding
-  apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRoleBinding
   metadata:
     name: service-catalog-namespace-viewer-binding
   roleRef:
     name: namespace-viewer
-  userNames:
-    - system:serviceaccount:kube-service-catalog:service-catalog-apiserver
+  subjects:
+  - kind: ServiceAccount
+    name: service-catalog-apiserver
+    namespace: kube-service-catalog
 
-- kind: ClusterRoleBinding
-  apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRoleBinding
   metadata:
     name: service-catalog-controller-namespace-viewer-binding
   roleRef:
     name: namespace-viewer
-  userNames:
-    - system:serviceaccount:kube-service-catalog:service-catalog-controller
+  subjects:
+  - kind: ServiceAccount
+    name: service-catalog-controller
+    namespace: kube-service-catalog
 
-- kind: ClusterRole
-  apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRole
   metadata:
     name: service-catalog-controller
   rules:
@@ -102,6 +109,7 @@ objects:
     verbs:
     - create
     - update
+    - patch
     - delete
     - get
     - list
@@ -109,19 +117,22 @@ objects:
   - apiGroups:
     - servicecatalog.k8s.io
     resources:
-    - brokers/status
-    - instances/status
-    - bindings/status
+    - clusterservicebrokers/status
+    - serviceinstances/status
+    - servicebindings/status
+    - servicebindings/finalizers
+    - serviceinstances/reference
     verbs:
     - update
   - apiGroups:
     - servicecatalog.k8s.io
     resources:
-    - brokers
-    - instances
-    - bindings
+    - clusterservicebrokers
+    - serviceinstances
+    - servicebindings
     verbs:
     - list
+    - get
     - watch
   - apiGroups:
     - ""
@@ -133,7 +144,8 @@ objects:
   - apiGroups:
     - servicecatalog.k8s.io
     resources:
-    - serviceclasses
+    - clusterserviceclasses
+    - clusterserviceplans
     verbs:
     - create
     - delete
@@ -154,17 +166,19 @@ objects:
     - list
     - watch
 
-- kind: ClusterRoleBinding
-  apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRoleBinding
   metadata:
     name: service-catalog-controller-binding
   roleRef:
     name: service-catalog-controller
-  userNames:
-    - system:serviceaccount:kube-service-catalog:service-catalog-controller
-
-- kind: Role
-  apiVersion: v1
+  subjects:
+  - kind: ServiceAccount
+    name: service-catalog-controller
+    namespace: kube-service-catalog
+  
+- apiVersion: authorization.openshift.io/v1
+  kind: Role
   metadata:
     name: endpoint-accessor
   rules:
@@ -179,21 +193,38 @@ objects:
     - create
     - update
 
-- kind: RoleBinding
-  apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
+  kind: RoleBinding
   metadata:
-    name: endpoint-accessor-binding
+    name: endpointer-accessor-binding
   roleRef:
     name: endpoint-accessor
     namespace: kube-service-catalog
-  userNames:
-    - system:serviceaccount:kube-service-catalog:service-catalog-controller
+  subjects:
+  - kind: ServiceAccount
+    namespace: kube-service-catalog
+    name: service-catalog-controller
 
-- kind: ClusterRoleBinding
-  apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
+  kind: RoleBinding
+  metadata:
+    name: extension-apiserver-authentication-reader-binding
+    namespace: ${KUBE_SYSTEM_NAMESPACE}
+  roleRef:
+    name: extension-apiserver-authentication-reader
+    namespace: ${KUBE_SYSTEM_NAMESPACE}
+  subjects:
+  - kind: ServiceAccount
+    name: service-catalog-apiserver
+    namespace: kube-service-catalog
+
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRoleBinding
   metadata:
     name: system:auth-delegator-binding
   roleRef:
     name: system:auth-delegator
-  userNames:
-    - system:serviceaccount:kube-service-catalog:service-catalog-apiserver
+  subjects:
+  - kind: ServiceAccount
+    name: service-catalog-apiserver
+    namespace: kube-service-catalog

--- a/roles/openshift_service_catalog/files/kubesystem_roles_bindings.yml
+++ b/roles/openshift_service_catalog/files/kubesystem_roles_bindings.yml
@@ -4,8 +4,8 @@ metadata:
   name: kube-system-service-catalog
 objects:
 
-- kind: Role
-  apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
+  kind: Role
   metadata:
     name: extension-apiserver-authentication-reader
     namespace: ${KUBE_SYSTEM_NAMESPACE}
@@ -19,16 +19,18 @@ objects:
     verbs:
     - get
 
-- kind: RoleBinding
-  apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
+  kind: RoleBinding
   metadata:
     name: extension-apiserver-authentication-reader-binding
     namespace: ${KUBE_SYSTEM_NAMESPACE}
   roleRef:
     name: extension-apiserver-authentication-reader
-    namespace: kube-system
-  userNames:
-    - system:serviceaccount:kube-service-catalog:service-catalog-apiserver
+    namespace: ${KUBE_SYSTEM_NAMESPACE}
+  subjects:
+  - kind: ServiceAccount
+    name: service-catalog-apiserver
+    namespace: kube-service-catalog
 
 parameters:
 - description: Do not change this value.

--- a/roles/openshift_service_catalog/tasks/generate_certs.yml
+++ b/roles/openshift_service_catalog/tasks/generate_certs.yml
@@ -41,14 +41,14 @@
   register: apiserver_ca
 
 - shell: >
-    oc get apiservices.apiregistration.k8s.io/v1alpha1.servicecatalog.k8s.io -n kube-service-catalog || echo "not found"
+    oc get apiservices.apiregistration.k8s.io/v1beta1.servicecatalog.k8s.io -n kube-service-catalog || echo "not found"
   register: get_apiservices
   changed_when: no
 
 - name: Create api service
   oc_obj:
     state: present
-    name: v1alpha1.servicecatalog.k8s.io
+    name: v1beta1.servicecatalog.k8s.io
     kind: apiservices.apiregistration.k8s.io
     namespace: "kube-service-catalog"
     content:
@@ -57,7 +57,7 @@
         apiVersion: apiregistration.k8s.io/v1beta1
         kind: APIService
         metadata:
-          name: v1alpha1.servicecatalog.k8s.io
+          name: v1beta1.servicecatalog.k8s.io
         spec:
           group: servicecatalog.k8s.io
           version: v1alpha1

--- a/roles/openshift_service_catalog/tasks/generate_certs.yml
+++ b/roles/openshift_service_catalog/tasks/generate_certs.yml
@@ -36,6 +36,15 @@
     - name: tls.key
       path: "{{ generated_certs_dir }}/apiserver.key"
 
+- name: Create service-catalog-ssl secret
+  oc_secret:
+    state: present
+    name: service-catalog-ssl
+    namespace: kube-service-catalog
+    files:
+    - name: tls.crt
+      path: "{{ generated_certs_dir }}/apiserver.crt"
+
 - slurp:
     src: "{{ generated_certs_dir }}/ca.crt"
   register: apiserver_ca

--- a/roles/openshift_service_catalog/tasks/generate_certs.yml
+++ b/roles/openshift_service_catalog/tasks/generate_certs.yml
@@ -60,7 +60,7 @@
           name: v1beta1.servicecatalog.k8s.io
         spec:
           group: servicecatalog.k8s.io
-          version: v1alpha1
+          version: v1beta1
           service:
             namespace: "kube-service-catalog"
             name: apiserver

--- a/roles/openshift_service_catalog/tasks/install.yml
+++ b/roles/openshift_service_catalog/tasks/install.yml
@@ -90,14 +90,14 @@
   vars:
     original_content: "{{ edit_yaml.results.results[0] | to_yaml }}"
   when:
-    - not edit_yaml.results.results[0] | oo_contains_rule(['servicecatalog.k8s.io'], ['instances', 'bindings'], ['create', 'update', 'delete', 'get', 'list', 'watch']) or not edit_yaml.results.results[0] | oo_contains_rule(['settings.k8s.io'], ['podpresets'], ['create', 'update', 'delete', 'get', 'list', 'watch'])
+    - not edit_yaml.results.results[0] | oo_contains_rule(['servicecatalog.k8s.io'], ['serviceinstances', 'servicebindings'], ['create', 'update', 'delete', 'get', 'list', 'watch']) or not edit_yaml.results.results[0] | oo_contains_rule(['settings.k8s.io'], ['podpresets'], ['create', 'update', 'delete', 'get', 'list', 'watch'])
 
 # only do this if we don't already have the updated role info
 - name: update edit role for service catalog and pod preset access
   command: >
     oc replace -f {{ mktemp.stdout }}/edit_sc_patch.yml
   when:
-    - not edit_yaml.results.results[0] | oo_contains_rule(['servicecatalog.k8s.io'], ['instances', 'bindings'], ['create', 'update', 'delete', 'get', 'list', 'watch']) or not edit_yaml.results.results[0] | oo_contains_rule(['settings.k8s.io'], ['podpresets'], ['create', 'update', 'delete', 'get', 'list', 'watch'])
+    - not edit_yaml.results.results[0] | oo_contains_rule(['servicecatalog.k8s.io'], ['serviceinstances', 'servicebindings'], ['create', 'update', 'delete', 'get', 'list', 'watch']) or not edit_yaml.results.results[0] | oo_contains_rule(['settings.k8s.io'], ['podpresets'], ['create', 'update', 'delete', 'get', 'list', 'watch'])
 
 - oc_obj:
     name: admin
@@ -113,14 +113,14 @@
   vars:
     original_content: "{{ admin_yaml.results.results[0] | to_yaml }}"
   when:
-    - not admin_yaml.results.results[0] | oo_contains_rule(['servicecatalog.k8s.io'], ['instances', 'bindings'], ['create', 'update', 'delete', 'get', 'list', 'watch']) or not admin_yaml.results.results[0] | oo_contains_rule(['settings.k8s.io'], ['podpresets'], ['create', 'update', 'delete', 'get', 'list', 'watch'])
+    - not admin_yaml.results.results[0] | oo_contains_rule(['servicecatalog.k8s.io'], ['serviceinstances', 'servicebindings'], ['create', 'update', 'delete', 'get', 'list', 'watch']) or not admin_yaml.results.results[0] | oo_contains_rule(['settings.k8s.io'], ['podpresets'], ['create', 'update', 'delete', 'get', 'list', 'watch'])
 
 # only do this if we don't already have the updated role info
 - name: update admin role for service catalog and pod preset access
   command: >
     oc replace -f {{ mktemp.stdout }}/admin_sc_patch.yml
   when:
-    - not admin_yaml.results.results[0] | oo_contains_rule(['servicecatalog.k8s.io'], ['instances', 'bindings'], ['create', 'update', 'delete', 'get', 'list', 'watch']) or not admin_yaml.results.results[0] | oo_contains_rule(['settings.k8s.io'], ['podpresets'], ['create', 'update', 'delete', 'get', 'list', 'watch'])
+    - not admin_yaml.results.results[0] | oo_contains_rule(['servicecatalog.k8s.io'], ['serviceinstances', 'servicebindings'], ['create', 'update', 'delete', 'get', 'list', 'watch']) or not admin_yaml.results.results[0] | oo_contains_rule(['settings.k8s.io'], ['podpresets'], ['create', 'update', 'delete', 'get', 'list', 'watch'])
 
 - oc_adm_policy_user:
     namespace: kube-service-catalog

--- a/roles/openshift_service_catalog/tasks/remove.yml
+++ b/roles/openshift_service_catalog/tasks/remove.yml
@@ -1,7 +1,7 @@
 ---
 - name: Remove Service Catalog APIServer
   command: >
-    oc delete apiservices.apiregistration.k8s.io/v1alpha1.servicecatalog.k8s.io --ignore-not-found -n kube-service-catalog
+    oc delete apiservices.apiregistration.k8s.io/v1beta1.servicecatalog.k8s.io --ignore-not-found -n kube-service-catalog
 
 - name: Remove Policy Binding
   command: >
@@ -13,7 +13,7 @@
 #    state: absent
 #    namespace: "kube-service-catalog"
 #    kind: apiservices.apiregistration.k8s.io
-#    name: v1alpha1.servicecatalog.k8s.io
+#    name: v1beta1.servicecatalog.k8s.io
 
 - name: Remove Service Catalog API Server route
   oc_obj:

--- a/roles/openshift_service_catalog/templates/api_server.j2
+++ b/roles/openshift_service_catalog/templates/api_server.j2
@@ -41,7 +41,9 @@ spec:
         - --cors-allowed-origins
         - {{ cors_allowed_origin }}
         - --admission-control
-        - "KubernetesNamespaceLifecycle"
+        - KubernetesNamespaceLifecycle,DefaultServicePlan,ServiceBindingsLifecycle,ServicePlanChangeValidator,BrokerAuthSarCheck
+        - --feature-gates
+        - OriginatingIdentity=true
         image: {{ openshift_service_catalog_image_prefix }}service-catalog:{{ openshift_service_catalog_image_version }}
         command: ["/usr/bin/apiserver"]
         imagePullPolicy: Always

--- a/roles/openshift_service_catalog/templates/controller_manager.j2
+++ b/roles/openshift_service_catalog/templates/controller_manager.j2
@@ -31,7 +31,12 @@ spec:
         args:
         - -v
         - "5"
-        - "--leader-election-namespace=$(K8S_NAMESPACE)"
+        - --leader-election-namespace
+        - kube-service-catalog
+        - --broker-relist-interval
+        - "5m"
+        - --feature-gates
+        - OriginatingIdentity=true
         image: {{ openshift_service_catalog_image_prefix }}service-catalog:{{ openshift_service_catalog_image_version }}
         command: ["/usr/bin/controller-manager"]
         imagePullPolicy: Always

--- a/roles/openshift_service_catalog/templates/controller_manager.j2
+++ b/roles/openshift_service_catalog/templates/controller_manager.j2
@@ -46,7 +46,19 @@ spec:
           protocol: TCP
         resources: {}
         terminationMessagePath: /dev/termination-log
+        volumeMounts:
+        - mountPath: /var/run/kubernetes-service-catalog
+          name: service-catalog-ssl
+          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       securityContext: {}
       terminationGracePeriodSeconds: 30
+      volumes:
+      - name: service-catalog-ssl
+        secret:
+          defaultMode: 420
+          items:
+          - key: tls.crt
+            path: apiserver.crt
+          secretName: apiserver-ssl

--- a/roles/template_service_broker/tasks/install.yml
+++ b/roles/template_service_broker/tasks/install.yml
@@ -6,7 +6,7 @@
     - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
     - "default_images.yml"
 
-- name: set ansible_service_broker facts
+- name: set template_service_broker facts
   set_fact:
     template_service_broker_prefix: "{{ template_service_broker_prefix | default(__template_service_broker_prefix) }}"
     template_service_broker_version: "{{ template_service_broker_version | default(__template_service_broker_version) }}"
@@ -62,7 +62,7 @@
   when: openshift_master_config_dir is undefined
 
 - slurp:
-    src: "{{ openshift_master_config_dir }}/ca.crt"
+    src: "{{ openshift_master_config_dir }}/service-signer.crt"
   register: __ca_bundle
 
 # Register with broker

--- a/roles/template_service_broker/tasks/main.yml
+++ b/roles/template_service_broker/tasks/main.yml
@@ -2,7 +2,7 @@
 # do any asserts here
 
 - include: install.yml
-  when: not template_service_broker_remove | default(false) | bool
+  when: template_service_broker_install | default(false) | bool
 
 - include: remove.yml
   when: template_service_broker_remove | default(false) | bool

--- a/roles/template_service_broker/tasks/main.yml
+++ b/roles/template_service_broker/tasks/main.yml
@@ -2,7 +2,7 @@
 # do any asserts here
 
 - include: install.yml
-  when: template_service_broker_install | default(false) | bool
+  when: not template_service_broker_remove | default(false) | bool
 
 - include: remove.yml
   when: template_service_broker_remove | default(false) | bool


### PR DESCRIPTION
Fixes Bug 1496694 [1].

* Use resource name `ClusterServiceBroker` instead of `ServiceBroker`.
* Use resource name `ClusterServiceClass` instead of `ServiceClass`.
* Use resource name `ServiceInstance` instead of `Instance`.
* Use resource name `ServiceBinding` instead of `Binding`.
* Use `api v1beta1.servicecatalog.k8s.io` instead of `v1alpha1.servicecatalog.k8s.io`.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1496694