### PR TITLE
Remove remaining haproxy files with uninstallation

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -525,3 +525,7 @@
     with_items:
     - /etc/ansible/facts.d/openshift.fact
     - /var/lib/haproxy/stats
+    # Here we remove only limits.conf rather than directory, as users may put their files.
+    # - /etc/systemd/system/haproxy.service.d
+    - /etc/systemd/system/haproxy.service.d/limits.conf
+    - /etc/systemd/system/haproxy.service


### PR DESCRIPTION
Although OpenShift LB(HAProxy) distributes
`/etc/systemd/system/haproxy.service.d/limits.conf` and
`/etc/systemd/system/haproxy.service`, uninstall playbook does not
remove them now.

This patch changes to remove these files.