### PR TITLE
openshift_hosted: Add docker-gc

### DIFF
--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -123,6 +123,15 @@ openshift_release=v3.7
 # use this option if you are sure you know what you are doing!
 #openshift_docker_systemcontainer_image_override="registry.example.com/container-engine:latest"
 #openshift_crio_systemcontainer_image_override="registry.example.com/cri-o:latest"
+# NOTE: The following crio docker-gc items are tech preview and likely shouldn't be used
+# unless you know what you are doing!!
+# The following two variables are used when opneshift_use_crio is True
+# and cleans up after builds that pass through docker.
+# Enable docker garbage collection when using cri-o
+#openshift_crio_enable_docker_gc=false
+# Node Selectors to run the garbage collection
+#openshift_crio_docker_gc_node_selector: {'runtime': 'cri-o'}
+
 # Items added, as is, to end of /etc/sysconfig/docker OPTIONS
 # Default value: "--log-driver=journald"
 #openshift_docker_options="-l warn --ipv6=false"

--- a/playbooks/common/openshift-cluster/install_docker_gc.yml
+++ b/playbooks/common/openshift-cluster/install_docker_gc.yml
@@ -1,0 +1,7 @@
+---
+- name: Install docker gc
+  hosts: oo_first_master
+  gather_facts: false
+  tasks:
+    - include_role:
+        name: openshift_docker_gc

--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -24,6 +24,11 @@
 - include: openshift_prometheus.yml
   when: openshift_hosted_prometheus_deploy | default(False) | bool
 
+- include: install_docker_gc.yml
+  when:
+  - openshift_use_crio | default(False) | bool
+  - openshift_crio_enable_docker_gc | default(False) | bool
+
 - name: Hosted Install Checkpoint End
   hosts: oo_all_hosts
   gather_facts: false

--- a/roles/openshift_docker_gc/defaults/main.yml
+++ b/roles/openshift_docker_gc/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+r_enable_docker_gc: "{{ openshift_crio_enable_docker_gc | default(False) }}"
+r_docker_gc_node_selectors: "{{ openshift_crio_docker_gc_node_selector | default({}) }}"

--- a/roles/openshift_docker_gc/meta/main.yml
+++ b/roles/openshift_docker_gc/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  author: OpenShift
+  description: docker garbage collection
+  company: Red Hat, Inc
+  license: ASL 2.0
+  min_ansible_version: 2.2
+  platforms:
+  - name: EL
+    versions:
+    - 7
+dependencies:
+- role: lib_openshift

--- a/roles/openshift_docker_gc/tasks/main.yaml
+++ b/roles/openshift_docker_gc/tasks/main.yaml
@@ -1,0 +1,27 @@
+---
+- name: Create docker-gc tempdir
+  command: mktemp -d
+  register: templates_tmpdir
+
+# NOTE: oc_adm_policy_user does not support -z (yet)
+- name: Add dockergc as priviledged
+  shell: oc adm policy add-scc-to-user -z dockergc privileged
+#  oc_adm_policy_user:
+#    user: dockergc
+#    resource_kind: scc
+#    resource_name: privileged
+#    state: present
+
+- name: Create dockergc DaemonSet
+  become: yes
+  template:
+    src: dockergc-ds.yaml.j2
+    dest: "{{ templates_tmpdir.stdout }}/dockergc-ds.yaml"
+
+- name: Apply dockergc DaemonSet
+  oc_obj:
+    state: present
+    kind: DaemonSet
+    name: "dockergc"
+    files:
+    - "{{ templates_tmpdir.stdout }}/dockergc-ds.yaml"

--- a/roles/openshift_docker_gc/templates/dockergc-ds.yaml.j2
+++ b/roles/openshift_docker_gc/templates/dockergc-ds.yaml.j2
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: dockergc
+  # You must grant privileged via: oadm policy add-scc-to-user -z dockergc privileged
+  # in order for the dockergc to access the docker socket and root directory
+- apiVersion: extensions/v1beta1
+  kind: DaemonSet
+  metadata:
+    name: dockergc
+    labels:
+      app: dockergc
+  spec:
+    template:
+      metadata:
+        labels:
+          app: dockergc
+        name: dockergc
+      spec:
+{# Only set nodeSelector if the dict is not empty #}
+{% if r_docker_gc_node_selectors %}
+        nodeSelector:
+{% for k,v in r_docker_gc_node_selectors.items() %}
+          {{ k }}: {{ v }}{% endfor %}{% endif %}
+
+        serviceAccountName: dockergc
+        containers:
+        - image: openshift/origin:latest
+          args:
+          - "ex"
+          - "dockergc"
+          - "--image-gc-low-threshold=60"
+          - "--image-gc-high-threshold=80"
+          - "--minimum-ttl-duration=1h0m0s"
+          securityContext:
+            privileged: true
+          name: dockergc
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 50m
+          volumeMounts:
+          - name: docker-root
+            readOnly:  true
+            mountPath: /var/lib/docker
+          - name: docker-socket
+            readOnly:  false
+            mountPath: /var/run/docker.sock
+        volumes:
+        - name: docker-root
+          hostPath:
+            path: /var/lib/docker
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock


### PR DESCRIPTION
Two new inventory variables have been created:

- ``openshift_crio_enable_docker_gc``: Enable docker_gc daemon set
- ``openshift_crio_docker_gc_node_selector``: Optional dictionary to use node
selector

When ``openshift_crio_enable_docker_gc`` and ``openshift_use_crio`` are both true
then ``docker_gc`` daemonset will be created along with adding a ``docker-gc``
sa.