### PR TITLE
Remove 'Not Started' status from playbook checkpoint

### DIFF
--- a/roles/installer_checkpoint/callback_plugins/installer_checkpoint.py
+++ b/roles/installer_checkpoint/callback_plugins/installer_checkpoint.py
@@ -159,11 +159,6 @@ class CallbackModule(CallbackBase):
                         self._display.display(
                             '\tThis phase can be restarted by running: {}'.format(
                                 phase_attributes[phase]['playbook']))
-                else:
-                    # Phase was not found in custom stats
-                    self._display.display(
-                        '{}{}: {}'.format(phase_title, ' ' * padding, 'Not Started'),
-                        color=C.COLOR_SKIP)
 
         self._display.display("", screen_only=True)
 


### PR DESCRIPTION
Playbook status should only be reported for phases that have completed
or which have been started.  Reporting 'Not Started' could be confusing
when running playbooks that do not have an 'installer phase'.

Fixes #5675 

Installer now just reports what has been run:
```
INSTALLER STATUS *****************************************************************************************
Initialization             : Complete
etcd Install               : Complete
Master Install             : Complete
Master Additional Install  : Complete
Node Install               : Complete
Hosted Install             : Complete
```