### PR TITLE
docker: copy Docker metadata to the alternative storage path

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -60,10 +60,11 @@
         state: stopped
         name: "{{ openshift.docker.service_name }}"
 
-    - name: "Ensure {{ docker_alt_storage_path }} exists"
-      file:
-        path: "{{ docker_alt_storage_path }}"
-        state: directory
+    - name: copy "{{ docker_default_storage_path }}" to "{{ docker_alt_storage_path }}"
+      command: "cp -r {{ docker_default_storage_path }} {{ docker_alt_storage_path }}"
+      register: results
+      failed_when:
+        - results.rc != 0
 
     - name: "Set the selinux context on {{ docker_alt_storage_path }}"
       command: "semanage fcontext -a -e {{ docker_default_storage_path }} {{ docker_alt_storage_path }}"


### PR DESCRIPTION
Copy the Docker metadata to the alternative storage path.

Addresses:

https://github.com/openshift/openshift-ansible/pull/6007#issuecomment-345661409
