### PR TITLE
Fix CA Bundle passed to service-catalog broker for ansible-service-broker

### DIFF
--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -123,7 +123,7 @@
   register: asb_client_secret
 
 - set_fact:
-    service_ca_crt: asb_client_secret.results.results.0.data['service-ca.crt']
+    service_ca_crt: "{{ asb_client_secret.results.results.0.data['service-ca.crt'] }}"
 
 # Using oc_obj because oc_service doesn't seem to allow annotations
 # TODO: Extend oc_service to allow annotations


### PR DESCRIPTION
Use the actual data from the cert in the CABundle specified for the service-catalog broker for ansible-service-broker.