### PR TITLE
Add in-tree CI scripts

### DIFF
--- a/test/ci/README.md
+++ b/test/ci/README.md
@@ -1,0 +1,14 @@
+This directory contains scripts and other files that are executed by our
+CI integration tests.
+
+CI should call a script.  The only arguments that each script should accept
+are:
+
+1) Path to openshift-ansible/playbooks
+2) Inventory path.
+3) Extra vars path.
+
+Ideally, inventory path and extra vars should live somewhere in this
+subdirectory instead of the CI's source.
+
+Extravars should typically be unnecessary.

--- a/test/ci/extra_vars/default.yml
+++ b/test/ci/extra_vars/default.yml
@@ -1,0 +1,4 @@
+---
+# Using extra_vars is typically not ideal.  Please don't use extra_vars
+# unless there is no other way to accomplish a task.
+openshift_this_var_is_not_used: True

--- a/test/ci/install.sh
+++ b/test/ci/install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -x
+
+# Argument 1: path to openshift-ansible/playbooks
+# Argument 2: inventory path
+# Argument 3: Extra vars path
+
+echo "Running prerequisites"
+
+ansible-playbook -vv            \
+                 --inventory $2 \
+                 --e @$3        \
+                 $1/prerequisites.yml
+
+echo "Running network_manager setup"
+
+playbook_base='/usr/share/ansible/openshift-ansible/playbooks/'
+if [[ -s "$1/openshift-node/network_manager.yml" ]]; then
+   playbook="$1/openshift-node/network_manager.yml"
+else
+   playbook="$1/byo/openshift-node/network_manager.yml"
+fi
+ansible-playbook -vv            \
+                 --inventory $1 \
+                 --e @$2        \
+                ${playbook}
+
+echo "Running openshift-ansible deploy_cluster"
+
+ansible-playbook -vv            \
+                 --inventory $2 \
+                 --e @$3        \
+                 $1/deploy_cluster.yml

--- a/test/ci/inventory/group_vars/OSEv3/checks.yml
+++ b/test/ci/inventory/group_vars/OSEv3/checks.yml
@@ -1,0 +1,4 @@
+---
+openshift_check_min_host_disk_gb: 10
+openshift_check_min_host_memory_gb: 8
+openshift_disable_check: package_update,package_availability

--- a/test/ci/inventory/group_vars/OSEv3/general.yml
+++ b/test/ci/inventory/group_vars/OSEv3/general.yml
@@ -1,0 +1,23 @@
+---
+debug_level: 5
+osm_default_node_selector: "region=infra"
+osm_controller_args:
+  enable-hostpath-provisioner:
+    - "true"
+openshift_hosted_router_selector: "region=infra"
+openshift_hosted_router_create_certificate: true
+openshift_hosted_registry_selector: "region=infra"
+openshift_master_audit_config:
+  enabled: true
+openshift_master_identity_providers:
+  - name: "allow_all"
+    login: "true"
+    challenge: "true"
+    kind: "AllowAllPasswordIdentityProvider"
+openshift_template_service_broker_namespaces:
+  - "openshift"
+ansible_ssh_user: "ec2-user"
+enable_excluders: "false"
+osm_cluster_network_cidr: "10.128.0.0/14"
+openshift_portal_net: "172.30.0.0/16"
+osm_host_subnet_length: 9

--- a/test/ci/inventory/group_vars/OSEv3/logging.yml
+++ b/test/ci/inventory/group_vars/OSEv3/logging.yml
@@ -1,0 +1,37 @@
+---
+openshift_logging_use_mux: false
+openshift_logging_use_ops: true
+openshift_logging_es_log_appenders:
+  - "console"
+openshift_logging_fluentd_journal_read_from_head: false
+openshift_logging_fluentd_audit_container_engine: true
+
+openshift_logging_curator_cpu_request: "100m"
+openshift_logging_curator_memory_limit: "32Mi"
+openshift_logging_curator_ops_cpu_request: "100m"
+openshift_logging_curator_ops_memory_limit: "32Mi"
+openshift_logging_elasticsearch_proxy_cpu_request: "100m"
+openshift_logging_elasticsearch_proxy_memory_limit: "32Mi"
+openshift_logging_es_cpu_request: "400m"
+openshift_logging_es_memory_limit: "4Gi"
+openshift_logging_es_ops_cpu_request: "400m"
+openshift_logging_es_ops_memory_limit: "4Gi"
+openshift_logging_eventrouter_cpu_request: "100m"
+openshift_logging_eventrouter_memory_limit: "64Mi"
+openshift_logging_fluentd_cpu_request: "100m"
+openshift_logging_fluentd_memory_limit: "256Mi"
+openshift_logging_kibana_cpu_request: "100m"
+openshift_logging_kibana_memory_limit: "128Mi"
+openshift_logging_kibana_ops_cpu_request: "100m"
+openshift_logging_kibana_ops_memory_limit: "128Mi"
+openshift_logging_kibana_ops_proxy_cpu_request: "100m"
+openshift_logging_kibana_ops_proxy_memory_limit: "64Mi"
+openshift_logging_kibana_proxy_cpu_request: "100m"
+openshift_logging_kibana_proxy_memory_limit: "64Mi"
+openshift_logging_mux_cpu_request: "400m"
+openshift_logging_mux_memory_limit: "256Mi"
+
+# TODO: remove this once we have oauth-proxy images built that are in step
+#       with the logging images (version and prefix)
+openshift_logging_elasticsearch_proxy_image_prefix: "docker.io/openshift/"
+openshift_logging_elasticsearch_proxy_image_version: "v1.0.0"

--- a/test/ci/inventory/group_vars/all.yml
+++ b/test/ci/inventory/group_vars/all.yml
@@ -1,0 +1,13 @@
+---
+openshift_deployment_type: origin
+etcd_data_dir: "${ETCD_DATA_DIR}"
+openshift_node_port_range: '30000-32000'
+osm_controller_args:
+  enable-hostpath-provisioner:
+    - "true"
+
+# These env vars are created by the CI.  This allows us
+# to test specific versions of openshift.
+openshift_pkg_version: "{{ lookup('env', 'ORIGIN_PKG_VERSION') }}"
+openshift_release: "{{ lookup('env', 'ORIGIN_RELEASE') }}"
+oreg_url: "openshift/origin-${component}:{{ lookup('env', 'ORIGIN_COMMIT') }}"

--- a/test/ci/inventory/host_vars/localhost.yml
+++ b/test/ci/inventory/host_vars/localhost.yml
@@ -1,0 +1,8 @@
+---
+openshift_node_labels:
+  region: infra
+  zone: default
+openshift_schedulable: True
+ansible_become: True
+ansible_become_user: root
+ansible_connection: local

--- a/test/ci/inventory/local.txt
+++ b/test/ci/inventory/local.txt
@@ -1,0 +1,23 @@
+[OSEv3]
+
+[OSEv3:children]
+masters
+nodes
+etcd
+lb
+nfs
+
+[lb]
+# Empty, but present to pass integration tests.
+
+[nfs]
+# Empty, but present to pass integration tests.
+
+[masters]
+localhost
+
+[nodes]
+localhost
+
+[etcd]
+localhost


### PR DESCRIPTION
Currently, the scripts that contain testing inventory
and actually execute the running of openshift-ansible
plays are kept in the CI jobs themselves.

This commit adds scripts into our tree so we can have
better control over variables, differences between branches,
and more transparency to end users for how we run our
integration tests.