### PR TITLE
Adding no_log to registry_auth.

### DIFF
--- a/roles/container_runtime/tasks/registry_auth.yml
+++ b/roles/container_runtime/tasks/registry_auth.yml
@@ -15,6 +15,7 @@
   - not openshift_docker_alternative_creds | bool
   - oreg_auth_user is defined
   - (not docker_cli_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
+  no_log: True
 
 # docker_creds is a custom module from lib_utils
 # 'docker login' requires a docker.service running on the local host, this is an
@@ -30,3 +31,4 @@
   - openshift_docker_alternative_creds | bool
   - oreg_auth_user is defined
   - (not docker_cli_auth_credentials_stat.stat.exists or oreg_auth_credentials_replace) | bool
+  no_log: True


### PR DESCRIPTION
We were seeing credentials show up in our jenkins logs.  We'd prefer if they were not logged.  I'm not sure the repercussions but these are sensitive and probably should be `no_log`.