### PR TITLE
Remove oauth_template bits from openshift_facts

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -84,6 +84,9 @@ openshift_release=v3.7
 
 # Configure extensions in the master config for console customization
 # See: https://docs.openshift.org/latest/install_config/web_console_customization.html#serving-static-files
+#openshift_master_oauth_templates:
+#  login: /path/to/login-template.html
+# openshift_master_oauth_template is deprecated.  Use openshift_master_oauth_templates instead.
 #openshift_master_oauth_template=/path/to/login-template.html
 
 # Configure imagePolicyConfig in the master config

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -656,26 +656,6 @@ def set_nodename(facts):
     return facts
 
 
-def migrate_oauth_template_facts(facts):
-    """
-    Migrate an old oauth template fact to a newer format if it's present.
-
-    The legacy 'oauth_template' fact was just a filename, and assumed you were
-    setting the 'login' template.
-
-    The new pluralized 'oauth_templates' fact is a dict mapping the template
-    name to a filename.
-
-    Simplify the code after this by merging the old fact into the new.
-    """
-    if 'master' in facts and 'oauth_template' in facts['master']:
-        if 'oauth_templates' not in facts['master']:
-            facts['master']['oauth_templates'] = {"login": facts['master']['oauth_template']}
-        elif 'login' not in facts['master']['oauth_templates']:
-            facts['master']['oauth_templates']['login'] = facts['master']['oauth_template']
-    return facts
-
-
 def format_url(use_ssl, hostname, port, path=''):
     """ Format url based on ssl flag, hostname, port and path
 
@@ -1387,7 +1367,6 @@ class OpenShiftFacts(object):
         facts = merge_facts(facts,
                             local_facts,
                             additive_facts_to_overwrite)
-        facts = migrate_oauth_template_facts(facts)
         facts['current_config'] = get_current_config(facts)
         facts = set_url_facts_if_unset(facts)
         facts = set_identity_providers_if_unset(facts)

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -82,6 +82,15 @@ openshift_master_valid_grant_methods:
 
 openshift_master_is_scaleup_host: False
 
+# openshift_master_oauth_template is deprecated.  Should be added to deprecations
+# and removed.
+openshift_master_oauth_template: False
+openshift_master_oauth_templates_default:
+  login: "{{ openshift_master_oauth_template }}"
+openshift_master_oauth_templates: "{{ openshift_master_oauth_template | ternary(openshift_master_oauth_templates_default, False) }}"
+# Here we combine openshift_master_oath_template into 'login' key of openshift_master_oath_templates, if not present.
+l_openshift_master_oauth_templates: "{{ openshift_master_oauth_templates | default(openshift_master_oauth_templates_default) }}"
+
 # These defaults assume forcing journald persistence, fsync to disk once
 # a second, rate-limiting to 10,000 logs a second, no forwarding to
 # syslog or wall, using 8GB of disk space maximum, using 10MB journal

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -152,8 +152,8 @@ oauthConfig:
 {% if 'oauth_always_show_provider_selection' in openshift.master %}
   alwaysShowProviderSelection: {{ openshift.master.oauth_always_show_provider_selection }}
 {% endif %}
-{% if 'oauth_templates' in openshift.master %}
-  templates:{{ openshift.master.oauth_templates | lib_utils_to_padded_yaml(level=2) }}
+{% if l_openshift_master_oauth_templates %}
+  templates:{{ l_openshift_master_oauth_templates | lib_utils_to_padded_yaml(level=2) }}
 {% endif %}
   assetPublicURL: {{ openshift.master.public_console_url }}/
   grantConfig:

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -74,8 +74,6 @@
       master_count: "{{ openshift_master_count | default(None) }}"
       admission_plugin_config: "{{openshift_master_admission_plugin_config }}"
       kube_admission_plugin_config: "{{openshift_master_kube_admission_plugin_config | default(None) }}"  # deprecated, merged with admission_plugin_config
-      oauth_template: "{{ openshift_master_oauth_template | default(None) }}"  # deprecated in origin 1.2 / OSE 3.2
-      oauth_templates: "{{ openshift_master_oauth_templates | default(None) }}"
       oauth_always_show_provider_selection: "{{ openshift_master_oauth_always_show_provider_selection | default(None) }}"
       image_policy_config: "{{ openshift_master_image_policy_config | default(None) }}"
       dynamic_provisioning_enabled: "{{ openshift_master_dynamic_provisioning_enabled | default(None) }}"


### PR DESCRIPTION
This commit moves some deprecated variable logic
outside of openshift_facts and into role defaults.