### PR TITLE
Nuke /var/lib/dockershim/sandbox/* while nodes are drained

### DIFF
--- a/roles/openshift_node_upgrade/tasks/main.yml
+++ b/roles/openshift_node_upgrade/tasks/main.yml
@@ -98,6 +98,12 @@
   failed_when: false
   when: not openshift.common.is_containerized | bool
 
+# https://bugzilla.redhat.com/show_bug.cgi?id=1513054
+- name: Clean up dockershim data
+  file:
+    path: "/var/lib/dockershim/sandbox/"
+    state: absent
+
 - name: Upgrade openvswitch
   package:
     name: openvswitch


### PR DESCRIPTION
Fixes an issue where 3.6 nodes created checkpoint files which could lead to problems after upgrading to 3.7.
As implemented this will happen during all node upgrades regardless of installed or target version.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1513054