### PR TITLE
Clean up after management install

### DIFF
--- a/playbooks/common/openshift-management/config.yml
+++ b/playbooks/common/openshift-management/config.yml
@@ -9,16 +9,22 @@
         installer_phase_management: "In Progress"
       aggregate: false
 
-- name: Setup CFME
+- name: Setup Management
   hosts: oo_first_master
   pre_tasks:
-  - name: Create a temporary place to evaluate the PV templates
-    command: mktemp -d /tmp/openshift-ansible-XXXXXXX
+  - name: Create a temporary place to store management templates
+    command: mktemp -d /tmp/openshift-management-XXXXXXX
     register: r_openshift_management_mktemp
     changed_when: false
 
+  post_tasks:
+  - name: Cleanup the temporary place for management template storage
+    file:
+      state: absent
+      path: "{{ hostvars[groups.masters.0].r_openshift_management_mktemp.stdout }}"
+
   tasks:
-  - name: Run the CFME Setup Role
+  - name: Run the Management Setup Role
     include_role:
       name: openshift_management
     vars:

--- a/roles/openshift_management/tasks/main.yml
+++ b/roles/openshift_management/tasks/main.yml
@@ -88,6 +88,12 @@
     create: True
     params: "{{ openshift_management_template_parameters }}"
 
+# TODO: Wrap this in a try/catch block thing so we don't destroy
+# installs. Find a way to add it to checkpoint output or something.
+
+# NOTE: If this fails then the post_tasks that run the temp dir
+# cleanup are not run. it would be nice to find a way to fix that.
+
 - name: Wait for the app to come up. May take several minutes, 30s check intervals, 10m max
   command: "oc logs {{ openshift_management_flavor }}-0 -n {{ openshift_management_project }}"
   register: app_seeding_logs

--- a/roles/openshift_management/tasks/uninstall.yml
+++ b/roles/openshift_management/tasks/uninstall.yml
@@ -14,7 +14,7 @@
 - name: Remove the project
   command: "oc delete -n {{ openshift_management_project }} project {{ openshift_management_project }}"
 
-- name: Verify project has been destroyed
+- name: Verify project has been destroyed, 3s check intervals, 90s max
   command: "oc get project {{ openshift_management_project }}"
   ignore_errors: True
   register: project_terminated


### PR DESCRIPTION
We forgot to clean up the temporary directory after installation. This
results in garbage left on the remote hosts.

* Add post_tasks block to management install which removes the temp
  dir created in the pre_tasks block

Also clean up some lingering documentation product references/task names