### PR TITLE
[3.6] Add undefined reg auth variables to node_upgrade role

### DIFF
--- a/roles/openshift_node_upgrade/defaults/main.yml
+++ b/roles/openshift_node_upgrade/defaults/main.yml
@@ -1,2 +1,7 @@
 ---
+# oreg_url is defined by user input
+oreg_host: "{{ oreg_url.split('/')[0] if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"
+oreg_auth_credentials_path: "{{ openshift.common.data_dir }}/.docker"
+oreg_auth_credentials_replace: False
+
 l_bind_docker_reg_auth: False


### PR DESCRIPTION
Currently, several variables are undefined in the node
upgrade role.

This commit adds the necessary default values.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1506896