### PR TITLE
Ensure controllerConfig.serviceServingCert is correctly set during upgrade.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_3/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/master_config_upgrade.yml
@@ -41,12 +41,12 @@
 
 - modify_yaml:
     dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
-    yaml_key: 'controllerConfig.servicesServingCert.signer.certFile'
+    yaml_key: 'controllerConfig.serviceServingCert.signer.certFile'
     yaml_value: service-signer.crt
 
 - modify_yaml:
     dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
-    yaml_key: 'controllerConfig.servicesServingCert.signer.keyFile'
+    yaml_key: 'controllerConfig.serviceServingCert.signer.keyFile'
     yaml_value: service-signer.key
 
 - modify_yaml:

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/master_config_upgrade.yml
@@ -14,3 +14,13 @@
     dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
     yaml_key: 'kubernetesMasterConfig.admissionConfig'
     yaml_value:
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'controllerConfig.serviceServingCert.signer.certFile'
+    yaml_value: service-signer.crt
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'controllerConfig.serviceServingCert.signer.keyFile'
+    yaml_value: service-signer.key

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/master_config_upgrade.yml
@@ -14,3 +14,13 @@
     dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
     yaml_key: 'kubernetesMasterConfig.admissionConfig'
     yaml_value:
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'controllerConfig.serviceServingCert.signer.certFile'
+    yaml_value: service-signer.crt
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'controllerConfig.serviceServingCert.signer.keyFile'
+    yaml_value: service-signer.key

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/master_config_upgrade.yml
@@ -14,3 +14,13 @@
     dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
     yaml_key: 'kubernetesMasterConfig.admissionConfig'
     yaml_value:
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'controllerConfig.serviceServingCert.signer.certFile'
+    yaml_value: service-signer.crt
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'controllerConfig.serviceServingCert.signer.keyFile'
+    yaml_value: service-signer.key

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/master_config_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/master_config_upgrade.yml
@@ -19,3 +19,13 @@
     dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
     yaml_key: 'controllerConfig.election.lockName'
     yaml_value: 'openshift-master-controllers'
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'controllerConfig.serviceServingCert.signer.certFile'
+    yaml_value: service-signer.crt
+
+- modify_yaml:
+    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    yaml_key: 'controllerConfig.serviceServingCert.signer.keyFile'
+    yaml_value: service-signer.key


### PR DESCRIPTION
A typo was originally introduced in https://github.com/openshift/openshift-ansible/pull/2449 causing an incorrect key to be configured within the master config. This commit ensures that the correct key is set during upgrades.

/cc @dlbewley 
https://bugzilla.redhat.com/show_bug.cgi?id=1500981
