### PR TITLE
Allow install on nodes where OVS is already being used

### DIFF
--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -15,8 +15,9 @@
     name: openvswitch
     state: restarted
   when:
-  - (not skip_node_svc_handlers | default(False) | bool)
-  - not (ovs_service_status_changed | default(false) | bool)
+  - not skip_node_svc_handlers | default(False) | bool
+  - not skip_ovs_svc_handlers | default(False) | bool
+  - not ovs_service_status_changed | default(false) | bool
   - openshift_node_use_openshift_sdn | bool
   - not openshift_node_bootstrap
   register: l_openshift_node_stop_openvswitch_result
@@ -29,7 +30,8 @@
 - name: restart openvswitch pause
   pause: seconds=15
   when:
-  - (not skip_node_svc_handlers | default(False) | bool)
+  - not skip_node_svc_handlers | default(False) | bool
+  - not skip_ovs_svc_handlers | default(False) | bool
   - openshift.common.is_containerized | bool
 
 - name: restart node


### PR DESCRIPTION
Add skip_ovs_svc_handlers variable that allows the deployer to
essentially say "don't restart my OpenVSwitch".

When the byo nodes already use OVS for something, restarting
OpenVSwitch has the capacity to brick them networking-wise. We hit
this when integrating OpenShift with TripleO.

This was tested manually and OpenShift's br0 seemed to coexist with
OpenStack's br-ex just fine, i could deploy pods and expose them as
services and curl them that way.