### PR TITLE
Include Deprecation: Convert to import_playbook

### DIFF
--- a/playbooks/aws/openshift-cluster/build_ami.yml
+++ b/playbooks/aws/openshift-cluster/build_ami.yml
@@ -17,7 +17,7 @@
     - name: openshift_aws_region
       msg: "openshift_aws_region={{ openshift_aws_region | default('us-east-1') }}"
 
-- include: provision_instance.yml
+- import_playbook: provision_instance.yml
   vars:
     openshift_aws_node_group_type: compute
 
@@ -33,8 +33,8 @@
 
 # This is the part that installs all of the software and configs for the instance
 # to become a node.
-- include: ../../openshift-node/private/image_prep.yml
+- import_playbook: ../../openshift-node/private/image_prep.yml
 
-- include: seal_ami.yml
+- import_playbook: seal_ami.yml
   vars:
     openshift_aws_ami_name: "openshift-gi-{{ lookup('pipe', 'date +%Y%m%d%H%M')}}"

--- a/playbooks/aws/openshift-cluster/hosted.yml
+++ b/playbooks/aws/openshift-cluster/hosted.yml
@@ -1,19 +1,19 @@
 ---
-- include: ../../openshift-hosted/private/config.yml
+- import_playbook: ../../openshift-hosted/private/config.yml
 
-- include: ../../openshift-metrics/private/config.yml
+- import_playbook: ../../openshift-metrics/private/config.yml
   when: openshift_metrics_install_metrics | default(false) | bool
 
-- include: ../../openshift-logging/private/config.yml
+- import_playbook: ../../openshift-logging/private/config.yml
   when: openshift_logging_install_logging | default(false) | bool
 
-- include: ../../openshift-prometheus/private/config.yml
+- import_playbook: ../../openshift-prometheus/private/config.yml
   when: openshift_hosted_prometheus_deploy | default(false) | bool
 
-- include: ../../openshift-service-catalog/private/config.yml
+- import_playbook: ../../openshift-service-catalog/private/config.yml
   when: openshift_enable_service_catalog | default(false) | bool
 
-- include: ../../openshift-management/private/config.yml
+- import_playbook: ../../openshift-management/private/config.yml
   when: openshift_management_install_management | default(false) | bool
 
 - name: Print deprecated variable warning message if necessary

--- a/playbooks/aws/openshift-cluster/install.yml
+++ b/playbooks/aws/openshift-cluster/install.yml
@@ -16,31 +16,31 @@
       tasks_from: master_facts.yml
 
 - name: run the init
-  include: ../../init/main.yml
+  import_playbook: ../../init/main.yml
 
 - name: perform the installer openshift-checks
-  include: ../../openshift-checks/private/install.yml
+  import_playbook: ../../openshift-checks/private/install.yml
 
 - name: etcd install
-  include: ../../openshift-etcd/private/config.yml
+  import_playbook: ../../openshift-etcd/private/config.yml
 
 - name: include nfs
-  include: ../../openshift-nfs/private/config.yml
+  import_playbook: ../../openshift-nfs/private/config.yml
   when: groups.oo_nfs_to_config | default([]) | count > 0
 
 - name: include loadbalancer
-  include: ../../openshift-loadbalancer/private/config.yml
+  import_playbook: ../../openshift-loadbalancer/private/config.yml
   when: groups.oo_lb_to_config | default([]) | count > 0
 
 - name: include openshift-master config
-  include: ../../openshift-master/private/config.yml
+  import_playbook: ../../openshift-master/private/config.yml
 
 - name: include master additional config
-  include: ../../openshift-master/private/additional_config.yml
+  import_playbook: ../../openshift-master/private/additional_config.yml
 
 - name: include master additional config
-  include: ../../openshift-node/private/config.yml
+  import_playbook: ../../openshift-node/private/config.yml
 
 - name: include openshift-glusterfs
-  include: ../../openshift-glusterfs/private/config.yml
+  import_playbook: ../../openshift-glusterfs/private/config.yml
   when: groups.oo_glusterfs_to_config | default([]) | count > 0

--- a/playbooks/aws/openshift-cluster/prerequisites.yml
+++ b/playbooks/aws/openshift-cluster/prerequisites.yml
@@ -1,6 +1,6 @@
 ---
-- include: provision_vpc.yml
+- import_playbook: provision_vpc.yml
 
-- include: provision_ssh_keypair.yml
+- import_playbook: provision_ssh_keypair.yml
 
-- include: provision_sec_group.yml
+- import_playbook: provision_sec_group.yml

--- a/playbooks/aws/openshift-cluster/provision_install.yml
+++ b/playbooks/aws/openshift-cluster/provision_install.yml
@@ -4,16 +4,16 @@
 # this playbook is run with the following parameters:
 # ansible-playbook -i openshift-ansible-inventory provision_install.yml
 - name: Include the provision.yml playbook to create cluster
-  include: provision.yml
+  import_playbook: provision.yml
 
 - name: Include the install.yml playbook to install cluster on masters
-  include: install.yml
+  import_playbook: install.yml
 
 - name: provision the infra/compute playbook to install node resources
-  include: provision_nodes.yml
+  import_playbook: provision_nodes.yml
 
 - name: Include the accept.yml playbook to accept nodes into the cluster
-  include: accept.yml
+  import_playbook: accept.yml
 
 - name: Include the hosted.yml playbook to finish the hosted configuration
-  include: hosted.yml
+  import_playbook: hosted.yml

--- a/playbooks/byo/openshift-cluster/upgrades/docker/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/docker/upgrade.yml
@@ -1,5 +1,5 @@
 ---
 # Playbook to upgrade Docker to the max allowable version for an OpenShift cluster.
-- include: ../../../../init/evaluate_groups.yml
+- import_playbook: ../../../../init/evaluate_groups.yml
 
-- include: ../../../../common/openshift-cluster/upgrades/docker/docker_upgrade.yml
+- import_playbook: ../../../../common/openshift-cluster/upgrades/docker/docker_upgrade.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_6/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_6/upgrade.yml
@@ -2,4 +2,4 @@
 #
 # Full Control Plane + Nodes Upgrade
 #
-- include: ../../../../common/openshift-cluster/upgrades/v3_6/upgrade.yml
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_6/upgrade.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
@@ -11,4 +11,4 @@
 #
 # You can run the upgrade_nodes.yml playbook after this to upgrade these components separately.
 #
-- include: ../../../../common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
@@ -4,4 +4,4 @@
 #
 # Upgrades nodes only, but requires the control plane to have already been upgraded.
 #
-- include: ../../../../common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_7/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_7/upgrade.yml
@@ -2,4 +2,4 @@
 #
 # Full Control Plane + Nodes Upgrade
 #
-- include: ../../../../common/openshift-cluster/upgrades/v3_7/upgrade.yml
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_7/upgrade.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -11,4 +11,4 @@
 #
 # You can run the upgrade_nodes.yml playbook after this to upgrade these components separately.
 #
-- include: ../../../../common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_7/upgrade_nodes.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_7/upgrade_nodes.yml
@@ -4,4 +4,4 @@
 #
 # Upgrades nodes only, but requires the control plane to have already been upgraded.
 #
-- include: ../../../../common/openshift-cluster/upgrades/v3_7/upgrade_nodes.yml
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_7/upgrade_nodes.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_7/upgrade_scale_groups.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_7/upgrade_scale_groups.yml
@@ -4,4 +4,4 @@
 #
 # Upgrades scale group nodes only.
 #
-- include: ../../../../common/openshift-cluster/upgrades/upgrade_scale_group.yml
+- import_playbook: ../../../../common/openshift-cluster/upgrades/upgrade_scale_group.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_8/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_8/upgrade.yml
@@ -2,4 +2,4 @@
 #
 # Full Control Plane + Nodes Upgrade
 #
-- include: ../../../../common/openshift-cluster/upgrades/v3_8/upgrade.yml
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_8/upgrade.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml
@@ -11,4 +11,4 @@
 #
 # You can run the upgrade_nodes.yml playbook after this to upgrade these components separately.
 #
-- include: ../../../../common/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_8/upgrade_nodes.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_8/upgrade_nodes.yml
@@ -4,4 +4,4 @@
 #
 # Upgrades nodes only, but requires the control plane to have already been upgraded.
 #
-- include: ../../../../common/openshift-cluster/upgrades/v3_8/upgrade_nodes.yml
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_8/upgrade_nodes.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_9/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_9/upgrade.yml
@@ -2,4 +2,4 @@
 #
 # Full Control Plane + Nodes Upgrade
 #
-- include: ../../../../common/openshift-cluster/upgrades/v3_9/upgrade.yml
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_9/upgrade.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
@@ -11,4 +11,4 @@
 #
 # You can run the upgrade_nodes.yml playbook after this to upgrade these components separately.
 #
-- include: ../../../../common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_9/upgrade_nodes.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_9/upgrade_nodes.yml
@@ -4,4 +4,4 @@
 #
 # Upgrades nodes only, but requires the control plane to have already been upgraded.
 #
-- include: ../../../../common/openshift-cluster/upgrades/v3_9/upgrade_nodes.yml
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_9/upgrade_nodes.yml

--- a/playbooks/byo/openshift_facts.yml
+++ b/playbooks/byo/openshift_facts.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
 - name: Gather Cluster facts
   hosts: oo_all_hosts

--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../init/evaluate_groups.yml
+- import_playbook: ../init/evaluate_groups.yml
 
 - name: Subscribe hosts, update repos and update OS packages
   hosts: oo_all_hosts

--- a/playbooks/common/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -1,11 +1,11 @@
 ---
-- include: ../../../../init/evaluate_groups.yml
+- import_playbook: ../../../../init/evaluate_groups.yml
   vars:
     # Do not allow adding hosts during upgrade.
     g_new_master_hosts: []
     g_new_node_hosts: []
 
-- include: ../initialize_nodes_to_upgrade.yml
+- import_playbook: ../initialize_nodes_to_upgrade.yml
 
 - name: Check for appropriate Docker versions
   hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
@@ -19,7 +19,7 @@
       msg: Cannot upgrade Docker on Atomic operating systems.
     when: openshift.common.is_atomic | bool
 
-  - include: upgrade_check.yml
+  - include_tasks: upgrade_check.yml
     when: docker_upgrade is not defined or docker_upgrade | bool
 
 
@@ -59,7 +59,7 @@
     retries: 60
     delay: 60
 
-  - include: tasks/upgrade.yml
+  - include_tasks: tasks/upgrade.yml
     when: l_docker_upgrade is defined and l_docker_upgrade | bool
 
   - name: Set node schedulability

--- a/playbooks/common/openshift-cluster/upgrades/docker/tasks/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/tasks/upgrade.yml
@@ -44,5 +44,5 @@
   register: result
   until: result | success
 
-- include: restart.yml
+- include_tasks: restart.yml
   when: not skip_docker_restart | default(False) | bool

--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -1,11 +1,11 @@
 ---
-- include: ../../../init/evaluate_groups.yml
+- import_playbook: ../../../init/evaluate_groups.yml
   vars:
     # Do not allow adding hosts during upgrade.
     g_new_master_hosts: []
     g_new_node_hosts: []
 
-- include: ../../../init/facts.yml
+- import_playbook: ../../../init/facts.yml
 
 - name: Ensure firewall is not switched during upgrade
   hosts: oo_all_hosts

--- a/playbooks/common/openshift-cluster/upgrades/pre/tasks/verify_docker_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/tasks/verify_docker_upgrade_targets.yml
@@ -1,7 +1,7 @@
 ---
 # Only check if docker upgrade is required if docker_upgrade is not
 # already set to False.
-- include: ../../docker/upgrade_check.yml
+- include_tasks: ../../docker/upgrade_check.yml
   when:
   - docker_upgrade is not defined or (docker_upgrade | bool)
   - not (openshift.common.is_atomic | bool)

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -17,7 +17,7 @@
         embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
 
 - name: Backup and upgrade etcd
-  include: ../../../openshift-etcd/private/upgrade_main.yml
+  import_playbook: ../../../openshift-etcd/private/upgrade_main.yml
 
 # Create service signer cert when missing. Service signer certificate
 # is added to master config in the master_config_upgrade hook.
@@ -30,7 +30,7 @@
     register: service_signer_cert_stat
     changed_when: false
 
-- include: create_service_signer_cert.yml
+- import_playbook: create_service_signer_cert.yml
 
 # oc adm migrate storage should be run prior to etcd v3 upgrade
 # See: https://github.com/openshift/origin/pull/14625#issuecomment-308467060
@@ -71,7 +71,7 @@
   - debug: msg="Running master pre-upgrade hook {{ openshift_master_upgrade_pre_hook }}"
     when: openshift_master_upgrade_pre_hook is defined
 
-  - include: "{{ openshift_master_upgrade_pre_hook }}"
+  - include_tasks: "{{ openshift_master_upgrade_pre_hook }}"
     when: openshift_master_upgrade_pre_hook is defined
 
   - include_role:
@@ -82,20 +82,20 @@
   - debug: msg="Running master upgrade hook {{ openshift_master_upgrade_hook }}"
     when: openshift_master_upgrade_hook is defined
 
-  - include: "{{ openshift_master_upgrade_hook }}"
+  - include_tasks: "{{ openshift_master_upgrade_hook }}"
     when: openshift_master_upgrade_hook is defined
 
-  - include: ../../../openshift-master/private/tasks/restart_hosts.yml
+  - include_tasks: ../../../openshift-master/private/tasks/restart_hosts.yml
     when: openshift.common.rolling_restart_mode == 'system'
 
-  - include: ../../../openshift-master/private/tasks/restart_services.yml
+  - include_tasks: ../../../openshift-master/private/tasks/restart_services.yml
     when: openshift.common.rolling_restart_mode == 'services'
 
   # Run the post-upgrade hook if defined:
   - debug: msg="Running master post-upgrade hook {{ openshift_master_upgrade_post_hook }}"
     when: openshift_master_upgrade_post_hook is defined
 
-  - include: "{{ openshift_master_upgrade_post_hook }}"
+  - include_tasks: "{{ openshift_master_upgrade_post_hook }}"
     when: openshift_master_upgrade_post_hook is defined
 
   - name: Post master upgrade - Upgrade clusterpolicies storage
@@ -275,7 +275,7 @@
   roles:
   - openshift_facts
   tasks:
-  - include: docker/tasks/upgrade.yml
+  - include_tasks: docker/tasks/upgrade.yml
     when: l_docker_upgrade is defined and l_docker_upgrade | bool and not openshift.common.is_atomic | bool
 
 - name: Drain and upgrade master nodes

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_scale_group.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_scale_group.yml
@@ -13,7 +13,7 @@
     - "'oo_sg_new_nodes' not in groups or groups.oo_sg_new_nodes|length == 0"
 
 - name: initialize upgrade bits
-  include: init.yml
+  import_playbook: init.yml
 
 - name: Drain and upgrade nodes
   hosts: oo_sg_current_nodes

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
@@ -2,7 +2,7 @@
 #
 # Full Control Plane + Nodes Upgrade
 #
-- include: ../init.yml
+- import_playbook: ../init.yml
   tags:
   - pre_upgrade
 
@@ -17,7 +17,7 @@
 
 # Pre-upgrade
 
-- include: ../initialize_nodes_to_upgrade.yml
+- import_playbook: ../initialize_nodes_to_upgrade.yml
   tags:
   - pre_upgrade
 
@@ -43,27 +43,27 @@
     - openshift_http_proxy is defined or openshift_https_proxy is defined
     - openshift_generate_no_proxy_hosts | default(True) | bool
 
-- include: ../pre/verify_inventory_vars.yml
+- import_playbook: ../pre/verify_inventory_vars.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_health_checks.yml
+- import_playbook: ../pre/verify_health_checks.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_control_plane_running.yml
+- import_playbook: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_master_excluders.yml
+- import_playbook: ../disable_master_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_node_excluders.yml
+- import_playbook: ../disable_node_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../../../../init/version.yml
+- import_playbook: ../../../../init/version.yml
   tags:
   - pre_upgrade
   vars:
@@ -73,29 +73,29 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-- include: ../../../../openshift-master/private/validate_restart.yml
+- import_playbook: ../../../../openshift-master/private/validate_restart.yml
   tags:
   - pre_upgrade
 
 - name: Verify upgrade targets
   hosts: oo_masters_to_config:oo_nodes_to_upgrade
   tasks:
-  - include: ../pre/verify_upgrade_targets.yml
+  - include_tasks: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
 - name: Verify docker upgrade targets
   hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
   tasks:
-  - include: ../pre/tasks/verify_docker_upgrade_targets.yml
+  - include_tasks: ../pre/tasks/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: validator.yml
+- import_playbook: validator.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/gate_checks.yml
+- import_playbook: ../pre/gate_checks.yml
   tags:
   - pre_upgrade
 
@@ -107,12 +107,12 @@
 - name: Cleanup unused Docker images
   hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
   tasks:
-  - include: ../cleanup_unused_images.yml
+  - include_tasks: ../cleanup_unused_images.yml
 
-- include: ../upgrade_control_plane.yml
+- import_playbook: ../upgrade_control_plane.yml
   vars:
     master_config_hook: "v3_6/master_config_upgrade.yml"
 
-- include: ../upgrade_nodes.yml
+- import_playbook: ../upgrade_nodes.yml
 
-- include: ../post_control_plane.yml
+- import_playbook: ../post_control_plane.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
@@ -11,7 +11,7 @@
 #
 # You can run the upgrade_nodes.yml playbook after this to upgrade these components separately.
 #
-- include: ../init.yml
+- import_playbook: ../init.yml
   tags:
   - pre_upgrade
 
@@ -25,7 +25,7 @@
       openshift_upgrade_min: "{{ '1.5' if deployment_type == 'origin' else '3.5' }}"
 
 # Pre-upgrade
-- include: ../initialize_nodes_to_upgrade.yml
+- import_playbook: ../initialize_nodes_to_upgrade.yml
   tags:
   - pre_upgrade
 
@@ -51,23 +51,23 @@
     - openshift_http_proxy is defined or openshift_https_proxy is defined
     - openshift_generate_no_proxy_hosts | default(True) | bool
 
-- include: ../pre/verify_inventory_vars.yml
+- import_playbook: ../pre/verify_inventory_vars.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_health_checks.yml
+- import_playbook: ../pre/verify_health_checks.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_control_plane_running.yml
+- import_playbook: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_master_excluders.yml
+- import_playbook: ../disable_master_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../../../../init/version.yml
+- import_playbook: ../../../../init/version.yml
   tags:
   - pre_upgrade
   vars:
@@ -77,29 +77,29 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-- include: ../../../../openshift-master/private/validate_restart.yml
+- import_playbook: ../../../../openshift-master/private/validate_restart.yml
   tags:
   - pre_upgrade
 
 - name: Verify upgrade targets
   hosts: oo_masters_to_config
   tasks:
-  - include: ../pre/verify_upgrade_targets.yml
+  - include_tasks: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
 - name: Verify docker upgrade targets
   hosts: oo_masters_to_config:oo_etcd_to_config
   tasks:
-  - include: ../pre/tasks/verify_docker_upgrade_targets.yml
+  - include_tasks: ../pre/tasks/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: validator.yml
+- import_playbook: validator.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/gate_checks.yml
+- import_playbook: ../pre/gate_checks.yml
   tags:
   - pre_upgrade
 
@@ -111,10 +111,10 @@
 - name: Cleanup unused Docker images
   hosts: oo_masters_to_config:oo_etcd_to_config
   tasks:
-  - include: ../cleanup_unused_images.yml
+  - include_tasks: ../cleanup_unused_images.yml
 
-- include: ../upgrade_control_plane.yml
+- import_playbook: ../upgrade_control_plane.yml
   vars:
     master_config_hook: "v3_6/master_config_upgrade.yml"
 
-- include: ../post_control_plane.yml
+- import_playbook: ../post_control_plane.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
@@ -4,7 +4,7 @@
 #
 # Upgrades nodes only, but requires the control plane to have already been upgraded.
 #
-- include: ../init.yml
+- import_playbook: ../init.yml
   tags:
   - pre_upgrade
 
@@ -18,7 +18,7 @@
       openshift_upgrade_min: "{{ '1.5' if deployment_type == 'origin' else '3.5' }}"
 
 # Pre-upgrade
-- include: ../initialize_nodes_to_upgrade.yml
+- import_playbook: ../initialize_nodes_to_upgrade.yml
   tags:
   - pre_upgrade
 
@@ -44,19 +44,19 @@
     - openshift_http_proxy is defined or openshift_https_proxy is defined
     - openshift_generate_no_proxy_hosts | default(True) | bool
 
-- include: ../pre/verify_inventory_vars.yml
+- import_playbook: ../pre/verify_inventory_vars.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_health_checks.yml
+- import_playbook: ../pre/verify_health_checks.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_node_excluders.yml
+- import_playbook: ../disable_node_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../../../../init/version.yml
+- import_playbook: ../../../../init/version.yml
   tags:
   - pre_upgrade
   vars:
@@ -74,25 +74,25 @@
   - fail: msg="Master running {{ openshift.common.version }} must be upgraded to {{ openshift_version }} before node upgrade can be run."
     when: openshift.common.version != openshift_version
 
-- include: ../pre/verify_control_plane_running.yml
+- import_playbook: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade
 
 - name: Verify upgrade targets
   hosts: oo_nodes_to_upgrade
   tasks:
-  - include: ../pre/verify_upgrade_targets.yml
+  - include_tasks: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
 - name: Verify docker upgrade targets
   hosts: oo_nodes_to_upgrade
   tasks:
-  - include: ../pre/tasks/verify_docker_upgrade_targets.yml
+  - include_tasks: ../pre/tasks/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/gate_checks.yml
+- import_playbook: ../pre/gate_checks.yml
   tags:
   - pre_upgrade
 
@@ -104,6 +104,6 @@
 - name: Cleanup unused Docker images
   hosts: oo_nodes_to_upgrade
   tasks:
-  - include: ../cleanup_unused_images.yml
+  - include_tasks: ../cleanup_unused_images.yml
 
-- include: ../upgrade_nodes.yml
+- import_playbook: ../upgrade_nodes.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
@@ -2,7 +2,7 @@
 #
 # Full Control Plane + Nodes Upgrade
 #
-- include: ../init.yml
+- import_playbook: ../init.yml
   tags:
   - pre_upgrade
 
@@ -17,11 +17,11 @@
 
 # Pre-upgrade
 
-- include: ../initialize_nodes_to_upgrade.yml
+- import_playbook: ../initialize_nodes_to_upgrade.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_etcd3_backend.yml
+- import_playbook: ../pre/verify_etcd3_backend.yml
   tags:
   - pre_upgrade
 
@@ -47,27 +47,27 @@
     - openshift_http_proxy is defined or openshift_https_proxy is defined
     - openshift_generate_no_proxy_hosts | default(True) | bool
 
-- include: ../pre/verify_inventory_vars.yml
+- import_playbook: ../pre/verify_inventory_vars.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_health_checks.yml
+- import_playbook: ../pre/verify_health_checks.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_control_plane_running.yml
+- import_playbook: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_master_excluders.yml
+- import_playbook: ../disable_master_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_node_excluders.yml
+- import_playbook: ../disable_node_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../../../../init/version.yml
+- import_playbook: ../../../../init/version.yml
   tags:
   - pre_upgrade
   vars:
@@ -77,29 +77,29 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-- include: ../../../../openshift-master/private/validate_restart.yml
+- import_playbook: ../../../../openshift-master/private/validate_restart.yml
   tags:
   - pre_upgrade
 
 - name: Verify upgrade targets
   hosts: oo_masters_to_config:oo_nodes_to_upgrade
   tasks:
-  - include: ../pre/verify_upgrade_targets.yml
+  - include_tasks: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
 - name: Verify docker upgrade targets
   hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
   tasks:
-  - include: ../pre/tasks/verify_docker_upgrade_targets.yml
+  - include_tasks: ../pre/tasks/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: validator.yml
+- import_playbook: validator.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/gate_checks.yml
+- import_playbook: ../pre/gate_checks.yml
   tags:
   - pre_upgrade
 
@@ -111,9 +111,9 @@
 - name: Cleanup unused Docker images
   hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
   tasks:
-  - include: ../cleanup_unused_images.yml
+  - include_tasks: ../cleanup_unused_images.yml
 
-- include: ../upgrade_control_plane.yml
+- import_playbook: ../upgrade_control_plane.yml
   vars:
     master_config_hook: "v3_7/master_config_upgrade.yml"
 
@@ -131,6 +131,6 @@
       name: "{{ openshift.common.service_type }}-master-controllers"
       state: started
 
-- include: ../upgrade_nodes.yml
+- import_playbook: ../upgrade_nodes.yml
 
-- include: ../post_control_plane.yml
+- import_playbook: ../post_control_plane.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -11,7 +11,7 @@
 #
 # You can run the upgrade_nodes.yml playbook after this to upgrade these components separately.
 #
-- include: ../init.yml
+- import_playbook: ../init.yml
   tags:
   - pre_upgrade
 
@@ -25,11 +25,11 @@
       openshift_upgrade_min: '3.6'
 
 # Pre-upgrade
-- include: ../initialize_nodes_to_upgrade.yml
+- import_playbook: ../initialize_nodes_to_upgrade.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_etcd3_backend.yml
+- import_playbook: ../pre/verify_etcd3_backend.yml
   tags:
   - pre_upgrade
 
@@ -55,23 +55,23 @@
     - openshift_http_proxy is defined or openshift_https_proxy is defined
     - openshift_generate_no_proxy_hosts | default(True) | bool
 
-- include: ../pre/verify_inventory_vars.yml
+- import_playbook: ../pre/verify_inventory_vars.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_health_checks.yml
+- import_playbook: ../pre/verify_health_checks.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_control_plane_running.yml
+- import_playbook: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_master_excluders.yml
+- import_playbook: ../disable_master_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../../../../init/version.yml
+- import_playbook: ../../../../init/version.yml
   tags:
   - pre_upgrade
   vars:
@@ -81,29 +81,29 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-- include: ../../../../openshift-master/private/validate_restart.yml
+- import_playbook: ../../../../openshift-master/private/validate_restart.yml
   tags:
   - pre_upgrade
 
 - name: Verify upgrade targets
   hosts: oo_masters_to_config
   tasks:
-  - include: ../pre/verify_upgrade_targets.yml
+  - include_tasks: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
 - name: Verify docker upgrade targets
   hosts: oo_masters_to_config:oo_etcd_to_config
   tasks:
-  - include: ../pre/tasks/verify_docker_upgrade_targets.yml
+  - include_tasks: ../pre/tasks/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: validator.yml
+- import_playbook: validator.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/gate_checks.yml
+- import_playbook: ../pre/gate_checks.yml
   tags:
   - pre_upgrade
 
@@ -115,9 +115,9 @@
 - name: Cleanup unused Docker images
   hosts: oo_masters_to_config:oo_etcd_to_config
   tasks:
-  - include: ../cleanup_unused_images.yml
+  - include_tasks: ../cleanup_unused_images.yml
 
-- include: ../upgrade_control_plane.yml
+- import_playbook: ../upgrade_control_plane.yml
   vars:
     master_config_hook: "v3_7/master_config_upgrade.yml"
 
@@ -135,4 +135,4 @@
       name: "{{ openshift.common.service_type }}-master-controllers"
       state: started
 
-- include: ../post_control_plane.yml
+- import_playbook: ../post_control_plane.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_nodes.yml
@@ -4,7 +4,7 @@
 #
 # Upgrades nodes only, but requires the control plane to have already been upgraded.
 #
-- include: ../init.yml
+- import_playbook: ../init.yml
   tags:
   - pre_upgrade
 
@@ -18,7 +18,7 @@
       openshift_upgrade_min: '3.6'
 
 # Pre-upgrade
-- include: ../initialize_nodes_to_upgrade.yml
+- import_playbook: ../initialize_nodes_to_upgrade.yml
   tags:
   - pre_upgrade
 
@@ -44,19 +44,19 @@
     - openshift_http_proxy is defined or openshift_https_proxy is defined
     - openshift_generate_no_proxy_hosts | default(True) | bool
 
-- include: ../pre/verify_inventory_vars.yml
+- import_playbook: ../pre/verify_inventory_vars.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_health_checks.yml
+- import_playbook: ../pre/verify_health_checks.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_node_excluders.yml
+- import_playbook: ../disable_node_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../../../../init/version.yml
+- import_playbook: ../../../../init/version.yml
   tags:
   - pre_upgrade
   vars:
@@ -74,25 +74,25 @@
   - fail: msg="Master running {{ openshift.common.version }} must be upgraded to {{ openshift_version }} before node upgrade can be run."
     when: openshift.common.version != openshift_version
 
-- include: ../pre/verify_control_plane_running.yml
+- import_playbook: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade
 
 - name: Verify upgrade targets
   hosts: oo_nodes_to_upgrade
   tasks:
-  - include: ../pre/verify_upgrade_targets.yml
+  - include_tasks: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
 - name: Verify docker upgrade targets
   hosts: oo_nodes_to_upgrade
   tasks:
-  - include: ../pre/tasks/verify_docker_upgrade_targets.yml
+  - include_tasks: ../pre/tasks/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/gate_checks.yml
+- import_playbook: ../pre/gate_checks.yml
   tags:
   - pre_upgrade
 
@@ -104,6 +104,6 @@
 - name: Cleanup unused Docker images
   hosts: oo_nodes_to_upgrade
   tasks:
-  - include: ../cleanup_unused_images.yml
+  - include_tasks: ../cleanup_unused_images.yml
 
-- include: ../upgrade_nodes.yml
+- import_playbook: ../upgrade_nodes.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade.yml
@@ -2,7 +2,7 @@
 #
 # Full Control Plane + Nodes Upgrade
 #
-- include: ../init.yml
+- import_playbook: ../init.yml
   tags:
   - pre_upgrade
 
@@ -17,11 +17,11 @@
 
 # Pre-upgrade
 
-- include: ../initialize_nodes_to_upgrade.yml
+- import_playbook: ../initialize_nodes_to_upgrade.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_etcd3_backend.yml
+- import_playbook: ../pre/verify_etcd3_backend.yml
   tags:
   - pre_upgrade
 
@@ -47,27 +47,27 @@
     - openshift_http_proxy is defined or openshift_https_proxy is defined
     - openshift_generate_no_proxy_hosts | default(True) | bool
 
-- include: ../pre/verify_inventory_vars.yml
+- import_playbook: ../pre/verify_inventory_vars.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_health_checks.yml
+- import_playbook: ../pre/verify_health_checks.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_control_plane_running.yml
+- import_playbook: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_master_excluders.yml
+- import_playbook: ../disable_master_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_node_excluders.yml
+- import_playbook: ../disable_node_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../../../../init/version.yml
+- import_playbook: ../../../../init/version.yml
   tags:
   - pre_upgrade
   vars:
@@ -77,29 +77,29 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-- include: ../../../../openshift-master/private/validate_restart.yml
+- import_playbook: ../../../../openshift-master/private/validate_restart.yml
   tags:
   - pre_upgrade
 
 - name: Verify upgrade targets
   hosts: oo_masters_to_config:oo_nodes_to_upgrade
   tasks:
-  - include: ../pre/verify_upgrade_targets.yml
+  - include_tasks: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
 - name: Verify docker upgrade targets
   hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
   tasks:
-  - include: ../pre/tasks/verify_docker_upgrade_targets.yml
+  - include_tasks: ../pre/tasks/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: validator.yml
+- import_playbook: validator.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/gate_checks.yml
+- import_playbook: ../pre/gate_checks.yml
   tags:
   - pre_upgrade
 
@@ -111,9 +111,9 @@
 - name: Cleanup unused Docker images
   hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
   tasks:
-  - include: ../cleanup_unused_images.yml
+  - include_tasks: ../cleanup_unused_images.yml
 
-- include: ../upgrade_control_plane.yml
+- import_playbook: ../upgrade_control_plane.yml
   vars:
     master_config_hook: "v3_7/master_config_upgrade.yml"
 
@@ -131,6 +131,6 @@
       name: "{{ openshift.common.service_type }}-master-controllers"
       state: started
 
-- include: ../upgrade_nodes.yml
+- import_playbook: ../upgrade_nodes.yml
 
-- include: ../post_control_plane.yml
+- import_playbook: ../post_control_plane.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml
@@ -11,7 +11,7 @@
 #
 # You can run the upgrade_nodes.yml playbook after this to upgrade these components separately.
 #
-- include: ../init.yml
+- import_playbook: ../init.yml
   tags:
   - pre_upgrade
 
@@ -25,11 +25,11 @@
       openshift_upgrade_min: '3.7'
 
 # Pre-upgrade
-- include: ../initialize_nodes_to_upgrade.yml
+- import_playbook: ../initialize_nodes_to_upgrade.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_etcd3_backend.yml
+- import_playbook: ../pre/verify_etcd3_backend.yml
   tags:
   - pre_upgrade
 
@@ -55,23 +55,23 @@
     - openshift_http_proxy is defined or openshift_https_proxy is defined
     - openshift_generate_no_proxy_hosts | default(True) | bool
 
-- include: ../pre/verify_inventory_vars.yml
+- import_playbook: ../pre/verify_inventory_vars.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_health_checks.yml
+- import_playbook: ../pre/verify_health_checks.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_control_plane_running.yml
+- import_playbook: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_master_excluders.yml
+- import_playbook: ../disable_master_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../../../../init/version.yml
+- import_playbook: ../../../../init/version.yml
   tags:
   - pre_upgrade
   vars:
@@ -81,29 +81,29 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     openshift_protect_installed_version: False
 
-- include: ../../../../openshift-master/private/validate_restart.yml
+- import_playbook: ../../../../openshift-master/private/validate_restart.yml
   tags:
   - pre_upgrade
 
 - name: Verify upgrade targets
   hosts: oo_masters_to_config
   tasks:
-  - include: ../pre/verify_upgrade_targets.yml
+  - include_tasks: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
 - name: Verify docker upgrade targets
   hosts: oo_masters_to_config:oo_etcd_to_config
   tasks:
-  - include: ../pre/tasks/verify_docker_upgrade_targets.yml
+  - include_tasks: ../pre/tasks/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: validator.yml
+- import_playbook: validator.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/gate_checks.yml
+- import_playbook: ../pre/gate_checks.yml
   tags:
   - pre_upgrade
 
@@ -115,9 +115,9 @@
 - name: Cleanup unused Docker images
   hosts: oo_masters_to_config:oo_etcd_to_config
   tasks:
-  - include: ../cleanup_unused_images.yml
+  - include_tasks: ../cleanup_unused_images.yml
 
-- include: ../upgrade_control_plane.yml
+- import_playbook: ../upgrade_control_plane.yml
   vars:
     master_config_hook: "v3_7/master_config_upgrade.yml"
 
@@ -135,4 +135,4 @@
       name: "{{ openshift.common.service_type }}-master-controllers"
       state: started
 
-- include: ../post_control_plane.yml
+- import_playbook: ../post_control_plane.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade_nodes.yml
@@ -4,7 +4,7 @@
 #
 # Upgrades nodes only, but requires the control plane to have already been upgraded.
 #
-- include: ../init.yml
+- import_playbook: ../init.yml
   tags:
   - pre_upgrade
 
@@ -18,7 +18,7 @@
       openshift_upgrade_min: '3.7'
 
 # Pre-upgrade
-- include: ../initialize_nodes_to_upgrade.yml
+- import_playbook: ../initialize_nodes_to_upgrade.yml
   tags:
   - pre_upgrade
 
@@ -44,19 +44,19 @@
     - openshift_http_proxy is defined or openshift_https_proxy is defined
     - openshift_generate_no_proxy_hosts | default(True) | bool
 
-- include: ../pre/verify_inventory_vars.yml
+- import_playbook: ../pre/verify_inventory_vars.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_health_checks.yml
+- import_playbook: ../pre/verify_health_checks.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_node_excluders.yml
+- import_playbook: ../disable_node_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../../../../init/version.yml
+- import_playbook: ../../../../init/version.yml
   tags:
   - pre_upgrade
   vars:
@@ -74,25 +74,25 @@
   - fail: msg="Master running {{ openshift.common.version }} must be upgraded to {{ openshift_version }} before node upgrade can be run."
     when: openshift.common.version != openshift_version
 
-- include: ../pre/verify_control_plane_running.yml
+- import_playbook: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade
 
 - name: Verify upgrade targets
   hosts: oo_nodes_to_upgrade
   tasks:
-  - include: ../pre/verify_upgrade_targets.yml
+  - include_tasks: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
 - name: Verify docker upgrade targets
   hosts: oo_nodes_to_upgrade
   tasks:
-  - include: ../pre/tasks/verify_docker_upgrade_targets.yml
+  - include_tasks: ../pre/tasks/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/gate_checks.yml
+- import_playbook: ../pre/gate_checks.yml
   tags:
   - pre_upgrade
 
@@ -104,6 +104,6 @@
 - name: Cleanup unused Docker images
   hosts: oo_nodes_to_upgrade
   tasks:
-  - include: ../cleanup_unused_images.yml
+  - include_tasks: ../cleanup_unused_images.yml
 
-- include: ../upgrade_nodes.yml
+- import_playbook: ../upgrade_nodes.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade.yml
@@ -2,7 +2,7 @@
 #
 # Full Control Plane + Nodes Upgrade
 #
-- include: ../init.yml
+- import_playbook: ../init.yml
   tags:
   - pre_upgrade
 
@@ -17,11 +17,11 @@
 
 # Pre-upgrade
 
-- include: ../initialize_nodes_to_upgrade.yml
+- import_playbook: ../initialize_nodes_to_upgrade.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_etcd3_backend.yml
+- import_playbook: ../pre/verify_etcd3_backend.yml
   tags:
   - pre_upgrade
 
@@ -47,27 +47,27 @@
     - openshift_http_proxy is defined or openshift_https_proxy is defined
     - openshift_generate_no_proxy_hosts | default(True) | bool
 
-- include: ../pre/verify_inventory_vars.yml
+- import_playbook: ../pre/verify_inventory_vars.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_health_checks.yml
+- import_playbook: ../pre/verify_health_checks.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_control_plane_running.yml
+- import_playbook: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_master_excluders.yml
+- import_playbook: ../disable_master_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_node_excluders.yml
+- import_playbook: ../disable_node_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../../../../init/version.yml
+- import_playbook: ../../../../init/version.yml
   tags:
   - pre_upgrade
   vars:
@@ -83,29 +83,29 @@
     # docker is configured and running.
     skip_docker_role: True
 
-- include: ../../../../openshift-master/private/validate_restart.yml
+- import_playbook: ../../../../openshift-master/private/validate_restart.yml
   tags:
   - pre_upgrade
 
 - name: Verify upgrade targets
   hosts: oo_masters_to_config:oo_nodes_to_upgrade
   tasks:
-  - include: ../pre/verify_upgrade_targets.yml
+  - include_tasks: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
 - name: Verify docker upgrade targets
   hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
   tasks:
-  - include: ../pre/tasks/verify_docker_upgrade_targets.yml
+  - import_tasks: ../pre/tasks/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: validator.yml
+- import_playbook: validator.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/gate_checks.yml
+- import_playbook: ../pre/gate_checks.yml
   tags:
   - pre_upgrade
 
@@ -117,9 +117,9 @@
 - name: Cleanup unused Docker images
   hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
   tasks:
-  - include: ../cleanup_unused_images.yml
+  - include_tasks: ../cleanup_unused_images.yml
 
-- include: ../upgrade_control_plane.yml
+- import_playbook: ../upgrade_control_plane.yml
   vars:
     master_config_hook: "v3_7/master_config_upgrade.yml"
 
@@ -137,6 +137,6 @@
       name: "{{ openshift.common.service_type }}-master-controllers"
       state: started
 
-- include: ../upgrade_nodes.yml
+- import_playbook: ../upgrade_nodes.yml
 
-- include: ../post_control_plane.yml
+- import_playbook: ../post_control_plane.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
@@ -11,7 +11,7 @@
 #
 # You can run the upgrade_nodes.yml playbook after this to upgrade these components separately.
 #
-- include: ../init.yml
+- import_playbook: ../init.yml
   tags:
   - pre_upgrade
 
@@ -25,11 +25,11 @@
       openshift_upgrade_min: '3.7'
 
 # Pre-upgrade
-- include: ../initialize_nodes_to_upgrade.yml
+- import_playbook: ../initialize_nodes_to_upgrade.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_etcd3_backend.yml
+- import_playbook: ../pre/verify_etcd3_backend.yml
   tags:
   - pre_upgrade
 
@@ -55,23 +55,23 @@
     - openshift_http_proxy is defined or openshift_https_proxy is defined
     - openshift_generate_no_proxy_hosts | default(True) | bool
 
-- include: ../pre/verify_inventory_vars.yml
+- import_playbook: ../pre/verify_inventory_vars.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_health_checks.yml
+- import_playbook: ../pre/verify_health_checks.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_control_plane_running.yml
+- import_playbook: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_master_excluders.yml
+- import_playbook: ../disable_master_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../../../../init/version.yml
+- import_playbook: ../../../../init/version.yml
   tags:
   - pre_upgrade
   vars:
@@ -87,29 +87,29 @@
     # docker is configured and running.
     skip_docker_role: True
 
-- include: ../../../../openshift-master/private/validate_restart.yml
+- import_playbook: ../../../../openshift-master/private/validate_restart.yml
   tags:
   - pre_upgrade
 
 - name: Verify upgrade targets
   hosts: oo_masters_to_config
   tasks:
-  - include: ../pre/verify_upgrade_targets.yml
+  - include_tasks: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
 - name: Verify docker upgrade targets
   hosts: oo_masters_to_config:oo_etcd_to_config
   tasks:
-  - include: ../pre/tasks/verify_docker_upgrade_targets.yml
+  - include_tasks: ../pre/tasks/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: validator.yml
+- import_playbook: validator.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/gate_checks.yml
+- import_playbook: ../pre/gate_checks.yml
   tags:
   - pre_upgrade
 
@@ -121,9 +121,9 @@
 - name: Cleanup unused Docker images
   hosts: oo_masters_to_config:oo_etcd_to_config
   tasks:
-  - include: ../cleanup_unused_images.yml
+  - include_tasks: ../cleanup_unused_images.yml
 
-- include: ../upgrade_control_plane.yml
+- import_playbook: ../upgrade_control_plane.yml
   vars:
     master_config_hook: "v3_7/master_config_upgrade.yml"
 
@@ -141,4 +141,4 @@
       name: "{{ openshift.common.service_type }}-master-controllers"
       state: started
 
-- include: ../post_control_plane.yml
+- import_playbook: ../post_control_plane.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_nodes.yml
@@ -4,7 +4,7 @@
 #
 # Upgrades nodes only, but requires the control plane to have already been upgraded.
 #
-- include: ../init.yml
+- import_playbook: ../init.yml
   tags:
   - pre_upgrade
 
@@ -18,7 +18,7 @@
       openshift_upgrade_min: '3.7'
 
 # Pre-upgrade
-- include: ../initialize_nodes_to_upgrade.yml
+- import_playbook: ../initialize_nodes_to_upgrade.yml
   tags:
   - pre_upgrade
 
@@ -44,19 +44,19 @@
     - openshift_http_proxy is defined or openshift_https_proxy is defined
     - openshift_generate_no_proxy_hosts | default(True) | bool
 
-- include: ../pre/verify_inventory_vars.yml
+- import_playbook: ../pre/verify_inventory_vars.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/verify_health_checks.yml
+- import_playbook: ../pre/verify_health_checks.yml
   tags:
   - pre_upgrade
 
-- include: ../disable_node_excluders.yml
+- import_playbook: ../disable_node_excluders.yml
   tags:
   - pre_upgrade
 
-- include: ../../../../init/version.yml
+- import_playbook: ../../../../init/version.yml
   tags:
   - pre_upgrade
   vars:
@@ -80,25 +80,25 @@
   - fail: msg="Master running {{ openshift.common.version }} must be upgraded to {{ openshift_version }} before node upgrade can be run."
     when: openshift.common.version != openshift_version
 
-- include: ../pre/verify_control_plane_running.yml
+- import_playbook: ../pre/verify_control_plane_running.yml
   tags:
   - pre_upgrade
 
 - name: Verify upgrade targets
   hosts: oo_nodes_to_upgrade
   tasks:
-  - include: ../pre/verify_upgrade_targets.yml
+  - include_tasks: ../pre/verify_upgrade_targets.yml
   tags:
   - pre_upgrade
 
 - name: Verify docker upgrade targets
   hosts: oo_nodes_to_upgrade
   tasks:
-  - include: ../pre/tasks/verify_docker_upgrade_targets.yml
+  - include_tasks: ../pre/tasks/verify_docker_upgrade_targets.yml
   tags:
   - pre_upgrade
 
-- include: ../pre/gate_checks.yml
+- import_playbook: ../pre/gate_checks.yml
   tags:
   - pre_upgrade
 
@@ -110,6 +110,6 @@
 - name: Cleanup unused Docker images
   hosts: oo_nodes_to_upgrade
   tasks:
-  - include: ../cleanup_unused_images.yml
+  - include_tasks: ../cleanup_unused_images.yml
 
-- include: ../upgrade_nodes.yml
+- import_playbook: ../upgrade_nodes.yml

--- a/playbooks/gcp/provision.yml
+++ b/playbooks/gcp/provision.yml
@@ -10,4 +10,4 @@
       name: openshift_gcp
 
 - name: run the cluster deploy
-  include: ../deploy_cluster.yml
+  import_playbook: ../deploy_cluster.yml

--- a/playbooks/openshift-hosted/redeploy-registry-certificates.yml
+++ b/playbooks/openshift-hosted/redeploy-registry-certificates.yml
@@ -1,4 +1,4 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/redeploy-registry-certificates.yml
+- import_playbook: private/redeploy-registry-certificates.yml

--- a/playbooks/openshift-hosted/redeploy-router-certificates.yml
+++ b/playbooks/openshift-hosted/redeploy-router-certificates.yml
@@ -1,4 +1,4 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/redeploy-router-certificates.yml
+- import_playbook: private/redeploy-router-certificates.yml

--- a/playbooks/openshift-logging/config.yml
+++ b/playbooks/openshift-logging/config.yml
@@ -4,6 +4,6 @@
 # Hosted logging on.  See inventory/byo/hosts.*.example for the
 # currently supported method.
 #
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/config.yml
+- import_playbook: private/config.yml

--- a/playbooks/openshift-master/private/redeploy-certificates.yml
+++ b/playbooks/openshift-master/private/redeploy-certificates.yml
@@ -1,6 +1,6 @@
 ---
-- include: certificates-backup.yml
+- import_playbook: certificates-backup.yml
 
-- include: certificates.yml
+- import_playbook: certificates.yml
   vars:
     openshift_certificates_redeploy: true

--- a/playbooks/openshift-master/private/redeploy-openshift-ca.yml
+++ b/playbooks/openshift-master/private/redeploy-openshift-ca.yml
@@ -207,7 +207,7 @@
       group: "{{ 'root' if item == 'root' else _ansible_ssh_user_gid.stdout  }}"
     with_items: "{{ client_users }}"
 
-- include: restart.yml
+- import_playbook: restart.yml
   # Do not restart masters when master or etcd certificates were previously expired.
   when:
   # masters
@@ -272,7 +272,7 @@
       state: absent
     changed_when: false
 
-- include: ../../openshift-node/private/restart.yml
+- import_playbook: ../../openshift-node/private/restart.yml
   # Do not restart nodes when node, master or etcd certificates were previously expired.
   when:
   # nodes

--- a/playbooks/openshift-master/redeploy-certificates.yml
+++ b/playbooks/openshift-master/redeploy-certificates.yml
@@ -1,6 +1,6 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/redeploy-certificates.yml
+- import_playbook: private/redeploy-certificates.yml
 
-- include: private/restart.yml
+- import_playbook: private/restart.yml

--- a/playbooks/openshift-master/redeploy-openshift-ca.yml
+++ b/playbooks/openshift-master/redeploy-openshift-ca.yml
@@ -1,4 +1,4 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/redeploy-openshift-ca.yml
+- import_playbook: private/redeploy-openshift-ca.yml

--- a/playbooks/openshift-node/private/redeploy-certificates.yml
+++ b/playbooks/openshift-node/private/redeploy-certificates.yml
@@ -1,6 +1,6 @@
 ---
-- include: certificates-backup.yml
+- import_playbook: certificates-backup.yml
 
-- include: certificates.yml
+- import_playbook: certificates.yml
   vars:
     openshift_certificates_redeploy: true

--- a/playbooks/openshift-node/redeploy-certificates.yml
+++ b/playbooks/openshift-node/redeploy-certificates.yml
@@ -1,6 +1,6 @@
 ---
-- include: ../init/main.yml
+- import_playbook: ../init/main.yml
 
-- include: private/redeploy-certificates.yml
+- import_playbook: private/redeploy-certificates.yml
 
-- include: private/restart.yml
+- import_playbook: private/restart.yml

--- a/playbooks/openstack/openshift-cluster/install.yml
+++ b/playbooks/openstack/openshift-cluster/install.yml
@@ -9,4 +9,4 @@
 # some logic here?
 
 - name: run the cluster deploy
-  include: ../../deploy_cluster.yml
+  import_playbook: ../../deploy_cluster.yml

--- a/playbooks/openstack/openshift-cluster/provision.yml
+++ b/playbooks/openstack/openshift-cluster/provision.yml
@@ -10,7 +10,7 @@
 
 # NOTE(shadower): Bring in the host groups:
 - name: evaluate groups
-  include: ../../init/evaluate_groups.yml
+  import_playbook: ../../init/evaluate_groups.yml
 
 
 - name: Wait for the nodes and gather their facts
@@ -27,7 +27,7 @@
     setup:
 
 - name: set common facts
-  include: ../../init/facts.yml
+  import_playbook: ../../init/facts.yml
 
 
 # TODO(shadower): consider splitting this up so people can stop here

--- a/playbooks/openstack/openshift-cluster/provision_install.yml
+++ b/playbooks/openstack/openshift-cluster/provision_install.yml
@@ -1,9 +1,9 @@
 ---
 - name: Check the prerequisites for cluster provisioning in OpenStack
-  include: prerequisites.yml
+  import_playbook: prerequisites.yml
 
 - name: Include the provision.yml playbook to create cluster
-  include: provision.yml
+  import_playbook: provision.yml
 
 - name: Include the install.yml playbook to install cluster
-  include: install.yml
+  import_playbook: install.yml

--- a/playbooks/prerequisites.yml
+++ b/playbooks/prerequisites.yml
@@ -1,5 +1,5 @@
 ---
-- include: init/main.yml
+- import_playbook: init/main.yml
   vars:
     skip_verison: True
 

--- a/playbooks/redeploy-certificates.yml
+++ b/playbooks/redeploy-certificates.yml
@@ -1,26 +1,26 @@
 ---
-- include: init/main.yml
+- import_playbook: init/main.yml
 
-- include: openshift-etcd/private/redeploy-certificates.yml
+- import_playbook: openshift-etcd/private/redeploy-certificates.yml
 
-- include: openshift-master/private/redeploy-certificates.yml
+- import_playbook: openshift-master/private/redeploy-certificates.yml
 
-- include: openshift-node/private/redeploy-certificates.yml
+- import_playbook: openshift-node/private/redeploy-certificates.yml
 
-- include: openshift-etcd/private/restart.yml
+- import_playbook: openshift-etcd/private/restart.yml
   vars:
     g_etcd_certificates_expired: "{{ ('expired' in (hostvars | oo_select_keys(groups['etcd']) | oo_collect('check_results.check_results.etcd') | oo_collect('health'))) | bool }}"
 
-- include: openshift-master/private/restart.yml
+- import_playbook: openshift-master/private/restart.yml
 
-- include: openshift-node/private/restart.yml
+- import_playbook: openshift-node/private/restart.yml
 
-- include: openshift-hosted/private/redeploy-router-certificates.yml
+- import_playbook: openshift-hosted/private/redeploy-router-certificates.yml
   when: openshift_hosted_manage_router | default(true) | bool
 
-- include: openshift-hosted/private/redeploy-registry-certificates.yml
+- import_playbook: openshift-hosted/private/redeploy-registry-certificates.yml
   when: openshift_hosted_manage_registry | default(true) | bool
 
-- include: openshift-master/private/revert-client-ca.yml
+- import_playbook: openshift-master/private/revert-client-ca.yml
 
-- include: openshift-master/private/restart.yml
+- import_playbook: openshift-master/private/restart.yml


### PR DESCRIPTION
* Converts playbooks/ to use `import_playbook`.
* Updates remaining `include:` tasks to `include_tasks:`

Trello: https://trello.com/c/ZTyZu3UM/484-3-ansible-24-include-deprecation