### PR TITLE
dist.iteritems() no longer exists in Python 3.

### DIFF
--- a/roles/nickhammond.logrotate/templates/logrotate.d.j2
+++ b/roles/nickhammond.logrotate/templates/logrotate.d.j2
@@ -7,7 +7,7 @@
   {% endfor -%}
   {% endif %}
   {%- if item.scripts is defined -%}
-  {%- for name, script in item.scripts.iteritems() -%}
+  {%- for name, script in item.scripts.items() -%}
   {{ name }}
     {{ script }}
   endscript

--- a/roles/openshift_hosted/tasks/storage/glusterfs.yml
+++ b/roles/openshift_hosted/tasks/storage/glusterfs.yml
@@ -12,7 +12,7 @@
     namespace: "{{ openshift_hosted_registry_namespace }}"
     state: list
     kind: pod
-    selector: "{% for label, value in registry_dc.results.results[0].spec.selector.iteritems() %}{{ label }}={{ value }}{% if not loop.last %},{% endif %}{% endfor %}"
+    selector: "{% for label, value in registry_dc.results.results[0].spec.selector.items() %}{{ label }}={{ value }}{% if not loop.last %},{% endif %}{% endfor %}"
   register: registry_pods
   until:
   - "registry_pods.results.results[0]['items'] | count > 0"

--- a/roles/openshift_logging_curator/templates/curator.j2
+++ b/roles/openshift_logging_curator/templates/curator.j2
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: aggregated-logging-curator
 {% if curator_node_selector is iterable and curator_node_selector | length > 0 %}
       nodeSelector:
-{% for key, value in curator_node_selector.iteritems() %}
+{% for key, value in curator_node_selector.items() %}
         {{key}}: "{{value}}"
 {% endfor %}
 {% endif %}

--- a/roles/openshift_logging_elasticsearch/templates/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/es.j2
@@ -34,7 +34,7 @@ spec:
 {% endfor %}
 {% if es_node_selector is iterable and es_node_selector | length > 0 %}
       nodeSelector:
-{% for key, value in es_node_selector.iteritems() %}
+{% for key, value in es_node_selector.items() %}
         {{key}}: "{{value}}"
 {% endfor %}
 {% endif %}

--- a/roles/openshift_logging_elasticsearch/templates/pvc.j2
+++ b/roles/openshift_logging_elasticsearch/templates/pvc.j2
@@ -6,7 +6,7 @@ metadata:
     logging-infra: support
 {% if annotations is defined %}
   annotations:
-{% for key,value in annotations.iteritems() %}
+{% for key,value in annotations.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% endif %}
@@ -14,7 +14,7 @@ spec:
 {% if pv_selector is defined and pv_selector is mapping %}
   selector:
     matchLabels:
-{% for key,value in pv_selector.iteritems() %}
+{% for key,value in pv_selector.items() %}
       {{key}}: {{value}}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_logging_elasticsearch/templates/route_reencrypt.j2
+++ b/roles/openshift_logging_elasticsearch/templates/route_reencrypt.j2
@@ -4,7 +4,7 @@ metadata:
   name: "{{obj_name}}"
 {% if labels is defined%}
   labels:
-{% for key, value in labels.iteritems() %}
+{% for key, value in labels.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_logging_eventrouter/templates/eventrouter-template.j2
+++ b/roles/openshift_logging_eventrouter/templates/eventrouter-template.j2
@@ -55,7 +55,7 @@ objects:
           serviceAccountName: aggregated-logging-eventrouter
 {% if node_selector is iterable and node_selector | length > 0 %}
           nodeSelector:
-{% for key, value in node_selector.iteritems() %}
+{% for key, value in node_selector.items() %}
             {{ key }}: "{{ value }}"
 {% endfor %}
 {% endif %}

--- a/roles/openshift_logging_kibana/templates/kibana.j2
+++ b/roles/openshift_logging_kibana/templates/kibana.j2
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aggregated-logging-kibana
 {% if kibana_node_selector is iterable and kibana_node_selector | length > 0 %}
       nodeSelector:
-{% for key, value in kibana_node_selector.iteritems() %}
+{% for key, value in kibana_node_selector.items() %}
         {{ key }}: "{{ value }}"
 {% endfor %}
 {% endif %}

--- a/roles/openshift_logging_kibana/templates/route_reencrypt.j2
+++ b/roles/openshift_logging_kibana/templates/route_reencrypt.j2
@@ -4,7 +4,7 @@ metadata:
   name: "{{obj_name}}"
 {% if labels is defined%}
   labels:
-{% for key, value in labels.iteritems() %}
+{% for key, value in labels.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_logging_mux/templates/mux.j2
+++ b/roles/openshift_logging_mux/templates/mux.j2
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: aggregated-logging-mux
 {% if mux_node_selector is iterable and mux_node_selector | length > 0 %}
       nodeSelector:
-{% for key, value in mux_node_selector.iteritems() %}
+{% for key, value in mux_node_selector.items() %}
         {{key}}: "{{value}}"
 {% endfor %}
 {% endif %}

--- a/roles/openshift_master/templates/htpasswd.j2
+++ b/roles/openshift_master/templates/htpasswd.j2
@@ -1,5 +1,5 @@
 {% if 'htpasswd_users' in openshift.master %}
-{%   for user,pass in openshift.master.htpasswd_users.iteritems() %}
+{%   for user,pass in openshift.master.htpasswd_users.items() %}
 {{     user ~ ':' ~ pass }}
 {%   endfor %}
 {% endif %}

--- a/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
@@ -24,7 +24,7 @@ spec:
         - {{openshift_metrics_cassandra_storage_group}}
 {% if node_selector is iterable and node_selector | length > 0 %}
       nodeSelector:
-{% for key, value in node_selector.iteritems() %}
+{% for key, value in node_selector.items() %}
         {{key}}: "{{value}}"
 {% endfor %}
 {% endif %}

--- a/roles/openshift_metrics/templates/hawkular_metrics_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_metrics_rc.j2
@@ -19,7 +19,7 @@ spec:
       serviceAccount: hawkular
 {% if node_selector is iterable and node_selector | length > 0 %}
       nodeSelector:
-{% for key, value in node_selector.iteritems() %}
+{% for key, value in node_selector.items() %}
         {{key}}: "{{value}}"
 {% endfor %}
 {% endif %}

--- a/roles/openshift_metrics/templates/hawkular_openshift_agent_ds.j2
+++ b/roles/openshift_metrics/templates/hawkular_openshift_agent_ds.j2
@@ -19,7 +19,7 @@ spec:
       serviceAccount: hawkular-openshift-agent
 {% if node_selector is iterable and node_selector | length > 0 %}
       nodeSelector:
-{% for key, value in node_selector.iteritems() %}
+{% for key, value in node_selector.items() %}
         {{key}}: "{{value}}"
 {% endfor %}
 {% endif %}

--- a/roles/openshift_metrics/templates/heapster.j2
+++ b/roles/openshift_metrics/templates/heapster.j2
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
 {% if node_selector is iterable and node_selector | length > 0 %}
       nodeSelector:
-{% for key, value in node_selector.iteritems() %}
+{% for key, value in node_selector.items() %}
         {{key}}: "{{value}}"
 {% endfor %}
 {% endif %}

--- a/roles/openshift_metrics/templates/pvc.j2
+++ b/roles/openshift_metrics/templates/pvc.j2
@@ -7,13 +7,13 @@ metadata:
     metrics-infra: support
 {% elif labels %}
   labels:
-{% for key, value in labels.iteritems() %}
+{% for key, value in labels.items() %}
     {{ key }}: {{ value }}
 {% endfor %}
 {% endif %}
 {% if annotations is defined and annotations %}
   annotations:
-{% for key,value in annotations.iteritems() %}
+{% for key,value in annotations.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% endif %}
@@ -21,7 +21,7 @@ spec:
 {% if pv_selector is defined and pv_selector is mapping %}
   selector:
     matchLabels:
-{% for key,value in pv_selector.iteritems() %}
+{% for key,value in pv_selector.items() %}
       {{key}}: {{value}}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_metrics/templates/rolebinding.j2
+++ b/roles/openshift_metrics/templates/rolebinding.j2
@@ -4,7 +4,7 @@ metadata:
   name: {{obj_name}}
 {% if labels is defined %}
   labels:
-{% for k, v in labels.iteritems() %}
+{% for k, v in labels.items() %}
     {{ k }}: {{ v }}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_metrics/templates/route.j2
+++ b/roles/openshift_metrics/templates/route.j2
@@ -7,7 +7,7 @@ metadata:
 {% endif %}
 {% if labels is defined and labels %}
   labels:
-{% for k, v in labels.iteritems() %}
+{% for k, v in labels.items() %}
     {{ k }}: {{ v }}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_metrics/templates/secret.j2
+++ b/roles/openshift_metrics/templates/secret.j2
@@ -4,15 +4,15 @@ metadata:
   name: "{{ name }}"
 {% if annotations is defined%}
   annotations:
-{% for key, value in annotations.iteritems() %}
+{% for key, value in annotations.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% endif %}
   labels:
-{% for k, v in labels.iteritems() %}
+{% for k, v in labels.items() %}
     {{ k }}: {{ v }}
 {% endfor %}
 data:
-{% for k, v in data.iteritems() %}
+{% for k, v in data.items() %}
   {{ k }}: {{ v }}
 {% endfor %}

--- a/roles/openshift_metrics/templates/service.j2
+++ b/roles/openshift_metrics/templates/service.j2
@@ -4,13 +4,13 @@ metadata:
   name: "{{obj_name}}"
 {% if annotations is defined%}
   annotations:
-{% for key, value in annotations.iteritems() %}
+{% for key, value in annotations.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% endif %}
 {% if labels is defined%}
   labels:
-{% for key, value in labels.iteritems() %}
+{% for key, value in labels.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% endif %}
@@ -22,7 +22,7 @@ spec:
   ports:
 {% for port in ports %}
   -
-{% for key, value in port.iteritems() %}
+{% for key, value in port.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% if port.targetPort is undefined %}
@@ -33,6 +33,6 @@ spec:
     targetPort: {{service_targetPort}}
 {% endif %}
   selector:
-  {% for key, value in selector.iteritems() %}
+  {% for key, value in selector.items() %}
   {{key}}: {{value}}
   {% endfor %}

--- a/roles/openshift_metrics/templates/serviceaccount.j2
+++ b/roles/openshift_metrics/templates/serviceaccount.j2
@@ -4,7 +4,7 @@ metadata:
   name: {{obj_name}}
 {% if labels is defined%}
   labels:
-{% for key, value in labels.iteritems() %}
+{% for key, value in labels.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -724,7 +724,7 @@ resources:
           type:        node
           subtype:     app
           node_labels:
-{% for k, v in openshift_openstack_cluster_node_labels.app.iteritems() %}
+{% for k, v in openshift_openstack_cluster_node_labels.app.items() %}
             {{ k|e }}: {{ v|e }}
 {% endfor %}
           image:       {{ openshift_openstack_node_image }}
@@ -788,7 +788,7 @@ resources:
           type:        node
           subtype:     infra
           node_labels:
-{% for k, v in openshift_openstack_cluster_node_labels.infra.iteritems() %}
+{% for k, v in openshift_openstack_cluster_node_labels.infra.items() %}
             {{ k|e }}: {{ v|e }}
 {% endfor %}
           image:       {{ openshift_openstack_infra_image }}

--- a/roles/openshift_persistent_volumes/templates/persistent-volume.yml.j2
+++ b/roles/openshift_persistent_volumes/templates/persistent-volume.yml.j2
@@ -9,7 +9,7 @@ items:
     name: "{{ volume.name }}"
 {% if volume.labels is defined and volume.labels is mapping %}
     labels:
-{% for key,value in volume.labels.iteritems() %}
+{% for key,value in volume.labels.items() %}
       {{ key }}: {{ value }}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_prometheus/templates/prometheus.j2
+++ b/roles/openshift_prometheus/templates/prometheus.j2
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: prometheus
 {% if openshift_prometheus_node_selector is iterable and openshift_prometheus_node_selector | length > 0 %}
       nodeSelector:
-{% for key, value in openshift_prometheus_node_selector.iteritems() %}
+{% for key, value in openshift_prometheus_node_selector.items() %}
         {{ key }}: "{{ value }}"
 {% endfor %}
 {% endif %}

--- a/roles/openshift_provisioners/templates/clusterrolebinding.j2
+++ b/roles/openshift_provisioners/templates/clusterrolebinding.j2
@@ -4,7 +4,7 @@ metadata:
   name: {{obj_name}}
 {% if labels is defined%}
   labels:
-{% for key, value in labels.iteritems() %}
+{% for key, value in labels.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_provisioners/templates/efs.j2
+++ b/roles/openshift_provisioners/templates/efs.j2
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: "{{deploy_serviceAccount}}"
 {% if node_selector is iterable and node_selector | length > 0 %}
       nodeSelector:
-{% for key, value in node_selector.iteritems() %}
+{% for key, value in node_selector.items() %}
         {{key}}: "{{value}}"
 {% endfor %}
 {% endif %}

--- a/roles/openshift_provisioners/templates/pv.j2
+++ b/roles/openshift_provisioners/templates/pv.j2
@@ -4,13 +4,13 @@ metadata:
   name: {{obj_name}}
 {% if annotations is defined %}
   annotations:
-{% for key,value in annotations.iteritems() %}
+{% for key,value in annotations.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% endif %}
 {% if labels is defined%}
   labels:
-{% for key, value in labels.iteritems() %}
+{% for key, value in labels.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_provisioners/templates/pvc.j2
+++ b/roles/openshift_provisioners/templates/pvc.j2
@@ -4,7 +4,7 @@ metadata:
   name: {{obj_name}}
 {% if annotations is defined %}
   annotations:
-{% for key,value in annotations.iteritems() %}
+{% for key,value in annotations.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% endif %}
@@ -12,7 +12,7 @@ spec:
 {% if pv_selector is defined and pv_selector is mapping %}
   selector:
     matchLabels:
-{% for key,value in pv_selector.iteritems() %}
+{% for key,value in pv_selector.items() %}
       {{key}}: {{value}}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_provisioners/templates/secret.j2
+++ b/roles/openshift_provisioners/templates/secret.j2
@@ -4,7 +4,7 @@ metadata:
   name: {{obj_name}}
 {% if labels is defined%}
   labels:
-{% for key, value in labels.iteritems() %}
+{% for key, value in labels.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_provisioners/templates/serviceaccount.j2
+++ b/roles/openshift_provisioners/templates/serviceaccount.j2
@@ -4,7 +4,7 @@ metadata:
   name: {{obj_name}}
 {% if labels is defined%}
   labels:
-{% for key, value in labels.iteritems() %}
+{% for key, value in labels.items() %}
     {{key}}: {{value}}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_service_catalog/templates/api_server.j2
+++ b/roles/openshift_service_catalog/templates/api_server.j2
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: service-catalog-apiserver
       nodeSelector:
-{% for key, value in node_selector.iteritems() %}
+{% for key, value in node_selector.items() %}
           {{key}}: "{{value}}"
 {% endfor %}
       containers:

--- a/roles/openshift_service_catalog/templates/controller_manager.j2
+++ b/roles/openshift_service_catalog/templates/controller_manager.j2
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: service-catalog-controller
       nodeSelector:
-{% for key, value in node_selector.iteritems() %}
+{% for key, value in node_selector.items() %}
         {{key}}: "{{value}}"
 {% endfor %}
       containers:


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-ansible/issues/6255.