### PR TITLE
Add openshift_facts to upgrade plays for service_type

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -32,6 +32,7 @@
   any_errors_fatal: true
 
   roles:
+  - openshift_facts
   - lib_openshift
 
   tasks:

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
@@ -121,6 +121,8 @@
 - name: Cycle all controller services to force new leader election mode
   hosts: oo_masters_to_config
   gather_facts: no
+  roles:
+  - role: openshift_facts
   tasks:
   - name: Stop {{ openshift_service_type }}-master-controllers
     systemd:

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -125,6 +125,8 @@
 - name: Cycle all controller services to force new leader election mode
   hosts: oo_masters_to_config
   gather_facts: no
+  roles:
+  - role: openshift_facts
   tasks:
   - name: Stop {{ openshift_service_type }}-master-controllers
     systemd:

--- a/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade.yml
@@ -121,6 +121,8 @@
 - name: Cycle all controller services to force new leader election mode
   hosts: oo_masters_to_config
   gather_facts: no
+  roles:
+  - role: openshift_facts
   tasks:
   - name: Stop {{ openshift_service_type }}-master-controllers
     systemd:

--- a/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml
@@ -125,6 +125,8 @@
 - name: Cycle all controller services to force new leader election mode
   hosts: oo_masters_to_config
   gather_facts: no
+  roles:
+  - role: openshift_facts
   tasks:
   - name: Stop {{ openshift_service_type }}-master-controllers
     systemd:

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade.yml
@@ -127,6 +127,8 @@
 - name: Cycle all controller services to force new leader election mode
   hosts: oo_masters_to_config
   gather_facts: no
+  roles:
+  - role: openshift_facts
   tasks:
   - name: Stop {{ openshift.common.service_type }}-master-controllers
     systemd:

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
@@ -131,6 +131,8 @@
 - name: Cycle all controller services to force new leader election mode
   hosts: oo_masters_to_config
   gather_facts: no
+  roles:
+  - role: openshift_facts
   tasks:
   - name: Stop {{ openshift.common.service_type }}-master-controllers
     systemd:


### PR DESCRIPTION
Bring openshift_facts into scope for plays that utilize
openshift_service_type as it is defined there.