### PR TITLE
[3.7] Add docker auth credentials to system container install

### DIFF
--- a/roles/openshift_node/templates/openshift.docker.node.dep.service
+++ b/roles/openshift_node/templates/openshift.docker.node.dep.service
@@ -6,6 +6,12 @@ Before={{ openshift.common.service_type }}-node.service
 {% if openshift_use_crio|default(false) %}Wants=cri-o.service{% endif %}
 
 [Service]
-ExecStart=/bin/bash -c "if [[ -f /usr/bin/docker-current ]]; then echo \"DOCKER_ADDTL_BIND_MOUNTS=--volume=/usr/bin/docker-current:/usr/bin/docker-current:ro --volume=/etc/sysconfig/docker:/etc/sysconfig/docker:ro --volume=/etc/containers/registries:/etc/containers/registries:ro\" > /etc/sysconfig/{{ openshift.common.service_type }}-node-dep; else echo \"#DOCKER_ADDTL_BIND_MOUNTS=\" > /etc/sysconfig/{{ openshift.common.service_type }}-node-dep; fi"
+ExecStart=/bin/bash -c 'if [[ -f /usr/bin/docker-current ]]; \
+ then echo DOCKER_ADDTL_BIND_MOUNTS=\"--volume=/usr/bin/docker-current:/usr/bin/docker-current:ro \
+ --volume=/etc/sysconfig/docker:/etc/sysconfig/docker:ro \
+ --volume=/etc/containers/registries:/etc/containers/registries:ro \
+ {% if l_bind_docker_reg_auth %} --volume={{ oreg_auth_credentials_path }}:/root/.docker:ro{% endif %}\" > \
+ /etc/sysconfig/{{ openshift.common.service_type }}-node-dep; \
+ else echo "#DOCKER_ADDTL_BIND_MOUNTS=" > /etc/sysconfig/{{ openshift.common.service_type }}-node-dep; fi'
 ExecStop=
 SyslogIdentifier={{ openshift.common.service_type }}-node-dep


### PR DESCRIPTION
This commit adds docker auth credentials mount to
system container systemd unit file.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1514324