### PR TITLE
reconcile registry-console and docker_image_availability

### DIFF
--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -400,10 +400,11 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_hosted_routers=[{'name': 'router1', 'certificate': {'certfile': '/path/to/certificate/abc.crt', 'keyfile': '/path/to/certificate/abc.key', 'cafile': '/path/to/certificate/ca.crt'}, 'replicas': 1, 'serviceaccount': 'router', 'namespace': 'default', 'stats_port': 1936, 'edits': [], 'images': 'openshift3/ose-${component}:${version}', 'selector': 'type=router1', 'ports': ['80:80', '443:443']}, {'name': 'router2', 'certificate': {'certfile': '/path/to/certificate/xyz.crt', 'keyfile': '/path/to/certificate/xyz.key', 'cafile': '/path/to/certificate/ca.crt'}, 'replicas': 1, 'serviceaccount': 'router', 'namespace': 'default', 'stats_port': 1936, 'edits': [{'action': 'append', 'key': 'spec.template.spec.containers[0].env', 'value': {'name': 'ROUTE_LABELS', 'value': 'route=external'}}], 'images': 'openshift3/ose-${component}:${version}', 'selector': 'type=router2', 'ports': ['80:80', '443:443']}]
 
 # OpenShift Registry Console Options
-# Override the console image prefix for enterprise deployments, not used in origin
-# default is "registry.access.redhat.com/openshift3/" and the image appended is "registry-console"
+# Override the console image prefix:
+# origin default is "cockpit/" and the image appended is "kubernetes"
+# enterprise default is "registry.access.redhat.com/openshift3/" and the image appended is "registry-console"
 #openshift_cockpit_deployer_prefix=registry.example.com/myrepo/
-# Override image version, defaults to latest for origin, matches the product version for enterprise
+# Override image version, defaults to latest for origin, vX.Y product version for enterprise
 #openshift_cockpit_deployer_version=1.4.1
 
 # Openshift Registry Options

--- a/roles/cockpit-ui/tasks/main.yml
+++ b/roles/cockpit-ui/tasks/main.yml
@@ -37,7 +37,6 @@
       cp {{ openshift_master_config_dir }}/admin.kubeconfig {{ openshift_hosted_kubeconfig }}
     changed_when: False
 
-  # TODO: Need to fix the origin and enterprise templates so that they both respect IMAGE_PREFIX
   - name: Deploy registry-console
     command: >
       {{ openshift.common.client_binary }} new-app --template=registry-console

--- a/roles/openshift_hosted_templates/files/v3.6/origin/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.6/origin/registry-console.yaml
@@ -27,7 +27,7 @@ objects:
         spec:
           containers:
             - name: registry-console
-              image: ${IMAGE_NAME}:${IMAGE_VERSION}
+              image: ${IMAGE_PREFIX}kubernetes:${IMAGE_VERSION}
               ports:
                 - containerPort: 9090
                   protocol: TCP
@@ -89,7 +89,7 @@ objects:
         - annotations: null
           from:
             kind: DockerImage
-            name: ${IMAGE_NAME}:${IMAGE_VERSION}
+            name: ${IMAGE_PREFIX}kubernetes:${IMAGE_VERSION}
           name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
@@ -100,9 +100,9 @@ objects:
     redirectURIs:
       - "${COCKPIT_KUBE_URL}"
 parameters:
-  - description: "Container image name"
-    name: IMAGE_NAME
-    value: "cockpit/kubernetes"
+  - description: 'Specify "registry/namespace" prefix for container image; e.g. for "registry.example.com/cockpit/kubernetes:latest", set prefix "registry.example.com/cockpit/"'
+    name: IMAGE_PREFIX
+    value: "cockpit/"
   - description: 'Specify image version; e.g. for "cockpit/kubernetes:latest", set version "latest"'
     name: IMAGE_VERSION
     value: latest

--- a/roles/openshift_hosted_templates/files/v3.7/origin/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.7/origin/registry-console.yaml
@@ -27,7 +27,7 @@ objects:
         spec:
           containers:
             - name: registry-console
-              image: ${IMAGE_NAME}:${IMAGE_VERSION}
+              image: ${IMAGE_PREFIX}kubernetes:${IMAGE_VERSION}
               ports:
                 - containerPort: 9090
                   protocol: TCP
@@ -89,7 +89,7 @@ objects:
         - annotations: null
           from:
             kind: DockerImage
-            name: ${IMAGE_NAME}:${IMAGE_VERSION}
+            name: ${IMAGE_PREFIX}kubernetes:${IMAGE_VERSION}
           name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
@@ -100,9 +100,9 @@ objects:
     redirectURIs:
       - "${COCKPIT_KUBE_URL}"
 parameters:
-  - description: "Container image name"
-    name: IMAGE_NAME
-    value: "cockpit/kubernetes"
+  - description: 'Specify "registry/namespace" prefix for container image; e.g. for "registry.example.com/cockpit/kubernetes:latest", set prefix "registry.example.com/cockpit/"'
+    name: IMAGE_PREFIX
+    value: "cockpit/"
   - description: 'Specify image version; e.g. for "cockpit/kubernetes:latest", set version "latest"'
     name: IMAGE_VERSION
     value: latest


### PR DESCRIPTION
One commit to fix [bug 1497310](https://bugzilla.redhat.com/show_bug.cgi?id=1497310)
    
The registry console is a special case in more than one way. This adds logic to incorporate the `openshift_cockpit_deployer_*` variables into determining what its image will be in `docker_image_availability`.
    
Along the way I noticed the origin and enterprise templates for this were not consistent. Now they are, and the example hosts file is updated.
