### PR TITLE
Temporarily set master servingInfo.clientCA as client-ca-bundle.crt during rolling CA redeployment.

### DIFF
--- a/playbooks/byo/openshift-cluster/redeploy-certificates.yml
+++ b/playbooks/byo/openshift-cluster/redeploy-certificates.yml
@@ -42,3 +42,7 @@
 
 - include: ../../common/openshift-cluster/redeploy-certificates/registry.yml
   when: openshift_hosted_manage_registry | default(true) | bool
+
+- include: ../../common/openshift-master/revert-client-ca.yml
+
+- include: ../../common/openshift-master/restart.yml

--- a/playbooks/common/openshift-cluster/redeploy-certificates/openshift-ca.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/openshift-ca.yml
@@ -43,11 +43,6 @@
     when: (g_master_config_output.content|b64decode|from_yaml).oauthConfig.masterCA != 'ca-bundle.crt'
   - modify_yaml:
       dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
-      yaml_key: servingInfo.clientCA
-      yaml_value: ca.crt
-    when: (g_master_config_output.content|b64decode|from_yaml).servingInfo.clientCA != 'ca.crt'
-  - modify_yaml:
-      dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
       yaml_key: etcdClientInfo.ca
       yaml_value: ca-bundle.crt
     when:
@@ -67,6 +62,13 @@
     when:
     - groups.oo_etcd_to_config | default([]) | length == 0
     - (g_master_config_output.content|b64decode|from_yaml).etcdConfig.servingInfo.clientCA != 'ca-bundle.crt'
+  # Set servingInfo.clientCA to client-ca-bundle.crt in order to roll the CA certificate.
+  # This change will be reverted in playbooks/byo/openshift-cluster/redeploy-certificates.yml
+  - modify_yaml:
+      dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      yaml_key: servingInfo.clientCA
+      yaml_value: client-ca-bundle.crt
+    when: (g_master_config_output.content|b64decode|from_yaml).servingInfo.clientCA != 'client-ca-bundle.crt'
 
 - name: Copy current OpenShift CA to legacy directory
   hosts: oo_masters_to_config
@@ -155,6 +157,7 @@
     - ca.key
     - ca-bundle.crt
     - ca.serial.txt
+    - client-ca-bundle.crt
     delegate_to: "{{ openshift_ca_host }}"
     run_once: true
     changed_when: false
@@ -173,6 +176,7 @@
     - ca.key
     - ca-bundle.crt
     - ca.serial.txt
+    - client-ca-bundle.crt
   - name: Update master client kubeconfig CA data
     kubeclient_ca:
       client_path: "{{ openshift.common.config_base }}/master/openshift-master.kubeconfig"

--- a/playbooks/common/openshift-master/revert-client-ca.yml
+++ b/playbooks/common/openshift-master/revert-client-ca.yml
@@ -1,0 +1,17 @@
+---
+- name: Set servingInfo.clientCA = ca.crt in master config
+  hosts: oo_masters_to_config
+  tasks:
+  - name: Read master config
+    slurp:
+      src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+    register: g_master_config_output
+
+  # servingInfo.clientCA may be set as the client-ca-bundle.crt from
+  # CA redeployment and this task reverts that change.
+  - name: Set servingInfo.clientCA = ca.crt in master config
+    modify_yaml:
+      dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      yaml_key: servingInfo.clientCA
+      yaml_value: ca.crt
+    when: (g_master_config_output.content|b64decode|from_yaml).servingInfo.clientCA != 'ca.crt'

--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -106,6 +106,36 @@
   delegate_to: "{{ openshift_ca_host }}"
   run_once: true
 
+# Create client-ca-bundle.crt containing old and new OpenShift CA
+# certificates. This bundle will be used when rolling the OpenShift CA
+# certificate.
+- name: Create client-ca-bundle.crt
+  block:
+  - command: mktemp -d /tmp/openshift-ansible-XXXXXX
+    register: openshift_ca_clientconfig_tmpdir
+    delegate_to: "{{ openshift_ca_host }}"
+  - copy:
+      src: "{{ item }}"
+      dest: "{{ openshift_ca_clientconfig_tmpdir.stdout }}/"
+      remote_src: true
+    with_items: "{{ g_master_legacy_ca_result.files | default([]) | oo_collect('path') }}"
+    delegate_to: "{{ openshift_ca_host }}"
+    run_once: true
+  - copy:
+      src: "{{ openshift_ca_config_dir }}/ca.crt"
+      dest: "{{ openshift_ca_clientconfig_tmpdir.stdout }}/"
+      remote_src: true
+    delegate_to: "{{ openshift_ca_host }}"
+    run_once: true
+  - assemble:
+      src: "{{ openshift_ca_clientconfig_tmpdir.stdout }}"
+      dest: "{{ openshift_ca_config_dir }}/client-ca-bundle.crt"
+      mode: 0644
+      owner: root
+      group: root
+    delegate_to: "{{ openshift_ca_host }}"
+    run_once: true
+
 - name: Test local loopback context
   command: >
     {{ hostvars[openshift_ca_host].openshift.common.client_binary }} config view

--- a/roles/openshift_master_facts/filter_plugins/openshift_master.py
+++ b/roles/openshift_master_facts/filter_plugins/openshift_master.py
@@ -510,7 +510,7 @@ class FilterModule(object):
                  'master.kubelet-client.crt',
                  'master.kubelet-client.key']
         if bool(include_ca):
-            certs += ['ca.crt', 'ca.key', 'ca-bundle.crt']
+            certs += ['ca.crt', 'ca.key', 'ca-bundle.crt', 'client-ca-bundle.crt']
         if bool(include_keys):
             certs += ['serviceaccounts.private.key',
                       'serviceaccounts.public.key']


### PR DESCRIPTION
This PR temporarily configures master `servingInfo.clientCA` as `client-ca-bundle.crt` during CA redeploy so that clients referencing the old OpenShift CA can continue to function until all cluster certificates have been replaced and `servingInfo.clientCA` is reset to `ca.crt`.

`client-ca-bundle.crt` is a new bundle created by the `openshift_ca` role which contains old and new OpenShift CA certificates.

https://bugzilla.redhat.com/show_bug.cgi?id=1509124

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1493276