### PR TITLE
remove schedulable from openshift_facts

### DIFF
--- a/playbooks/openshift-node/private/manage_node.yml
+++ b/playbooks/openshift-node/private/manage_node.yml
@@ -6,6 +6,7 @@
   roles:
   - role: openshift_manage_node
     openshift_master_host: "{{ groups.oo_first_master.0 }}"
+    openshift_manage_node_is_master: "{{ ('oo_masters_to_config' in group_names) | bool }}"
   tasks:
   - name: Create group for deployment type
     group_by: key=oo_nodes_deployment_type_{{ openshift.common.deployment_type }}

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -446,24 +446,6 @@ def normalize_provider_facts(provider, metadata):
     return facts
 
 
-def set_node_schedulability(facts):
-    """ Set schedulable facts if not already present in facts dict
-        Args:
-            facts (dict): existing facts
-        Returns:
-            dict: the facts dict updated with the generated schedulable
-            facts if they were not already present
-
-    """
-    if 'node' in facts:
-        if 'schedulable' not in facts['node']:
-            if 'master' in facts:
-                facts['node']['schedulable'] = False
-            else:
-                facts['node']['schedulable'] = True
-    return facts
-
-
 # pylint: disable=too-many-branches
 def set_selectors(facts):
     """ Set selectors facts if not already present in facts dict
@@ -1838,7 +1820,6 @@ class OpenShiftFacts(object):
         facts['current_config'] = get_current_config(facts)
         facts = set_url_facts_if_unset(facts)
         facts = set_project_cfg_facts_if_unset(facts)
-        facts = set_node_schedulability(facts)
         facts = set_selectors(facts)
         facts = set_identity_providers_if_unset(facts)
         facts = set_deployment_facts_if_unset(facts)

--- a/roles/openshift_manage_node/defaults/main.yml
+++ b/roles/openshift_manage_node/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# openshift_manage_node_is_master is set at the play level.
+openshift_manage_node_is_master: False
+
+# Default is to be schedulable except for master nodes.
+l_openshift_manage_schedulable: "{{ openshift_schedulable | default(not openshift_manage_node_is_master) }}"

--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -37,7 +37,7 @@
 - name: Set node schedulability
   oc_adm_manage_node:
     node: "{{ openshift.node.nodename | lower }}"
-    schedulable: "{{ 'true' if openshift.node.schedulable | bool else 'false' }}"
+    schedulable: "{{ 'true' if l_openshift_manage_schedulable | bool else 'false' }}"
   retries: 10
   delay: 5
   register: node_schedulable

--- a/roles/openshift_node_facts/tasks/main.yml
+++ b/roles/openshift_node_facts/tasks/main.yml
@@ -15,7 +15,6 @@
       kubelet_args: "{{ openshift_node_kubelet_args | default(None) }}"
       labels: "{{ openshift_node_labels | default(None) }}"
       registry_url: "{{ oreg_url_node | default(oreg_url) | default(None) }}"
-      schedulable: "{{ openshift_schedulable | default(openshift_scheduleable) | default(None) }}"
       sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
       storage_plugin_deps: "{{ osn_storage_plugin_deps | default(None) }}"
       set_node_ip: "{{ openshift_set_node_ip | default(None) }}"


### PR DESCRIPTION
This commit removes schedulable from openshift_facts in
favor of detecting whether or not a host is a master
via inventory.