### PR TITLE
Don't log credentials pulled from inventory file

### DIFF
--- a/playbooks/init/basic_facts.yml
+++ b/playbooks/init/basic_facts.yml
@@ -15,6 +15,7 @@
   - name: Run openshift_sanitize_inventory to set variables
     import_role:
       name: openshift_sanitize_inventory
+    no_log: True
 
   - name: Detecting Operating System from ostree_booted
     stat:

--- a/playbooks/init/version.yml
+++ b/playbooks/init/version.yml
@@ -6,6 +6,7 @@
   - include_role:
       name: openshift_version
       tasks_from: first_master.yml
+    no_log: True
   - debug: msg="openshift_pkg_version set to {{ openshift_pkg_version | default('') }}"
 
 # NOTE: We set this even on etcd hosts as they may also later run as masters,

--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -144,3 +144,4 @@
   when:
   - master_controllers_aws.rc == 0
   - not (openshift_cloudprovider_kind is defined and openshift_cloudprovider_kind == 'aws' and openshift_cloudprovider_aws_access_key is defined and openshift_cloudprovider_aws_secret_key is defined)
+  no_log: True


### PR DESCRIPTION
This will prevent cloud provider credentials from accidentally being logged to the console during config updates.

Tested with openshift-ansible-3.7.14-1:

```
TASK [openshift_node : Configure AWS Cloud Provider Settings] *******************************
Monday 18 December 2017  13:04:27 -0800 (0:00:00.037)       0:14:02.635 *******
skipping: [ec2-34-207-241-28.compute-1.amazonaws.com] => (item=(censored due to no_log))
skipping: [ec2-34-207-241-28.compute-1.amazonaws.com] => (item=(censored due to no_log))
```