### PR TITLE
Regex anchors changed to match protocol start and ports.

### DIFF
--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -60,10 +60,10 @@ controllers: '*'
 corsAllowedOrigins:
   # anchor with start (\A) and end (\z) of the string, make the check case insensitive ((?i)) and escape hostname
 {% for origin in ['127.0.0.1', 'localhost', openshift.common.ip, openshift.common.public_ip] | union(openshift.common.all_hostnames) | unique %}
-  - (?i)\A{{ origin | regex_escape() }}\z
+  - (?i)//{{ origin | regex_escape() }}(:|\z)
 {% endfor %}
 {% for custom_origin in openshift.master.custom_cors_origins | default("") %}
-  - (?i)\A{{ custom_origin | regex_escape() }}\z
+  - (?i)//{{ custom_origin | regex_escape() }}(:|\z)
 {% endfor %}
 {% if 'disabled_features' in openshift.master %}
 disabledFeatures: {{ openshift.master.disabled_features | to_json }}


### PR DESCRIPTION
This is a follow up fix for this pr: https://github.com/openshift/openshift-ansible/pull/5264

Fix for this bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1482903