### PR TITLE
Ensure journald persistence directories exist

### DIFF
--- a/roles/openshift_master/tasks/journald.yml
+++ b/roles/openshift_master/tasks/journald.yml
@@ -3,6 +3,11 @@
   stat: path=/etc/systemd/journald.conf
   register: journald_conf_file
 
+- name: Create journald persistence directories
+  file:
+    path: /var/log/journal
+    state: directory
+
 - name: Update journald setup
   replace:
     dest: /etc/systemd/journald.conf


### PR DESCRIPTION
Currently, we configure openshfit masters to modify journald
to use persistent storage.  The directory structure must be
created manually according to documentation.

This commit ensures the needed directory is created.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1506141