### PR TITLE
Ensure GCP image build instance gets cleaned up on teardown

### DIFF
--- a/roles/openshift_gcp/templates/remove.j2.sh
+++ b/roles/openshift_gcp/templates/remove.j2.sh
@@ -68,6 +68,12 @@ fi
     done
 ) &
 
+# Instances and disks used for image building
+(
+    teardown "{{ openshift_gcp_prefix }}build-image-instance" compute instances --zone "{{ openshift_gcp_zone }}"
+    teardown "{{ openshift_gcp_prefix }}build-image-instance" compute disks --zone "{{ openshift_gcp_zone }}"
+) &
+
 # DNS
 (
 dns_zone="{{ dns_managed_zone | default(openshift_gcp_prefix + 'managed-zone') }}"


### PR DESCRIPTION
@kwoodson this is to ensure that when we build the image under the context we also tear it down in case something fails halfway through (in the CI jobs)

/kind bug