### PR TITLE
1506750 Validate node hostname and IP address

### DIFF
--- a/playbooks/init/validate_hostnames.yml
+++ b/playbooks/init/validate_hostnames.yml
@@ -1,6 +1,7 @@
 ---
 - name: Validate node hostnames
   hosts: oo_nodes_to_config
+  any_errors_fatal: true
   tasks:
   - name: Query DNS for IP address of {{ openshift.common.hostname }}
     shell:
@@ -8,16 +9,35 @@
     register: lookupip
     changed_when: false
     failed_when: false
-  - name: Warn user about bad openshift_hostname values
-    pause:
-      prompt:
+
+  - name: Validate openshift_hostname when defined
+    fail:
+      msg: >
         The hostname {{ openshift.common.hostname }} for {{ ansible_nodename }}
         doesn't resolve to an IP address owned by this host. Please set
         openshift_hostname variable to a hostname that when resolved on the host
-        in question resolves to an IP address matching an interface on this
-        host. This host will fail liveness checks for pods utilizing hostPorts,
-        press ENTER to continue or CTRL-C to abort.
-      seconds: "{{ 10 if openshift_override_hostname_check | default(false) | bool else omit }}"
+        in question resolves to an IP address matching an interface on this host.
+        This will ensure proper functionality of OpenShift networking features.
+        Inventory setting: openshift_hostname={{ openshift_hostname }}
+        This check can be overridden by setting openshift_hostname_check=false in
+        the inventory.
+        See https://docs.openshift.org/latest/install_config/install/advanced_install.html#configuring-host-variables
     when:
     - lookupip.stdout != '127.0.0.1'
     - lookupip.stdout not in ansible_all_ipv4_addresses
+    - openshift_hostname_check | default(true)
+
+  - name: Validate openshift_ip exists on node when defined
+    fail:
+      msg: >
+        The IP address {{ openshift_ip }} does not exist on {{ ansible_nodename }}.
+        Please set the openshift_ip variable to an IP address of this node.
+        This will ensure proper functionality of OpenShift networking features.
+        Inventory setting: openshift_ip={{ openshift_ip }}
+        This check can be overridden by setting openshift_ip_check=false in
+        the inventory.
+        See https://docs.openshift.org/latest/install_config/install/advanced_install.html#configuring-host-variables
+    when:
+    - openshift_ip is defined
+    - openshift_ip not in ansible_all_ipv4_addresses
+    - openshift_ip_check | default(true)


### PR DESCRIPTION
- Replaces use of `pause` with a `fail` task.  `pause` only runs on one host, therefore the check was not run for all nodes
- Adds check for valid openshift_ip

Fixes 1506750

https://bugzilla.redhat.com/show_bug.cgi?id=1506750