### PR TITLE
Collect coverage for every tox env separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ multi_ec2.yaml
 .cache
 .tox/
 .coverage
+.coverage.*
 *.egg-info
 .eggs
 cover/
+cover-*/

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,4 +14,3 @@ python_files =
 addopts =
     --cov=.
     --cov-report=term
-    --cov-report=html

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ minversion=2.3.1
 envlist =
     py{27,35}-{flake8,pylint,unit}
     py27-{yamllint,ansible_syntax,generate_validation}
+    cov
 skipsdist=True
 skip_missing_interpreters=True
 
@@ -14,10 +15,17 @@ deps =
     unit: -eutils
     py35-flake8: flake8-bugbear==17.3.0
 
+setenv =
+    py{27,35}-unit: COVERAGE_FILE={envdir}/.coverage
+
 commands =
+    unit: coverage erase
     unit: pytest {posargs}
+    unit: coverage html -d cover-{envname}
     flake8: flake8 {posargs}
     pylint: python setup.py lint
     yamllint: python setup.py yamllint
     generate_validation: python setup.py generate_validation
     ansible_syntax: python setup.py ansible_syntax
+    cov: /usr/bin/env bash -c '{envpython} -m coverage combine {toxworkdir}/py*/.coverage'
+    cov: coverage html


### PR DESCRIPTION
Each testenv in tox should store coverage in a separate file to avoid
overwriting data from the last one. After coverage is collected, coverage data is combined and
HTML report report is being prepared. The combined coverage is being reported to Coveralls.

Related to #3417 - now a combined HTML report would be displayed.