### PR TITLE
Remove reading shell environment in rhel_subscribe

### DIFF
--- a/roles/rhel_subscribe/README.md
+++ b/roles/rhel_subscribe/README.md
@@ -22,7 +22,7 @@ Name of the pool to attach (optional).
 
 Custom hostname for the Satellite server (optional).
 
-### `ose_version`
+### `openshift_release`
 
 Version for the OpenShift Enterprise repositories.
 

--- a/roles/rhel_subscribe/README.md
+++ b/roles/rhel_subscribe/README.md
@@ -1,0 +1,29 @@
+RHEL Subscribe
+==============
+
+Subscribes the RHEL servers and add the OpenShift enterprise repos.
+
+Role variables
+--------------
+
+### `rhsub_user`
+
+Username for the subscription-manager.
+
+### `rhsub_pass`
+
+Password for the subscription-manager.
+
+### `rhsub_pool`
+
+Name of the pool to attach (optional).
+
+### `rhsub_server`
+
+Custom hostname for the Satellite server (optional).
+
+### `ose_version`
+
+Version for the OpenShift Enterprise repositories.
+
+Example: `3.6`

--- a/roles/rhel_subscribe/defaults/main.yml
+++ b/roles/rhel_subscribe/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
 rhsub_pool: 'Red Hat OpenShift Container Platform, Premium*'
-ose_version: '3.6'

--- a/roles/rhel_subscribe/defaults/main.yml
+++ b/roles/rhel_subscribe/defaults/main.yml
@@ -1,2 +1,3 @@
+---
 rhsub_pool: 'Red Hat OpenShift Container Platform, Premium*'
 ose_version: '3.6'

--- a/roles/rhel_subscribe/defaults/main.yml
+++ b/roles/rhel_subscribe/defaults/main.yml
@@ -1,0 +1,2 @@
+rhsub_pool: 'Red Hat OpenShift Container Platform, Premium*'
+ose_version: '3.6'

--- a/roles/rhel_subscribe/tasks/enterprise.yml
+++ b/roles/rhel_subscribe/tasks/enterprise.yml
@@ -2,18 +2,11 @@
 - name: Disable all repositories
   command: subscription-manager repos --disable="*"
 
-- set_fact:
-    default_ose_version: '3.6'
-  when: deployment_type == 'openshift-enterprise'
-
-- set_fact:
-    ose_version: "{{ lookup('env', 'ose_version') | default(default_ose_version, True) }}"
-
 - fail:
     msg: "{{ ose_version }} is not a valid version for {{ deployment_type }} deployment type"
   when:
     - deployment_type == 'openshift-enterprise'
-    - ose_version not in ['3.1', '3.2', '3.3', '3.4', '3.5', '3.6'] )
+    - ose_version not in ['3.1', '3.2', '3.3', '3.4', '3.5', '3.6']
 
 - name: Enable RHEL repositories
   command: subscription-manager repos \

--- a/roles/rhel_subscribe/tasks/enterprise.yml
+++ b/roles/rhel_subscribe/tasks/enterprise.yml
@@ -1,4 +1,10 @@
 ---
+- set_fact:
+    openshift_release: "{{ openshift_release[1:] }}"
+  when:
+  - openshift_release is defined
+  - openshift_release[0] == 'v'
+
 - name: Disable all repositories
   command: subscription-manager repos --disable="*"
 
@@ -6,7 +12,7 @@
   command: subscription-manager repos \
                --enable="rhel-7-server-rpms" \
                --enable="rhel-7-server-extras-rpms" \
-               --enable="rhel-7-server-ose-{{ openshift_release }}-rpms" \
+               --enable="rhel-7-server-ose-{{ (openshift_release | default('')).split('.')[0:2] | join('.') }}-rpms" \
                --enable="rhel-7-fast-datapath-rpms"
   register: subscribe_repos
   until: subscribe_repos | succeeded

--- a/roles/rhel_subscribe/tasks/enterprise.yml
+++ b/roles/rhel_subscribe/tasks/enterprise.yml
@@ -2,12 +2,6 @@
 - name: Disable all repositories
   command: subscription-manager repos --disable="*"
 
-- fail:
-    msg: "{{ ose_version }} is not a valid version for {{ deployment_type }} deployment type"
-  when:
-    - deployment_type == 'openshift-enterprise'
-    - ose_version not in ['3.1', '3.2', '3.3', '3.4', '3.5', '3.6']
-
 - name: Enable RHEL repositories
   command: subscription-manager repos \
                --enable="rhel-7-server-rpms" \

--- a/roles/rhel_subscribe/tasks/enterprise.yml
+++ b/roles/rhel_subscribe/tasks/enterprise.yml
@@ -6,7 +6,7 @@
   command: subscription-manager repos \
                --enable="rhel-7-server-rpms" \
                --enable="rhel-7-server-extras-rpms" \
-               --enable="rhel-7-server-ose-{{ ose_version }}-rpms" \
+               --enable="rhel-7-server-ose-{{ openshift_release }}-rpms" \
                --enable="rhel-7-fast-datapath-rpms"
   register: subscribe_repos
   until: subscribe_repos | succeeded

--- a/roles/rhel_subscribe/tasks/main.yml
+++ b/roles/rhel_subscribe/tasks/main.yml
@@ -3,23 +3,17 @@
 #       to make it able to attach to a pool
 #       to make it able to enable repositories
 
-- set_fact:
-    rhel_subscription_pool: "{{ lookup('env', 'rhel_subscription_pool') | default(rhsub_pool | default('Red Hat OpenShift Container Platform, Premium*')) }}"
-    rhel_subscription_user: "{{ lookup('env', 'rhel_subscription_user') | default(rhsub_user | default(omit, True)) }}"
-    rhel_subscription_pass: "{{ lookup('env', 'rhel_subscription_pass') | default(rhsub_pass | default(omit, True)) }}"
-    rhel_subscription_server: "{{ lookup('env', 'rhel_subscription_server') | default(rhsub_server | default(omit, True)) }}"
-
 - fail:
     msg: "This role is only supported for Red Hat hosts"
   when: ansible_distribution != 'RedHat'
 
 - fail:
-    msg: Either rhsub_user or the rhel_subscription_user env variable are required for this role.
-  when: rhel_subscription_user is not defined
+    msg: The rhsub_user variable is required for this role.
+  when: rhsub_user is not defined or not rhsub_user
 
 - fail:
-    msg: Either rhsub_pass or the rhel_subscription_pass env variable are required for this role.
-  when: rhel_subscription_pass is not defined
+    msg: The rhsub_pass variable is required for this role.
+  when: rhsub_pass is not defined or not rhsub_pass
 
 - name: Detecting Atomic Host Operating System
   stat:
@@ -27,10 +21,10 @@
   register: ostree_booted
 
 - name: Satellite preparation
-  command: "rpm -Uvh http://{{ rhel_subscription_server }}/pub/katello-ca-consumer-latest.noarch.rpm"
+  command: "rpm -Uvh http://{{ rhsub_server }}/pub/katello-ca-consumer-latest.noarch.rpm"
   args:
     creates: /etc/rhsm/ca/katello-server-ca.pem
-  when: rhel_subscription_server is defined and rhel_subscription_server
+  when: rhsub_server is defined and rhsub_server
 
 - name: Install Red Hat Subscription manager
   yum:
@@ -39,26 +33,26 @@
 
 - name: RedHat subscriptions
   redhat_subscription:
-    username: "{{ rhel_subscription_user }}"
-    password: "{{ rhel_subscription_pass }}"
+    username: "{{ rhsub_user }}"
+    password: "{{ rhsub_pass }}"
   register: rh_subscription
   until: rh_subscription | succeeded
 
 - name: Retrieve the OpenShift Pool ID
-  command: subscription-manager list --available --matches="{{ rhel_subscription_pool }}" --pool-only
+  command: subscription-manager list --available --matches="{{ rhsub_pool }}" --pool-only
   register: openshift_pool_id
   until: openshift_pool_id | succeeded
   changed_when: False
 
 - name: Determine if OpenShift Pool Already Attached
-  command: subscription-manager list --consumed --matches="{{ rhel_subscription_pool }}" --pool-only
+  command: subscription-manager list --consumed --matches="{{ rhsub_pool }}" --pool-only
   register: openshift_pool_attached
   until: openshift_pool_attached | succeeded
   changed_when: False
   when: openshift_pool_id.stdout == ''
 
 - fail:
-    msg: "Unable to find pool matching {{ rhel_subscription_pool }} in available or consumed pools"
+    msg: "Unable to find pool matching {{ rhsub_pool }} in available or consumed pools"
   when: openshift_pool_id.stdout == '' and openshift_pool_attached is defined and openshift_pool_attached.stdout == ''
 
 - name: Attach to OpenShift Pool

--- a/roles/rhel_subscribe/tasks/main.yml
+++ b/roles/rhel_subscribe/tasks/main.yml
@@ -63,5 +63,4 @@
 
 - include: enterprise.yml
   when:
-  - deployment_type == 'openshift-enterprise'
   - not ostree_booted.stat.exists | bool


### PR DESCRIPTION
The rhel_subscribe role used to read the shell environment variables for
its input with a broken fallback to Ansible variables.

This updates the role to only use Ansible vars. If the user wants to do
an env lookup, they can do so when calling the role.