### PR TITLE
Initial Kuryr Ports Pool Support

### DIFF
--- a/roles/kuryr/README.md
+++ b/roles/kuryr/README.md
@@ -31,6 +31,11 @@ pods. This allows to have interconnectivity between pods and OpenStack VMs.
 * ``kuryr_openstack_pod_service_id=service_subnet_uuid``
 * ``kuryr_openstack_pod_project_id=pod_project_uuid``
 * ``kuryr_openstack_worker_nodes_subnet_id=worker_nodes_subnet_uuid``
+* ``kuryr_openstack_enable_pools=True``
+* ``kuryr_openstack_pool_max=0``
+* ``kuryr_openstack_pool_min=1``
+* ``kuryr_openstack_pool_batch=5``
+* ``kuryr_openstack_pool_update_frequency=20``
 
 ## Kuryr resources
 

--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -161,6 +161,14 @@ data:
     # The driver that provides VIFs for Kubernetes Pods. (string value)
     pod_vif_driver = nested-vlan
 
+    # The driver that manages VIFs pools for Kubernetes Pods (string value)
+    vif_pool_driver = {{ kuryr_openstack_enable_pools | default(False) | ternary('nested', 'noop') }}
+
+    [vif_pool]
+    ports_pool_max = {{ kuryr_openstack_pool_max | default(0) }}
+    ports_pool_min = {{ kuryr_openstack_pool_min | default(1) }}
+    ports_pool_batch = {{ kuryr_openstack_pool_batch | default(5) }}
+    ports_pool_update_frequency = {{ kuryr_openstack_pool_update_frequency | default(20) }}
 
     [neutron]
     # Configuration options for OpenStack Neutron


### PR DESCRIPTION
This commits enables the ports pool driver when deploying kuryr
networking on top of OpenShift in containers. It also exposes
some configuration options such as the maximum and minimum pool
sizes, as well as the bulk subports creation size and the time
between pools update actions.