### PR TITLE
[3.7 backport] Add role to configure project request template

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -85,6 +85,8 @@
 
   roles:
   - openshift_manageiq
+  - role: openshift_project_request_template
+    when: openshift_project_request_template_manage
   # Create the new templates shipped in 3.2, existing templates are left
   # unmodified. This prevents the subsequent role definition for
   # openshift_examples from failing when trying to replace templates that do

--- a/playbooks/common/openshift-master/additional_config.yml
+++ b/playbooks/common/openshift-master/additional_config.yml
@@ -19,6 +19,8 @@
   roles:
   - role: openshift_master_cluster
     when: openshift_master_ha | bool and openshift.master.cluster_method == "pacemaker"
+  - role: openshift_project_request_template
+    when: openshift_project_request_template_manage
   - role: openshift_examples
     when: openshift_install_examples | default(true, true) | bool
     registry_url: "{{ openshift.master.registry_url }}"

--- a/roles/openshift_project_request_template/README.md
+++ b/roles/openshift_project_request_template/README.md
@@ -1,0 +1,33 @@
+OpenShift Project Request Template
+==================================
+
+Configure template used when creating new projects. If enabled only the template is managed. It must still be enabled in the OpenShift master configuration. The base template is created using `oc adm create-bootstrap-project-template` and can be modified by setting `openshift_project_request_template_edits`.
+
+
+Requirements
+------------
+
+
+Role Variables
+--------------
+
+From this role:
+
+| Name                                         | Default value   | Description                                    |
+|----------------------------------------------|-----------------|------------------------------------------------|
+| openshift_project_request_template_manage    | false           | Whether to manage the project request template |
+| openshift_project_request_template_namespace | default         | Namespace for template                         |
+| openshift_project_request_template_name      | project-request | Template name                                  |
+| openshift_project_request_template_edits     | []              | Changes for template                           |
+
+
+Dependencies
+------------
+
+* lib_utils
+
+
+License
+-------
+
+Apache License Version 2.0

--- a/roles/openshift_project_request_template/defaults/main.yml
+++ b/roles/openshift_project_request_template/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+openshift_project_request_template_manage: false
+openshift_project_request_template_namespace: default
+openshift_project_request_template_name: project-request
+openshift_project_request_template_edits: []

--- a/roles/openshift_project_request_template/meta/main.yml
+++ b/roles/openshift_project_request_template/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: Michael Hanselmann
+  description: Configure project request template
+  company: VSHN AG
+  license: Apache License, Version 2.0
+  min_ansible_version: 2.2
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+dependencies:
+- role: lib_utils

--- a/roles/openshift_project_request_template/tasks/main.yml
+++ b/roles/openshift_project_request_template/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- name: Create temp file for template
+  command: mktemp /tmp/openshift-ansible-XXXXXX.yaml
+  register: mktemp
+  changed_when: False
+
+- name: Generate default project template
+  command: |
+    {{ openshift.common.client_binary | quote }} \
+      --config {{ openshift.common.config_base | quote }}/master/admin.kubeconfig \
+      --output yaml \
+      adm create-bootstrap-project-template \
+      --name {{ openshift_project_request_template_name | quote }}
+  register: default_project_template
+
+- name: Write default project template to file
+  copy:
+    mode=0600
+    content="{{ default_project_template.stdout }}"
+    dest="{{ mktemp.stdout }}"
+
+- name: Apply template modifications
+  yedit:
+    state: present
+    src: "{{ mktemp.stdout }}"
+    edits: "{{ openshift_project_request_template_edits }}"
+  when: "openshift_project_request_template_edits | length > 0"
+
+- name: Create or update project request template
+  command: |
+    {{ openshift.common.client_binary }} \
+      --config {{ openshift.common.config_base }}/master/admin.kubeconfig \
+      --namespace {{ openshift_project_request_template_namespace | quote }} \
+      apply --filename {{ mktemp.stdout }}
+
+- name: Delete temp file
+  file:
+    name: "{{ mktemp.stdout }}"
+    state: absent
+  changed_when: False


### PR DESCRIPTION
This change was merged into master in #5500.

The OpenShift master role already supports changing the master
configuration to refer to a project template, but there's no way to
manage that template directly. This role adds the necessary code to
generate a default template and to apply customizations using the
"yedit" module.