### PR TITLE
aws: Fix misnamed variable in provisioning_vars.yml.example

### DIFF
--- a/playbooks/aws/provisioning_vars.yml.example
+++ b/playbooks/aws/provisioning_vars.yml.example
@@ -46,7 +46,7 @@ openshift_pkg_version: # -3.7.0
 
 # Name of the subnet in the vpc to use.  Needs to be set if using a pre-existing
 # vpc + subnet.
-#openshift_aws_subnet_name:
+#openshift_aws_subnet_az:
 
 # -------------- #
 # Security Group #


### PR DESCRIPTION
This typo (?) in `provisioning_vars.yml.example` tripped me up while trying to run `provision_install.yml` using a configuration based on the example file.