### PR TITLE
CFME: Use cluster_hostname if cluster_public_hostname isn't available

### DIFF
--- a/roles/openshift_management/tasks/add_container_provider.yml
+++ b/roles/openshift_management/tasks/add_container_provider.yml
@@ -10,6 +10,18 @@
 - name: Ensure OpenShift facts are loaded
   openshift_facts:
 
+- name: Ensure we use openshift_master_cluster_public_hostname if it is available
+  set_fact:
+    l_cluster_hostname: "{{ openshift.master.cluster_public_hostname }}"
+  when:
+    - openshift.master.cluster_public_hostname is defined
+
+- name: Ensure we default to the first master if openshift_master_cluster_public_hostname is unavailable
+  set_fact:
+    l_cluster_hostname: "{{ openshift.master.cluster_hostname }}"
+  when:
+    - l_cluster_hostname is not defined
+
 - name: Ensure the management SA Secrets are read
   oc_serviceaccount_secret:
     state: list
@@ -59,7 +71,7 @@
       connection_configurations:
         - authentication: {auth_key: "{{ management_bearer_token }}", authtype: bearer, type: AuthToken}
           endpoint: {role: default, security_protocol: ssl-without-validation, verify_ssl: 0}
-      hostname: "{{ openshift.master.cluster_public_hostname }}"
+      hostname: "{{ l_cluster_hostname }}"
       name: "{{ openshift_management_project }}"
       port: "{{ openshift.master.api_port }}"
       type: "ManageIQ::Providers::Openshift::ContainerManager"


### PR DESCRIPTION
The CFME 'automatically add provider' playbook would fail if
openshift_master_cluster_public_hostname was not defined in the
inventory. Now we use that value if it is available, and fallback to
using the masters 'cluster_hostname' otherwise.

* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1506951