### PR TITLE
Must directly specify google-cloud-sdk version

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -10,14 +10,7 @@ COPY images/installer/origin-extra-root /
 # install ansible and deps
 RUN INSTALL_PKGS="python-lxml pyOpenSSL python2-cryptography openssl java-1.8.0-openjdk-headless python2-passlib httpd-tools openssh-clients origin-clients" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
- && echo '[google-cloud-sdk]' > /etc/yum.repos.d/google-cloud-sdk.repo \
- && echo 'baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64' >> /etc/yum.repos.d/google-cloud-sdk.repo \
- && echo 'enabled=1' >> /etc/yum.repos.d/google-cloud-sdk.repo \
- && echo 'gpgcheck=1' >> /etc/yum.repos.d/google-cloud-sdk.repo \
- && echo 'repo_gpgcheck=1' >> /etc/yum.repos.d/google-cloud-sdk.repo \
- && echo 'gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg' >> /etc/yum.repos.d/google-cloud-sdk.repo \
- && echo '       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg' >> /etc/yum.repos.d/google-cloud-sdk.repo \
- && EPEL_PKGS="ansible python2-boto google-cloud-cdk" \
+ && EPEL_PKGS="ansible python2-boto google-cloud-sdk-183.0.0 which" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
  && rpm -V $INSTALL_PKGS $EPEL_PKGS \

--- a/images/installer/origin-extra-root/etc/yum.repos.d/google-cloud-sdk.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/google-cloud-sdk.repo
@@ -1,0 +1,8 @@
+[google-cloud-sdk]
+name=google-cloud-sdk
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg


### PR DESCRIPTION
The upstream forces versions on packages, and rpm -V fails when it does
not match. Also add which, used by gcloud.

Fixes break https://ci.openshift.redhat.com/jenkins/job/build-and-release-latest-openshift-ansible-images/210/console