### PR TITLE
Bug 1511357: Task "Reload generated facts" failed while scaling up containerized masters

### DIFF
--- a/playbooks/openshift-loadbalancer/private/config.yml
+++ b/playbooks/openshift-loadbalancer/private/config.yml
@@ -24,7 +24,7 @@
                                                                                openshift_use_nuage | default(false),
                                                                                nuage_mon_rest_server_port | default(none)))
                                           + openshift_loadbalancer_additional_backends | default([]) }}"
-    openshift_image_tag: "{{ hostvars[groups.oo_first_master.0].openshift_image_tag }}"
+    openshift_image_tag: "{{ hostvars[groups.oo_masters_to_config.0].openshift_image_tag }}"
   roles:
   - role: openshift_loadbalancer
   - role: tuned

--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -19,7 +19,8 @@
 
 - name: Reload generated facts
   openshift_facts:
-  when: hostvars[openshift_ca_host].install_result is changed
+  when:
+  - hostvars[openshift_ca_host].install_result | default({'changed':false}) is changed
 
 - name: Create openshift_ca_config_dir if it does not exist
   file:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1511357

Registered `install_result` wasn't available when the install task was skipped for containerized hosts so default it.

I also ran into an issue accessing `openshift_image_tag` on the first master since we run `openshift_version` against `oo_masters_to_config`. `oo_masters_to_config` will not contain `oo_first_master` during scaleup so pull it from the master we did run the `openshift_version` role against. The BZ inventory doesn't contain a load balancer host so this is just something I ran into.