### PR TITLE
Minor tweaks to ansible.cfg and example inventory

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,6 +11,9 @@
 
 # Additional default options for OpenShift Ansible
 callback_plugins = callback_plugins/
+filter_plugins = filter_plugins/
+lookup_plugins = lookup_plugins/
+library = library/
 forks = 20
 host_key_checking = False
 retry_files_enabled = False
@@ -25,13 +28,7 @@ fact_caching_timeout = 600
 callback_whitelist = profile_tasks
 
 # Uncomment to use the provided BYO inventory
-#hostfile = inventory/byo/hosts
-
-# Uncomment to use the provided GCE dynamic inventory script
-#hostfile = inventory/gce/gce.py
-
-# Uncomment to use the provided AWS dynamic inventory script
-#hostfile = inventory/aws/ec2.py
+#inventory = inventory/byo/hosts.example
 
 [inventory]
 # fail more helpfully when the inventory file does not parse (Ansible 2.4+)

--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -17,9 +17,9 @@ nfs
 # SSH user, this user should allow ssh based auth without requiring a
 # password. If using ssh key based auth, then the key should be managed by an
 # ssh agent.
-ansible_ssh_user=root
+ansible_user=root
 
-# If ansible_ssh_user is not root, ansible_become must be set to true and the
+# If ansible_user is not root, ansible_become must be set to true and the
 # user must be configured for passwordless sudo
 #ansible_become=yes
 
@@ -1087,3 +1087,6 @@ ose3-lb-ansible.test.example.com containerized=false
 [nodes]
 ose3-master[1:3]-ansible.test.example.com
 ose3-node[1:2]-ansible.test.example.com openshift_node_labels="{'region': 'primary', 'zone': 'default'}"
+
+[nfs]
+ose3-nfs-ansible.test.example.com


### PR DESCRIPTION
- Adds reference to plugins and library path to support removal of symlinks
- Removes references to old example inventories
- Corrects deprecated ansible_ssh_user
- Adds [nfs] group for proper parsing of the example inventory