### PR TITLE
Bug 1509052 - Remove logfile from broker config

### DIFF
--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -316,7 +316,6 @@
               etcd_host: 0.0.0.0
               etcd_port: 2379
             log:
-              logfile: /var/log/ansible-service-broker/asb.log
               stdout: true
               level: {{ ansible_service_broker_log_level }}
               color: true


### PR DESCRIPTION
Logging to a file inside the broker container will eventually consume the container's available disk space. This is not necessary as the broker is already logging to stdout and this is well supported in OpenShift.