### PR TITLE
cri-o: error out when node is a Docker container

### DIFF
--- a/roles/docker/tasks/systemcontainer_crio.yml
+++ b/roles/docker/tasks/systemcontainer_crio.yml
@@ -36,6 +36,12 @@
     state: present
   when: not openshift.common.is_atomic | bool
 
+- name: Check we are not using node as a Docker container with CRI-O
+  fail: msg='Cannot use CRI-O with node configured as a Docker container'
+  when:
+    - openshift.common.is_containerized | bool
+    - not openshift.common.is_node_system_container | bool
+
 # Used to pull and install the system container
 - name: Ensure atomic is installed
   package:


### PR DESCRIPTION
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1489555

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>