### PR TITLE
[3.7 cherrypick] registry-console tech debt

### DIFF
--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -401,9 +401,10 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 
 # OpenShift Registry Console Options
 # Override the console image prefix:
-# origin default is "cockpit/" and the image appended is "kubernetes"
-# enterprise default is "registry.access.redhat.com/openshift3/" and the image appended is "registry-console"
+# origin default is "cockpit/", enterprise default is "openshift3/"
 #openshift_cockpit_deployer_prefix=registry.example.com/myrepo/
+# origin default is "kubernetes", enterprise default is "registry-console"
+#openshift_cockpit_deployer_basename=my-console
 # Override image version, defaults to latest for origin, vX.Y product version for enterprise
 #openshift_cockpit_deployer_version=1.4.1
 

--- a/roles/cockpit-ui/tasks/main.yml
+++ b/roles/cockpit-ui/tasks/main.yml
@@ -41,6 +41,7 @@
     command: >
       {{ openshift.common.client_binary }} new-app --template=registry-console
       {% if openshift_cockpit_deployer_prefix is defined  %}-p IMAGE_PREFIX="{{ openshift_cockpit_deployer_prefix }}"{% endif %}
+      {% if openshift_cockpit_deployer_basename is defined  %}-p IMAGE_BASENAME="{{ openshift_cockpit_deployer_basename }}"{% endif %}
       {% if openshift_cockpit_deployer_version is defined  %}-p IMAGE_VERSION="{{ openshift_cockpit_deployer_version }}"{% endif %}
       -p OPENSHIFT_OAUTH_PROVIDER_URL="{{ openshift.master.public_api_url }}"
       -p REGISTRY_HOST="{{ docker_registry_route.results[0].spec.host }}"

--- a/roles/openshift_health_checker/test/docker_image_availability_test.py
+++ b/roles/openshift_health_checker/test/docker_image_availability_test.py
@@ -217,7 +217,7 @@ def test_registry_availability(image, registries, connection_test_failed, skopeo
             'foo.io/openshift3/ose-docker-registry:f13ac45',
             'foo.io/openshift3/ose-haproxy-router:f13ac45',
             # registry-console is not constructed/versioned the same as the others.
-            'registry.access.redhat.com/openshift3/registry-console:vtest',
+            'openshift3/registry-console:vtest',
             # containerized images aren't built from oreg_url
             'openshift3/node:vtest',
             'openshift3/openvswitch:vtest',
@@ -261,7 +261,7 @@ def test_required_images(deployment_type, is_containerized, groups, oreg_url, ex
             openshift_deployment_type="openshift-enterprise",
             openshift_image_tag="vtest",
         ),
-        "registry.access.redhat.com/openshift3/registry-console:vtest",
+        "openshift3/registry-console:vtest",
     ), (
         dict(
             openshift_deployment_type="openshift-enterprise",

--- a/roles/openshift_hosted_templates/files/v3.6/enterprise/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.6/enterprise/registry-console.yaml
@@ -27,7 +27,7 @@ objects:
         spec:
           containers:
             - name: registry-console
-              image: ${IMAGE_PREFIX}registry-console:${IMAGE_VERSION}
+              image: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
               ports:
                 - containerPort: 9090
                   protocol: TCP
@@ -89,7 +89,7 @@ objects:
         - annotations: null
           from:
             kind: DockerImage
-            name: ${IMAGE_PREFIX}registry-console:${IMAGE_VERSION}
+            name: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
           name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
@@ -102,7 +102,10 @@ objects:
 parameters:
   - description: 'Specify "registry/repository" prefix for container image; e.g. for "registry.access.redhat.com/openshift3/registry-console:latest", set prefix "registry.access.redhat.com/openshift3/"'
     name: IMAGE_PREFIX
-    value: "registry.access.redhat.com/openshift3/"
+    value: "openshift3/"
+  - description: 'Specify component name for container image; e.g. for "registry.access.redhat.com/openshift3/registry-console:latest", use base name "registry-console"'
+    name: IMAGE_BASENAME
+    value: "registry-console"
   - description: 'Specify image version; e.g. for "registry.access.redhat.com/openshift3/registry-console:v3.6", set version "v3.6"'
     name: IMAGE_VERSION
     value: "v3.6"

--- a/roles/openshift_hosted_templates/files/v3.6/origin/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.6/origin/registry-console.yaml
@@ -27,7 +27,7 @@ objects:
         spec:
           containers:
             - name: registry-console
-              image: ${IMAGE_PREFIX}kubernetes:${IMAGE_VERSION}
+              image: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
               ports:
                 - containerPort: 9090
                   protocol: TCP
@@ -89,7 +89,7 @@ objects:
         - annotations: null
           from:
             kind: DockerImage
-            name: ${IMAGE_PREFIX}kubernetes:${IMAGE_VERSION}
+            name: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
           name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
@@ -103,6 +103,9 @@ parameters:
   - description: 'Specify "registry/namespace" prefix for container image; e.g. for "registry.example.com/cockpit/kubernetes:latest", set prefix "registry.example.com/cockpit/"'
     name: IMAGE_PREFIX
     value: "cockpit/"
+  - description: 'Specify component name for container image; e.g. for "registry.example.com/cockpit/kubernetes:latest", use base name "kubernetes"'
+    name: IMAGE_BASENAME
+    value: "kubernetes"
   - description: 'Specify image version; e.g. for "cockpit/kubernetes:latest", set version "latest"'
     name: IMAGE_VERSION
     value: latest

--- a/roles/openshift_hosted_templates/files/v3.7/enterprise/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.7/enterprise/registry-console.yaml
@@ -27,7 +27,7 @@ objects:
         spec:
           containers:
             - name: registry-console
-              image: ${IMAGE_PREFIX}registry-console:${IMAGE_VERSION}
+              image: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
               ports:
                 - containerPort: 9090
                   protocol: TCP
@@ -89,7 +89,7 @@ objects:
         - annotations: null
           from:
             kind: DockerImage
-            name: ${IMAGE_PREFIX}registry-console:${IMAGE_VERSION}
+            name: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
           name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
@@ -102,7 +102,10 @@ objects:
 parameters:
   - description: 'Specify "registry/repository" prefix for container image; e.g. for "registry.access.redhat.com/openshift3/registry-console:latest", set prefix "registry.access.redhat.com/openshift3/"'
     name: IMAGE_PREFIX
-    value: "registry.access.redhat.com/openshift3/"
+    value: "openshift3/"
+  - description: 'Specify component name for container image; e.g. for "registry.access.redhat.com/openshift3/registry-console:latest", use base name "registry-console"'
+    name: IMAGE_BASENAME
+    value: "registry-console"
   - description: 'Specify image version; e.g. for "registry.access.redhat.com/openshift3/registry-console:v3.7", set version "v3.7"'
     name: IMAGE_VERSION
     value: "v3.7"

--- a/roles/openshift_hosted_templates/files/v3.7/origin/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.7/origin/registry-console.yaml
@@ -27,7 +27,7 @@ objects:
         spec:
           containers:
             - name: registry-console
-              image: ${IMAGE_PREFIX}kubernetes:${IMAGE_VERSION}
+              image: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
               ports:
                 - containerPort: 9090
                   protocol: TCP
@@ -89,7 +89,7 @@ objects:
         - annotations: null
           from:
             kind: DockerImage
-            name: ${IMAGE_PREFIX}kubernetes:${IMAGE_VERSION}
+            name: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
           name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
@@ -103,6 +103,9 @@ parameters:
   - description: 'Specify "registry/namespace" prefix for container image; e.g. for "registry.example.com/cockpit/kubernetes:latest", set prefix "registry.example.com/cockpit/"'
     name: IMAGE_PREFIX
     value: "cockpit/"
+  - description: 'Specify component name for container image; e.g. for "registry.example.com/cockpit/kubernetes:latest", use base name "kubernetes"'
+    name: IMAGE_BASENAME
+    value: "kubernetes"
   - description: 'Specify image version; e.g. for "cockpit/kubernetes:latest", set version "latest"'
     name: IMAGE_VERSION
     value: latest


### PR DESCRIPTION
Cherrypick of https://github.com/openshift/openshift-ansible/pull/6114

Fixes the construction and checking of registry-console images to be as similar as it can get to those constructed from the traditional oreg_url without tacking on ose- or origin- to the base name.
