### PR TITLE
Python - Passlib error

### DIFF
--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -6,7 +6,7 @@
 - name: Check that python-passlib is available on the control host
   assert:
     that:
-      - "'not installed' not in passlib_result.stdout"
+      - "'not installed' in passlib_result.stdout"
     msg: "python-passlib rpm must be installed on control host"
 
 - name: Set default image variables based on deployment_type


### PR DESCRIPTION
Hi,

TASK [openshift_metrics : Check that python-passlib is available on the control host] *************************************************************************************************
fatal: [openshift.domain.com]: FAILED! => {
    "assertion": "'not installed' not in passlib_result.stdout", 
    "changed": false, 
    "evaluated_to": false, 
    "failed": true
}
MSG:
python-passlib rpm must be installed on control host

:rpm -q python2-passlib
:python2-passlib-1.7.0-4.el7.noarch
:python -c 'import passlib ' 2>/dev/null || echo not installed
: 



