### PR TITLE
Fix no_log warnings for custom module

### DIFF
--- a/roles/lib_openshift/library/oc_adm_router.py
+++ b/roles/lib_openshift/library/oc_adm_router.py
@@ -3154,14 +3154,14 @@ def main():
             external_host_insecure=dict(default=False, type='bool'),
             external_host_partition_path=dict(default=None, type='str'),
             external_host_username=dict(default=None, type='str'),
-            external_host_password=dict(default=None, type='str'),
-            external_host_private_key=dict(default=None, type='str'),
+            external_host_password=dict(default=None, type='str', no_log=True),
+            external_host_private_key=dict(default=None, type='str', no_log=True),
             # Metrics
             expose_metrics=dict(default=False, type='bool'),
             metrics_image=dict(default=None, type='str'),
             # Stats
             stats_user=dict(default=None, type='str'),
-            stats_password=dict(default=None, type='str'),
+            stats_password=dict(default=None, type='str', no_log=True),
             stats_port=dict(default=1936, type='int'),
             # extra
             cacert_file=dict(default=None, type='str'),

--- a/roles/lib_openshift/src/ansible/oc_adm_router.py
+++ b/roles/lib_openshift/src/ansible/oc_adm_router.py
@@ -34,14 +34,14 @@ def main():
             external_host_insecure=dict(default=False, type='bool'),
             external_host_partition_path=dict(default=None, type='str'),
             external_host_username=dict(default=None, type='str'),
-            external_host_password=dict(default=None, type='str'),
-            external_host_private_key=dict(default=None, type='str'),
+            external_host_password=dict(default=None, type='str', no_log=True),
+            external_host_private_key=dict(default=None, type='str', no_log=True),
             # Metrics
             expose_metrics=dict(default=False, type='bool'),
             metrics_image=dict(default=None, type='str'),
             # Stats
             stats_user=dict(default=None, type='str'),
-            stats_password=dict(default=None, type='str'),
+            stats_password=dict(default=None, type='str', no_log=True),
             stats_port=dict(default=1936, type='int'),
             # extra
             cacert_file=dict(default=None, type='str'),


### PR DESCRIPTION
We need to set no_log for password and private_key
variables.