### PR TITLE
[3.6] Bug 1491636 - honor ES ops node selector

### DIFF
--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -174,6 +174,7 @@
     openshift_logging_elasticsearch_pvc_size: "{{ openshift_logging_es_ops_pvc_size }}"
     openshift_logging_elasticsearch_pvc_dynamic: "{{ openshift_logging_es_ops_pvc_dynamic }}"
     openshift_logging_elasticsearch_pvc_pv_selector: "{{ openshift_logging_es_ops_pv_selector }}"
+    openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_ops_nodeselector }}"
     openshift_logging_elasticsearch_memory_limit: "{{ openshift_logging_es_ops_memory_limit }}"
     openshift_logging_elasticsearch_cpu_limit: "{{ openshift_logging_es_ops_cpu_limit }}"
     openshift_logging_elasticsearch_cpu_request: "{{ openshift_logging_es_ops_cpu_request }}"


### PR DESCRIPTION
The user provided value of `openshift_logging_es_ops_nodeselector` was honored only when there was already existing ES ops dc.

It is related to the same BZ as https://github.com/openshift/openshift-ansible/pull/5857 but the issue is different.