### PR TITLE
Remove provisioner restrictions on oc_storageclass

### DIFF
--- a/roles/lib_openshift/library/oc_storageclass.py
+++ b/roles/lib_openshift/library/oc_storageclass.py
@@ -1664,7 +1664,7 @@ def main():
             name=dict(default=None, type='str'),
             annotations=dict(default=None, type='dict'),
             parameters=dict(default=None, type='dict'),
-            provisioner=dict(required=True, type='str', choices=['aws-ebs', 'gce-pd', 'glusterfs', 'cinder']),
+            provisioner=dict(required=True, type='str'),
             api_version=dict(default='v1', type='str'),
             default_storage_class=dict(default="false", type='str'),
         ),

--- a/roles/lib_openshift/src/ansible/oc_storageclass.py
+++ b/roles/lib_openshift/src/ansible/oc_storageclass.py
@@ -14,7 +14,7 @@ def main():
             name=dict(default=None, type='str'),
             annotations=dict(default=None, type='dict'),
             parameters=dict(default=None, type='dict'),
-            provisioner=dict(required=True, type='str', choices=['aws-ebs', 'gce-pd', 'glusterfs', 'cinder']),
+            provisioner=dict(required=True, type='str'),
             api_version=dict(default='v1', type='str'),
             default_storage_class=dict(default="false", type='str'),
         ),


### PR DESCRIPTION
Fixes #5835

Make possible to use EFS as default provisioner on AWS instead EBS like

```
apiVersion: storage.k8s.io/v1beta1
kind: StorageClass
metadata:
  name: slow
provisioner: example.com/aws-efs
parameters:
  gidMin: "40000"
  gidMax: "50000"
  gidAllocate: "true"
```