### PR TITLE
Fix undefined variable for master upgrades

### DIFF
--- a/roles/openshift_master/tasks/upgrade_facts.yml
+++ b/roles/openshift_master/tasks/upgrade_facts.yml
@@ -21,6 +21,10 @@
     oreg_host: "{{ oreg_url.split('/')[0] if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"
   when: oreg_host is not defined
 
+- set_fact:
+    oreg_auth_credentials_replace: False
+  when: oreg_auth_credentials_replace is not defined
+
 - name: Set openshift_master_debug_level
   set_fact:
     openshift_master_debug_level: "{{ debug_level | default(2) }}"


### PR DESCRIPTION
Currently, oreg_auth_credentials_replace is undefined
during master upgrades.

This commit ensures this variable is defined during
upgrades.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1503415