### PR TITLE
Load kernel modules dm_thin_pool, dm_mirror, dm_snapshot

### DIFF
--- a/playbooks/common/openshift-glusterfs/config.yml
+++ b/playbooks/common/openshift-glusterfs/config.yml
@@ -27,6 +27,15 @@
     when:
     - openshift_storage_glusterfs_registry_is_native | default(True) | bool
 
+- name: Load kernel modules required
+  hosts: glusterfs
+  tasks:
+  - include_role:
+      name: openshift_storage_glusterfs
+      tasks_from: load_modules.yml
+    when:
+    - openshift_storage_glusterfs_is_native | default(True) | bool
+
 - name: Configure GlusterFS
   hosts: oo_first_master
   tasks:

--- a/roles/openshift_storage_glusterfs/tasks/load_modules.yml
+++ b/roles/openshift_storage_glusterfs/tasks/load_modules.yml
@@ -1,0 +1,6 @@
+---
+- name: Load kernel modules
+  tasks:
+  - modprobe: name=dm_thin_pool state=present
+  - modprobe: name=dm_mirror state=present
+  - modprobe: name=dm_snapshot state=present

--- a/roles/openshift_storage_glusterfs/tasks/load_modules.yml
+++ b/roles/openshift_storage_glusterfs/tasks/load_modules.yml
@@ -1,6 +1,7 @@
 ---
-- name: Load kernel modules
   tasks:
-  - modprobe: name=dm_thin_pool state=present
-  - modprobe: name=dm_mirror state=present
-  - modprobe: name=dm_snapshot state=present
+  - name: Load kernel modules
+    modprobe: 
+      name=dm_thin_pool state=present
+      name=dm_mirror state=present
+      name=dm_snapshot state=present


### PR DESCRIPTION
Load kernel modules dm_thin_pool, dm_mirror, dm_snapshot as part of glusterfs setup.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>