### PR TITLE
container-engine: ensure /var/lib/containers/ is properly labelled

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -25,6 +25,15 @@
     - not l_use_system_container
     - not l_use_crio_only
 
+- name: Ensure /var/lib/containers exists
+  file:
+    path: /var/lib/containers
+    state: directory
+
+- name: Fix SELinux Permissions on /var/lib/containers
+  command: "restorecon -R /var/lib/containers/"
+  changed_when: false
+
 - name: Use System Container Docker if Requested
   include: systemcontainer_docker.yml
   when:

--- a/roles/docker/tasks/systemcontainer_crio.yml
+++ b/roles/docker/tasks/systemcontainer_crio.yml
@@ -170,10 +170,6 @@
     dest: /etc/cni/net.d/openshift-sdn.conf
     src: 80-openshift-sdn.conf.j2
 
-- name: Fix SELinux Permissions on /var/lib/containers
-  command: "restorecon -R /var/lib/containers/"
-  changed_when: false
-
 - name: Start the CRI-O service
   systemd:
     name: "cri-o"


### PR DESCRIPTION
we were doing it only when CRI-O is installed.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1509880

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>