### PR TITLE
[3.7 backport] Allow cluster IP for docker-registry service to be set

### DIFF
--- a/roles/openshift_hosted/README.md
+++ b/roles/openshift_hosted/README.md
@@ -27,6 +27,7 @@ From this role:
 | openshift_hosted_registry_replicas    | Number of nodes matching selector        | The number of replicas to configure.                                                                                     |
 | openshift_hosted_registry_selector    | region=infra                             | Node selector used when creating registry. The OpenShift registry will only be deployed to nodes matching this selector. |
 | openshift_hosted_registry_cert_expire_days | `730` (2 years)                     | Validity of the certificates in days. Works only with OpenShift version 1.5 (3.5) and later.                             |
+| openshift_hosted_registry_clusterip   | None                                     | Cluster IP for registry service                                                                                          |
 
 If you specify `openshift_hosted_registry_kind=glusterfs`, the following
 variables also control configuration behavior:

--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -80,6 +80,7 @@ r_openshift_hosted_registry_os_firewall_allow:
 openshift_hosted_registry_serviceaccount: registry
 openshift_hosted_registry_volumes: []
 openshift_hosted_registry_env_vars: {}
+openshift_hosted_registry_clusterip: null
 
 # These edits are being specified only to prevent 'changed' on rerun
 openshift_hosted_registry_edits:

--- a/roles/openshift_hosted/tasks/registry.yml
+++ b/roles/openshift_hosted/tasks/registry.yml
@@ -89,6 +89,7 @@
       docker-registry: default
     session_affinity: ClientIP
     service_type: ClusterIP
+    clusterip: '{{ openshift_hosted_registry_clusterip | default(omit) }}'
 
 - include: secure.yml
   static: no


### PR DESCRIPTION
This change was originally merged into master in #5571.

For historical reasons a small set of programs in our environments rely
on the cluster-internal Docker registry having the IP address
"172.30.1.1". So far we always had to patch in that address manually.
Adding a variable on the "openshift_hosted" role allows the IP address
to be set correctly when a cluster is installed.

(cherry picked from commit 4abb7381bdf439dfc1ab371be231f856620d7e19)