### PR TITLE
Allow number of retries in openshift_management to be configurable

### DIFF
--- a/roles/openshift_management/defaults/main.yml
+++ b/roles/openshift_management/defaults/main.yml
@@ -3,6 +3,8 @@
 openshift_management_project: openshift-management
 # Namespace/project description
 openshift_management_project_description: CloudForms Management Engine
+# Number of retries when waiting for the app to start (retried every 30 seconds)
+openshift_management_pod_rollout_retries: 30
 
 ######################################################################
 # BASE TEMPLATE AND DATABASE OPTIONS

--- a/roles/openshift_management/tasks/main.yml
+++ b/roles/openshift_management/tasks/main.yml
@@ -88,9 +88,9 @@
     create: True
     params: "{{ openshift_management_template_parameters }}"
 
-- name: Wait for the app to come up. May take several minutes, 30s check intervals, 10m max
+- name: Wait for the app to come up. May take several minutes, 30s check intervals, {{ openshift_management_pod_rollout_retries }} retries
   command: "oc logs {{ openshift_management_flavor }}-0 -n {{ openshift_management_project }}"
   register: app_seeding_logs
   until: app_seeding_logs.stdout.find('Server starting complete') != -1
   delay: 30
-  retries: 20
+  retries: "{{ openshift_management_pod_rollout_retries }}"


### PR DESCRIPTION
This fixes issue #6333.

> In roles/openshift_management/tasks/main.yml, there's a task "Wait for the app to come up".
It waits for a maximum of 10 minutes until ManageIQ / CFME is ready before it reports success.
>
>This timeout is too low in some cases, because it's a big docker image and downloading it takes quite a while. It'd be best if this timeout would be configurable in the inventory file instead of being hardcoded.

cc @sdodson @bazulay