### PR TITLE
Add gcloud to the installer image

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -10,7 +10,14 @@ COPY images/installer/origin-extra-root /
 # install ansible and deps
 RUN INSTALL_PKGS="python-lxml pyOpenSSL python2-cryptography openssl java-1.8.0-openjdk-headless python2-passlib httpd-tools openssh-clients origin-clients" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
- && EPEL_PKGS="ansible python2-boto" \
+ && echo '[google-cloud-sdk]' > /etc/yum.repos.d/google-cloud-sdk.repo \
+ && echo 'baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64' >> /etc/yum.repos.d/google-cloud-sdk.repo \
+ && echo 'enabled=1' >> /etc/yum.repos.d/google-cloud-sdk.repo \
+ && echo 'gpgcheck=1' >> /etc/yum.repos.d/google-cloud-sdk.repo \
+ && echo 'repo_gpgcheck=1' >> /etc/yum.repos.d/google-cloud-sdk.repo \
+ && echo 'gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg' >> /etc/yum.repos.d/google-cloud-sdk.repo \
+ && echo '       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg' >> /etc/yum.repos.d/google-cloud-sdk.repo \
+ && EPEL_PKGS="ansible python2-boto google-cloud-cdk" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
  && rpm -V $INSTALL_PKGS $EPEL_PKGS \

--- a/images/installer/Dockerfile.rhel7
+++ b/images/installer/Dockerfile.rhel7
@@ -5,7 +5,7 @@ MAINTAINER OpenShift Team <dev@lists.openshift.redhat.com>
 USER root
 
 # Playbooks, roles, and their dependencies are installed from packages.
-RUN INSTALL_PKGS="atomic-openshift-utils atomic-openshift-clients python-boto openssl java-1.8.0-openjdk-headless httpd-tools" \
+RUN INSTALL_PKGS="atomic-openshift-utils atomic-openshift-clients python-boto openssl java-1.8.0-openjdk-headless httpd-tools google-cloud-sdk" \
  && yum repolist > /dev/null \
  && yum-config-manager --enable rhel-7-server-ose-3.7-rpms \
  && yum-config-manager --enable rhel-7-server-rh-common-rpms \


### PR DESCRIPTION
The installer image will become our default cloud operations image for
tasks that overlap with ansible, and will also be the image for
provioning. We will eventually add others like awscli for support roles.

Prereq for moving origin-gce into this repo

@sdodson as discussed earlier (bypasses the need to get this in our tree for now)