### PR TITLE
[3.6] Use existing OPENSHIFT_DEFAULT_REGISTRY setting during masters scaleup

### DIFF
--- a/playbooks/common/openshift-master/config.yml
+++ b/playbooks/common/openshift-master/config.yml
@@ -5,6 +5,19 @@
     t_oo_option_master_debug_level: "{{ lookup('oo_option', 'openshift_master_debug_level') }}"
 
   pre_tasks:
+  # Per https://bugzilla.redhat.com/show_bug.cgi?id=1469336
+  #
+  # When scaling up a cluster upgraded from OCP <= 3.5, ensure that
+  # OPENSHIFT_DEFAULT_REGISTRY is present as defined on the existing
+  # masters, or absent if such is the case.
+  - name: Detect if this host is a new master in a scale up
+    set_fact:
+      g_openshift_master_is_scaleup: "{{ openshift.common.hostname in ( groups['new_masters'] | default([]) ) }}"
+
+  - name: Scaleup Detection
+    debug:
+      var: g_openshift_master_is_scaleup
+
   - name: Check for RPM generated config marker file .config_managed
     stat:
       path: /etc/origin/.config_managed
@@ -69,7 +82,7 @@
         ha: "{{ openshift_master_ha | default(groups.oo_masters | length > 1) }}"
         master_count: "{{ openshift_master_count | default(groups.oo_masters | length) }}"
 
-- name: Inspect state of first master session secrets and config
+- name: Inspect state of first master config settings
   hosts: oo_first_master
   roles:
   - role: openshift_facts
@@ -97,6 +110,42 @@
   - name: Set etcd3 fact
     set_fact:
       l_etcd3_enabled: "{{ etcd3_grep.rc == 0 | bool }}"
+
+  - name: Check if atomic-openshift-master sysconfig exists yet
+    stat:
+      path: /etc/sysconfig/atomic-openshift-master
+    register: l_aom_exists
+
+  - name: Preserve OPENSHIFT_DEFAULT_REGISTRY master parameter if present
+    command: awk '/^OPENSHIFT_DEFAULT_REGISTRY/' /etc/sysconfig/atomic-openshift-master
+    register: l_default_registry_defined
+    when: l_aom_exists.stat.exists | bool
+
+  - name: Check if atomic-openshift-master-api sysconfig exists yet
+    stat:
+      path: /etc/sysconfig/atomic-openshift-master-api
+    register: l_aom_api_exists
+
+  - name: Preserve OPENSHIFT_DEFAULT_REGISTRY master-api parameter if present
+    command: awk '/^OPENSHIFT_DEFAULT_REGISTRY/' /etc/sysconfig/atomic-openshift-master-api
+    register: l_default_registry_defined_api
+    when: l_aom_api_exists.stat.exists | bool
+
+  - name: Check if atomic-openshift-master-controllers sysconfig exists yet
+    stat:
+      path: /etc/sysconfig/atomic-openshift-master-controllers
+    register: l_aom_controllers_exists
+
+  - name: Preserve OPENSHIFT_DEFAULT_REGISTRY master-controllers parameter if present
+    command: awk '/^OPENSHIFT_DEFAULT_REGISTRY/' /etc/sysconfig/atomic-openshift-master-controllers
+    register: l_default_registry_defined_controllers
+    when: l_aom_controllers_exists.stat.exists | bool
+
+  - name: Update facts with OPENSHIFT_DEFAULT_REGISTRY value
+    set_fact:
+      l_default_registry_value: "{{ l_default_registry_defined.stdout | default('') }}"
+      l_default_registry_value_api: "{{ l_default_registry_defined_api.stdout | default('') }}"
+      l_default_registry_value_controllers: "{{ l_default_registry_defined_controllers.stdout | default('') }}"
 
 - name: Generate master session secrets
   hosts: oo_first_master
@@ -145,6 +194,10 @@
     etcd_cert_prefix: "master.etcd-"
     r_openshift_master_clean_install: "{{ hostvars[groups.oo_first_master.0].l_clean_install }}"
     r_openshift_master_etcd3_storage: "{{ hostvars[groups.oo_first_master.0].l_etcd3_enabled }}"
+    openshift_master_is_scaleup_host: "{{ g_openshift_master_is_scaleup | default(false) }}"
+    openshift_master_default_registry_value: "{{ hostvars[groups.oo_first_master.0].l_default_registry_value }}"
+    openshift_master_default_registry_value_api: "{{ hostvars[groups.oo_first_master.0].l_default_registry_value_api }}"
+    openshift_master_default_registry_value_controllers: "{{ hostvars[groups.oo_first_master.0].l_default_registry_value_controllers }}"
   - role: nuage_master
     when: openshift.common.use_nuage | bool
   - role: calico_master

--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -25,7 +25,7 @@
   when: openshift.common.is_containerized | bool and not openshift.common.is_master_system_container | bool
 
 # workaround for missing systemd unit files
-- name: Create the systemd unit files
+- name: "Create the {{ openshift.common.service_type }} systemd unit file"
   template:
     src: "master_docker/master.docker.service.j2"
     dest: "{{ containerized_svc_dir }}/{{ openshift.common.service_type }}-master.service"
@@ -34,7 +34,7 @@
   - not openshift.common.is_master_system_container | bool
   register: create_master_unit_file
 
-- name: Install Master service file
+- name: "Install {{ openshift.common.service_type }} systemd unit file"
   copy:
     dest: "/etc/systemd/system/{{ openshift.common.service_type }}-master.service"
     src: "{{ openshift.common.service_type }}-master.service"
@@ -46,7 +46,7 @@
 - command: systemctl daemon-reload
   when: create_master_unit_file | changed
 
-- name: Create the ha systemd unit files
+- name: Create the ha systemd unit files for api and controller services
   template:
     src: "{{ ha_svc_template_path }}/atomic-openshift-master-{{ item }}.service.j2"
     dest: "{{ containerized_svc_dir }}/{{ openshift.common.service_type }}-master-{{ item }}.service"

--- a/roles/openshift_master/templates/atomic-openshift-master.j2
+++ b/roles/openshift_master/templates/atomic-openshift-master.j2
@@ -1,6 +1,9 @@
 OPTIONS=--loglevel={{ openshift.master.debug_level | default(2) }}
 CONFIG_FILE={{ openshift_master_config_file }}
-{% if openshift_push_via_dns | default(false) %}
+{# Preserve existing OPENSHIFT_DEFAULT_REGISTRY settings in scale up runs #}
+{% if openshift_master_is_scaleup_host %}
+{{ openshift_master_default_registry_value }}
+{% elif openshift_push_via_dns | default(false) %}
 OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000
 {% endif %}
 {% if openshift.common.is_containerized | bool %}

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.j2
@@ -1,6 +1,9 @@
 OPTIONS=--loglevel={{ openshift.master.debug_level }} --listen={{ 'https' if openshift.master.api_use_ssl else 'http' }}://{{ openshift.master.bind_addr }}:{{ openshift.master.api_port }} --master={{ openshift.master.loopback_api_url }}
 CONFIG_FILE={{ openshift_master_config_file }}
-{% if openshift_push_via_dns | default(false) %}
+{# Preserve existing OPENSHIFT_DEFAULT_REGISTRY settings in scale up runs #}
+{% if openshift_master_is_scaleup_host %}
+{{ openshift_master_default_registry_value_api }}
+{% elif openshift_push_via_dns | default(false) %}
 OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000
 {% endif %}
 {% if openshift.common.is_containerized | bool %}

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.j2
@@ -1,6 +1,9 @@
 OPTIONS=--loglevel={{ openshift.master.debug_level }} --listen={{ 'https' if openshift.master.api_use_ssl else 'http' }}://{{ openshift.master.bind_addr }}:{{ openshift.master.controllers_port }}
 CONFIG_FILE={{ openshift_master_config_file }}
-{% if openshift_push_via_dns | default(false) %}
+{# Preserve existing OPENSHIFT_DEFAULT_REGISTRY settings in scale up runs #}
+{% if openshift_master_is_scaleup_host %}
+{{ openshift_master_default_registry_value_controllers }}
+{% elif openshift_push_via_dns | default(false) %}
 OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000
 {% endif %}
 {% if openshift.common.is_containerized | bool %}

--- a/roles/openshift_master/vars/main.yml
+++ b/roles/openshift_master/vars/main.yml
@@ -20,3 +20,4 @@ openshift_master_valid_grant_methods:
 - deny
 
 l_is_ha: "{{ openshift.master.ha is defined and openshift.master.ha | bool }}"
+openshift_master_is_scaleup_host: False


### PR DESCRIPTION
This backports https://github.com/openshift/openshift-ansible/pull/4894 to 3.6.

----


Fixes a bug which reported that AFTER a cluster upgrade from OCP 3.5
to 3.6, any masters which are later added via the scaleup playbooks
are setting a value for OPENSHIFT_DEFAULT_REGISTRY which is
inconsistent with the already configured masters.

* OPENSHIFT_DEFAULT_REGISTRY value is saved from oo_first_master
* The new scaleup master has a fact set noting it is a scaleup host
* The saved OPENSHIFT_DEFAULT_REGISTRY value is used instead of the
  default for 3.6, which is to use a hard-coded registry value of
  'docker-registry.default.svc:5000'

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1469336