### PR TITLE
Bug 1509680- Fix ansible-service-broker registry settings/validations 

### DIFF
--- a/roles/ansible_service_broker/defaults/main.yml
+++ b/roles/ansible_service_broker/defaults/main.yml
@@ -14,3 +14,4 @@ ansible_service_broker_launch_apb_on_bind: false
 ansible_service_broker_image_pull_policy: IfNotPresent
 ansible_service_broker_sandbox_role: edit
 ansible_service_broker_auto_escalate: false
+ansible_service_broker_local_registry_whitelist: []

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -312,6 +312,9 @@
                 org:  {{ ansible_service_broker_registry_organization }}
                 tag:  {{ ansible_service_broker_registry_tag }}
                 white_list: {{ ansible_service_broker_registry_whitelist }}
+              - type: local_registry
+                namespaces: ['openshift']
+                white_list: {{ ansible_service_broker_local_registry_whitelist }}
             dao:
               etcd_host: 0.0.0.0
               etcd_port: 2379

--- a/roles/ansible_service_broker/tasks/validate_facts.yml
+++ b/roles/ansible_service_broker/tasks/validate_facts.yml
@@ -1,11 +1,9 @@
 ---
 - name: validate Dockerhub registry settings
-  fail: msg="To use the dockerhub registry, you must provide the ansible_service_broker_registry_user. ansible_service_broker_registry_password, and ansible_service_broker_registry_organization parameters"
+  fail: msg="To use the dockerhub registry, you must provide the ansible_service_broker_registry_organization"
   when:
     - ansible_service_broker_registry_type == 'dockerhub'
-    - not (ansible_service_broker_registry_user and
-        ansible_service_broker_registry_password and
-        ansible_service_broker_registry_organization)
+    - not ansible_service_broker_registry_organization
 
 
 - name: validate RHCC registry settings

--- a/roles/ansible_service_broker/vars/default_images.yml
+++ b/roles/ansible_service_broker/vars/default_images.yml
@@ -12,6 +12,6 @@ __ansible_service_broker_registry_name: dh
 __ansible_service_broker_registry_url: null
 __ansible_service_broker_registry_user: null
 __ansible_service_broker_registry_password: null
-__ansible_service_broker_registry_organization: null
+__ansible_service_broker_registry_organization: ansibleplaybookbundle
 __ansible_service_broker_registry_tag: latest
 __ansible_service_broker_registry_whitelist: []


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1509680

- Remove outdated dockerhub registry validations
- Add the local openshift registry by default
  - Add whitelist parameter for local registry
- Set default dockerhub org to ansibleplaybookbundle