### PR TITLE
Correct openshift_release regular expression

### DIFF
--- a/roles/openshift_sanitize_inventory/tasks/main.yml
+++ b/roles/openshift_sanitize_inventory/tasks/main.yml
@@ -47,7 +47,7 @@
 - name: Abort when openshift_release is invalid
   when:
     - openshift_release is defined
-    - not openshift_release | match('\d+(\.\d+){1,3}$')
+    - not openshift_release | match('^\d+(\.\d+){1,3}$')
   fail:
     msg: |-
       openshift_release is "{{ openshift_release }}" which is not a valid version string.


### PR DESCRIPTION
Match only versions like:
3.7
3.7.0
3.7.0.0

Avoids matches like:
3.7.0.0.0.0