### PR TITLE
tox.ini: simplify unit test reqs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,11 +12,11 @@ skip_install=True
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
+    unit: -eutils
     py35-flake8: flake8-bugbear==17.3.0
     integration: docker-py==1.10.6
 
 commands =
-    unit: pip install -e utils
     unit: pytest {posargs}
     flake8: flake8 {posargs}
     pylint: python setup.py lint


### PR DESCRIPTION
Rather than using a command to install ooinstall in the venv, just do so
as part of creation and leave the command to just run unit tests.