### PR TITLE
strip dash when comparing version with Python3

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -37,7 +37,7 @@
     fail:
       msg: "OpenShift {{ avail_openshift_version }} is available, but {{ openshift_upgrade_target }} or greater is required"
     when:
-    - openshift_pkg_version | default('0.0', True) | version_compare(openshift_release, '<')
+    - (openshift_pkg_version | default('-0.0', True)).split('-')[1] | version_compare(openshift_release, '<')
 
 - name: Fail when openshift version does not meet minium requirement for Origin upgrade
   fail:


### PR DESCRIPTION
Python3 complains about ``Version comparison: unorderable types: str() < int()`` otherwise.