### PR TITLE
bug 1501599.  Omit logging project from overcommit restrictions

### DIFF
--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -36,6 +36,14 @@
   - openshift_logging_label_key != ""
   - openshift_logging_label_value is defined
 
+- name: Annotate Logging Project to allow overcommit
+  oc_edit:
+    kind: ns
+    name: "{{ openshift_logging_namespace }}"
+    separator: '#'
+    content:
+      metadata#annotations#quota.openshift.io/cluster-resource-override-enabled: "false"
+
 - name: Create logging cert directory
   file:
     path: "{{ openshift.common.config_base }}/logging"


### PR DESCRIPTION
This PR:
* Annotates the logging project to remove overcommit restrictions