### PR TITLE
Make clearer *_nfs_directory and *_volume_name

### DIFF
--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -432,7 +432,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # NFS Host Group
 # An NFS volume will be created with path "nfs_directory/volume_name"
 # on the host within the [nfs] host group.  For example, the volume
-# path using these options would be "/exports/registry"
+# path using these options would be "/exports/registry".  "exports" is
+# is the name of the export served by the nfs server.  "registry" is
+# the name of a directory inside of "/exports".
 #openshift_hosted_registry_storage_kind=nfs
 #openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
 # nfs_directory must conform to DNS-1123 subdomain must consist of lower case
@@ -445,7 +447,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # External NFS Host
 # NFS volume must already exist with path "nfs_directory/_volume_name" on
 # the storage_host. For example, the remote volume path using these
-# options would be "nfs.example.com:/exports/registry"
+# options would be "nfs.example.com:/exports/registry".  "exports" is
+# is the name of the export served by the nfs server.  "registry" is
+# the name of a directory inside of "/exports".
 #openshift_hosted_registry_storage_kind=nfs
 #openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
 #openshift_hosted_registry_storage_host=nfs.example.com
@@ -517,7 +521,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Option A - NFS Host Group
 # An NFS volume will be created with path "nfs_directory/volume_name"
 # on the host within the [nfs] host group.  For example, the volume
-# path using these options would be "/exports/metrics"
+# path using these options would be "/exports/metrics".  "exports" is
+# is the name of the export served by the nfs server.  "metrics" is
+# the name of a directory inside of "/exports".
 #openshift_metrics_storage_kind=nfs
 #openshift_metrics_storage_access_modes=['ReadWriteOnce']
 #openshift_metrics_storage_nfs_directory=/exports
@@ -529,7 +535,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Option B - External NFS Host
 # NFS volume must already exist with path "nfs_directory/_volume_name" on
 # the storage_host. For example, the remote volume path using these
-# options would be "nfs.example.com:/exports/metrics"
+# options would be "nfs.example.com:/exports/metrics".  "exports" is
+# is the name of the export served by the nfs server.  "metrics" is
+# the name of a directory inside of "/exports".
 #openshift_metrics_storage_kind=nfs
 #openshift_metrics_storage_access_modes=['ReadWriteOnce']
 #openshift_metrics_storage_host=nfs.example.com
@@ -571,7 +579,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Option A - NFS Host Group
 # An NFS volume will be created with path "nfs_directory/volume_name"
 # on the host within the [nfs] host group.  For example, the volume
-# path using these options would be "/exports/logging"
+# path using these options would be "/exports/logging".  "exports" is
+# is the name of the export served by the nfs server.  "logging" is
+# the name of a directory inside of "/exports".
 #openshift_logging_storage_kind=nfs
 #openshift_logging_storage_access_modes=['ReadWriteOnce']
 #openshift_logging_storage_nfs_directory=/exports
@@ -583,7 +593,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Option B - External NFS Host
 # NFS volume must already exist with path "nfs_directory/_volume_name" on
 # the storage_host. For example, the remote volume path using these
-# options would be "nfs.example.com:/exports/logging"
+# options would be "nfs.example.com:/exports/logging".  "exports" is
+# is the name of the export served by the nfs server.  "logging" is
+# the name of a directory inside of "/exports".
 #openshift_logging_storage_kind=nfs
 #openshift_logging_storage_access_modes=['ReadWriteOnce']
 #openshift_logging_storage_host=nfs.example.com


### PR DESCRIPTION
When on-site with a customer, `openshift_metrics_storage_nfs_directory` and `openshift_metrics_storage_volume_name` were unclear to them.  The PR adds a bit more verbiage to make it obvious what the intent, meaning and purpose of those ansible vars are.