### PR TITLE
Fix prometheus default vars

### DIFF
--- a/roles/openshift_prometheus/tasks/main.yaml
+++ b/roles/openshift_prometheus/tasks/main.yaml
@@ -2,19 +2,8 @@
 - name: Set default image variables based on deployment_type
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
+    - "{{ openshift_deployment_type }}.yml"
     - "default_images.yml"
-
-- name: Set image facts
-  set_fact:
-    openshift_prometheus_image_prefix: "{{ openshift_prometheus_image_prefix | default(__openshift_prometheus_image_prefix) }}"
-    openshift_prometheus_image_version: "{{ openshift_prometheus_image_version | default(__openshift_prometheus_image_version) }}"
-    openshift_prometheus_proxy_image_prefix: "{{ openshift_prometheus_proxy_image_prefix | default(openshift_prometheus_image_prefix) }}"
-    openshift_prometheus_proxy_image_version: "{{ openshift_prometheus_proxy_image_version | default(__openshift_prometheus_proxy_image_version) }}"
-    openshift_prometheus_alertmanager_image_prefix: "{{ openshift_prometheus_altermanager_image_prefix | default(openshift_prometheus_image_prefix) }}"
-    openshift_prometheus_alertmanager_image_version: "{{ openshift_prometheus_alertmanager_image_version | default(__openshift_prometheus_alertmanager_image_version) }}"
-    openshift_prometheus_alertbuffer_image_prefix: "{{ openshift_prometheus_alertbuffer_image_prefix | default(openshift_prometheus_image_prefix) }}"
-    openshift_prometheus_alertbuffer_image_version: "{{ openshift_prometheus_alertbuffer_image_version | default(__openshift_prometheus_alertbuffer_image_version) }}"
 
 - name: Create temp directory for doing work in on target
   command: mktemp -td openshift-prometheus-ansible-XXXXXX

--- a/roles/openshift_prometheus/templates/prometheus.j2
+++ b/roles/openshift_prometheus/templates/prometheus.j2
@@ -23,28 +23,28 @@ spec:
 {% if openshift_prometheus_node_selector is iterable and openshift_prometheus_node_selector | length > 0 %}
       nodeSelector:
 {% for key, value in openshift_prometheus_node_selector.iteritems() %}
-        {{key}}: "{{value}}"
+        {{ key }}: "{{ value }}"
 {% endfor %}
 {% endif %}
       containers:
       # Deploy Prometheus behind an oauth proxy
       - name: prom-proxy
-        image: "{{openshift_prometheus_proxy_image_prefix}}oauth-proxy:{{openshift_prometheus_proxy_image_version}}"
+        image: "{{ l_openshift_prometheus_proxy_image_prefix }}oauth-proxy:{{ l_openshift_prometheus_proxy_image_version }}"
         imagePullPolicy: IfNotPresent
         resources:
           requests:
 {% if openshift_prometheus_oauth_proxy_memory_requests is defined and openshift_prometheus_oauth_proxy_memory_requests is not none %}
-            memory: "{{openshift_prometheus_oauth_proxy_memory_requests}}"
+            memory: "{{ openshift_prometheus_oauth_proxy_memory_requests }}"
 {% endif %}
 {% if openshift_prometheus_oauth_proxy_cpu_requests is defined and openshift_prometheus_oauth_proxy_cpu_requests is not none %}
-            cpu: "{{openshift_prometheus_oauth_proxy_cpu_requests}}"
+            cpu: "{{ openshift_prometheus_oauth_proxy_cpu_requests }}"
 {% endif %}
           limits:
 {% if openshift_prometheus_oauth_proxy_memory_limit is defined and openshift_prometheus_oauth_proxy_memory_limit is not none %}
-            memory: "{{openshift_prometheus_oauth_proxy_memory_limit}}"
+            memory: "{{ openshift_prometheus_oauth_proxy_memory_limit }}"
 {% endif %}
 {% if openshift_prometheus_oauth_proxy_cpu_limit is defined and openshift_prometheus_oauth_proxy_cpu_limit is not none %}
-            cpu: "{{openshift_prometheus_oauth_proxy_cpu_limit}}"
+            cpu: "{{ openshift_prometheus_oauth_proxy_cpu_limit }}"
 {% endif %}
         ports:
         - containerPort: 8443
@@ -79,22 +79,22 @@ spec:
         - --storage.tsdb.min-block-duration=2m
         - --config.file=/etc/prometheus/prometheus.yml
         - --web.listen-address=localhost:9090
-        image: "{{openshift_prometheus_image_prefix}}prometheus:{{openshift_prometheus_image_version}}"
+        image: "{{ l_openshift_prometheus_image_prefix }}prometheus:{{ l_openshift_prometheus_image_version }}"
         imagePullPolicy: IfNotPresent
         resources:
           requests:
 {% if openshift_prometheus_memory_requests is defined and openshift_prometheus_memory_requests is not none %}
-            memory: "{{openshift_prometheus_memory_requests}}"
+            memory: "{{ openshift_prometheus_memory_requests }}"
 {% endif %}
 {% if openshift_prometheus_cpu_requests is defined and openshift_prometheus_cpu_requests is not none %}
-            cpu: "{{openshift_prometheus_cpu_requests}}"
+            cpu: "{{ openshift_prometheus_cpu_requests }}"
 {% endif %}
           limits:
 {% if openshift_prometheus_memory_limit is defined and openshift_prometheus_memory_limit is not none %}
             memory: "{{ openshift_prometheus_memory_limit }}"
 {% endif %}
 {% if openshift_prometheus_cpu_limit is defined and openshift_prometheus_cpu_limit is not none %}
-            cpu: "{{openshift_prometheus_cpu_limit}}"
+            cpu: "{{ openshift_prometheus_cpu_limit }}"
 {% endif %}
 
         volumeMounts:
@@ -105,22 +105,22 @@ spec:
 
       # Deploy alertmanager behind prometheus-alert-buffer behind an oauth proxy
       - name: alerts-proxy
-        image: "{{openshift_prometheus_proxy_image_prefix}}oauth-proxy:{{openshift_prometheus_proxy_image_version}}"
+        image: "{{ l_openshift_prometheus_proxy_image_prefix }}oauth-proxy:{{ l_openshift_prometheus_proxy_image_version }}"
         imagePullPolicy: IfNotPresent
         resources:
           requests:
 {% if openshift_prometheus_oauth_proxy_memory_requests is defined and openshift_prometheus_oauth_proxy_memory_requests is not none %}
-            memory: "{{openshift_prometheus_oauth_proxy_memory_requests}}"
+            memory: "{{ openshift_prometheus_oauth_proxy_memory_requests }}"
 {% endif %}
 {% if openshift_prometheus_oauth_proxy_cpu_requests is defined and openshift_prometheus_oauth_proxy_cpu_requests is not none %}
-            cpu: "{{openshift_prometheus_oauth_proxy_cpu_requests}}"
+            cpu: "{{ openshift_prometheus_oauth_proxy_cpu_requests }}"
 {% endif %}
           limits:
 {% if openshift_prometheus_oauth_proxy_memory_limit is defined and openshift_prometheus_oauth_proxy_memory_limit is not none %}
-            memory: "{{openshift_prometheus_oauth_proxy_memory_limit}}"
+            memory: "{{ openshift_prometheus_oauth_proxy_memory_limit }}"
 {% endif %}
 {% if openshift_prometheus_oauth_proxy_cpu_limit is defined and openshift_prometheus_oauth_proxy_cpu_limit is not none %}
-            cpu: "{{openshift_prometheus_oauth_proxy_cpu_limit}}"
+            cpu: "{{ openshift_prometheus_oauth_proxy_cpu_limit }}"
 {% endif %}
         ports:
         - containerPort: 9443
@@ -149,22 +149,22 @@ spec:
       - name: alert-buffer
         args:
         - --storage-path=/alert-buffer/messages.db
-        image: "{{openshift_prometheus_alertbuffer_image_prefix}}prometheus-alert-buffer:{{openshift_prometheus_alertbuffer_image_version}}"
+        image: "{{ l_openshift_prometheus_alertbuffer_image_prefix }}prometheus-alert-buffer:{{ l_openshift_prometheus_alertbuffer_image_version }}"
         imagePullPolicy: IfNotPresent
         resources:
           requests:
 {% if openshift_prometheus_alertbuffer_memory_requests is defined and openshift_prometheus_alertbuffer_memory_requests is not none %}
-            memory: "{{openshift_prometheus_alertbuffer_memory_requests}}"
+            memory: "{{ openshift_prometheus_alertbuffer_memory_requests }}"
 {% endif %}
 {% if openshift_prometheus_alertbuffer_cpu_requests is defined and openshift_prometheus_alertbuffer_cpu_requests is not none %}
-            cpu: "{{openshift_prometheus_alertbuffer_cpu_requests}}"
+            cpu: "{{ openshift_prometheus_alertbuffer_cpu_requests }}"
 {% endif %}
           limits:
 {% if openshift_prometheus_alertbuffer_memory_limit is defined and openshift_prometheus_alertbuffer_memory_limit is not none %}
-            memory: "{{openshift_prometheus_alertbuffer_memory_limit}}"
+            memory: "{{ openshift_prometheus_alertbuffer_memory_limit }}"
 {% endif %}
 {% if openshift_prometheus_alertbuffer_cpu_limit is defined and openshift_prometheus_alertbuffer_cpu_limit is not none %}
-            cpu: "{{openshift_prometheus_alertbuffer_cpu_limit}}"
+            cpu: "{{ openshift_prometheus_alertbuffer_cpu_limit }}"
 {% endif %}
         volumeMounts:
         - mountPath: /alert-buffer
@@ -176,22 +176,22 @@ spec:
       - name: alertmanager
         args:
         - -config.file=/etc/alertmanager/alertmanager.yml
-        image: "{{openshift_prometheus_alertmanager_image_prefix}}prometheus-alertmanager:{{openshift_prometheus_alertmanager_image_version}}"
+        image: "{{ l_openshift_prometheus_alertmanager_image_prefix }}prometheus-alertmanager:{{ l_openshift_prometheus_alertmanager_image_version }}"
         imagePullPolicy: IfNotPresent
         resources:
           requests:
 {% if openshift_prometheus_alertmanager_memory_requests is defined and openshift_prometheus_alertmanager_memory_requests is not none %}
-            memory: "{{openshift_prometheus_alertmanager_memory_requests}}"
+            memory: "{{ openshift_prometheus_alertmanager_memory_requests }}"
 {% endif %}
 {% if openshift_prometheus_alertmanager_cpu_requests is defined and openshift_prometheus_alertmanager_cpu_requests is not none %}
-            cpu: "{{openshift_prometheus_alertmanager_cpu_requests}}"
+            cpu: "{{ openshift_prometheus_alertmanager_cpu_requests }}"
 {% endif %}
           limits:
 {% if openshift_prometheus_alertmanager_memory_limit is defined and openshift_prometheus_alertmanager_memory_limit is not none %}
-            memory: "{{openshift_prometheus_alertmanager_memory_limit}}"
+            memory: "{{ openshift_prometheus_alertmanager_memory_limit }}"
 {% endif %}
 {% if openshift_prometheus_alertmanager_cpu_limit is defined and openshift_prometheus_alertmanager_cpu_limit is not none %}
-            cpu: "{{openshift_prometheus_alertmanager_cpu_limit}}"
+            cpu: "{{ openshift_prometheus_alertmanager_cpu_limit }}"
 {% endif %}
         ports:
         - containerPort: 9093

--- a/roles/openshift_prometheus/vars/default_images.yml
+++ b/roles/openshift_prometheus/vars/default_images.yml
@@ -1,7 +1,12 @@
 ---
-# image defaults
-__openshift_prometheus_image_prefix: "openshift/"
-__openshift_prometheus_image_version: "v2.0.0-dev.3"
-__openshift_prometheus_proxy_image_version: "v1.0.0"
-__openshift_prometheus_alertmanager_image_version: "v0.9.1"
-__openshift_prometheus_alertbuffer_image_version: "v0.0.2"
+# image prefix defaults
+l_openshift_prometheus_image_prefix: "{{ openshift_prometheus_image_prefix | default('openshift/') }}"
+l_openshift_prometheus_proxy_image_prefix: "{{ openshift_prometheus_proxy_image_prefix | default(l_openshift_prometheus_image_prefix) }}"
+l_openshift_prometheus_alertmanager_image_prefix: "{{ openshift_prometheus_altermanager_image_prefix | default(l_openshift_prometheus_image_prefix) }}"
+l_openshift_prometheus_alertbuffer_image_prefix: "{{ openshift_prometheus_alertbuffer_image_prefix | default(l_openshift_prometheus_image_prefix) }}"
+
+# image version defaults
+l_openshift_prometheus_image_version: "{{ openshift_prometheus_image_version | default('v2.0.0-dev.3') }}"
+l_openshift_prometheus_proxy_image_version: "{{ openshift_prometheus_proxy_image_version | default('v1.0.0') }}"
+l_openshift_prometheus_alertmanager_image_version: "{{ openshift_prometheus_alertmanager_image_version | default('v0.9.1') }}"
+l_openshift_prometheus_alertbuffer_image_version: "{{ openshift_prometheus_alertbuffer_image_version | default('v0.0.2') }}"

--- a/roles/openshift_prometheus/vars/openshift-enterprise.yml
+++ b/roles/openshift_prometheus/vars/openshift-enterprise.yml
@@ -1,7 +1,12 @@
 ---
-# image defaults
-__openshift_prometheus_image_prefix: "registry.access.redhat.com/openshift3/"
-__openshift_prometheus_image_version: "v3.7"
-__openshift_prometheus_proxy_image_version: "v3.7"
-__openshift_prometheus_alertmanager_image_version: "v3.7"
-__openshift_prometheus_alertbuffer_image_version: "v3.7"
+# image prefix defaults
+l_openshift_prometheus_image_prefix: "{{ openshift_prometheus_image_prefix | default('registry.access.redhat.com/openshift3/') }}"
+l_openshift_prometheus_proxy_image_prefix: "{{ openshift_prometheus_proxy_image_prefix | default(l_openshift_prometheus_image_prefix) }}"
+l_openshift_prometheus_alertmanager_image_prefix: "{{ openshift_prometheus_altermanager_image_prefix | default(l_openshift_prometheus_image_prefix) }}"
+l_openshift_prometheus_alertbuffer_image_prefix: "{{ openshift_prometheus_alertbuffer_image_prefix | default(l_openshift_prometheus_image_prefix) }}"
+
+# image version defaults
+l_openshift_prometheus_image_version: "{{ openshift_prometheus_image_version | default('v3.7') }}"
+l_openshift_prometheus_proxy_image_version: "{{ openshift_prometheus_proxy_image_version | default('v3.7') }}"
+l_openshift_prometheus_alertmanager_image_version: "{{ openshift_prometheus_alertmanager_image_version | default('v3.7') }}"
+l_openshift_prometheus_alertbuffer_image_version: "{{ openshift_prometheus_alertbuffer_image_version | default('v3.7') }}"


### PR DESCRIPTION
Currently, prometheus role tries to set some defaults depending
on openshift_deployment_type.

This commit simplifies that logic.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1509782