### PR TITLE
Fix uninstall option for prometheus

### DIFF
--- a/roles/openshift_prometheus/tasks/install_prometheus.yaml
+++ b/roles/openshift_prometheus/tasks/install_prometheus.yaml
@@ -3,7 +3,7 @@
 # namespace
 - name: Add prometheus project
   oc_project:
-    state: "{{ state }}"
+    state: present
     name: "{{ openshift_prometheus_namespace }}"
     node_selector: "{{ openshift_prometheus_node_selector | oo_selector_to_string_list() }}"
     description: Prometheus
@@ -11,7 +11,7 @@
 # secrets
 - name: Set alert and prometheus secrets
   oc_secret:
-    state: "{{ state }}"
+    state: present
     name: "{{ item }}-proxy"
     namespace: "{{ openshift_prometheus_namespace }}"
     contents:
@@ -24,7 +24,7 @@
 # serviceaccount
 - name: create prometheus serviceaccount
   oc_serviceaccount:
-    state: "{{ state }}"
+    state: present
     name: prometheus
     namespace: "{{ openshift_prometheus_namespace }}"
     #    TODO add annotations when supproted
@@ -48,7 +48,7 @@
 # create clusterrolebinding for prometheus serviceaccount
 - name: Set cluster-reader permissions for prometheus
   oc_adm_policy_user:
-    state: "{{ state }}"
+    state: present
     namespace: "{{ openshift_prometheus_namespace }}"
     resource_kind: cluster-role
     resource_name: cluster-reader
@@ -58,7 +58,7 @@
 # TODO join into 1 task with loop
 - name: Create prometheus service
   oc_service:
-    state: "{{ state }}"
+    state: present
     name: "{{ item.name }}"
     namespace: "{{ openshift_prometheus_namespace }}"
     selector:
@@ -76,7 +76,7 @@
 
 - name: Create alerts service
   oc_service:
-    state: "{{ state }}"
+    state: present
     name: "{{ item.name }}"
     namespace: "{{ openshift_prometheus_namespace }}"
     selector:
@@ -111,7 +111,7 @@
 # create prometheus and alerts routes
 - name: create prometheus and alerts routes
   oc_route:
-    state: "{{ state }}"
+    state: present
     name: "{{ item.name }}"
     namespace: "{{ openshift_prometheus_namespace }}"
     service_name: "{{ item.name }}"
@@ -185,7 +185,7 @@
 # In prometheus configmap create "additional.rules" section if file exists
 - name: Set prometheus configmap
   oc_configmap:
-    state: "{{ state }}"
+    state: present
     name: "prometheus"
     namespace: "{{ openshift_prometheus_namespace }}"
     from_file:
@@ -196,7 +196,7 @@
 
 - name: Set prometheus configmap
   oc_configmap:
-    state: "{{ state }}"
+    state: present
     name: "prometheus"
     namespace: "{{ openshift_prometheus_namespace }}"
     from_file:
@@ -212,7 +212,7 @@
 
 - name: Set alertmanager configmap
   oc_configmap:
-    state: "{{ state }}"
+    state: present
     name: "prometheus-alerts"
     namespace: "{{ openshift_prometheus_namespace }}"
     from_file:
@@ -229,7 +229,7 @@
 
 - name: Set prometheus stateful set
   oc_obj:
-    state: "{{ state }}"
+    state: present
     name: "prometheus"
     namespace: "{{ openshift_prometheus_namespace }}"
     kind: statefulset

--- a/roles/openshift_prometheus/tasks/main.yaml
+++ b/roles/openshift_prometheus/tasks/main.yaml
@@ -21,8 +21,10 @@
   changed_when: False
 
 - include: install_prometheus.yaml
-  vars:
-    state: "{{ openshift_prometheus_state }}"
+  when: openshift_prometheus_state == 'present'
+
+- include: uninstall_prometheus.yaml
+  when: openshift_prometheus_state == 'absent'
 
 - name: Delete temp directory
   file:

--- a/roles/openshift_prometheus/tasks/uninstall_prometheus.yaml
+++ b/roles/openshift_prometheus/tasks/uninstall_prometheus.yaml
@@ -1,0 +1,7 @@
+---
+
+# remove namespace - This will delete all the objects inside the namespace
+- name: Remove prometheus project
+  oc_project:
+    state: absent
+    name: "{{ openshift_prometheus_namespace }}"


### PR DESCRIPTION
Only remove prometheus namespace when uninstalling.
This will remove all the contained objects.

bz: https://bugzilla.redhat.com/show_bug.cgi?id=1492544