### PR TITLE
Instance profile support.

### DIFF
--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 openshift_aws_create_s3: True
 openshift_aws_create_iam_cert: True
+openshift_aws_create_iam_role: False
 openshift_aws_create_security_groups: True
 openshift_aws_create_launch_config: True
 openshift_aws_create_scale_group: True
@@ -16,6 +17,10 @@ openshift_aws_iam_cert_name: "{{ openshift_aws_clusterid }}-master-external"
 openshift_aws_iam_cert_path: ''
 openshift_aws_iam_cert_key_path: ''
 openshift_aws_scale_group_basename: "{{ openshift_aws_clusterid }} openshift"
+
+openshift_aws_iam_role_name: openshift_node_describe_instances
+openshift_aws_iam_role_policy_json: "{{ lookup('file', 'describeinstances.json') }}"
+openshift_aws_iam_role_policy_name: "describe_instances"
 
 openshift_aws_iam_kms_alias: "alias/{{ openshift_aws_clusterid }}_kms"
 openshift_aws_ami: ''
@@ -135,6 +140,9 @@ openshift_aws_master_group_config:
     wait_for_instances: True
     termination_policy: "{{ openshift_aws_node_group_termination_policy }}"
     replace_all_instances: "{{ openshift_aws_node_group_replace_all_instances }}"
+    iam_role: "{{ openshift_aws_iam_role_name }}"
+    policy_name: "{{ openshift_aws_iam_role_policy_name }}"
+    policy_json: "{{ openshift_aws_iam_role_policy_json }}"
     elbs: "{{ openshift_aws_elb_name_dict['master'].keys()| map('extract', openshift_aws_elb_name_dict['master']) | list }}"
 
 openshift_aws_node_group_config:
@@ -155,6 +163,9 @@ openshift_aws_node_group_config:
       type: compute
     termination_policy: "{{ openshift_aws_node_group_termination_policy }}"
     replace_all_instances: "{{ openshift_aws_node_group_replace_all_instances }}"
+    iam_role: "{{ openshift_aws_iam_role_name }}"
+    policy_name: "{{ openshift_aws_iam_role_policy_name }}"
+    policy_json: "{{ openshift_aws_iam_role_policy_json }}"
   # The 'infra' key is always required here.
   infra:
     instance_type: m4.xlarge
@@ -172,6 +183,9 @@ openshift_aws_node_group_config:
       type: infra
     termination_policy: "{{ openshift_aws_node_group_termination_policy }}"
     replace_all_instances: "{{ openshift_aws_node_group_replace_all_instances }}"
+    iam_role: "{{ openshift_aws_iam_role_name }}"
+    policy_name: "{{ openshift_aws_iam_role_policy_name }}"
+    policy_json: "{{ openshift_aws_iam_role_policy_json }}"
     elbs: "{{ openshift_aws_elb_name_dict['infra'].keys()| map('extract', openshift_aws_elb_name_dict['infra']) | list }}"
 
 openshift_aws_elb_tags: "{{ openshift_aws_kube_tags }}"

--- a/roles/openshift_aws/files/describeinstances.json
+++ b/roles/openshift_aws/files/describeinstances.json
@@ -1,0 +1,15 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "ec2:DescribeInstances"
+            ],
+            "Resource": [
+                "*"
+            ],
+            "Effect": "Allow",
+            "Sid": "Stmt1438195894000"
+        }
+    ]
+}

--- a/roles/openshift_aws/files/trustpolicy.json
+++ b/roles/openshift_aws/files/trustpolicy.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/roles/openshift_aws/tasks/build_node_group.yml
+++ b/roles/openshift_aws/tasks/build_node_group.yml
@@ -27,6 +27,9 @@
 - set_fact:
     l_epoch_time: "{{ ansible_date_time.epoch }}"
 
+- when: openshift_aws_create_iam_role
+  include: iam_role.yml
+
 - when: openshift_aws_create_launch_config
   include: launch_config.yml
 

--- a/roles/openshift_aws/tasks/iam_role.yml
+++ b/roles/openshift_aws/tasks/iam_role.yml
@@ -1,0 +1,36 @@
+---
+#####
+# Instance profiles consist of two parts. The first part is creating a role
+# in which the instance has access and will use this role's permissions
+# to make API calls on his behalf.  This role requires a trust policy
+# which links a service (ec2) to the role.  This states that this role
+# has access to make call ec2 API calls.
+# See ../files/trustpolicy.json
+#
+# Currently openshift-node requires
+# access to the AWS API to call describeinstances.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1510519
+#####
+- name: Create an iam role
+  iam_role:
+    name: "{{ item.value.iam_role }}"
+    assume_role_policy_document: "{{ lookup('file','trustpolicy.json') }}"
+    state: "{{ openshift_aws_iam_role_state | default('present') }}"
+  when: item.value.iam_role is defined
+  with_dict: "{{ l_nodes_to_build }}"
+
+#####
+# The second part of this task file is linking the role to a policy
+# that specifies which calls the role can make to the ec2 API.
+# Currently all that is required is DescribeInstances.
+# See ../files/describeinstances.json
+#####
+- name: create an iam policy
+  iam_policy:
+    iam_type: role
+    iam_name: "{{ item.value.iam_role }}"
+    policy_json: "{{ item.value.policy_json }}"
+    policy_name: "{{ item.value.policy_name }}"
+    state: "{{ openshift_aws_iam_role_state | default('present') }}"
+  when: item.value.iam_role is defined
+  with_dict: "{{ l_nodes_to_build }}"

--- a/roles/openshift_aws/tasks/launch_config_create.yml
+++ b/roles/openshift_aws/tasks/launch_config_create.yml
@@ -15,6 +15,10 @@
     image_id: "{{ l_aws_ami_map[launch_config_item.key] | default(openshift_aws_ami) }}"
     instance_type: "{{ launch_config_item.value.instance_type }}"
     security_groups: "{{ openshift_aws_launch_config_security_group_id  | default(ec2sgs.security_groups | map(attribute='group_id')| list) }}"
+    instance_profile_name: "{{ launch_config_item.value.iam_role if launch_config_item.value.iam_role is defined and
+                                                                    launch_config_item.value.iam_role != '' and
+                                                                    openshift_aws_create_iam_role
+                                                                 else omit }}"
     user_data: "{{ lookup('template', 'user_data.j2') }}"
     key_name: "{{ openshift_aws_ssh_key_name }}"
     ebs_optimized: False

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -115,3 +115,5 @@ openshift_node_config_dir: "{{ openshift_node_config_dir_default }}"
 
 openshift_node_image_config_latest_default: "{{ openshift_image_config_latest | default(False) }}"
 openshift_node_image_config_latest: "{{ openshift_node_image_config_latest_default }}"
+
+openshift_node_use_instance_profiles: False

--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -34,6 +34,7 @@
 - name: include aws sysconfig credentials
   include: aws.yml
   static: yes
+  when: not (openshift_node_use_instance_profiles | default(False))
 
 #- name: update the ExecStart to have bootstrap
 #  lineinfile:

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -49,6 +49,7 @@
 - name: include aws provider credentials
   include: aws.yml
   static: yes
+  when: not (openshift_node_use_instance_profiles | default(False))
 
 # Necessary because when you're on a node that's also a master the master will be
 # restarted after the node restarts docker and it will take up to 60 seconds for


### PR DESCRIPTION
Purpose of this PR is to remove the AWS cloud-provider credentials from the node and use instance profiles during provisioning time.