### PR TITLE
CNS installer mislabeling Heketi route

### DIFF
--- a/roles/openshift_storage_glusterfs/files/v3.6/deploy-heketi-template.yml
+++ b/roles/openshift_storage_glusterfs/files/v3.6/deploy-heketi-template.yml
@@ -29,11 +29,12 @@ objects:
 - kind: Route
   apiVersion: v1
   metadata:
-    name: ${HEKETI_ROUTE}
+    name: deploy-heketi-${CLUSTER_NAME}
     labels:
       glusterfs: deploy-heketi-${CLUSTER_NAME}-route
       deploy-heketi: support
   spec:
+    host: ${HEKETI_ROUTE}   
     to:
       kind: Service
       name: deploy-heketi-${CLUSTER_NAME}

--- a/roles/openshift_storage_glusterfs/files/v3.6/heketi-template.yml
+++ b/roles/openshift_storage_glusterfs/files/v3.6/heketi-template.yml
@@ -27,10 +27,11 @@ objects:
 - kind: Route
   apiVersion: v1
   metadata:
-    name: ${HEKETI_ROUTE}
+    name: heketi-${CLUSTER_NAME}
     labels:
       glusterfs: heketi-${CLUSTER_NAME}-route
   spec:
+    host: ${HEKETI_ROUTE}
     to:
       kind: Service
       name: heketi-${CLUSTER_NAME}

--- a/roles/openshift_storage_glusterfs/files/v3.7/deploy-heketi-template.yml
+++ b/roles/openshift_storage_glusterfs/files/v3.7/deploy-heketi-template.yml
@@ -29,11 +29,12 @@ objects:
 - kind: Route
   apiVersion: v1
   metadata:
-    name: ${HEKETI_ROUTE}
+    name: deploy-heketi-${CLUSTER_NAME}
     labels:
       glusterfs: deploy-heketi-${CLUSTER_NAME}-route
       deploy-heketi: support
   spec:
+    host: ${HEKETI_ROUTE}
     to:
       kind: Service
       name: deploy-heketi-${CLUSTER_NAME}

--- a/roles/openshift_storage_glusterfs/files/v3.7/heketi-template.yml
+++ b/roles/openshift_storage_glusterfs/files/v3.7/heketi-template.yml
@@ -27,10 +27,11 @@ objects:
 - kind: Route
   apiVersion: v1
   metadata:
-    name: ${HEKETI_ROUTE}
+    name: heketi-${CLUSTER_NAME}
     labels:
       glusterfs: heketi-${CLUSTER_NAME}-route
   spec:
+    host: ${HEKETI_ROUTE}
     to:
       kind: Service
       name: heketi-${CLUSTER_NAME}


### PR DESCRIPTION
When attempting to install CNS using the Advanced Installation instructions, the Ansible playbook crashes every single time with the following error:"TASK [openshift_storage_glusterfs : Determine StorageClass heketi URL] 

*************************************************************************************************************** FAILED! => {"failed": true, "msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'spec'\n\nThe error appears to have been in '/opt/git/openshift-3.6-setup/openshift-ansible/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml': line 238, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Determine StorageClass heketi URL\n  ^ here\n\nexception type: <class 'ansible.errors.AnsibleUndefinedVariable'>\nexception: 'dict object' has no attribute 'spec'"}"Debugging quickly leads us to the problem: the previous task (openshift_storage_glusterfs : Get heketi route) attempts to get the Heketi route by the name "heketi-{{ glusterfs_name }}". But when listing the routes that exist in the project that Gluster is installed in, no route exists with that name.


Signed-off-by: jkaurredhat <jkaur@redhat.com>