### PR TITLE
Re-add challenge auth verification to github and google

### DIFF
--- a/roles/openshift_master_facts/filter_plugins/openshift_master.py
+++ b/roles/openshift_master_facts/filter_plugins/openshift_master.py
@@ -426,6 +426,12 @@ class GoogleIdentityProvider(IdentityProviderOauthBase):
         IdentityProviderOauthBase.__init__(self, api_version, idp)
         self._optional += [['hostedDomain', 'hosted_domain']]
 
+    def validate(self):
+        ''' validate this idp instance '''
+        if self.challenge:
+            raise errors.AnsibleFilterError("|failed provider {0} does not "
+                                            "allow challenge authentication".format(self.__class__.__name__))
+
 
 class GitHubIdentityProvider(IdentityProviderOauthBase):
     """ GitHubIdentityProvider
@@ -443,6 +449,12 @@ class GitHubIdentityProvider(IdentityProviderOauthBase):
         IdentityProviderOauthBase.__init__(self, api_version, idp)
         self._optional += [['organizations'],
                            ['teams']]
+
+    def validate(self):
+        ''' validate this idp instance '''
+        if self.challenge:
+            raise errors.AnsibleFilterError("|failed provider {0} does not "
+                                            "allow challenge authentication".format(self.__class__.__name__))
 
 
 class FilterModule(object):


### PR DESCRIPTION
Recent commit removed these checks.  These two auth providers
are specifically excluded in origin, thus we should enable
the checks to ensure challenge auth is not enabled for these
providers.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1444367