### PR TITLE
Fix to missing Ansible facts directory

### DIFF
--- a/playbooks/init/main.yml
+++ b/playbooks/init/main.yml
@@ -12,6 +12,11 @@
         installer_phase_initialize:
           status: "In Progress"
           start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+  - name: Ensure Ansible facts directory exists
+    file:
+      path: /etc/ansible/facts.d
+      recurse: true
+      state: directory
 
 - import_playbook: evaluate_groups.yml
 


### PR DESCRIPTION
EC2s come out of the box without an /etc/ansible/facts.d directory.  openshift_facts.py python script lands files in this directory.  This is the highest possible point to ensure /etc/ansible/facts.d exists.