### PR TITLE
Retry service account bootstrap kubeconfig creation

### DIFF
--- a/roles/openshift_master/tasks/bootstrap.yml
+++ b/roles/openshift_master/tasks/bootstrap.yml
@@ -4,6 +4,9 @@
 - name: create service account kubeconfig with csr rights
   command: "oc serviceaccounts create-kubeconfig node-bootstrapper -n openshift-infra"
   register: kubeconfig_out
+  until: kubeconfig_out.rc == 0
+  retries: 24
+  delay: 5
 
 - name: put service account kubeconfig into a file on disk for bootstrap
   copy:


### PR DESCRIPTION
Pulled back from the larger refactor so this job can be enabled.

@kwoodson back porting so I can turn the job on