### PR TITLE
Use openshift testing repos for openstack

### DIFF
--- a/playbooks/openstack/README.md
+++ b/playbooks/openstack/README.md
@@ -183,8 +183,13 @@ Then run the provision + install playbook -- this will create the OpenStack
 resources:
 
 ```bash
-$ ansible-playbook --user openshift -i inventory openshift-ansible/playbooks/openstack/openshift-cluster/provision_install.yaml
+$ ansible-playbook --user openshift -i inventory \
+  openshift-ansible/playbooks/openstack/openshift-cluster/provision_install.yaml \
+  -e openshift_repos_enable_testing=true
 ```
+
+Note, you may want to use the testing repo for development purposes only.
+Normally, `openshift_repos_enable_testing` should not be specified.
 
 If you're using multiple inventories, make sure you pass the path to
 the right one to `-i`.

--- a/playbooks/openstack/README.md
+++ b/playbooks/openstack/README.md
@@ -24,7 +24,7 @@ The OpenStack release must be Newton (for Red Hat OpenStack this is
 version 10) or newer. It must also satisfy these requirements:
 
 * Heat (Orchestration) must be available
-* The deployment image (CentOS 7 or RHEL 7) must be loaded
+* The deployment image (CentOS 7.4 or RHEL 7) must be loaded
 * The deployment flavor must be available to your user
   - `m1.medium` / 4GB RAM + 40GB disk should be enough for testing
   - look at

--- a/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -1,6 +1,7 @@
 ---
+## Openshift product versions and repos to install from
 openshift_deployment_type: origin
-openshift_repos_enable_testing: true
+#openshift_repos_enable_testing: true
 #openshift_deployment_type: openshift-enterprise
 #openshift_release: v3.5
 openshift_master_default_subdomain: "apps.{{ openshift_openstack_clusterid }}.{{ openshift_openstack_public_dns_domain }}"

--- a/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -1,5 +1,6 @@
 ---
 openshift_deployment_type: origin
+openshift_repos_enable_testing: true
 #openshift_deployment_type: openshift-enterprise
 #openshift_release: v3.5
 openshift_master_default_subdomain: "apps.{{ openshift_openstack_clusterid }}.{{ openshift_openstack_public_dns_domain }}"


### PR DESCRIPTION
Use testing openshift repos to sidestep packaging issues for 3.6 clients being
used in 3.7 deployments or something.
Poke host requirements Centos 7.4 as 7.3 can't see that testing repo.

Related https://github.com/openshift/openshift-ansible/issues/6086