### PR TITLE
Fix undefined variable when metrics role is skipped

### DIFF
--- a/roles/openshift_metrics/tasks/install_metrics.yaml
+++ b/roles/openshift_metrics/tasks/install_metrics.yaml
@@ -41,6 +41,7 @@
     file_name: "{{ item.source }}"
     file_content: "{{ item.content | b64decode | from_yaml }}"
   with_items: "{{ object_defs.results }}"
+  when: object_defs is defined
 
 - find:
     paths: "{{ mktemp.stdout }}/templates"


### PR DESCRIPTION
The metrics role fails when it is skipped (using Ansible 2.3). The
problem is caused by skipping a registration of `object_defs` variable
and subsequent evaluation of the same variable in the next task which
triggers a failure.