### PR TITLE
[3.6] 1507934 Move etcd_quota_backend_bytes to etcd_common

### DIFF
--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -8,6 +8,3 @@ etcd_advertise_client_urls: "{{ etcd_url_scheme }}://{{ etcd_ip }}:{{ etcd_clien
 etcd_listen_client_urls: "{{ etcd_url_scheme }}://{{ etcd_ip }}:{{ etcd_client_port }}"
 
 etcd_systemd_dir: "/etc/systemd/system/{{ etcd_service }}.service.d"
-
-# set the backend quota to 4GB by default
-etcd_quota_backend_bytes: 4294967296

--- a/roles/etcd_common/defaults/main.yml
+++ b/roles/etcd_common/defaults/main.yml
@@ -73,3 +73,6 @@ etcd_advertise_client_urls: "{{ etcd_url_scheme }}://{{ etcd_ip }}:{{ etcd_clien
 etcd_listen_client_urls: "{{ etcd_url_scheme }}://{{ etcd_ip }}:{{ etcd_client_port }}"
 
 etcd_systemd_dir: "/etc/systemd/system/{{ etcd_service }}.service.d"
+
+# set the backend quota to 4GB by default
+etcd_quota_backend_bytes: 4294967296


### PR DESCRIPTION
Moves etcd_quota_backend_bytes variable so it is available to both install and upgrade etcd roles.

Fixes 1507934

https://bugzilla.redhat.com/show_bug.cgi?id=1507934