### PR TITLE
Fix inventory symlinks in origin-ansible container.

### DIFF
--- a/images/installer/root/usr/local/bin/run
+++ b/images/installer/root/usr/local/bin/run
@@ -18,7 +18,7 @@ INVENTORY="$(mktemp)"
 if [[ -v INVENTORY_FILE ]]; then
   # Make a copy so that ALLOW_ANSIBLE_CONNECTION_LOCAL below
   # does not attempt to modify the original
-  cp -a ${INVENTORY_FILE} ${INVENTORY}
+  cp ${INVENTORY_FILE} ${INVENTORY}
 elif [[ -v INVENTORY_DIR ]]; then
   INVENTORY="$(mktemp -d)"
   cp -R ${INVENTORY_DIR}/* ${INVENTORY}


### PR DESCRIPTION
When attempting to run openshift-ansible in a kubernetes pod, we
attempted to use a configmap to mount in our inventory to run against.
However kubernetes mounts configmaps/secrets volumes through the use of
relative symlinks. The use of "cp -a" in this script then copies a
relative symlink to /tmp which is now dangling, and ansible will fail to
run.

This patch changes to just copy the file regularly resulting in a value
temp file that is not a symlink.