### PR TITLE
Adding .ini to inventory_ignore_extensions

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -26,7 +26,7 @@ fact_caching = jsonfile
 fact_caching_connection = $HOME/ansible/facts
 fact_caching_timeout = 600
 callback_whitelist = profile_tasks
-inventory_ignore_extensions = secrets.py, .pyc, .cfg, .crt
+inventory_ignore_extensions = secrets.py, .pyc, .cfg, .crt, .ini
 # work around privilege escalation timeouts in ansible:
 timeout = 30
 


### PR DESCRIPTION
Adding the `.ini` extension to the `inventory_ignore_extensions` in `ansible.cfg` as otherwise dynamic inventories (such as `ec2.py`) may fail due to attempts to parse the `.ini` file.