### PR TITLE
Add support for storage classes to openshift_prometheus role.

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -641,6 +641,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_prometheus_storage_volume_size=10Gi
 #openshift_prometheus_storage_labels={'storage': 'prometheus'}
 #openshift_prometheus_storage_type='pvc'
+#openshift_prometheus_storage_class=glusterfs-storage
 # For prometheus-alertmanager
 #openshift_prometheus_alertmanager_storage_kind=nfs
 #openshift_prometheus_alertmanager_storage_access_modes=['ReadWriteOnce']
@@ -650,6 +651,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_prometheus_alertmanager_storage_volume_size=10Gi
 #openshift_prometheus_alertmanager_storage_labels={'storage': 'prometheus-alertmanager'}
 #openshift_prometheus_alertmanager_storage_type='pvc'
+#openshift_prometheus_alertmanager_storage_class=glusterfs-storage
 # For prometheus-alertbuffer
 #openshift_prometheus_alertbuffer_storage_kind=nfs
 #openshift_prometheus_alertbuffer_storage_access_modes=['ReadWriteOnce']
@@ -659,6 +661,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_prometheus_alertbuffer_storage_volume_size=10Gi
 #openshift_prometheus_alertbuffer_storage_labels={'storage': 'prometheus-alertbuffer'}
 #openshift_prometheus_alertbuffer_storage_type='pvc'
+#openshift_prometheus_alertbuffer_storage_class=glusterfs-storage
 #
 # Option B - External NFS Host
 # NFS volume must already exist with path "nfs_directory/_volume_name" on
@@ -672,6 +675,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_prometheus_storage_volume_size=10Gi
 #openshift_prometheus_storage_labels={'storage': 'prometheus'}
 #openshift_prometheus_storage_type='pvc'
+#openshift_prometheus_storage_class=glusterfs-storage
 # For prometheus-alertmanager
 #openshift_prometheus_alertmanager_storage_kind=nfs
 #openshift_prometheus_alertmanager_storage_access_modes=['ReadWriteOnce']
@@ -681,6 +685,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_prometheus_alertmanager_storage_volume_size=10Gi
 #openshift_prometheus_alertmanager_storage_labels={'storage': 'prometheus-alertmanager'}
 #openshift_prometheus_alertmanager_storage_type='pvc'
+#openshift_prometheus_alertmanager_storage_class=glusterfs-storage
 # For prometheus-alertbuffer
 #openshift_prometheus_alertbuffer_storage_kind=nfs
 #openshift_prometheus_alertbuffer_storage_access_modes=['ReadWriteOnce']
@@ -690,6 +695,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_prometheus_alertbuffer_storage_volume_size=10Gi
 #openshift_prometheus_alertbuffer_storage_labels={'storage': 'prometheus-alertbuffer'}
 #openshift_prometheus_alertbuffer_storage_type='pvc'
+#openshift_prometheus_alertbuffer_storage_class=glusterfs-storage
 #
 # Option C - none -- Prometheus, alertmanager and alertbuffer will use emptydir volumes
 # which are destroyed when pods are deleted

--- a/roles/openshift_prometheus/README.md
+++ b/roles/openshift_prometheus/README.md
@@ -38,11 +38,13 @@ openshift_prometheus_args=['--storage.tsdb.retention=6h', '--storage.tsdb.min-bl
 Each prometheus component (prometheus, alertmanager, alertbuffer) can set pv claim by setting corresponding role variable:
 ```
 openshift_prometheus_<COMPONENT>_storage_type: <VALUE> (pvc, emptydir)
+openshift_prometheus_<COMPONENT>_storage_class: <VALUE>
 openshift_prometheus_<COMPONENT>_pvc_(name|size|access_modes|pv_selector): <VALUE>
 ```
 e.g
 ```
 openshift_prometheus_storage_type: pvc
+openshift_prometheus_storage_class: glusterfs-storage
 openshift_prometheus_alertmanager_pvc_name: alertmanager
 openshift_prometheus_alertbuffer_pvc_size: 10G
 openshift_prometheus_pvc_access_modes: [ReadWriteOnce]

--- a/roles/openshift_prometheus/defaults/main.yaml
+++ b/roles/openshift_prometheus/defaults/main.yaml
@@ -23,6 +23,7 @@ openshift_prometheus_pvc_name: prometheus
 openshift_prometheus_pvc_size: "{{ openshift_prometheus_storage_volume_size | default('10Gi') }}"
 openshift_prometheus_pvc_access_modes: [ReadWriteOnce]
 openshift_prometheus_pvc_pv_selector: "{{ openshift_prometheus_storage_labels | default({}) }}"
+openshift_prometheus_sc_name: "{{ openshift_prometheus_storage_class | default(None) }}"
 
 # One of ['emptydir', 'pvc']
 openshift_prometheus_alertmanager_storage_type: "emptydir"
@@ -30,6 +31,7 @@ openshift_prometheus_alertmanager_pvc_name: prometheus-alertmanager
 openshift_prometheus_alertmanager_pvc_size: "{{ openshift_prometheus_alertmanager_storage_volume_size | default('10Gi') }}"
 openshift_prometheus_alertmanager_pvc_access_modes: [ReadWriteOnce]
 openshift_prometheus_alertmanager_pvc_pv_selector: "{{ openshift_prometheus_alertmanager_storage_labels | default({}) }}"
+openshift_prometheus_alertmanager_sc_name: "{{ openshift_prometheus_alertmanager_storage_class | default(None) }}"
 
 # One of ['emptydir', 'pvc']
 openshift_prometheus_alertbuffer_storage_type: "emptydir"
@@ -37,6 +39,7 @@ openshift_prometheus_alertbuffer_pvc_name: prometheus-alertbuffer
 openshift_prometheus_alertbuffer_pvc_size: "{{ openshift_prometheus_alertbuffer_storage_volume_size | default('10Gi') }}"
 openshift_prometheus_alertbuffer_pvc_access_modes: [ReadWriteOnce]
 openshift_prometheus_alertbuffer_pvc_pv_selector: "{{ openshift_prometheus_alertbuffer_storage_labels | default({}) }}"
+openshift_prometheus_alertbuffer_sc_name: "{{ openshift_prometheus_alertbuffer_storage_class | default(None) }}"
 
 # container resources
 openshift_prometheus_cpu_limit: null

--- a/roles/openshift_prometheus/tasks/install_prometheus.yaml
+++ b/roles/openshift_prometheus/tasks/install_prometheus.yaml
@@ -131,6 +131,7 @@
     access_modes: "{{ openshift_prometheus_pvc_access_modes }}"
     volume_capacity: "{{ openshift_prometheus_pvc_size }}"
     selector: "{{ openshift_prometheus_pvc_pv_selector }}"
+    storage_class_name: "{{ openshift_prometheus_sc_name }}"
   when: openshift_prometheus_storage_type == 'pvc'
 
 - name: create alertmanager pvc
@@ -140,6 +141,7 @@
     access_modes: "{{ openshift_prometheus_alertmanager_pvc_access_modes }}"
     volume_capacity: "{{ openshift_prometheus_alertmanager_pvc_size }}"
     selector: "{{ openshift_prometheus_alertmanager_pvc_pv_selector }}"
+    storage_class_name: "{{ openshift_prometheus_alertmanager_sc_name }}"
   when: openshift_prometheus_alertmanager_storage_type == 'pvc'
 
 - name: create alertbuffer pvc
@@ -149,6 +151,7 @@
     access_modes: "{{ openshift_prometheus_alertbuffer_pvc_access_modes }}"
     volume_capacity: "{{ openshift_prometheus_alertbuffer_pvc_size }}"
     selector: "{{ openshift_prometheus_alertbuffer_pvc_pv_selector }}"
+    storage_class_name: "{{ openshift_prometheus_alertbuffer_sc_name }}"
   when: openshift_prometheus_alertbuffer_storage_type == 'pvc'
 
 # prometheus configmap


### PR DESCRIPTION
This PR adds support to specify storage classes for prometheus, prometheus_alertmanager and prometheus_alertbuffer.

Tested on top of CNS.

Example usage:

openshift_prometheus_storage_volume_size=5Gi
openshift_prometheus_alertmanager_storage_volume_size=5Gi
openshift_prometheus_alertbuffer_storage_volume_size=5Gi
openshift_prometheus_storage_class=glusterfs-storage
openshift_prometheus_alertmanager_storage_class=glusterfs-storage
openshift_prometheus_alertbuffer_storage_class=glusterfs-storage

/cc @zgalor 