### PR TITLE
Bug 1505681 - default ES proxy image to logging image

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -20,20 +20,22 @@ When `openshift_logging_install_logging` is set to `False` the `openshift_loggin
 
 ### Optional vars:
 - `openshift_logging_purge_logging`: When `openshift_logging_install_logging` is set to 'False' to trigger uninstalation and `openshift_logging_purge_logging` is set to 'True', it will completely and irreversibly remove all logging persistent data including PVC. Defaults to 'False'.
-- `openshift_logging_image_prefix`: The prefix for the logging images to use. Defaults to 'docker.io/openshift/origin-'.
-- `openshift_logging_curator_image_prefix`: Setting the image prefix for Curator image. Defaults to `openshift_logging_image_prefix`.
-- `openshift_logging_elasticsearch_image_prefix`: Setting the image prefix for Elasticsearch image. Defaults to `openshift_logging_image_prefix`.
-- `openshift_logging_fluentd_image_prefix`: Setting the image prefix for Fluentd image. Defaults to `openshift_logging_image_prefix`.
-- `openshift_logging_kibana_image_prefix`: Setting the image prefix for Kibana image. Defaults to `openshift_logging_image_prefix`.
-- `openshift_logging_kibana_proxy_image_prefix`: Setting the image prefix for Kibana proxy image. Defaults to `openshift_logging_image_prefix`.
+- `openshift_logging_image_prefix`: The prefix for all of the logging images to use. The order in which prefix will be determined is 1) each component image has own default, 2) setting `openshift_logging_image_prefix` selects prefix for all components, 3) the prefix can be cherry-picked with `openshift_logging_{{component}}_image_prefix` for a specific component, eg. `openshift_logging_elasticsearch_image_prefix`.
+- `openshift_logging_curator_image_prefix`: Setting the image prefix for Curator image. Defaults to either `docker.io/openshift/origin-` or `registry.access.redhat.com/openshift3/` depending on `openshift_deployment_type`.
+- `openshift_logging_elasticsearch_image_prefix`: Setting the image prefix for Elasticsearch image. Defaults to either `docker.io/openshift/origin-` or `registry.access.redhat.com/openshift3/` depending on `openshift_deployment_type`.
+- `openshift_logging_elasticsearch_proxy_image_prefix`: Setting the image prefix for Elasticsearch proxy image. Defaults to either `docker.io/openshift/origin-` or `registry.access.redhat.com/openshift3/` depending on `openshift_deployment_type`.
+- `openshift_logging_fluentd_image_prefix`: Setting the image prefix for Fluentd image. Defaults to either `docker.io/openshift/origin-` or `registry.access.redhat.com/openshift3/` depending on `openshift_deployment_type`.
+- `openshift_logging_kibana_image_prefix`: Setting the image prefix for Kibana image. Defaults to either `docker.io/openshift/origin-` or `registry.access.redhat.com/openshift3/` depending on `openshift_deployment_type`.
+- `openshift_logging_kibana_proxy_image_prefix`: Setting the image prefix for Kibana proxy image. Defaults to either `docker.io/openshift/origin-` or `registry.access.redhat.com/openshift3/` depending on `openshift_deployment_type`.
 - `openshift_logging_mux_image_prefix`: Setting the image prefix for Mux image. Defaults to `openshift_logging_image_prefix`.
-- `openshift_logging_image_version`: The image version for the logging images to use. Defaults to 'latest'.
-- `openshift_logging_curator_image_version`: Setting the image version for Curator image. Defaults to `openshift_logging_image_version`.
-- `openshift_logging_elasticsearch_image_version`: Setting the image version for Elasticsearch image. Defaults to `openshift_logging_image_version`.
-- `openshift_logging_fluentd_image_version`: Setting the image version for Fluentd image. Defaults to `openshift_logging_image_version`.
-- `openshift_logging_kibana_image_version`: Setting the image version for Kibana image. Defaults to `openshift_logging_image_version`.
-- `openshift_logging_kibana_proxy_image_version`: Setting the image version for Kibana proxy image. Defaults to `openshift_logging_image_version`.
-- `openshift_logging_mux_image_version`: Setting the image version for Mux image. Defaults to `openshift_logging_image_version`.
+- `openshift_logging_image_version`: The version for all of the logging images to use. The order in which version will be determined is 1) each component image has own default, 2) setting `openshift_logging_image_version` selects version for all components, 3) the version can be cherry-picked with `openshift_logging_{{component}}_image_version` for a specific component, eg. `openshift_logging_elasticsearch_image_version`.
+- `openshift_logging_curator_image_version`: Setting the image version for Curator image. Defaults to `__openshift_logging_image_version`.
+- `openshift_logging_elasticsearch_image_version`: Setting the image version for Elasticsearch image. Defaults to `__openshift_logging_image_version`.
+- `openshift_logging_elasticsearch_proxy_image_version`: Setting the image version for Elasticsearch proxy image. Defaults to `__openshift_logging_image_version`.
+- `openshift_logging_fluentd_image_version`: Setting the image version for Fluentd image. Defaults to `__openshift_logging_image_version`.
+- `openshift_logging_kibana_image_version`: Setting the image version for Kibana image. Defaults to `__openshift_logging_image_version`.
+- `openshift_logging_kibana_proxy_image_version`: Setting the image version for Kibana proxy image. Defaults to `__openshift_logging_image_version`.
+- `openshift_logging_mux_image_version`: Setting the image version for Mux image. Defaults to `__openshift_logging_image_version`.
 - `openshift_logging_use_ops`: If 'True', set up a second ES and Kibana cluster for infrastructure logs. Defaults to 'False'.
 - `openshift_logging_master_url`: The URL for the Kubernetes master, this does not need to be public facing but should be accessible from within the cluster. Defaults to 'https://kubernetes.default.svc.{{openshift.common.dns_domain}}'.
 - `openshift_logging_master_public_url`: The public facing URL for the Kubernetes master, this is used for Authentication redirection. Defaults to 'https://{{openshift.common.public_hostname}}:{{openshift.master.api_port}}'.

--- a/roles/openshift_logging/tasks/main.yaml
+++ b/roles/openshift_logging/tasks/main.yaml
@@ -9,11 +9,6 @@
     - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
     - "default_images.yml"
 
-- name: Set logging image facts
-  set_fact:
-    openshift_logging_image_prefix: "{{ openshift_logging_image_prefix | default(__openshift_logging_image_prefix) }}"
-    openshift_logging_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_version) }}"
-
 - name: Create temp directory for doing work in
   command: mktemp -d /tmp/openshift-logging-ansible-XXXXXX
   register: mktemp

--- a/roles/openshift_logging_curator/defaults/main.yml
+++ b/roles/openshift_logging_curator/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ### General logging settings
 openshift_logging_curator_image_prefix: "{{ openshift_logging_image_prefix | default(__openshift_logging_image_prefix) }}"
-openshift_logging_curator_image_version: "{{ openshift_logging_image_version | default('latest') }}"
+openshift_logging_curator_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_version) }}"
 openshift_logging_curator_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"
 openshift_logging_curator_master_url: "https://kubernetes.default.svc.cluster.local"
 

--- a/roles/openshift_logging_curator/tasks/determine_version.yaml
+++ b/roles/openshift_logging_curator/tasks/determine_version.yaml
@@ -1,16 +1,16 @@
 ---
 # debating making this a module instead?
 - fail:
-    msg: Missing version to install provided by 'openshift_logging_image_version'
-  when: not openshift_logging_image_version or openshift_logging_image_version == ''
+    msg: Missing version to install provided by 'openshift_logging_curator_image_version'
+  when: not openshift_logging_curator_image_version or openshift_logging_curator_image_version == ''
 
 - set_fact:
     curator_version: "{{ __latest_curator_version }}"
-  when: openshift_logging_image_version == 'latest'
+  when: openshift_logging_curator_image_version == 'latest'
 
 # should we just assume that we will have the correct major version?
-- set_fact: curator_version="{{ openshift_logging_image_version | regex_replace('^v?(?P<major>\d)\.(?P<minor>\d).*$', '3_\\g<minor>') }}"
-  when: openshift_logging_image_version != 'latest'
+- set_fact: curator_version="{{ openshift_logging_curator_image_version | regex_replace('^v?(?P<major>\d)\.(?P<minor>\d).*$', '3_\\g<minor>') }}"
+  when: openshift_logging_curator_image_version != 'latest'
 
 - fail:
     msg: Invalid version specified for Curator

--- a/roles/openshift_logging_elasticsearch/defaults/main.yml
+++ b/roles/openshift_logging_elasticsearch/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ### Common settings
 openshift_logging_elasticsearch_image_prefix: "{{ openshift_logging_image_prefix | default(__openshift_logging_image_prefix) }}"
-openshift_logging_elasticsearch_image_version: "{{ openshift_logging_image_version | default('latest') }}"
+openshift_logging_elasticsearch_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_version) }}"
 openshift_logging_elasticsearch_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"
 openshift_logging_elasticsearch_namespace: logging
 
@@ -63,3 +63,7 @@ openshift_logging_es_port: 9200
 openshift_logging_es_ca: /etc/fluent/keys/ca
 openshift_logging_es_client_cert: /etc/fluent/keys/cert
 openshift_logging_es_client_key: /etc/fluent/keys/key
+
+# elasticsearch proxy image defaults
+openshift_logging_elasticsearch_proxy_image_prefix: "{{ openshift_logging_image_prefix | default(__openshift_logging_elasticsearch_proxy_image_prefix) }}"
+openshift_logging_elasticsearch_proxy_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_elasticsearch_proxy_image_version) }}"

--- a/roles/openshift_logging_elasticsearch/tasks/determine_version.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/determine_version.yaml
@@ -1,18 +1,18 @@
 ---
 # debating making this a module instead?
 - fail:
-    msg: Missing version to install provided by 'openshift_logging_image_version'
-  when: not openshift_logging_image_version or openshift_logging_image_version == ''
+    msg: Missing version to install provided by 'openshift_logging_elasticsearch_image_version'
+  when: not openshift_logging_elasticsearch_image_version or openshift_logging_elasticsearch_image_version == ''
 
 - set_fact:
     es_version: "{{ __latest_es_version }}"
-  when: openshift_logging_image_version == 'latest'
+  when: openshift_logging_elasticsearch_image_version == 'latest'
 
-- debug: var=openshift_logging_image_version
+- debug: var=openshift_logging_elasticsearch_image_version
 
 # should we just assume that we will have the correct major version?
-- set_fact: es_version="{{ openshift_logging_image_version | regex_replace('^v?(?P<major>\d)\.(?P<minor>\d).*$', '3_\\g<minor>') }}"
-  when: openshift_logging_image_version != 'latest'
+- set_fact: es_version="{{ openshift_logging_elasticsearch_image_version | regex_replace('^v?(?P<major>\d)\.(?P<minor>\d).*$', '3_\\g<minor>') }}"
+  when: openshift_logging_elasticsearch_image_version != 'latest'
 
 - fail:
     msg: Invalid version specified for Elasticsearch

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -23,11 +23,6 @@
     - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
     - "default_images.yml"
 
-- name: Set elasticsearch_prefix image facts
-  set_fact:
-    openshift_logging_elasticsearch_proxy_image_prefix: "{{ openshift_logging_elasticsearch_proxy_image_prefix | default(__openshift_logging_elasticsearch_proxy_image_prefix) }}"
-    openshift_logging_elasticsearch_proxy_image_version: "{{ openshift_logging_elasticsearch_proxy_image_version | default(__openshift_logging_elasticsearch_proxy_image_version) }}"
-
 # allow passing in a tempdir
 - name: Create temp directory for doing work in
   command: mktemp -d /tmp/openshift-logging-ansible-XXXXXX

--- a/roles/openshift_logging_elasticsearch/vars/openshift-enterprise.yml
+++ b/roles/openshift_logging_elasticsearch/vars/openshift-enterprise.yml
@@ -1,3 +1,3 @@
 ---
-__openshift_logging_elasticsearch_proxy_image_prefix: "{{ openshift_logging_image_prefix | default('registry.access.redhat.com/openshift3/') }}"
-__openshift_logging_elasticsearch_proxy_image_version: "v3.7"
+__openshift_logging_elasticsearch_proxy_image_prefix: "{{ __openshift_logging_image_prefix }}"
+__openshift_logging_elasticsearch_proxy_image_version: "{{ __openshift_logging_image_version }}"

--- a/roles/openshift_logging_eventrouter/README.md
+++ b/roles/openshift_logging_eventrouter/README.md
@@ -11,8 +11,8 @@ A pod forwarding kubernetes events to EFK aggregated logging stack.
 
 Configuration variables:
 
-- `openshift_logging_eventrouter_image_prefix`: The prefix for the eventrouter logging image. Defaults to `openshift_logging_image_prefix`.
-- `openshift_logging_eventrouter_image_version`: The image version for the logging eventrouter. Defaults to 'latest'.
+- `openshift_logging_eventrouter_image_prefix`: The prefix for the eventrouter logging image. Defaults to either `docker.io/openshift/origin-` or `registry.access.redhat.com/openshift3/` depending on `openshift_deployment_type`.
+- `openshift_logging_eventrouter_image_version`: The image version for the logging eventrouter. Defaults to `__openshift_logging_image_version`.
 - `openshift_logging_eventrouter_sink`: Select a sink for eventrouter, supported 'stdout' and 'glog'. Defaults to 'stdout'.
 - `openshift_logging_eventrouter_nodeselector`: A map of labels (e.g. {"node":"infra","region":"west"} to select the nodes where the pod will land.
 - `openshift_logging_eventrouter_cpu_request`: The minimum amount of CPU to allocate to eventrouter. Defaults to '100m'.

--- a/roles/openshift_logging_eventrouter/defaults/main.yaml
+++ b/roles/openshift_logging_eventrouter/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 openshift_logging_eventrouter_image_prefix: "{{ openshift_logging_image_prefix | default(__openshift_logging_image_prefix) }}"
-openshift_logging_eventrouter_image_version: "{{ openshift_logging_image_version | default('latest') }}"
+openshift_logging_eventrouter_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_version) }}"
 openshift_logging_eventrouter_replicas: 1
 openshift_logging_eventrouter_sink: stdout
 openshift_logging_eventrouter_nodeselector: ""

--- a/roles/openshift_logging_fluentd/defaults/main.yml
+++ b/roles/openshift_logging_fluentd/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ### General logging settings
 openshift_logging_fluentd_image_prefix: "{{ openshift_logging_image_prefix | default(__openshift_logging_image_prefix) }}"
-openshift_logging_fluentd_image_version: "{{ openshift_logging_image_version | default('latest') }}"
+openshift_logging_fluentd_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_version) }}"
 openshift_logging_fluentd_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"
 openshift_logging_fluentd_master_url: "https://kubernetes.default.svc.{{ openshift.common.dns_domain }}"
 openshift_logging_fluentd_namespace: logging

--- a/roles/openshift_logging_fluentd/tasks/determine_version.yaml
+++ b/roles/openshift_logging_fluentd/tasks/determine_version.yaml
@@ -1,16 +1,16 @@
 ---
 # debating making this a module instead?
 - fail:
-    msg: Missing version to install provided by 'openshift_logging_image_version'
-  when: not openshift_logging_image_version or openshift_logging_image_version == ''
+    msg: Missing version to install provided by 'openshift_logging_fluentd_image_version'
+  when: not openshift_logging_fluentd_image_version or openshift_logging_fluentd_image_version == ''
 
 - set_fact:
     fluentd_version: "{{ __latest_fluentd_version }}"
-  when: openshift_logging_image_version == 'latest'
+  when: openshift_logging_fluentd_image_version == 'latest'
 
 # should we just assume that we will have the correct major version?
-- set_fact: fluentd_version="{{ openshift_logging_image_version | regex_replace('^v?(?P<major>\d)\.(?P<minor>\d).*$', '3_\\g<minor>') }}"
-  when: openshift_logging_image_version != 'latest'
+- set_fact: fluentd_version="{{ openshift_logging_fluentd_image_version | regex_replace('^v?(?P<major>\d)\.(?P<minor>\d).*$', '3_\\g<minor>') }}"
+  when: openshift_logging_fluentd_image_version != 'latest'
 
 - fail:
     msg: Invalid version specified for Fluentd

--- a/roles/openshift_logging_kibana/defaults/main.yml
+++ b/roles/openshift_logging_kibana/defaults/main.yml
@@ -3,7 +3,7 @@
 openshift_logging_kibana_master_url: "https://kubernetes.default.svc.cluster.local"
 openshift_logging_kibana_master_public_url: "https://kubernetes.default.svc.cluster.local"
 openshift_logging_kibana_image_prefix: "{{ openshift_logging_image_prefix | default(__openshift_logging_image_prefix) }}"
-openshift_logging_kibana_image_version: "{{ openshift_logging_image_version | default('latest') }}"
+openshift_logging_kibana_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_version) }}"
 openshift_logging_kibana_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"
 openshift_logging_kibana_namespace: logging
 
@@ -26,7 +26,7 @@ openshift_logging_kibana_ops_deployment: false
 
 # Proxy settings
 openshift_logging_kibana_proxy_image_prefix: "{{ openshift_logging_image_prefix | default(__openshift_logging_image_prefix) }}"
-openshift_logging_kibana_proxy_image_version: "{{ openshift_logging_image_version | default('latest') }}"
+openshift_logging_kibana_proxy_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_version) }}"
 openshift_logging_kibana_proxy_debug: false
 openshift_logging_kibana_proxy_cpu_limit: null
 openshift_logging_kibana_proxy_cpu_request: 100m

--- a/roles/openshift_logging_kibana/tasks/determine_version.yaml
+++ b/roles/openshift_logging_kibana/tasks/determine_version.yaml
@@ -1,16 +1,16 @@
 ---
 # debating making this a module instead?
 - fail:
-    msg: Missing version to install provided by 'openshift_logging_image_version'
-  when: not openshift_logging_image_version or openshift_logging_image_version == ''
+    msg: Missing version to install provided by 'openshift_logging_kibana_image_version'
+  when: not openshift_logging_kibana_image_version or openshift_logging_kibana_image_version == ''
 
 - set_fact:
     kibana_version: "{{ __latest_kibana_version }}"
-  when: openshift_logging_image_version == 'latest'
+  when: openshift_logging_kibana_image_version == 'latest'
 
 # should we just assume that we will have the correct major version?
-- set_fact: kibana_version="{{ openshift_logging_image_version | regex_replace('^v?(?P<major>\d)\.(?P<minor>\d).*$', '3_\\g<minor>') }}"
-  when: openshift_logging_image_version != 'latest'
+- set_fact: kibana_version="{{ openshift_logging_kibana_image_version | regex_replace('^v?(?P<major>\d)\.(?P<minor>\d).*$', '3_\\g<minor>') }}"
+  when: openshift_logging_kibana_image_version != 'latest'
 
 - fail:
     msg: Invalid version specified for Kibana

--- a/roles/openshift_logging_mux/defaults/main.yml
+++ b/roles/openshift_logging_mux/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ### General logging settings
 openshift_logging_mux_image_prefix: "{{ openshift_logging_image_prefix | default(__openshift_logging_image_prefix) }}"
-openshift_logging_mux_image_version: "{{ openshift_logging_image_version | default('latest') }}"
+openshift_logging_mux_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_version) }}"
 openshift_logging_mux_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"
 openshift_logging_mux_master_url: "https://kubernetes.default.svc.{{ openshift.common.dns_domain }}"
 openshift_logging_mux_master_public_url: "{{ openshift_hosted_logging_master_public_url | default('https://' + openshift.common.public_hostname + ':' ~ (openshift_master_api_port | default('8443', true))) }}"

--- a/roles/openshift_logging_mux/tasks/determine_version.yaml
+++ b/roles/openshift_logging_mux/tasks/determine_version.yaml
@@ -1,16 +1,16 @@
 ---
 # debating making this a module instead?
 - fail:
-    msg: Missing version to install provided by 'openshift_logging_image_version'
-  when: not openshift_logging_image_version or openshift_logging_image_version == ''
+    msg: Missing version to install provided by 'openshift_logging_mux_image_version'
+  when: not openshift_logging_mux_image_version or openshift_logging_mux_image_version == ''
 
 - set_fact:
     mux_version: "{{ __latest_mux_version }}"
-  when: openshift_logging_image_version == 'latest'
+  when: openshift_logging_mux_image_version == 'latest'
 
 # should we just assume that we will have the correct major version?
-- set_fact: mux_version="{{ openshift_logging_image_version | regex_replace('^v?(?P<major>\d)\.(?P<minor>\d).*$', '3_\\g<minor>') }}"
-  when: openshift_logging_image_version != 'latest'
+- set_fact: mux_version="{{ openshift_logging_mux_image_version | regex_replace('^v?(?P<major>\d)\.(?P<minor>\d).*$', '3_\\g<minor>') }}"
+  when: openshift_logging_mux_image_version != 'latest'
 
 - fail:
     msg: Invalid version specified for mux


### PR DESCRIPTION
The convention in defaulting logging images is: 
`openshift_logging_*_image_prefix <- __openshift_logging_image_prefix`

The `openshift_logging_elasticsearch_proxy_image_prefix` was defaulted directly to the repository preventing user to set `openshift_logging_image_prefix` to all logging images at once.

This change also removes default for `openshift_logging_image_prefix` and leaves setting this to user if he wants to change the prefix for all images at once.