### PR TITLE
docker: Create openshift_docker_is_node_or_master variable

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -29,3 +29,6 @@ r_crio_os_firewall_deny: []
 r_crio_os_firewall_allow:
 - service: crio
   port: 10010/tcp
+
+
+openshift_docker_is_node_or_master: "{{ True if inventory_hostname in (groups['oo_masters_to_config']|default([])) or inventory_hostname in (groups['oo_nodes_to_config']|default([])) else False | bool }}"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -35,4 +35,4 @@
   include: systemcontainer_crio.yml
   when:
     - l_use_crio
-    - inventory_hostname in groups['oo_masters_to_config'] or inventory_hostname in groups['oo_nodes_to_config']
+    - openshift_docker_is_node_or_master | bool

--- a/roles/docker/tasks/systemcontainer_crio.yml
+++ b/roles/docker/tasks/systemcontainer_crio.yml
@@ -3,16 +3,16 @@
 # TODO: Much of this file is shared with container engine tasks
 - set_fact:
     l_insecure_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l2_docker_insecure_registries)) }}"
-  when: l2_docker_insecure_registries
+  when: l2_docker_insecure_registries | bool
 - set_fact:
     l_crio_registries: "{{ l2_docker_additional_registries + ['docker.io'] }}"
-  when: l2_docker_additional_registries
+  when: l2_docker_additional_registries | bool
 - set_fact:
     l_crio_registries: "{{ ['docker.io'] }}"
-  when: not l2_docker_additional_registries
+  when: not (l2_docker_additional_registries | bool)
 - set_fact:
     l_additional_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l_crio_registries)) }}"
-  when: l2_docker_additional_registries
+  when: l2_docker_additional_registries | bool
 
 - set_fact:
     l_openshift_image_tag: "{{ openshift_image_tag | string }}"


### PR DESCRIPTION
This can be used in place of:

    inventory_hostname in groups['oo_masters_to_config'] or \
    inventory_hostname in groups['oo_nodes_to_config']

While the previous version works, this change helps with the tasks are
run during AMI creation.

Code written by Kenny Woodson @kwoodson.