### PR TITLE
Fix ami building.

### DIFF
--- a/playbooks/init/main.yml
+++ b/playbooks/init/main.yml
@@ -18,8 +18,10 @@
 - import_playbook: facts.yml
 
 - import_playbook: sanity_checks.yml
+  when: not (skip_sanity_checks | default(False))
 
 - import_playbook: validate_hostnames.yml
+  when: not (skip_validate_hostnames | default(False))
 
 - import_playbook: repos.yml
 

--- a/playbooks/openshift-node/private/image_prep.yml
+++ b/playbooks/openshift-node/private/image_prep.yml
@@ -1,12 +1,10 @@
 ---
 - name: normalize groups
-  import_playbook: ../../init/evaluate_groups.yml
-
-- name: initialize the facts
-  import_playbook: ../../init/facts.yml
-
-- name: initialize the repositories
-  import_playbook: ../../init/repos.yml
+  import_playbook: ../../prerequisites.yml
+  vars:
+    skip_version: True
+    skip_sanity_checks: True
+    skip_validate_hostnames: True
 
 - name: run node config setup
   import_playbook: setup.yml


### PR DESCRIPTION
With the recent refactors and moving the docker role to the container_runtime this has broken the AMI building process.  The changes here calls the prerequisites in order to get the correct runtime installed.