### PR TITLE
[1.5] Add master config upgrade hook to upgrade-all plays

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_5/upgrade.yml
@@ -114,6 +114,8 @@
   - include: ../cleanup_unused_images.yml
 
 - include: ../upgrade_control_plane.yml
+  vars:
+    master_config_hook: "v3_5/master_config_upgrade.yml"
 
 - include: ../upgrade_nodes.yml
 


### PR DESCRIPTION
Currently, in 1.5, 3.6, 1.7 upgrade-all plays, control
plane upgrades are not called correctly.

This commit ensures the master config hook is appropriately
applied during these upgrades to match the steps in
control plane only upgrades.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1486054
(cherry picked from commit ae494abf95c0904e0b61887eca8e430a32e33646)

Backports: https://github.com/openshift/openshift-ansible/pull/5875