### PR TITLE
Adding meta directory so other repos can use ansible-galaxy to declar…

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies:


### PR DESCRIPTION
…e dependencies

Other repositories such as https://github.com/redhat-cop/casl-ansible and https://github.com/openshift/openshift-ansible-contrib would like to be able to use ansible-galaxy to declare dependencies, and align releases with release branches in openshift-ansible. This will allow us to do so.

cc: @oybed @tomassedovic @sdodson 