### PR TITLE
Declare Prometheus port

### DIFF
--- a/roles/openshift_prometheus/README.md
+++ b/roles/openshift_prometheus/README.md
@@ -19,6 +19,8 @@ For default values, see [`defaults/main.yaml`](defaults/main.yaml).
 
 - `openshift_prometheus_node_selector`: Selector for the nodes prometheus will be deployed on.
 
+- `openshift_prometheus_web_listen_address`: specify listen address for prometheus. Defaults to `localhost`.
+
 - `openshift_prometheus_<COMPONENT>_image_prefix`: specify image prefix for the component 
 
 - `openshift_prometheus_<COMPONENT>_image_version`: specify image version for the component 

--- a/roles/openshift_prometheus/defaults/main.yaml
+++ b/roles/openshift_prometheus/defaults/main.yaml
@@ -6,6 +6,8 @@ openshift_prometheus_namespace: openshift-metrics
 
 openshift_prometheus_node_selector: {"region":"infra"}
 
+openshift_prometheus_web_listen_address: "localhost"
+
 # additional prometheus rules file
 openshift_prometheus_additional_rules_file: null
 

--- a/roles/openshift_prometheus/templates/prometheus.j2
+++ b/roles/openshift_prometheus/templates/prometheus.j2
@@ -78,7 +78,7 @@ spec:
         - --storage.tsdb.retention=6h
         - --storage.tsdb.min-block-duration=2m
         - --config.file=/etc/prometheus/prometheus.yml
-        - --web.listen-address=localhost:9090
+        - --web.listen-address={{ openshift_prometheus_web_listen_address }}:9090
         image: "{{ l_openshift_prometheus_image_prefix }}prometheus:{{ l_openshift_prometheus_image_version }}"
         imagePullPolicy: IfNotPresent
         resources:
@@ -96,6 +96,9 @@ spec:
 {% if openshift_prometheus_cpu_limit is defined and openshift_prometheus_cpu_limit is not none %}
             cpu: "{{ openshift_prometheus_cpu_limit }}"
 {% endif %}
+        ports:
+        - containerPort: 9090
+          name: web
 
         volumeMounts:
         - mountPath: /etc/prometheus


### PR DESCRIPTION
This is required if, for some reason, you want to bypass the oauth proxy.