### PR TITLE
GCP cannot use growpart utils from AWS due to conflicting package

### DIFF
--- a/playbooks/aws/openshift-cluster/build_ami.yml
+++ b/playbooks/aws/openshift-cluster/build_ami.yml
@@ -28,6 +28,8 @@
     set_fact:
       ansible_ssh_user: "{{ openshift_aws_build_ami_ssh_user | default(ansible_ssh_user) }}"
       openshift_node_bootstrap: True
+      openshift_node_image_prep_packages:
+      - cloud-utils-growpart
 
 # This is the part that installs all of the software and configs for the instance
 # to become a node.

--- a/roles/openshift_gcp/templates/provision.j2.sh
+++ b/roles/openshift_gcp/templates/provision.j2.sh
@@ -313,11 +313,11 @@ fi
 
 # wait until all node groups are stable
 {% for node_group in openshift_gcp_node_group_config %}
-{% if node_group.bootstrap | default(False) %}
-# not waiting for {{ node_group.name }} due to bootstrapping
-{% else %}
+{% if node_group.wait_for_stable | default(False) or not (node_group.bootstrap | default(False)) %}
 # wait for stable {{ node_group.name }}
 ( gcloud --project "{{ openshift_gcp_project }}" compute instance-groups managed wait-until-stable "{{ openshift_gcp_prefix }}ig-{{ node_group.suffix }}" --zone "{{ openshift_gcp_zone }}" --timeout=600 ) &
+{% else %}
+# not waiting for {{ node_group.name }} due to bootstrapping
 {% endif %}
 {% endfor %}
 

--- a/roles/openshift_gcp/templates/remove.j2.sh
+++ b/roles/openshift_gcp/templates/remove.j2.sh
@@ -161,5 +161,12 @@ for i in `jobs -p`; do wait $i; done
 
 for i in `jobs -p`; do wait $i; done
 
+# Images specifically located under this cluster prefix family
+for name in $( gcloud --project "{{ openshift_gcp_project }}" compute images list "--filter=family={{ openshift_gcp_prefix }}images" '--format=value(name)' ); do
+    ( gcloud --project "{{ openshift_gcp_project }}" compute images delete "${name}" ) &
+done
+
 # Network
-teardown "{{ openshift_gcp_network_name }}" compute networks
+( teardown "{{ openshift_gcp_network_name }}" compute networks ) &
+
+for i in `jobs -p`; do wait $i; done

--- a/roles/openshift_gcp/templates/remove.j2.sh
+++ b/roles/openshift_gcp/templates/remove.j2.sh
@@ -37,7 +37,7 @@ function teardown() {
 # scale down {{ node_group.name }}
 (
     # performs a delete and scale down as one operation to ensure maximum parallelism
-    if ! instances=$( gcloud --project "{{ openshift_gcp_project }}" compute instance-groups managed list-instances "{{ openshift_gcp_prefix }}ig-{{ node_group.suffix }}" --zone "{{ openshift_gcp_zone }}" --format='value[terminator=","](instance)' ); then
+    if ! instances=$( gcloud --project "{{ openshift_gcp_project }}" compute instance-groups managed list-instances "{{ openshift_gcp_prefix }}ig-{{ node_group.suffix }}" --zone "{{ openshift_gcp_zone }}" --format='value[terminator=","](instance)' 2>/dev/null ); then
         exit 0
     fi
     instances="${instances%?}"
@@ -57,6 +57,15 @@ function teardown() {
 if gsutil ls -p "{{ openshift_gcp_project }}" "gs://{{ openshift_gcp_registry_bucket_name }}" &>/dev/null; then
     gsutil -m rm -r "gs://{{ openshift_gcp_registry_bucket_name }}"
 fi
+) &
+
+# Project metadata prefixed with {{ openshift_gcp_prefix }}
+(
+    for key in $( gcloud --project "{{ openshift_gcp_project }}" compute project-info describe --flatten=commonInstanceMetadata.items[] '--format=value(commonInstanceMetadata.items.key)' ); do
+        if [[ "${key}" == "{{ openshift_gcp_prefix }}"* ]]; then
+            gcloud --project "{{ openshift_gcp_project }}" compute project-info remove-metadata "--keys=${key}"
+        fi
+    done
 ) &
 
 # DNS

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -71,7 +71,7 @@ openshift_master_bootstrap_enabled: False
 
 openshift_master_client_binary: "{{ openshift.common.client_binary if openshift is defined else 'oc' }}"
 
-openshift_master_config_imageconfig_format: "{{ oreg_url if oreg_url != '' else 'registry.access.redhat.com/openshift3/ose-${component}:${version}' }}"
+openshift_master_config_imageconfig_format: "{{ openshift.node.registry_url }}"
 
 # these are for the default settings in a generated node-config.yaml
 openshift_master_node_config_default_edits:

--- a/roles/openshift_master/tasks/bootstrap.yml
+++ b/roles/openshift_master/tasks/bootstrap.yml
@@ -42,6 +42,7 @@
     --node-dir={{ mktempout.stdout }}/
     --node=CONFIGMAP
     --hostnames=test
+    --dns-ip=0.0.0.0
     --certificate-authority={{ openshift_master_config_dir }}/ca.crt
     --signer-cert={{ openshift_master_config_dir }}/ca.crt
     --signer-key={{ openshift_master_config_dir }}/ca.key

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -9,7 +9,7 @@ openshift_service_type: "{{ 'origin' if openshift_deployment_type == 'origin' el
 
 openshift_image_tag: ''
 
-openshift_node_ami_prep_packages:
+default_r_openshift_node_image_prep_packages:
 - "{{ openshift_service_type }}-master"
 - "{{ openshift_service_type }}-node"
 - "{{ openshift_service_type }}-docker-excluder"
@@ -33,7 +33,6 @@ openshift_node_ami_prep_packages:
 - python-dbus
 - PyYAML
 - yum-utils
-- cloud-utils-growpart
 # gluster
 - glusterfs-fuse
 # nfs
@@ -54,6 +53,7 @@ openshift_node_ami_prep_packages:
 # - container-selinux
 # - atomic
 #
+r_openshift_node_image_prep_packages: "{{ default_r_openshift_node_image_prep_packages | union(openshift_node_image_prep_packages | default([])) }}"
 
 openshift_node_bootstrap: False
 

--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -3,7 +3,7 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items: "{{ openshift_node_ami_prep_packages }}"
+  with_items: "{{ r_openshift_node_image_prep_packages }}"
 
 - name: create the directory for node
   file:


### PR DESCRIPTION
Allow cloud provider specific packages to be specified. Also, fix a wait condition in openshift_gcp to allow masters to be bootstrapped nodes.

@kwoodson