### PR TITLE
Change prometheus default namespace to 'openshift-metrics'

### DIFF
--- a/roles/openshift_prometheus/defaults/main.yaml
+++ b/roles/openshift_prometheus/defaults/main.yaml
@@ -2,7 +2,7 @@
 # defaults file for openshift_prometheus
 openshift_prometheus_state: present
 
-openshift_prometheus_namespace: prometheus
+openshift_prometheus_namespace: openshift-metrics
 
 openshift_prometheus_node_selector: {"region":"infra"}
 


### PR DESCRIPTION
Changing default namespace from 'prometheus' to 'openshift-metrics'
issue: https://github.com/openshift/openshift-ansible/issues/6058