### PR TITLE
Default to /etc/resolv.conf instead of /etc/origin/node/resolv.conf

### DIFF
--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -82,7 +82,7 @@ openshift_master_node_config_default_edits:
 - key: dnsDomain
   value: cluster.local
 - key: dnsRecursiveResolvConf
-  value: /etc/origin/node/resolv.conf
+  value: /etc/resolv.conf
 - key: imageConfig.format
   value: "{{ openshift_master_config_imageconfig_format }}"
 - key: kubeletArguments.cloud-config

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -2,7 +2,7 @@ allowDisabledDocker: false
 apiVersion: v1
 {% if openshift.common.version_gte_3_6 %}
 dnsBindAddress: 127.0.0.1:53
-dnsRecursiveResolvConf: /etc/origin/node/resolv.conf
+dnsRecursiveResolvConf: /etc/resolv.conf
 {% endif %}
 dnsDomain: {{ openshift.common.dns_domain }}
 {% if 'dns_ip' in openshift.node %}

--- a/roles/openshift_node_upgrade/tasks/main.yml
+++ b/roles/openshift_node_upgrade/tasks/main.yml
@@ -158,7 +158,7 @@
   - key: "dnsBindAddress"
     value: "127.0.0.1:53"
   - key: "dnsRecursiveResolvConf"
-    value: "/etc/origin/node/resolv.conf"
+    value: "/etc/resolv.conf"
 
 # Restart all services
 - include: restart.yml


### PR DESCRIPTION
There is no task that currently sets up /etc/origin/node/resolv.conf
but the service is configured to load that file when it starts.

Since the file is missing, this is causing the service to fail.
Fix this by resorting to a sane default in the meantime.

Fixes: #5812