### PR TITLE
Update deprecation checks - include:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -334,9 +334,9 @@ class OpenShiftAnsibleSyntaxCheck(Command):
                 result = self.deprecate_jinja2_in_when(yaml_contents, yaml_file)
                 has_errors = result or has_errors
 
-                # TODO (rteague): This test will be enabled once we move to Ansible 2.4
-                # result = self.deprecate_include(yaml_contents, yaml_file)
-                # has_errors = result or has_errors
+                # Check for usage of include: directive
+                result = self.deprecate_include(yaml_contents, yaml_file)
+                has_errors = result or has_errors
 
         if not has_errors:
             print('...PASSED')

--- a/test/integration/openshift_health_checker/preflight/playbooks/package_availability_missing_required.yml
+++ b/test/integration/openshift_health_checker/preflight/playbooks/package_availability_missing_required.yml
@@ -1,6 +1,6 @@
 ---
 # NOTE: this test is probably superfluous since openshift_version already does it
-- include: ../../setup_container.yml
+- import_playbook: ../../setup_container.yml
   vars:
     image: preflight-aos-package-checks
     l_host_vars:
@@ -15,7 +15,7 @@
     - block:
 
         # put the repo back to disabled
-        - include: tasks/enable_repo.yml
+        - include_tasks: tasks/enable_repo.yml
           vars: { repo_name: "ose-3.2", repo_enabled: 0 }
 
         - action: openshift_health_check
@@ -23,4 +23,4 @@
             checks: [ 'package_availability' ]
 
       always:  # destroy the container whether check passed or not
-        - include: ../../teardown_container.yml
+        - include_tasks: ../../teardown_container.yml

--- a/test/integration/openshift_health_checker/preflight/playbooks/package_availability_succeeds.yml
+++ b/test/integration/openshift_health_checker/preflight/playbooks/package_availability_succeeds.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../setup_container.yml
+- import_playbook: ../../setup_container.yml
   vars:
     image: preflight-aos-package-checks
     l_host_vars:
@@ -17,4 +17,4 @@
             checks: [ 'package_availability' ]
 
       always:  # destroy the container whether check passed or not
-        - include: ../../teardown_container.yml
+        - include_tasks: ../../teardown_container.yml

--- a/test/integration/openshift_health_checker/preflight/playbooks/package_update_dep_missing.yml
+++ b/test/integration/openshift_health_checker/preflight/playbooks/package_update_dep_missing.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../setup_container.yml
+- import_playbook: ../../setup_container.yml
   vars:
     image: preflight-aos-package-checks
     l_host_vars:
@@ -14,7 +14,7 @@
   post_tasks:
     - block:
 
-        - include: tasks/enable_repo.yml
+        - include_tasks: tasks/enable_repo.yml
           vars: { repo_name: "break-yum" }
 
         - action: openshift_health_check
@@ -22,4 +22,4 @@
             checks: [ 'package_update' ]
 
       always:  # destroy the container whether check passed or not
-        - include: ../../teardown_container.yml
+        - include_tasks: ../../teardown_container.yml

--- a/test/integration/openshift_health_checker/preflight/playbooks/package_update_repo_broken.yml
+++ b/test/integration/openshift_health_checker/preflight/playbooks/package_update_repo_broken.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../setup_container.yml
+- import_playbook: ../../setup_container.yml
   vars:
     image: preflight-aos-package-checks
     l_host_vars:
@@ -14,7 +14,7 @@
   post_tasks:
     - block:
 
-        - include: tasks/enable_repo.yml
+        - include_tasks: tasks/enable_repo.yml
           vars: { repo_name: "break-yum" }
 
         - name: Break the break-yum repo
@@ -29,4 +29,4 @@
             checks: [ 'package_update' ]
 
       always:  # destroy the container whether check passed or not
-        - include: ../../teardown_container.yml
+        - include_tasks: ../../teardown_container.yml

--- a/test/integration/openshift_health_checker/preflight/playbooks/package_update_repo_disabled.yml
+++ b/test/integration/openshift_health_checker/preflight/playbooks/package_update_repo_disabled.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../setup_container.yml
+- import_playbook: ../../setup_container.yml
   vars:
     image: preflight-aos-package-checks
     l_host_vars:
@@ -19,4 +19,4 @@
             checks: [ 'package_update' ]
 
       always:  # destroy the container whether check passed or not
-        - include: ../../teardown_container.yml
+        - include_tasks: ../../teardown_container.yml

--- a/test/integration/openshift_health_checker/preflight/playbooks/package_update_repo_unreachable.yml
+++ b/test/integration/openshift_health_checker/preflight/playbooks/package_update_repo_unreachable.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../setup_container.yml
+- import_playbook: ../../setup_container.yml
   vars:
     image: preflight-aos-package-checks
     l_host_vars:
@@ -14,7 +14,7 @@
   post_tasks:
     - block:
 
-        - include: tasks/enable_repo.yml
+        - include_tasks: tasks/enable_repo.yml
           vars: { repo_name: "break-yum" }
 
         - name: Remove the local repo entirely
@@ -25,4 +25,4 @@
             checks: [ 'package_update' ]
 
       always:  # destroy the container whether check passed or not
-        - include: ../../teardown_container.yml
+        - include_tasks: ../../teardown_container.yml

--- a/test/integration/openshift_health_checker/preflight/playbooks/package_version_matches.yml
+++ b/test/integration/openshift_health_checker/preflight/playbooks/package_version_matches.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../setup_container.yml
+- import_playbook: ../../setup_container.yml
   vars:
     image: preflight-aos-package-checks
     l_host_vars:
@@ -15,7 +15,7 @@
     - block:
 
         # disable extras so we control docker version
-        - include: tasks/enable_repo.yml
+        - include_tasks: tasks/enable_repo.yml
           vars: { repo_file: "CentOS-Base", repo_name: "extras", repo_enabled: 0 }
 
         - action: openshift_health_check
@@ -23,4 +23,4 @@
             checks: [ 'package_version' ]
 
       always:  # destroy the container whether check passed or not
-        - include: ../../teardown_container.yml
+        - include_tasks: ../../teardown_container.yml

--- a/test/integration/openshift_health_checker/preflight/playbooks/package_version_mismatches.yml
+++ b/test/integration/openshift_health_checker/preflight/playbooks/package_version_mismatches.yml
@@ -1,6 +1,6 @@
 ---
 # NOTE: this test is probably superfluous since openshift_version already does it
-- include: ../../setup_container.yml
+- import_playbook: ../../setup_container.yml
   vars:
     image: preflight-aos-package-checks
     l_host_vars:
@@ -16,14 +16,14 @@
     - block:
 
         # put the repo back to disabled
-        - include: tasks/enable_repo.yml
+        - include_tasks: tasks/enable_repo.yml
           vars: { repo_name: "ose-3.2", repo_enabled: 0 }
         # test with wrong repo enabled
-        - include: tasks/enable_repo.yml
+        - include_tasks: tasks/enable_repo.yml
           vars: { repo_name: "ose-3.3" }
         - action: openshift_health_check
           args:
             checks: [ 'package_version' ]
 
       always:  # destroy the container whether check passed or not
-        - include: ../../teardown_container.yml
+        - include_tasks: ../../teardown_container.yml

--- a/test/integration/openshift_health_checker/preflight/playbooks/package_version_multiple.yml
+++ b/test/integration/openshift_health_checker/preflight/playbooks/package_version_multiple.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../setup_container.yml
+- import_playbook: ../../setup_container.yml
   vars:
     image: preflight-aos-package-checks
     l_host_vars:
@@ -14,11 +14,11 @@
     - block:
 
         # enable repo with extra minor version available
-        - include: tasks/enable_repo.yml
+        - include_tasks: tasks/enable_repo.yml
           vars: { repo_name: "ose-3.3" }
 
         # disable extras so we control docker version
-        - include: tasks/enable_repo.yml
+        - include_tasks: tasks/enable_repo.yml
           vars: { repo_file: "CentOS-Base", repo_name: "extras", repo_enabled: 0 }
 
         - action: openshift_health_check
@@ -26,4 +26,4 @@
             checks: [ 'package_version' ]
 
       always:  # destroy the container whether check passed or not
-        - include: ../../teardown_container.yml
+        - include_tasks: ../../teardown_container.yml

--- a/test/integration/openshift_health_checker/preflight/playbooks/package_version_origin.yml
+++ b/test/integration/openshift_health_checker/preflight/playbooks/package_version_origin.yml
@@ -1,5 +1,5 @@
 ---
-- include: ../../setup_container.yml
+- import_playbook: ../../setup_container.yml
   vars:
     image: preflight-aos-package-checks
     l_host_vars:
@@ -17,4 +17,4 @@
             checks: [ 'package_version' ]
 
       always:  # destroy the container whether check passed or not
-        - include: ../../teardown_container.yml
+        - include_tasks: ../../teardown_container.yml

--- a/test/integration/openshift_health_checker/setup_container.yml
+++ b/test/integration/openshift_health_checker/setup_container.yml
@@ -48,14 +48,14 @@
   tasks:
 
     # run before openshift_version to prevent it breaking
-    - include: preflight/playbooks/tasks/enable_repo.yml
+    - include_tasks: preflight/playbooks/tasks/enable_repo.yml
       vars: { repo_name: "ose-3.2" }
 
-- include: ../../../playbooks/init/main.yml
+- import_playbook: ../../../playbooks/init/main.yml
 
 - hosts: all
   tasks:
 
     # put it back like it was for the tests
-    - include: preflight/playbooks/tasks/enable_repo.yml
+    - include_tasks: preflight/playbooks/tasks/enable_repo.yml
       vars: { repo_name: "ose-3.2", enabled: False }


### PR DESCRIPTION
Updating deprecation tests to check for `include:` directive usage.

Trello: https://trello.com/c/ZTyZu3UM/484-3-ansible-24-include-deprecation

Fixes: https://github.com/openshift/openshift-ansible/issues/5586