### PR TITLE
[3.6] Use the currently attached pvc for an ES dc if available

### DIFF
--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -78,7 +78,7 @@
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
     openshift_logging_elasticsearch_deployment_name: "{{ item.0.name }}"
-    openshift_logging_elasticsearch_pvc_name: "{{ openshift_logging_es_pvc_prefix ~ '-' ~ item.2 if item.1 is none else item.1 }}"
+    openshift_logging_elasticsearch_pvc_name: "{{ item.0.volumes['elasticsearch-storage'].persistentVolumeClaim.claimName if item.0.volumes['elasticsearch-storage'].persistentVolumeClaim is defined else openshift_logging_es_pvc_prefix ~ '-' ~ item.2 if item.1 is none else item.1 }}"
     openshift_logging_elasticsearch_replica_count: "{{ openshift_logging_es_cluster_size | int }}"
 
     openshift_logging_elasticsearch_storage_type: "{{ elasticsearch_storage_type }}"
@@ -136,7 +136,7 @@
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
     openshift_logging_elasticsearch_deployment_name: "{{ item.0.name }}"
-    openshift_logging_elasticsearch_pvc_name: "{{ openshift_logging_es_ops_pvc_prefix ~ '-' ~ item.2 if item.1 is none else item.1 }}"
+    openshift_logging_elasticsearch_pvc_name: "{{ item.0.volumes['elasticsearch-storage'].persistentVolumeClaim.claimName if item.0.volumes['elasticsearch-storage'].persistentVolumeClaim is defined else openshift_logging_es_ops_pvc_prefix ~ '-' ~ item.2 if item.1 is none else item.1 }}"
     openshift_logging_elasticsearch_ops_deployment: true
     openshift_logging_elasticsearch_replica_count: "{{ openshift_logging_es_ops_cluster_size | int }}"
 


### PR DESCRIPTION
Otherwise fall back to current logic of labelled PVCs or creating if necessary.

This is to address https://bugzilla.redhat.com/show_bug.cgi?id=1508150

Backport of https://github.com/openshift/openshift-ansible/pull/5983

The order of the PVC priority is as follows:
1. The PVC currently claimed on the DC
1. A PVC from the list of PVCs as collected by logging_facts
1. Create a new PVC