### PR TITLE
Fix oreg_auth_credentials_create register var

### DIFF
--- a/roles/openshift_master/tasks/registry_auth.yml
+++ b/roles/openshift_master/tasks/registry_auth.yml
@@ -33,7 +33,7 @@
   - openshift_docker_alternative_creds | default(False) | bool
   - oreg_auth_user is defined
   - (not docker_cli_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
-  register: master_oreg_auth_credentials_create
+  register: master_oreg_auth_credentials_create_alt
   notify:
   - restart master api
   - restart master controllers
@@ -45,4 +45,8 @@
   when:
   - openshift.common.is_containerized | bool
   - oreg_auth_user is defined
-  - (master_oreg_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace or master_oreg_auth_credentials_create.changed) | bool
+  - >
+      (master_oreg_auth_credentials_stat.stat.exists
+      or oreg_auth_credentials_replace
+      or master_oreg_auth_credentials_create.changed
+      or master_oreg_auth_credentials_create_alt.changed) | bool

--- a/roles/openshift_node/tasks/registry_auth.yml
+++ b/roles/openshift_node/tasks/registry_auth.yml
@@ -32,7 +32,7 @@
     - openshift_docker_alternative_creds | bool
     - oreg_auth_user is defined
     - (not node_oreg_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
-  register: node_oreg_auth_credentials_create
+  register: node_oreg_auth_credentials_create_alt
   notify:
     - restart node
 
@@ -43,4 +43,8 @@
   when:
     - openshift.common.is_containerized | bool
     - oreg_auth_user is defined
-    - (node_oreg_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace or node_oreg_auth_credentials_create.changed) | bool
+    - >
+        (node_oreg_auth_credentials_stat.stat.exists
+        or oreg_auth_credentials_replace
+        or node_oreg_auth_credentials_create.changed
+        or node_oreg_auth_credentials_create_alt.changed) | bool


### PR DESCRIPTION
There is a variable collision for the *oreg_auth_credentials_create
variables in openshift_master and openshift_node registry_create
tasks.

This commit ensures standard and alternative oreg auth
credential placement tasks don't use the same register
variable.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1520866