### PR TITLE
Move cluster.local domain to first in resolv.conf search.

### DIFF
--- a/roles/openshift_node/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node/files/networkmanager/99-origin-dns.sh
@@ -117,7 +117,7 @@ EOF
       if ! grep -qw search ${NEW_RESOLV_CONF}; then
         echo 'search cluster.local' >> ${NEW_RESOLV_CONF}
       elif ! grep -q 'search.*cluster.local' ${NEW_RESOLV_CONF}; then
-        sed -i '/^search/ s/$/ cluster.local/' ${NEW_RESOLV_CONF}
+        sed -i 's/\<search\>/& cluster.local/' ${NEW_RESOLV_CONF}
       fi
       cp -Z ${NEW_RESOLV_CONF} /etc/resolv.conf
     fi


### PR DESCRIPTION
Making cluster local first domain will force to prefer it in search for service names. Current way can prove brutal in case your server domains redirects all dns queries to it's www page or other redirection takes place.