### PR TITLE
[1.5] Remove incorrect validation for OpenIDIdentityProvider

### DIFF
--- a/roles/openshift_master_facts/filter_plugins/openshift_master.py
+++ b/roles/openshift_master_facts/filter_plugins/openshift_master.py
@@ -386,7 +386,6 @@ class OpenIDIdentityProvider(IdentityProviderOauthBase):
 
     def validate(self):
         ''' validate this idp instance '''
-        IdentityProviderOauthBase.validate(self)
         if not isinstance(self.provider['claims'], dict):
             raise errors.AnsibleFilterError("|failed claims for provider {0} "
                                             "must be a dictionary".format(self.__class__.__name__))


### PR DESCRIPTION
Currently, OpenIDIdentityProvider does not support
'challenge=true' in openshift-ansible.

This is incorrect, the auth plugin OpenIDIdentityProvider
does support this.

This commit removes the unnecessary validation of
challenge key.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1444367
Fixes: https://github.com/openshift/openshift-ansible/issues/4417
(cherry picked from commit 9879c765a5a9cce14003aac26e414c84ec8e4cce)

Backports: https://github.com/openshift/openshift-ansible/pull/5828