### PR TITLE
Remove container_runtime from the openshift_version

### DIFF
--- a/roles/openshift_version/meta/main.yml
+++ b/roles/openshift_version/meta/main.yml
@@ -13,5 +13,4 @@ galaxy_info:
   - cloud
 dependencies:
 - role: lib_utils
-- role: container_runtime
 - role: openshift_facts


### PR DESCRIPTION
We meant to remove this before merging #6316