### PR TITLE
Ensure upgrades apply latest journald settings

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -90,6 +90,9 @@
 
   - include_vars: ../../../../roles/openshift_master/vars/main.yml
 
+  - name: Update journald config
+    include: ../../../../roles/openshift_master/tasks/journald.yml
+
   - name: Remove any legacy systemd units and update systemd units
     include: ../../../../roles/openshift_master/tasks/systemd_units.yml
 

--- a/roles/openshift_master/tasks/journald.yml
+++ b/roles/openshift_master/tasks/journald.yml
@@ -1,0 +1,22 @@
+---
+- name: Checking for journald.conf
+  stat: path=/etc/systemd/journald.conf
+  register: journald_conf_file
+
+- name: Update journald setup
+  replace:
+    dest: /etc/systemd/journald.conf
+    regexp: '^(\#| )?{{ item.var }}=\s*.*?$'
+    replace: ' {{ item.var }}={{ item.val }}'
+    backup: yes
+  with_items: "{{ journald_vars_to_replace | default([]) }}"
+  when: journald_conf_file.stat.exists
+  register: journald_update
+
+# I need to restart journald immediatelly, otherwise it gets into way during
+# further steps in ansible
+- name: Restart journald
+  systemd:
+    name: systemd-journald
+    state: restarted
+  when: journald_update | changed

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -177,30 +177,11 @@
     local_facts:
       no_proxy_etcd_host_ips: "{{ openshift_no_proxy_etcd_host_ips }}"
 
+- name: Update journald config
+  include: journald.yml
+
 - name: Install the systemd units
   include: systemd_units.yml
-
-- name: Checking for journald.conf
-  stat: path=/etc/systemd/journald.conf
-  register: journald_conf_file
-
-- name: Update journald setup
-  replace:
-    dest: /etc/systemd/journald.conf
-    regexp: '^(\#| )?{{ item.var }}=\s*.*?$'
-    replace: ' {{ item.var }}={{ item.val }}'
-    backup: yes
-  with_items: "{{ journald_vars_to_replace | default([]) }}"
-  when: journald_conf_file.stat.exists
-  register: journald_update
-
-# I need to restart journald immediatelly, otherwise it gets into way during
-# further steps in ansible
-- name: Restart journald
-  systemd:
-    name: systemd-journald
-    state: restarted
-  when: journald_update | changed
 
 - name: Install Master system container
   include: system_container.yml


### PR DESCRIPTION
Currently, existing clusters might not have journald
configurations applied. This may result in a rate-
limiting of important log messages on openshift-masters.

This commit ensures that journald settings are applied
during the upgrade process openshif-masters.

Fixes: https://github.com/openshift/openshift-ansible/issues/5642