### PR TITLE
[bz1501271] Attempt to use ami ssh user and default to ansible_ssh_user.

### DIFF
--- a/playbooks/aws/openshift-cluster/build_ami.yml
+++ b/playbooks/aws/openshift-cluster/build_ami.yml
@@ -26,7 +26,7 @@
   tasks:
   - name: set the user to perform installation
     set_fact:
-      ansible_ssh_user: "{{ openshift_aws_build_ami_ssh_user | default('root') }}"
+      ansible_ssh_user: "{{ openshift_aws_build_ami_ssh_user | default(ansible_ssh_user) }}"
       openshift_node_bootstrap: True
 
 # This is the part that installs all of the software and configs for the instance


### PR DESCRIPTION
This is a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1501271 that defaults the user to root.  This now attempts to use `openshift_aws_build_ami_ssh_user` and defaults to `ansible_ssh_user`.