### PR TITLE
Workaround the fact that package state=present with dnf fails for already installed but excluded packages.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/docker/upgrade_check.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/upgrade_check.yml
@@ -16,7 +16,7 @@
   changed_when: no
 
 - name: Get current version of Docker
-  command: "{{ repoquery_cmd }} --installed --qf '%{version}' docker"
+  command: "{{ repoquery_installed }} --qf '%{version}' docker"
   register: curr_docker_version
   retries: 4
   until: curr_docker_version | succeeded

--- a/playbooks/init/facts.yml
+++ b/playbooks/init/facts.yml
@@ -154,6 +154,7 @@
   - name: initialize_facts set_fact repoquery command
     set_fact:
       repoquery_cmd: "{{ 'dnf repoquery --latest-limit 1 -d 0' if ansible_pkg_mgr == 'dnf' else 'repoquery --plugins' }}"
+      repoquery_installed: "{{ 'dnf repoquery --latest-limit 1 -d 0 --disableexcludes=all --installed' if ansible_pkg_mgr == 'dnf' else 'repoquery --plugins --installed' }}"
 
   - name: initialize_facts set_fact on openshift_docker_hosted_registry_network
     set_fact:

--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -33,9 +33,10 @@
 
 # Make sure Docker is installed, but does not update a running version.
 # Docker upgrades are handled by a separate playbook.
+# Note: The curr_docker_version.stdout check can be removed when https://github.com/ansible/ansible/issues/33187 gets fixed.
 - name: Install Docker
   package: name=docker{{ '-' + docker_version if docker_version is defined else '' }} state=present
-  when: not openshift.common.is_atomic | bool
+  when: not openshift.common.is_atomic | bool and not curr_docker_version | skipped and not curr_docker_version.stdout != ''
 
 - block:
   # Extend the default Docker service unit file when using iptables-services

--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get current installed Docker version
-  command: "{{ repoquery_cmd }} --installed --qf '%{version}' docker"
+  command: "{{ repoquery_installed }} --qf '%{version}' docker"
   when: not openshift.common.is_atomic | bool
   register: curr_docker_version
   retries: 4


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-ansible/issues/5517.