### PR TITLE
add quote to values in /etc/sysconfig/atomic-openshift-node

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -40,7 +40,7 @@
   lineinfile:
     dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
     regexp: "^{{ item.key }}="
-    line: "{{ item.key }}={{ item.value }}"
+    line: "{{ item.key }}=\"{{ item.value }}\""
     create: true
   with_dict: "{{ openshift.node.env_vars | default({}) }}"
   notify:


### PR DESCRIPTION
In the containerized installation, values configured in
`/etc/sysconfig/atomic-openshift-node` are used as environmental
variables from `EnvironmentFile=` in
`/etc/systemd/system/atomic-openshift-node.service`. Therfore, if
configuration has multiple values with space like:


~~~
OPTIONS=--loglevel=3 --disable=proxy
~~~

importing the env variables fails. This patch add the double quote
(`""`) to each variables.

You can reproduce the issue with following steps:

1. Setting In /etc/sysconfig/atomic-openshift-node
~~~
OPTIONS=--loglevel=3 --disable=proxy
~~~

2. import the env variables (and fail)

~~~
# source /etc/sysconfig/atomic-openshift-node
-bash: --disable=proxy: command not found
~~~