### PR TITLE
Fix cockpit image name if checked out from a private registry

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -354,7 +354,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # OpenShift Registry Console Options
 # Override the console image prefix for enterprise deployments, not used in origin
 # default is "registry.access.redhat.com/openshift3/" and the image appended is "registry-console"
-#openshift_cockpit_deployer_prefix=registry.example.com/myrepo/
+#openshift_cockpit_deployer_name=registry.example.com/myrepo/image-name
 # Override image version, defaults to latest for origin, matches the product version for enterprise
 #openshift_cockpit_deployer_version=1.4.1
 

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -362,7 +362,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # OpenShift Registry Console Options
 # Override the console image prefix for enterprise deployments, not used in origin
 # default is "registry.access.redhat.com/openshift3/" and the image appended is "registry-console"
-#openshift_cockpit_deployer_prefix=registry.example.com/myrepo/
+#openshift_cockpit_deployer_name=registry.example.com/myrepo/image-name
 # Override image version, defaults to latest for origin, matches the product version for enterprise
 #openshift_cockpit_deployer_version=1.4.1
 

--- a/roles/cockpit-ui/tasks/main.yml
+++ b/roles/cockpit-ui/tasks/main.yml
@@ -41,8 +41,9 @@
   - name: Deploy registry-console
     command: >
       {{ openshift.common.client_binary }} new-app --template=registry-console
-      {% if openshift_cockpit_deployer_prefix is defined  %}-p IMAGE_PREFIX="{{ openshift_cockpit_deployer_prefix }}"{% endif %}
-      {% if openshift_cockpit_deployer_version is defined  %}-p IMAGE_VERSION="{{ openshift_cockpit_deployer_version }}"{% endif %}
+      {% if openshift_cockpit_deployer_prefix is defined and openshift_deployment_type == 'enterprise' %} -p IMAGE_PREFIX="{{ openshift_cockpit_deployer_prefix }}"{% endif %}
+      {% if openshift_cockpit_deployer_name is defined and openshift_deployment_type == 'origin' %} -p IMAGE_NAME="{{ openshift_cockpit_deployer_name }}"{% endif %}
+      {% if openshift_cockpit_deployer_version is defined  %} -p IMAGE_VERSION="{{ openshift_cockpit_deployer_version }}"{% endif %}
       -p OPENSHIFT_OAUTH_PROVIDER_URL="{{ openshift.master.public_api_url }}"
       -p REGISTRY_HOST="{{ docker_registry_route.results[0].spec.host }}"
       -p COCKPIT_KUBE_URL="https://{{ registry_console_cockpit_kube.results.results[0].spec.host }}"


### PR DESCRIPTION
This PR is a fix of the issue #5767.