### PR TITLE
Add networkmanager check to sanity checks

### DIFF
--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -1,5 +1,7 @@
 ---
 - import_playbook: init/main.yml
+  vars:
+    l_networkman_check_hosts: "oo_nodes_to_config"
 
 - import_playbook: openshift-checks/private/install.yml
 

--- a/playbooks/init/sanity_checks.yml
+++ b/playbooks/init/sanity_checks.yml
@@ -17,3 +17,18 @@
   # node_group_checks is a custom action plugin defined in lib_utils.
   - name: Validate openshift_node_groups and openshift_node_group_name
     node_group_checks: {}
+
+# l_networkman_check_hosts may be passed in via playbooks/deploy_cluster.yml
+# and master/node scaleup plays
+- name: Verify Node NetworkManager
+  # We only want to run this on new installs and node/master scaleup.
+  hosts: "{{ l_networkman_check_hosts | default('all:!all') }}"
+  tasks:
+  - name: Check for NetworkManager service
+    command: 'systemctl show NetworkManager'
+    register: nm_show
+    changed_when: false
+    ignore_errors: True
+  - fail: msg="Currently, NetworkManager must be installed and enabled prior to installation."
+    when:
+    - not ('ActiveState=active' in nm_show.stdout) | bool

--- a/playbooks/openshift-master/scaleup.yml
+++ b/playbooks/openshift-master/scaleup.yml
@@ -36,6 +36,7 @@
     # oo_masters contains both existing and new masters; oo_masters_to_config just new.
     l_init_fact_hosts: "oo_masters:oo_etcd_to_config:oo_lb_to_config:oo_nodes_to_config"
     l_sanity_check_hosts: "{{ groups['oo_nodes_to_config'] | union(groups['oo_masters']) }}"
+    l_networkman_check_hosts: "oo_nodes_to_config"
 
 - import_playbook: ../init/version.yml
   vars:


### PR DESCRIPTION
This commit adds a fail-fast check for network manager,
otherwise an install can fail minutes later.