### PR TITLE
Remove unneeded master config updates during upgrades

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_4/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/master_config_upgrade.yml
@@ -1,22 +1,6 @@
 ---
 - modify_yaml:
     dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
-    yaml_key: 'admissionConfig.pluginConfig'
-    yaml_value: "{{ openshift.master.admission_plugin_config }}"
-  when: "'admission_plugin_config' in openshift.master"
-
-- modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
-    yaml_key: 'admissionConfig.pluginOrderOverride'
-    yaml_value:
-
-- modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
-    yaml_key: 'kubernetesMasterConfig.admissionConfig'
-    yaml_value:
-
-- modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
     yaml_key: 'controllerConfig.serviceServingCert.signer.certFile'
     yaml_value: service-signer.crt
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/master_config_upgrade.yml
@@ -1,22 +1,6 @@
 ---
 - modify_yaml:
     dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
-    yaml_key: 'admissionConfig.pluginConfig'
-    yaml_value: "{{ openshift.master.admission_plugin_config }}"
-  when: "'admission_plugin_config' in openshift.master"
-
-- modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
-    yaml_key: 'admissionConfig.pluginOrderOverride'
-    yaml_value:
-
-- modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
-    yaml_key: 'kubernetesMasterConfig.admissionConfig'
-    yaml_value:
-
-- modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
     yaml_key: 'controllerConfig.serviceServingCert.signer.certFile'
     yaml_value: service-signer.crt
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/master_config_upgrade.yml
@@ -1,22 +1,6 @@
 ---
 - modify_yaml:
     dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
-    yaml_key: 'admissionConfig.pluginConfig'
-    yaml_value: "{{ openshift.master.admission_plugin_config }}"
-  when: "'admission_plugin_config' in openshift.master"
-
-- modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
-    yaml_key: 'admissionConfig.pluginOrderOverride'
-    yaml_value:
-
-- modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
-    yaml_key: 'kubernetesMasterConfig.admissionConfig'
-    yaml_value:
-
-- modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
     yaml_key: 'controllerConfig.serviceServingCert.signer.certFile'
     yaml_value: service-signer.crt
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/master_config_upgrade.yml
@@ -1,22 +1,6 @@
 ---
 - modify_yaml:
     dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
-    yaml_key: 'admissionConfig.pluginConfig'
-    yaml_value: "{{ openshift.master.admission_plugin_config }}"
-  when: "'admission_plugin_config' in openshift.master"
-
-- modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
-    yaml_key: 'admissionConfig.pluginOrderOverride'
-    yaml_value:
-
-- modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
-    yaml_key: 'kubernetesMasterConfig.admissionConfig'
-    yaml_value:
-
-- modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
     yaml_key: 'controllerConfig.election.lockName'
     yaml_value: 'openshift-master-controllers'
 


### PR DESCRIPTION
Currently, upgrade_control_plane.yml will add any
missing sections to the openshift master's config.

These additions are only needed once.  Users who
perform multiple upgrades to their clusters over
time do not need to have these variables re-inserted.

Currently, re-inserting these variables can cause
unwanted local changes.

This commit ensures that the variables are only
inserted into openshift master's config once.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1486054
