### PR TITLE
Clean up host-local IPAM data while nodes are drained

### DIFF
--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -21,6 +21,12 @@
     path: "/var/lib/dockershim/sandbox/"
     state: absent
 
+# https://bugzilla.redhat.com/show_bug.cgi?id=1518912
+- name: Clean up IPAM data
+  file:
+    path: "/var/lib/cni/networks/openshift-sdn/"
+    state: absent
+
 # Disable Swap Block (pre)
 - block:
   - name: Remove swap entries from /etc/fstab


### PR DESCRIPTION
Something is causing IP address assignments for some pods to be leaked. We need to do better cleanup/gc from the code. However, if we're deleting stale docker checkpoints during ansible upgrade (#6110), it makes sense to delete stale IPAM assignments too.

We'll want to backport this to 3.7.

Partly fixes https://bugzilla.redhat.com/show_bug.cgi?id=1518912