### PR TITLE
Change dnsmasq to bind-interfaces + except-interfaces

### DIFF
--- a/roles/openshift_node_dnsmasq/defaults/main.yml
+++ b/roles/openshift_node_dnsmasq/defaults/main.yml
@@ -1,2 +1,7 @@
 ---
 openshift_node_dnsmasq_install_network_manager_hook: true
+
+# lo must always be present in this list or dnsmasq will conflict with
+# the node's dns service.
+openshift_node_dnsmasq_except_interfaces:
+- lo

--- a/roles/openshift_node_dnsmasq/templates/origin-dns.conf.j2
+++ b/roles/openshift_node_dnsmasq/templates/origin-dns.conf.j2
@@ -4,4 +4,7 @@ no-negcache
 max-cache-ttl=1
 enable-dbus
 bind-interfaces
-listen-address={{ openshift.node.dns_ip }}
+{% for interface in openshift_node_dnsmasq_except_interfaces %}
+except-interface={{ interface }}
+{% endfor %}
+# End of config


### PR DESCRIPTION
Currently, we have to set the listen ip for dnsmasq via ansible
during installation.

This commit enables dnsmasq to bind-interfaces + exclude interfaces
to ensure dnsmasq doesn't listen on lo interface.