### PR TITLE
docker: set credentials when using system container

### DIFF
--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -153,16 +153,6 @@
 - set_fact:
     docker_service_status_changed: "{{ (r_docker_package_docker_start_result | changed) and (r_docker_already_running_result.stdout != 'ActiveState=active' ) }}"
 
-- name: Check for credentials file for registry auth
-  stat:
-    path: "{{ docker_cli_auth_config_path }}/config.json"
-  when: oreg_auth_user is defined
-  register: docker_cli_auth_credentials_stat
-
-- name: Create credentials for docker cli registry auth
-  command: "docker --config={{ docker_cli_auth_config_path }} login -u {{ oreg_auth_user }} -p {{ oreg_auth_password }} {{ oreg_host }}"
-  when:
-  - oreg_auth_user is defined
-  - (not docker_cli_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
+- include: registry_auth.yml
 
 - meta: flush_handlers

--- a/roles/docker/tasks/registry_auth.yml
+++ b/roles/docker/tasks/registry_auth.yml
@@ -1,0 +1,12 @@
+---
+- name: Check for credentials file for registry auth
+  stat:
+    path: "{{ docker_cli_auth_config_path }}/config.json"
+  when: oreg_auth_user is defined
+  register: docker_cli_auth_credentials_stat
+
+- name: Create credentials for docker cli registry auth
+  command: "docker --config={{ docker_cli_auth_config_path }} login -u {{ oreg_auth_user }} -p {{ oreg_auth_password }} {{ oreg_host }}"
+  when:
+  - oreg_auth_user is defined
+  - (not docker_cli_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool

--- a/roles/docker/tasks/systemcontainer_docker.yml
+++ b/roles/docker/tasks/systemcontainer_docker.yml
@@ -173,4 +173,6 @@
 - set_fact:
     docker_service_status_changed: "{{ r_docker_systemcontainer_docker_start_result | changed }}"
 
+- include: registry_auth.yml
+
 - meta: flush_handlers


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1505744

While the changes in https://github.com/openshift/openshift-ansible/pull/5878 are blocked on the new feature in atomic.   We can't still pull system containers from a registry that requires authenticatio but with this patch at least we can use authentication with Docker (which should be the same for CRI-O) to work.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>