### PR TITLE
GlusterFS: Remove image option from heketi command

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/heketi_deploy_part2.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_deploy_part2.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create heketi DB volume
-  command: "{{ glusterfs_heketi_client }} setup-openshift-heketi-storage --image {{ glusterfs_heketi_image}}:{{ glusterfs_heketi_version }} --listfile /tmp/heketi-storage.json"
+  command: "{{ glusterfs_heketi_client }} setup-openshift-heketi-storage --listfile /tmp/heketi-storage.json"
   register: setup_storage
 
 - name: Copy heketi-storage list


### PR DESCRIPTION
Reverts #5562, option has been removed from heketi command

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1502054

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>