### PR TITLE
Fix preupgrade authorization objects are in sync minor versions

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -9,7 +9,12 @@
 
 - name: Ensure firewall is not switched during upgrade
   hosts: oo_all_hosts
+  vars:
+    openshift_master_installed_version: "{{ hostvars[groups.oo_first_master.0].openshift.common.version }}"
   tasks:
+  - name: set currently installed version
+    set_fact:
+      openshift_currently_installed_version: "{{ openshift_master_installed_version }}"
   - name: Check if iptables is running
     command: systemctl status iptables
     changed_when: false

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/validator.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/validator.yml
@@ -15,7 +15,7 @@
   - name: Confirm OpenShift authorization objects are in sync
     command: >
       {{ openshift.common.client_binary }} adm migrate authorization
-    when: openshift_upgrade_target | version_compare('3.8','<')
+    when: openshift_currently_installed_version | version_compare('3.7','<')
     changed_when: false
     register: l_oc_result
     until: l_oc_result.rc == 0


### PR DESCRIPTION
Currently, we check that upgrade target is less than 3.8,
but this will break for minor upgrades.

This commit set's a fact early in the upgrade process to
deterime what the currently installed version on the
first master is.

This fact is used to determine if our currently installed
version is less than 3.7.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1508301