### PR TITLE
Add CentOS-OpenShift-Origin37 repo template.

### DIFF
--- a/roles/openshift_repos/templates/CentOS-OpenShift-Origin37.repo.j2
+++ b/roles/openshift_repos/templates/CentOS-OpenShift-Origin37.repo.j2
@@ -1,0 +1,27 @@
+[centos-openshift-origin37]
+name=CentOS OpenShift Origin
+baseurl=http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin37/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
+
+[centos-openshift-origin37-testing]
+name=CentOS OpenShift Origin Testing
+baseurl=http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin37/
+enabled={{ 1 if openshift_repos_enable_testing else 0 }}
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
+
+[centos-openshift-origin37-debuginfo]
+name=CentOS OpenShift Origin DebugInfo
+baseurl=http://debuginfo.centos.org/centos/7/paas/x86_64/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
+
+[centos-openshift-origin37-source]
+name=CentOS OpenShift Origin Source
+baseurl=http://vault.centos.org/centos/7/paas/Source/openshift-origin37/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS


### PR DESCRIPTION
CentOS repo configs are based on `openshift_release` so adding in a 37 repo template.
