### PR TITLE
bz#1505097: make openshift_release or openshift_image_tag mandatory for containerized installation

### DIFF
--- a/roles/openshift_version/tasks/first_master_containerized_version.yml
+++ b/roles/openshift_version/tasks/first_master_containerized_version.yml
@@ -1,4 +1,13 @@
 ---
+- set_fact:
+    l_use_crio_only: "{{ openshift_use_crio_only | default(false) }}"
+
+- name: Validate openshift_release or openshift_image_tag is specified
+  fail:
+    msg: "openshift_release or openshift_image_tag must be specified for enterprise version of containerized installation."
+  when:
+  - (openshift_release is not defined and openshift_image_tag is not defined | bool) and deployment_type == 'openshift-enterprise'
+
 - name: Set containerized version to configure if openshift_image_tag specified
   set_fact:
     # Expects a leading "v" in inventory, strip it off here unless

--- a/roles/openshift_version/tasks/first_master_containerized_version.yml
+++ b/roles/openshift_version/tasks/first_master_containerized_version.yml
@@ -6,7 +6,9 @@
   fail:
     msg: "openshift_release or openshift_image_tag must be specified for enterprise version of containerized installation."
   when:
-  - (openshift_release is not defined and openshift_image_tag is not defined | bool) and deployment_type == 'openshift-enterprise'
+  - openshift_release is not defined
+  - openshift_image_tag is not defined
+  - deployment_type == 'openshift-enterprise'
 
 - name: Set containerized version to configure if openshift_image_tag specified
   set_fact:


### PR DESCRIPTION
containerized installation pulls **latest** 3.x image if
openshift_release or openshift_image_tag was not specified. Due to
this, following problem happened:

  1. we finished 3.3 installation several months ago (3.3.x was the latest at that time)
  2. we used same inventory file and add new node (3.6.x is the latest now)
  3. new node was installed with 3.6.x with same inventory file.

To avoid such issue, containerized installation should make
openshift_release or openshift_image_tag mandatory.