### PR TITLE
openshift_logging_{fluentd,mux}_file_buffer_limit mismatch

### DIFF
--- a/roles/openshift_logging_fluentd/templates/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/fluentd.j2
@@ -130,7 +130,7 @@ spec:
               containerName: "{{ daemonset_container_name }}"
               resource: limits.memory
         - name: "FILE_BUFFER_LIMIT"
-          value: "{{ openshift_logging_fluentd_file_buffer_limit | default('256i') }}"
+          value: "{{ openshift_logging_fluentd_file_buffer_limit | default('256Mi') }}"
 {% if openshift_logging_mux_client_mode is defined and
      ((openshift_logging_mux_allow_external is defined and openshift_logging_mux_allow_external | bool) or
       (openshift_logging_use_mux is defined and openshift_logging_use_mux | bool)) %}

--- a/roles/openshift_logging_mux/defaults/main.yml
+++ b/roles/openshift_logging_mux/defaults/main.yml
@@ -63,4 +63,4 @@ openshift_logging_mux_file_buffer_pvc_access_modes: ['ReadWriteOnce']
 openshift_logging_mux_file_buffer_storage_group: '65534'
 
 openshift_logging_mux_file_buffer_pvc_prefix: "logging-mux"
-openshift_logging_mux_file_buffer_limit: 256Mi
+openshift_logging_mux_file_buffer_limit: 2Gi


### PR DESCRIPTION
. fixing a typo in fluentd template
. adjusting the default value of openshift_logging_mux_file_buffer_limit