### PR TITLE
Remove openshift.common.cli_image

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -12,7 +12,7 @@
 
 - name: Verify containers are available for upgrade
   command: >
-    docker pull {{ openshift.common.cli_image }}:{{ openshift_image_tag }}
+    docker pull {{ openshift_cli_image }}:{{ openshift_image_tag }}
   register: pull_result
   changed_when: "'Downloaded newer image' in pull_result.stdout"
   when: openshift.common.is_containerized | bool

--- a/playbooks/init/facts.yml
+++ b/playbooks/init/facts.yml
@@ -107,7 +107,6 @@
       local_facts:
         deployment_type: "{{ openshift_deployment_type }}"
         deployment_subtype: "{{ openshift_deployment_subtype | default(None) }}"
-        cli_image: "{{ osm_image | default(None) }}"
         hostname: "{{ openshift_hostname | default(None) }}"
         ip: "{{ openshift_ip | default(None) }}"
         is_containerized: "{{ l_is_containerized | default(None) }}"

--- a/roles/openshift_cli/tasks/main.yml
+++ b/roles/openshift_cli/tasks/main.yml
@@ -12,13 +12,13 @@
 - block:
   - name: Pull CLI Image
     command: >
-      docker pull {{ openshift.common.cli_image }}:{{ openshift_image_tag }}
+      docker pull {{ openshift_cli_image }}:{{ openshift_image_tag }}
     register: pull_result
     changed_when: "'Downloaded newer image' in pull_result.stdout"
 
   - name: Copy client binaries/symlinks out of CLI image for use on the host
     openshift_container_binary_sync:
-      image: "{{ openshift.common.cli_image }}"
+      image: "{{ openshift_cli_image }}"
       tag: "{{ openshift_image_tag }}"
       backend: "docker"
   when:
@@ -28,13 +28,13 @@
 - block:
   - name: Pull CLI Image
     command: >
-      atomic pull --storage ostree {{ 'docker:' if system_images_registry == 'docker' else system_images_registry + '/' }}{{ openshift.common.cli_image }}:{{ openshift_image_tag }}
+      atomic pull --storage ostree {{ 'docker:' if system_images_registry == 'docker' else system_images_registry + '/' }}{{ openshift_cli_image }}:{{ openshift_image_tag }}
     register: pull_result
     changed_when: "'Pulling layer' in pull_result.stdout"
 
   - name: Copy client binaries/symlinks out of CLI image for use on the host
     openshift_container_binary_sync:
-      image: "{{ '' if system_images_registry == 'docker' else system_images_registry + '/' }}{{ openshift.common.cli_image }}"
+      image: "{{ '' if system_images_registry == 'docker' else system_images_registry + '/' }}{{ openshift_cli_image }}"
       tag: "{{ openshift_image_tag }}"
       backend: "atomic"
   when:

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+openshift_cli_image_dict:
+  origin: 'openshift/origin'
+  openshift-enterprise: 'openshift3/ose'
+
+openshift_cli_image: "{{ osm_image | default(openshift_cli_image_dict[openshift_deployment_type]) }}"

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1628,7 +1628,6 @@ def set_container_facts_if_unset(facts):
     deployment_type = facts['common']['deployment_type']
     if deployment_type == 'openshift-enterprise':
         master_image = 'openshift3/ose'
-        cli_image = master_image
         node_image = 'openshift3/node'
         ovs_image = 'openshift3/openvswitch'
         pod_image = 'openshift3/ose-pod'
@@ -1637,7 +1636,6 @@ def set_container_facts_if_unset(facts):
         deployer_image = 'openshift3/ose-deployer'
     else:
         master_image = 'openshift/origin'
-        cli_image = master_image
         node_image = 'openshift/node'
         ovs_image = 'openshift/openvswitch'
         pod_image = 'openshift/origin-pod'
@@ -1656,8 +1654,6 @@ def set_container_facts_if_unset(facts):
 
     if 'is_containerized' not in facts['common']:
         facts['common']['is_containerized'] = facts['common']['is_atomic']
-    if 'cli_image' not in facts['common']:
-        facts['common']['cli_image'] = cli_image
     if 'pod_image' not in facts['common']:
         facts['common']['pod_image'] = pod_image
     if 'router_image' not in facts['common']:

--- a/roles/openshift_version/tasks/set_version_containerized.yml
+++ b/roles/openshift_version/tasks/set_version_containerized.yml
@@ -20,7 +20,7 @@
 
 - name: Lookup latest containerized version if no version specified
   command: >
-    docker run --rm {{ openshift.common.cli_image }}:latest version
+    docker run --rm {{ openshift_cli_image }}:latest version
   register: cli_image_version
   when:
   - openshift_version is not defined
@@ -43,7 +43,7 @@
 # and use that value instead.
 - name: Set precise containerized version to configure if openshift_release specified
   command: >
-    docker run --rm {{ openshift.common.cli_image }}:v{{ openshift_version }} version
+    docker run --rm {{ openshift_cli_image }}:v{{ openshift_version }} version
   register: cli_image_version
   when:
   - openshift_version is defined


### PR DESCRIPTION
This commit removes openshift.common.cli_image in
favor of openshift_cli_image.