### PR TITLE
Add retry logic to docker auth credentials

### DIFF
--- a/roles/docker/tasks/registry_auth.yml
+++ b/roles/docker/tasks/registry_auth.yml
@@ -7,6 +7,10 @@
 
 - name: Create credentials for docker cli registry auth
   command: "docker --config={{ docker_cli_auth_config_path }} login -u {{ oreg_auth_user }} -p {{ oreg_auth_password }} {{ oreg_host }}"
+  register: openshift_docker_credentials_create_res
+  retries: 3
+  delay: 5
+  until: openshift_docker_credentials_create_res.rc == 0
   when:
   - oreg_auth_user is defined
   - (not docker_cli_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool

--- a/roles/openshift_master/tasks/registry_auth.yml
+++ b/roles/openshift_master/tasks/registry_auth.yml
@@ -11,6 +11,9 @@
   - oreg_auth_user is defined
   - (not master_oreg_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
   register: master_oreg_auth_credentials_create
+  retries: 3
+  delay: 5
+  until: master_oreg_auth_credentials_create.rc == 0
   notify:
   - restart master api
   - restart master controllers

--- a/roles/openshift_node/tasks/registry_auth.yml
+++ b/roles/openshift_node/tasks/registry_auth.yml
@@ -11,6 +11,9 @@
     - oreg_auth_user is defined
     - (not node_oreg_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
   register: node_oreg_auth_credentials_create
+  retries: 3
+  delay: 5
+  until: node_oreg_auth_credentials_create.rc == 0
   notify:
     - restart node
 

--- a/roles/openshift_node_upgrade/tasks/registry_auth.yml
+++ b/roles/openshift_node_upgrade/tasks/registry_auth.yml
@@ -11,6 +11,9 @@
     - oreg_auth_user is defined
     - (not node_oreg_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
   register: node_oreg_auth_credentials_create
+  retries: 3
+  delay: 5
+  until: node_oreg_auth_credentials_create.rc == 0
   notify:
     - restart node
 


### PR DESCRIPTION
This commit enables retry on docker login commands.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1506931