### PR TITLE
Remove base package install

### DIFF
--- a/playbooks/common/openshift-cluster/initialize_openshift_version.yml
+++ b/playbooks/common/openshift-cluster/initialize_openshift_version.yml
@@ -1,15 +1,4 @@
 ---
-# openshift_install_base_package_group may be set in a play variable to limit
-# the host groups the base package is installed on.  This is currently used
-# for master/control-plane upgrades.
-- name: Set version_install_base_package true on masters and nodes
-  hosts: "{{ openshift_install_base_package_group | default('oo_masters_to_config:oo_nodes_to_config') }}"
-  tasks:
-  - name: Set version_install_base_package true
-    set_fact:
-      version_install_base_package: True
-    when: version_install_base_package is not defined
-
 # NOTE: requires openshift_facts be run
 - name: Determine openshift_version to configure on first master
   hosts: oo_first_master

--- a/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_3/upgrade_control_plane.yml
@@ -68,7 +68,6 @@
     # defined, and overriding the normal behavior of protecting the installed version
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
-    openshift_install_base_package_group: "oo_masters_to_config"
 
     # We skip the docker role at this point in upgrade to prevent
     # unintended package, container, or config upgrades which trigger

--- a/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_4/upgrade_control_plane.yml
@@ -68,7 +68,6 @@
     # defined, and overriding the normal behavior of protecting the installed version
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
-    openshift_install_base_package_group: "oo_masters_to_config"
 
     # We skip the docker role at this point in upgrade to prevent
     # unintended package, container, or config upgrades which trigger

--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade_control_plane.yml
@@ -72,7 +72,6 @@
     # defined, and overriding the normal behavior of protecting the installed version
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
-    openshift_install_base_package_group: "oo_masters_to_config"
 
     # We skip the docker role at this point in upgrade to prevent
     # unintended package, container, or config upgrades which trigger

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
@@ -76,7 +76,6 @@
     # defined, and overriding the normal behavior of protecting the installed version
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
-    openshift_install_base_package_group: "oo_masters_to_config"
 
     # We skip the docker role at this point in upgrade to prevent
     # unintended package, container, or config upgrades which trigger

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -80,7 +80,6 @@
     # defined, and overriding the normal behavior of protecting the installed version
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
-    openshift_install_base_package_group: "oo_masters_to_config"
 
     # We skip the docker role at this point in upgrade to prevent
     # unintended package, container, or config upgrades which trigger

--- a/roles/openshift_version/defaults/main.yml
+++ b/roles/openshift_version/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
 openshift_protect_installed_version: True
-version_install_base_package: False

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -5,16 +5,6 @@
     is_containerized: "{{ openshift.common.is_containerized | default(False) | bool }}"
     is_atomic: "{{ openshift.common.is_atomic | default(False) | bool }}"
 
-# This is only needed on masters and nodes; version_install_base_package
-# should be set by a play externally.
-- name: Install the base package for versioning
-  package:
-    name: "{{ openshift.common.service_type }}{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
-    state: present
-  when:
-  - not is_containerized | bool
-  - version_install_base_package | bool
-
 # Block attempts to install origin without specifying some kind of version information.
 # This is because the latest tags for origin are usually alpha builds, which should not
 # be used by default. Users must indicate what they want.


### PR DESCRIPTION
Currently, base atomic-openshift package is
installed for versioning.

This doesn't appear to be necessary.

This commit removes this step.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1504196