### PR TITLE
Ensure /etc/containers exists before adding registries

### DIFF
--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -85,6 +85,11 @@
   notify:
   - restart docker
 
+- name: Ensure /etc/containers directory exists
+  file:
+    path: /etc/containers
+    state: directory
+
 - name: Place additional/blocked/insecure registries in /etc/containers/registries.conf
   template:
     dest: "{{ containers_registries_conf_path }}"


### PR DESCRIPTION
Installation fails if /etc/containers does not exist on nodes. Make sure that this directory exists before placing registries.conf inside.