### PR TITLE
crio: change socket path to /var/run/crio/crio.sock

### DIFF
--- a/roles/container_runtime/templates/crio.conf.j2
+++ b/roles/container_runtime/templates/crio.conf.j2
@@ -27,7 +27,7 @@ storage_option = [
 [crio.api]
 
 # listen is the path to the AF_LOCAL socket on which crio will listen.
-listen = "/var/run/crio.sock"
+listen = "/var/run/crio/crio.sock"
 
 # stream_address is the IP address on which the stream server will listen
 stream_address = ""

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -20,9 +20,9 @@ kubeletArguments: {{ openshift.node.kubelet_args | default(None) | to_padded_yam
   container-runtime:
   - remote
   container-runtime-endpoint:
-  - /var/run/crio.sock
+  - /var/run/crio/crio.sock
   image-service-endpoint:
-  - /var/run/crio.sock
+  - /var/run/crio/crio.sock
   node-labels:
   - router=true
   - registry=true


### PR DESCRIPTION
it is required for OpenShift 3.9

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>