### PR TITLE
Revert "crio: change socket path to /var/run/crio/crio.sock"

### DIFF
--- a/roles/container_runtime/templates/crio.conf.j2
+++ b/roles/container_runtime/templates/crio.conf.j2
@@ -27,7 +27,7 @@ storage_option = [
 [crio.api]
 
 # listen is the path to the AF_LOCAL socket on which crio will listen.
-listen = "/var/run/crio/crio.sock"
+listen = "/var/run/crio.sock"
 
 # stream_address is the IP address on which the stream server will listen
 stream_address = ""

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -18,9 +18,9 @@ kubeletArguments: {{  l2_openshift_node_kubelet_args  | default(None) | lib_util
   container-runtime:
   - remote
   container-runtime-endpoint:
-  - /var/run/crio/crio.sock
+  - /var/run/crio.sock
   image-service-endpoint:
-  - /var/run/crio/crio.sock
+  - /var/run/crio.sock
   node-labels:
   - router=true
   - registry=true


### PR DESCRIPTION
This reverts commit 646dac7564181c8ca8be9f16dcb5887cfbb7d8fb.

This change wasn't compatible with 3.8 but we're merging all changes from master back into release-3.8 as we don't intend to manually backport fixes to 3.8.