### PR TITLE
Split prometheus image defaults to prefix and version

### DIFF
--- a/roles/openshift_prometheus/README.md
+++ b/roles/openshift_prometheus/README.md
@@ -19,7 +19,9 @@ For default values, see [`defaults/main.yaml`](defaults/main.yaml).
 
 - `openshift_prometheus_node_selector`: Selector for the nodes prometheus will be deployed on.
 
-- `openshift_prometheus_image_<COMPONENT>`: specify image for the component 
+- `openshift_prometheus_<COMPONENT>_image_prefix`: specify image prefix for the component 
+
+- `openshift_prometheus_<COMPONENT>_image_version`: specify image version for the component 
 
 ## PVC related variables
 Each prometheus component (prometheus, alertmanager, alertbuffer) can set pv claim by setting corresponding role variable:

--- a/roles/openshift_prometheus/defaults/main.yaml
+++ b/roles/openshift_prometheus/defaults/main.yaml
@@ -6,11 +6,15 @@ openshift_prometheus_namespace: prometheus
 
 openshift_prometheus_node_selector: {"region":"infra"}
 
-# images
-openshift_prometheus_image_proxy: "openshift/oauth-proxy:v1.0.0"
-openshift_prometheus_image_prometheus: "openshift/prometheus:v2.0.0-dev.3"
-openshift_prometheus_image_alertmanager: "openshift/prometheus-alertmanager:v0.9.1"
-openshift_prometheus_image_alertbuffer: "openshift/prometheus-alert-buffer:v0.0.2"
+# image defaults
+openshift_prometheus_image_prefix: "openshift/"
+openshift_prometheus_image_version: "v2.0.0-dev.3"
+openshift_prometheus_proxy_image_prefix: "openshift/"
+openshift_prometheus_proxy_image_version: "v1.0.0"
+openshift_prometheus_alertmanager_image_prefix: "openshift/"
+openshift_prometheus_alertmanager_image_version: "v0.9.1"
+openshift_prometheus_alertbuffer_image_prefix: "openshift/"
+openshift_prometheus_alertbuffer_image_version: "v0.0.2"
 
 # additional prometheus rules file
 openshift_prometheus_additional_rules_file: null

--- a/roles/openshift_prometheus/templates/prometheus.j2
+++ b/roles/openshift_prometheus/templates/prometheus.j2
@@ -29,7 +29,7 @@ spec:
       containers:
       # Deploy Prometheus behind an oauth proxy
       - name: prom-proxy
-        image: "{{ openshift_prometheus_image_proxy }}"
+        image: "{{openshift_prometheus_proxy_image_prefix}}oauth-proxy:{{openshift_prometheus_proxy_image_version}}"
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -79,7 +79,7 @@ spec:
         - --storage.tsdb.min-block-duration=2m
         - --config.file=/etc/prometheus/prometheus.yml
         - --web.listen-address=localhost:9090
-        image: "{{ openshift_prometheus_image_prometheus }}"
+        image: "{{openshift_prometheus_image_prefix}}prometheus:{{openshift_prometheus_image_version}}"
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -105,7 +105,7 @@ spec:
 
       # Deploy alertmanager behind prometheus-alert-buffer behind an oauth proxy
       - name: alerts-proxy
-        image: "{{ openshift_prometheus_image_proxy }}"
+        image: "{{openshift_prometheus_proxy_image_prefix}}oauth-proxy:{{openshift_prometheus_proxy_image_version}}"
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -149,7 +149,7 @@ spec:
       - name: alert-buffer
         args:
         - --storage-path=/alert-buffer/messages.db
-        image: "{{ openshift_prometheus_image_alertbuffer }}"
+        image: "{{openshift_prometheus_alertbuffer_image_prefix}}prometheus-alert-buffer:{{openshift_prometheus_alertbuffer_image_version}}"
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -176,7 +176,7 @@ spec:
       - name: alertmanager
         args:
         - -config.file=/etc/alertmanager/alertmanager.yml
-        image: "{{ openshift_prometheus_image_alertmanager }}"
+        image: "{{openshift_prometheus_alertmanager_image_prefix}}prometheus-alertmanager:{{openshift_prometheus_alertmanager_image_version}}"
         imagePullPolicy: IfNotPresent
         resources:
           requests:


### PR DESCRIPTION
To allow easier testing and deployment from different repos, image defaults were split to prefix and version that can be set externally.

bz: https://bugzilla.redhat.com/show_bug.cgi?id=1493431