### PR TITLE
Revert #5148 - hosted registry cannot talk to API when proxy is set

### DIFF
--- a/roles/openshift_hosted/tasks/registry.yml
+++ b/roles/openshift_hosted/tasks/registry.yml
@@ -46,14 +46,6 @@
     openshift_hosted_registry_env_vars: "{{ openshift_hosted_registry_env_vars | combine({'OPENSHIFT_DEFAULT_REGISTRY':'docker-registry.default.svc:5000'}) }}"
   when: openshift_push_via_dns | bool
 
-- name: Update registry proxy settings for dc/docker-registry
-  set_fact:
-    openshift_hosted_registry_env_vars: "{{ {'HTTPS_PROXY': (openshift.common.https_proxy | default('')),
-                                             'HTTP_PROXY':  (openshift.common.http_proxy  | default('')),
-                                             'NO_PROXY':    (openshift.common.no_proxy    | default(''))}
-                                           | combine(openshift_hosted_registry_env_vars) }}"
-  when: (openshift.common.https_proxy | default(False)) or (openshift.common.http_proxy | default('')) != ''
-
 - name: Create the registry service account
   oc_serviceaccount:
     name: "{{ openshift_hosted_registry_serviceaccount }}"


### PR DESCRIPTION
When PROXY is set in `hosted` registry , the registry cannot talk to the kubernetes master API by IP address (since it isn't in no_proxy) returning a 503

From the logs:

```
192.168.104.1 - - [03/Jan/2018:19:56:00 +0000] "GET /openshift/token?account=serviceaccount&scope=repository%3Atest-http-dh%2Fhttpd-ex%3Apush%2Cpull HTTP/1.1" 401 0 "" "docker/1.12.6 go/go1.8.3 kernel/3.10.0-693.5.2.el7.x86_64 os/linux arch/amd64 UpstreamClient(go-dockerclient)"
time="2018-01-03T19:57:00.095021815Z" level=debug msg="invalid token: Get https://192.168.128.1:443/apis/user.openshift.io/v1/users/~: Service Unavailable" go.version=go1.8.3 http.request.host="docker-registry.default.svc:5000" http.request.id=2049fd4b-742f-4001-ab8a-a92173258c17 http.request.method=GET http.request.remoteaddr="192.168.104.1:41522" http.request.uri="/openshift/token?account=serviceaccount&scope=repository%3Atest-http-dh%2Fhttpd-ex%3Apush%2Cpull" http.request.useragent="docker/1.12.6 go/go1.8.3 kernel/3.10.0-693.5.2.el7.x86_64 os/linux arch/amd64 UpstreamClient(go-dockerclient)" instance.id=24f814aa-ba9e-405c-9db4-94481942b04b openshift.logger=registry
```

Or directly from the pod:
```
sh-4.2$ curl https://192.168.128.1:443/apis/user.openshift.io/v1/users/~
curl: (56) Received HTTP code 503 from proxy after CONNECT
```

Removing these environment variables from the hosted registry DC immediately resolves connectivity to the masters/API and pushes succeed.

I am not certain under what circumstances the hosted-registry needs outbound connectivity.. if it does then likely the only way to fix this and enable that outbound access would be to dynamically add the IPs of the masters to the no_proxy (since ranges are not supported) or to hit the masters by an dns name and not via the IP
 
**Bugzilla Reference**: https://bugzilla.redhat.com/show_bug.cgi?id=1544073