### PR TITLE
Ability to specify default tolerations via the buildconfig defaulter

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -899,6 +899,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_buildoverrides_image_labels=[{'name':'imagelabelname1','value':'imagelabelvalue1'}]
 #openshift_buildoverrides_nodeselectors={'nodelabel1':'nodelabelvalue1'}
 #openshift_buildoverrides_annotations={'annotationkey1':'annotationvalue1'}
+#openshift_buildoverrides_tolerations=[{'key':'mykey1','value':'myvalue1','effect':'NoSchedule','operator':'Equal'}]
 
 # Or you may optionally define your own build overrides configuration serialized as json
 #openshift_buildoverrides_json='{"BuildOverrides":{"configuration":{"apiVersion":"v1","kind":"BuildDefaultsConfig","forcePull":"true"}}}'

--- a/roles/openshift_buildoverrides/vars/main.yml
+++ b/roles/openshift_buildoverrides/vars/main.yml
@@ -9,3 +9,4 @@ buildoverrides_yaml:
       imageLabels: "{{ openshift_buildoverrides_image_labels | default(None) }}"
       nodeSelector: "{{ openshift_buildoverrides_nodeselectors | default(None) }}"
       annotations: "{{ openshift_buildoverrides_annotations | default(None) }}"
+      tolerations: "{{ openshift_buildoverrides_tolerations | default(None) }}"


### PR DESCRIPTION
Trello: https://trello.com/c/LNxlMjjU/1435-5-ability-to-specify-default-tolerations-via-the-buildconfig-defaulter-builds

Dependent on:
https://github.com/openshift/origin/pull/17955