### PR TITLE
disk_availability check: include submount storage

### DIFF
--- a/roles/openshift_health_checker/test/disk_availability_test.py
+++ b/roles/openshift_health_checker/test/disk_availability_test.py
@@ -96,6 +96,24 @@ def test_cannot_determine_available_disk(desc, ansible_mounts, expect_chunks):
             'size_available': 20 * 10**9 + 1,
         }],
     ),
+    (
+        ['oo_masters_to_config'],
+        0,
+        [{
+            'mount': '/',
+            'size_available': 2 * 10**9,
+        }, {  # not enough directly on /var
+            'mount': '/var',
+            'size_available': 10 * 10**9 + 1,
+        }, {
+            # but subdir mounts add up to enough
+            'mount': '/var/lib/docker',
+            'size_available': 20 * 10**9 + 1,
+        }, {
+            'mount': '/var/lib/origin',
+            'size_available': 20 * 10**9 + 1,
+        }],
+    ),
 ])
 def test_succeeds_with_recommended_disk_space(group_names, configured_min, ansible_mounts):
     task_vars = dict(
@@ -104,9 +122,10 @@ def test_succeeds_with_recommended_disk_space(group_names, configured_min, ansib
         ansible_mounts=ansible_mounts,
     )
 
-    result = DiskAvailability(fake_execute_module, task_vars).run()
+    check = DiskAvailability(fake_execute_module, task_vars)
+    check.run()
 
-    assert not result.get('failed', False)
+    assert not check.failures
 
 
 @pytest.mark.parametrize('name,group_names,configured_min,ansible_mounts,expect_chunks', [


### PR DESCRIPTION
Fixes bug [1491566](https://bugzilla.redhat.com/show_bug.cgi?id=1491566)
    
In order to determine how much storage is under a path, include any mounts that are below it in addition to the path itself.
