### PR TITLE
[1.5] Run registry auth after docker restart

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -140,6 +140,9 @@
 - set_fact:
     docker_service_status_changed: "{{ (start_result | changed) and (r_docker_already_running_result.stdout != 'ActiveState=active' ) }}"
 
+- meta: flush_handlers
+
+# This needs to run after docker is restarted to account for proxy settings.
 - name: Check for credentials file for registry auth
   stat:
     path: "{{ docker_cli_auth_config_path }}/config.json"
@@ -151,5 +154,3 @@
   when:
   - oreg_auth_user is defined
   - (not docker_cli_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
-
-- meta: flush_handlers


### PR DESCRIPTION
Currently, docker login may fail if a proxy is added to the config
but docker is already running.

This is due to the fact that 'docker login' must have a functioning
docker.service running (with valid network connection) to complete.

Currently, handlers restart the docker service at the end of
the role. This doesn't allow for updating proxy settings before
running docker login.

This commit moves 'docker login' command after flushing handlers.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1511869
(cherry picked from commit 68b66faed0a5fc4364e50daa5e4a9a1b42a12734)

Backports: https://github.com/openshift/openshift-ansible/pull/6094