### PR TITLE
Adding vpc and subnetwork creation to AMI build.

### DIFF
--- a/playbooks/aws/openshift-cluster/build_ami.yml
+++ b/playbooks/aws/openshift-cluster/build_ami.yml
@@ -17,6 +17,12 @@
     - name: openshift_aws_region
       msg: "openshift_aws_region={{ openshift_aws_region | default('us-east-1') }}"
 
+# this is required when installing in fresh region or account
+- include: provision_vpc.yml
+
+# this is required when installing in fresh region or account
+- include: provision_sg.yml
+
 - include: provision_instance.yml
   vars:
     openshift_aws_node_group_type: compute

--- a/playbooks/aws/openshift-cluster/provision_sg.yml
+++ b/playbooks/aws/openshift-cluster/provision_sg.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - name: create the necessary security groups
+    include_role:
+      name: openshift_aws
+      tasks_from: security_group.yml

--- a/playbooks/aws/openshift-cluster/provision_vpc.yml
+++ b/playbooks/aws/openshift-cluster/provision_vpc.yml
@@ -3,7 +3,7 @@
   connection: local
   gather_facts: no
   tasks:
-  - name: create a vpc
+  - name: create a vpc for our openshift installation
     include_role:
       name: openshift_aws
       tasks_from: vpc.yml


### PR DESCRIPTION
The purpose of this PR is to add the vpc and subnetwork creation back to the AMI building process.

When testing this on a fresh installation the vpc and subnetworks were missing.  If we want to default these creations to false then that's fine but we need to at least attempt to install them or provision_instances.yml fails to find the proper subnetworks.
