### PR TITLE
Only remove empty keys from env if env exists

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1563,7 +1563,8 @@ def set_builddefaults_facts(facts):
                 # Scaffold out the full expected datastructure
                 facts['master']['admission_plugin_config'] = {'BuildDefaults': {'configuration': {'env': {}}}}
             facts['master']['admission_plugin_config'].update(builddefaults['config'])
-            delete_empty_keys(facts['master']['admission_plugin_config']['BuildDefaults']['configuration']['env'])
+            if 'env' in facts['master']['admission_plugin_config']['BuildDefaults']['configuration']:
+                delete_empty_keys(facts['master']['admission_plugin_config']['BuildDefaults']['configuration']['env'])
 
     return facts
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1469387

https://github.com/openshift/openshift-ansible/pull/5375 Fixed this but only fixed it for scenarios where admissinPluginConfig wasn't previously set.