### PR TITLE
Fix missing docker option signature-verification

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 docker_cli_auth_config_path: '/root/.docker'
+openshift_docker_signature_verification: False
 
 # oreg_url is defined by user input.
 oreg_host: "{{ oreg_url.split('/')[0] if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"

--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -115,11 +115,12 @@
     dest: /etc/sysconfig/docker
     regexp: '^OPTIONS=.*$'
     line: "OPTIONS='\
-      {% if ansible_selinux.status | default(None) == 'enabled' and docker_selinux_enabled | default(true) | bool %} --selinux-enabled {% endif %}\
-      {% if docker_log_driver is defined  %} --log-driver {{ docker_log_driver }}{% endif %}\
-      {% if docker_log_options is defined %} {{ docker_log_options |  oo_split() | oo_prepend_strings_in_list('--log-opt ') | join(' ')}}{% endif %}\
-      {% if docker_options is defined %} {{ docker_options }}{% endif %}\
-      {% if docker_disable_push_dockerhub is defined %} --confirm-def-push={{ docker_disable_push_dockerhub | bool }}{% endif %}'"
+      {% if ansible_selinux.status | default(None) == 'enabled' and docker_selinux_enabled | default(true) | bool %} --selinux-enabled {% endif %} \
+      {% if docker_log_driver is defined  %} --log-driver {{ docker_log_driver }}{% endif %} \
+      {% if docker_log_options is defined %} {{ docker_log_options |  oo_split() | oo_prepend_strings_in_list('--log-opt ') | join(' ')}}{% endif %} \
+      {% if docker_options is defined %} {{ docker_options }}{% endif %} \
+      {% if docker_disable_push_dockerhub is defined %} --confirm-def-push={{ docker_disable_push_dockerhub | bool }}{% endif %} \
+      --signature-verification={{ openshift_docker_signature_verification | bool }}'"
   when: docker_check.stat.isreg is defined and docker_check.stat.isreg
   notify:
   - restart docker


### PR DESCRIPTION
Currently, docker 1.12 can be configured to use the
run-time parameter of 'signature-verification'

By default, rpm installation of docker results in
'--signature-verification=false' being added to
OPTIONS in /etc/sysconfig/docker

Currently, openshift-ansible does not preserve that
value.  This can cause docker to be unable to pull
images from a previously working source due to a
change in configuration.

This commit adds the option with the default
as provided by the rpm installation.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1502560