### PR TITLE
[3.6] disk_availability check: include submount storage

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/disk_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/disk_availability.py
@@ -1,6 +1,7 @@
 """Check that there is enough disk space in predefined paths."""
 
 import tempfile
+import os.path
 
 from openshift_checks import OpenShiftCheck, OpenShiftCheckException
 
@@ -120,11 +121,21 @@ class DiskAvailability(OpenShiftCheck):
 
         return {}
 
+    def find_ansible_submounts(self, path):
+        """Return a list of ansible_mounts that are below the given path."""
+        base = os.path.join(path, "")
+        return [
+            mount
+            for mount in self.get_var("ansible_mounts")
+            if mount["mount"].startswith(base)
+        ]
+
     def free_bytes(self, path):
         """Return the size available in path based on ansible_mounts."""
+        submounts = sum(mnt.get('size_available', 0) for mnt in self.find_ansible_submounts(path))
         mount = self.find_ansible_mount(path)
         try:
-            return mount['size_available']
+            return mount['size_available'] + submounts
         except KeyError:
             raise OpenShiftCheckException(
                 'Unable to retrieve disk availability for "{path}".\n'

--- a/roles/openshift_health_checker/test/disk_availability_test.py
+++ b/roles/openshift_health_checker/test/disk_availability_test.py
@@ -96,6 +96,24 @@ def test_cannot_determine_available_disk(desc, ansible_mounts, expect_chunks):
             'size_available': 20 * 10**9 + 1,
         }],
     ),
+    (
+        ['oo_masters_to_config'],
+        0,
+        [{
+            'mount': '/',
+            'size_available': 2 * 10**9,
+        }, {  # not enough directly on /var
+            'mount': '/var',
+            'size_available': 10 * 10**9 + 1,
+        }, {
+            # but subdir mounts add up to enough
+            'mount': '/var/lib/docker',
+            'size_available': 20 * 10**9 + 1,
+        }, {
+            'mount': '/var/lib/origin',
+            'size_available': 20 * 10**9 + 1,
+        }],
+    ),
 ])
 def test_succeeds_with_recommended_disk_space(group_names, configured_min, ansible_mounts):
     task_vars = dict(


### PR DESCRIPTION
Backport https://github.com/openshift/openshift-ansible/pull/5816 to 3.6

In order to determine how much storage is under a path, include any mounts that are below it in addition to the path itself.
