### PR TITLE
Include Deprecation - openshift-checks

### DIFF
--- a/playbooks/openshift-checks/adhoc.yml
+++ b/playbooks/openshift-checks/adhoc.yml
@@ -20,6 +20,6 @@
     action: openshift_health_check
     when: openshift_checks is undefined or not openshift_checks
 
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/adhoc.yml
+- import_playbook: private/adhoc.yml

--- a/playbooks/openshift-checks/health.yml
+++ b/playbooks/openshift-checks/health.yml
@@ -1,4 +1,4 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/health.yml
+- import_playbook: private/health.yml

--- a/playbooks/openshift-checks/pre-install.yml
+++ b/playbooks/openshift-checks/pre-install.yml
@@ -1,4 +1,4 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/pre-install.yml
+- import_playbook: private/pre-install.yml


### PR DESCRIPTION
This PR addresses all `include:` directives within components of the openshift-checks playbooks.

Trello: https://trello.com/c/ZTyZu3UM/484-3-ansible-24-include-deprecation