### PR TITLE
Allow modifying and adding prometheus application arguments

### DIFF
--- a/roles/openshift_prometheus/README.md
+++ b/roles/openshift_prometheus/README.md
@@ -23,6 +23,13 @@ For default values, see [`defaults/main.yaml`](defaults/main.yaml).
 
 - `openshift_prometheus_<COMPONENT>_image_version`: specify image version for the component 
 
+- `openshift_prometheus_args`: Modify or add arguments for prometheus application
+
+e.g
+```
+openshift_prometheus_args=['--storage.tsdb.retention=6h', '--storage.tsdb.min-block-duration=5s', '--storage.tsdb.max-block-duration=6m']
+```
+
 ## PVC related variables
 Each prometheus component (prometheus, alertmanager, alertbuffer) can set pv claim by setting corresponding role variable:
 ```

--- a/roles/openshift_prometheus/defaults/main.yaml
+++ b/roles/openshift_prometheus/defaults/main.yaml
@@ -9,6 +9,9 @@ openshift_prometheus_node_selector: {"region":"infra"}
 # additional prometheus rules file
 openshift_prometheus_additional_rules_file: null
 
+#prometheus application arguments
+openshift_prometheus_args: ['--storage.tsdb.retention=6h', '--storage.tsdb.min-block-duration=2m']
+
 # storage
 # One of ['emptydir', 'pvc']
 openshift_prometheus_storage_type: "emptydir"

--- a/roles/openshift_prometheus/templates/prometheus.j2
+++ b/roles/openshift_prometheus/templates/prometheus.j2
@@ -75,8 +75,9 @@ spec:
 
       - name: prometheus
         args:
-        - --storage.tsdb.retention=6h
-        - --storage.tsdb.min-block-duration=2m
+{% for arg in openshift_prometheus_args %}
+        - {{ arg }}
+{% endfor %}
         - --config.file=/etc/prometheus/prometheus.yml
         - --web.listen-address=localhost:9090
         image: "{{ l_openshift_prometheus_image_prefix }}prometheus:{{ l_openshift_prometheus_image_version }}"


### PR DESCRIPTION
`config.file` and `web.listen-address` args remain unconfigurable (Changing those will break deployment)
Storage defaults moved to a list parameter `openshift_prometheus_args` that can be modified and extended.

issue: https://github.com/openshift/openshift-ansible/issues/6137