### PR TITLE
Include Deprecation - openshift-loadbalancer

### DIFF
--- a/playbooks/openshift-loadbalancer/config.yml
+++ b/playbooks/openshift-loadbalancer/config.yml
@@ -1,4 +1,4 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/config.yml
+- import_playbook: private/config.yml

--- a/roles/openshift_loadbalancer/tasks/main.yml
+++ b/roles/openshift_loadbalancer/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - name: setup firewall
-  include: firewall.yml
-  static: yes
+  import_tasks: firewall.yml
 
 - name: Install haproxy
   package: name=haproxy state=present

--- a/roles/os_firewall/tasks/main.yml
+++ b/roles/os_firewall/tasks/main.yml
@@ -8,12 +8,12 @@
   set_fact:
     r_os_firewall_is_atomic: "{{ r_os_firewall_ostree_booted.stat.exists }}"
 
-- include: firewalld.yml
+- include_tasks: firewalld.yml
   when:
   - os_firewall_enabled | bool
   - os_firewall_use_firewalld | bool
 
-- include: iptables.yml
+- include_tasks: iptables.yml
   when:
   - os_firewall_enabled | bool
   - not os_firewall_use_firewalld | bool


### PR DESCRIPTION
This PR addresses all `include:` directives within components of the openshift-loadbalancer playbooks.

Trello: https://trello.com/c/ZTyZu3UM/484-3-ansible-24-include-deprecation