### PR TITLE
Docker: make use of new etc/containers/registries.conf optional

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -20,6 +20,7 @@ l2_docker_additional_registries: "{% if openshift_docker_additional_registries i
 l2_docker_blocked_registries: "{% if openshift_docker_blocked_registries is string %}{% if openshift_docker_blocked_registries == '' %}[]{% elif ',' in openshift_docker_blocked_registries %}{{ openshift_docker_blocked_registries.split(',') | list }}{% else %}{{ [ openshift_docker_blocked_registries ] }}{% endif %}{% else %}{{ openshift_docker_blocked_registries }}{% endif %}"
 l2_docker_insecure_registries: "{% if openshift_docker_insecure_registries is string %}{% if openshift_docker_insecure_registries == '' %}[]{% elif ',' in openshift_docker_insecure_registries %}{{ openshift_docker_insecure_registries.split(',') | list }}{% else %}{{ [ openshift_docker_insecure_registries ] }}{% endif %}{% else %}{{ openshift_docker_insecure_registries }}{% endif %}"
 
+openshift_docker_use_etc_containers: False
 containers_registries_conf_path: /etc/containers/registries.conf
 
 r_crio_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"

--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -81,6 +81,7 @@
   template:
     dest: "{{ containers_registries_conf_path }}"
     src: registries.conf
+  when: openshift_docker_use_etc_containers | bool
   notify:
   - restart docker
 


### PR DESCRIPTION
Currently, not all versions of docker support using
/etc/containers/registries.conf

This commit makes the use of that file optional.