### PR TITLE
Ensure cloudprovider config path matches in openshift_node / openshift_cloud_provider.

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -18,19 +18,19 @@ openshift_node_kubelet_args_dict:
     cloud-provider:
     - aws
     cloud-config:
-    - "{{ openshift_config_base ~ '/aws.conf' }}"
+    - "{{ openshift_config_base ~ '/cloudprovider/aws.conf' }}"
     node-labels: "{{ l_node_kubelet_node_labels }}"
   openstack:
     cloud-provider:
     - openstack
     cloud-config:
-    - "{{ openshift_config_base ~ '/openstack.conf' }}"
+    - "{{ openshift_config_base ~ '/cloudprovider/openstack.conf' }}"
     node-labels: "{{ l_node_kubelet_node_labels }}"
   gce:
     cloud-provider:
     - gce
     cloud-config:
-    - "{{ openshift_config_base ~ '/gce.conf' }}"
+    - "{{ openshift_config_base ~ '/cloudprovider/gce.conf' }}"
     node-labels: "{{ l_node_kubelet_node_labels }}"
   undefined:
     node-labels: "{{ l_node_kubelet_node_labels }}"


### PR DESCRIPTION
`openshift_cloud_provider` could be absorbed into `openshift_node` so that there's only one source of truth for this config dir (as a default) but for now I will just make sure that they match.