### PR TITLE
Remove openshift.common.service_type

### DIFF
--- a/DEPLOYMENT_TYPES.md
+++ b/DEPLOYMENT_TYPES.md
@@ -10,7 +10,7 @@ The table below outlines the defaults per `openshift_deployment_type`:
 
 | openshift_deployment_type                                       | origin                                   | openshift-enterprise                   |
 |-----------------------------------------------------------------|------------------------------------------|----------------------------------------|
-| **openshift.common.service_type** (also used for package names) | origin                                   | atomic-openshift                       |
+| **openshift_service_type** (also used for package names)        | origin                                   | atomic-openshift                       |
 | **openshift.common.config_base**                                | /etc/origin                              | /etc/origin                            |
 | **openshift_data_dir**                                          | /var/lib/origin                          | /var/lib/origin                        |
 | **openshift.master.registry_url openshift.node.registry_url**   | openshift/origin-${component}:${version} | openshift3/ose-${component}:${version} |

--- a/playbooks/common/openshift-cluster/upgrades/disable_master_excluders.yml
+++ b/playbooks/common/openshift-cluster/upgrades/disable_master_excluders.yml
@@ -5,7 +5,6 @@
   roles:
   - role: openshift_excluder
     r_openshift_excluder_action: disable
-    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
     r_openshift_excluder_verify_upgrade: true
     r_openshift_excluder_upgrade_target: "{{ openshift_upgrade_target }}"
     r_openshift_excluder_package_state: latest

--- a/playbooks/common/openshift-cluster/upgrades/disable_node_excluders.yml
+++ b/playbooks/common/openshift-cluster/upgrades/disable_node_excluders.yml
@@ -5,7 +5,6 @@
   roles:
   - role: openshift_excluder
     r_openshift_excluder_action: disable
-    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
     r_openshift_excluder_verify_upgrade: true
     r_openshift_excluder_upgrade_target: "{{ openshift_upgrade_target }}"
     r_openshift_excluder_package_state: latest

--- a/playbooks/common/openshift-cluster/upgrades/docker/tasks/restart.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/tasks/restart.yml
@@ -11,9 +11,9 @@
   with_items:
     - etcd_container
     - openvswitch
-    - "{{ openshift.common.service_type }}-master-api"
-    - "{{ openshift.common.service_type }}-master-controllers"
-    - "{{ openshift.common.service_type }}-node"
+    - "{{ openshift_service_type }}-master-api"
+    - "{{ openshift_service_type }}-master-controllers"
+    - "{{ openshift_service_type }}-node"
   failed_when: false
   when: openshift.common.is_containerized | bool
 

--- a/playbooks/common/openshift-cluster/upgrades/docker/tasks/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/tasks/upgrade.yml
@@ -4,9 +4,9 @@
 - name: Stop containerized services
   service: name={{ item }} state=stopped
   with_items:
-    - "{{ openshift.common.service_type }}-master-api"
-    - "{{ openshift.common.service_type }}-master-controllers"
-    - "{{ openshift.common.service_type }}-node"
+    - "{{ openshift_service_type }}-master-api"
+    - "{{ openshift_service_type }}-master-controllers"
+    - "{{ openshift_service_type }}-node"
     - etcd_container
     - openvswitch
   failed_when: false

--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -114,7 +114,6 @@
   roles:
   - role: openshift_excluder
     r_openshift_excluder_action: enable
-    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
   post_tasks:
   # Check if any masters are using pluginOrderOverride and warn if so, only for 1.3/3.3 and beyond:
   - name: grep pluginOrderOverride

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_control_plane_running.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_control_plane_running.yml
@@ -13,21 +13,21 @@
     block:
     - set_fact:
         master_services:
-        - "{{ openshift.common.service_type }}-master"
+        - "{{ openshift_service_type }}-master"
 
     # In case of the non-ha to ha upgrade.
-    - name: Check if the {{ openshift.common.service_type }}-master-api.service exists
+    - name: Check if the {{ openshift_service_type }}-master-api.service exists
       command: >
-        systemctl list-units {{ openshift.common.service_type }}-master-api.service --no-legend
+        systemctl list-units {{ openshift_service_type }}-master-api.service --no-legend
       register: master_api_service_status
 
     - set_fact:
         master_services:
-        - "{{ openshift.common.service_type }}-master-api"
-        - "{{ openshift.common.service_type }}-master-controllers"
+        - "{{ openshift_service_type }}-master-api"
+        - "{{ openshift_service_type }}-master-controllers"
       when:
       - master_api_service_status.stdout_lines | length > 0
-      - (openshift.common.service_type + '-master-api.service') in master_api_service_status.stdout_lines[0]
+      - (openshift_service_type + '-master-api.service') in master_api_service_status.stdout_lines[0]
 
     - name: Ensure Master is running
       service:

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -21,7 +21,7 @@
   block:
   - name: Check latest available OpenShift RPM version
     repoquery:
-      name: "{{ openshift.common.service_type }}"
+      name: "{{ openshift_service_type }}"
       ignore_excluders: true
     register: repoquery_out
 

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -45,7 +45,6 @@
       name: openshift_excluder
     vars:
       r_openshift_excluder_action: enable
-      r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
   - name: Set node schedulability
     oc_adm_manage_node:
       node: "{{ openshift.node.nodename | lower }}"

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
@@ -122,13 +122,13 @@
   hosts: oo_masters_to_config
   gather_facts: no
   tasks:
-  - name: Stop {{ openshift.common.service_type }}-master-controllers
+  - name: Stop {{ openshift_service_type }}-master-controllers
     systemd:
-      name: "{{ openshift.common.service_type }}-master-controllers"
+      name: "{{ openshift_service_type }}-master-controllers"
       state: stopped
-  - name: Start {{ openshift.common.service_type }}-master-controllers
+  - name: Start {{ openshift_service_type }}-master-controllers
     systemd:
-      name: "{{ openshift.common.service_type }}-master-controllers"
+      name: "{{ openshift_service_type }}-master-controllers"
       state: started
 
 - include: ../upgrade_nodes.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -126,13 +126,13 @@
   hosts: oo_masters_to_config
   gather_facts: no
   tasks:
-  - name: Stop {{ openshift.common.service_type }}-master-controllers
+  - name: Stop {{ openshift_service_type }}-master-controllers
     systemd:
-      name: "{{ openshift.common.service_type }}-master-controllers"
+      name: "{{ openshift_service_type }}-master-controllers"
       state: stopped
-  - name: Start {{ openshift.common.service_type }}-master-controllers
+  - name: Start {{ openshift_service_type }}-master-controllers
     systemd:
-      name: "{{ openshift.common.service_type }}-master-controllers"
+      name: "{{ openshift_service_type }}-master-controllers"
       state: started
 
 - include: ../post_control_plane.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade.yml
@@ -122,13 +122,13 @@
   hosts: oo_masters_to_config
   gather_facts: no
   tasks:
-  - name: Stop {{ openshift.common.service_type }}-master-controllers
+  - name: Stop {{ openshift_service_type }}-master-controllers
     systemd:
-      name: "{{ openshift.common.service_type }}-master-controllers"
+      name: "{{ openshift_service_type }}-master-controllers"
       state: stopped
-  - name: Start {{ openshift.common.service_type }}-master-controllers
+  - name: Start {{ openshift_service_type }}-master-controllers
     systemd:
-      name: "{{ openshift.common.service_type }}-master-controllers"
+      name: "{{ openshift_service_type }}-master-controllers"
       state: started
 
 - include: ../upgrade_nodes.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml
@@ -126,13 +126,13 @@
   hosts: oo_masters_to_config
   gather_facts: no
   tasks:
-  - name: Stop {{ openshift.common.service_type }}-master-controllers
+  - name: Stop {{ openshift_service_type }}-master-controllers
     systemd:
-      name: "{{ openshift.common.service_type }}-master-controllers"
+      name: "{{ openshift_service_type }}-master-controllers"
       state: stopped
-  - name: Start {{ openshift.common.service_type }}-master-controllers
+  - name: Start {{ openshift_service_type }}-master-controllers
     systemd:
-      name: "{{ openshift.common.service_type }}-master-controllers"
+      name: "{{ openshift_service_type }}-master-controllers"
       state: started
 
 - include: ../post_control_plane.yml

--- a/playbooks/openshift-etcd/private/embedded2external.yml
+++ b/playbooks/openshift-etcd/private/embedded2external.yml
@@ -22,7 +22,7 @@
       name: openshift_master
       tasks_from: check_master_api_is_ready.yml
   - set_fact:
-      master_service: "{{ openshift.common.service_type + '-master' }}"
+      master_service: "{{ openshift_service_type + '-master' }}"
       embedded_etcd_backup_suffix: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
   - debug:
       msg: "master service name: {{ master_service }}"

--- a/playbooks/openshift-etcd/private/migrate.yml
+++ b/playbooks/openshift-etcd/private/migrate.yml
@@ -28,8 +28,8 @@
   tasks:
   - set_fact:
       master_services:
-      - "{{ openshift.common.service_type + '-master-controllers' }}"
-      - "{{ openshift.common.service_type + '-master-api' }}"
+      - "{{ openshift_service_type + '-master-controllers' }}"
+      - "{{ openshift_service_type + '-master-api' }}"
   - debug:
       msg: "master service name: {{ master_services }}"
   - name: Stop masters

--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -19,7 +19,6 @@
   roles:
   - role: openshift_excluder
     r_openshift_excluder_action: disable
-    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
 
 - name: Gather and set facts for master hosts
   hosts: oo_masters_to_config
@@ -228,6 +227,8 @@
 - name: Configure API Aggregation on masters
   hosts: oo_masters
   serial: 1
+  roles:
+  - role: openshift_facts
   tasks:
   - include_tasks: tasks/wire_aggregator.yml
 
@@ -237,7 +238,6 @@
   roles:
   - role: openshift_excluder
     r_openshift_excluder_action: enable
-    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
 
 - name: Master Install Checkpoint End
   hosts: all

--- a/playbooks/openshift-master/private/scaleup.yml
+++ b/playbooks/openshift-master/private/scaleup.yml
@@ -20,11 +20,11 @@
     - restart master controllers
   handlers:
   - name: restart master api
-    service: name={{ openshift.common.service_type }}-master-controllers state=restarted
+    service: name={{ openshift_service_type }}-master-controllers state=restarted
     notify: verify api server
   # We retry the controllers because the API may not be 100% initialized yet.
   - name: restart master controllers
-    command: "systemctl restart {{ openshift.common.service_type }}-master-controllers"
+    command: "systemctl restart {{ openshift_service_type }}-master-controllers"
     retries: 3
     delay: 5
     register: result

--- a/playbooks/openshift-master/private/tasks/wire_aggregator.yml
+++ b/playbooks/openshift-master/private/tasks/wire_aggregator.yml
@@ -180,13 +180,13 @@
 
 #restart master serially here
 - name: restart master api
-  systemd: name={{ openshift.common.service_type }}-master-api state=restarted
+  systemd: name={{ openshift_service_type }}-master-api state=restarted
   when:
   - yedit_output.changed
 
 # We retry the controllers because the API may not be 100% initialized yet.
 - name: restart master controllers
-  command: "systemctl restart {{ openshift.common.service_type }}-master-controllers"
+  command: "systemctl restart {{ openshift_service_type }}-master-controllers"
   retries: 3
   delay: 5
   register: result

--- a/playbooks/openshift-node/private/enable_excluders.yml
+++ b/playbooks/openshift-node/private/enable_excluders.yml
@@ -5,4 +5,3 @@
   roles:
   - role: openshift_excluder
     r_openshift_excluder_action: enable
-    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"

--- a/playbooks/openshift-node/private/restart.yml
+++ b/playbooks/openshift-node/private/restart.yml
@@ -23,9 +23,9 @@
     with_items:
     - etcd_container
     - openvswitch
-    - "{{ openshift.common.service_type }}-master-api"
-    - "{{ openshift.common.service_type }}-master-controllers"
-    - "{{ openshift.common.service_type }}-node"
+    - "{{ openshift_service_type }}-master-api"
+    - "{{ openshift_service_type }}-master-controllers"
+    - "{{ openshift_service_type }}-node"
     failed_when: false
     when: openshift.common.is_containerized | bool
 
@@ -40,7 +40,7 @@
 
   - name: restart node
     service:
-      name: "{{ openshift.common.service_type }}-node"
+      name: "{{ openshift_service_type }}-node"
       state: restarted
 
   - name: Wait for node to be ready

--- a/playbooks/openshift-node/private/setup.yml
+++ b/playbooks/openshift-node/private/setup.yml
@@ -5,7 +5,6 @@
   roles:
   - role: openshift_excluder
     r_openshift_excluder_action: disable
-    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
 
 - name: Evaluate node groups
   hosts: localhost

--- a/roles/flannel/handlers/main.yml
+++ b/roles/flannel/handlers/main.yml
@@ -15,7 +15,7 @@
 
 - name: restart node
   systemd:
-    name: "{{ openshift.common.service_type }}-node"
+    name: "{{ openshift_service_type }}-node"
     state: restarted
   register: l_restart_node_result
   until: not l_restart_node_result | failed

--- a/roles/kuryr/tasks/node.yaml
+++ b/roles/kuryr/tasks/node.yaml
@@ -36,7 +36,7 @@
 
 - name: Configure OpenShift node with disabled service proxy
   lineinfile:
-    dest: "/etc/sysconfig/{{ openshift.common.service_type }}-node"
+    dest: "/etc/sysconfig/{{ openshift_service_type }}-node"
     regexp: '^OPTIONS="?(.*?)"?$'
     backrefs: yes
     backup: yes
@@ -44,5 +44,5 @@
 
 - name: force node restart to disable the proxy
   service:
-    name: "{{ openshift.common.service_type }}-node"
+    name: "{{ openshift_service_type }}-node"
     state: restarted

--- a/roles/nuage_master/handlers/main.yaml
+++ b/roles/nuage_master/handlers/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: restart master api
-  systemd: name={{ openshift.common.service_type }}-master-api state=restarted
+  systemd: name={{ openshift_service_type }}-master-api state=restarted
   when: >
     (openshift_master_ha | bool) and
     (not master_api_service_status_changed | default(false))
@@ -8,7 +8,7 @@
 # TODO: need to fix up ignore_errors here
 # We retry the controllers because the API may not be 100% initialized yet.
 - name: restart master controllers
-  command: "systemctl restart {{ openshift.common.service_type }}-master-controllers"
+  command: "systemctl restart {{ openshift_service_type }}-master-controllers"
   retries: 3
   delay: 5
   register: result

--- a/roles/nuage_node/handlers/main.yaml
+++ b/roles/nuage_node/handlers/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: restart node
   become: yes
-  systemd: name={{ openshift.common.service_type }}-node daemon-reload=yes state=restarted
+  systemd: name={{ openshift_service_type }}-node daemon-reload=yes state=restarted
 
 - name: save iptable rules
   become: yes

--- a/roles/nuage_node/vars/main.yaml
+++ b/roles/nuage_node/vars/main.yaml
@@ -23,5 +23,5 @@ cni_conf_dir: "/etc/cni/net.d/"
 cni_bin_dir: "/opt/cni/bin/"
 
 nuage_plugin_crt_dir: /usr/share/vsp-openshift
-openshift_atomic_node_config_file: /etc/sysconfig/{{ openshift.common.service_type }}-node
+openshift_atomic_node_config_file: /etc/sysconfig/{{ openshift_service_type }}-node
 nuage_atomic_docker_additional_mounts: "NUAGE_ADDTL_BIND_MOUNTS=-v /var/usr/share/vsp-openshift:/var/usr/share/vsp-openshift -v /etc/default:/etc/default -v /var/run:/var/run -v /opt/cni/bin:/opt/cni/bin -v /etc/cni/net.d:/etc/cni/net.d"

--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Install the base package for admin tooling
   package:
-    name: "{{ openshift.common.service_type }}{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
+    name: "{{ openshift_service_type }}{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
     state: present
   when: not openshift.common.is_containerized | bool
   register: install_result

--- a/roles/openshift_cli/tasks/main.yml
+++ b/roles/openshift_cli/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install clients
-  package: name={{ openshift.common.service_type }}-clients state=present
+  package: name={{ openshift_service_type }}-clients state=present
   when: not openshift.common.is_containerized | bool
   register: result
   until: result | success

--- a/roles/openshift_excluder/README.md
+++ b/roles/openshift_excluder/README.md
@@ -28,7 +28,7 @@ Role Variables
 | r_openshift_excluder_verify_upgrade       | false   | true, false     | When upgrading, this variable should be set to true when calling the role |
 | r_openshift_excluder_package_state        | present | present, latest | Use 'latest' to upgrade openshift_excluder package                        |
 | r_openshift_excluder_docker_package_state | present | present, latest | Use 'latest' to upgrade docker_excluder package                           |
-| r_openshift_excluder_service_type         | None    |                 | (Required) Defined as openshift.common.service_type e.g. atomic-openshift |
+| r_openshift_excluder_service_type         | None    |                 | (Required) Defined as openshift_service_type e.g. atomic-openshift        |
 | r_openshift_excluder_upgrade_target       | None    |                 | Required when r_openshift_excluder_verify_upgrade is true, defined as openshift_upgrade_target by Upgrade playbooks e.g. '3.6'|
 
 Dependencies
@@ -46,15 +46,12 @@ Example Playbook
   # Disable all excluders
   - role: openshift_excluder
     r_openshift_excluder_action: disable
-    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
   # Enable all excluders
   - role: openshift_excluder
     r_openshift_excluder_action: enable
-    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
   # Disable all excluders and verify appropriate excluder packages are available for upgrade
   - role: openshift_excluder
     r_openshift_excluder_action: disable
-    r_openshift_excluder_service_type: "{{ openshift.common.service_type }}"
     r_openshift_excluder_verify_upgrade: true
     r_openshift_excluder_upgrade_target: "{{ openshift_upgrade_target }}"
     r_openshift_excluder_package_state: latest

--- a/roles/openshift_excluder/defaults/main.yml
+++ b/roles/openshift_excluder/defaults/main.yml
@@ -2,7 +2,7 @@
 # keep the 'current' package or update to 'latest' if available?
 r_openshift_excluder_package_state: present
 r_openshift_excluder_docker_package_state: present
-
+r_openshift_excluder_service_type: "{{ openshift_service_type }}"
 # Legacy variables are included for backwards compatibility with v3.5
 # Inventory variables                   Legacy
 # openshift_enable_excluders            enable_excluders

--- a/roles/openshift_excluder/meta/main.yml
+++ b/roles/openshift_excluder/meta/main.yml
@@ -12,4 +12,5 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
+- role: openshift_facts
 - role: lib_utils

--- a/roles/openshift_excluder/tasks/main.yml
+++ b/roles/openshift_excluder/tasks/main.yml
@@ -19,11 +19,6 @@
       msg: "openshift_excluder role can only be called with 'enable' or 'disable'"
     when: r_openshift_excluder_action not in ['enable', 'disable']
 
-  - name: Fail if r_openshift_excluder_service_type is not defined
-    fail:
-      msg: "r_openshift_excluder_service_type must be specified for this role"
-    when: r_openshift_excluder_service_type is not defined
-
   - name: Fail if r_openshift_excluder_upgrade_target is not defined
     fail:
       msg: "r_openshift_excluder_upgrade_target must be provided when using this role for upgrades"

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -98,3 +98,9 @@ openshift_prometheus_alertbuffer_storage_create_pvc: False
 openshift_router_selector: "region=infra"
 openshift_hosted_router_selector: "{{ openshift_router_selector }}"
 openshift_hosted_registry_selector: "{{ openshift_router_selector }}"
+
+openshift_service_type_dict:
+  origin: origin
+  openshift-enterprise: atomic-openshift
+
+openshift_service_type: "{{ openshift_service_type_dict[openshift_deployment_type] }}"

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -537,7 +537,7 @@ def set_aggregate_facts(facts):
 
 def set_deployment_facts_if_unset(facts):
     """ Set Facts that vary based on deployment_type. This currently
-        includes common.service_type, master.registry_url, node.registry_url,
+        includes master.registry_url, node.registry_url,
         node.storage_plugin_deps
 
         Args:
@@ -549,14 +549,6 @@ def set_deployment_facts_if_unset(facts):
     # disabled to avoid breaking up facts related to deployment type into
     # multiple methods for now.
     # pylint: disable=too-many-statements, too-many-branches
-    if 'common' in facts:
-        deployment_type = facts['common']['deployment_type']
-        if 'service_type' not in facts['common']:
-            service_type = 'atomic-openshift'
-            if deployment_type == 'origin':
-                service_type = 'origin'
-            facts['common']['service_type'] = service_type
-
     for role in ('master', 'node'):
         if role in facts:
             deployment_type = facts['common']['deployment_type']
@@ -1020,8 +1012,13 @@ def get_container_openshift_version(facts):
     If containerized, see if we can determine the installed version via the
     systemd environment files.
     """
+    deployment_type = facts['common']['deployment_type']
+    service_type_dict = {'origin': 'origin',
+                         'openshift-enterprise': 'atomic-openshift'}
+    service_type = service_type_dict[deployment_type]
+
     for filename in ['/etc/sysconfig/%s-master-controllers', '/etc/sysconfig/%s-node']:
-        env_path = filename % facts['common']['service_type']
+        env_path = filename % service_type
         if not os.path.exists(env_path):
             continue
 

--- a/roles/openshift_health_checker/defaults/main.yml
+++ b/roles/openshift_health_checker/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-openshift_protect_installed_version: True
-
 openshift_service_type_dict:
   origin: origin
   openshift-enterprise: atomic-openshift

--- a/roles/openshift_health_checker/openshift_checks/package_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/package_availability.py
@@ -15,7 +15,9 @@ class PackageAvailability(NotContainerizedMixin, OpenShiftCheck):
         return super(PackageAvailability, self).is_active() and self.get_var("ansible_pkg_mgr") == "yum"
 
     def run(self):
-        rpm_prefix = self.get_var("openshift", "common", "service_type")
+        rpm_prefix = self.get_var("openshift_service_type")
+        if self._templar is not None:
+            rpm_prefix = self._templar.template(rpm_prefix)
         group_names = self.get_var("group_names", default=[])
 
         packages = set()

--- a/roles/openshift_health_checker/openshift_checks/package_version.py
+++ b/roles/openshift_health_checker/openshift_checks/package_version.py
@@ -41,7 +41,9 @@ class PackageVersion(NotContainerizedMixin, OpenShiftCheck):
         return super(PackageVersion, self).is_active() and master_or_node
 
     def run(self):
-        rpm_prefix = self.get_var("openshift", "common", "service_type")
+        rpm_prefix = self.get_var("openshift_service_type")
+        if self._templar is not None:
+            rpm_prefix = self._templar.template(rpm_prefix)
         openshift_release = self.get_var("openshift_release", default='')
         deployment_type = self.get_var("openshift_deployment_type")
         check_multi_minor_release = deployment_type in ['openshift-enterprise']

--- a/roles/openshift_health_checker/test/docker_image_availability_test.py
+++ b/roles/openshift_health_checker/test/docker_image_availability_test.py
@@ -8,12 +8,12 @@ def task_vars():
     return dict(
         openshift=dict(
             common=dict(
-                service_type='origin',
                 is_containerized=False,
                 is_atomic=False,
             ),
             docker=dict(),
         ),
+        openshift_service_type='origin',
         openshift_deployment_type='origin',
         openshift_image_tag='',
         group_names=['oo_nodes_to_config', 'oo_masters_to_config'],

--- a/roles/openshift_health_checker/test/etcd_traffic_test.py
+++ b/roles/openshift_health_checker/test/etcd_traffic_test.py
@@ -37,8 +37,9 @@ def test_log_matches_high_traffic_msg(group_names, matched, failed, extra_words)
     task_vars = dict(
         group_names=group_names,
         openshift=dict(
-            common=dict(service_type="origin", is_containerized=False),
-        )
+            common=dict(is_containerized=False),
+        ),
+        openshift_service_type="origin"
     )
 
     result = EtcdTraffic(execute_module, task_vars).run()

--- a/roles/openshift_health_checker/test/ovs_version_test.py
+++ b/roles/openshift_health_checker/test/ovs_version_test.py
@@ -10,10 +10,11 @@ def test_openshift_version_not_supported():
     openshift_release = '111.7.0'
 
     task_vars = dict(
-        openshift=dict(common=dict(service_type='origin')),
+        openshift=dict(common=dict()),
         openshift_release=openshift_release,
         openshift_image_tag='v' + openshift_release,
         openshift_deployment_type='origin',
+        openshift_service_type='origin'
     )
 
     with pytest.raises(OpenShiftCheckException) as excinfo:
@@ -27,9 +28,10 @@ def test_invalid_openshift_release_format():
         return {}
 
     task_vars = dict(
-        openshift=dict(common=dict(service_type='origin')),
+        openshift=dict(common=dict()),
         openshift_image_tag='v0',
         openshift_deployment_type='origin',
+        openshift_service_type='origin'
     )
 
     with pytest.raises(OpenShiftCheckException) as excinfo:
@@ -47,9 +49,10 @@ def test_invalid_openshift_release_format():
 ])
 def test_ovs_package_version(openshift_release, expected_ovs_version):
     task_vars = dict(
-        openshift=dict(common=dict(service_type='origin')),
+        openshift=dict(common=dict()),
         openshift_release=openshift_release,
         openshift_image_tag='v' + openshift_release,
+        openshift_service_type='origin'
     )
     return_value = {}  # note: check.execute_module modifies return hash contents
 

--- a/roles/openshift_health_checker/test/package_availability_test.py
+++ b/roles/openshift_health_checker/test/package_availability_test.py
@@ -19,13 +19,13 @@ def test_is_active(pkg_mgr, is_containerized, is_active):
 
 @pytest.mark.parametrize('task_vars,must_have_packages,must_not_have_packages', [
     (
-        dict(openshift=dict(common=dict(service_type='openshift'))),
+        dict(openshift_service_type='origin'),
         set(),
         set(['openshift-master', 'openshift-node']),
     ),
     (
         dict(
-            openshift=dict(common=dict(service_type='origin')),
+            openshift_service_type='origin',
             group_names=['oo_masters_to_config'],
         ),
         set(['origin-master']),
@@ -33,7 +33,7 @@ def test_is_active(pkg_mgr, is_containerized, is_active):
     ),
     (
         dict(
-            openshift=dict(common=dict(service_type='atomic-openshift')),
+            openshift_service_type='atomic-openshift',
             group_names=['oo_nodes_to_config'],
         ),
         set(['atomic-openshift-node']),
@@ -41,7 +41,7 @@ def test_is_active(pkg_mgr, is_containerized, is_active):
     ),
     (
         dict(
-            openshift=dict(common=dict(service_type='atomic-openshift')),
+            openshift_service_type='atomic-openshift',
             group_names=['oo_masters_to_config', 'oo_nodes_to_config'],
         ),
         set(['atomic-openshift-master', 'atomic-openshift-node']),

--- a/roles/openshift_health_checker/test/package_version_test.py
+++ b/roles/openshift_health_checker/test/package_version_test.py
@@ -4,9 +4,12 @@ from openshift_checks.package_version import PackageVersion, OpenShiftCheckExcep
 
 
 def task_vars_for(openshift_release, deployment_type):
+    service_type_dict = {'origin': 'origin',
+                         'openshift-enterprise': 'atomic-openshift'}
+    service_type = service_type_dict[deployment_type]
     return dict(
         ansible_pkg_mgr='yum',
-        openshift=dict(common=dict(service_type=deployment_type)),
+        openshift_service_type=service_type,
         openshift_release=openshift_release,
         openshift_image_tag='v' + openshift_release,
         openshift_deployment_type=deployment_type,
@@ -29,7 +32,7 @@ def test_openshift_version_not_supported():
 def test_invalid_openshift_release_format():
     task_vars = dict(
         ansible_pkg_mgr='yum',
-        openshift=dict(common=dict(service_type='origin')),
+        openshift_service_type='origin',
         openshift_image_tag='v0',
         openshift_deployment_type='origin',
     )

--- a/roles/openshift_logging/handlers/main.yml
+++ b/roles/openshift_logging/handlers/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: restart master api
-  systemd: name={{ openshift.common.service_type }}-master-api state=restarted
+  systemd: name={{ openshift_service_type }}-master-api state=restarted
   when: (not (master_api_service_status_changed | default(false) | bool))
   notify: Verify API Server
 
 # We retry the controllers because the API may not be 100% initialized yet.
 - name: restart master controllers
-  command: "systemctl restart {{ openshift.common.service_type }}-master-controllers"
+  command: "systemctl restart {{ openshift_service_type }}-master-controllers"
   retries: 3
   delay: 5
   register: result

--- a/roles/openshift_master/handlers/main.yml
+++ b/roles/openshift_master/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart master api
   systemd:
-    name: "{{ openshift.common.service_type }}-master-api"
+    name: "{{ openshift_service_type }}-master-api"
     state: restarted
   when:
   - not (master_api_service_status_changed | default(false) | bool)
@@ -10,7 +10,7 @@
 
 # We retry the controllers because the API may not be 100% initialized yet.
 - name: restart master controllers
-  command: "systemctl restart {{ openshift.common.service_type }}-master-controllers"
+  command: "systemctl restart {{ openshift_service_type }}-master-controllers"
   retries: 3
   delay: 5
   register: result

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Install Master package
   package:
-    name: "{{ openshift.common.service_type }}-master{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
+    name: "{{ openshift_service_type }}-master{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
     state: present
   when:
   - not openshift.common.is_containerized | bool
@@ -141,7 +141,7 @@
 # The template file will stomp any other settings made.
 - block:
   - name: check whether our docker-registry setting exists in the env file
-    command: "awk '/^OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000/' /etc/sysconfig/{{ openshift.common.service_type }}-master"
+    command: "awk '/^OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000/' /etc/sysconfig/{{ openshift_service_type }}-master"
     failed_when: false
     changed_when: false
     register: l_already_set
@@ -203,7 +203,7 @@
 
 - name: Start and enable master api on first master
   systemd:
-    name: "{{ openshift.common.service_type }}-master-api"
+    name: "{{ openshift_service_type }}-master-api"
     enabled: yes
     state: started
   when:
@@ -214,7 +214,7 @@
   delay: 60
 
 - name: Dump logs from master-api if it failed
-  command: journalctl --no-pager -n 100 -u {{ openshift.common.service_type }}-master-api
+  command: journalctl --no-pager -n 100 -u {{ openshift_service_type }}-master-api
   when:
   - l_start_result | failed
 
@@ -230,7 +230,7 @@
 
 - name: Start and enable master api all masters
   systemd:
-    name: "{{ openshift.common.service_type }}-master-api"
+    name: "{{ openshift_service_type }}-master-api"
     enabled: yes
     state: started
   when:
@@ -241,7 +241,7 @@
   delay: 60
 
 - name: Dump logs from master-api if it failed
-  command: journalctl --no-pager -n 100 -u {{ openshift.common.service_type }}-master-api
+  command: journalctl --no-pager -n 100 -u {{ openshift_service_type }}-master-api
   when:
   - l_start_result | failed
 
@@ -258,7 +258,7 @@
 
 - name: Start and enable master controller service
   systemd:
-    name: "{{ openshift.common.service_type }}-master-controllers"
+    name: "{{ openshift_service_type }}-master-controllers"
     enabled: yes
     state: started
   register: l_start_result
@@ -267,7 +267,7 @@
   delay: 60
 
 - name: Dump logs from master-controllers if it failed
-  command: journalctl --no-pager -n 100 -u {{ openshift.common.service_type }}-master-controllers
+  command: journalctl --no-pager -n 100 -u {{ openshift_service_type }}-master-controllers
   when:
   - l_start_result | failed
 

--- a/roles/openshift_master/tasks/restart.yml
+++ b/roles/openshift_master/tasks/restart.yml
@@ -1,7 +1,7 @@
 ---
 - name: Restart master API
   service:
-    name: "{{ openshift.common.service_type }}-master-api"
+    name: "{{ openshift_service_type }}-master-api"
     state: restarted
   when: openshift_master_ha | bool
 - name: Wait for master API to come back online
@@ -14,7 +14,7 @@
   when: openshift_master_ha | bool
 - name: Restart master controllers
   service:
-    name: "{{ openshift.common.service_type }}-master-controllers"
+    name: "{{ openshift_service_type }}-master-controllers"
     state: restarted
   # Ignore errrors since it is possible that type != simple for
   # pre-3.1.1 installations.

--- a/roles/openshift_master/tasks/system_container.yml
+++ b/roles/openshift_master/tasks/system_container.yml
@@ -8,12 +8,12 @@
 
 - name: Check Master system container package
   command: >
-    atomic containers list --no-trunc -a -f container={{ openshift.common.service_type }}-master
+    atomic containers list --no-trunc -a -f container={{ openshift_service_type }}-master
 
 # HA
 - name: Install or Update HA api master system container
   oc_atomic_container:
-    name: "{{ openshift.common.service_type }}-master-api"
+    name: "{{ openshift_service_type }}-master-api"
     image: "{{ 'docker:' if system_images_registry == 'docker' else system_images_registry + '/' }}{{ openshift.master.master_system_image }}:{{ openshift_image_tag }}"
     state: latest
     values:
@@ -21,7 +21,7 @@
 
 - name: Install or Update HA controller master system container
   oc_atomic_container:
-    name: "{{ openshift.common.service_type }}-master-controllers"
+    name: "{{ openshift_service_type }}-master-controllers"
     image: "{{ 'docker:' if system_images_registry == 'docker' else system_images_registry + '/' }}{{ openshift.master.master_system_image }}:{{ openshift_image_tag }}"
     state: latest
     values:

--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -13,7 +13,7 @@
 
 - name: Disable the legacy master service if it exists
   systemd:
-    name: "{{ openshift.common.service_type }}-master"
+    name: "{{ openshift_service_type }}-master"
     state: stopped
     enabled: no
     masked: yes
@@ -21,7 +21,7 @@
 
 - name: Remove the legacy master service if it exists
   file:
-    path: "{{ containerized_svc_dir }}/{{ openshift.common.service_type }}-master.service"
+    path: "{{ containerized_svc_dir }}/{{ openshift_service_type }}-master.service"
     state: absent
   ignore_errors: true
   when:
@@ -40,7 +40,7 @@
 - name: Create the ha systemd unit files
   template:
     src: "{{ ha_svc_template_path }}/atomic-openshift-master-{{ item }}.service.j2"
-    dest: "{{ containerized_svc_dir }}/{{ openshift.common.service_type }}-master-{{ item }}.service"
+    dest: "{{ containerized_svc_dir }}/{{ openshift_service_type }}-master-{{ item }}.service"
   when:
   - not l_is_master_system_container | bool
   with_items:
@@ -55,7 +55,7 @@
 
 - name: enable master services
   systemd:
-    name: "{{ openshift.common.service_type }}-master-{{ item }}"
+    name: "{{ openshift_service_type }}-master-{{ item }}"
     enabled: yes
   with_items:
   - api
@@ -64,13 +64,13 @@
   - not l_is_master_system_container | bool
 
 - name: Preserve Master API Proxy Config options
-  command: grep PROXY /etc/sysconfig/{{ openshift.common.service_type }}-master-api
+  command: grep PROXY /etc/sysconfig/{{ openshift_service_type }}-master-api
   register: l_master_api_proxy
   failed_when: false
   changed_when: false
 
 - name: Preserve Master API AWS options
-  command: grep AWS_ /etc/sysconfig/{{ openshift.common.service_type }}-master-api
+  command: grep AWS_ /etc/sysconfig/{{ openshift_service_type }}-master-api
   register: master_api_aws
   failed_when: false
   changed_when: false
@@ -78,7 +78,7 @@
 - name: Create the master api service env file
   template:
     src: "{{ ha_svc_template_path }}/atomic-openshift-master-api.j2"
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-master-api
+    dest: /etc/sysconfig/{{ openshift_service_type }}-master-api
     backup: true
   notify:
   - restart master api
@@ -89,7 +89,7 @@
   - "'http_proxy' not in openshift.common"
   - "'https_proxy' not in openshift.common"
   lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-master-api
+    dest: /etc/sysconfig/{{ openshift_service_type }}-master-api
     line: "{{ item }}"
   with_items: "{{ l_master_api_proxy.stdout_lines | default([]) }}"
 
@@ -98,19 +98,19 @@
   - master_api_aws.rc == 0
   - not (openshift_cloudprovider_kind is defined and openshift_cloudprovider_kind == 'aws' and openshift_cloudprovider_aws_access_key is defined and openshift_cloudprovider_aws_secret_key is defined)
   lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-master-api
+    dest: /etc/sysconfig/{{ openshift_service_type }}-master-api
     line: "{{ item }}"
   with_items: "{{ master_api_aws.stdout_lines | default([]) }}"
   no_log: True
 
 - name: Preserve Master Controllers Proxy Config options
-  command: grep PROXY /etc/sysconfig/{{ openshift.common.service_type }}-master-controllers
+  command: grep PROXY /etc/sysconfig/{{ openshift_service_type }}-master-controllers
   register: master_controllers_proxy
   failed_when: false
   changed_when: false
 
 - name: Preserve Master Controllers AWS options
-  command: grep AWS_ /etc/sysconfig/{{ openshift.common.service_type }}-master-controllers
+  command: grep AWS_ /etc/sysconfig/{{ openshift_service_type }}-master-controllers
   register: master_controllers_aws
   failed_when: false
   changed_when: false
@@ -118,14 +118,14 @@
 - name: Create the master controllers service env file
   template:
     src: "{{ ha_svc_template_path }}/atomic-openshift-master-controllers.j2"
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-master-controllers
+    dest: /etc/sysconfig/{{ openshift_service_type }}-master-controllers
     backup: true
   notify:
   - restart master controllers
 
 - name: Restore Master Controllers Proxy Config Options
   lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-master-controllers
+    dest: /etc/sysconfig/{{ openshift_service_type }}-master-controllers
     line: "{{ item }}"
   with_items: "{{ master_controllers_proxy.stdout_lines | default([]) }}"
   when:
@@ -135,7 +135,7 @@
 
 - name: Restore Master Controllers AWS Options
   lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-master-controllers
+    dest: /etc/sysconfig/{{ openshift_service_type }}-master-controllers
     line: "{{ item }}"
   with_items: "{{ master_controllers_aws.stdout_lines | default([]) }}"
   when:

--- a/roles/openshift_master/tasks/upgrade/rpm_upgrade.yml
+++ b/roles/openshift_master/tasks/upgrade/rpm_upgrade.yml
@@ -12,11 +12,11 @@
   package: name={{ master_pkgs | join(',') }} state=present
   vars:
     master_pkgs:
-      - "{{ openshift.common.service_type }}{{ openshift_pkg_version }}"
-      - "{{ openshift.common.service_type }}-master{{ openshift_pkg_version }}"
-      - "{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
-      - "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version }}"
-      - "{{ openshift.common.service_type }}-clients{{ openshift_pkg_version }}"
-      - "tuned-profiles-{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
+      - "{{ openshift_service_type }}{{ openshift_pkg_version }}"
+      - "{{ openshift_service_type }}-master{{ openshift_pkg_version }}"
+      - "{{ openshift_service_type }}-node{{ openshift_pkg_version }}"
+      - "{{ openshift_service_type }}-sdn-ovs{{ openshift_pkg_version }}"
+      - "{{ openshift_service_type }}-clients{{ openshift_pkg_version }}"
+      - "tuned-profiles-{{ openshift_service_type }}-node{{ openshift_pkg_version }}"
   register: result
   until: result | success

--- a/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-api.service.j2
+++ b/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-api.service.j2
@@ -3,18 +3,18 @@ Description=Atomic OpenShift Master API
 Documentation=https://github.com/openshift/origin
 After=etcd_container.service
 Wants=etcd_container.service
-Before={{ openshift.common.service_type }}-node.service
+Before={{ openshift_service_type }}-node.service
 After={{ openshift_docker_service_name }}.service
 PartOf={{ openshift_docker_service_name }}.service
 Requires={{ openshift_docker_service_name }}.service
 
 [Service]
-EnvironmentFile=/etc/sysconfig/{{ openshift.common.service_type }}-master-api
+EnvironmentFile=/etc/sysconfig/{{ openshift_service_type }}-master-api
 Environment=GOTRACEBACK=crash
-ExecStartPre=-/usr/bin/docker rm -f {{ openshift.common.service_type}}-master-api
+ExecStartPre=-/usr/bin/docker rm -f {{ openshift_service_type}}-master-api
 ExecStart=/usr/bin/docker run --rm --privileged --net=host \
-  --name {{ openshift.common.service_type }}-master-api \
-  --env-file=/etc/sysconfig/{{ openshift.common.service_type }}-master-api \
+  --name {{ openshift_service_type }}-master-api \
+  --env-file=/etc/sysconfig/{{ openshift_service_type }}-master-api \
   -v {{ r_openshift_master_data_dir }}:{{ r_openshift_master_data_dir }} \
   -v /var/log:/var/log -v /var/run/docker.sock:/var/run/docker.sock \
   -v {{ openshift.common.config_base }}:{{ openshift.common.config_base }} \
@@ -24,14 +24,14 @@ ExecStart=/usr/bin/docker run --rm --privileged --net=host \
   {{ openshift.master.master_image }}:${IMAGE_VERSION} start master api \
   --config=${CONFIG_FILE} $OPTIONS
 ExecStartPost=/usr/bin/sleep 10
-ExecStop=/usr/bin/docker stop {{ openshift.common.service_type }}-master-api
+ExecStop=/usr/bin/docker stop {{ openshift_service_type }}-master-api
 LimitNOFILE=131072
 LimitCORE=infinity
 WorkingDirectory={{ r_openshift_master_data_dir }}
-SyslogIdentifier={{ openshift.common.service_type }}-master-api
+SyslogIdentifier={{ openshift_service_type }}-master-api
 Restart=always
 RestartSec=5s
 
 [Install]
 WantedBy={{ openshift_docker_service_name }}.service
-WantedBy={{ openshift.common.service_type }}-node.service
+WantedBy={{ openshift_service_type }}-node.service

--- a/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-controllers.service.j2
+++ b/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-controllers.service.j2
@@ -1,19 +1,19 @@
 [Unit]
 Description=Atomic OpenShift Master Controllers
 Documentation=https://github.com/openshift/origin
-Wants={{ openshift.common.service_type }}-master-api.service
-After={{ openshift.common.service_type }}-master-api.service
+Wants={{ openshift_service_type }}-master-api.service
+After={{ openshift_service_type }}-master-api.service
 After={{ openshift_docker_service_name }}.service
 Requires={{ openshift_docker_service_name }}.service
 PartOf={{ openshift_docker_service_name }}.service
 
 [Service]
-EnvironmentFile=/etc/sysconfig/{{ openshift.common.service_type }}-master-controllers
+EnvironmentFile=/etc/sysconfig/{{ openshift_service_type }}-master-controllers
 Environment=GOTRACEBACK=crash
-ExecStartPre=-/usr/bin/docker rm -f {{ openshift.common.service_type}}-master-controllers
+ExecStartPre=-/usr/bin/docker rm -f {{ openshift_service_type}}-master-controllers
 ExecStart=/usr/bin/docker run --rm --privileged --net=host \
-  --name {{ openshift.common.service_type }}-master-controllers \
-  --env-file=/etc/sysconfig/{{ openshift.common.service_type }}-master-controllers \
+  --name {{ openshift_service_type }}-master-controllers \
+  --env-file=/etc/sysconfig/{{ openshift_service_type }}-master-controllers \
   -v {{ r_openshift_master_data_dir }}:{{ r_openshift_master_data_dir }} \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v {{ openshift.common.config_base }}:{{ openshift.common.config_base }} \
@@ -23,11 +23,11 @@ ExecStart=/usr/bin/docker run --rm --privileged --net=host \
   {{ openshift.master.master_image }}:${IMAGE_VERSION} start master controllers \
   --config=${CONFIG_FILE} $OPTIONS
 ExecStartPost=/usr/bin/sleep 10
-ExecStop=/usr/bin/docker stop {{ openshift.common.service_type }}-master-controllers
+ExecStop=/usr/bin/docker stop {{ openshift_service_type }}-master-controllers
 LimitNOFILE=131072
 LimitCORE=infinity
 WorkingDirectory={{ r_openshift_master_data_dir }}
-SyslogIdentifier={{ openshift.common.service_type }}-master-controllers
+SyslogIdentifier={{ openshift_service_type }}-master-controllers
 Restart=always
 RestartSec=5s
 

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.service.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.service.j2
@@ -3,12 +3,12 @@ Description=Atomic OpenShift Master API
 Documentation=https://github.com/openshift/origin
 After=network-online.target
 After=etcd.service
-Before={{ openshift.common.service_type }}-node.service
+Before={{ openshift_service_type }}-node.service
 Requires=network-online.target
 
 [Service]
 Type=notify
-EnvironmentFile=/etc/sysconfig/{{ openshift.common.service_type }}-master-api
+EnvironmentFile=/etc/sysconfig/{{ openshift_service_type }}-master-api
 Environment=GOTRACEBACK=crash
 ExecStart=/usr/bin/openshift start master api --config=${CONFIG_FILE} $OPTIONS
 LimitNOFILE=131072
@@ -20,4 +20,4 @@ RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target
-WantedBy={{ openshift.common.service_type }}-node.service
+WantedBy={{ openshift_service_type }}-node.service

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.service.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.service.j2
@@ -2,19 +2,19 @@
 Description=Atomic OpenShift Master Controllers
 Documentation=https://github.com/openshift/origin
 After=network-online.target
-After={{ openshift.common.service_type }}-master-api.service
-Wants={{ openshift.common.service_type }}-master-api.service
+After={{ openshift_service_type }}-master-api.service
+Wants={{ openshift_service_type }}-master-api.service
 Requires=network-online.target
 
 [Service]
 Type=notify
-EnvironmentFile=/etc/sysconfig/{{ openshift.common.service_type }}-master-controllers
+EnvironmentFile=/etc/sysconfig/{{ openshift_service_type }}-master-controllers
 Environment=GOTRACEBACK=crash
 ExecStart=/usr/bin/openshift start master controllers --config=${CONFIG_FILE} $OPTIONS
 LimitNOFILE=131072
 LimitCORE=infinity
 WorkingDirectory={{ r_openshift_master_data_dir }}
-SyslogIdentifier={{ openshift.common.service_type }}-master-controllers
+SyslogIdentifier={{ openshift_service_type }}-master-controllers
 Restart=always
 RestartSec=5s
 

--- a/roles/openshift_metrics/handlers/main.yml
+++ b/roles/openshift_metrics/handlers/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: restart master api
-  systemd: name={{ openshift.common.service_type }}-master-api state=restarted
+  systemd: name={{ openshift_service_type }}-master-api state=restarted
   when: (not (master_api_service_status_changed | default(false) | bool))
   notify: Verify API Server
 
 # We retry the controllers because the API may not be 100% initialized yet.
 - name: restart master controllers
-  command: "systemctl restart {{ openshift.common.service_type }}-master-controllers"
+  command: "systemctl restart {{ openshift_service_type }}-master-controllers"
   retries: 3
   delay: 5
   register: result

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -14,7 +14,11 @@ r_openshift_node_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }
 l_is_node_system_container: "{{ (openshift_use_node_system_container | default(openshift_use_system_containers | default(false)) | bool) }}"
 
 openshift_deployment_type: "{{ openshift_deployment_type | default('origin') }}"
-openshift_service_type: "{{ 'origin' if openshift_deployment_type == 'origin' else 'atomic-openshift' }}"
+openshift_service_type_dict:
+  origin: origin
+  openshift-enterprise: atomic-openshift
+
+openshift_service_type: "{{ openshift_service_type_dict[openshift_deployment_type] }}"
 
 system_images_registry_dict:
   openshift-enterprise: "registry.access.redhat.com"

--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -34,7 +34,7 @@
 
 - name: restart node
   systemd:
-    name: "{{ openshift.common.service_type }}-node"
+    name: "{{ openshift_service_type }}-node"
     state: restarted
   register: l_openshift_node_restart_node_result
   until: not l_openshift_node_restart_node_result | failed

--- a/roles/openshift_node/tasks/aws.yml
+++ b/roles/openshift_node/tasks/aws.yml
@@ -1,7 +1,7 @@
 ---
 - name: Configure AWS Cloud Provider Settings
   lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
+    dest: /etc/sysconfig/{{ openshift_service_type }}-node
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
     create: true

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -38,7 +38,7 @@
 
 - name: Configure Node Environment Variables
   lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
+    dest: /etc/sysconfig/{{ openshift_service_type }}-node
     regexp: "^{{ item.key }}="
     line: "{{ item.key }}={{ item.value }}"
     create: true
@@ -76,7 +76,7 @@
     - name: Start and enable node dep
       systemd:
         daemon_reload: yes
-        name: "{{ openshift.common.service_type }}-node-dep"
+        name: "{{ openshift_service_type }}-node-dep"
         enabled: yes
         state: started
 
@@ -84,7 +84,7 @@
   block:
     - name: Start and enable node
       systemd:
-        name: "{{ openshift.common.service_type }}-node"
+        name: "{{ openshift_service_type }}-node"
         enabled: yes
         state: started
         daemon_reload: yes
@@ -95,7 +95,7 @@
       ignore_errors: true
 
     - name: Dump logs from node service if it failed
-      command: journalctl --no-pager -n 100 -u {{ openshift.common.service_type }}-node
+      command: journalctl --no-pager -n 100 -u {{ openshift_service_type }}-node
       when: node_start_result | failed
 
     - name: Abort if node failed to start

--- a/roles/openshift_node/tasks/config/configure-node-settings.yml
+++ b/roles/openshift_node/tasks/config/configure-node-settings.yml
@@ -1,7 +1,7 @@
 ---
 - name: Configure Node settings
   lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
+    dest: /etc/sysconfig/{{ openshift_service_type }}-node
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
     create: true

--- a/roles/openshift_node/tasks/config/configure-proxy-settings.yml
+++ b/roles/openshift_node/tasks/config/configure-proxy-settings.yml
@@ -1,7 +1,7 @@
 ---
 - name: Configure Proxy Settings
   lineinfile:
-    dest: /etc/sysconfig/{{ openshift.common.service_type }}-node
+    dest: /etc/sysconfig/{{ openshift_service_type }}-node
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
     create: true

--- a/roles/openshift_node/tasks/config/install-node-deps-docker-service-file.yml
+++ b/roles/openshift_node/tasks/config/install-node-deps-docker-service-file.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install Node dependencies docker service file
   template:
-    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node-dep.service"
+    dest: "/etc/systemd/system/{{ openshift_service_type }}-node-dep.service"
     src: openshift.docker.node.dep.service
   notify:
   - reload systemd units

--- a/roles/openshift_node/tasks/config/install-node-docker-service-file.yml
+++ b/roles/openshift_node/tasks/config/install-node-docker-service-file.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install Node docker service file
   template:
-    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
+    dest: "/etc/systemd/system/{{ openshift_service_type }}-node.service"
     src: openshift.docker.node.service
   notify:
   - reload systemd units

--- a/roles/openshift_node/tasks/docker/upgrade.yml
+++ b/roles/openshift_node/tasks/docker/upgrade.yml
@@ -1,6 +1,6 @@
 ---
 # input variables:
-# - openshift.common.service_type
+# - openshift_service_type
 # - openshift.common.is_containerized
 # - docker_upgrade_nuke_images
 # - docker_version

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -3,14 +3,14 @@
   block:
   - name: Install Node package
     package:
-      name: "{{ openshift.common.service_type }}-node{{ (openshift_pkg_version | default('')) | oo_image_tag_to_rpm_version(include_dash=True) }}"
+      name: "{{ openshift_service_type }}-node{{ (openshift_pkg_version | default('')) | oo_image_tag_to_rpm_version(include_dash=True) }}"
       state: present
     register: result
     until: result | success
 
   - name: Install sdn-ovs package
     package:
-      name: "{{ openshift.common.service_type }}-sdn-ovs{{ (openshift_pkg_version | default('')) | oo_image_tag_to_rpm_version(include_dash=True) }}"
+      name: "{{ openshift_service_type }}-sdn-ovs{{ (openshift_pkg_version | default('')) | oo_image_tag_to_rpm_version(include_dash=True) }}"
       state: present
     when:
     - openshift_node_use_openshift_sdn | bool

--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -8,10 +8,10 @@
 
 - name: Install or Update node system container
   oc_atomic_container:
-    name: "{{ openshift.common.service_type }}-node"
+    name: "{{ openshift_service_type }}-node"
     image: "{{ 'docker:' if system_images_registry == 'docker' else system_images_registry + '/' }}{{ openshift.node.node_system_image }}:{{ openshift_image_tag }}"
     values:
     - "DNS_DOMAIN={{ openshift.common.dns_domain }}"
     - "DOCKER_SERVICE={{ openshift_docker_service_name }}.service"
-    - "MASTER_SERVICE={{ openshift.common.service_type }}.service"
+    - "MASTER_SERVICE={{ openshift_service_type }}.service"
     state: latest

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install Node service file
   template:
-    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
+    dest: "/etc/systemd/system/{{ openshift_service_type }}-node.service"
     src: "{{ openshift.common.is_containerized | bool | ternary('openshift.docker.node.service', 'node.service.j2') }}"
   when: not l_is_node_system_container | bool
   notify:

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -17,7 +17,7 @@
     name: "{{ item }}"
     state: stopped
   with_items:
-  - "{{ openshift.common.service_type }}-node"
+  - "{{ openshift_service_type }}-node"
   - openvswitch
   failed_when: false
 
@@ -26,8 +26,8 @@
     name: "{{ item }}"
     state: stopped
   with_items:
-  - "{{ openshift.common.service_type }}-master-controllers"
-  - "{{ openshift.common.service_type }}-master-api"
+  - "{{ openshift_service_type }}-master-controllers"
+  - "{{ openshift_service_type }}-master-api"
   - etcd_container
   failed_when: false
   when: openshift.common.is_containerized | bool
@@ -80,9 +80,9 @@
   with_items:
   - etcd_container
   - openvswitch
-  - "{{ openshift.common.service_type }}-master-api"
-  - "{{ openshift.common.service_type }}-master-controllers"
-  - "{{ openshift.common.service_type }}-node"
+  - "{{ openshift_service_type }}-master-api"
+  - "{{ openshift_service_type }}-master-controllers"
+  - "{{ openshift_service_type }}-node"
   failed_when: false
   when: openshift.common.is_containerized | bool
 
@@ -91,7 +91,7 @@
     name: "{{ item }}"
     state: stopped
   with_items:
-  - "{{ openshift.common.service_type }}-node"
+  - "{{ openshift_service_type }}-node"
   - openvswitch
   failed_when: false
   when: not openshift.common.is_containerized | bool

--- a/roles/openshift_node/tasks/upgrade/restart.yml
+++ b/roles/openshift_node/tasks/upgrade/restart.yml
@@ -1,6 +1,6 @@
 ---
 # input variables:
-# - openshift.common.service_type
+# - openshift_service_type
 # - openshift.common.is_containerized
 # - openshift.common.hostname
 # - openshift.master.api_port
@@ -27,9 +27,9 @@
   with_items:
     - etcd_container
     - openvswitch
-    - "{{ openshift.common.service_type }}-master-api"
-    - "{{ openshift.common.service_type }}-master-controllers"
-    - "{{ openshift.common.service_type }}-node"
+    - "{{ openshift_service_type }}-master-api"
+    - "{{ openshift_service_type }}-master-controllers"
+    - "{{ openshift_service_type }}-node"
   failed_when: false
 
 - name: Wait for master API to come back online

--- a/roles/openshift_node/tasks/upgrade/rpm_upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade/rpm_upgrade.yml
@@ -1,13 +1,13 @@
 ---
 # input variables:
-# - openshift.common.service_type
+# - openshift_service_type
 # - component
 # - openshift_pkg_version
 # - openshift.common.is_atomic
 
 # We verified latest rpm available is suitable, so just yum update.
 - name: Upgrade packages
-  package: "name={{ openshift.common.service_type }}-{{ component }}{{ openshift_pkg_version }} state=present"
+  package: "name={{ openshift_service_type }}-{{ component }}{{ openshift_pkg_version }} state=present"
   register: result
   until: result | success
 
@@ -19,7 +19,7 @@
 
 - name: Install Node service file
   template:
-    dest: "/etc/systemd/system/{{ openshift.common.service_type }}-node.service"
+    dest: "/etc/systemd/system/{{ openshift_service_type }}-node.service"
     src: "node.service.j2"
   register: l_node_unit
 

--- a/roles/openshift_node/templates/openshift.docker.node.dep.service
+++ b/roles/openshift_node/templates/openshift.docker.node.dep.service
@@ -1,11 +1,11 @@
 [Unit]
 Requires={{ openshift_docker_service_name }}.service
 After={{ openshift_docker_service_name }}.service
-PartOf={{ openshift.common.service_type }}-node.service
-Before={{ openshift.common.service_type }}-node.service
+PartOf={{ openshift_service_type }}-node.service
+Before={{ openshift_service_type }}-node.service
 {% if openshift_use_crio %}Wants=cri-o.service{% endif %}
 
 [Service]
-ExecStart=/bin/bash -c "if [[ -f /usr/bin/docker-current ]]; then echo \"DOCKER_ADDTL_BIND_MOUNTS=--volume=/usr/bin/docker-current:/usr/bin/docker-current:ro --volume=/etc/sysconfig/docker:/etc/sysconfig/docker:ro --volume=/etc/containers/registries:/etc/containers/registries:ro\" > /etc/sysconfig/{{ openshift.common.service_type }}-node-dep; else echo \"#DOCKER_ADDTL_BIND_MOUNTS=\" > /etc/sysconfig/{{ openshift.common.service_type }}-node-dep; fi"
+ExecStart=/bin/bash -c "if [[ -f /usr/bin/docker-current ]]; then echo \"DOCKER_ADDTL_BIND_MOUNTS=--volume=/usr/bin/docker-current:/usr/bin/docker-current:ro --volume=/etc/sysconfig/docker:/etc/sysconfig/docker:ro --volume=/etc/containers/registries:/etc/containers/registries:ro\" > /etc/sysconfig/{{ openshift_service_type }}-node-dep; else echo \"#DOCKER_ADDTL_BIND_MOUNTS=\" > /etc/sysconfig/{{ openshift_service_type }}-node-dep; fi"
 ExecStop=
-SyslogIdentifier={{ openshift.common.service_type }}-node-dep
+SyslogIdentifier={{ openshift_service_type }}-node-dep

--- a/roles/openshift_node/templates/openshift.docker.node.service
+++ b/roles/openshift_node/templates/openshift.docker.node.service
@@ -1,5 +1,5 @@
 [Unit]
-After={{ openshift.common.service_type }}-master.service
+After={{ openshift_service_type }}-master.service
 After={{ openshift_docker_service_name }}.service
 After=openvswitch.service
 PartOf={{ openshift_docker_service_name }}.service
@@ -10,20 +10,20 @@ PartOf=openvswitch.service
 After=ovsdb-server.service
 After=ovs-vswitchd.service
 {% endif %}
-Wants={{ openshift.common.service_type }}-master.service
-Requires={{ openshift.common.service_type }}-node-dep.service
-After={{ openshift.common.service_type }}-node-dep.service
+Wants={{ openshift_service_type }}-master.service
+Requires={{ openshift_service_type }}-node-dep.service
+After={{ openshift_service_type }}-node-dep.service
 Requires=dnsmasq.service
 After=dnsmasq.service
 
 [Service]
-EnvironmentFile=/etc/sysconfig/{{ openshift.common.service_type }}-node
-EnvironmentFile=/etc/sysconfig/{{ openshift.common.service_type }}-node-dep
-ExecStartPre=-/usr/bin/docker rm -f {{ openshift.common.service_type }}-node
+EnvironmentFile=/etc/sysconfig/{{ openshift_service_type }}-node
+EnvironmentFile=/etc/sysconfig/{{ openshift_service_type }}-node-dep
+ExecStartPre=-/usr/bin/docker rm -f {{ openshift_service_type }}-node
 ExecStartPre=/usr/bin/cp /etc/origin/node/node-dnsmasq.conf /etc/dnsmasq.d/
 ExecStartPre=/usr/bin/dbus-send --system --dest=uk.org.thekelleys.dnsmasq /uk/org/thekelleys/dnsmasq uk.org.thekelleys.SetDomainServers array:string:/in-addr.arpa/127.0.0.1,/{{ openshift.common.dns_domain }}/127.0.0.1
-ExecStart=/usr/bin/docker run --name {{ openshift.common.service_type }}-node \
-  --rm --privileged --net=host --pid=host --env-file=/etc/sysconfig/{{ openshift.common.service_type }}-node \
+ExecStart=/usr/bin/docker run --name {{ openshift_service_type }}-node \
+  --rm --privileged --net=host --pid=host --env-file=/etc/sysconfig/{{ openshift_service_type }}-node \
   -v /:/rootfs:ro,rslave -e CONFIG_FILE=${CONFIG_FILE} -e OPTIONS=${OPTIONS} \
   -e HOST=/rootfs -e HOST_ETC=/host-etc \
   -v {{ openshift_node_data_dir }}:{{ openshift_node_data_dir }}:rslave \
@@ -40,10 +40,10 @@ ExecStart=/usr/bin/docker run --name {{ openshift.common.service_type }}-node \
   {% if l_bind_docker_reg_auth %} -v {{ oreg_auth_credentials_path }}:/root/.docker:ro{% endif %}\
   {{ openshift.node.node_image }}:${IMAGE_VERSION}
 ExecStartPost=/usr/bin/sleep 10
-ExecStop=/usr/bin/docker stop {{ openshift.common.service_type }}-node
+ExecStop=/usr/bin/docker stop {{ openshift_service_type }}-node
 ExecStopPost=/usr/bin/rm /etc/dnsmasq.d/node-dnsmasq.conf
 ExecStopPost=/usr/bin/dbus-send --system --dest=uk.org.thekelleys.dnsmasq /uk/org/thekelleys/dnsmasq uk.org.thekelleys.SetDomainServers array:string:
-SyslogIdentifier={{ openshift.common.service_type }}-node
+SyslogIdentifier={{ openshift_service_type }}-node
 Restart=always
 RestartSec=5s
 

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -101,13 +101,13 @@
     when: is_containerized | bool
 
   - block:
-    - name: Get available {{ openshift.common.service_type}} version
+    - name: Get available {{ openshift_service_type}} version
       repoquery:
-        name: "{{ openshift.common.service_type}}"
+        name: "{{ openshift_service_type}}"
         ignore_excluders: true
       register: rpm_results
     - fail:
-        msg: "Package {{ openshift.common.service_type}} not found"
+        msg: "Package {{ openshift_service_type}} not found"
       when: not rpm_results.results.package_found
     - set_fact:
         openshift_rpm_version: "{{ rpm_results.results.versions.available_versions.0 | default('0.0', True) }}"
@@ -196,7 +196,7 @@
       - openshift_version.startswith(openshift_release) | bool
       msg: |-
         You requested openshift_release {{ openshift_release }}, which is not matched by
-        the latest OpenShift RPM we detected as {{ openshift.common.service_type }}-{{ openshift_version }}
+        the latest OpenShift RPM we detected as {{ openshift_service_type }}-{{ openshift_version }}
         on host {{ inventory_hostname }}.
         We will only install the latest RPMs, so please ensure you are getting the release
         you expect. You may need to adjust your Ansible inventory, modify the repositories

--- a/roles/openshift_version/tasks/set_version_rpm.yml
+++ b/roles/openshift_version/tasks/set_version_rpm.yml
@@ -8,14 +8,14 @@
   - openshift_version is not defined
 
 - block:
-  - name: Get available {{ openshift.common.service_type}} version
+  - name: Get available {{ openshift_service_type}} version
     repoquery:
-      name: "{{ openshift.common.service_type}}"
+      name: "{{ openshift_service_type}}"
       ignore_excluders: true
     register: rpm_results
 
   - fail:
-      msg: "Package {{ openshift.common.service_type}} not found"
+      msg: "Package {{ openshift_service_type}} not found"
     when: not rpm_results.results.package_found
 
   - set_fact:

--- a/test/integration/openshift_health_checker/setup_container.yml
+++ b/test/integration/openshift_health_checker/setup_container.yml
@@ -46,7 +46,6 @@
 
 - hosts: all
   tasks:
-
     # run before openshift_version to prevent it breaking
     - include: preflight/playbooks/tasks/enable_repo.yml
       vars: { repo_name: "ose-3.2" }


### PR DESCRIPTION
This commit removes openshift.common.service_type
in favor of openshift_service_type.