### PR TITLE
Include Deprecation - openshift-etcd

### DIFF
--- a/playbooks/common/openshift-cluster/redeploy-certificates/etcd-ca.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/etcd-ca.yml
@@ -39,7 +39,7 @@
   tasks:
   - include_role:
       name: etcd
-      tasks_from: distribute_ca
+      tasks_from: distribute_ca.yml
     vars:
       etcd_sync_cert_dir: "{{ hostvars['localhost'].g_etcd_mktemp.stdout }}"
       etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"

--- a/playbooks/openshift-etcd/certificates.yml
+++ b/playbooks/openshift-etcd/certificates.yml
@@ -1,6 +1,6 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/ca.yml
+- import_playbook: private/ca.yml
 
-- include: private/certificates.yml
+- import_playbook: private/certificates.yml

--- a/playbooks/openshift-etcd/config.yml
+++ b/playbooks/openshift-etcd/config.yml
@@ -1,4 +1,4 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/config.yml
+- import_playbook: private/config.yml

--- a/playbooks/openshift-etcd/embedded2external.yml
+++ b/playbooks/openshift-etcd/embedded2external.yml
@@ -1,4 +1,4 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/embedded2external.yml
+- import_playbook: private/embedded2external.yml

--- a/playbooks/openshift-etcd/migrate.yml
+++ b/playbooks/openshift-etcd/migrate.yml
@@ -1,4 +1,4 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/migrate.yml
+- import_playbook: private/migrate.yml

--- a/playbooks/openshift-etcd/private/certificates.yml
+++ b/playbooks/openshift-etcd/private/certificates.yml
@@ -1,4 +1,4 @@
 ---
-- include: server_certificates.yml
+- import_playbook: server_certificates.yml
 
-- include: master_etcd_certificates.yml
+- import_playbook: master_etcd_certificates.yml

--- a/playbooks/openshift-etcd/private/config.yml
+++ b/playbooks/openshift-etcd/private/config.yml
@@ -11,9 +11,9 @@
           status: "In Progress"
           start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- include: ca.yml
+- import_playbook: ca.yml
 
-- include: certificates.yml
+- import_playbook: certificates.yml
 
 - name: Configure etcd
   hosts: oo_etcd_to_config

--- a/playbooks/openshift-etcd/private/embedded2external.yml
+++ b/playbooks/openshift-etcd/private/embedded2external.yml
@@ -49,9 +49,9 @@
       r_etcd_common_backup_sufix_name: "{{ embedded_etcd_backup_suffix }}"
 
 # 3. deploy certificates (for etcd and master)
-- include: ca.yml
+- import_playbook: ca.yml
 
-- include: server_certificates.yml
+- import_playbook: server_certificates.yml
 
 - name: Backup etcd client certificates for master host
   hosts: oo_first_master
@@ -61,12 +61,12 @@
       tasks_from: backup_master_etcd_certificates
 
 - name: Redeploy master etcd certificates
-  include: master_etcd_certificates.yml
+  import_playbook: master_etcd_certificates.yml
   vars:
     etcd_certificates_redeploy: "{{ true }}"
 
 # 4. deploy external etcd
-- include: config.yml
+- import_playbook: config.yml
 
 # 5. stop external etcd
 - name: Cleanse etcd

--- a/playbooks/openshift-etcd/private/migrate.yml
+++ b/playbooks/openshift-etcd/private/migrate.yml
@@ -114,7 +114,7 @@
     set_fact:
       r_etcd_migrate_success: true
 
-- include: ./scaleup.yml
+- import_playbook: scaleup.yml
 
 - name: Gate on etcd migration
   hosts: oo_masters_to_config

--- a/playbooks/openshift-etcd/restart.yml
+++ b/playbooks/openshift-etcd/restart.yml
@@ -1,4 +1,4 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/restart.yml
+- import_playbook: private/restart.yml

--- a/playbooks/openshift-etcd/scaleup.yml
+++ b/playbooks/openshift-etcd/scaleup.yml
@@ -1,4 +1,4 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/scaleup.yml
+- import_playbook: private/scaleup.yml

--- a/roles/etcd/tasks/backup.archive.yml
+++ b/roles/etcd/tasks/backup.archive.yml
@@ -1,3 +1,3 @@
 ---
-- include: backup/vars.yml
-- include: backup/archive.yml
+- include_tasks: backup/vars.yml
+- include_tasks: backup/archive.yml

--- a/roles/etcd/tasks/backup.copy.yml
+++ b/roles/etcd/tasks/backup.copy.yml
@@ -1,3 +1,3 @@
 ---
-- include: backup/vars.yml
-- include: backup/copy.yml
+- include_tasks: backup/vars.yml
+- include_tasks: backup/copy.yml

--- a/roles/etcd/tasks/backup.fetch.yml
+++ b/roles/etcd/tasks/backup.fetch.yml
@@ -1,3 +1,3 @@
 ---
-- include: backup/vars.yml
-- include: backup/fetch.yml
+- include_tasks: backup/vars.yml
+- include_tasks: backup/fetch.yml

--- a/roles/etcd/tasks/backup.force_new_cluster.yml
+++ b/roles/etcd/tasks/backup.force_new_cluster.yml
@@ -1,5 +1,5 @@
 ---
-- include: backup/vars.yml
+- include_tasks: backup/vars.yml
 
 - name: Move content of etcd backup under the etcd data directory
   command: >
@@ -9,4 +9,4 @@
   command: >
     chown -R etcd:etcd "{{ etcd_data_dir }}"
 
-- include: auxiliary/force_new_cluster.yml
+- include_tasks: auxiliary/force_new_cluster.yml

--- a/roles/etcd/tasks/backup.unarchive.yml
+++ b/roles/etcd/tasks/backup.unarchive.yml
@@ -1,3 +1,3 @@
 ---
-- include: backup/vars.yml
-- include: backup/unarchive.yml
+- include_tasks: backup/vars.yml
+- include_tasks: backup/unarchive.yml

--- a/roles/etcd/tasks/backup.yml
+++ b/roles/etcd/tasks/backup.yml
@@ -1,2 +1,2 @@
 ---
-- include: backup/backup.yml
+- include_tasks: backup/backup.yml

--- a/roles/etcd/tasks/backup/backup.yml
+++ b/roles/etcd/tasks/backup/backup.yml
@@ -1,5 +1,5 @@
 ---
-- include: vars.yml
+- include_tasks: vars.yml
 
 # TODO: replace shell module with command and update later checks
 - name: Check available disk space for etcd backup

--- a/roles/etcd/tasks/backup_ca_certificates.yml
+++ b/roles/etcd/tasks/backup_ca_certificates.yml
@@ -1,2 +1,2 @@
 ---
-- include: certificates/backup_ca_certificates.yml
+- include_tasks: certificates/backup_ca_certificates.yml

--- a/roles/etcd/tasks/backup_generated_certificates.yml
+++ b/roles/etcd/tasks/backup_generated_certificates.yml
@@ -1,2 +1,2 @@
 ---
-- include: certificates/backup_generated_certificates.yml
+- include_tasks: certificates/backup_generated_certificates.yml

--- a/roles/etcd/tasks/backup_master_etcd_certificates.yml
+++ b/roles/etcd/tasks/backup_master_etcd_certificates.yml
@@ -1,2 +1,2 @@
 ---
-- include: certificates/backup_master_etcd_certificates.yml
+- include_tasks: certificates/backup_master_etcd_certificates.yml

--- a/roles/etcd/tasks/backup_server_certificates.yml
+++ b/roles/etcd/tasks/backup_server_certificates.yml
@@ -1,2 +1,2 @@
 ---
-- include: certificates/backup_server_certificates.yml
+- include_tasks: certificates/backup_server_certificates.yml

--- a/roles/etcd/tasks/ca.yml
+++ b/roles/etcd/tasks/ca.yml
@@ -1,2 +1,2 @@
 ---
-- include: certificates/deploy_ca.yml
+- include_tasks: certificates/deploy_ca.yml

--- a/roles/etcd/tasks/check_cluster_health.yml
+++ b/roles/etcd/tasks/check_cluster_health.yml
@@ -1,2 +1,2 @@
 ---
-- include: migration/check_cluster_health.yml
+- include_tasks: migration/check_cluster_health.yml

--- a/roles/etcd/tasks/clean_data.yml
+++ b/roles/etcd/tasks/clean_data.yml
@@ -1,2 +1,2 @@
 ---
-- include: auxiliary/clean_data.yml
+- include_tasks: auxiliary/clean_data.yml

--- a/roles/etcd/tasks/client_certificates.yml
+++ b/roles/etcd/tasks/client_certificates.yml
@@ -1,2 +1,2 @@
 ---
-- include: certificates/fetch_client_certificates_from_ca.yml
+- include_tasks: certificates/fetch_client_certificates_from_ca.yml

--- a/roles/etcd/tasks/disable_etcd.yml
+++ b/roles/etcd/tasks/disable_etcd.yml
@@ -1,2 +1,2 @@
 ---
-- include: auxiliary/disable_etcd.yml
+- include_tasks: auxiliary/disable_etcd.yml

--- a/roles/etcd/tasks/distribute_ca
+++ b/roles/etcd/tasks/distribute_ca
@@ -1,2 +1,0 @@
----
-- include: certificates/distribute_ca.yml

--- a/roles/etcd/tasks/distribute_ca.yml
+++ b/roles/etcd/tasks/distribute_ca.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: certificates/distribute_ca.yml

--- a/roles/etcd/tasks/drop_etcdctl.yml
+++ b/roles/etcd/tasks/drop_etcdctl.yml
@@ -1,2 +1,2 @@
 ---
-- include: auxiliary/drop_etcdctl.yml
+- include_tasks: auxiliary/drop_etcdctl.yml

--- a/roles/etcd/tasks/fetch_backup.yml
+++ b/roles/etcd/tasks/fetch_backup.yml
@@ -1,8 +1,8 @@
 ---
-- include: backup/vars.yml
+- include_tasks: backup/vars.yml
 
-- include: backup/archive.yml
+- include_tasks: backup/archive.yml
 
-- include: backup/sync_backup.yml
+- include_tasks: backup/sync_backup.yml
 
-- include: backup/
+- include_tasks: backup/

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -7,14 +7,13 @@
     etcd_ip: "{{ etcd_ip }}"
 
 - name: setup firewall
-  include: firewall.yml
-  static: yes
+  import_tasks: firewall.yml
 
 - name: Install etcd
   package: name=etcd{{ '-' + etcd_version if etcd_version is defined else '' }} state=present
   when: not etcd_is_containerized | bool
 
-- include: drop_etcdctl.yml
+- include_tasks: drop_etcdctl.yml
   when:
   - openshift_etcd_etcdctl_profile | default(true) | bool
 
@@ -101,7 +100,7 @@
     when: not l_is_etcd_system_container | bool
 
   - name: Install Etcd system container
-    include: system_container.yml
+    include_tasks: system_container.yml
     when: l_is_etcd_system_container | bool
   when: etcd_is_containerized | bool
 

--- a/roles/etcd/tasks/migrate.add_ttls.yml
+++ b/roles/etcd/tasks/migrate.add_ttls.yml
@@ -1,2 +1,2 @@
 ---
-- include: migration/add_ttls.yml
+- include_tasks: migration/add_ttls.yml

--- a/roles/etcd/tasks/migrate.configure_master.yml
+++ b/roles/etcd/tasks/migrate.configure_master.yml
@@ -1,2 +1,2 @@
 ---
-- include: migration/configure_master.yml
+- include_tasks: migration/configure_master.yml

--- a/roles/etcd/tasks/migrate.pre_check.yml
+++ b/roles/etcd/tasks/migrate.pre_check.yml
@@ -1,2 +1,2 @@
 ---
-- include: migration/check.yml
+- include_tasks: migration/check.yml

--- a/roles/etcd/tasks/migrate.yml
+++ b/roles/etcd/tasks/migrate.yml
@@ -1,2 +1,2 @@
 ---
-- include: migration/migrate.yml
+- include_tasks: migration/migrate.yml

--- a/roles/etcd/tasks/migration/check.yml
+++ b/roles/etcd/tasks/migration/check.yml
@@ -1,7 +1,7 @@
 ---
 
 # Check the cluster is healthy
-- include: check_cluster_health.yml
+- include_tasks: check_cluster_health.yml
 
 # Check if there is at least one v2 snapshot
 - name: Check if there is at least one v2 snapshot
@@ -39,7 +39,7 @@
 # - with_items not supported over block
 
 # Check the cluster status for the first time
-- include: check_cluster_status.yml
+- include_tasks: check_cluster_status.yml
 
 # Check the cluster status for the second time
 - block:
@@ -50,7 +50,7 @@
       seconds: 5
     when: not l_etcd_cluster_status_ok | bool
 
-  - include: check_cluster_status.yml
+  - include_tasks: check_cluster_status.yml
     when: not l_etcd_cluster_status_ok | bool
 
 
@@ -63,5 +63,5 @@
       seconds: 5
     when: not l_etcd_cluster_status_ok | bool
 
-  - include: check_cluster_status.yml
+  - include_tasks: check_cluster_status.yml
     when: not l_etcd_cluster_status_ok | bool

--- a/roles/etcd/tasks/remove_ca_certificates.yml
+++ b/roles/etcd/tasks/remove_ca_certificates.yml
@@ -1,2 +1,2 @@
 ---
-- include: certificates/remove_ca_certificates.yml
+- include_tasks: certificates/remove_ca_certificates.yml

--- a/roles/etcd/tasks/remove_generated_certificates.yml
+++ b/roles/etcd/tasks/remove_generated_certificates.yml
@@ -1,2 +1,2 @@
 ---
-- include: certificates/remove_generated_certificates.yml
+- include_tasks: certificates/remove_generated_certificates.yml

--- a/roles/etcd/tasks/retrieve_ca_certificates.yml
+++ b/roles/etcd/tasks/retrieve_ca_certificates.yml
@@ -1,2 +1,2 @@
 ---
-- include: certificates/retrieve_ca_certificates.yml
+- include_tasks: certificates/retrieve_ca_certificates.yml

--- a/roles/etcd/tasks/server_certificates.yml
+++ b/roles/etcd/tasks/server_certificates.yml
@@ -1,6 +1,6 @@
 ---
-- include: ca.yml
+- include_tasks: ca.yml
   when:
   - etcd_ca_setup | default(True) | bool
 
-- include: certificates/fetch_server_certificates_from_ca.yml
+- include_tasks: certificates/fetch_server_certificates_from_ca.yml

--- a/roles/etcd/tasks/upgrade_image.yml
+++ b/roles/etcd/tasks/upgrade_image.yml
@@ -1,2 +1,2 @@
 ---
-- include: upgrade/upgrade_image.yml
+- include_tasks: upgrade/upgrade_image.yml

--- a/roles/etcd/tasks/upgrade_rpm.yml
+++ b/roles/etcd/tasks/upgrade_rpm.yml
@@ -1,2 +1,2 @@
 ---
-- include: upgrade/upgrade_rpm.yml
+- include_tasks: upgrade/upgrade_rpm.yml

--- a/roles/os_firewall/tasks/main.yml
+++ b/roles/os_firewall/tasks/main.yml
@@ -8,12 +8,12 @@
   set_fact:
     r_os_firewall_is_atomic: "{{ r_os_firewall_ostree_booted.stat.exists }}"
 
-- include: firewalld.yml
+- include_tasks: firewalld.yml
   when:
   - os_firewall_enabled | bool
   - os_firewall_use_firewalld | bool
 
-- include: iptables.yml
+- include_tasks: iptables.yml
   when:
   - os_firewall_enabled | bool
   - not os_firewall_use_firewalld | bool


### PR DESCRIPTION
This PR addresses all `include:` directives within components of the openshift-etcd playbooks.

Trello: https://trello.com/c/ZTyZu3UM/484-3-ansible-24-include-deprecation