### PR TITLE
[3.6] Ensure proper variable templating for skopeo auth credentials

### DIFF
--- a/roles/openshift_health_checker/action_plugins/openshift_health_check.py
+++ b/roles/openshift_health_checker/action_plugins/openshift_health_check.py
@@ -90,7 +90,12 @@ class ActionModule(ActionBase):
                     "duplicate check name '{}' in: '{}' and '{}'"
                     "".format(name, full_class_name(cls), full_class_name(other_cls))
                 )
-            known_checks[name] = cls(execute_module=self._execute_module, tmp=tmp, task_vars=task_vars)
+            known_checks[name] = cls(
+                execute_module=self._execute_module,
+                tmp=tmp,
+                task_vars=task_vars,
+                templar=self._templar
+            )
         return known_checks
 
 

--- a/roles/openshift_health_checker/openshift_checks/__init__.py
+++ b/roles/openshift_health_checker/openshift_checks/__init__.py
@@ -53,10 +53,13 @@ class OpenShiftCheck(object):
     This is stored so that it can be invoked in subclasses via check.execute_module("name", args)
     which provides the check's stored task_vars and tmp.
     """
-
-    def __init__(self, execute_module=None, task_vars=None, tmp=None):
+    # pylint: disable=too-many-arguments
+    def __init__(self, execute_module=None, task_vars=None, tmp=None, templar=None):
+        # store a method for executing ansible modules from the check
         self._execute_module = execute_module
         self.task_vars = task_vars or {}
+        # We may need to template some task_vars
+        self._templar = templar
         self.tmp = tmp
         # mainly for testing purposes; see execute_module_with_retries
         self._module_retries = 3

--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -60,10 +60,15 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
         # for the oreg_url registry there may be credentials specified
         components = self.get_var("oreg_url", default="").split('/')
         self.registries["oreg"] = "" if len(components) < 3 else components[0]
+
+        # Retrieve and template registry credentials, if provided
         self.skopeo_command_creds = ""
         oreg_auth_user = self.get_var('oreg_auth_user', default='')
         oreg_auth_password = self.get_var('oreg_auth_password', default='')
         if oreg_auth_user != '' and oreg_auth_password != '':
+            if self._templar is not None:
+                oreg_auth_user = self._templar.template(oreg_auth_user)
+                oreg_auth_password = self._templar.template(oreg_auth_password)
             self.skopeo_command_creds = "--creds={}:{}".format(quote(oreg_auth_user), quote(oreg_auth_password))
 
         # record whether we could reach a registry or not (and remember results)

--- a/roles/openshift_health_checker/test/action_plugin_test.py
+++ b/roles/openshift_health_checker/test/action_plugin_test.py
@@ -16,7 +16,7 @@ def fake_check(name='fake_check', tags=None, is_active=True, run_return=None, ru
         tags = _tags or []
         changed = False
 
-        def __init__(self, execute_module=None, task_vars=None, tmp=None):
+        def __init__(self, execute_module=None, task_vars=None, tmp=None, templar=None):
             pass
 
         def is_active(self):


### PR DESCRIPTION
Currently, docker_image_availability.py plugin check is
using the raw strings for variables from task_vars.

This results in any variables that utilized within the
plugin to be un-templated.  For instance, if variable
"x" is set to "{{ y }}" and y is set to "2", one
would expect that x == 2 inside the plugin.  Currently,
the plugin will use the string "{{ y }}" for the value
of x instead of templating the variable.

This commit ensures skopeo registry auth credentials
are templated properly.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1500698
(cherry picked from commit 23b37a72ef60e7d7830321ba65c5e98bf9563232)

Backports: https://github.com/openshift/openshift-ansible/pull/5781