### PR TITLE
[1.5] 1516469 Add lib_openshift dependency for etcd role

### DIFF
--- a/roles/etcd/meta/main.yml
+++ b/roles/etcd/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
   - cloud
   - system
 dependencies:
+- role: lib_openshift
 - role: os_firewall
   os_firewall_allow:
   - service: etcd


### PR DESCRIPTION
The etcd role uses oc_atomic_container which is a module from lib_openshift.

https://bugzilla.redhat.com/show_bug.cgi?id=1516469

