### PR TITLE
[WIP] Hostlevel DNS/connectivity pre-flight checks

### DIFF
--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -818,6 +818,17 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Setting this variable to true will override that check.
 #openshift_override_hostname_check=true
 
+# openshift-ansible will fail when it detects that a host
+# could not resove all of the cluster members' hostnames. This mis-configuration might
+# be problematic for the cluster setup and for pods using host networking.
+# Setting this variable to true will override that check.
+#openshift_override_resolve_check=true
+
+# openshift-ansible will fail when it detects that a host
+# could not ping all of the cluster members'. This mis-configuration is probably
+# not problematic at all. Setting this variable to true will override that check.
+#openshift_override_icmp_check=true
+
 # openshift_use_dnsmasq is deprecated.  This must be true, or installs will fail
 # in versions >= 3.6
 #openshift_use_dnsmasq=False

--- a/playbooks/byo/openshift-checks/README.md
+++ b/playbooks/byo/openshift-checks/README.md
@@ -18,7 +18,8 @@ callback plugin summarizes execution errors at the end of a playbook run.
 
 1. Pre-install playbook ([pre-install.yml](pre-install.yml)) - verifies system
    requirements and look for common problems that can prevent a successful
-   installation of a production cluster.
+   installation of a production cluster. Includes simple hosts level checks
+   for DNS resolve and ICMP ping.
 
 2. Diagnostic playbook ([health.yml](health.yml)) - check an existing cluster
    for known signs of problems.

--- a/playbooks/byo/openshift-checks/connectivity.yml
+++ b/playbooks/byo/openshift-checks/connectivity.yml
@@ -1,0 +1,6 @@
+---
+- include: ../openshift-cluster/initialize_groups.yml
+
+- include: ../../common/openshift-cluster/std_include.yml
+
+- include: ../../common/openshift-checks/connectivity.yml

--- a/playbooks/common/openshift-checks/adhoc.yml
+++ b/playbooks/common/openshift-checks/adhoc.yml
@@ -11,3 +11,8 @@
     action: openshift_health_check
     args:
       checks: '{{ openshift_checks | default([]) }}'
+
+# TODO(bogdando) trigger from the connectivity.py check
+- include: connectivity.yml
+  when: ('@connectivity' in openshift_checks | default([]) or
+         'connectivity' in openshift_checks | default([]))

--- a/playbooks/common/openshift-checks/connectivity.yml
+++ b/playbooks/common/openshift-checks/connectivity.yml
@@ -1,0 +1,23 @@
+---
+- name: OpenShift hosts level DNS/connectivity checks
+  hosts: oo_all_hosts
+  tasks:
+    - name: Check DNS resolve for cluster hosts
+      command: getent ahostsv4 {{ item }}
+      register: lookuphost
+      changed_when: false
+      check_mode: false
+      with_items: "{{ groups.oo_all_hosts }}"
+      when:
+        - item not in [ openshift.common.hostname, ansible_nodename ]
+        - not openshift_override_resolve_check | default(false) | bool
+
+    - name: Check ICMP ping for cluster hosts
+      command: ping -c3 -W1 -w2 {{ item }}
+      register: pinghost
+      changed_when: false
+      check_mode: false
+      with_items: "{{ groups.oo_all_hosts }}"
+      when:
+        - item not in [ openshift.common.hostname, ansible_nodename ]
+        - not openshift_override_icmp_check | default(false) | bool

--- a/playbooks/common/openshift-checks/pre-install.yml
+++ b/playbooks/common/openshift-checks/pre-install.yml
@@ -11,3 +11,6 @@
     action: openshift_health_check
     args:
       checks: ['@preflight']
+
+# TODO(bogdando) trigger from the connectivity.py check
+- include: connectivity.yml

--- a/roles/openshift_health_checker/openshift_checks/connectivity.py
+++ b/roles/openshift_health_checker/openshift_checks/connectivity.py
@@ -1,0 +1,22 @@
+"""Check auto-discovery entry for an external connectivity check."""
+
+from openshift_checks import OpenShiftCheck
+
+
+class ConnectivityExternal(OpenShiftCheck):
+    """Check is not managed here. It is an ansible playbook."""
+
+    name = "connectivity"
+    tags = ["pre-flight", "connectivity"]
+
+    def is_active(self):
+        """It is always active as externally managed."""
+        return super(ConnectivityExternal, self).is_active()
+
+    def run(self):
+        # TODO(bogdando) implement an ansible playbook call
+        # for the external playbook. For now, it is included
+        # elsewhere
+        self.register_log("Not implemented",
+                          "Use ansible to invoke this connectivity check")
+        return {}


### PR DESCRIPTION
* Add a common pre-flight check to test cluster nodes DNS resolve and
  a smoke connectivity test with ICMP ping.
* Add openshift_override_resolve_check, openshift_override_icmp_check
  (default to False) to allow overriding those checks.
* Add an auto-discovery stub for the added connectivity check and
  tag to be listed alongside the *.py scripted checks and tags.
* Trigger those checks from the common checks pre-install playbook.
  Included as a standard ansible task for now.
* Also trigger the checks from the common checks adhock playbook, if
  openshift_checks has the '@connectivity' tag.
  Included as a standard ansible task for now.
* Allow the connectivity checks to be directly invoked as a playbook
  as well.

TODO implement the check playbook invocation in the connectivity.py
to replace the include directives.

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>