### PR TITLE
Adding ability to update ami drive size.

### DIFF
--- a/roles/openshift_aws/tasks/provision_instance.yml
+++ b/roles/openshift_aws/tasks/provision_instance.yml
@@ -14,11 +14,7 @@
     instance_type: m4.xlarge
     vpc_subnet_id: "{{ openshift_aws_subnet_id | default(subnetout.subnets[0].id) }}"
     image: "{{ openshift_aws_base_ami }}"
-    volumes:
-    - device_name: /dev/sdb
-      volume_type: gp2
-      volume_size: 100
-      delete_on_termination: true
+    volumes: "{{ openshift_aws_node_group_config_node_volumes }}"
     wait: yes
     exact_count: 1
     count_tag:


### PR DESCRIPTION
AMI building needs to be configurable for the instance drive size.  This makes the docker-storage-setup step work with openshift-ansible settings.