### PR TITLE
Use DCNAME for logging Elasticsearch SG index name

### DIFF
--- a/roles/openshift_logging/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging/templates/elasticsearch.yml.j2
@@ -14,6 +14,7 @@ index:
     flush_threshold_period: 5m
 
 node:
+  name: ${DC_NAME}
   master: true
   data: true
   max_local_storage_nodes: 1
@@ -62,7 +63,7 @@ path:
 searchguard:
   authcz.admin_dn:
   - CN=system.admin,OU=OpenShift,O=Logging
-  config_index_name: ".searchguard.${HOSTNAME}"
+  config_index_name: ".searchguard.${DC_NAME}"
   ssl:
     transport:
       enabled: true

--- a/roles/openshift_logging/templates/es.j2
+++ b/roles/openshift_logging/templates/es.j2
@@ -59,6 +59,8 @@ spec:
               containerPort: 9300
               name: "cluster"
           env:
+            - name: "DC_NAME"
+              value: "{{deploy_name}}"
             -
               name: "NAMESPACE"
               valueFrom:


### PR DESCRIPTION
This PR fixes:
* https://bugzilla.redhat.com/show_bug.cgi?id=1493820 The issue where ES has problems staring up.

It is the 1.5 part of the fix that was missed in the installer.  The companion installer PR for later releases is #4364.  
The 1.5 logging PR that goes with this is https://github.com/openshift/origin-aggregated-logging/pull/519