### PR TITLE
Fix edit and admin role patching for service catalog

### DIFF
--- a/roles/openshift_service_catalog/templates/sc_role_patching.j2
+++ b/roles/openshift_service_catalog/templates/sc_role_patching.j2
@@ -3,8 +3,8 @@
   - "servicecatalog.k8s.io"
   attributeRestrictions: null
   resources:
-  - instances
-  - bindings
+  - serviceinstances
+  - servicebindings
   verbs:
   - create
   - update


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1496694.

Update the jinja files used to patch the edit and admin ClusterRoles so that it uses the new resource names of ServiceInstances and ServiceBindings.