### PR TITLE
fix TSB template node selector

### DIFF
--- a/files/origin-components/apiserver-template.yaml
+++ b/files/origin-components/apiserver-template.yaml
@@ -61,7 +61,8 @@ objects:
               path: /healthz
               port: 8443
               scheme: HTTPS
-        nodeSelector: "${{NODE_SELECTOR}}"
+        nodeSelector: 
+          "${{NODE_SELECTOR}}"
         volumes:
         - name: serving-cert
           secret:


### PR DESCRIPTION
As per NodeSelector documentation (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/):
```
nodeSelector:
    disktype: ssd
```

Error:
```
TASK [template_service_broker : Apply template file] **************************************************************************************************************************************************************
Tuesday 19 December 2017  08:08:17 +0000 (0:00:02.305)       1:35:20.885 ****** 
fatal: [54.147.119.223]: FAILED! => {"changed": true, "cmd": "/usr/local/bin/oc process -f "/tmp/tsb-ansible-2dCR8s/apiserver-template.yaml" --param API_SERVER_CONFIG="kind: TemplateServiceBrokerConfignapiVersion: config.templateservicebroker.openshift.io/v1ntemplateNamespaces:n- openshiftn" --param IMAGE="registry.access.redhat.com/openshift3/ose:v3.7" --param NODE_SELECTOR='"ocp-node-type=master"' | /usr/local/bin/oc apply -f -", "delta": "0:00:00.416081", "end": "2017-12-19 03:08:20.162091", "msg": "non-zero return code", "rc": 1, "start": "2017-12-19 03:08:19.746010", "stderr": "Error from server (BadRequest): DaemonSet in version "v1beta1" cannot be handled as a DaemonSet: [pos 2304]: json: expect char '{' but got char '"'", "stderr_lines": ["Error from server (BadRequest): DaemonSet in version "v1beta1" cannot be handled as a DaemonSet: [pos 2304]: json: expect char '{' but got char '"'"], "stdout": "configmap "apiserver-config" creatednserviceaccount "apiserver" creatednservice "apiserver" creatednserviceaccount "templateservicebroker-client" creatednsecret "templateservicebroker-client" created", "stdout_lines": ["configmap "apiserver-config" created", "serviceaccount "apiserver" created", "service "apiserver" created", "serviceaccount "templateservicebroker-client" created", "secret "templateservicebroker-client" created"]}
 [WARNING]: Failure using method (v2_runner_on_failed) in callback plugin (<ansible.plugins.callback.mail.CallbackModule object at 0x7ff499d61050>): [Errno 111] Connection refused

/usr/local/bin/oc process -f "/tmp/tsb-ansible-KXhFLz/apiserver-template.yaml" --param API_SERVER_CONFIG="kind: TemplateServiceBrokerConfignapiVersion: config.templateservicebroker.openshift.io/v1ntemplateNamespaces:n- openshiftn" --param IMAGE="registry.access.redhat.com/openshift3/ose:v3.7" --param NODE_SELECTOR='"ocp-node-type:master"' | /usr/local/bin/oc apply -f -
```
this part:
```
json: expect char '{' but got char '"'"], 
```

this happens due wrong indentation in YAML json, generated in the backend is invalid.

ping @jim-minter 
