### PR TITLE
[3.6] Fix undefined variable for master upgrades

### DIFF
--- a/roles/openshift_master/tasks/registry_auth.yml
+++ b/roles/openshift_master/tasks/registry_auth.yml
@@ -9,6 +9,10 @@
     oreg_host: "{{ oreg_url.split('/')[0] if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"
   when: oreg_host is not defined
 
+- set_fact:
+    oreg_auth_credentials_replace: False
+  when: oreg_auth_credentials_replace is not defined
+
 - name: Check for credentials file for registry auth
   stat:
     path: "{{ oreg_auth_credentials_path }}"


### PR DESCRIPTION
Currently, oreg_auth_credentials_replace is undefined
during master upgrades.

This commit ensures this variable is defined during
upgrades.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1503415
(cherry picked from commit 7206730139d06f478931ebf5db3d483cd07ac224)

Backports: https://github.com/openshift/openshift-ansible/pull/5792