### PR TITLE
[bz 1511404] Backporting a fix for router cert copy

### DIFF
--- a/roles/openshift_hosted/tasks/router/router.yml
+++ b/roles/openshift_hosted/tasks/router/router.yml
@@ -21,7 +21,8 @@
     src: "{{ item }}"
   with_items: "{{ openshift_hosted_routers | oo_collect(attribute='certificate') |
                   oo_select_keys_from_list(['keyfile', 'certfile', 'cafile']) }}"
-  when: ( not openshift_hosted_router_create_certificate | bool ) or openshift_hosted_router_certificate != {}
+  when: ( not openshift_hosted_router_create_certificate | bool ) or openshift_hosted_router_certificate != {} or
+        (  openshift_hosted_routers | oo_collect(attribute='certificate') | oo_select_keys_from_list(['keyfile', 'certfile', 'cafile'])|length > 0 )
 
 # This is for when we desire a cluster signed cert
 # The certificate is generated and placed in master_config_dir/
@@ -34,8 +35,8 @@
       hostnames:
       - "{{ openshift_master_default_subdomain | default('router.default.svc.cluster.local') }}"
       - "*.{{ openshift_master_default_subdomain | default('router.default.svc.cluster.local') }}"
-      cert: "{{ ('/etc/origin/master/' ~ (item.certificate.certfile | basename)) if 'certfile' in item.certificate else ((openshift_master_config_dir) ~ '/openshift-router.crt') }}"
-      key: "{{ ('/etc/origin/master/' ~ (item.certificate.keyfile | basename)) if 'keyfile' in item.certificate else ((openshift_master_config_dir) ~ '/openshift-router.key') }}"
+      cert: "{{ openshift_master_config_dir ~ '/openshift-router.crt' }}"
+      key: "{{ openshift_master_config_dir ~ '/openshift-router.key' }}"
     with_items: "{{ openshift_hosted_routers }}"
 
   - name: set the openshift_hosted_router_certificate
@@ -44,9 +45,10 @@
         certfile: "{{ openshift_master_config_dir ~ '/openshift-router.crt' }}"
         keyfile: "{{ openshift_master_config_dir ~ '/openshift-router.key' }}"
         cafile: "{{ openshift_master_config_dir ~ '/ca.crt' }}"
-
-  # End Block
-  when: ( openshift_hosted_router_create_certificate | bool ) and openshift_hosted_router_certificate == {}
+  when:
+  - openshift_hosted_router_create_certificate | bool
+  - openshift_hosted_router_certificate == {}
+  - openshift_hosted_routers | oo_collect(attribute='certificate') | oo_select_keys_from_list(['keyfile', 'certfile', 'cafile'])|length == 0
 
 - name: Create the router service account(s)
   oc_serviceaccount:


### PR DESCRIPTION
This is the fix that went into 3.7.  QE cloned 3.7 bug to 3.6 https://bugzilla.redhat.com/show_bug.cgi?id=1511404

The issue with 3.7 is that we refactored the hosted playbooks.  This is the same code as what is in 3.7 but I could not cherry pick because of the 3.7 refactor.
```
error: could not apply bfbafeb... [Bug 1509354] Check if routers have certificates and use them
```