### PR TITLE
Fix docker_image_availability checks

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/__init__.py
+++ b/roles/openshift_health_checker/openshift_checks/__init__.py
@@ -95,6 +95,13 @@ class OpenShiftCheck(object):
         # These are intended to be a sequential record of what the check observed and determined.
         self.logs = []
 
+    def template_var(self, var_to_template):
+        """Return a templated variable if self._templar is not None, else
+           just return the variable as-is"""
+        if self._templar is not None:
+            return self._templar.template(var_to_template)
+        return var_to_template
+
     @abstractproperty
     def name(self):
         """The name of this check, usually derived from the class name."""


### PR DESCRIPTION
This commit ensures that oreg_url is properly templated
by ansible before being consumed in the logic.

This commit also adds a method to the base health check
class to detect if self._templar is none, and return
the appropriate templated/untemplated version of the
variable.  This is mostly for unit tests.