### PR TITLE
Ensure that clients are version bound

### DIFF
--- a/roles/openshift_cli/tasks/main.yml
+++ b/roles/openshift_cli/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install clients
-  package: name={{ openshift_service_type }}-clients state=present
+  package: name={{ openshift_service_type }}-clients{{ openshift_pkg_version | default('') }} state=present
   when: not openshift.common.is_containerized | bool
   register: result
   until: result | success


### PR DESCRIPTION
The client packages were installed without a version specified. Which means that as soon as you try to install specific versions of other packages those will fail like this.

```
  1. Hosts:    localhost
     Play:     Create OpenShift certificates for master hosts
     Task:     Install the base package for admin tooling
     Message:  Error: Package: origin-3.7.0-1.0.7ed6862.x86_64 (centos-openshift-origin)
                          Requires: origin-clients = 3.7.0-1.0.7ed6862
                          Installed: origin-clients-3.8.0-0.alpha.1.11.4f0db51.x86_64 (@origin-local-release)
                              origin-clients = 3.8.0-0.alpha.1.11.4f0db51
                          Available: origin-clients-3.6.0-1.0.c4dd4cf.x86_64 (centos-openshift-origin)
                              origin-clients = 3.6.0-1.0.c4dd4cf
                          Available: origin-clients-3.6.1-1.0.008f2d5.x86_64 (centos-openshift-origin)
                              origin-clients = 3.6.1-1.0.008f2d5
                          Available: origin-clients-3.7.0-0.alpha.1.859.5d7f1b8.x86_64 (centos-paas-sig-openshift-origin37-rpms)
                              origin-clients = 3.7.0-0.alpha.1.859.5d7f1b8
                          Available: origin-clients-3.7.0-0.rc.0.0.e92d5c5.x86_64 (centos-paas-sig-openshift-origin37-rpms)
                              origin-clients = 3.7.0-0.rc.0.0.e92d5c5
                          Available: origin-clients-3.7.0-1.0.7ed6862.x86_64 (centos-openshift-origin)
                              origin-clients = 3.7.0-1.0.7ed6862
```