### PR TITLE
Remove unnecessarily complicated pkg_version

### DIFF
--- a/roles/openshift_excluder/tasks/install.yml
+++ b/roles/openshift_excluder/tasks/install.yml
@@ -5,10 +5,9 @@
   - r_openshift_excluder_install_ran is not defined
 
   block:
-
   - name: Install docker excluder - yum
     package:
-      name: "{{ r_openshift_excluder_service_type }}-docker-excluder{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) +  '*' }}"
+      name: "{{ r_openshift_excluder_service_type }}-docker-excluder"
       state: "{{ r_openshift_excluder_docker_package_state }}"
     when:
     - r_openshift_excluder_enable_docker_excluder | bool
@@ -33,7 +32,7 @@
 
   - name: Install openshift excluder - yum
     package:
-      name: "{{ r_openshift_excluder_service_type }}-excluder{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) + '*' }}"
+      name: "{{ r_openshift_excluder_service_type }}-docker-excluder"
       state: "{{ r_openshift_excluder_package_state }}"
     when:
     - r_openshift_excluder_enable_openshift_excluder | bool

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -3,14 +3,14 @@
   block:
   - name: Install Node package
     package:
-      name: "{{ openshift_service_type }}-node{{ (openshift_pkg_version | default('')) | oo_image_tag_to_rpm_version(include_dash=True) }}"
+      name: "{{ openshift.common.service_type }}-node"
       state: present
     register: result
     until: result | success
 
   - name: Install sdn-ovs package
     package:
-      name: "{{ openshift_service_type }}-sdn-ovs{{ (openshift_pkg_version | default('')) | oo_image_tag_to_rpm_version(include_dash=True) }}"
+      name: "{{ openshift.common.service_type }}-sdn-ovs"
       state: present
     when:
     - openshift_node_use_openshift_sdn | bool


### PR DESCRIPTION
Fixes task failures by removing unnecessarily complicated pkg_version vars.

Tested six deployments in the last 12 hours with no failures in tasks.