### PR TITLE
Remove duplicate init import in network_manager.yml

### DIFF
--- a/playbooks/openshift-node/private/network_manager.yml
+++ b/playbooks/openshift-node/private/network_manager.yml
@@ -1,6 +1,4 @@
 ---
-- import_playbook: ../../init/evaluate_groups.yml
-
 - name: Install and configure NetworkManager
   hosts: oo_all_hosts
   become: yes


### PR DESCRIPTION
evaluate_groups.yml import is already provided by openshift-node/network_manager.yml.