### PR TITLE
no hardcoded system registry for registry-console

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -20,7 +20,7 @@ DEPLOYMENT_IMAGE_INFO = {
         "namespace": "openshift3",
         "name": "ose",
         "registry_console_template": "${prefix}registry-console:${version}",
-        "registry_console_prefix": "registry.access.redhat.com/openshift3/",
+        "registry_console_prefix": "openshift3/",
         "registry_console_default_version": "${short_version}",
     },
 }


### PR DESCRIPTION
Having the redhat registry hardcoded here prevents being able to
override it with some other registry