### PR TITLE
Configurable node config location.

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -110,5 +110,8 @@ openshift_node_use_kuryr: "{{ openshift_node_use_kuryr_default }}"
 openshift_node_data_dir_default: "{{ openshift_data_dir | default('/var/lib/origin') }}"
 openshift_node_data_dir: "{{ openshift_node_data_dir_default }}"
 
+openshift_node_config_dir_default: "/etc/origin/node"
+openshift_node_config_dir: "{{ openshift_node_config_dir_default }}"
+
 openshift_node_image_config_latest_default: "{{ openshift_image_config_latest | default(False) }}"
 openshift_node_image_config_latest: "{{ openshift_node_image_config_latest_default }}"

--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -25,11 +25,11 @@
     state: "{{ item.state | default('present') }}"
   with_items:
   # add the kubeconfig
-  - line: "KUBECONFIG=/etc/origin/node/bootstrap.kubeconfig"
+  - line: "KUBECONFIG={{ openshift_node_data_dir }}/bootstrap.kubeconfig"
     regexp: "^KUBECONFIG=.*"
   # remove the config file.  This comes from openshift_facts
-  - regexp: "^CONFIG_FILE=.*"
-    state: absent
+  - line: "CONFIG_FILE={{ openshift_node_data_dir }}/"
+    regexp: "^CONFIG_FILE=.*"
 
 - name: include aws sysconfig credentials
   include: aws.yml

--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -25,10 +25,10 @@
     state: "{{ item.state | default('present') }}"
   with_items:
   # add the kubeconfig
-  - line: "KUBECONFIG={{ openshift_node_data_dir }}/bootstrap.kubeconfig"
+  - line: "KUBECONFIG={{ openshift_node_config_dir }}/bootstrap.kubeconfig"
     regexp: "^KUBECONFIG=.*"
   # remove the config file.  This comes from openshift_facts
-  - line: "CONFIG_FILE={{ openshift_node_data_dir }}/"
+  - line: "CONFIG_FILE={{ openshift_node_config_dir }}/node-config.yaml"
     regexp: "^CONFIG_FILE=.*"
 
 - name: include aws sysconfig credentials
@@ -76,7 +76,7 @@
     state: link
     force: yes
   with_items:
-  - /var/lib/origin/openshift.local.config/node/node-client-ca.crt
+  - "{{ openshift_node_config_dir }}/node-client-ca.crt"
 
 - when: rpmgenerated_config.stat.exists
   block:


### PR DESCRIPTION
Allow the node config location to be configurable.

This currently defaults to /var/lib/origin.  It should be /etc/origin/node/node-config.yaml.