### PR TITLE
Adjusting the default PVC size of MUX file buffer to the default MUX file buffer size

### DIFF
--- a/roles/openshift_logging_mux/defaults/main.yml
+++ b/roles/openshift_logging_mux/defaults/main.yml
@@ -56,7 +56,7 @@ openshift_logging_mux_file_buffer_storage_type: "emptydir"
 openshift_logging_mux_file_buffer_pvc_name: "logging-mux-pvc"
 
 # required if the PVC does not already exist
-openshift_logging_mux_file_buffer_pvc_size: 1Gi
+openshift_logging_mux_file_buffer_pvc_size: 2Gi
 openshift_logging_mux_file_buffer_pvc_dynamic: false
 openshift_logging_mux_file_buffer_pvc_pv_selector: {}
 openshift_logging_mux_file_buffer_pvc_access_modes: ['ReadWriteOnce']


### PR DESCRIPTION

Adjusting the default PVC size of MUX file buffer (openshift_logging_mux_file_buffer_pvc_size) to the default MUX file buffer size (openshift_logging_mux_file_buffer_limit == 2Gi).