### PR TITLE
Retry restarting journald

### DIFF
--- a/roles/openshift_master/tasks/journald.yml
+++ b/roles/openshift_master/tasks/journald.yml
@@ -21,7 +21,9 @@
 # I need to restart journald immediatelly, otherwise it gets into way during
 # further steps in ansible
 - name: Restart journald
-  systemd:
-    name: systemd-journald
-    state: restarted
+  command: "systemctl restart systemd-journald"
+  retries: 3
+  delay: 5
+  register: result
+  until: result.rc == 0
   when: journald_update | changed


### PR DESCRIPTION
Sometimes journald fails to restart cleanly during upgrades.

This commit retries restarting 3 times.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1506141