### PR TITLE
Give service-catalog controller-manager permissions to update status of ClusterServiceClasses and ClusterServicePlans

### DIFF
--- a/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
+++ b/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
@@ -118,6 +118,8 @@ objects:
     - servicecatalog.k8s.io
     resources:
     - clusterservicebrokers/status
+    - clusterserviceclasses/status
+    - clusterserviceplans/status
     - serviceinstances/status
     - servicebindings/status
     - servicebindings/finalizers


### PR DESCRIPTION
Add to ClusterRole service-catalog-controller permissions to perform updates on clusterserviceclasses/status and clusterserviceplans/status.