### PR TITLE
Correct groupname during upgrade_control_plane play

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -129,7 +129,7 @@
 
 # All controllers must be stopped at the same time then restarted
 - name: Cycle all controller services to force new leader election mode
-  hosts: oo_etcd_to_config
+  hosts: oo_masters_to_config
   gather_facts: no
   tasks:
   - name: Stop {{ openshift.common.service_type }}-master-controllers


### PR DESCRIPTION
Currently, upgrade_control_plane calls tasks meant for
master on etcd group.

This commit corrects the groupname.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1508734