### PR TITLE
Enable SC, ASB, TSB by default

### DIFF
--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -27,7 +27,7 @@
   when: openshift_logging_install_logging | default(false) | bool
 
 - include: service_catalog.yml
-  when: openshift_enable_service_catalog | default(false) | bool
+  when: openshift_enable_service_catalog | default(true) | bool
 
 - include: ../openshift-management/config.yml
   when: openshift_management_install_management | default(false) | bool

--- a/roles/ansible_service_broker/tasks/main.yml
+++ b/roles/ansible_service_broker/tasks/main.yml
@@ -2,7 +2,7 @@
 # do any asserts here
 
 - include: install.yml
-  when: ansible_service_broker_install | default(false) | bool
+  when: ansible_service_broker_install | default(true) | bool
 
 - include: remove.yml
   when: ansible_service_broker_remove | default(false) | bool

--- a/roles/openshift_sanitize_inventory/tasks/main.yml
+++ b/roles/openshift_sanitize_inventory/tasks/main.yml
@@ -69,3 +69,21 @@
     - openshift_clusterid is not defined
     - openshift_cloudprovider_kind is defined
     - openshift_cloudprovider_kind == 'aws'
+
+- name: Ensure ansible_service_broker_remove and ansible_service_broker_install are mutually exclusive
+  fail:
+    msg: >
+      Ensure ansible_service_broker_remove and ansible_service_broker_install are mutually exclusive,
+      do not set both to true. ansible_service_broker_install defaults to true.
+  when:
+    - ansible_service_broker_remove | default(false) | bool
+    - ansible_service_broker_install | default(true) | bool
+
+- name: Ensure template_service_broker_remove and template_service_broker_install are mutually exclusive
+  fail:
+    msg: >
+      Ensure that template_service_broker_remove and template_service_broker_install are mutually exclusive,
+      do not set both to true. template_service_broker_remove defaults to true.
+  when:
+    - template_service_broker_remove | default(false) | bool
+    - template_service_broker_install | default(true) | bool

--- a/roles/openshift_service_catalog/tasks/generate_certs.yml
+++ b/roles/openshift_service_catalog/tasks/generate_certs.yml
@@ -60,7 +60,7 @@
   register: apiserver_ca
 
 - shell: >
-    oc get apiservices.apiregistration.k8s.io/v1beta1.servicecatalog.k8s.io -n kube-service-catalog || echo "not found"
+    {{ openshift.common.client_binary }} --config=/etc/origin/master/admin.kubeconfig get apiservices.apiregistration.k8s.io/v1beta1.servicecatalog.k8s.io -n kube-service-catalog || echo "not found"
   register: get_apiservices
   changed_when: no
 

--- a/roles/openshift_service_catalog/tasks/install.yml
+++ b/roles/openshift_service_catalog/tasks/install.yml
@@ -38,7 +38,7 @@
 
     - name: Make kube-service-catalog project network global
       command: >
-        oc adm pod-network make-projects-global kube-service-catalog
+        {{ openshift.common.client_binary }} --config=/etc/origin/master/admin.kubeconfig adm pod-network make-projects-global kube-service-catalog
 
 - include: generate_certs.yml
 
@@ -93,7 +93,7 @@
 # only do this if we don't already have the updated role info
 - name: update edit role for service catalog and pod preset access
   command: >
-    oc replace -f {{ mktemp.stdout }}/edit_sc_patch.yml
+    {{ openshift.common.client_binary }} --config=/etc/origin/master/admin.kubeconfig replace -f {{ mktemp.stdout }}/edit_sc_patch.yml
   when:
     - not edit_yaml.results.results[0] | oo_contains_rule(['servicecatalog.k8s.io'], ['serviceinstances', 'servicebindings'], ['create', 'update', 'delete', 'get', 'list', 'watch']) or not edit_yaml.results.results[0] | oo_contains_rule(['settings.k8s.io'], ['podpresets'], ['create', 'update', 'delete', 'get', 'list', 'watch'])
 
@@ -116,7 +116,7 @@
 # only do this if we don't already have the updated role info
 - name: update admin role for service catalog and pod preset access
   command: >
-    oc replace -f {{ mktemp.stdout }}/admin_sc_patch.yml
+    {{ openshift.common.client_binary }} --config=/etc/origin/master/admin.kubeconfig replace -f {{ mktemp.stdout }}/admin_sc_patch.yml
   when:
     - not admin_yaml.results.results[0] | oo_contains_rule(['servicecatalog.k8s.io'], ['serviceinstances', 'servicebindings'], ['create', 'update', 'delete', 'get', 'list', 'watch']) or not admin_yaml.results.results[0] | oo_contains_rule(['settings.k8s.io'], ['podpresets'], ['create', 'update', 'delete', 'get', 'list', 'watch'])
 
@@ -139,7 +139,7 @@
 # only do this if we don't already have the updated role info
 - name: update view role for service catalog access
   command: >
-    oc replace -f {{ mktemp.stdout }}/view_sc_patch.yml
+    {{ openshift.common.client_binary }} --config=/etc/origin/master/admin.kubeconfig replace -f {{ mktemp.stdout }}/view_sc_patch.yml
   when:
     - not view_yaml.results.results[0] | oo_contains_rule(['servicecatalog.k8s.io'], ['serviceinstances', 'servicebindings'], ['get', 'list', 'watch'])
 

--- a/roles/openshift_service_catalog/tasks/remove.yml
+++ b/roles/openshift_service_catalog/tasks/remove.yml
@@ -1,7 +1,7 @@
 ---
 - name: Remove Service Catalog APIServer
   command: >
-    oc delete apiservices.apiregistration.k8s.io/v1beta1.servicecatalog.k8s.io --ignore-not-found -n kube-service-catalog
+    {{ openshift.common.client_binary }} --config=/etc/origin/master/admin.kubeconfig delete apiservices.apiregistration.k8s.io/v1beta1.servicecatalog.k8s.io --ignore-not-found -n kube-service-catalog
 
 # TODO: this module doesn't currently remove this
 #- name: Remove service catalog api service
@@ -48,7 +48,7 @@
 
 - name: Remove Service Catalog kube-system Role Bindinds
   shell: >
-    oc process kube-system-service-catalog-role-bindings -n kube-system | oc delete --ignore-not-found -f -
+    {{ openshift.common.client_binary }} --config=/etc/origin/master/admin.kubeconfig process kube-system-service-catalog-role-bindings -n kube-system | {{ openshift.common.client_binary }} --config=/etc/origin/master/admin.kubeconfig delete --ignore-not-found -f -
 
 - oc_obj:
     kind: template
@@ -58,7 +58,7 @@
 
 - name: Remove Service Catalog kube-service-catalog Role Bindinds
   shell: >
-    oc process service-catalog-role-bindings -n kube-service-catalog | oc delete --ignore-not-found -f -
+    {{ openshift.common.client_binary }} --config=/etc/origin/master/admin.kubeconfig process service-catalog-role-bindings -n kube-service-catalog | {{ openshift.common.client_binary }} --config=/etc/origin/master/admin.kubeconfig delete --ignore-not-found -f -
 
 - oc_obj:
     kind: template

--- a/roles/template_service_broker/tasks/main.yml
+++ b/roles/template_service_broker/tasks/main.yml
@@ -2,7 +2,7 @@
 # do any asserts here
 
 - include: install.yml
-  when: template_service_broker_install | default(false) | bool
+  when: template_service_broker_install | default(true) | bool
 
 - include: remove.yml
   when: template_service_broker_remove | default(false) | bool


### PR DESCRIPTION
It was decided that SC, ASB, and TSB should be installed by default.

This will not install the components on an upgrade from 3.6 to 3.7, that will require that you run the sc playbook on your own.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1508085