### PR TITLE
[3.7] Update openshift_logging use of securitycontextconstraints

### DIFF
--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -27,7 +27,7 @@
 
 - name: set ansible-service-broker image facts using set prefix and tag
   set_fact:
-    ansible_service_broker_image: "{{ ansible_service_broker_image_prefix }}ansible-service-broker:{{ ansible_service_broker_image_tag }}"
+    ansible_service_broker_image: "{{ ansible_service_broker_image_prefix }}origin-ansible-service-broker:{{ ansible_service_broker_image_tag }}"
     ansible_service_broker_etcd_image: "{{ ansible_service_broker_etcd_image_prefix }}etcd:{{ ansible_service_broker_etcd_image_tag }}"
 
 - include: validate_facts.yml

--- a/roles/openshift_logging/library/openshift_logging_facts.py
+++ b/roles/openshift_logging/library/openshift_logging_facts.py
@@ -249,7 +249,7 @@ class OpenshiftLoggingFacts(OCBaseCommand):
     def facts_for_sccs(self):
         ''' Gathers facts for SCCs used with logging '''
         self.default_keys_for("sccs")
-        scc = self.oc_command("get", "scc", name="privileged")
+        scc = self.oc_command("get", "securitycontextconstraints", name="privileged")
         if len(scc["users"]) == 0:
             return
         for item in scc["users"]:


### PR DESCRIPTION
in origin 3.7  there is no "scc" option.
and ansible-service-broker image not update