### PR TITLE
Fix a few small issues in service catalog uninstall

### DIFF
--- a/roles/ansible_service_broker/tasks/remove.yml
+++ b/roles/ansible_service_broker/tasks/remove.yml
@@ -85,9 +85,9 @@
 
 - name: remove secret for broker auth
   oc_obj:
-    name: asb-auth-secret
+    name: asb-client
     namespace: openshift-ansible-service-broker
-    kind: Broker
+    kind: Secret
     state: absent
 
 # TODO: saw a oc_configmap in the library, but didn't understand how to get it to do the following:
@@ -99,11 +99,17 @@
     kind: ConfigMap
 
 # TODO: Is this going to work?
+- shell: >
+    oc get apiservices.apiregistration.k8s.io/v1beta1.servicecatalog.k8s.io -n kube-service-catalog || echo "not found"
+  register: get_apiservices
+  changed_when: no
+
 - name: remove broker object from the catalog
   oc_obj:
     name: ansible-service-broker
     state: absent
-    kind: ServiceBroker
+    kind: ClusterServiceBroker
+  when: not "'not found' in get_apiservices.stdout"
 
 - name: remove openshift-ansible-service-broker project
   oc_project:

--- a/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
+++ b/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: service-catalog
+  name: service-catalog-role-bindings
 objects:
 
 - apiVersion: authorization.openshift.io/v1

--- a/roles/openshift_service_catalog/files/kubesystem_roles_bindings.yml
+++ b/roles/openshift_service_catalog/files/kubesystem_roles_bindings.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: kube-system-service-catalog
+  name: kube-system-service-catalog-role-bindings
 objects:
 
 - apiVersion: authorization.openshift.io/v1

--- a/roles/openshift_service_catalog/tasks/generate_certs.yml
+++ b/roles/openshift_service_catalog/tasks/generate_certs.yml
@@ -16,6 +16,16 @@
     --key={{ generated_certs_dir }}/ca.key --cert={{ generated_certs_dir }}/ca.crt
     --serial={{ generated_certs_dir }}/apiserver.serial.txt --name=service-catalog-signer
 
+- name: Delete old apiserver.crt
+  file:
+    path: "{{ generated_certs_dir }}/apiserver.crt"
+    state: absent
+
+- name: Delete old apiserver.key
+  file:
+    path: "{{ generated_certs_dir }}/apiserver.key"
+    state: absent
+
 - name: Generating server keys
   oc_adm_ca_server_cert:
     cert: "{{ generated_certs_dir }}/apiserver.crt"

--- a/roles/openshift_service_catalog/tasks/install.yml
+++ b/roles/openshift_service_catalog/tasks/install.yml
@@ -47,16 +47,15 @@
     dest: "{{ mktemp.stdout }}/kubeservicecatalog_roles_bindings.yml"
 
 - oc_obj:
-    name: service-catalog
+    name: service-catalog-role-bindings
     kind: template
     namespace: "kube-service-catalog"
     files:
       - "{{ mktemp.stdout }}/kubeservicecatalog_roles_bindings.yml"
-    delete_after: yes
 
 - oc_process:
     create: True
-    template_name: service-catalog
+    template_name: service-catalog-role-bindings
     namespace: "kube-service-catalog"
 
 - copy:
@@ -64,16 +63,15 @@
     dest: "{{ mktemp.stdout }}/kubesystem_roles_bindings.yml"
 
 - oc_obj:
-    name: kube-system-service-catalog
+    name: kube-system-service-catalog-role-bindings
     kind: template
     namespace: kube-system
     files:
       - "{{ mktemp.stdout }}/kubesystem_roles_bindings.yml"
-    delete_after: yes
 
 - oc_process:
     create: True
-    template_name: kube-system-service-catalog
+    template_name: kube-system-service-catalog-role-bindings
     namespace: kube-system
 
 - oc_obj:

--- a/roles/openshift_service_catalog/tasks/remove.yml
+++ b/roles/openshift_service_catalog/tasks/remove.yml
@@ -48,7 +48,7 @@
 
 - name: Remove Service Catalog kube-system Role Bindinds
   shell: >
-    oc process kube-system-service-catalog-role-bindings -n kube-system | oc delete --ignore-not-found -f - 
+    oc process kube-system-service-catalog-role-bindings -n kube-system | oc delete --ignore-not-found -f -
 
 - oc_obj:
     kind: template
@@ -58,14 +58,14 @@
 
 - name: Remove Service Catalog kube-service-catalog Role Bindinds
   shell: >
-    oc process service-catalog-role-bindings -n kube-service-catalog | oc delete --ignore-not-found -f - 
+    oc process service-catalog-role-bindings -n kube-service-catalog | oc delete --ignore-not-found -f -
 
 - oc_obj:
     kind: template
     name: "service-catalog-role-bindings"
     namespace: kube-service-catalog
     state: absent
-    
+
 - name: Remove Service Catalog namespace
   oc_project:
     state: absent

--- a/roles/openshift_service_catalog/tasks/remove.yml
+++ b/roles/openshift_service_catalog/tasks/remove.yml
@@ -3,9 +3,10 @@
   command: >
     oc delete apiservices.apiregistration.k8s.io/v1beta1.servicecatalog.k8s.io --ignore-not-found -n kube-service-catalog
 
-- name: Remove Policy Binding
-  command: >
-    oc delete policybindings/kube-system:default -n kube-system --ignore-not-found
+# TODO: policybinding is not a resource type. what was the original intention of this?
+#- name: Remove Policy Binding
+#  command: >
+#    oc delete policybindings/kube-system:default -n kube-system --ignore-not-found
 
 # TODO: this module doesn't currently remove this
 #- name: Remove service catalog api service

--- a/roles/openshift_service_catalog/tasks/remove.yml
+++ b/roles/openshift_service_catalog/tasks/remove.yml
@@ -3,11 +3,6 @@
   command: >
     oc delete apiservices.apiregistration.k8s.io/v1beta1.servicecatalog.k8s.io --ignore-not-found -n kube-service-catalog
 
-# TODO: policybinding is not a resource type. what was the original intention of this?
-#- name: Remove Policy Binding
-#  command: >
-#    oc delete policybindings/kube-system:default -n kube-system --ignore-not-found
-
 # TODO: this module doesn't currently remove this
 #- name: Remove service catalog api service
 #  oc_obj:
@@ -51,6 +46,26 @@
     kind: deployment
     name: controller-manager
 
+- name: Remove Service Catalog kube-system Role Bindinds
+  shell: >
+    oc process kube-system-service-catalog-role-bindings -n kube-system | oc delete --ignore-not-found -f - 
+
+- oc_obj:
+    kind: template
+    name: "kube-system-service-catalog-role-bindings"
+    namespace: kube-system
+    state: absent
+
+- name: Remove Service Catalog kube-service-catalog Role Bindinds
+  shell: >
+    oc process service-catalog-role-bindings -n kube-service-catalog | oc delete --ignore-not-found -f - 
+
+- oc_obj:
+    kind: template
+    name: "service-catalog-role-bindings"
+    namespace: kube-service-catalog
+    state: absent
+    
 - name: Remove Service Catalog namespace
   oc_project:
     state: absent

--- a/roles/template_service_broker/tasks/remove.yml
+++ b/roles/template_service_broker/tasks/remove.yml
@@ -13,11 +13,11 @@
 
 - name: Delete TSB broker
   shell: >
-    oc process -f "{{ mktemp.stdout }}/{{ __tsb_broker_file }}" | oc delete -f -
+    oc process -f "{{ mktemp.stdout }}/{{ __tsb_broker_file }}" | oc delete --ignore-not-found -f -
 
 - name: Delete TSB objects
   shell: >
-    oc process -f "{{ mktemp.stdout }}/{{ __tsb_template_file }}" | kubectl delete -f -
+    oc process -f "{{ mktemp.stdout }}/{{ __tsb_template_file }}" | oc delete --ignore-not-found -f -
 
 - name: empty out tech preview extension file for service console UI
   copy:


### PR DESCRIPTION
* Service catalog install was not re-creating the apiserver.crt and apiserver.key files when generating certs. But the ca.crt and ca.key files were being re-created. This was causing non-verifiable certs to be used when service catalog was uninstalled and re-installed. The service catalog installer was changed to delete the apiserver.crt and apiserver.key files so that they are re-created using the new ca.crt and ca.key files.

* The asb auth token secret was not being deleted correctly and causing the uninstaller to fail.

* The asb uninstaller was attempting to delete the broker registration from the service catalog. However, the service catalog is uninstalled first. When the asb uninstaller would fail when attempting to delete the ClusterServiceBroker. The uninstaller was changed to verify that the servicecatalog APIService exists first before attempting to delete the ClusterServiceBroker.

* The service catalog uninstaller was attempting to delete policybindings. The server does not have a resource type name policybinding. I do not know what the intention is there, but I have commented out that part of the uninstaller.