### PR TITLE
add nfs storage type

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -345,10 +345,12 @@ Note: Containerized storage hosts are not currently supported.
     existing, existing_host = is_host_already_node_or_master(hostname_or_ip, hosts)
     if existing and existing_host.is_node():
         existing_host.roles.append('storage')
+        existing_host.other_variables['openshift_hosted_registry_storage_kind'] = 'nfs'
     else:
         host_props['connect_to'] = hostname_or_ip
         host_props['preconfigured'] = False
         host_props['roles'] = ['storage']
+        host_props['openshift_hosted_registry_storage_kind'] = 'nfs'
         storage = Host(**host_props)
         hosts.append(storage)
 


### PR DESCRIPTION
Previously the playbooks would automatically assign a storage type if there were nfs hosts available. but this changed in #3085 so we need to set it whenever we intend to use nfs storage