### PR TITLE
Run registry auth after docker restart

### DIFF
--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -154,6 +154,7 @@
 - set_fact:
     docker_service_status_changed: "{{ (r_docker_package_docker_start_result | changed) and (r_docker_already_running_result.stdout != 'ActiveState=active' ) }}"
 
-- include: registry_auth.yml
-
 - meta: flush_handlers
+
+# This needs to run after docker is restarted to account for proxy settings.
+- include: registry_auth.yml


### PR DESCRIPTION
Currently, docker login may fail if a proxy is added to the config
but docker is already running.

This is due to the fact that 'docker login' must have a functioning
docker.service running (with valid network connection) to complete.

Currently, handlers restart the docker service at the end of
the role.  This doesn't allow for updating proxy settings before
running docker login.

This commit moves 'docker login' command after flushing handlers.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1511869