### PR TITLE
Do not escalate privileges in logging stack deployment task

### DIFF
--- a/roles/openshift_logging/tasks/main.yaml
+++ b/roles/openshift_logging/tasks/main.yaml
@@ -31,3 +31,4 @@
   local_action: file path="{{local_tmp.stdout}}" state=absent
   tags: logging_cleanup
   changed_when: False
+  become: no

--- a/roles/openshift_logging_fluentd/tasks/label_and_wait.yaml
+++ b/roles/openshift_logging_fluentd/tasks/label_and_wait.yaml
@@ -8,3 +8,4 @@
 
 # wait half a second between labels
 - local_action: command sleep {{ openshift_logging_fluentd_label_delay | default('.5') }}
+  become: no


### PR DESCRIPTION
This PR is to avoid escalating privileges when not required for `local_action`s in the openshift-logging playbook, it completes the work started in #6205.