### PR TITLE
Use PV configured path when installing gluster backed registry

### DIFF
--- a/roles/openshift_hosted/README.md
+++ b/roles/openshift_hosted/README.md
@@ -34,7 +34,7 @@ variables also control configuration behavior:
 
 | Name                                         | Default value | Description                                                                  |
 |----------------------------------------------|---------------|------------------------------------------------------------------------------|
-| openshift_hosted_registry_storage_glusterfs_discover  | False                        | Whether to get the registry volume information from the cluster instead of using defaults
+| openshift_hosted_registry_discover_glusterfs_path     | False                        | Whether to get the registry volume information from the cluster instead of using defaults
 | openshift_hosted_registry_storage_glusterfs_endpoints | glusterfs-registry-endpoints | The name for the Endpoints resource that will point the registry to the GlusterFS nodes
 | openshift_hosted_registry_storage_glusterfs_path      | glusterfs-registry-volume    | The name for the GlusterFS volume that will provide registry storage
 | openshift_hosted_registry_storage_glusterfs_readonly  | False                        | Whether the GlusterFS volume should be read-only

--- a/roles/openshift_hosted/README.md
+++ b/roles/openshift_hosted/README.md
@@ -34,6 +34,7 @@ variables also control configuration behavior:
 
 | Name                                         | Default value | Description                                                                  |
 |----------------------------------------------|---------------|------------------------------------------------------------------------------|
+| openshift_hosted_registry_storage_glusterfs_discover  | False                        | Whether to get the registry volume information from the cluster instead of using defaults
 | openshift_hosted_registry_storage_glusterfs_endpoints | glusterfs-registry-endpoints | The name for the Endpoints resource that will point the registry to the GlusterFS nodes
 | openshift_hosted_registry_storage_glusterfs_path      | glusterfs-registry-volume    | The name for the GlusterFS volume that will provide registry storage
 | openshift_hosted_registry_storage_glusterfs_readonly  | False                        | Whether the GlusterFS volume should be read-only

--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -89,6 +89,7 @@ openshift_hosted_registry_serviceaccount: registry
 openshift_hosted_registry_volumes: []
 openshift_hosted_registry_env_vars: {}
 openshift_hosted_registry_clusterip: null
+openshift_hosted_registry_storage_glusterfs_path_discover: False
 
 # These edits are being specified only to prevent 'changed' on rerun
 openshift_hosted_registry_edits:

--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -89,7 +89,7 @@ openshift_hosted_registry_serviceaccount: registry
 openshift_hosted_registry_volumes: []
 openshift_hosted_registry_env_vars: {}
 openshift_hosted_registry_clusterip: null
-openshift_hosted_registry_storage_glusterfs_path_discover: False
+openshift_hosted_registry_discover_glusterfs_path: False
 
 # These edits are being specified only to prevent 'changed' on rerun
 openshift_hosted_registry_edits:

--- a/roles/openshift_hosted/tasks/storage/glusterfs.yml
+++ b/roles/openshift_hosted/tasks/storage/glusterfs.yml
@@ -25,6 +25,18 @@
   set_fact:
     openshift_hosted_registry_fsgroup: "{{ registry_pods.results.results[0]['items'][0].spec.securityContext.fsGroup }}"
 
+- name: Get registry PersistentVolume
+  oc_obj:
+    namespace: "{{ openshift_hosted_registry_namespace }}"
+    state: list
+    kind: pv
+    name: "{{ openshift_hosted_registry_storage_volume_name }}-glusterfs-volume"
+  register: registry_pv
+
+- name: Determine registry volume path
+  set_fact:
+    openshift_hosted_registry_storage_glusterfs_path: "{{ openshift_hosted_registry_storage_glusterfs_path | default(registry_pv.results.results[0].spec.glusterfs.path) }}"
+
 - name: Create temp mount directory
   command: mktemp -d /tmp/openshift-glusterfs-registry-XXXXXX
   register: mktemp

--- a/roles/openshift_hosted/tasks/storage/glusterfs.yml
+++ b/roles/openshift_hosted/tasks/storage/glusterfs.yml
@@ -32,7 +32,7 @@
     kind: pv
     name: "{{ openshift_hosted_registry_storage_volume_name }}-glusterfs-volume"
   register: l_registry_storage_glusterfs_path_discover
-  when: openshift_hosted_registry_storage_glusterfs_path_discover
+  when: openshift_hosted_registry_discover_glusterfs_path
 
 - name: Create temp mount directory
   command: mktemp -d /tmp/openshift-glusterfs-registry-XXXXXX

--- a/roles/openshift_hosted/tasks/storage/glusterfs.yml
+++ b/roles/openshift_hosted/tasks/storage/glusterfs.yml
@@ -31,11 +31,8 @@
     state: list
     kind: pv
     name: "{{ openshift_hosted_registry_storage_volume_name }}-glusterfs-volume"
-  register: registry_pv
-
-- name: Determine registry volume path
-  set_fact:
-    openshift_hosted_registry_storage_glusterfs_path: "{{ openshift_hosted_registry_storage_glusterfs_path | default(registry_pv.results.results[0].spec.glusterfs.path) }}"
+  register: l_registry_storage_glusterfs_path_discover
+  when: openshift_hosted_registry_storage_glusterfs_path_discover
 
 - name: Create temp mount directory
   command: mktemp -d /tmp/openshift-glusterfs-registry-XXXXXX
@@ -47,8 +44,10 @@
   mount:
     state: mounted
     fstype: glusterfs
-    src: "{% if 'glusterfs_registry' in groups %}{% set node = groups.glusterfs_registry[0] %}{% elif 'glusterfs' in groups %}{% set node = groups.glusterfs[0] %}{% endif %}{% if openshift_hosted_registry_storage_glusterfs_ips is defined and openshift_hosted_registry_storage_glusterfs_ips|length > 0 %}{{ openshift_hosted_registry_storage_glusterfs_ips[0] }}{% elif 'glusterfs_hostname' in hostvars[node] %}{{ hostvars[node].glusterfs_hostname }}{% elif 'openshift' in hostvars[node] %}{{ hostvars[node].openshift.node.nodename }}{% else %}{{ node }}{% endif %}:/{{ openshift_hosted_registry_storage_glusterfs_path }}"
+    src: "{% if 'glusterfs_registry' in groups %}{% set node = groups.glusterfs_registry[0] %}{% elif 'glusterfs' in groups %}{% set node = groups.glusterfs[0] %}{% endif %}{% if openshift_hosted_registry_storage_glusterfs_ips is defined and openshift_hosted_registry_storage_glusterfs_ips|length > 0 %}{{ openshift_hosted_registry_storage_glusterfs_ips[0] }}{% elif 'glusterfs_hostname' in hostvars[node] %}{{ hostvars[node].glusterfs_hostname }}{% elif 'openshift' in hostvars[node] %}{{ hostvars[node].openshift.node.nodename }}{% else %}{{ node }}{% endif %}:/{{ l_registry_storage_glusterfs_path }}"
     name: "{{ mktemp.stdout }}"
+  vars:
+    l_registry_storage_glusterfs_path: "{{ l_registry_storage_glusterfs_path_discover.results.results[0].spec.glusterfs.path | default(openshift_hosted_registry_storage_glusterfs_path) }}"
 
 - name: Set registry volume permissions
   file:


### PR DESCRIPTION
Today, the glusterfs volume path is assumed to match the name of the persistent volume, however we have found this not flexible in our enviornment and is causing installation to fail when using PVC/PVs in our external gluster environment.

Instead, I am leaving the ability to override given a known external volume name, but set the default path to align with the gluster volume path as configured in the kubernetes volume claim for consistency with what is actually deployed in the environment

This change should be valid in master but we need the change added to release-3.7 so that we can complete successful deployment without continuing to run a forked openshift-ansible