### PR TITLE
Add readiness probe to kuryr controller pod

### DIFF
--- a/roles/kuryr/templates/controller-deployment.yaml.j2
+++ b/roles/kuryr/templates/controller-deployment.yaml.j2
@@ -22,6 +22,13 @@ spec:
       - image: kuryr/controller:latest
         imagePullPolicy: IfNotPresent
         name: controller
+{% if kuryr_openstack_enable_pools | default(false) %}
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/pools_loaded
+{% endif %}
         terminationMessagePath: "/dev/termination-log"
         # FIXME(dulek): This shouldn't be required, but without it selinux is
         #               complaining about access to kuryr.conf.


### PR DESCRIPTION
This commits adds a readiness probe to the kuryr controller
when the kuryr ports pool functionality is enabled. This way
the controller will not be set as ready until all the pre-created
ports have been loaded into their respective pools and are ready
to be used by the pods.