### PR TITLE
Fixing docker crio installation.

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -53,7 +53,7 @@
 
 - when:
     - l_use_crio
-    - dockerstat.stat.islink is defined and not (dockerstat.stat.islink | bool)
+    - dockerstat.stat.islnk is defined and not (dockerstat.stat.islnk | bool)
   block:
     - name: stop the current running docker
       systemd:


### PR DESCRIPTION
This is the correct check for whether the docker storage is a symlink.

Not sure how this squeaked through.  We will need this in 3.7 for CRI-O.