### PR TITLE
Bug 151186 - Adding configuration for keeping transient namespace on error.

### DIFF
--- a/roles/ansible_service_broker/defaults/main.yml
+++ b/roles/ansible_service_broker/defaults/main.yml
@@ -10,6 +10,8 @@ ansible_service_broker_dev_broker: false
 ansible_service_broker_refresh_interval: 600s
 # Recommended you do not enable this for now
 ansible_service_broker_launch_apb_on_bind: false
+ansible_service_broker_keep_namespace_on_error: true
+ansible_service_broker_keep_namespace: false
 
 ansible_service_broker_image_pull_policy: IfNotPresent
 ansible_service_broker_sandbox_role: edit

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -430,6 +430,8 @@
               bearer_token_file: ""
               sandbox_role: {{ ansible_service_broker_sandbox_role }}
               image_pull_policy: {{ ansible_service_broker_image_pull_policy }}
+              keep_namespace: {{ ansible_service_broker_keep_namespace | bool | lower }}
+              keep_namespace_on_error: {{ ansible_service_broker_keep_namespace_on_error | bool | lower }}
             broker:
               dev_broker: {{ ansible_service_broker_dev_broker | bool | lower }}
               bootstrap_on_startup: {{ ansible_service_broker_bootstrap_on_startup | bool | lower }}


### PR DESCRIPTION
Adding default for `keep_namespace_on_error` in the broker config.