### PR TITLE
Replace hawkular with middleware manager

### DIFF
--- a/roles/openshift_examples/files/examples/v3.6/cfme-templates/jboss-middleware-manager-template-ephemeral.yaml
+++ b/roles/openshift_examples/files/examples/v3.6/cfme-templates/jboss-middleware-manager-template-ephemeral.yaml
@@ -24,7 +24,6 @@ metadata:
     description: Middleware Manager all-in-one
     iconClass: icon-jboss
     tags: middleware-manager,metrics,alerts,cloudforms,cassandra
-
 parameters:
 - name: HAWKULAR_SERVICES_IMAGE
   description: What docker image should be used for Middleware Manager.
@@ -38,14 +37,6 @@ parameters:
   description: Maximum amount of memory for Cassandra container.
   displayName: Cassandra Memory Limit
   value: 2Gi
-- name: CASSANDRA_DATA_LIMIT
-  description: Maximum amount data used by Cassandra container.
-  displayName: Cassandra Container Data Limit
-  value: 2Gi
-- name: HAWKULAR_SERVICES_DATA_LIMIT
-  description: Maximum amount data used by Middleware Manager container (mostly logging).
-  displayName: Middleware Manager Container Data Limit
-  value: 1Gi
 - name: ROUTE_NAME
   description: Public route with this name will be created.
   displayName: Route Name
@@ -74,7 +65,6 @@ objects:
     annotations:
       description: Exposes and load balances the application pods
       service.alpha.openshift.io/dependencies: '[{"name":"hawkular-cassandra","namespace":"","kind":"Service"}]'
-      service.alpha.openshift.io/serving-cert-secret-name: hawkular-ssl-secret
     name: hawkular-services
   spec:
     ports:
@@ -130,7 +120,7 @@ objects:
     selector:
       name: hawkular-services
     strategy:
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -143,24 +133,15 @@ objects:
             value: remote
           - name: CASSANDRA_NODES
             value: hawkular-cassandra
-          - name: HAWKULAR_USE_SSL
-            value: 'true'
           - name: HAWKULAR_USER
             value: ${HAWKULAR_USER}
           - name: HAWKULAR_PASSWORD
             value: ${HAWKULAR_PASSWORD}
-          - name: HAWKULAR_PUBLIC_KEY_FILENAME
-            value: /client-secrets/tls.crt
-          - name: HAWKULAR_PRIVATE_KEY_FILENAME
-            value: /client-secrets/tls.key
           imagePullPolicy: IfNotPresent
           name: hawkular-services
           volumeMounts:
           - name: h-services-data
             mountPath: /var/opt/hawkular
-          - name: hawkular-secret-volume
-            mountPath: /client-secrets/
-            readOnly: true
           ports:
           - containerPort: 8080
           - containerPort: 8443
@@ -175,7 +156,7 @@ objects:
             exec:
               command:
               - /opt/hawkular/bin/ready.sh
-            initialDelaySeconds: 120
+            initialDelaySeconds: 35
             timeoutSeconds: 15
             periodSeconds: 20
             successThreshold: 1
@@ -188,11 +169,7 @@ objects:
         restartPolicy: Always
         volumes:
         - name: h-services-data
-          persistentVolumeClaim:
-            claimName: h-services-pvc
-        - name: hawkular-secret-volume
-          secret:
-            secretName: hawkular-ssl-secret
+          emptyDir: {}
 
 - apiVersion: v1
   kind: DeploymentConfig
@@ -205,7 +182,7 @@ objects:
     selector:
       name: hawkular-cassandra
     strategy:
-      type: Recreate
+      type: Rolling
       rollingParams:
         timeoutSeconds: 300
     template:
@@ -217,9 +194,6 @@ objects:
         - image: ${CASSANDRA_IMAGE}
           imagePullPolicy: Always
           name: hawkular-cassandra
-          env:
-          - name: DATA_VOLUME
-            value: /var/lib/cassandra
           volumeMounts:
           - name: cassandra-data
             mountPath: /var/lib/cassandra
@@ -228,15 +202,15 @@ objects:
           - containerPort: 9160
           readinessProbe:
             exec:
-              command: ['nodetool', 'status']
-            initialDelaySeconds: 30
+              command: [nodetool, status]
+            initialDelaySeconds: 15
             timeoutSeconds: 10
             periodSeconds: 15
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 6
           livenessProbe:
             exec:
-              command: ['nodetool', 'status']
+              command: [nodetool, status]
             initialDelaySeconds: 300
             timeoutSeconds: 10
             periodSeconds: 15
@@ -247,26 +221,4 @@ objects:
               memory: ${CASSANDRA_MEMORY_LIMIT}
         volumes:
         - name: cassandra-data
-          persistentVolumeClaim:
-            claimName: cassandra-pvc
-
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: h-services-pvc
-  spec:
-    accessModes:
-      - ReadWriteOnce
-    resources:
-      requests:
-        storage: ${HAWKULAR_SERVICES_DATA_LIMIT}
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: cassandra-pvc
-  spec:
-    accessModes:
-      - ReadWriteOnce
-    resources:
-      requests:
-        storage: ${CASSANDRA_DATA_LIMIT}
+          emptyDir: {}

--- a/roles/openshift_examples/files/examples/v3.7/cfme-templates/jboss-middleware-manager-template-ephemeral.yaml
+++ b/roles/openshift_examples/files/examples/v3.7/cfme-templates/jboss-middleware-manager-template-ephemeral.yaml
@@ -24,7 +24,6 @@ metadata:
     description: Middleware Manager all-in-one
     iconClass: icon-jboss
     tags: middleware-manager,metrics,alerts,cloudforms,cassandra
-
 parameters:
 - name: HAWKULAR_SERVICES_IMAGE
   description: What docker image should be used for Middleware Manager.
@@ -38,14 +37,6 @@ parameters:
   description: Maximum amount of memory for Cassandra container.
   displayName: Cassandra Memory Limit
   value: 2Gi
-- name: CASSANDRA_DATA_LIMIT
-  description: Maximum amount data used by Cassandra container.
-  displayName: Cassandra Container Data Limit
-  value: 2Gi
-- name: HAWKULAR_SERVICES_DATA_LIMIT
-  description: Maximum amount data used by Middleware Manager container (mostly logging).
-  displayName: Middleware Manager Container Data Limit
-  value: 1Gi
 - name: ROUTE_NAME
   description: Public route with this name will be created.
   displayName: Route Name
@@ -74,7 +65,6 @@ objects:
     annotations:
       description: Exposes and load balances the application pods
       service.alpha.openshift.io/dependencies: '[{"name":"hawkular-cassandra","namespace":"","kind":"Service"}]'
-      service.alpha.openshift.io/serving-cert-secret-name: hawkular-ssl-secret
     name: hawkular-services
   spec:
     ports:
@@ -130,7 +120,7 @@ objects:
     selector:
       name: hawkular-services
     strategy:
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -143,24 +133,15 @@ objects:
             value: remote
           - name: CASSANDRA_NODES
             value: hawkular-cassandra
-          - name: HAWKULAR_USE_SSL
-            value: 'true'
           - name: HAWKULAR_USER
             value: ${HAWKULAR_USER}
           - name: HAWKULAR_PASSWORD
             value: ${HAWKULAR_PASSWORD}
-          - name: HAWKULAR_PUBLIC_KEY_FILENAME
-            value: /client-secrets/tls.crt
-          - name: HAWKULAR_PRIVATE_KEY_FILENAME
-            value: /client-secrets/tls.key
           imagePullPolicy: IfNotPresent
           name: hawkular-services
           volumeMounts:
           - name: h-services-data
             mountPath: /var/opt/hawkular
-          - name: hawkular-secret-volume
-            mountPath: /client-secrets/
-            readOnly: true
           ports:
           - containerPort: 8080
           - containerPort: 8443
@@ -175,7 +156,7 @@ objects:
             exec:
               command:
               - /opt/hawkular/bin/ready.sh
-            initialDelaySeconds: 120
+            initialDelaySeconds: 35
             timeoutSeconds: 15
             periodSeconds: 20
             successThreshold: 1
@@ -188,11 +169,7 @@ objects:
         restartPolicy: Always
         volumes:
         - name: h-services-data
-          persistentVolumeClaim:
-            claimName: h-services-pvc
-        - name: hawkular-secret-volume
-          secret:
-            secretName: hawkular-ssl-secret
+          emptyDir: {}
 
 - apiVersion: v1
   kind: DeploymentConfig
@@ -205,7 +182,7 @@ objects:
     selector:
       name: hawkular-cassandra
     strategy:
-      type: Recreate
+      type: Rolling
       rollingParams:
         timeoutSeconds: 300
     template:
@@ -217,9 +194,6 @@ objects:
         - image: ${CASSANDRA_IMAGE}
           imagePullPolicy: Always
           name: hawkular-cassandra
-          env:
-          - name: DATA_VOLUME
-            value: /var/lib/cassandra
           volumeMounts:
           - name: cassandra-data
             mountPath: /var/lib/cassandra
@@ -228,15 +202,15 @@ objects:
           - containerPort: 9160
           readinessProbe:
             exec:
-              command: ['nodetool', 'status']
-            initialDelaySeconds: 30
+              command: [nodetool, status]
+            initialDelaySeconds: 15
             timeoutSeconds: 10
             periodSeconds: 15
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 6
           livenessProbe:
             exec:
-              command: ['nodetool', 'status']
+              command: [nodetool, status]
             initialDelaySeconds: 300
             timeoutSeconds: 10
             periodSeconds: 15
@@ -247,26 +221,4 @@ objects:
               memory: ${CASSANDRA_MEMORY_LIMIT}
         volumes:
         - name: cassandra-data
-          persistentVolumeClaim:
-            claimName: cassandra-pvc
-
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: h-services-pvc
-  spec:
-    accessModes:
-      - ReadWriteOnce
-    resources:
-      requests:
-        storage: ${HAWKULAR_SERVICES_DATA_LIMIT}
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: cassandra-pvc
-  spec:
-    accessModes:
-      - ReadWriteOnce
-    resources:
-      requests:
-        storage: ${CASSANDRA_DATA_LIMIT}
+          emptyDir: {}

--- a/roles/openshift_examples/files/examples/v3.7/cfme-templates/jboss-middleware-manager-template.yaml
+++ b/roles/openshift_examples/files/examples/v3.7/cfme-templates/jboss-middleware-manager-template.yaml
@@ -18,17 +18,17 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: hawkular-services
+  name: middleware-manager
   annotations:
-    openshift.io/display-name: Hawkular Services
-    description: Hawkular-Services all-in-one (including Hawkular Metrics, Hawkular Alerts and Hawkular Inventory).
-    iconClass: icon-wildfly
-    tags: hawkular,hawkular-services,metrics,alerts,manageiq,cassandra
+    openshift.io/display-name: Middleware Manager
+    description: Middleware Manager all-in-one
+    iconClass: icon-jboss
+    tags: middleware-manager,metrics,alerts,cloudforms,cassandra
 
 parameters:
 - name: HAWKULAR_SERVICES_IMAGE
-  description: What docker image should be used for hawkular-services.
-  displayName: Hawkular Services Docker Image
+  description: What docker image should be used for Middleware Manager.
+  displayName: Middleware Manager Docker Image
   value: registry.access.redhat.com/jboss-mm-7-tech-preview/middleware-manager:latest
 - name: CASSANDRA_IMAGE
   description: What docker image should be used for cassandra node.
@@ -43,29 +43,29 @@ parameters:
   displayName: Cassandra Container Data Limit
   value: 2Gi
 - name: HAWKULAR_SERVICES_DATA_LIMIT
-  description: Maximum amount data used by hawkular-services container (mostly logging).
-  displayName: Hawkular Services Container Data Limit
+  description: Maximum amount data used by Middleware Manager container (mostly logging).
+  displayName: Middleware Manager Container Data Limit
   value: 1Gi
 - name: ROUTE_NAME
   description: Public route with this name will be created.
   displayName: Route Name
-  value: hawkular-services
+  value: middleware-manager
 - name: ROUTE_HOSTNAME
-  description: Under this hostname the Hawkular Services will be accessible, if left blank a value will be defaulted.
+  description: Under this hostname the Middleware Manager will be accessible, if left blank a value will be defaulted.
   displayName: Hostname
 - name: HAWKULAR_USER
-  description: Username that is used for accessing the Hawkular Services, if left blank a value will be generated.
-  displayName: Hawkular User
+  description: Username that is used for accessing the Middleware Manager, if left blank a value will be generated.
+  displayName: Middleware Manager User
   from: '[a-zA-Z0-9]{16}'
   generate: expression
 - name: HAWKULAR_PASSWORD
-  description: Password that is used for accessing the Hawkular Services, if left blank a value will be generated.
-  displayName: Hawkular Password
+  description: Password that is used for accessing the Middleware Manager, if left blank a value will be generated.
+  displayName: Middleware Manager Password
   from: '[a-zA-Z0-9]{16}'
   generate: expression
 labels:
-  template: hawkular-services
-message: Credentials for hawkular-services are ${HAWKULAR_USER}:${HAWKULAR_PASSWORD}
+  template: middleware-manager
+message: Credentials for Middleware Manager are ${HAWKULAR_USER}:${HAWKULAR_PASSWORD}
 
 objects:
 - apiVersion: v1
@@ -74,6 +74,7 @@ objects:
     annotations:
       description: Exposes and load balances the application pods
       service.alpha.openshift.io/dependencies: '[{"name":"hawkular-cassandra","namespace":"","kind":"Service"}]'
+      service.alpha.openshift.io/serving-cert-secret-name: hawkular-ssl-secret
     name: hawkular-services
   spec:
     ports:
@@ -81,6 +82,10 @@ objects:
       port: 8080
       protocol: TCP
       targetPort: 8080
+    - name: https-8443-tcp
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
     - name: admin-9990-tcp
       port: 9990
       protocol: TCP
@@ -138,31 +143,41 @@ objects:
             value: remote
           - name: CASSANDRA_NODES
             value: hawkular-cassandra
+          - name: HAWKULAR_USE_SSL
+            value: 'true'
           - name: HAWKULAR_USER
             value: ${HAWKULAR_USER}
           - name: HAWKULAR_PASSWORD
             value: ${HAWKULAR_PASSWORD}
+          - name: HAWKULAR_PUBLIC_KEY_FILENAME
+            value: /client-secrets/tls.crt
+          - name: HAWKULAR_PRIVATE_KEY_FILENAME
+            value: /client-secrets/tls.key
           imagePullPolicy: IfNotPresent
           name: hawkular-services
           volumeMounts:
           - name: h-services-data
             mountPath: /var/opt/hawkular
+          - name: hawkular-secret-volume
+            mountPath: /client-secrets/
+            readOnly: true
           ports:
           - containerPort: 8080
+          - containerPort: 8443
           - containerPort: 9990
           livenessProbe:
             exec:
               command:
               - /opt/hawkular/bin/ready.sh
             initialDelaySeconds: 180
-            timeoutSeconds: 3
+            timeoutSeconds: 15
           readinessProbe:
             exec:
               command:
               - /opt/hawkular/bin/ready.sh
             initialDelaySeconds: 120
-            timeoutSeconds: 3
-            periodSeconds: 5
+            timeoutSeconds: 15
+            periodSeconds: 20
             successThreshold: 1
             failureThreshold: 12
           resources:
@@ -175,6 +190,9 @@ objects:
         - name: h-services-data
           persistentVolumeClaim:
             claimName: h-services-pvc
+        - name: hawkular-secret-volume
+          secret:
+            secretName: hawkular-ssl-secret
 
 - apiVersion: v1
   kind: DeploymentConfig
@@ -241,7 +259,7 @@ objects:
       - ReadWriteOnce
     resources:
       requests:
-        storage: 1Gi
+        storage: ${HAWKULAR_SERVICES_DATA_LIMIT}
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
@@ -251,4 +269,4 @@ objects:
       - ReadWriteOnce
     resources:
       requests:
-        storage: 1Gi
+        storage: ${CASSANDRA_DATA_LIMIT}


### PR DESCRIPTION
This PR replace all display name and descriptions of the template to middleware manager, also, now is using service signed certificates for SSL communication.
