### PR TITLE
Add os_firewall to prerequisites.yml

### DIFF
--- a/playbooks/openshift-etcd/private/config.yml
+++ b/playbooks/openshift-etcd/private/config.yml
@@ -19,7 +19,6 @@
   hosts: oo_etcd_to_config
   any_errors_fatal: true
   roles:
-  - role: os_firewall
   - role: openshift_clock
   - role: openshift_etcd
     etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"

--- a/playbooks/openshift-loadbalancer/private/config.yml
+++ b/playbooks/openshift-loadbalancer/private/config.yml
@@ -11,13 +11,6 @@
           status: "In Progress"
           start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- name: Configure firewall load balancers
-  hosts: oo_lb_to_config:!oo_masters_to_config:!oo_nodes_to_config
-  vars:
-    openshift_image_tag: "{{ hostvars[groups.oo_first_master.0].openshift_image_tag }}"
-  roles:
-  - role: os_firewall
-
 - name: Configure load balancers
   hosts: oo_lb_to_config
   vars:

--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -180,7 +180,6 @@
                                                 | oo_collect('openshift.common.ip') | default([]) | join(',')
                                                 }}"
   roles:
-  - role: os_firewall
   - role: openshift_master_facts
   - role: openshift_hosted_facts
   - role: openshift_clock

--- a/playbooks/openshift-nfs/private/config.yml
+++ b/playbooks/openshift-nfs/private/config.yml
@@ -14,7 +14,6 @@
 - name: Configure nfs
   hosts: oo_nfs_to_config
   roles:
-  - role: os_firewall
   - role: openshift_storage_nfs
 
 - name: NFS Install Checkpoint End

--- a/playbooks/openshift-node/private/configure_nodes.yml
+++ b/playbooks/openshift-node/private/configure_nodes.yml
@@ -10,7 +10,6 @@
                                                 | oo_collect('openshift.common.hostname') | default([]) | join (',')
                                                 }}"
   roles:
-  - role: os_firewall
   - role: openshift_clock
   - role: openshift_node
   - role: tuned

--- a/playbooks/openshift-node/private/containerized_nodes.yml
+++ b/playbooks/openshift-node/private/containerized_nodes.yml
@@ -12,7 +12,6 @@
                                                 }}"
 
   roles:
-  - role: os_firewall
   - role: openshift_clock
   - role: openshift_node
     openshift_ca_host: "{{ groups.oo_first_master.0 }}"

--- a/playbooks/prerequisites.yml
+++ b/playbooks/prerequisites.yml
@@ -3,4 +3,10 @@
   vars:
     skip_verison: True
 
+# This is required for container runtime for crio, only needs to run once.
+- name: Configure os_firewall
+  hosts: oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_nfs_to_config:oo_nodes_to_config
+  roles:
+  - role: os_firewall
+
 - import_playbook: container-runtime/private/config.yml


### PR DESCRIPTION
This needs to be in place for crio.

This role only installs and enables iptables, thus
should only be run once.