### PR TITLE
Include Deprecation - openshift-metrics

### DIFF
--- a/playbooks/openshift-metrics/config.yml
+++ b/playbooks/openshift-metrics/config.yml
@@ -1,4 +1,4 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/config.yml
+- import_playbook: private/config.yml

--- a/roles/openshift_metrics/tasks/generate_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_certificates.yaml
@@ -8,4 +8,4 @@
     --serial='{{ mktemp.stdout }}/ca.serial.txt'
     --name="metrics-signer@{{lookup('pipe','date +%s')}}"
 
-- include: generate_hawkular_certificates.yaml
+- include_tasks: generate_hawkular_certificates.yaml

--- a/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
@@ -1,13 +1,13 @@
 ---
 - name: generate hawkular-metrics certificates
-  include: setup_certificate.yaml
+  include_tasks: setup_certificate.yaml
   vars:
     component: hawkular-metrics
     hostnames: "hawkular-metrics,hawkular-metrics.{{ openshift_metrics_project }}.svc.cluster.local,{{ openshift_metrics_hawkular_hostname }}"
   changed_when: no
 
 - name: generate hawkular-cassandra certificates
-  include: setup_certificate.yaml
+  include_tasks: setup_certificate.yaml
   vars:
     component: hawkular-cassandra
     hostnames: hawkular-cassandra

--- a/roles/openshift_metrics/tasks/install_heapster.yaml
+++ b/roles/openshift_metrics/tasks/install_heapster.yaml
@@ -66,4 +66,4 @@
         namespace: "{{ openshift_metrics_project }}"
   changed_when: no
 
-- include: generate_heapster_secrets.yaml
+- include_tasks: generate_heapster_secrets.yaml

--- a/roles/openshift_metrics/tasks/install_metrics.yaml
+++ b/roles/openshift_metrics/tasks/install_metrics.yaml
@@ -1,8 +1,8 @@
 ---
-- include: pre_install.yaml
+- include_tasks: pre_install.yaml
 
 - name: Install Metrics
-  include: "{{ role_path }}/tasks/install_{{ include_file }}.yaml"
+  include_tasks: "install_{{ include_file }}.yaml"
   with_items:
     - support
     - heapster
@@ -13,11 +13,11 @@
   when: not openshift_metrics_heapster_standalone | bool
 
 - name: Install Heapster Standalone
-  include: install_heapster.yaml
+  include_tasks: install_heapster.yaml
   when: openshift_metrics_heapster_standalone | bool
 
 - name: Install Hawkular OpenShift Agent (HOSA)
-  include: install_hosa.yaml
+  include_tasks: install_hosa.yaml
   when: openshift_metrics_install_hawkular_agent | default(false) | bool
 
 - find:
@@ -34,7 +34,7 @@
   changed_when: no
 
 - name: Create objects
-  include: oc_apply.yaml
+  include_tasks: oc_apply.yaml
   vars:
     kubeconfig: "{{ mktemp.stdout }}/admin.kubeconfig"
     namespace: "{{ openshift_metrics_project }}"
@@ -58,7 +58,7 @@
   changed_when: no
 
 - name: Create Hawkular Agent objects
-  include: oc_apply.yaml
+  include_tasks: oc_apply.yaml
   vars:
     kubeconfig: "{{ mktemp.stdout }}/admin.kubeconfig"
     namespace: "{{ openshift_metrics_hawkular_agent_namespace }}"
@@ -67,7 +67,7 @@
   with_items: "{{ hawkular_agent_object_defs.results }}"
   when: openshift_metrics_install_hawkular_agent | bool
 
-- include: update_master_config.yaml
+- include_tasks: update_master_config.yaml
 
 - command: >
     {{openshift.common.client_binary}}
@@ -80,11 +80,11 @@
   changed_when: no
 
 - name: Scaling down cluster to recognize changes
-  include: stop_metrics.yaml
+  include_tasks: stop_metrics.yaml
   when: existing_metrics_rc.stdout_lines | length > 0
 
 - name: Scaling up cluster
-  include: start_metrics.yaml
+  include_tasks: start_metrics.yaml
   tags: openshift_metrics_start_cluster
   when:
     - openshift_metrics_start_cluster | default(true) | bool

--- a/roles/openshift_metrics/tasks/install_support.yaml
+++ b/roles/openshift_metrics/tasks/install_support.yaml
@@ -19,7 +19,7 @@
 - fail: msg="'keytool' is unavailable. Please install java-1.8.0-openjdk-headless on the control node"
   when: keytool_check.rc  == 1
 
-- include: generate_certificates.yaml
-- include: generate_serviceaccounts.yaml
-- include: generate_services.yaml
-- include: generate_rolebindings.yaml
+- include_tasks: generate_certificates.yaml
+- include_tasks: generate_serviceaccounts.yaml
+- include_tasks: generate_services.yaml
+- include_tasks: generate_rolebindings.yaml

--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -43,15 +43,15 @@
   check_mode: no
   tags: metrics_init
 
-- include: install_metrics.yaml
+- include_tasks: install_metrics.yaml
   when:
     - openshift_metrics_install_metrics | bool
 
-- include: uninstall_metrics.yaml
+- include_tasks: uninstall_metrics.yaml
   when:
     - not openshift_metrics_install_metrics | bool
 
-- include: uninstall_hosa.yaml
+- include_tasks: uninstall_hosa.yaml
   when: not openshift_metrics_install_hawkular_agent | bool
 
 - name: Delete temp directory

--- a/roles/openshift_metrics/tasks/uninstall_metrics.yaml
+++ b/roles/openshift_metrics/tasks/uninstall_metrics.yaml
@@ -1,6 +1,6 @@
 ---
 - name: stop metrics
-  include: stop_metrics.yaml
+  include_tasks: stop_metrics.yaml
 
 - name: remove metrics components
   command: >


### PR DESCRIPTION
This PR addresses all `include:` directives within components of the openshift-metrics playbooks.

Trello: https://trello.com/c/ZTyZu3UM/484-3-ansible-24-include-deprecation