### PR TITLE
[openstack] Custom dns prefixes and domains

### DIFF
--- a/playbooks/openstack/advanced-configuration.md
+++ b/playbooks/openstack/advanced-configuration.md
@@ -165,6 +165,14 @@ your servers will be under. With the default values, this will be
 That sudomain can be set as well by the `openshift_openstack_app_subdomain` variable in
 the inventory.
 
+If you want to use different public and private DNS records for your externally
+managed servers, specify `openshift_openstack_public_hostname_suffix` and/or
+`openshift_openstack_private_hostname_suffix`. These suffixes default to the
+`openshift_openstack_clusterid` subdomain. Or you may want to specify another
+private domain with `openshift_openstack_private_dns_domain`. Note that
+the servers' hostnames will not be updated. The deployment may be done on the
+arbitrary named hosts.
+
 The `openstack_<role name>_hostname` is a set of variables used for customising
 public names of Nova servers provisioned with a given role. When such a variable stays commented,
 default value (usually the role name) is used.
@@ -196,6 +204,16 @@ optional `key_name`, which normally defaults to the cluster's DNS domain.
 This just illustrates a compatibility mode with a DNS service deployed
 by OpenShift on OSP10 reference architecture, and used in a mixed mode with
 another external DNS server.
+
+If you manage an external DNS server deployed elsewhere (or a separate view)
+for private FQDNs, you may want to define
+`openshift_openstack_external_nsupdate_keys` like this:
+
+    openshift_openstack_external_nsupdate_keys:
+      private:
+        key_secret: <some nsupdate key 2>
+        key_algorithm: 'hmac-sha256'
+        server: <private DNS server IP>
 
 ## Flannel networking
 

--- a/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -4,9 +4,7 @@ openshift_deployment_type: origin
 #openshift_repos_enable_testing: true
 #openshift_deployment_type: openshift-enterprise
 #openshift_release: v3.5
-openshift_master_default_subdomain: "apps.{{ openshift_openstack_clusterid }}.{{ openshift_openstack_public_dns_domain }}"
 
-openshift_master_cluster_public_hostname: "console.{{ openshift_openstack_clusterid }}.{{ openshift_openstack_public_dns_domain }}"
 
 osm_default_node_selector: 'region=primary'
 

--- a/roles/openshift_openstack/defaults/main.yml
+++ b/roles/openshift_openstack/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+openshift_openstack_clusterid: 'openshift'
 openshift_openstack_stack_state: 'present'
 
 openshift_openstack_ssh_ingress_cidr: 0.0.0.0/0
@@ -44,13 +45,20 @@ openshift_openstack_container_storage_setup:
 # populate-dns
 openshift_openstack_dns_records_add: []
 
-openshift_openstack_full_dns_domain: "{{ (openshift_openstack_clusterid|trim == '') | ternary(openshift_openstack_public_dns_domain, openshift_openstack_clusterid + '.' + openshift_openstack_public_dns_domain) }}"
-openshift_openstack_app_subdomain: "apps"
+openshift_openstack_app_subdomain: 'apps'
+openshift_openstack_public_hostname_suffix: "{{ openshift_openstack_clusterid|trim }}"
+openshift_openstack_private_hostname_suffix: "{{ openshift_openstack_clusterid|trim }}"
+openshift_openstack_public_dns_domain: 'example.com'
 
+openshift_openstack_private_dns_domain: "{{ openshift_openstack_public_dns_domain }}"
+openshift_openstack_full_public_dns_domain: "{{ (openshift_openstack_public_hostname_suffix == '') | ternary(openshift_openstack_public_dns_domain, openshift_openstack_public_hostname_suffix + '.' + openshift_openstack_public_dns_domain) }}"
+openshift_openstack_full_private_dns_domain: "{{ (openshift_openstack_private_hostname_suffix == '') | ternary(openshift_openstack_private_dns_domain, openshift_openstack_private_hostname_suffix + '.' + openshift_openstack_private_dns_domain) }}"
+openshift_master_default_subdomain: "{{ openshift_openstack_app_subdomain }}.{{ openshift_openstack_full_public_dns_domain }}"
+openshift_master_cluster_public_hostname: "console.{{ openshift_openstack_full_public_dns_domain }}"
+openshift_master_cluster_hostname: "console.{{ openshift_openstack_full_private_dns_domain }}"
 
 # heat vars
-openshift_openstack_clusterid: openshift
-openshift_openstack_stack_name: "{{ openshift_openstack_clusterid }}.{{ openshift_openstack_public_dns_domain }}"
+openshift_openstack_stack_name: "{{ openshift_openstack_full_public_dns_domain }}"
 openshift_openstack_subnet_prefix: "192.168.99"
 openshift_openstack_master_hostname: master
 openshift_openstack_infra_hostname: infra-node

--- a/roles/openshift_openstack/defaults/main.yml
+++ b/roles/openshift_openstack/defaults/main.yml
@@ -46,13 +46,15 @@ openshift_openstack_container_storage_setup:
 openshift_openstack_dns_records_add: []
 
 openshift_openstack_app_subdomain: 'apps'
-openshift_openstack_public_hostname_suffix: "{{ openshift_openstack_clusterid|trim }}"
-openshift_openstack_private_hostname_suffix: "{{ openshift_openstack_clusterid|trim }}"
+openshift_openstack_public_hostname_suffix: ''
+openshift_openstack_private_hostname_suffix: ''
 openshift_openstack_public_dns_domain: 'example.com'
 
 openshift_openstack_private_dns_domain: "{{ openshift_openstack_public_dns_domain }}"
-openshift_openstack_full_public_dns_domain: "{{ (openshift_openstack_public_hostname_suffix == '') | ternary(openshift_openstack_public_dns_domain, openshift_openstack_public_hostname_suffix + '.' + openshift_openstack_public_dns_domain) }}"
-openshift_openstack_full_private_dns_domain: "{{ (openshift_openstack_private_hostname_suffix == '') | ternary(openshift_openstack_private_dns_domain, openshift_openstack_private_hostname_suffix + '.' + openshift_openstack_private_dns_domain) }}"
+openshift_openstack_public_subdomain: "{{ openshift_openstack_clusterid|trim + '.' + openshift_openstack_public_dns_domain }}"
+openshift_openstack_private_subdomain: "{{ openshift_openstack_clusterid|trim + '.' + openshift_openstack_private_dns_domain }}"
+openshift_openstack_full_public_dns_domain: "{{ (openshift_openstack_public_hostname_suffix|trim == '') | ternary(openshift_openstack_public_subdomain, openshift_openstack_public_hostname_suffix + '.' + openshift_openstack_public_subdomain) }}"
+openshift_openstack_full_private_dns_domain: "{{ (openshift_openstack_private_hostname_suffix|trim == '') | ternary(openshift_openstack_private_subdomain, openshift_openstack_private_hostname_suffix + '.' + openshift_openstack_private_subdomain) }}"
 openshift_master_default_subdomain: "{{ openshift_openstack_app_subdomain }}.{{ openshift_openstack_full_public_dns_domain }}"
 openshift_master_cluster_public_hostname: "console.{{ openshift_openstack_full_public_dns_domain }}"
 openshift_master_cluster_hostname: "console.{{ openshift_openstack_full_private_dns_domain }}"

--- a/roles/openshift_openstack/tasks/populate-dns.yml
+++ b/roles/openshift_openstack/tasks/populate-dns.yml
@@ -11,14 +11,14 @@
 
 - name: "Add public master cluster hostname records to the private A records (single master)"
   set_fact:
-    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(openshift_openstack_full_dns_domain, ''))[:-1], 'ip': hostvars[groups.masters[0]].private_v4 } ] }}"
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(openshift_openstack_full_public_dns_domain, ''))[:-1], 'ip': hostvars[groups.masters[0]].private_v4 } ] }}"
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openshift_openstack_num_masters == 1
 
 - name: "Add public master cluster hostname records to the private A records (multi-master)"
   set_fact:
-    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(openshift_openstack_full_dns_domain, ''))[:-1], 'ip': hostvars[groups.lb[0]].private_v4 } ] }}"
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(openshift_openstack_full_public_dns_domain, ''))[:-1], 'ip': hostvars[groups.lb[0]].private_v4 } ] }}"
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openshift_openstack_num_masters > 1
@@ -28,7 +28,7 @@
     nsupdate_server_private: "{{ openshift_openstack_external_nsupdate_keys['private']['server'] }}"
     nsupdate_key_secret_private: "{{ openshift_openstack_external_nsupdate_keys['private']['key_secret'] }}"
     nsupdate_key_algorithm_private: "{{ openshift_openstack_external_nsupdate_keys['private']['key_algorithm'] }}"
-    nsupdate_private_key_name: "{{ openshift_openstack_external_nsupdate_keys['private']['key_name']|default('private-' + openshift_openstack_full_dns_domain) }}"
+    nsupdate_private_key_name: "{{ openshift_openstack_external_nsupdate_keys['private']['key_name']|default('private-' + openshift_openstack_full_private_dns_domain) }}"
   when:
     - openshift_openstack_external_nsupdate_keys['private'] is defined
 
@@ -37,9 +37,9 @@
   set_fact:
     private_named_records:
       - view: "private"
-        zone: "{{ openshift_openstack_full_dns_domain }}"
+        zone: "{{ openshift_openstack_full_private_dns_domain }}"
         server: "{{ nsupdate_server_private }}"
-        key_name: "{{ nsupdate_private_key_name|default('private-' + openshift_openstack_full_dns_domain) }}"
+        key_name: "{{ nsupdate_private_key_name|default('private-' + openshift_openstack_full_private_dns_domain) }}"
         key_secret: "{{ nsupdate_key_secret_private }}"
         key_algorithm: "{{ nsupdate_key_algorithm_private | lower }}"
         entries: "{{ private_records }}"
@@ -60,14 +60,14 @@
 
 - name: "Add public master cluster hostname records to the public A records (single master)"
   set_fact:
-    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(openshift_openstack_full_dns_domain, ''))[:-1], 'ip': hostvars[groups.masters[0]].public_v4 } ] }}"
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(openshift_openstack_full_public_dns_domain, ''))[:-1], 'ip': hostvars[groups.masters[0]].public_v4 } ] }}"
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openshift_openstack_num_masters == 1
 
 - name: "Add public master cluster hostname records to the public A records (multi-master)"
   set_fact:
-    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(openshift_openstack_full_dns_domain, ''))[:-1], 'ip': hostvars[groups.lb[0]].public_v4 } ] }}"
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(openshift_openstack_full_public_dns_domain, ''))[:-1], 'ip': hostvars[groups.lb[0]].public_v4 } ] }}"
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openshift_openstack_num_masters > 1
@@ -77,7 +77,7 @@
     nsupdate_server_public: "{{ openshift_openstack_external_nsupdate_keys['public']['server'] }}"
     nsupdate_key_secret_public: "{{ openshift_openstack_external_nsupdate_keys['public']['key_secret'] }}"
     nsupdate_key_algorithm_public: "{{ openshift_openstack_external_nsupdate_keys['public']['key_algorithm'] }}"
-    nsupdate_public_key_name: "{{ openshift_openstack_external_nsupdate_keys['public']['key_name']|default('public-' + openshift_openstack_full_dns_domain) }}"
+    nsupdate_public_key_name: "{{ openshift_openstack_external_nsupdate_keys['public']['key_name']|default('public-' + openshift_openstack_full_public_dns_domain) }}"
   when:
     - openshift_openstack_external_nsupdate_keys['public'] is defined
 
@@ -85,9 +85,9 @@
   set_fact:
     public_named_records:
       - view: "public"
-        zone: "{{ openshift_openstack_full_dns_domain }}"
+        zone: "{{ openshift_openstack_full_public_dns_domain }}"
         server: "{{ nsupdate_server_public }}"
-        key_name: "{{ nsupdate_public_key_name|default('public-' + openshift_openstack_full_dns_domain) }}"
+        key_name: "{{ nsupdate_public_key_name|default('public-' + openshift_openstack_full_public_dns_domain) }}"
         key_secret: "{{ nsupdate_key_secret_public }}"
         key_algorithm: "{{ nsupdate_key_algorithm_public | lower }}"
         entries: "{{ public_records }}"


### PR DESCRIPTION
Support separate public/private DNS records, yet limited to an                  
external DNS managed elsewhere. Users may benefit from this                     
feature by sending nsupdates to private and/or public servers                   
as they want it.                                                                
                                                                                
Additional changes:                                                             
                                                                                
* Name Heat stack by openshift_openstack_full_public_dns_domain                 
* Add openshift_openstack_public_dns_domain to the role defaults                
  to not rely on the group vars example only.                                   
* Move openshift_master_cluster_public_hostname                                 
  and openshift_master_default_subdomain from the group vars                    
  example to the role defaults, where the values these take are                 
  now evaluated.                                                                
* Evaluate openshift_master_cluster_hostname based on a private                 
  domain name as it may be different to the public name now. 

Describe configuration scenarios for external public and private
DNS servers managing public and custom private domain records for the
openshift cluster nodes.

Specify manual commands required to deploy DNS service with automation
playbooks for osp 10 on ocp 3.6 ref arch coming from openshift-ansible-contrib.

This improves UX with DNS stack not managed in openshift-ansible.

**How to test:**

* With defaults, e2e should pass
* Follow the included guide to verify an external public and private DNS server.
