### PR TITLE
Moving removal of unwanted artifacts to image_prep.

### DIFF
--- a/playbooks/common/openshift-node/clean_image.yml
+++ b/playbooks/common/openshift-node/clean_image.yml
@@ -1,0 +1,10 @@
+---
+- name: Configure nodes
+  hosts: oo_nodes_to_config:!oo_containerized_master_nodes
+  tasks:
+  - name: Remove any ansible facts created during AMI creation
+    file:
+      path: "/etc/ansible/facts.d/{{ item }}"
+      state: absent
+    with_items:
+    - openshift.fact

--- a/playbooks/common/openshift-node/image_prep.yml
+++ b/playbooks/common/openshift-node/image_prep.yml
@@ -19,3 +19,6 @@
 
 - name: Re-enable excluders
   include: enable_excluders.yml
+
+- name: Remove any undesired artifacts from build
+  include: clean_image.yml

--- a/roles/openshift_aws/tasks/seal_ami.yml
+++ b/roles/openshift_aws/tasks/seal_ami.yml
@@ -1,11 +1,4 @@
 ---
-- name: Remove any ansible facts created during AMI creation
-  file:
-    path: "/etc/ansible/facts.d/{{ item }}"
-    state: absent
-  with_items:
-  - openshift.fact
-
 - name: fetch newly created instances
   ec2_remote_facts:
     region: "{{ openshift_aws_region }}"


### PR DESCRIPTION
Move the artifact cleanup to the `image_prep.yml`.  This is the proper place since the recent refactoring has moved and modularized the ami building process.

`roles/openshift_aws/tasks/seal_ami.yml` is not the proper place to remove artifacts since the `playbooks/aws/openshift-cluster/seal_ami.yml` calls `localhost` with a `local` connection.  This causes the remove statement to attempt to remove the file from the localhost. 