### PR TITLE
Fix the typos of openshift module

### DIFF
--- a/roles/lib_openshift/library/oc_image.py
+++ b/roles/lib_openshift/library/oc_image.py
@@ -55,15 +55,15 @@ from ansible.module_utils.basic import AnsibleModule
 DOCUMENTATION = '''
 ---
 module: oc_image
-short_description: Create, modify, and idempotently manage openshift labels.
+short_description: Create, modify, and idempotently manage openshift images.
 description:
-  - Modify openshift labels programmatically.
+  - Modify openshift images programmatically.
 options:
   state:
     description:
     - State controls the action that will be taken with resource
     - 'present' will create.  Does _not_ support update.
-    - 'list' will read the labels
+    - 'list' will read the images
     default: present
     choices: ["present", "list"]
     aliases: []

--- a/roles/lib_openshift/src/doc/image
+++ b/roles/lib_openshift/src/doc/image
@@ -4,15 +4,15 @@
 DOCUMENTATION = '''
 ---
 module: oc_image
-short_description: Create, modify, and idempotently manage openshift labels.
+short_description: Create, modify, and idempotently manage openshift images.
 description:
-  - Modify openshift labels programmatically.
+  - Modify openshift images programmatically.
 options:
   state:
     description:
     - State controls the action that will be taken with resource
     - 'present' will create.  Does _not_ support update.
-    - 'list' will read the labels
+    - 'list' will read the images
     default: present
     choices: ["present", "list"]
     aliases: []


### PR DESCRIPTION
Maybe the commets are copied from oc_label.py. 
But in oc_image.py, the usage term should be image