### PR TITLE
Bug 1491636 - honor node selectors

### DIFF
--- a/roles/openshift_sanitize_inventory/tasks/__deprecations_logging.yml
+++ b/roles/openshift_sanitize_inventory/tasks/__deprecations_logging.yml
@@ -21,16 +21,22 @@
       openshift_logging_image_pull_secret: openshift_hosted_logging_image_pull_secret
       openshift_logging_kibana_hostname: openshift_hosted_logging_hostname
       openshift_logging_kibana_ops_hostname: openshift_hosted_logging_ops_hostname
+      openshift_logging_kibana_nodeselector: openshift_hosted_logging_kibana_nodeselector
+      openshift_logging_kibana_ops_nodeselector: openshift_hosted_logging_kibana_ops_nodeselector
       openshift_logging_fluentd_journal_source: openshift_hosted_logging_journal_source
       openshift_logging_fluentd_journal_read_from_head: openshift_hosted_logging_journal_read_from_head
+      openshift_logging_fluentd_nodeselector: openshift_hosted_logging_fluentd_nodeselector_label
       openshift_logging_es_memory_limit: openshift_hosted_logging_elasticsearch_instance_ram
       openshift_logging_es_nodeselector: openshift_hosted_logging_elasticsearch_nodeselector
+      openshift_logging_es_ops_nodeselector: openshift_hosted_logging_elasticsearch_ops_nodeselector
       openshift_logging_es_ops_memory_limit: openshift_hosted_logging_elasticsearch_ops_instance_ram
       openshift_logging_storage_access_modes: openshift_hosted_logging_storage_access_modes
       openshift_logging_master_public_url: openshift_hosted_logging_master_public_url
       openshift_logging_image_prefix: openshift_hosted_logging_deployer_prefix
       openshift_logging_image_version: openshift_hosted_logging_deployer_version
       openshift_logging_install_logging: openshift_hosted_logging_deploy
+      openshift_logging_curator_nodeselector: openshift_hosted_logging_curator_nodeselector
+      openshift_logging_curator_ops_nodeselector: openshift_hosted_logging_curator_ops_nodeselector
 
 
 - set_fact:
@@ -40,9 +46,3 @@
     openshift_logging_elasticsearch_ops_pvc_dynamic: "{{ 'true' if openshift_loggingops_storage_kind | default(none) == 'dynamic' else '' }}"
     openshift_logging_elasticsearch_ops_pvc_size: "{{ openshift_loggingops_storage_volume_size | default('10Gi') if openshift_loggingops_storage_kind | default(none) in ['dynamic','nfs'] else ''  }}"
     openshift_logging_elasticsearch_ops_pvc_prefix: "{{ 'logging-es-ops' if openshift_loggingops_storage_kind | default(none) == 'dynamic' else '' }}"
-    openshift_logging_curator_nodeselector: "{{ openshift_hosted_logging_curator_nodeselector | default('') | map_from_pairs }}"
-    openshift_logging_curator_ops_nodeselector: "{{ openshift_hosted_logging_curator_ops_nodeselector | default('') | map_from_pairs }}"
-    openshift_logging_kibana_nodeselector: "{{ openshift_hosted_logging_kibana_nodeselector | default('') | map_from_pairs }}"
-    openshift_logging_kibana_ops_nodeselector: "{{ openshift_hosted_logging_kibana_ops_nodeselector | default('') | map_from_pairs }}"
-    openshift_logging_fluentd_nodeselector: "{{ openshift_hosted_logging_fluentd_nodeselector_label | default('logging-infra-fluentd=true') | map_from_pairs }}"
-    openshift_logging_es_ops_nodeselector: "{{ openshift_hosted_logging_elasticsearch_ops_nodeselector | default('') | map_from_pairs }}"


### PR DESCRIPTION
The deprecation of `*_hosted_*` vars made logging node selectors set in the inventory to be ignored.

Node selectors were set as 'facts' and they have higher priority than inventory variables. Setting logging node selectors could be achieved only by using command line --extra-vars.

It is related to the same BZ as https://github.com/openshift/openshift-ansible/pull/5858 but the issue is different.