### PR TITLE
ansible.cfg: error when inventory does not parse

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -33,6 +33,10 @@ callback_whitelist = profile_tasks
 # Uncomment to use the provided AWS dynamic inventory script
 #hostfile = inventory/aws/ec2.py
 
+[inventory]
+# fail more helpfully when the inventory file does not parse (Ansible 2.4+)
+unparsed_is_failed=true
+
 # Additional ssh options for OpenShift Ansible
 [ssh_connection]
 pipelining = True

--- a/utils/etc/ansible.cfg
+++ b/utils/etc/ansible.cfg
@@ -29,6 +29,10 @@ deprecation_warnings = False
 # ssh_args - set if provided by user (cli)
 # control_path
 
+[inventory]
+# fail more helpfully when the inventory file does not parse (Ansible 2.4+)
+unparsed_is_failed=true
+
 # Additional ssh options for OpenShift Ansible
 [ssh_connection]
 # shorten the ControlPath which is often too long; when it is,


### PR DESCRIPTION
As of Ansible 2.4 this option exists:
https://github.com/ansible/ansible/issues/15035#issuecomment-329672168

The kind of error you get later when this is your real problem tends to be *very* confusing. Much better to just fail right away.

I cannot think of any scenario in which it would be preferable to proceed when inventory parsing fails.