### PR TITLE
Fix hosted_reg_router selectors

### DIFF
--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -94,11 +94,6 @@ openshift_prometheus_alertbuffer_storage_access_modes:
 openshift_prometheus_alertbuffer_storage_create_pv: True
 openshift_prometheus_alertbuffer_storage_create_pvc: False
 
-
-openshift_router_selector: "region=infra"
-openshift_hosted_router_selector: "{{ openshift_router_selector }}"
-openshift_hosted_registry_selector: "{{ openshift_router_selector }}"
-
 openshift_service_type_dict:
   origin: origin
   openshift-enterprise: atomic-openshift


### PR DESCRIPTION
This commit removes duplicate (and incorrect) assignment
of openshift_hosted_registry_selector and
openshift_hosted_router_selector

Fixes https://github.com/openshift/origin/issues/17682