### PR TITLE
Fix provider network support at openstack playbook

### DIFF
--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -483,7 +483,7 @@ resources:
           floating_network:
             if:
               - no_floating
-              - null
+              - ''
               - {{ openshift_openstack_external_network_name }}
 {% if openshift_openstack_provider_network_name %}
           attach_float_net: false
@@ -549,8 +549,13 @@ resources:
           secgrp:
             - { get_resource: lb-secgrp }
             - { get_resource: common-secgrp }
-{% if not openshift_openstack_provider_network_name %}
-          floating_network: {{ openshift_openstack_external_network_name }}
+          floating_network:
+            if:
+              - no_floating
+              - ''
+              - {{ openshift_openstack_external_network_name }}
+{% if openshift_openstack_provider_network_name %}
+          attach_float_net: false
 {% endif %}
           volume_size: {{ openshift_openstack_lb_volume_size }}
 {% if not openshift_openstack_provider_network_name %}
@@ -615,7 +620,7 @@ resources:
           floating_network:
             if:
               - no_floating
-              - null
+              - ''
               - {{ openshift_openstack_external_network_name }}
 {% if openshift_openstack_provider_network_name %}
           attach_float_net: false
@@ -685,7 +690,7 @@ resources:
           floating_network:
             if:
               - no_floating
-              - null
+              - ''
               - {{ openshift_openstack_external_network_name }}
 {% if openshift_openstack_provider_network_name %}
           attach_float_net: false
@@ -752,8 +757,13 @@ resources:
 {% endif %}
             - { get_resource: infra-secgrp }
             - { get_resource: common-secgrp }
-{% if not openshift_openstack_provider_network_name %}
-          floating_network: {{ openshift_openstack_external_network_name }}
+          floating_network:
+            if:
+              - no_floating
+              - ''
+              - {{ openshift_openstack_external_network_name }}
+{% if openshift_openstack_provider_network_name %}
+          attach_float_net: false
 {% endif %}
           volume_size: {{ openshift_openstack_infra_volume_size }}
 {% if openshift_openstack_infra_server_group_policies|length > 0 %}

--- a/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
@@ -102,13 +102,11 @@ parameters:
     label: Attach-float-net
     description: A switch for floating network port connection
 
-{% if not openshift_openstack_provider_network_name %}
   floating_network:
     type: string
     default: ''
     label: Floating network
     description: Network to allocate floating IP from
-{% endif %}
 
   availability_zone:
     type: string


### PR DESCRIPTION
It ensures no floating ips are attached if a provider
network is used