### PR TITLE
Uninstall tuned-profiles-atomic-openshift-node as defined in origin.spec

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -124,7 +124,7 @@
         - origin-clients
         - origin-node
         - origin-sdn-ovs
-        - tuned-profiles-openshift-node
+        - tuned-profiles-atomic-openshift-node
         - tuned-profiles-origin-node
 
       - name: Remove flannel package


### PR DESCRIPTION
The origin.spec file defines two variants of tuned rpm packages:
tuned-profiles-atomic-openshift-node and tuned-profiles-origin-node.
Uninstall them both.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1509129