### PR TITLE
Switch up the cluster install order.

### DIFF
--- a/playbooks/aws/openshift-cluster/hosted.yml
+++ b/playbooks/aws/openshift-cluster/hosted.yml
@@ -1,0 +1,22 @@
+---
+- include: ../../common/openshift-cluster/openshift_hosted.yml
+
+- include: ../../common/openshift-cluster/openshift_metrics.yml
+  when: openshift_metrics_install_metrics | default(false) | bool
+
+- include: ../../common/openshift-cluster/openshift_logging.yml
+  when: openshift_logging_install_logging | default(false) | bool
+
+- include: ../../common/openshift-cluster/service_catalog.yml
+  when: openshift_enable_service_catalog | default(false) | bool
+
+- include: ../../common/openshift-management/config.yml
+  when: openshift_management_install_management | default(false) | bool
+
+- name: Print deprecated variable warning message if necessary
+  hosts: oo_first_master
+  gather_facts: no
+  tasks:
+  - debug: msg="{{__deprecation_message}}"
+    when:
+    - __deprecation_message | default ('') | length > 0

--- a/playbooks/aws/openshift-cluster/install.yml
+++ b/playbooks/aws/openshift-cluster/install.yml
@@ -21,5 +21,29 @@
 - name: run the std_include
   include: ../../common/openshift-cluster/std_include.yml
 
-- name: run the config
-  include: ../../common/openshift-cluster/config.yml
+- name: perform the installer openshift-checks
+  include: ../../common/openshift-checks/install.yml
+
+- name: etcd install
+  include: ../../common/openshift-etcd/config.yml
+
+- name: include nfs
+  include: ../../common/openshift-nfs/config.yml
+  when: groups.oo_nfs_to_config | default([]) | count > 0
+
+- name: include loadbalancer
+  include: ../../common/openshift-loadbalancer/config.yml
+  when: groups.oo_lb_to_config | default([]) | count > 0
+
+- name: include openshift-master config
+  include: ../../common/openshift-master/config.yml
+
+- name: include master additional config
+  include: ../../common/openshift-master/additional_config.yml
+
+- name: include master additional config
+  include: ../../common/openshift-node/config.yml
+
+- name: include openshift-glusterfs
+  include: ../../common/openshift-glusterfs/config.yml
+  when: groups.oo_glusterfs_to_config | default([]) | count > 0

--- a/playbooks/aws/openshift-cluster/provision_install.yml
+++ b/playbooks/aws/openshift-cluster/provision_install.yml
@@ -6,11 +6,14 @@
 - name: Include the provision.yml playbook to create cluster
   include: provision.yml
 
-- name: Include the install.yml playbook to install cluster
+- name: Include the install.yml playbook to install cluster on masters
   include: install.yml
 
-- name: Include the install.yml playbook to install cluster
+- name: provision the infra/compute playbook to install node resources
   include: provision_nodes.yml
 
 - name: Include the accept.yml playbook to accept nodes into the cluster
   include: accept.yml
+
+- name: Include the hosted.yml playbook to finish the hosted configuration
+  include: hosted.yml


### PR DESCRIPTION
The purpose of this pull request is to change the order of installation to the following:

- Provision masters
- Install masters
- Provision node groups (infra/compute)
- Join nodes to cluster (approval process)
- Call hosted playbooks on entire cluster

This model of install is a bit more robust than the previous one of bringing up nodes after hosted has been installed.  This method allows us to have all nodes available when the services are being configured rather than after-the-fact.