### PR TITLE
openshift_checks: ignore hidden files in checks dir

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/__init__.py
+++ b/roles/openshift_health_checker/openshift_checks/__init__.py
@@ -372,7 +372,7 @@ def load_checks(path=None, subpkg=""):
             modules = modules + load_checks(os.path.join(path, name), subpkg + "." + name)
             continue
 
-        if name.endswith(".py") and name not in LOADER_EXCLUDES:
+        if name.endswith(".py") and not name.startswith(".") and name not in LOADER_EXCLUDES:
             modules.append(import_module(__package__ + subpkg + "." + name[:-3]))
 
     return modules


### PR DESCRIPTION
`load_checks`: Ignore hidden files when scanning the directory for checks.

This commit restores the changes that were originally made in #5035, which were [unintentionally reverted](https://github.com/openshift/openshift-ansible/pull/5274#discussion_r151440313) by #5274.