### PR TITLE
Remove delegate_to from openshift_facts within the openshift_ca role.

### DIFF
--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -18,9 +18,7 @@
 
 - name: Reload generated facts
   openshift_facts:
-  when: install_result | changed
-  delegate_to: "{{ openshift_ca_host }}"
-  run_once: true
+  when: hostvars[openshift_ca_host].install_result | changed
 
 - name: Create openshift_ca_config_dir if it does not exist
   file:


### PR DESCRIPTION
Just reload facts on all hosts when we've updated the base package on the first master.

https://bugzilla.redhat.com/show_bug.cgi?id=1507083