### PR TITLE
Fix preupgrade authorization objects are in sync

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_7/validator.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/validator.yml
@@ -15,7 +15,7 @@
   - name: Confirm OpenShift authorization objects are in sync
     command: >
       {{ openshift.common.client_binary }} adm migrate authorization
-    when: openshift_version | version_compare('3.7','<')
+    when: openshift_upgrade_target | version_compare('3.8','<')
     changed_when: false
     register: l_oc_result
     until: l_oc_result.rc == 0


### PR DESCRIPTION
Currently, this task is executed based on openshift_version.

openshift_version is based on the upgrade target, thus not
the currently install versions.

This commit ensures that the task executes as intended.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1508301