### PR TITLE
management: users must acknowledge use of beta software

### DIFF
--- a/playbooks/byo/openshift-management/config.yml
+++ b/playbooks/byo/openshift-management/config.yml
@@ -1,6 +1,6 @@
 ---
 - include: ../openshift-cluster/initialize_groups.yml
 
-- include: ../../common/openshift-cluster/evaluate_groups.yml
+- include: ../../common/openshift-cluster/std_include.yml
 
 - include: ../../common/openshift-management/config.yml

--- a/roles/openshift_management/tasks/validate.yml
+++ b/roles/openshift_management/tasks/validate.yml
@@ -2,12 +2,25 @@
 # Validate configuration parameters passed to the openshift_management role
 
 ######################################################################
+# BETA ACKNOWLEDGEMENT
+- name: Ensure BETA software notice has been acknowledged
+  assert:
+    that:
+      - openshift_management_install_beta | default(false) | bool
+    msg: |
+      openshift-management (CFME/MIQ) is currently BETA status. You
+      must set openshift_management_install_beta to true to
+      acknowledge that you accept this risk and understand that
+      support is limited or nonexistent.
+  when:
+    - openshift_deployment_type == 'openshift-enterprise'
+
+######################################################################
 # CORE PARAMETERS
 - name: Ensure openshift_management_app_template is valid
   assert:
     that:
       - openshift_management_app_template in __openshift_management_app_templates
-
     msg: |
       "openshift_management_app_template must be one of {{
       __openshift_management_app_templates | join(', ') }}"


### PR DESCRIPTION
Adds a new role variable, openshift_management_install_beta. This
variable defaults to false. The value of this variable is checked
during the validation phase.

* If true, the install will not continue.

* If false, The user is presented with an informative message letting
  them know this is beta software and there is low/no support at this
  time. The installation will abort and instruct the user how to
  continue.