### PR TITLE
Add etcd as part of inventory file

### DIFF
--- a/inventory/byo/hosts.byo.glusterfs.external.example
+++ b/inventory/byo/hosts.byo.glusterfs.external.example
@@ -19,6 +19,7 @@
 [OSEv3:children]
 masters
 nodes
+etcd
 # Specify there will be GlusterFS nodes
 glusterfs
 
@@ -38,6 +39,9 @@ master  openshift_schedulable=False
 node0   openshift_schedulable=True
 node1   openshift_schedulable=True
 node2   openshift_schedulable=True
+
+[etcd]
+master
 
 # Specify the glusterfs group, which contains the nodes of the external
 # GlusterFS cluster. At a minimum, each node must have "glusterfs_hostname" 

--- a/inventory/byo/hosts.byo.glusterfs.mixed.example
+++ b/inventory/byo/hosts.byo.glusterfs.mixed.example
@@ -19,6 +19,7 @@
 [OSEv3:children]
 masters
 nodes
+etcd
 # Specify there will be GlusterFS nodes
 glusterfs
 
@@ -41,6 +42,9 @@ master  openshift_schedulable=False
 node0   openshift_schedulable=True
 node1   openshift_schedulable=True
 node2   openshift_schedulable=True
+
+[etcd]
+master
 
 # Specify the glusterfs group, which contains the nodes of the external
 # GlusterFS cluster. At a minimum, each node must have "glusterfs_hostname" 

--- a/inventory/byo/hosts.byo.glusterfs.native.example
+++ b/inventory/byo/hosts.byo.glusterfs.native.example
@@ -16,6 +16,7 @@
 [OSEv3:children]
 masters
 nodes
+etcd
 # Specify there will be GlusterFS nodes
 glusterfs
 
@@ -33,6 +34,9 @@ master  openshift_schedulable=False
 node0   openshift_schedulable=True
 node1   openshift_schedulable=True
 node2   openshift_schedulable=True
+
+[etcd]
+master
 
 # Specify the glusterfs group, which contains the nodes that will host
 # GlusterFS storage pods. At a minimum, each node must have a

--- a/inventory/byo/hosts.byo.glusterfs.registry-only.example
+++ b/inventory/byo/hosts.byo.glusterfs.registry-only.example
@@ -20,6 +20,7 @@
 [OSEv3:children]
 masters
 nodes
+etcd
 # Specify there will be GlusterFS nodes
 glusterfs_registry
 
@@ -39,6 +40,9 @@ master  openshift_schedulable=False
 node0   openshift_node_labels="{'region': 'infra'}" openshift_schedulable=True
 node1   openshift_node_labels="{'region': 'infra'}" openshift_schedulable=True
 node2   openshift_node_labels="{'region': 'infra'}" openshift_schedulable=True
+
+[etcd]
+master
 
 # Specify the glusterfs group, which contains the nodes that will host
 # GlusterFS storage pods. At a minimum, each node must have a

--- a/inventory/byo/hosts.byo.glusterfs.storage-and-registry.example
+++ b/inventory/byo/hosts.byo.glusterfs.storage-and-registry.example
@@ -20,6 +20,7 @@
 [OSEv3:children]
 masters
 nodes
+etcd
 # Specify there will be GlusterFS nodes
 glusterfs
 glusterfs_registry
@@ -45,6 +46,9 @@ node2   openshift_schedulable=True
 node3   openshift_node_labels="{'region': 'infra'}" openshift_schedulable=True
 node4   openshift_node_labels="{'region': 'infra'}" openshift_schedulable=True
 node5   openshift_node_labels="{'region': 'infra'}" openshift_schedulable=True
+
+[etcd]
+master
 
 # Specify the glusterfs group, which contains the nodes that will host
 # GlusterFS storage pods. At a minimum, each node must have a


### PR DESCRIPTION
Add etcd as part of inventory file.
Otherwise, it fails as "Running etcd as an embedded service is no longer supported."

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>