### PR TITLE
Move sanity_checks into custom action plugin

### DIFF
--- a/.papr.inventory
+++ b/.papr.inventory
@@ -6,7 +6,7 @@ etcd
 [OSEv3:vars]
 ansible_ssh_user=root
 ansible_python_interpreter=/usr/bin/python3
-deployment_type=origin
+openshift_deployment_type=origin
 openshift_image_tag="{{ lookup('env', 'OPENSHIFT_IMAGE_TAG') }}"
 openshift_master_default_subdomain="{{ lookup('env', 'RHCI_ocp_node1_IP') }}.xip.io"
 openshift_check_min_host_disk_gb=1.5

--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -941,7 +941,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_master_audit_config={"enabled": true, "auditFilePath": "/var/log/openpaas-oscp-audit/openpaas-oscp-audit.log", "maximumFileRetentionDays": 14, "maximumFileSizeMegabytes": 500, "maximumRetainedFiles": 5}
 
 # Enable origin repos that point at Centos PAAS SIG, defaults to true, only used
-# by deployment_type=origin
+# by openshift_deployment_type=origin
 #openshift_enable_origin_repo=false
 
 # Validity of the auto-generated OpenShift certificates in days.

--- a/playbooks/byo/rhel_subscribe.yml
+++ b/playbooks/byo/rhel_subscribe.yml
@@ -6,7 +6,7 @@
   roles:
   - role: rhel_subscribe
     when:
-    - deployment_type == 'openshift-enterprise'
+    - openshift_deployment_type == 'openshift-enterprise'
     - ansible_distribution == "RedHat"
     - rhsub_user is defined
     - rhsub_pass is defined

--- a/playbooks/common/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -12,9 +12,6 @@
   roles:
   - openshift_facts
   tasks:
-  - set_fact:
-      repoquery_cmd: "{{ 'dnf repoquery --latest-limit 1 -d 0' if ansible_pkg_mgr == 'dnf' else 'repoquery --plugins' }}"
-
   - fail:
       msg: Cannot upgrade Docker on Atomic operating systems.
     when: openshift_is_atomic | bool

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
@@ -5,11 +5,6 @@
   hosts: oo_first_master
   gather_facts: no
   tasks:
-  - fail:
-      msg: >
-        This upgrade is only supported for origin and openshift-enterprise
-        deployment types
-    when: deployment_type not in ['origin','openshift-enterprise']
 
   # Error out in situations where the user has older versions specified in their
   # inventory in any of the openshift_release, openshift_image_tag, and

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -49,5 +49,5 @@
   fail:
     msg: "This upgrade playbook must be run against OpenShift {{ openshift_upgrade_min }} or later"
   when:
-  - deployment_type == 'origin'
+  - openshift_deployment_type == 'origin'
   - openshift.common.version is version_compare(openshift_upgrade_min,'<')

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
@@ -13,7 +13,7 @@
   tasks:
   - set_fact:
       openshift_upgrade_target: '3.6'
-      openshift_upgrade_min: "{{ '1.5' if deployment_type == 'origin' else '3.5' }}"
+      openshift_upgrade_min: "{{ '1.5' if openshift_deployment_type == 'origin' else '3.5' }}"
 
 - import_playbook: ../pre/config.yml
   vars:

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
@@ -20,7 +20,7 @@
   tasks:
   - set_fact:
       openshift_upgrade_target: '3.6'
-      openshift_upgrade_min: "{{ '1.5' if deployment_type == 'origin' else '3.5' }}"
+      openshift_upgrade_min: "{{ '1.5' if openshift_deployment_type == 'origin' else '3.5' }}"
 
 - import_playbook: ../pre/config.yml
   vars:

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_nodes.yml
@@ -15,7 +15,7 @@
   tasks:
   - set_fact:
       openshift_upgrade_target: '3.6'
-      openshift_upgrade_min: "{{ '1.5' if deployment_type == 'origin' else '3.5' }}"
+      openshift_upgrade_min: "{{ '1.5' if openshift_deployment_type == 'origin' else '3.5' }}"
 
 - import_playbook: ../pre/config.yml
   vars:

--- a/playbooks/init/base_packages.yml
+++ b/playbooks/init/base_packages.yml
@@ -1,0 +1,37 @@
+---
+- name: Ensure that all non-node hosts are accessible
+  hosts: oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_nfs_to_config
+  any_errors_fatal: true
+  tasks:
+  - when:
+    - not openshift_is_atomic | bool
+    block:
+    - name: Ensure openshift-ansible installer package deps are installed
+      package:
+        name: "{{ item }}"
+        state: present
+      with_items:
+      - iproute
+      - "{{ 'python3-dbus' if ansible_distribution == 'Fedora' else 'dbus-python' }}"
+      - "{{ 'python3-PyYAML' if ansible_distribution == 'Fedora' else 'PyYAML' }}"
+      - yum-utils
+      register: result
+      until: result is succeeded
+
+    - name: Ensure various deps for running system containers are installed
+      package:
+        name: "{{ item }}"
+        state: present
+      with_items:
+      - atomic
+      - ostree
+      - runc
+      when:
+      - >
+        (openshift_use_system_containers | default(False)) | bool
+        or (openshift_use_etcd_system_container | default(False)) | bool
+        or (openshift_use_openvswitch_system_container | default(False)) | bool
+        or (openshift_use_node_system_container | default(False)) | bool
+        or (openshift_use_master_system_container | default(False)) | bool
+      register: result
+      until: result is succeeded

--- a/playbooks/init/facts.yml
+++ b/playbooks/init/facts.yml
@@ -21,6 +21,14 @@
       path: /run/ostree-booted
     register: ostree_booted
 
+  # TODO(michaelgugino) remove this line once CI is updated.
+  - name: set openshift_deployment_type if unset
+    set_fact:
+      openshift_deployment_type: "{{ deployment_type }}"
+    when:
+    - openshift_deployment_type is undefined
+    - deployment_type is defined
+
   - name: initialize_facts set fact openshift_is_atomic and openshift_is_containerized
     set_fact:
       openshift_is_atomic: "{{ ostree_booted.stat.exists }}"
@@ -47,39 +55,6 @@
         that:
         - l_atomic_docker_version.stdout | replace('"', '') is version_compare('1.12','>=')
         msg: Installation on Atomic Host requires Docker 1.12 or later. Please upgrade and restart the Atomic Host.
-
-  - when:
-    - not openshift_is_atomic | bool
-    block:
-    - name: Ensure openshift-ansible installer package deps are installed
-      package:
-        name: "{{ item }}"
-        state: present
-      with_items:
-      - iproute
-      - "{{ 'python3-dbus' if ansible_distribution == 'Fedora' else 'dbus-python' }}"
-      - "{{ 'python3-PyYAML' if ansible_distribution == 'Fedora' else 'PyYAML' }}"
-      - yum-utils
-      register: result
-      until: result is succeeded
-
-    - name: Ensure various deps for running system containers are installed
-      package:
-        name: "{{ item }}"
-        state: present
-      with_items:
-      - atomic
-      - ostree
-      - runc
-      when:
-      - >
-        (openshift_use_system_containers | default(False)) | bool
-        or (openshift_use_etcd_system_container | default(False)) | bool
-        or (openshift_use_openvswitch_system_container | default(False)) | bool
-        or (openshift_use_node_system_container | default(False)) | bool
-        or (openshift_use_master_system_container | default(False)) | bool
-      register: result
-      until: result is succeeded
 
   - name: Gather Cluster facts
     openshift_facts:

--- a/playbooks/init/facts.yml
+++ b/playbooks/init/facts.yml
@@ -28,26 +28,6 @@
 
   # TODO: Should this be moved into health checks??
   # Seems as though any check that happens with a corresponding fail should move into health_checks
-  - name: Validate python version - ans_dist is fedora and python is v3
-    fail:
-      msg: |
-        openshift-ansible requires Python 3 for {{ ansible_distribution }};
-        For information on enabling Python 3 with Ansible, see https://docs.ansible.com/ansible/python_3_support.html
-    when:
-    - ansible_distribution == 'Fedora'
-    - ansible_python['version']['major'] != 3
-
-  # TODO: Should this be moved into health checks??
-  # Seems as though any check that happens with a corresponding fail should move into health_checks
-  - name: Validate python version - ans_dist not Fedora and python must be v2
-    fail:
-      msg: "openshift-ansible requires Python 2 for {{ ansible_distribution }}"
-    when:
-    - ansible_distribution != 'Fedora'
-    - ansible_python['version']['major'] != 2
-
-  # TODO: Should this be moved into health checks??
-  # Seems as though any check that happens with a corresponding fail should move into health_checks
   # Fail as early as possible if Atomic and old version of Docker
   - when:
     - openshift_is_atomic | bool
@@ -135,11 +115,6 @@
       role: node
       local_facts:
         sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
-
-  - name: initialize_facts set_fact repoquery command
-    set_fact:
-      repoquery_cmd: "{{ 'dnf repoquery --latest-limit 1 -d 0' if ansible_pkg_mgr == 'dnf' else 'repoquery --plugins' }}"
-      repoquery_installed: "{{ 'dnf repoquery --latest-limit 1 -d 0 --disableexcludes=all --installed' if ansible_pkg_mgr == 'dnf' else 'repoquery --plugins --installed' }}"
 
 - name: Initialize special first-master variables
   hosts: oo_first_master

--- a/playbooks/init/main.yml
+++ b/playbooks/init/main.yml
@@ -20,9 +20,6 @@
 - import_playbook: sanity_checks.yml
   when: not (skip_sanity_checks | default(False))
 
-- import_playbook: validate_hostnames.yml
-  when: not (skip_validate_hostnames | default(False))
-
 - import_playbook: version.yml
   when: not (skip_verison | default(False))
 

--- a/playbooks/init/repos.yml
+++ b/playbooks/init/repos.yml
@@ -8,7 +8,7 @@
       name: rhel_subscribe
     when:
     - ansible_distribution == 'RedHat'
-    - deployment_type == 'openshift-enterprise'
+    - openshift_deployment_type == 'openshift-enterprise'
     - rhsub_user is defined
     - rhsub_pass is defined
   - name: initialize openshift repos

--- a/playbooks/init/sanity_checks.yml
+++ b/playbooks/init/sanity_checks.yml
@@ -1,51 +1,15 @@
 ---
 - name: Verify Requirements
-  hosts: oo_all_hosts
+  hosts: oo_first_master
+  roles:
+  - role: lib_utils
   tasks:
-  - fail:
-      msg: Flannel can not be used with openshift sdn, set openshift_use_openshift_sdn=false if you want to use flannel
-    when: openshift_use_openshift_sdn | default(true) | bool and openshift_use_flannel | default(false) | bool
-
-  - fail:
-      msg: Nuage sdn can not be used with openshift sdn, set openshift_use_openshift_sdn=false if you want to use nuage
-    when: openshift_use_openshift_sdn | default(true) | bool and openshift_use_nuage | default(false) | bool
-
-  - fail:
-      msg: Nuage sdn can not be used with flannel
-    when: openshift_use_flannel | default(false) | bool and openshift_use_nuage | default(false) | bool
-
-  - fail:
-      msg: Contiv can not be used with openshift sdn, set openshift_use_openshift_sdn=false if you want to use contiv
-    when: openshift_use_openshift_sdn | default(true) | bool and openshift_use_contiv | default(false) | bool
-
-  - fail:
-      msg: Contiv can not be used with flannel
-    when: openshift_use_flannel | default(false) | bool and openshift_use_contiv | default(false) | bool
-
-  - fail:
-      msg: Contiv can not be used with nuage
-    when: openshift_use_nuage | default(false) | bool and openshift_use_contiv | default(false) | bool
-
-  - fail:
-      msg: Calico can not be used with openshift sdn, set openshift_use_openshift_sdn=false if you want to use Calico
-    when: openshift_use_openshift_sdn | default(true) | bool and openshift_use_calico | default(false) | bool
-
-  - fail:
-      msg: The Calico playbook does not yet integrate with the Flannel playbook in Openshift. Set either openshift_use_calico or openshift_use_flannel, but not both.
-    when: openshift_use_calico | default(false) | bool and openshift_use_flannel | default(false) | bool
-
-  - fail:
-      msg: Calico can not be used with Nuage in Openshift. Set either openshift_use_calico or openshift_use_nuage, but not both
-    when: openshift_use_calico | default(false) | bool and openshift_use_nuage | default(false) | bool
-
-  - fail:
-      msg: Calico can not be used with Contiv in Openshift. Set either openshift_use_calico or openshift_use_contiv, but not both
-    when: openshift_use_calico | default(false) | bool and openshift_use_contiv | default(false) | bool
-
-  - fail:
-      msg: openshift_hostname must be 63 characters or less
-    when: openshift_hostname is defined and openshift_hostname | length > 63
-
-  - fail:
-      msg: openshift_public_hostname must be 63 characters or less
-    when: openshift_public_hostname is defined and openshift_public_hostname | length > 63
+  # sanity_checks is a custom action plugin defined in lib_utils.
+  # This module will loop through all the hostvars for each host
+  # specified in check_hosts.
+  # Since sanity_checks is an action_plugin, it executes on the control host.
+  # Thus, sanity_checks cannot gather new information about any hosts.
+  - name: Run variable sanity checks
+    sanity_checks:
+      check_hosts: "{{ groups['oo_all_hosts'] }}"
+    run_once: True

--- a/playbooks/openshift-glusterfs/README.md
+++ b/playbooks/openshift-glusterfs/README.md
@@ -63,7 +63,7 @@ glusterfs
 
 [OSEv3:vars]
 ansible_ssh_user=root
-deployment_type=origin
+openshift_deployment_type=origin
 
 [masters]
 master

--- a/playbooks/openshift-master/private/additional_config.yml
+++ b/playbooks/openshift-master/private/additional_config.yml
@@ -31,7 +31,7 @@
   - role: cockpit
     when:
     - not openshift_is_atomic | bool
-    - deployment_type == 'openshift-enterprise'
+    - openshift_deployment_type == 'openshift-enterprise'
     - osm_use_cockpit is undefined or osm_use_cockpit | bool
     - openshift.common.deployment_subtype != 'registry'
   - role: flannel_register

--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -47,7 +47,7 @@
       state: absent
     when:
     - rpmgenerated_config.stat.exists == true
-    - deployment_type == 'openshift-enterprise'
+    - openshift_deployment_type == 'openshift-enterprise'
     with_items:
     - master
     - node

--- a/playbooks/prerequisites.yml
+++ b/playbooks/prerequisites.yml
@@ -3,10 +3,12 @@
   vars:
     skip_verison: True
 
-- import_playbook: validate_hostnames.yml
+- import_playbook: init/validate_hostnames.yml
   when: not (skip_validate_hostnames | default(False))
 
 - import_playbook: init/repos.yml
+
+- import_playbook: init/base_packages.yml
 
 # This is required for container runtime for crio, only needs to run once.
 - name: Configure os_firewall

--- a/playbooks/prerequisites.yml
+++ b/playbooks/prerequisites.yml
@@ -3,6 +3,9 @@
   vars:
     skip_verison: True
 
+- import_playbook: validate_hostnames.yml
+  when: not (skip_validate_hostnames | default(False))
+
 - import_playbook: init/repos.yml
 
 # This is required for container runtime for crio, only needs to run once.

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -4,7 +4,7 @@
 - name: Set default image variables based on deployment type
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
+    - "{{ openshift_deployment_type }}.yml"
     - "default_images.yml"
 
 - name: set ansible_service_broker facts

--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -2,8 +2,6 @@
 docker_cli_auth_config_path: '/root/.docker'
 openshift_docker_signature_verification: False
 
-repoquery_cmd: "{{ 'dnf repoquery --latest-limit 1 -d 0' if ansible_pkg_mgr == 'dnf' else 'repoquery --plugins' }}"
-
 openshift_docker_alternative_creds: False
 
 # oreg_url is defined by user input.

--- a/roles/container_runtime/meta/main.yml
+++ b/roles/container_runtime/meta/main.yml
@@ -12,3 +12,4 @@ galaxy_info:
 dependencies:
 - role: lib_openshift
 - role: lib_utils
+- role: openshift_facts

--- a/roles/contiv_facts/tasks/main.yml
+++ b/roles/contiv_facts/tasks/main.yml
@@ -70,4 +70,4 @@
   when: has_rpm
 
 - include_tasks: fedora-install.yml
-  when: not is_atomic and ansible_distribution == "Fedora"
+  when: not openshift_is_atomic and ansible_distribution == "Fedora"

--- a/roles/lib_utils/action_plugins/sanity_checks.py
+++ b/roles/lib_utils/action_plugins/sanity_checks.py
@@ -1,0 +1,96 @@
+"""
+Ansible action plugin to ensure inventory variables are set
+appropriately and no conflicting options have been provided.
+"""
+from ansible.plugins.action import ActionBase
+from ansible import errors
+
+# Tuple of variable names and default values if undefined.
+NET_PLUGIN_LIST = (('openshift_use_openshift_sdn', True),
+                   ('openshift_use_flannel', False),
+                   ('openshift_use_nuage', False),
+                   ('openshift_use_contiv', False),
+                   ('openshift_use_calico', False))
+
+
+def to_bool(var_to_check):
+    """Determine a boolean value given the multiple
+       ways bools can be specified in ansible."""
+    yes_list = (True, 1, "True", "1", "true", "Yes", "yes")
+    return var_to_check in yes_list
+
+
+class ActionModule(ActionBase):
+    """Action plugin to execute sanity checks."""
+    def template_var(self, hostvars, host, varname):
+        """Retrieve a variable from hostvars and template it.
+           If undefined, return None type."""
+        res = hostvars[host].get(varname)
+        if res is None:
+            return None
+        return self._templar.template(res)
+
+    def network_plugin_check(self, hostvars, host):
+        """Ensure only one type of network plugin is enabled"""
+        res = []
+        # Loop through each possible network plugin boolean, determine the
+        # actual boolean value, and append results into a list.
+        for plugin, default_val in NET_PLUGIN_LIST:
+            res_temp = self.template_var(hostvars, host, plugin)
+            if res_temp is None:
+                res_temp = default_val
+            res.append(to_bool(res_temp))
+
+        if sum(res) != 1:
+            plugin_str = list(zip([x[0] for x in NET_PLUGIN_LIST], res))
+
+            msg = "Host Checked: {} Only one of must be true. Found: {}".format(host, plugin_str)
+            raise errors.AnsibleModuleError(msg)
+
+    def check_hostname_vars(self, hostvars, host):
+        """Checks to ensure openshift_hostname
+           and openshift_public_hostname
+           conform to the proper length of 63 characters or less"""
+        for varname in ('openshift_public_hostname', 'openshift_hostname'):
+            var_value = self.template_var(hostvars, host, varname)
+            if var_value and len(var_value) > 63:
+                msg = '{} must be 63 characters or less'.format(varname)
+                raise errors.AnsibleModuleError(msg)
+
+    def run_checks(self, hostvars, host):
+        """Execute the hostvars validations against host"""
+        # msg = hostvars[host]['ansible_default_ipv4']
+        self.network_plugin_check(hostvars, host)
+        self.check_hostname_vars(hostvars, host)
+
+    def run(self, tmp=None, task_vars=None):
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        # self.task_vars holds all in-scope variables.
+        # Ignore settting self.task_vars outside of init.
+        # pylint: disable=W0201
+        self.task_vars = task_vars or {}
+
+        # self._task.args holds task parameters.
+        # check_hosts is a parameter to this plugin, and should provide
+        # a list of hosts.
+        check_hosts = self._task.args.get('check_hosts')
+        if not check_hosts:
+            msg = "check_hosts is required"
+            raise errors.AnsibleModuleError(msg)
+
+        # We need to access each host's variables
+        hostvars = self.task_vars.get('hostvars')
+        if not hostvars:
+            msg = hostvars
+            raise errors.AnsibleModuleError(msg)
+
+        # We loop through each host in the provided list check_hosts
+        for host in check_hosts:
+            self.run_checks(hostvars, host)
+
+        result["changed"] = False
+        result["failed"] = False
+        result["msg"] = "Sanity Checks passed"
+
+        return result

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -5,8 +5,8 @@ openshift_cli_image_dict:
   origin: 'openshift/origin'
   openshift-enterprise: 'openshift3/ose'
 
-repoquery_cmd: "{{ ansible_pkg_mgr == 'dnf' | ternary('dnf repoquery --latest-limit 1 -d 0', 'repoquery --plugins') }}"
-repoquery_installed: "{{ ansible_pkg_mgr == 'dnf' | ternary('dnf repoquery --latest-limit 1 -d 0 --disableexcludes=all --installed', 'repoquery --plugins --installed') }}"
+repoquery_cmd: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --latest-limit 1 -d 0', 'repoquery --plugins') }}"
+repoquery_installed: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --latest-limit 1 -d 0 --disableexcludes=all --installed', 'repoquery --plugins --installed') }}"
 
 openshift_hosted_images_dict:
   origin: 'openshift/origin-${component}:${version}'

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -5,6 +5,9 @@ openshift_cli_image_dict:
   origin: 'openshift/origin'
   openshift-enterprise: 'openshift3/ose'
 
+repoquery_cmd: "{{ ansible_pkg_mgr == 'dnf' | ternary('dnf repoquery --latest-limit 1 -d 0', 'repoquery --plugins') }}"
+repoquery_installed: "{{ ansible_pkg_mgr == 'dnf' | ternary('dnf repoquery --latest-limit 1 -d 0 --disableexcludes=all --installed', 'repoquery --plugins --installed') }}"
+
 openshift_hosted_images_dict:
   origin: 'openshift/origin-${component}:${version}'
   openshift-enterprise: 'openshift3/ose-${component}:${version}'

--- a/roles/openshift_logging_curator/tasks/main.yaml
+++ b/roles/openshift_logging_curator/tasks/main.yaml
@@ -2,7 +2,7 @@
 - name: Set default image variables based on deployment_type
   include_vars: "{{ var_file_name }}"
   with_first_found:
-    - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
+    - "{{ openshift_deployment_type }}.yml"
     - "default_images.yml"
   loop_control:
     loop_var: var_file_name

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -15,10 +15,10 @@
     elasticsearch_name: "{{ 'logging-elasticsearch' ~ ( (openshift_logging_elasticsearch_ops_deployment | default(false) | bool) | ternary('-ops', '')) }}"
     es_component: "{{ 'es' ~ ( (openshift_logging_elasticsearch_ops_deployment | default(false) | bool) | ternary('-ops', '') ) }}"
 
-- name: Set default image variables based on deployment_type
+- name: Set default image variables based on openshift_deployment_type
   include_vars: "{{ var_file_name }}"
   with_first_found:
-    - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
+    - "{{ openshift_deployment_type }}.yml"
     - "default_images.yml"
   loop_control:
     loop_var: var_file_name

--- a/roles/openshift_logging_eventrouter/tasks/main.yaml
+++ b/roles/openshift_logging_eventrouter/tasks/main.yaml
@@ -1,8 +1,8 @@
 ---
-- name: Set default image variables based on deployment_type
+- name: Set default image variables based on openshift_deployment_type
   include_vars: "{{ var_file_name }}"
   with_first_found:
-    - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
+    - "{{ openshift_deployment_type }}.yml"
     - "default_images.yml"
   loop_control:
     loop_var: var_file_name

--- a/roles/openshift_logging_fluentd/tasks/main.yaml
+++ b/roles/openshift_logging_fluentd/tasks/main.yaml
@@ -34,10 +34,10 @@
     msg: WARNING Use of openshift_logging_mux_client_mode=minimal is not recommended due to current scaling issues
   when: openshift_logging_mux_client_mode is defined and openshift_logging_mux_client_mode == 'minimal'
 
-- name: Set default image variables based on deployment_type
+- name: Set default image variables based on openshift_deployment_type
   include_vars: "{{ var_file_name }}"
   with_first_found:
-    - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
+    - "{{ openshift_deployment_type }}.yml"
     - "default_images.yml"
   loop_control:
     loop_var: var_file_name

--- a/roles/openshift_logging_kibana/tasks/main.yaml
+++ b/roles/openshift_logging_kibana/tasks/main.yaml
@@ -1,9 +1,9 @@
 ---
 # fail is we don't have an endpoint for ES to connect to?
-- name: Set default image variables based on deployment_type
+- name: Set default image variables based on openshift_deployment_type
   include_vars: "{{ var_file_name }}"
   with_first_found:
-    - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
+    - "{{ openshift_deployment_type }}.yml"
     - "default_images.yml"
   loop_control:
     loop_var: var_file_name

--- a/roles/openshift_logging_mux/tasks/main.yaml
+++ b/roles/openshift_logging_mux/tasks/main.yaml
@@ -7,10 +7,10 @@
     msg: Operations logs destination is required
   when: not openshift_logging_mux_ops_host or openshift_logging_mux_ops_host == ''
 
-- name: Set default image variables based on deployment_type
+- name: Set default image variables based on openshift_deployment_type
   include_vars: "{{ var_file_name }}"
   with_first_found:
-    - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
+    - "{{ openshift_deployment_type }}.yml"
     - "default_images.yml"
   loop_control:
     loop_var: var_file_name

--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -9,10 +9,10 @@
       - "'not installed' not in passlib_result.stdout"
     msg: "python-passlib rpm must be installed on control host"
 
-- name: Set default image variables based on deployment_type
+- name: Set default image variables based on openshift_deployment_type
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
+    - "{{ openshift_deployment_type }}.yml"
     - "default_images.yml"
 
 - name: Set metrics image facts

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -3,7 +3,7 @@
     msg: "SELinux is disabled, This deployment type requires that SELinux is enabled."
   when:
     - (not ansible_selinux or ansible_selinux.status != 'enabled')
-    - deployment_type == 'openshift-enterprise'
+    - openshift_deployment_type == 'openshift-enterprise'
     - not openshift_use_crio
 
 - include_tasks: dnsmasq_install.yml

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -5,7 +5,6 @@
 # - node_config_hook
 # - openshift_pkg_version
 # - openshift_is_containerized
-# - deployment_type
 # - openshift_release
 
 # tasks file for openshift_node_upgrade

--- a/roles/openshift_prometheus/tasks/main.yaml
+++ b/roles/openshift_prometheus/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Set default image variables based on deployment_type
+- name: Set default image variables based on openshift_deployment_type
   include_vars: "{{ item }}"
   with_first_found:
     - "{{ openshift_deployment_type }}.yml"

--- a/roles/openshift_repos/tasks/main.yaml
+++ b/roles/openshift_repos/tasks/main.yaml
@@ -40,7 +40,7 @@
     - include_tasks: rhel_repos.yml
       when:
       - ansible_distribution == 'RedHat'
-      - deployment_type == 'openshift-enterprise'
+      - openshift_deployment_type == 'openshift-enterprise'
       - rhsub_user is defined
       - rhsub_pass is defined
 

--- a/roles/openshift_sanitize_inventory/tasks/main.yml
+++ b/roles/openshift_sanitize_inventory/tasks/main.yml
@@ -3,36 +3,10 @@
 # the user would also be aware of any deprecated variables they should note to adjust
 - include_tasks: deprecations.yml
 
-- name: Abort when conflicting deployment type variables are set
-  when:
-    - deployment_type is defined
-    - openshift_deployment_type is defined
-    - openshift_deployment_type != deployment_type
-  fail:
-    msg: |-
-      openshift_deployment_type is set to "{{ openshift_deployment_type }}".
-      deployment_type is set to "{{ deployment_type }}".
-      To avoid unexpected results, this conflict is not allowed.
-      deployment_type is deprecated in favor of openshift_deployment_type.
-      Please specify only openshift_deployment_type, or make both the same.
-
 - name: Standardize on latest variable names
   set_fact:
-    # goal is to deprecate deployment_type in favor of openshift_deployment_type.
-    # both will be accepted for now, but code should refer to the new name.
-    # TODO: once this is well-documented, add deprecation notice if using old name.
-    deployment_type: "{{ openshift_deployment_type | default(deployment_type) | default | string }}"
-    openshift_deployment_type: "{{ openshift_deployment_type | default(deployment_type) | default | string }}"
     deployment_subtype: "{{ openshift_deployment_subtype | default(deployment_subtype) | default('basic') | string }}"
     openshift_deployment_subtype: "{{ openshift_deployment_subtype | default(deployment_subtype) | default('basic') | string }}"
-
-- name: Abort when deployment type is invalid
-  # this variable is required; complain early and clearly if it is invalid.
-  when: openshift_deployment_type not in known_openshift_deployment_types
-  fail:
-    msg: |-
-      Please set openshift_deployment_type to one of:
-      {{ known_openshift_deployment_types | join(', ') }}
 
 - name: Normalize openshift_release
   set_fact:

--- a/roles/openshift_sanitize_inventory/vars/main.yml
+++ b/roles/openshift_sanitize_inventory/vars/main.yml
@@ -1,7 +1,4 @@
 ---
-# origin uses community packages named 'origin'
-# openshift-enterprise uses Red Hat packages named 'atomic-openshift'
-known_openshift_deployment_types: ['origin', 'openshift-enterprise']
 
 __deprecation_header: "[DEPRECATION WARNING]:"
 

--- a/roles/openshift_service_catalog/tasks/install.yml
+++ b/roles/openshift_service_catalog/tasks/install.yml
@@ -6,10 +6,10 @@
   register: mktemp
   changed_when: False
 
-- name: Set default image variables based on deployment_type
+- name: Set default image variables based on openshift_deployment_type
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
+    - "{{ openshift_deployment_type }}.yml"
     - "default_images.yml"
 
 - name: Set service_catalog image facts

--- a/roles/openshift_storage_glusterfs/defaults/main.yml
+++ b/roles/openshift_storage_glusterfs/defaults/main.yml
@@ -6,16 +6,16 @@ openshift_storage_glusterfs_nodeselector: "glusterfs={{ openshift_storage_gluste
 openshift_storage_glusterfs_use_default_selector: False
 openshift_storage_glusterfs_storageclass: True
 openshift_storage_glusterfs_storageclass_default: False
-openshift_storage_glusterfs_image: "{{ 'rhgs3/rhgs-server-rhel7' | quote if deployment_type == 'openshift-enterprise' else 'gluster/gluster-centos' | quote }}"
+openshift_storage_glusterfs_image: "{{ 'rhgs3/rhgs-server-rhel7' | quote if openshift_deployment_type == 'openshift-enterprise' else 'gluster/gluster-centos' | quote }}"
 openshift_storage_glusterfs_version: 'latest'
 openshift_storage_glusterfs_block_deploy: True
-openshift_storage_glusterfs_block_image: "{{ 'rhgs3/rhgs-gluster-block-prov-rhel7' | quote if deployment_type == 'openshift-enterprise' else 'gluster/glusterblock-provisioner' | quote }}"
+openshift_storage_glusterfs_block_image: "{{ 'rhgs3/rhgs-gluster-block-prov-rhel7' | quote if openshift_deployment_type == 'openshift-enterprise' else 'gluster/glusterblock-provisioner' | quote }}"
 openshift_storage_glusterfs_block_version: 'latest'
 openshift_storage_glusterfs_block_host_vol_create: True
 openshift_storage_glusterfs_block_host_vol_size: 100
 openshift_storage_glusterfs_block_host_vol_max: 15
 openshift_storage_glusterfs_s3_deploy: True
-openshift_storage_glusterfs_s3_image: "{{ 'rhgs3/rhgs-gluster-s3-server-rhel7' | quote if deployment_type == 'openshift-enterprise' else 'gluster/gluster-object' | quote }}"
+openshift_storage_glusterfs_s3_image: "{{ 'rhgs3/rhgs-gluster-s3-server-rhel7' | quote if openshift_deployment_type == 'openshift-enterprise' else 'gluster/gluster-object' | quote }}"
 openshift_storage_glusterfs_s3_version: 'latest'
 openshift_storage_glusterfs_s3_account: "{{ omit }}"
 openshift_storage_glusterfs_s3_user: "{{ omit }}"
@@ -29,7 +29,7 @@ openshift_storage_glusterfs_heketi_is_native: "{{ openshift_storage_glusterfs_is
 openshift_storage_glusterfs_heketi_is_missing: True
 openshift_storage_glusterfs_heketi_deploy_is_missing: True
 openshift_storage_glusterfs_heketi_cli: 'heketi-cli'
-openshift_storage_glusterfs_heketi_image: "{{ 'rhgs3/rhgs-volmanager-rhel7' | quote if deployment_type == 'openshift-enterprise' else 'heketi/heketi' | quote }}"
+openshift_storage_glusterfs_heketi_image: "{{ 'rhgs3/rhgs-volmanager-rhel7' | quote if openshift_deployment_type == 'openshift-enterprise' else 'heketi/heketi' | quote }}"
 openshift_storage_glusterfs_heketi_version: 'latest'
 openshift_storage_glusterfs_heketi_admin_key: "{{ omit }}"
 openshift_storage_glusterfs_heketi_user_key: "{{ omit }}"

--- a/roles/template_service_broker/tasks/install.yml
+++ b/roles/template_service_broker/tasks/install.yml
@@ -1,9 +1,9 @@
 ---
 # Fact setting
-- name: Set default image variables based on deployment type
+- name: Set default image variables based on openshift_deployment_type
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ openshift_deployment_type | default(deployment_type) }}.yml"
+    - "{{ openshift_deployment_type }}.yml"
     - "default_images.yml"
 
 - name: set template_service_broker facts

--- a/test/integration/openshift_health_checker/preflight/playbooks/package_availability_missing_required.yml
+++ b/test/integration/openshift_health_checker/preflight/playbooks/package_availability_missing_required.yml
@@ -4,7 +4,7 @@
   vars:
     image: preflight-aos-package-checks
     l_host_vars:
-      deployment_type: openshift-enterprise
+      openshift_deployment_type: openshift-enterprise
 
 - name: Fail as required packages cannot be installed
   hosts: all

--- a/test/integration/openshift_health_checker/preflight/playbooks/package_availability_succeeds.yml
+++ b/test/integration/openshift_health_checker/preflight/playbooks/package_availability_succeeds.yml
@@ -3,7 +3,7 @@
   vars:
     image: preflight-aos-package-checks
     l_host_vars:
-      deployment_type: origin
+      openshift_deployment_type: origin
 
 - name: Succeeds as Origin packages are public
   hosts: all

--- a/test/integration/openshift_health_checker/preflight/playbooks/package_version_matches.yml
+++ b/test/integration/openshift_health_checker/preflight/playbooks/package_version_matches.yml
@@ -3,7 +3,7 @@
   vars:
     image: preflight-aos-package-checks
     l_host_vars:
-      deployment_type: openshift-enterprise
+      openshift_deployment_type: openshift-enterprise
       openshift_release: 3.2
 
 - name: Success when AOS version matches openshift_release

--- a/test/integration/openshift_health_checker/preflight/playbooks/package_version_mismatches.yml
+++ b/test/integration/openshift_health_checker/preflight/playbooks/package_version_mismatches.yml
@@ -4,7 +4,7 @@
   vars:
     image: preflight-aos-package-checks
     l_host_vars:
-      deployment_type: openshift-enterprise
+      openshift_deployment_type: openshift-enterprise
       openshift_release: 3.2
 
 - name: Failure when AOS version doesn't match openshift_release


### PR DESCRIPTION
This commit moves sanity_checks tasks into a custom
action plugin that is only run against a single host.

This will result in a large reduction of tasks during initialization