### PR TITLE
Bug 1527178 - installation of logging stack failed: Invalid version s…

### DIFF
--- a/roles/openshift_logging_curator/vars/main.yml
+++ b/roles/openshift_logging_curator/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-__latest_curator_version: "3_6"
-__allowed_curator_versions: ["3_5", "3_6", "3_7"]
+__latest_curator_version: "3_8"
+__allowed_curator_versions: ["3_5", "3_6", "3_7", "3_8"]

--- a/roles/openshift_logging_elasticsearch/vars/main.yml
+++ b/roles/openshift_logging_elasticsearch/vars/main.yml
@@ -1,6 +1,6 @@
 ---
-__latest_es_version: "3_6"
-__allowed_es_versions: ["3_5", "3_6", "3_7"]
+__latest_es_version: "3_8"
+__allowed_es_versions: ["3_5", "3_6", "3_7", "3_8"]
 __allowed_es_types: ["data-master", "data-client", "master", "client"]
 __es_log_appenders: ['file', 'console']
 __kibana_index_modes: ["unique", "shared_ops"]

--- a/roles/openshift_logging_fluentd/vars/main.yml
+++ b/roles/openshift_logging_fluentd/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-__latest_fluentd_version: "3_6"
-__allowed_fluentd_versions: ["3_5", "3_6", "3_7"]
+__latest_fluentd_version: "3_8"
+__allowed_fluentd_versions: ["3_5", "3_6", "3_7", "3_8"]
 __allowed_fluentd_types: ["hosted", "secure-aggregator", "secure-host"]
 __allowed_mux_client_modes: ["minimal", "maximal"]

--- a/roles/openshift_logging_kibana/vars/main.yml
+++ b/roles/openshift_logging_kibana/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-__latest_kibana_version: "3_6"
-__allowed_kibana_versions: ["3_5", "3_6", "3_7"]
+__latest_kibana_version: "3_8"
+__allowed_kibana_versions: ["3_5", "3_6", "3_7", "3_8"]

--- a/roles/openshift_logging_mux/vars/main.yml
+++ b/roles/openshift_logging_mux/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-__latest_mux_version: "3_6"
-__allowed_mux_versions: ["3_5", "3_6", "3_7"]
+__latest_mux_version: "3_8"
+__allowed_mux_versions: ["3_5", "3_6", "3_7", "3_8"]


### PR DESCRIPTION
…pecified for Elasticsearch

openshift_logging_{curator,elasicsearch,fluentd,kibana,mux}/vars/main.yml:
- adding "3_8" to __allowed_.*_versions
- replacing the value of __latest_.*_version "3_6" with "3_8".

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1527178