### PR TITLE
Imagepull fails for provisioner pod because incorrect image prefix is provided in enterprise

### DIFF
--- a/roles/openshift_provisioners/defaults/main.yaml
+++ b/roles/openshift_provisioners/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 openshift_provisioners_install_provisioners: True
-openshift_provisioners_image_prefix: docker.io/openshift/origin-
+openshift_provisioners_image_prefix: "{{ 'registry.access.redhat.com/openshift3/ose-' if openshift_deployment_type == 'openshift-enterprise' else 'docker.io/openshift/origin-' }}" 
 openshift_provisioners_image_version: latest
 
 openshift_provisioners_efs: False


### PR DESCRIPTION
# oc logs provisioners-efs-1-rw74p -n openshift-infra
Error from server (BadRequest): container "efs-provisioner" in pod "provisioners-efs-1-rw74p" is waiting to start: trying and failing to pull image


Signed-off-by: jkaurredhat <jkaur@redhat.com>