### PR TITLE
Correct kublet_args cloud-provider directories

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -34,19 +34,19 @@ openshift_node_kubelet_args_dict:
     cloud-provider:
     - aws
     cloud-config:
-    - "{{ openshift_config_base ~ '/aws.conf' }}"
+    - "{{ openshift_config_base ~ '/cloudprovider/aws.conf' }}"
     node-labels: "{{ l_node_kubelet_node_labels }}"
   openstack:
     cloud-provider:
     - openstack
     cloud-config:
-    - "{{ openshift_config_base ~ '/openstack.conf' }}"
+    - "{{ openshift_config_base ~ '/cloudprovider/openstack.conf' }}"
     node-labels: "{{ l_node_kubelet_node_labels }}"
   gce:
     cloud-provider:
     - gce
     cloud-config:
-    - "{{ openshift_config_base ~ '/gce.conf' }}"
+    - "{{ openshift_config_base ~ '/cloudprovider/gce.conf' }}"
     node-labels: "{{ l_node_kubelet_node_labels }}"
   undefined:
     node-labels: "{{ l_node_kubelet_node_labels }}"


### PR DESCRIPTION
This commit updates kublet_args to correct
cloudprovider configuration file locaitons.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1527203