### PR TITLE
Always ensure atomic.conf is configured for system containers.

### DIFF
--- a/roles/docker/tasks/systemcontainer_crio.yml
+++ b/roles/docker/tasks/systemcontainer_crio.yml
@@ -82,36 +82,10 @@
         enabled: yes
         state: restarted
 
-
-- block:
-
-    - name: Add http_proxy to /etc/atomic.conf
-      lineinfile:
-        dest: /etc/atomic.conf
-        regexp: "^#?http_proxy[:=]{1}"
-        line: "http_proxy: {{ openshift.common.http_proxy | default('') }}"
-      when:
-        - openshift.common.http_proxy is defined
-        - openshift.common.http_proxy != ''
-
-    - name: Add https_proxy to /etc/atomic.conf
-      lineinfile:
-        dest: /etc/atomic.conf
-        regexp: "^#?https_proxy[:=]{1}"
-        line: "https_proxy: {{ openshift.common.https_proxy | default('') }}"
-      when:
-        - openshift.common.https_proxy is defined
-        - openshift.common.https_proxy != ''
-
-    - name: Add no_proxy to /etc/atomic.conf
-      lineinfile:
-        dest: /etc/atomic.conf
-        regexp: "^#?no_proxy[:=]{1}"
-        line: "no_proxy: {{ openshift.common.no_proxy | default('') }}"
-      when:
-        - openshift.common.no_proxy is defined
-        - openshift.common.no_proxy != ''
-
+- name: Ensure proxies are in the atomic.conf
+  include_role:
+    name: openshift_atomic
+    tasks_from: proxy
 
 - block:
 

--- a/roles/docker/tasks/systemcontainer_docker.yml
+++ b/roles/docker/tasks/systemcontainer_docker.yml
@@ -68,38 +68,10 @@
   retries: 3
   delay: 30
 
-
-# Set http_proxy, https_proxy, and no_proxy in /etc/atomic.conf
-# regexp: the line starts with or without #, followed by the string
-#         http_proxy, then either : or =
-- block:
-
-    - name: Add http_proxy to /etc/atomic.conf
-      lineinfile:
-        dest: /etc/atomic.conf
-        regexp: "^#?http_proxy[:=]{1}"
-        line: "http_proxy: {{ openshift.common.http_proxy | default('') }}"
-      when:
-        - openshift.common.http_proxy is defined
-        - openshift.common.http_proxy != ''
-
-    - name: Add https_proxy to /etc/atomic.conf
-      lineinfile:
-        dest: /etc/atomic.conf
-        regexp: "^#?https_proxy[:=]{1}"
-        line: "https_proxy: {{ openshift.common.https_proxy | default('') }}"
-      when:
-        - openshift.common.https_proxy is defined
-        - openshift.common.https_proxy != ''
-
-    - name: Add no_proxy to /etc/atomic.conf
-      lineinfile:
-        dest: /etc/atomic.conf
-        regexp: "^#?no_proxy[:=]{1}"
-        line: "no_proxy: {{ openshift.common.no_proxy | default('') }}"
-      when:
-        - openshift.common.no_proxy is defined
-        - openshift.common.no_proxy != ''
+- name: Ensure proxies are in the atomic.conf
+  include_role:
+    name: openshift_atomic
+    tasks_from: proxy
 
 - block:
 

--- a/roles/etcd/tasks/system_container.yml
+++ b/roles/etcd/tasks/system_container.yml
@@ -2,6 +2,11 @@
 - set_fact:
     l_etcd_src_data_dir: "{{ '/var/lib/origin/openshift.local.etcd' if r_etcd_common_embedded_etcd | bool else '/var/lib/etcd/' }}"
 
+- name: Ensure proxies are in the atomic.conf
+  include_role:
+    name: openshift_atomic
+    tasks_from: proxy
+
 - name: Pull etcd system container
   command: atomic pull --storage=ostree {{ openshift.etcd.etcd_image }}
   register: pull_result

--- a/roles/openshift_atomic/README.md
+++ b/roles/openshift_atomic/README.md
@@ -1,0 +1,28 @@
+OpenShift Atomic
+================
+
+This role houses atomic specific tasks.
+
+Requirements
+------------
+
+Role Variables
+--------------
+
+Dependencies
+------------
+
+Example Playbook
+----------------
+
+```
+- name: Ensure atomic proxies are defined
+  hosts: localhost
+  roles:
+  - role: openshift_atomic
+```
+
+License
+-------
+
+Apache License Version 2.0

--- a/roles/openshift_atomic/meta/main.yml
+++ b/roles/openshift_atomic/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  author: OpenShift
+  description: Atomic related tasks
+  company: Red Hat, Inc
+  license: ASL 2.0
+  min_ansible_version: 2.2
+  platforms:
+  - name: EL
+    versions:
+    - 7
+dependencies:
+- role: lib_openshift

--- a/roles/openshift_atomic/tasks/proxy.yml
+++ b/roles/openshift_atomic/tasks/proxy.yml
@@ -1,0 +1,32 @@
+---
+# Set http_proxy, https_proxy, and no_proxy in /etc/atomic.conf
+# regexp: the line starts with or without #, followed by the string
+#         http_proxy, then either : or =
+- block:
+
+    - name: Add http_proxy to /etc/atomic.conf
+      lineinfile:
+        dest: /etc/atomic.conf
+        regexp: "^#?http_proxy[:=]{1}"
+        line: "http_proxy: {{ openshift.common.http_proxy | default('') }}"
+      when:
+        - openshift.common.http_proxy is defined
+        - openshift.common.http_proxy != ''
+
+    - name: Add https_proxy to /etc/atomic.conf
+      lineinfile:
+        dest: /etc/atomic.conf
+        regexp: "^#?https_proxy[:=]{1}"
+        line: "https_proxy: {{ openshift.common.https_proxy | default('') }}"
+      when:
+        - openshift.common.https_proxy is defined
+        - openshift.common.https_proxy != ''
+
+    - name: Add no_proxy to /etc/atomic.conf
+      lineinfile:
+        dest: /etc/atomic.conf
+        regexp: "^#?no_proxy[:=]{1}"
+        line: "no_proxy: {{ openshift.common.no_proxy | default('') }}"
+      when:
+        - openshift.common.no_proxy is defined
+        - openshift.common.no_proxy != ''

--- a/roles/openshift_master/tasks/system_container.yml
+++ b/roles/openshift_master/tasks/system_container.yml
@@ -1,4 +1,9 @@
 ---
+- name: Ensure proxies are in the atomic.conf
+  include_role:
+    name: openshift_atomic
+    tasks_from: proxy
+
 - name: Pre-pull master system container image
   command: >
     atomic pull --storage=ostree {{ 'docker:' if openshift.common.system_images_registry == 'docker' else openshift.common.system_images_registry + '/' }}{{ openshift.master.master_system_image }}:{{ openshift_image_tag }}

--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -1,4 +1,9 @@
 ---
+- name: Ensure proxies are in the atomic.conf
+  include_role:
+    name: openshift_atomic
+    tasks_from: proxy
+
 - name: Pre-pull node system container image
   command: >
     atomic pull --storage=ostree {{ 'docker:' if openshift.common.system_images_registry == 'docker' else openshift.common.system_images_registry + '/' }}{{ openshift.node.node_system_image }}:{{ openshift_image_tag }}

--- a/roles/openshift_node/tasks/openvswitch_system_container.yml
+++ b/roles/openshift_node/tasks/openvswitch_system_container.yml
@@ -10,6 +10,11 @@
     l_service_name: "{{ openshift.docker.service_name }}"
   when: not l_use_crio
 
+- name: Ensure proxies are in the atomic.conf
+  include_role:
+    name: openshift_atomic
+    tasks_from: proxy
+
 - name: Pre-pull OpenVSwitch system container image
   command: >
     atomic pull --storage=ostree {{ 'docker:' if openshift.common.system_images_registry == 'docker' else openshift.common.system_images_registry + '/' }}{{ openshift.node.ovs_system_image }}:{{ openshift_image_tag }}


### PR DESCRIPTION
A new openshift_atomic role has been created for atomic specific tasks.
The first task added is proxy which handles updating /etc/atomic.conf to
ensure the proper proxy configuration is configured. This task file is
then included (via include_role) in system container related task files.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1503903