### PR TITLE
[3.7] Move openshift-prometheus out of openshift-hosted

### DIFF
--- a/playbooks/common/openshift-cluster/config.yml
+++ b/playbooks/common/openshift-cluster/config.yml
@@ -26,6 +26,9 @@
 - include: openshift_logging.yml
   when: openshift_logging_install_logging | default(false) | bool
 
+- include: openshift_prometheus.yml
+  when: openshift_hosted_prometheus_deploy | default(false) | bool
+
 - include: service_catalog.yml
   when: openshift_enable_service_catalog | default(true) | bool
 

--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -21,9 +21,6 @@
 
 - include: cockpit-ui.yml
 
-- include: openshift_prometheus.yml
-  when: openshift_hosted_prometheus_deploy | default(False) | bool
-
 - include: install_docker_gc.yml
   when:
   - openshift_use_crio | default(False) | bool


### PR DESCRIPTION
openshift-prometheus has it's own entry point and should not be run from within openshift-hosted.