### PR TITLE
Remove openshift_clock from meta depends

### DIFF
--- a/playbooks/openshift-etcd/private/ca.yml
+++ b/playbooks/openshift-etcd/private/ca.yml
@@ -2,6 +2,7 @@
 - name: Generate new etcd CA
   hosts: oo_first_etcd
   roles:
+  - role: openshift_clock
   - role: openshift_etcd_facts
   tasks:
   - include_role:

--- a/playbooks/openshift-etcd/private/config.yml
+++ b/playbooks/openshift-etcd/private/config.yml
@@ -20,6 +20,7 @@
   any_errors_fatal: true
   roles:
   - role: os_firewall
+  - role: openshift_clock
   - role: openshift_etcd
     etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"
     etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"

--- a/playbooks/openshift-node/private/configure_nodes.yml
+++ b/playbooks/openshift-node/private/configure_nodes.yml
@@ -12,6 +12,7 @@
                                                 }}"
   roles:
   - role: os_firewall
+  - role: openshift_clock
   - role: openshift_node
   - role: tuned
   - role: nickhammond.logrotate

--- a/playbooks/openshift-node/private/containerized_nodes.yml
+++ b/playbooks/openshift-node/private/containerized_nodes.yml
@@ -14,6 +14,7 @@
 
   roles:
   - role: os_firewall
+  - role: openshift_clock
   - role: openshift_node
     openshift_ca_host: "{{ groups.oo_first_master.0 }}"
   - role: nickhammond.logrotate

--- a/roles/openshift_etcd/meta/main.yml
+++ b/roles/openshift_etcd/meta/main.yml
@@ -13,7 +13,6 @@ galaxy_info:
   - cloud
 dependencies:
 - role: openshift_etcd_facts
-- role: openshift_clock
 - role: openshift_docker
   when: openshift.common.is_containerized | bool
 - role: etcd

--- a/roles/openshift_node/meta/main.yml
+++ b/roles/openshift_node/meta/main.yml
@@ -17,8 +17,6 @@ dependencies:
 - role: lib_openshift
 - role: lib_os_firewall
   when: not (openshift_node_upgrade_in_progress | default(False))
-- role: openshift_clock
-  when: not (openshift_node_upgrade_in_progress | default(False))
 - role: openshift_docker
 - role: openshift_cloud_provider
   when: not (openshift_node_upgrade_in_progress | default(False))


### PR DESCRIPTION
This commit adds openshift_clock role to required plays
instead of using meta_depends.