### PR TITLE
Don't use possibly undefined variables in error messages

### DIFF
--- a/roles/openshift_management/tasks/storage/nfs_server.yml
+++ b/roles/openshift_management/tasks/storage/nfs_server.yml
@@ -20,12 +20,26 @@
   when:
     - openshift_management_storage_class == "nfs_external"
 
-- name: Failed NFS server detection
+- name: Failed External NFS server detection
   assert:
     that:
       - openshift_management_nfs_server is defined
     msg: |
-      "Unable to detect an NFS server. The 'nfs_external'
-      openshift_management_storage_class option requires that you set
-      openshift_management_storage_nfs_external_hostname. NFS hosts detected
-      for local nfs services: {{ groups['oo_nfs_to_config'] | join(', ') }}"
+      Unable to detect an NFS server. The 'nfs_external'
+      openshift_management_storage_class option requires that you
+      manually set openshift_management_storage_nfs_external_hostname
+      parameter.
+  when:
+    - openshift_management_storage_class == 'nfs_external'
+
+- name: Failed Local NFS server detection
+  assert:
+    that:
+      - openshift_management_nfs_server is defined
+    msg: |
+      Unable to detect an NFS server. The 'nfs'
+      openshift_management_storage_class option requires that you have
+      an 'nfs' inventory group or manually set the
+      openshift_management_storage_nfs_local_hostname parameter.
+  when:
+    - openshift_management_storage_class == 'nfs'


### PR DESCRIPTION
In an error reporting task we were referencing a variable which may
not have been defined. Even though NFS server detection was working
correctly the undefined variable reference caused an
AnsibleUndefinedVariable error.

* Fixes CFME failing to deploy using external NFS storage

https://bugzilla.redhat.com/show_bug.cgi?id=1504535