### PR TITLE
Fix stale data in openshift_facts for logging

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -490,7 +490,7 @@ def set_selectors(facts):
         facts['hosted']['metrics'] = {}
     if 'selector' not in facts['hosted']['metrics'] or facts['hosted']['metrics']['selector'] in [None, 'None']:
         facts['hosted']['metrics']['selector'] = None
-    if 'logging' not in facts:
+    if 'logging' not in facts or not isinstance(facts['logging'], dict):
         facts['logging'] = {}
     if 'selector' not in facts['logging'] or facts['logging']['selector'] in [None, 'None']:
         facts['logging']['selector'] = None


### PR DESCRIPTION
Currently, some stale facts may be present in
'/etc/ansible/facts.d/openshift.fact' which causes
openshift_facts to fail.

This commit ensures that the data for the 'logging' key
in that file is a dictionary; otherwise we re-initialize
a new dictionary.

Fixes: https://github.com/openshift/openshift-ansible/issues/6057