### PR TITLE
allow uninstalling AWS objects created by prerequisite playbook

### DIFF
--- a/playbooks/aws/README.md
+++ b/playbooks/aws/README.md
@@ -198,3 +198,17 @@ At this point your cluster should be ready for workloads.  Proceed to deploy app
 ### Still to come
 
 There are more enhancements that are arriving for provisioning.  These will include more playbooks that enhance the provisioning capabilities.
+
+## Uninstall / Deprovisioning
+
+At this time, only deprovisioning of the output of the prerequisites step is provided. You can/must manually remove things like ELBs and scale groups before attempting to undo the work by the preprovisiong step.
+
+To undo the work done by the prerequisites playbook, simply call the uninstall_prerequisites.yml playbook. You should use the same inventory file and provisioning_vars.yml file that was used during provisioning.
+
+```
+ansible-playbook -i <previous inventory file> -e @<previous provisioning_vars file> uninstall_prerequisites.yml
+```
+
+This should result in removal of the security groups and VPC that were created.
+
+NOTE: If you want to also remove the ssh keys that were uploaded (**these ssh keys would be shared if you are running multiple clusters in the same AWS account** so we don't remove these by default) then you should add 'openshift_aws_enable_uninstall_shared_objects: True' to your provisioning_vars.yml file.

--- a/playbooks/aws/openshift-cluster/uninstall_prerequisites.yml
+++ b/playbooks/aws/openshift-cluster/uninstall_prerequisites.yml
@@ -1,0 +1,6 @@
+---
+- import_playbook: uninstall_sec_group.yml
+
+- import_playbook: uninstall_vpc.yml
+
+- import_playbook: uninstall_ssh_keypair.yml

--- a/playbooks/aws/openshift-cluster/uninstall_sec_group.yml
+++ b/playbooks/aws/openshift-cluster/uninstall_sec_group.yml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - name: delete security groups
+    include_role:
+      name: openshift_aws
+      tasks_from: uninstall_security_group.yml
+    when: openshift_aws_create_security_groups | default(True) | bool

--- a/playbooks/aws/openshift-cluster/uninstall_ssh_keypair.yml
+++ b/playbooks/aws/openshift-cluster/uninstall_ssh_keypair.yml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - name: remove ssh keypair(s)
+    include_role:
+      name: openshift_aws
+      tasks_from: uninstall_ssh_keys.yml
+    when: openshift_aws_users | default([]) | length  > 0

--- a/playbooks/aws/openshift-cluster/uninstall_vpc.yml
+++ b/playbooks/aws/openshift-cluster/uninstall_vpc.yml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - name: delete vpc
+    include_role:
+      name: openshift_aws
+      tasks_from: uninstall_vpc.yml
+    when: openshift_aws_create_vpc | default(True) | bool

--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -301,3 +301,7 @@ openshift_aws_node_user_data: ''
 openshift_aws_node_config_namespace: openshift-node
 
 openshift_aws_masters_groups: masters,etcd,nodes
+
+# By default, don't delete things like the shared IAM instance
+# profile and uploaded ssh keys
+openshift_aws_enable_uninstall_shared_objects: False

--- a/roles/openshift_aws/tasks/uninstall_security_group.yml
+++ b/roles/openshift_aws/tasks/uninstall_security_group.yml
@@ -1,0 +1,14 @@
+---
+- name: delete the node group sgs
+  oo_ec2_group:
+    state: absent
+    name: "{{ item.value.name}}"
+    region: "{{ openshift_aws_region }}"
+  with_dict: "{{ openshift_aws_node_security_groups }}"
+
+- name: delete the k8s sgs for the node group
+  oo_ec2_group:
+    state: absent
+    name: "{{ item.value.name }}_k8s"
+    region: "{{ openshift_aws_region }}"
+  with_dict: "{{ openshift_aws_node_security_groups }}"

--- a/roles/openshift_aws/tasks/uninstall_ssh_keys.yml
+++ b/roles/openshift_aws/tasks/uninstall_ssh_keys.yml
@@ -1,0 +1,9 @@
+---
+- name: Remove the public keys for the user(s)
+  ec2_key:
+    state: absent
+    name: "{{ item.key_name }}"
+    region: "{{ openshift_aws_region }}"
+  with_items: "{{ openshift_aws_users }}"
+  no_log: True
+  when: openshift_aws_enable_uninstall_shared_objects | bool

--- a/roles/openshift_aws/tasks/uninstall_vpc.yml
+++ b/roles/openshift_aws/tasks/uninstall_vpc.yml
@@ -1,0 +1,36 @@
+---
+- name: Fetch the VPC for the vpc.id
+  ec2_vpc_net_facts:
+    region: "{{ openshift_aws_region }}"
+    filters:
+      "tag:Name": "{{ openshift_aws_clusterid }}"
+  register: vpcout
+- debug:
+    var: vpcout
+    verbosity: 1
+
+- when: vpcout.vpcs | length > 0
+  block:
+  - name: delete the vpc igw
+    ec2_vpc_igw:
+      state: absent
+      region: "{{ openshift_aws_region }}"
+      vpc_id: "{{ vpcout.vpcs[0].id }}"
+    register: igw
+
+  - name: delete the vpc subnets
+    ec2_vpc_subnet:
+      state: absent
+      region: "{{ openshift_aws_region }}"
+      vpc_id: "{{ vpcout.vpcs[0].id }}"
+      cidr: "{{ item.cidr }}"
+      az: "{{ item.az }}"
+    with_items: "{{ openshift_aws_vpc.subnets[openshift_aws_region] }}"
+
+  - name: Delete AWS VPC
+    ec2_vpc_net:
+      state: absent
+      region: "{{ openshift_aws_region }}"
+      name: "{{ openshift_aws_clusterid }}"
+      cidr_block: "{{ openshift_aws_vpc.cidr }}"
+    register: vpc


### PR DESCRIPTION
add deprovisioners/uninstallers for objects created via playbooks/aws/openshift-cluster/prerequisites.yml

specifically: security groups, vpcs, and any ssh keys

introduce openshift_aws_enable_uninstall_shared_objects to protect AWS objects that would be shared in the case of multiple clusters co-existing in one AWS account. right now it protects the ssh keys, but it can/should be used to protect against deleting the shared IAM instance profile as well. default this variable to False to be on the safe side when uninstalling/deprovisioning.