### PR TITLE
syscontainers: fix runC label if needed

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -2,8 +2,36 @@
 # These tasks dispatch to the proper set of docker tasks based on the
 # inventory:openshift_docker_use_system_container variable
 
+- set_fact:
+    is_atomic: "{{ openshift.common.is_atomic | default(False) | bool }}"
+
 - include: udev_workaround.yml
   when: docker_udev_workaround | default(False) | bool
+
+# Used to pull and install the system container
+- name: Ensure atomic is installed
+  package:
+    name: atomic
+    state: present
+  when: not openshift.common.is_atomic | bool
+
+# At the time of writing the atomic command requires runc for it's own use. This
+# task is here in the even that the atomic package ever removes the dependency.
+- name: Ensure runc is installed
+  package:
+    name: runc
+    state: present
+  when: not openshift.common.is_atomic | bool
+
+- name: Fix SELinux label of runC if needed
+  file:
+    path: "/usr/bin/runc"
+    recurse: no
+    seuser: system_u
+    serole: object_r
+    setype: container_runtime_exec_t
+    selevel: s0
+  when: not is_atomic
 
 - set_fact:
     l_use_system_container: "{{ openshift.docker.use_system_container | default(False) }}"

--- a/roles/docker/tasks/systemcontainer_crio.yml
+++ b/roles/docker/tasks/systemcontainer_crio.yml
@@ -42,22 +42,6 @@
     - openshift.common.is_containerized | bool
     - not openshift.common.is_node_system_container | bool
 
-# Used to pull and install the system container
-- name: Ensure atomic is installed
-  package:
-    name: atomic
-    state: present
-  when: not openshift.common.is_atomic | bool
-
-# At the time of writing the atomic command requires runc for it's own use. This
-# task is here in the even that the atomic package ever removes the dependency.
-- name: Ensure runc is installed
-  package:
-    name: runc
-    state: present
-  when: not openshift.common.is_atomic | bool
-
-
 - name: Check that overlay is in the kernel
   shell: lsmod | grep overlay
   register: l_has_overlay_in_kernel

--- a/roles/docker/tasks/systemcontainer_docker.yml
+++ b/roles/docker/tasks/systemcontainer_docker.yml
@@ -35,21 +35,6 @@
     state: present
   when: not openshift.common.is_atomic | bool
 
-# Used to pull and install the system container
-- name: Ensure atomic is installed
-  package:
-    name: atomic
-    state: present
-  when: not openshift.common.is_atomic | bool
-
-# At the time of writing the atomic command requires runc for it's own use. This
-# task is here in the even that the atomic package ever removes the dependency.
-- name: Ensure runc is installed
-  package:
-    name: runc
-    state: present
-  when: not openshift.common.is_atomic | bool
-
 # Make sure Docker is installed so we are able to use the client
 - name: Install Docker so we can use the client
   package: name=docker{{ '-' + docker_version if docker_version is defined else '' }} state=present


### PR DESCRIPTION
The binary has the wrong label on RHEL 7.4, fix it if necessary.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>