### PR TITLE
Add kube service ipaddress to no_proxy list

### DIFF
--- a/playbooks/init/base_packages.yml
+++ b/playbooks/init/base_packages.yml
@@ -16,6 +16,7 @@
       - iproute
       - "{{ 'python3-dbus' if ansible_distribution == 'Fedora' else 'dbus-python' }}"
       - "{{ 'python3-PyYAML' if ansible_distribution == 'Fedora' else 'PyYAML' }}"
+      - "{{ 'python-ipaddress' if ansible_distribution != 'Fedora' else omit }}"
       - yum-utils
       register: result
       until: result is succeeded

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -18,6 +18,7 @@ import socket
 import ipaddress
 from distutils.util import strtobool
 from distutils.version import LooseVersion
+from ansible.module_utils.six import u
 from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves import configparser
 
@@ -1147,7 +1148,7 @@ def set_proxy_facts(facts):
                 if 'no_proxy_internal_hostnames' in common:
                     common['no_proxy'].extend(common['no_proxy_internal_hostnames'].split(','))
             # We always add local dns domain and ourselves no matter what
-            kube_svc_ip = ipaddress.ip_network(unicode(common['portal_net']))[1]
+            kube_svc_ip = str(ipaddress.ip_network(u(common['portal_net']))[1])
             common['no_proxy'].append(kube_svc_ip)
             common['no_proxy'].append('.' + common['dns_domain'])
             common['no_proxy'].append('.svc')

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -15,6 +15,7 @@ import os
 import yaml
 import struct
 import socket
+import ipaddress
 from distutils.util import strtobool
 from distutils.version import LooseVersion
 from ansible.module_utils.six import string_types
@@ -1146,6 +1147,8 @@ def set_proxy_facts(facts):
                 if 'no_proxy_internal_hostnames' in common:
                     common['no_proxy'].extend(common['no_proxy_internal_hostnames'].split(','))
             # We always add local dns domain and ourselves no matter what
+            kube_svc_ip = ipaddress.ip_network(unicode(common['portal_net']))[1]
+            common['no_proxy'].append(kube_svc_ip)
             common['no_proxy'].append('.' + common['dns_domain'])
             common['no_proxy'].append('.svc')
             common['no_proxy'].append(common['hostname'])


### PR DESCRIPTION
Computed as the first ip address in the portal_net

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1511870