### PR TITLE
containers: use registry.fedoraproject.org/latest instead of registry.fedoraproject.org/f2.X

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -115,7 +115,7 @@ l_crio_image: "{{ openshift_crio_systemcontainer_image_override | default(l_crio
 # systemcontainers_docker #
 # ----------------------- #
 l_crt_docker_image_prepend_dict:
-  Fedora: "registry.fedoraproject.org/f25"
+  Fedora: "registry.fedoraproject.org/latest"
   Centos: "docker.io/gscrivano"
   RedHat: "registry.access.redhat.com/openshift3"
 

--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -10,7 +10,7 @@ r_etcd_common_embedded_etcd: false
 
 osm_etcd_image: 'registry.access.redhat.com/rhel7/etcd'
 etcd_image_dict:
-  origin: "registry.fedoraproject.org/f26/etcd"
+  origin: "registry.fedoraproject.org/latest/etcd"
   openshift-enterprise: "{{ osm_etcd_image }}"
 etcd_image: "{{ etcd_image_dict[openshift_deployment_type | default('origin')] }}"
 


### PR DESCRIPTION
Now the Fedora registry has a nice /latest/ link that points always to the latest release of Fedora available, so we don't need to care of the fXY component in the name.  It also makes easier to update containers as the image name doesn't change.
