### PR TITLE
Ensure proper variable templating for skopeo auth credentials

### DIFF
--- a/roles/openshift_health_checker/action_plugins/openshift_health_check.py
+++ b/roles/openshift_health_checker/action_plugins/openshift_health_check.py
@@ -101,7 +101,8 @@ class ActionModule(ActionBase):
                 execute_module=self._execute_module,
                 tmp=tmp,
                 task_vars=task_vars,
-                want_full_results=want_full_results
+                want_full_results=want_full_results,
+                templar=self._templar
             )
         return known_checks
 

--- a/roles/openshift_health_checker/openshift_checks/__init__.py
+++ b/roles/openshift_health_checker/openshift_checks/__init__.py
@@ -65,12 +65,15 @@ class OpenShiftCheck(object):
     If the check can gather logs, tarballs, etc., do so when True; but no need to spend
     the time if they're not wanted (won't be written to output directory).
     """
-
-    def __init__(self, execute_module=None, task_vars=None, tmp=None, want_full_results=False):
+    # pylint: disable=too-many-arguments
+    def __init__(self, execute_module=None, task_vars=None, tmp=None, want_full_results=False,
+                 templar=None):
         # store a method for executing ansible modules from the check
         self._execute_module = execute_module
         # the task variables and tmpdir passed into the health checker task
         self.task_vars = task_vars or {}
+        # We may need to template some task_vars
+        self._templar = templar
         self.tmp = tmp
         # a boolean for disabling the gathering of results (files, computations) that won't
         # actually be recorded/used

--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -61,10 +61,15 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
         # for the oreg_url registry there may be credentials specified
         components = self.get_var("oreg_url", default="").split('/')
         self.registries["oreg"] = "" if len(components) < 3 else components[0]
+
+        # Retrieve and template registry credentials, if provided
         self.skopeo_command_creds = ""
         oreg_auth_user = self.get_var('oreg_auth_user', default='')
         oreg_auth_password = self.get_var('oreg_auth_password', default='')
         if oreg_auth_user != '' and oreg_auth_password != '':
+            if self._templar is not None:
+                oreg_auth_user = self._templar.template(oreg_auth_user)
+                oreg_auth_password = self._templar.template(oreg_auth_password)
             self.skopeo_command_creds = "--creds={}:{}".format(quote(oreg_auth_user), quote(oreg_auth_password))
 
         # record whether we could reach a registry or not (and remember results)


### PR DESCRIPTION
Currently, docker_image_availability.py plugin check is
using the raw strings for variables from task_vars.

This results in any variables that utilized within the
plugin to be un-templated.  For instance, if variable
"x" is set to "{{ y }}" and y is set to "2", one
would expect that x == 2 inside the plugin.  Currently,
the plugin will use the string "{{ y }}" for the value
of x instead of templating the variable.

This commit ensures skopeo registry auth credentials
are templated properly.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1500698