### PR TITLE
Fix master services list for etcd migration

### DIFF
--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -22,14 +22,18 @@
       r_etcd_common_embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
       etcd_peer: "{{ ansible_default_ipv4.address }}"
 
-# TODO: This will be different for release-3.6 branch
 - name: Prepare masters for etcd data migration
   hosts: oo_masters_to_config
   tasks:
   - set_fact:
       master_services:
+      - "{{ openshift.common.service_type + '-master' }}"
+  - set_fact:
+      master_services:
       - "{{ openshift.common.service_type + '-master-controllers' }}"
       - "{{ openshift.common.service_type + '-master-api' }}"
+    when:
+    - groups.oo_masters_to_config | length > 1 or openshift_version | version_compare('3.7','>=')
   - debug:
       msg: "master service name: {{ master_services }}"
   - name: Stop masters


### PR DESCRIPTION
We require that folks migrate to etcd v3 storage before upgrading to 3.7 and the 3.7 upgrade documentation also calls this out. So there's an incredibly strong chance that the 3.7 playbooks will be used to migrate from etcd v2 to v3. However in 3.6 if you had a single master it likely did not use the ha services. So check for that, this is slightly simplified logic copied from release-3.6 branch.