### PR TITLE
Remove include_role from etcd role

### DIFF
--- a/roles/etcd/tasks/system_container.yml
+++ b/roles/etcd/tasks/system_container.yml
@@ -1,8 +1,4 @@
 ---
-- name: Load lib_openshift modules
-  include_role:
-    name: lib_openshift
-
 - name: Pull etcd system container
   command: atomic pull --storage=ostree {{ openshift.etcd.etcd_image }}
   register: pull_result


### PR DESCRIPTION
Removes unnecessary include_role.  Followup to https://github.com/openshift/openshift-ansible/pull/6239