### PR TITLE
Move wait_for_pods to it's own play openshift_hosted

### DIFF
--- a/playbooks/openshift-hosted/private/config.yml
+++ b/playbooks/openshift-hosted/private/config.yml
@@ -21,6 +21,10 @@
 
 - import_playbook: openshift_hosted_registry.yml
 
+- import_playbook: openshift_hosted_wait_for_pods.yml
+
+- import_playbook: openshift_hosted_registry_storage.yml
+
 - import_playbook: cockpit-ui.yml
 
 - import_playbook: install_docker_gc.yml

--- a/playbooks/openshift-hosted/private/openshift_hosted_registry_storage.yml
+++ b/playbooks/openshift-hosted/private/openshift_hosted_registry_storage.yml
@@ -1,0 +1,13 @@
+---
+# This playbook waits for registry and router pods after both have been
+# created.  It is intended to allow the tasks of deploying both to complete
+# before polling to save time.
+- name: Poll for hosted pod deployments
+  hosts: oo_first_master
+  tasks:
+  - include_role:
+      name: openshift_hosted
+      tasks_from: registry_storage.yml
+    when:
+    - openshift_hosted_manage_registry | default(True) | bool
+    - openshift_hosted_registry_registryurl is defined

--- a/playbooks/openshift-hosted/private/openshift_hosted_wait_for_pods.yml
+++ b/playbooks/openshift-hosted/private/openshift_hosted_wait_for_pods.yml
@@ -1,0 +1,26 @@
+---
+# This playbook waits for registry and router pods after both have been
+# created.  It is intended to allow the tasks of deploying both to complete
+# before polling to save time.
+- name: Poll for hosted pod deployments
+  hosts: oo_first_master
+  tasks:
+  - include_role:
+      name: openshift_hosted
+      tasks_from: wait_for_pod.yml
+    vars:
+      l_openshift_hosted_wait_for_pod: "{{ openshift_hosted_router_wait }}"
+      l_openshift_hosted_wfp_items: "{{ openshift_hosted_routers }}"
+    when:
+    - openshift_hosted_manage_router | default(True) | bool
+    - openshift_hosted_router_registryurl is defined
+
+  - include_role:
+      name: openshift_hosted
+      tasks_from: wait_for_pod.yml
+    vars:
+      l_openshift_hosted_wait_for_pod: "{{ openshift_hosted_registry_wait }}"
+      l_openshift_hosted_wfp_items: "{{ r_openshift_hosted_registry_list }}"
+    when:
+    - openshift_hosted_manage_registry | default(True) | bool
+    - openshift_hosted_registry_registryurl is defined

--- a/roles/openshift_hosted/tasks/registry.yml
+++ b/roles/openshift_hosted/tasks/registry.yml
@@ -1,10 +1,4 @@
 ---
-- name: Create temp directory for doing work in
-  command: mktemp -d /tmp/openshift-hosted-ansible-XXXXXX
-  register: mktempHosted
-  changed_when: False
-  check_mode: no
-
 - name: setup firewall
   import_tasks: firewall.yml
   vars:
@@ -132,25 +126,10 @@
     edits: "{{ openshift_hosted_registry_edits }}"
     force: "{{ True|bool in openshift_hosted_registry_force }}"
 
+# TODO(michaelgugino) remove this set fact.  It is currently necessary due to
+# custom module not properly templating variables.
 - name: setup registry list
   set_fact:
     r_openshift_hosted_registry_list:
     - name: "{{ openshift_hosted_registry_name }}"
       namespace: "{{ openshift_hosted_registry_namespace }}"
-
-- name: Wait for pod (Registry)
-  include_tasks: wait_for_pod.yml
-  vars:
-    l_openshift_hosted_wait_for_pod: "{{ openshift_hosted_registry_wait }}"
-    l_openshift_hosted_wfp_items: "{{ r_openshift_hosted_registry_list }}"
-
-- include_tasks: storage/glusterfs.yml
-  when:
-  - openshift_hosted_registry_storage_kind | default(none) == 'glusterfs' or openshift_hosted_registry_storage_glusterfs_swap
-
-- name: Delete temp directory
-  file:
-    name: "{{ mktempHosted.stdout }}"
-    state: absent
-  changed_when: False
-  check_mode: no

--- a/roles/openshift_hosted/tasks/registry_storage.yml
+++ b/roles/openshift_hosted/tasks/registry_storage.yml
@@ -1,0 +1,4 @@
+---
+- include_tasks: storage/glusterfs.yml
+  when:
+  - openshift_hosted_registry_storage_kind | default(none) == 'glusterfs' or openshift_hosted_registry_storage_glusterfs_swap

--- a/roles/openshift_hosted/tasks/router.yml
+++ b/roles/openshift_hosted/tasks/router.yml
@@ -98,9 +98,3 @@
     ports: "{{ item.ports }}"
     stats_port: "{{ item.stats_port }}"
   with_items: "{{ openshift_hosted_routers }}"
-
-- name: Wait for pod (Routers)
-  include_tasks: wait_for_pod.yml
-  vars:
-    l_openshift_hosted_wait_for_pod: "{{ openshift_hosted_router_wait }}"
-    l_openshift_hosted_wfp_items: "{{ openshift_hosted_routers }}"

--- a/roles/openshift_hosted/tasks/wait_for_pod.yml
+++ b/roles/openshift_hosted/tasks/wait_for_pod.yml
@@ -7,7 +7,7 @@
                         --namespace {{ item.namespace | default('default') }} \
                         --config {{ openshift_master_config_dir }}/admin.kubeconfig
     async: 600
-    poll: 15
+    poll: 5
     with_items: "{{ l_openshift_hosted_wfp_items }}"
     failed_when: false
 
@@ -28,8 +28,8 @@
              -o jsonpath='{ .metadata.annotations.openshift\.io/deployment\.phase }'
     register: openshift_hosted_wfp_rc_phase
     until: "'Running' not in openshift_hosted_wfp_rc_phase.stdout"
-    delay: 15
-    retries: 40
+    delay: 5
+    retries: 60
     failed_when: "'Failed' in openshift_hosted_wfp_rc_phase.stdout"
     with_together:
     - "{{ l_openshift_hosted_wfp_items }}"


### PR DESCRIPTION
Currently, both registry and router pods need to
be polled for successful deployment.

Somtimes this can take up to a minute.

This commit attempts to deploy both pods
before polling either.  This should reduce
the average wait time for polling pods by 50%
as time spent polling the first will also allow
the second pod to continue it's own deployment.