### PR TITLE
Include Deprecation - Init Playbook Paths

### DIFF
--- a/playbooks/init/facts.yml
+++ b/playbooks/init/facts.yml
@@ -8,9 +8,8 @@
   hosts: oo_all_hosts
   tasks:
   - name: load openshift_facts module
-    include_role:
+    import_role:
       name: openshift_facts
-    static: yes
 
   # TODO: Should this role be refactored into health_checks??
   - name: Run openshift_sanitize_inventory to set variables

--- a/playbooks/init/main.yml
+++ b/playbooks/init/main.yml
@@ -13,17 +13,17 @@
           status: "In Progress"
           start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- include: evaluate_groups.yml
+- import_playbook: evaluate_groups.yml
 
-- include: facts.yml
+- import_playbook: facts.yml
 
-- include: sanity_checks.yml
+- import_playbook: sanity_checks.yml
 
-- include: validate_hostnames.yml
+- import_playbook: validate_hostnames.yml
 
-- include: repos.yml
+- import_playbook: repos.yml
 
-- include: version.yml
+- import_playbook: version.yml
 
 - name: Initialization Checkpoint End
   hosts: all

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -2,7 +2,7 @@
 # These tasks dispatch to the proper set of docker tasks based on the
 # inventory:openshift_docker_use_system_container variable
 
-- include: udev_workaround.yml
+- include_tasks: udev_workaround.yml
   when: docker_udev_workaround | default(False) | bool
 
 - set_fact:
@@ -20,7 +20,7 @@
     - not l_use_crio_only
 
 - name: Use Package Docker if Requested
-  include: package_docker.yml
+  include_tasks: package_docker.yml
   when:
     - not l_use_system_container
     - not l_use_crio_only
@@ -35,13 +35,13 @@
   changed_when: false
 
 - name: Use System Container Docker if Requested
-  include: systemcontainer_docker.yml
+  include_tasks: systemcontainer_docker.yml
   when:
     - l_use_system_container
     - not l_use_crio_only
 
 - name: Add CRI-O usage Requested
-  include: systemcontainer_crio.yml
+  include_tasks: systemcontainer_crio.yml
   when:
     - l_use_crio
     - openshift_docker_is_node_or_master | bool

--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -157,4 +157,4 @@
 - meta: flush_handlers
 
 # This needs to run after docker is restarted to account for proxy settings.
-- include: registry_auth.yml
+- include_tasks: registry_auth.yml

--- a/roles/docker/tasks/systemcontainer_crio.yml
+++ b/roles/docker/tasks/systemcontainer_crio.yml
@@ -162,7 +162,7 @@
     state: directory
 
 - name: setup firewall for CRI-O
-  include: crio_firewall.yml
+  include_tasks: crio_firewall.yml
   static: yes
 
 - name: Configure the CNI network
@@ -182,6 +182,6 @@
 
 # If we are using crio only, docker.service might not be available for
 # 'docker login'
-- include: registry_auth.yml
+- include_tasks: registry_auth.yml
   vars:
     openshift_docker_alternative_creds: "{{ l_use_crio_only }}"

--- a/roles/docker/tasks/systemcontainer_docker.yml
+++ b/roles/docker/tasks/systemcontainer_docker.yml
@@ -177,6 +177,6 @@
 
 # Since docker is running as a system container, docker login will fail to create
 # credentials.  Use alternate method if requiring authenticated registries.
-- include: registry_auth.yml
+- include_tasks: registry_auth.yml
   vars:
     openshift_docker_alternative_creds: True

--- a/roles/openshift_repos/tasks/main.yaml
+++ b/roles/openshift_repos/tasks/main.yaml
@@ -35,7 +35,7 @@
   - when: r_openshift_repos_has_run is not defined
     block:
 
-    - include: centos_repos.yml
+    - include_tasks: centos_repos.yml
       when:
       - ansible_os_family == "RedHat"
       - ansible_distribution != "Fedora"

--- a/roles/openshift_sanitize_inventory/tasks/deprecations.yml
+++ b/roles/openshift_sanitize_inventory/tasks/deprecations.yml
@@ -16,6 +16,6 @@
 
 # for with_fileglob Ansible resolves the path relative to the roles/<rolename>/files directory
 - name: Assign deprecated variables to correct counterparts
-  include: "{{ item }}"
+  include_tasks: "{{ item }}"
   with_fileglob:
   - "../tasks/__deprecations_*.yml"

--- a/roles/openshift_sanitize_inventory/tasks/main.yml
+++ b/roles/openshift_sanitize_inventory/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # We should print out deprecations prior to any failures so that if a play does fail for other reasons
 # the user would also be aware of any deprecated variables they should note to adjust
-- include: deprecations.yml
+- include_tasks: deprecations.yml
 
 - name: Abort when conflicting deployment type variables are set
   when:
@@ -53,7 +53,7 @@
       openshift_release is "{{ openshift_release }}" which is not a valid version string.
       Please set it to a version string like "3.4".
 
-- include: unsupported.yml
+- include_tasks: unsupported.yml
   when:
     - not openshift_enable_unsupported_configurations | default(false) | bool
 

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -93,11 +93,11 @@
   - inventory_hostname in groups['oo_masters_to_config'] or inventory_hostname in groups['oo_nodes_to_config']
   block:
   - name: Set openshift_version for rpm installation
-    include: set_version_rpm.yml
+    include_tasks: set_version_rpm.yml
     when: not is_containerized | bool
 
   - name: Set openshift_version for containerized installation
-    include: set_version_containerized.yml
+    include_tasks: set_version_containerized.yml
     when: is_containerized | bool
 
   - block:


### PR DESCRIPTION
This PR addresses all `include:` directives within components of the initialization playbooks.

For example:
```
$ ansible-playbook -i localhost, playbooks/init/main.yml --syntax-check
```

Trello: https://trello.com/c/ZTyZu3UM/484-3-ansible-24-include-deprecation