### PR TITLE
mux containerPort must be an int not a string

### DIFF
--- a/roles/openshift_logging_eventrouter/templates/eventrouter-template.j2
+++ b/roles/openshift_logging_eventrouter/templates/eventrouter-template.j2
@@ -42,7 +42,7 @@ objects:
         component: eventrouter
         logging-infra: eventrouter
         provider: openshift
-      replicas: ${REPLICAS}
+      replicas: "${{ '{{' }}REPLICAS{{ '}}' }}"
       template:
         metadata:
           labels:

--- a/roles/openshift_logging_mux/templates/mux.j2
+++ b/roles/openshift_logging_mux/templates/mux.j2
@@ -59,7 +59,7 @@ spec:
 {%   endif %}
 {% endif %}
         ports:
-        - containerPort: "{{ openshift_logging_mux_port }}"
+        - containerPort: {{ openshift_logging_mux_port }}
           name: mux-forward
         volumeMounts:
         - name: config


### PR DESCRIPTION
mux containerPort must be an int not a string
@jcantrill @ewolinetz need to merge this asap to fix logging CI