### PR TITLE
Remove bootstrap.yml from main.yml in openshift_node role

### DIFF
--- a/playbooks/openshift-node/private/image_prep.yml
+++ b/playbooks/openshift-node/private/image_prep.yml
@@ -12,6 +12,13 @@
 - name: run node config
   import_playbook: configure_nodes.yml
 
+- name: node bootstrap config
+  hosts: oo_nodes_to_config:!oo_containerized_master_nodes
+  tasks:
+    - include_role:
+        name: openshift_node
+        tasks_from: bootstrap.yml
+
 - name: Re-enable excluders
   import_playbook: enable_excluders.yml
 

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -99,7 +99,3 @@
 
 - include_tasks: config/workaround-bz1331590-ovs-oom-fix.yml
   when: openshift_node_use_openshift_sdn | default(true) | bool
-
-- name: include bootstrap node config
-  include_tasks: bootstrap.yml
-  when: openshift_node_bootstrap


### PR DESCRIPTION
This commit utilizes include_role for bootstrapping the
node instead of conditional include of tasks now that
the node role has no meta includes that have tasks.