### PR TITLE
[3.6 backport] Default groups.oo_new_etcd_to_config to an empty list

### DIFF
--- a/playbooks/common/openshift-etcd/scaleup.yml
+++ b/playbooks/common/openshift-etcd/scaleup.yml
@@ -66,7 +66,7 @@
       etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
       openshift_ca_host: "{{ groups.oo_first_master.0 }}"
       openshift_master_etcd_hosts: "{{ hostvars
-                                       | oo_select_keys(groups['oo_etcd_to_config'] | union(groups['oo_new_etcd_to_config']))
+                                       | oo_select_keys(groups['oo_etcd_to_config'] | union(groups['oo_new_etcd_to_config'] | default([])))
                                        | oo_collect('openshift.common.hostname')
                                        | default(none, true) }}"
       openshift_master_etcd_port: "{{ (etcd_client_port | default('2379')) if (groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config) else none }}"


### PR DESCRIPTION
Backports https://github.com/openshift/openshift-ansible/pull/5735