### PR TITLE
crio: Add failed_when to overlay check

### DIFF
--- a/roles/docker/tasks/systemcontainer_crio.yml
+++ b/roles/docker/tasks/systemcontainer_crio.yml
@@ -62,7 +62,7 @@
   shell: lsmod | grep overlay
   register: l_has_overlay_in_kernel
   ignore_errors: yes
-
+  failed_when: false
 
 - when: l_has_overlay_in_kernel.rc != 0
   block:


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1506399