### PR TITLE
since python3 dict.items() needs to be used instead of dict.iteritems()

### DIFF
--- a/roles/nickhammond.logrotate/templates/logrotate.d.j2
+++ b/roles/nickhammond.logrotate/templates/logrotate.d.j2
@@ -7,7 +7,7 @@
   {% endfor -%}
   {% endif %}
   {%- if item.scripts is defined -%}
-  {%- for name, script in item.scripts.iteritems() -%}
+  {%- for name, script in item.scripts.items() -%}
   {{ name }}
     {{ script }}
   endscript


### PR DESCRIPTION
iteritems() was removed in python3,
https://wiki.python.org/moin/Python3.0
 
And since the master requires us to use 2.3.0.0 ansible which in turn requires us to use python3.5.0
i think this needs to be fixed at least in master.