### PR TITLE
dnsmasq cache-size dns-forward-max change

### DIFF
--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -54,6 +54,8 @@ domain-needed
 server=/cluster.local/172.30.0.1
 server=/30.172.in-addr.arpa/172.30.0.1
 enable-dbus
+dns-forward-max=5000
+cache-size=5000
 EOF
       # New config file, must restart
       NEEDS_RESTART=1

--- a/roles/openshift_node_dnsmasq/templates/origin-dns.conf.j2
+++ b/roles/openshift_node_dnsmasq/templates/origin-dns.conf.j2
@@ -3,6 +3,8 @@ domain-needed
 no-negcache
 max-cache-ttl=1
 enable-dbus
+dns-forward-max=5000
+cache-size=5000
 bind-interfaces
 {% for interface in openshift_node_dnsmasq_except_interfaces %}
 except-interface={{ interface }}


### PR DESCRIPTION
On very large clusters dnsmasq performance suffers due to
limited cache-size and dns-forward-max values.

bug: 1482847
https://bugzilla.redhat.com/show_bug.cgi?id=1482847