### PR TITLE
Update boto version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
 ansible==2.4.0.0
-boto==2.34.0
+boto==2.48.0
 click==6.7
 pyOpenSSL==16.2.0
 # We need to disable ruamel.yaml for now because of test failures


### PR DESCRIPTION
This commit updates the boto version to be compatible with
ansible 2.4.0.