### PR TITLE
make rhsub_pass variable name consistant

### DIFF
--- a/roles/openshift_repos/tasks/main.yaml
+++ b/roles/openshift_repos/tasks/main.yaml
@@ -42,7 +42,7 @@
       - ansible_distribution == 'RedHat'
       - deployment_type == 'openshift-enterprise'
       - rhsub_user is defined
-      - rhsub_password is defined
+      - rhsub_pass is defined
 
     - include_tasks: centos_repos.yml
       when:


### PR DESCRIPTION
In one place, the subscription manager input for the account password is "rhsub_password".  That's inconsistent with the rest of the references, which use "rhsub_pass".  This PR changes the one place where the name is inconsistent.