### PR TITLE
Add support for hostpath persistent volume definitions

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -487,6 +487,14 @@ debug_level=2
 #openshift_hosted_registry_storage_openstack_volumeID=3a650b4f-c8c5-4e0a-8ca5-eaee11f16c57
 #openshift_hosted_registry_storage_volume_size=10Gi
 #
+# hostPath (local filesystem storage)
+# Suitable for "all-in-one" or proof of concept deployments
+# Must not be used for high-availability and production deployments
+#openshift_hosted_registry_storage_kind=hostpath
+#openshift_hosted_registry_storage_access_modes=['ReadWriteOnce']
+#openshift_hosted_registry_storage_hostpath_path=/var/lib/openshift_volumes
+#openshift_hosted_registry_storage_volume_size=10Gi
+#
 # AWS S3
 # S3 bucket must already exist.
 #openshift_hosted_registry_storage_kind=object

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -55,8 +55,10 @@ openshift_hosted_registry_storage_glusterfs_readOnly: False
 openshift_hosted_registry_storage_glusterfs_swap: False
 openshift_hosted_registry_storage_glusterfs_swapcopy: True
 openshift_hosted_registry_storage_glusterfs_ips: []
+openshift_hosted_registry_storage_hostpath_path: /var/lib/openshift_volumes
+# Default to ReadWriteOnce if using hostpath, else default to ReadWriteMany
 openshift_hosted_registry_storage_access_modes:
-  - 'ReadWriteMany'
+  - "{{ (openshift_hosted_registry_storage_kind == 'hostpath') | ternary('ReadWriteOnce', 'ReadWriteMany') }}"
 
 openshift_logging_storage_nfs_directory: '/exports'
 openshift_logging_storage_nfs_options: '*(rw,root_squash)'

--- a/roles/openshift_hosted/tasks/registry.yml
+++ b/roles/openshift_hosted/tasks/registry.yml
@@ -77,7 +77,7 @@
       type: persistentVolumeClaim
       claim_name: "{{ openshift_hosted_registry_storage_volume_name }}-claim"
   when:
-  - openshift_hosted_registry_storage_kind | default(none) in ['nfs', 'openstack', 'glusterfs', 'vsphere']
+  - openshift_hosted_registry_storage_kind | default(none) in ['nfs', 'glusterfs', 'hostpath', 'openstack', 'vsphere']
 
 - include_tasks: storage/glusterfs_endpoints.yml
   when:
@@ -96,3 +96,7 @@
     volume_mounts: "{{ openshift_hosted_registry_volumes }}"
     edits: "{{ openshift_hosted_registry_edits }}"
     force: "{{ True|bool in openshift_hosted_registry_force }}"
+
+- include_tasks: storage/hostpath.yml
+  when:
+  - openshift_hosted_registry_storage_kind | default(none) in ['hostpath']

--- a/roles/openshift_hosted/tasks/storage/hostpath.yml
+++ b/roles/openshift_hosted/tasks/storage/hostpath.yml
@@ -1,0 +1,31 @@
+---
+- name: Get registry DeploymentConfig
+  oc_obj:
+    namespace: "{{ openshift_hosted_registry_namespace }}"
+    state: list
+    kind: dc
+    name: "{{ openshift_hosted_registry_name }}"
+  register: registry_dc
+
+- name: Wait for registry pods
+  oc_obj:
+    namespace: "{{ openshift_hosted_registry_namespace }}"
+    state: list
+    kind: pod
+    selector: "{% for label, value in registry_dc.results.results[0].spec.selector.items() %}{{ label }}={{ value }}{% if not loop.last %},{% endif %}{% endfor %}"
+  register: registry_pods
+  until:
+  - "registry_pods.results.results[0]['items'] | count > 0"
+  # There must be as many matching pods with 'Ready' status True as there are expected replicas
+  - "registry_pods.results.results[0]['items'] | lib_utils_oo_collect(attribute='status.conditions') | lib_utils_oo_collect(attribute='status', filters={'type': 'Ready'}) | map('bool') | select | list | count == openshift_hosted_registry_replicas | int"
+  delay: 10
+  retries: 60
+
+# https://docs.openshift.com/container-platform/3.9/install_config/registry/deploy_registry_existing_clusters.html#registry-non-production-use
+- name: Ensure permissions on the hostpath match the pod configuration
+  file:
+    path: "{{ openshift_hosted_registry_storage_hostpath_path }}"
+    state: directory
+    owner: "{{ registry_pods.results.results[0]['items'][0].spec.containers[0].securityContext.runAsUser }}"
+    group: "{{ registry_pods.results.results[0]['items'][0].spec.securityContext.fsGroup }}"
+    mode: "2750"


### PR DESCRIPTION
hostpath volumes [1] mount a file or directory from the host node’s
filesystem into a pod. This adds support for declaring a hostPath
volume as a persistent volume and do a persistent volume claim for
one for the hosted registry.

[1]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath