### PR TITLE
crio: restorcon /var/lib/containers

### DIFF
--- a/roles/docker/tasks/systemcontainer_crio.yml
+++ b/roles/docker/tasks/systemcontainer_crio.yml
@@ -166,6 +166,10 @@
     dest: /etc/cni/net.d/openshift-sdn.conf
     src: 80-openshift-sdn.conf.j2
 
+- name: Fix SELinux Permissions on /var/lib/containers
+  command: "restorecon -R /var/lib/containers/"
+  changed_when: false
+
 - name: Start the CRI-O service
   systemd:
     name: "cri-o"


### PR DESCRIPTION
When using the cri-o system container some items in /var/lib/containers
end up having incorrect labels. This runs restorecon -R
/var/lib/containers after the system container is installed.

/cc @rhatdan @mrunalp @cevich