### PR TITLE
Force include_role to static for loading openshift_facts module

### DIFF
--- a/playbooks/common/openshift-cluster/initialize_facts.yml
+++ b/playbooks/common/openshift-cluster/initialize_facts.yml
@@ -10,6 +10,7 @@
   - name: load openshift_facts module
     include_role:
       name: openshift_facts
+    static: yes
 
   # TODO: Should this role be refactored into health_checks??
   - name: Run openshift_sanitize_inventory to set variables


### PR DESCRIPTION
Forward compatibility with Ansible 2.4.1

https://github.com/ansible/ansible/issues/31943