### PR TITLE
Allow disabling authorization migration check

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -3,22 +3,6 @@
 # Upgrade Masters
 ###############################################################################
 
-# oc adm migrate storage should be run prior to etcd v3 upgrade
-# See: https://github.com/openshift/origin/pull/14625#issuecomment-308467060
-- name: Pre master upgrade - Upgrade all storage
-  hosts: oo_first_master
-  tasks:
-  - name: Upgrade all storage
-    command: >
-      {{ openshift.common.client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-      migrate storage --include=* --confirm
-    register: l_pb_upgrade_control_plane_pre_upgrade_storage
-    when: openshift_upgrade_pre_storage_migration_enabled | default(true) | bool
-    failed_when:
-    - openshift_upgrade_pre_storage_migration_enabled | default(true) | bool
-    - l_pb_upgrade_control_plane_pre_upgrade_storage.rc != 0
-    - openshift_upgrade_pre_storage_migration_fatal | default(true) | bool
-
 # If facts cache were for some reason deleted, this fact may not be set, and if not set
 # it will always default to true. This causes problems for the etcd data dir fact detection
 # so we must first make sure this is set correctly before attempting the backup.
@@ -47,6 +31,22 @@
     changed_when: false
 
 - include: create_service_signer_cert.yml
+
+# oc adm migrate storage should be run prior to etcd v3 upgrade
+# See: https://github.com/openshift/origin/pull/14625#issuecomment-308467060
+- name: Pre master upgrade - Upgrade all storage
+  hosts: oo_first_master
+  tasks:
+  - name: Upgrade all storage
+    command: >
+      {{ openshift.common.client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      migrate storage --include=* --confirm
+    register: l_pb_upgrade_control_plane_pre_upgrade_storage
+    when: openshift_upgrade_pre_storage_migration_enabled | default(true) | bool
+    failed_when:
+    - openshift_upgrade_pre_storage_migration_enabled | default(true) | bool
+    - l_pb_upgrade_control_plane_pre_upgrade_storage.rc != 0
+    - openshift_upgrade_pre_storage_migration_fatal | default(true) | bool
 
 # Set openshift_master_facts separately. In order to reconcile
 # admission_config's, we currently must run openshift_master_facts and
@@ -153,7 +153,9 @@
       {{ openshift.common.client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
       migrate storage --include=clusterpolicies --confirm
     register: l_pb_upgrade_control_plane_post_upgrade_storage
-    when: openshift_upgrade_post_storage_migration_enabled | default(true) | bool
+    when:
+    - openshift_upgrade_post_storage_migration_enabled | default(true) | bool
+    - openshift_version | version_compare('3.7','<')
     failed_when:
     - openshift_upgrade_post_storage_migration_enabled | default(true) | bool
     - l_pb_upgrade_control_plane_post_upgrade_storage.rc != 0

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/validator.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/validator.yml
@@ -11,13 +11,15 @@
   tasks:
   - name: Check for invalid namespaces and SDN errors
     oc_objectvalidator:
-
+  # DO NOT DISABLE THIS, YOUR UPGRADE WILL FAIL IF YOU DO SO
   - name: Confirm OpenShift authorization objects are in sync
     command: >
       {{ openshift.common.client_binary }} adm migrate authorization
-    when: openshift_currently_installed_version | version_compare('3.7','<')
+    when:
+    - openshift_currently_installed_version | version_compare('3.7','<')
+    - openshift_upgrade_pre_authorization_migration_enabled | default(true) | bool
     changed_when: false
     register: l_oc_result
     until: l_oc_result.rc == 0
-    retries: 4
+    retries: 2
     delay: 15


### PR DESCRIPTION
Moves the etcd backup prior to the storage migrations as well