### PR TITLE
set use_manageiq true as default

### DIFF
--- a/playbooks/common/openshift-master/additional_config.yml
+++ b/playbooks/common/openshift-master/additional_config.yml
@@ -25,7 +25,7 @@
   - role: openshift_hosted_templates
     registry_url: "{{ openshift.master.registry_url }}"
   - role: openshift_manageiq
-    when: openshift_use_manageiq | default(false) | bool
+    when: openshift_use_manageiq | default(true) | bool
   - role: cockpit
     when:
     - openshift.common.is_atomic


### PR DESCRIPTION
It was recently changed to be false, probably by mistake in https://github.com/openshift/openshift-ansible/pull/5208

This is in line with previous PR to set this as default https://github.com/openshift/openshift-ansible/pull/1050