### PR TITLE
Renaming csr to bootstrap for consistency.

### DIFF
--- a/roles/openshift_aws/templates/user_data.j2
+++ b/roles/openshift_aws/templates/user_data.j2
@@ -9,7 +9,7 @@ write_files:
   content: |
     openshift_group_type: {{ openshift_aws_node_group_type }}
 {%   if openshift_aws_node_group_type != 'master' %}
-- path: /etc/origin/node/csr_kubeconfig
+- path: /etc/origin/node/bootstrap.kubeconfig
   owner: 'root:root'
   permissions: '0640'
   encoding: b64

--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -25,7 +25,7 @@
     state: "{{ item.state | default('present') }}"
   with_items:
   # add the kubeconfig
-  - line: "KUBECONFIG=/etc/origin/node/csr_kubeconfig"
+  - line: "KUBECONFIG=/etc/origin/node/bootstrap.kubeconfig"
     regexp: "^KUBECONFIG=.*"
   # remove the config file.  This comes from openshift_facts
   - regexp: "^CONFIG_FILE=.*"


### PR DESCRIPTION
Renaming the csr_kubeconfig to bootstrap.kubeconfig per Claytons request and consistency.