### PR TITLE
Add missing dependencies on openshift_facts role

### DIFF
--- a/roles/etcd/meta/main.yml
+++ b/roles/etcd/meta/main.yml
@@ -19,3 +19,4 @@ dependencies:
 - role: lib_openshift
 - role: lib_os_firewall
 - role: lib_utils
+- role: openshift_facts

--- a/roles/openshift_ca/meta/main.yml
+++ b/roles/openshift_ca/meta/main.yml
@@ -14,3 +14,4 @@ galaxy_info:
   - system
 dependencies:
 - role: openshift_cli
+- role: openshift_facts

--- a/roles/openshift_management/meta/main.yml
+++ b/roles/openshift_management/meta/main.yml
@@ -16,3 +16,4 @@ galaxy_info:
 dependencies:
 - role: lib_openshift
 - role: lib_utils
+- role: openshift_facts


### PR DESCRIPTION
All of these roles call the openshift_facts module but didn't include
the role in their dependencies which can lead to errors in Ansible 2.4.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1524102