### PR TITLE
Make openshift-ansible depend on all subpackages

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -21,7 +21,12 @@ Requires:      ansible >= 2.3
 Requires:      python2
 Requires:      python-six
 Requires:      tar
-Requires:      openshift-ansible-docs = %{version}
+Requires:      %{name}-docs = %{version}
+Requires:      %{name}-playbooks = %{version}
+Requires:      %{name}-roles = %{version}
+Requires:      %{name}-filter-plugins = %{version}
+Requires:      %{name}-lookup-plugins = %{version}
+Requires:      %{name}-callback-plugins = %{version}
 Requires:      java-1.8.0-openjdk-headless
 Requires:      httpd-tools
 Requires:      libselinux-python


### PR DESCRIPTION
This sets us up so that we can remove atomic-openshift-utils by ensuring that `yum install openshift-ansible` results in a set of packages installed that actually does something. 

Pre-requisites for https://github.com/openshift/aos-cd-jobs/pull/731 and https://github.com/openshift/openshift-ansible/pull/5563
Add the dependencies here, merge the aos-cd-jobs change, then merge the removal of atomic-openshift-utils.