### PR TITLE
Place-holder for prerequisites.yml

### DIFF
--- a/playbooks/prerequisites.yml
+++ b/playbooks/prerequisites.yml
@@ -1,0 +1,7 @@
+---
+- name: Place holder for prerequisites
+  hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: Debug placeholder
+    debug: msg="Prerequisites ran."


### PR DESCRIPTION
We need this file to be in place to add an additional step
to the CI jobs.

In subsequent PRs, we can add steps into this file.