### PR TITLE
Change 'oaproxy' port from 3000 to 5601 in kibana pod template.

### DIFF
--- a/roles/openshift_logging_kibana/templates/kibana.j2
+++ b/roles/openshift_logging_kibana/templates/kibana.j2
@@ -109,7 +109,7 @@ spec:
           ports:
             -
               name: "oaproxy"
-              containerPort: 3000
+              containerPort: 5601
           env:
             -
              name: "OAP_BACKEND_URL"


### PR DESCRIPTION
Exposed port named 'oaproxy':'3000' from Kibana Pod is used by kibana service and routes for accessing dashboard. But kibana dashboard is running on 5601 which needs to be exposed for outside world to access it.