### PR TITLE
Add missing symlinks in openshift-logging

### DIFF
--- a/playbooks/openshift-logging/private/filter_plugins
+++ b/playbooks/openshift-logging/private/filter_plugins
@@ -1,0 +1,1 @@
+../../../filter_plugins

--- a/playbooks/openshift-logging/private/lookup_plugins
+++ b/playbooks/openshift-logging/private/lookup_plugins
@@ -1,0 +1,1 @@
+../../../lookup_plugins


### PR DESCRIPTION
Unfortunately `--syntax-check` doesn't verify plugin availability.