### PR TITLE
Ensure node service is started.

### DIFF
--- a/roles/openshift_aws/templates/user_data.j2
+++ b/roles/openshift_aws/templates/user_data.j2
@@ -20,6 +20,7 @@ runcmd:
 - [ ansible-playbook, /root/openshift_bootstrap/bootstrap.yml]
 {%     endif %}
 {%     if launch_config_item.key != 'master' %}
+- [ systemctl, restart, NetworkManager]
 - [ systemctl, enable, {% if openshift_deployment_type == 'openshift-enterprise' %}atomic-openshift{% else %}origin{% endif %}-node]
 - [ systemctl, start, {% if openshift_deployment_type == 'openshift-enterprise' %}atomic-openshift{% else %}origin{% endif %}-node]
 {%     endif %}

--- a/roles/openshift_node/files/bootstrap.yml
+++ b/roles/openshift_node/files/bootstrap.yml
@@ -61,3 +61,11 @@
       with_items:
       - line: "BOOTSTRAP_CONFIG_NAME=node-config-{{ openshift_group_type }}"
         regexp: "^BOOTSTRAP_CONFIG_NAME=.*"
+
+    - name: "Start the {{ openshift_service_type }}-node service"
+      systemd:
+        daemon_reload: yes
+        state: restarted
+        enabled: True
+        name: "{{ openshift_service_type }}-node"
+        no_block: true


### PR DESCRIPTION
When bootstrapping nodes we need to restart networkmanager so that the /etc/resolv.conf is properly populated.  We also restart the node service after making changes to the unit files.