### PR TITLE
Put auth token secret for asb in the openshift-ansible-service-broker namespace

### DIFF
--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -109,6 +109,7 @@
 - name: create asb-client token secret
   oc_obj:
     name: asb-client
+    namespace: openshift-ansible-service-broker
     state: present
     kind: Secret
     content:
@@ -118,6 +119,7 @@
         kind: Secret
         metadata:
           name: asb-client
+          namespace: openshift-ansible-service-broker
           annotations:
             kubernetes.io/service-account.name: asb-client
         type: kubernetes.io/service-account-token


### PR DESCRIPTION
The registration of the ansible service broker with service catalog is expecting that the secret for the auth token be in the openshift-ansible-service-broker namespace.

https://github.com/openshift/openshift-ansible/blob/1431bceee461f9eb4a016fe4260ed42aa326ee68/roles/ansible_service_broker/tasks/install.yml#L340-L345