### PR TITLE
Add enterprise prometheus image defaults, simplify image_prefix

### DIFF
--- a/roles/openshift_prometheus/defaults/main.yaml
+++ b/roles/openshift_prometheus/defaults/main.yaml
@@ -6,16 +6,6 @@ openshift_prometheus_namespace: prometheus
 
 openshift_prometheus_node_selector: {"region":"infra"}
 
-# image defaults
-openshift_prometheus_image_prefix: "openshift/"
-openshift_prometheus_image_version: "v2.0.0-dev.3"
-openshift_prometheus_proxy_image_prefix: "openshift/"
-openshift_prometheus_proxy_image_version: "v1.0.0"
-openshift_prometheus_alertmanager_image_prefix: "openshift/"
-openshift_prometheus_alertmanager_image_version: "v0.9.1"
-openshift_prometheus_alertbuffer_image_prefix: "openshift/"
-openshift_prometheus_alertbuffer_image_version: "v0.0.2"
-
 # additional prometheus rules file
 openshift_prometheus_additional_rules_file: null
 

--- a/roles/openshift_prometheus/tasks/main.yaml
+++ b/roles/openshift_prometheus/tasks/main.yaml
@@ -1,4 +1,20 @@
 ---
+- name: Set default image variables based on deployment_type
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
+    - "default_images.yml"
+
+- name: Set image facts
+  set_fact:
+    openshift_prometheus_image_prefix: "{{ openshift_prometheus_image_prefix | default(__openshift_prometheus_image_prefix) }}"
+    openshift_prometheus_image_version: "{{ openshift_prometheus_image_version | default(__openshift_prometheus_image_version) }}"
+    openshift_prometheus_proxy_image_prefix: "{{ openshift_prometheus_proxy_image_prefix | default(openshift_prometheus_image_prefix) }}"
+    openshift_prometheus_proxy_image_version: "{{ openshift_prometheus_proxy_image_version | default(__openshift_prometheus_proxy_image_version) }}"
+    openshift_prometheus_alertmanager_image_prefix: "{{ openshift_prometheus_altermanager_image_prefix | default(openshift_prometheus_image_prefix) }}"
+    openshift_prometheus_alertmanager_image_version: "{{ openshift_prometheus_alertmanager_image_version | default(__openshift_prometheus_alertmanager_image_version) }}"
+    openshift_prometheus_alertbuffer_image_prefix: "{{ openshift_prometheus_alertbuffer_image_prefix | default(openshift_prometheus_image_prefix) }}"
+    openshift_prometheus_alertbuffer_image_version: "{{ openshift_prometheus_alertbuffer_image_version | default(__openshift_prometheus_alertbuffer_image_version) }}"
 
 - name: Create temp directory for doing work in on target
   command: mktemp -td openshift-prometheus-ansible-XXXXXX

--- a/roles/openshift_prometheus/vars/default_images.yml
+++ b/roles/openshift_prometheus/vars/default_images.yml
@@ -1,0 +1,7 @@
+---
+# image defaults
+__openshift_prometheus_image_prefix: "openshift/"
+__openshift_prometheus_image_version: "v2.0.0-dev.3"
+__openshift_prometheus_proxy_image_version: "v1.0.0"
+__openshift_prometheus_alertmanager_image_version: "v0.9.1"
+__openshift_prometheus_alertbuffer_image_version: "v0.0.2"

--- a/roles/openshift_prometheus/vars/openshift-enterprise.yml
+++ b/roles/openshift_prometheus/vars/openshift-enterprise.yml
@@ -1,0 +1,7 @@
+---
+# image defaults
+__openshift_prometheus_image_prefix: "registry.access.redhat.com/openshift3/"
+__openshift_prometheus_image_version: "v3.7"
+__openshift_prometheus_proxy_image_version: "v3.7"
+__openshift_prometheus_alertmanager_image_version: "v3.7"
+__openshift_prometheus_alertbuffer_image_version: "v3.7"


### PR DESCRIPTION
Only require that openshift_prometheus_image_prefix be set to affect all
other prefixes. Unfortunately the image_version for origin varies by
image so a common image_version cannot be used.