### PR TITLE
Remove unused osm_controller_lease_ttl

### DIFF
--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -310,9 +310,6 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_master_cluster_hostname=openshift-ansible.test.example.com
 #openshift_master_cluster_public_hostname=openshift-ansible.test.example.com
 
-# Override the default controller lease ttl
-#osm_controller_lease_ttl=30
-
 # Configure controller arguments
 #osm_controller_args={'resource-quota-sync-period': ['10s']}
 

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -88,7 +88,6 @@
       controller_args: "{{ osm_controller_args | default(None) }}"
       disabled_features: "{{ osm_disabled_features | default(None) }}"
       master_count: "{{ openshift_master_count | default(None) }}"
-      controller_lease_ttl: "{{ osm_controller_lease_ttl | default(None) }}"
       master_image: "{{ osm_image | default(None) }}"
       admission_plugin_config: "{{openshift_master_admission_plugin_config }}"
       kube_admission_plugin_config: "{{openshift_master_kube_admission_plugin_config | default(None) }}"  # deprecated, merged with admission_plugin_config


### PR DESCRIPTION
This variable is no longer used and references
should be removed.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1507449