### PR TITLE
[3.6] Enable oreg_auth credential replace during upgrades

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -4,6 +4,12 @@
     msg: Verify OpenShift is already installed
   when: openshift.common.version is not defined
 
+- name: Update oreg_auth docker login credentials if necessary
+  include_role:
+    name: docker
+    tasks_from: registry_auth.yml
+  when: oreg_auth_user is defined
+
 - name: Verify containers are available for upgrade
   command: >
     docker pull {{ openshift.common.cli_image }}:{{ openshift_image_tag }}

--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -140,16 +140,6 @@
 - set_fact:
     docker_service_status_changed: "{{ (r_docker_package_docker_start_result | changed) and (r_docker_already_running_result.stdout != 'ActiveState=active' ) }}"
 
-- name: Check for credentials file for registry auth
-  stat:
-    path: "{{ docker_cli_auth_config_path }}/config.json"
-  when: oreg_auth_user is defined
-  register: docker_cli_auth_credentials_stat
-
-- name: Create credentials for docker cli registry auth
-  command: "docker --config={{ docker_cli_auth_config_path }} login -u {{ oreg_auth_user }} -p {{ oreg_auth_password }} {{ oreg_host }}"
-  when:
-  - oreg_auth_user is defined
-  - (not docker_cli_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
+- include: registry_auth.yml
 
 - meta: flush_handlers

--- a/roles/docker/tasks/registry_auth.yml
+++ b/roles/docker/tasks/registry_auth.yml
@@ -1,0 +1,12 @@
+---
+- name: Check for credentials file for registry auth
+  stat:
+    path: "{{ docker_cli_auth_config_path }}/config.json"
+  when: oreg_auth_user is defined
+  register: docker_cli_auth_credentials_stat
+
+- name: Create credentials for docker cli registry auth
+  command: "docker --config={{ docker_cli_auth_config_path }} login -u {{ oreg_auth_user }} -p {{ oreg_auth_password }} {{ oreg_host }}"
+  when:
+  - oreg_auth_user is defined
+  - (not docker_cli_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool


### PR DESCRIPTION
Currently, upgrades run a docker image pull prior to
upgrading masters and nodes for containerized installs.

If using a secure registry, and a user wishes to upgrade
their credentials due to expiry, the image pull will fail.

This commit ensures docker login credentials are updated
during upgrades, if necessary.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1503995
(cherry picked from commit 1f0690622de8f26667d40a838298e63ffd3887f5)

Backports: https://github.com/openshift/openshift-ansible/pull/5814