### PR TITLE
Migrate to static:true for include_role

### DIFF
--- a/playbooks/adhoc/openshift_hosted_logging_efk.yaml
+++ b/playbooks/adhoc/openshift_hosted_logging_efk.yaml
@@ -13,4 +13,5 @@
   - include_role:
       name: openshift_logging
       tasks_from: update_master_config
+    static: true
     when: openshift_hosted_logging_deploy | default(false) | bool

--- a/playbooks/aws/openshift-cluster/install.yml
+++ b/playbooks/aws/openshift-cluster/install.yml
@@ -5,6 +5,7 @@
   - include_role:
       name: openshift_aws
       tasks_from: setup_master_group.yml
+    static: true
 
 - name: set the master facts for hostname to elb
   hosts: masters
@@ -14,6 +15,7 @@
   - include_role:
       name: openshift_aws
       tasks_from: master_facts.yml
+    static: true
 
 - name: run the init
   import_playbook: ../../init/main.yml

--- a/playbooks/aws/openshift-cluster/provision.yml
+++ b/playbooks/aws/openshift-cluster/provision.yml
@@ -15,3 +15,4 @@
     include_role:
       name: openshift_aws
       tasks_from: provision.yml
+    static: true

--- a/playbooks/aws/openshift-cluster/provision_instance.yml
+++ b/playbooks/aws/openshift-cluster/provision_instance.yml
@@ -10,3 +10,4 @@
     include_role:
       name: openshift_aws
       tasks_from: provision_instance.yml
+    static: true

--- a/playbooks/aws/openshift-cluster/provision_nodes.yml
+++ b/playbooks/aws/openshift-cluster/provision_nodes.yml
@@ -16,3 +16,4 @@
     include_role:
       name: openshift_aws
       tasks_from: provision_nodes.yml
+    static: true

--- a/playbooks/aws/openshift-cluster/provision_sec_group.yml
+++ b/playbooks/aws/openshift-cluster/provision_sec_group.yml
@@ -10,4 +10,5 @@
     include_role:
       name: openshift_aws
       tasks_from: security_group.yml
+    static: true
     when: openshift_aws_create_security_groups | default(True) | bool

--- a/playbooks/aws/openshift-cluster/provision_ssh_keypair.yml
+++ b/playbooks/aws/openshift-cluster/provision_ssh_keypair.yml
@@ -7,6 +7,7 @@
     include_role:
       name: openshift_aws
       tasks_from: ssh_keys.yml
+    static: true
     vars:
       openshift_aws_node_group_type: compute
     when: openshift_aws_users | default([]) | length  > 0

--- a/playbooks/aws/openshift-cluster/provision_vpc.yml
+++ b/playbooks/aws/openshift-cluster/provision_vpc.yml
@@ -7,4 +7,5 @@
     include_role:
       name: openshift_aws
       tasks_from: vpc.yml
+    static: true
     when: openshift_aws_create_vpc | default(True) | bool

--- a/playbooks/aws/openshift-cluster/seal_ami.yml
+++ b/playbooks/aws/openshift-cluster/seal_ami.yml
@@ -10,3 +10,4 @@
     include_role:
       name: openshift_aws
       tasks_from: seal_ami.yml
+    static: true

--- a/playbooks/common/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -19,6 +19,7 @@
   - include_role:
       name: container_runtime
       tasks_from: docker_upgrade_check.yml
+    static: true
     when: docker_upgrade is not defined or docker_upgrade | bool
 
 

--- a/playbooks/common/openshift-cluster/upgrades/pre/config.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/config.yml
@@ -75,3 +75,4 @@
   - include_role:
       name: container_runtime
       tasks_from: docker_upgrade_check.yml
+    static: true

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -8,6 +8,7 @@
   include_role:
     name: container_runtime
     tasks_from: registry_auth.yml
+  static: true
   when: oreg_auth_user is defined
 
 - name: Verify containers are available for upgrade

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -52,6 +52,7 @@
   tasks:
   - include_role:
       name: openshift_facts
+    static: true
 
   # Run the pre-upgrade hook if defined:
   - debug: msg="Running master pre-upgrade hook {{ openshift_master_upgrade_pre_hook }}"
@@ -63,6 +64,7 @@
   - include_role:
       name: openshift_master
       tasks_from: upgrade.yml
+    static: true
 
   # Run the upgrade hook prior to restarting services/system if defined:
   - debug: msg="Running master upgrade hook {{ openshift_master_upgrade_hook }}"
@@ -304,6 +306,7 @@
   - include_role:
       name: openshift_node
       tasks_from: upgrade.yml
+    static: true
     vars:
       openshift_node_upgrade_in_progress: True
   - name: Set node schedulability

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -7,6 +7,7 @@
   - include_role:
       name: openshift_node
       tasks_from: upgrade_pre.yml
+    static: true
     vars:
       openshift_node_upgrade_in_progress: True
 
@@ -46,6 +47,7 @@
   - include_role:
       name: openshift_node
       tasks_from: upgrade.yml
+    static: true
     vars:
       openshift_node_upgrade_in_progress: True
   - name: Set node schedulability
@@ -64,5 +66,6 @@
   tasks:
   - include_role:
       name: openshift_excluder
+    static: true
     vars:
       r_openshift_excluder_action: enable

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_scale_group.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_scale_group.yml
@@ -6,6 +6,7 @@
     include_role:
       name: openshift_aws
       tasks_from: upgrade_node_group.yml
+    static: true
 
   - fail:
       msg: "Ensure that new scale groups were provisioned before proceeding to update."
@@ -64,3 +65,4 @@
     include_role:
       name: openshift_aws
       tasks_from: remove_scale_group.yml
+    static: true

--- a/playbooks/container-runtime/private/config.yml
+++ b/playbooks/container-runtime/private/config.yml
@@ -11,18 +11,21 @@
     - include_role:
         name: container_runtime
         tasks_from: package_docker.yml
+      static: true
       when:
         - not openshift_docker_use_system_container | bool
         - not openshift_use_crio_only | bool
     - include_role:
         name: container_runtime
         tasks_from: systemcontainer_docker.yml
+      static: true
       when:
         - openshift_docker_use_system_container | bool
         - not openshift_use_crio_only | bool
     - include_role:
         name: container_runtime
         tasks_from: systemcontainer_crio.yml
+      static: true
       when:
         - openshift_use_crio | bool
         - openshift_docker_is_node_or_master | bool

--- a/playbooks/container-runtime/private/setup_storage.yml
+++ b/playbooks/container-runtime/private/setup_storage.yml
@@ -11,6 +11,7 @@
     - include_role:
         name: container_runtime
         tasks_from: docker_storage_setup_overlay.yml
+      static: true
       when:
         - container_runtime_docker_storage_type|default('') == "overlay2"
         - openshift_docker_is_node_or_master | bool

--- a/playbooks/gcp/provision.yml
+++ b/playbooks/gcp/provision.yml
@@ -8,6 +8,7 @@
   - name: provision a GCP cluster in the specified project
     include_role:
       name: openshift_gcp
+    static: true
 
 - name: run the cluster deploy
   import_playbook: ../deploy_cluster.yml

--- a/playbooks/init/facts.yml
+++ b/playbooks/init/facts.yml
@@ -15,6 +15,7 @@
   - name: Run openshift_sanitize_inventory to set variables
     include_role:
       name: openshift_sanitize_inventory
+    static: true
 
   - name: Detecting Operating System from ostree_booted
     stat:

--- a/playbooks/init/repos.yml
+++ b/playbooks/init/repos.yml
@@ -6,6 +6,7 @@
   - name: subscribe instances to Red Hat Subscription Manager
     include_role:
       name: rhel_subscribe
+    static: true
     when:
     - ansible_distribution == 'RedHat'
     - openshift_deployment_type == 'openshift-enterprise'
@@ -14,3 +15,4 @@
   - name: initialize openshift repos
     include_role:
       name: openshift_repos
+    static: true

--- a/playbooks/openshift-etcd/private/ca.yml
+++ b/playbooks/openshift-etcd/private/ca.yml
@@ -8,6 +8,7 @@
   - include_role:
       name: etcd
       tasks_from: ca.yml
+    static: true
     vars:
       etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"
       etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"

--- a/playbooks/openshift-etcd/private/certificates-backup.yml
+++ b/playbooks/openshift-etcd/private/certificates-backup.yml
@@ -6,9 +6,11 @@
   - include_role:
       name: etcd
       tasks_from: backup_generated_certificates.yml
+    static: true
   - include_role:
       name: etcd
       tasks_from: remove_generated_certificates.yml
+    static: true
 
 - name: Backup deployed etcd certificates
   hosts: oo_etcd_to_config
@@ -17,3 +19,4 @@
   - include_role:
       name: etcd
       tasks_from: backup_server_certificates.yml
+    static: true

--- a/playbooks/openshift-etcd/private/embedded2external.yml
+++ b/playbooks/openshift-etcd/private/embedded2external.yml
@@ -21,6 +21,7 @@
     include_role:
       name: openshift_master
       tasks_from: check_master_api_is_ready.yml
+    static: true
   - set_fact:
       master_service: "{{ openshift_service_type + '-master' }}"
       embedded_etcd_backup_suffix: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
@@ -35,6 +36,7 @@
   - include_role:
       name: etcd
       tasks_from: backup.yml
+    static: true
     vars:
       r_etcd_common_backup_tag: pre-migrate
       r_etcd_common_embedded_etcd: "{{ true }}"
@@ -43,6 +45,7 @@
   - include_role:
       name: etcd
       tasks_from: backup.archive.yml
+    static: true
     vars:
       r_etcd_common_backup_tag: pre-migrate
       r_etcd_common_embedded_etcd: "{{ true }}"
@@ -59,6 +62,7 @@
   - include_role:
       name: etcd
       tasks_from: backup_master_etcd_certificates.yml
+    static: true
 
 - name: Redeploy master etcd certificates
   import_playbook: master_etcd_certificates.yml
@@ -76,9 +80,11 @@
   - include_role:
       name: etcd
       tasks_from: disable_etcd.yml
+    static: true
   - include_role:
       name: etcd
       tasks_from: clean_data.yml
+    static: true
 
 # 6. copy the embedded etcd backup to the external host
 # TODO(jchaloup): if the etcd and first master are on the same host, just copy the directory
@@ -94,6 +100,7 @@
   - include_role:
       name: etcd
       tasks_from: backup.fetch.yml
+    static: true
     vars:
       etcd_backup_sync_directory: "{{ g_etcd_client_mktemp.stdout }}"
       r_etcd_common_backup_tag: pre-migrate
@@ -104,6 +111,7 @@
   - include_role:
       name: etcd
       tasks_from: backup.copy.yml
+    static: true
     vars:
       etcd_backup_sync_directory: "{{ g_etcd_client_mktemp.stdout }}"
       r_etcd_common_backup_tag: pre-migrate
@@ -125,6 +133,7 @@
   - include_role:
       name: etcd
       tasks_from: backup.unarchive.yml
+    static: true
     vars:
       r_etcd_common_backup_tag: pre-migrate
       r_etcd_common_backup_sufix_name: "{{ hostvars[groups.oo_first_master.0].embedded_etcd_backup_suffix }}"
@@ -132,6 +141,7 @@
   - include_role:
       name: etcd
       tasks_from: backup.force_new_cluster.yml
+    static: true
     vars:
       r_etcd_common_backup_tag: pre-migrate
       r_etcd_common_backup_sufix_name: "{{ hostvars[groups.oo_first_master.0].embedded_etcd_backup_suffix }}"
@@ -146,6 +156,7 @@
   - include_role:
       name: openshift_master
       tasks_from: configure_external_etcd.yml
+    static: true
     vars:
       etcd_peer_url_scheme: "https"
       etcd_ip: "{{ hostvars[groups.oo_etcd_to_config.0].openshift.common.ip }}"

--- a/playbooks/openshift-etcd/private/migrate.yml
+++ b/playbooks/openshift-etcd/private/migrate.yml
@@ -18,6 +18,7 @@
   - include_role:
       name: etcd
       tasks_from: migrate.pre_check.yml
+    static: true
     vars:
       etcd_peer: "{{ ansible_default_ipv4.address }}"
 
@@ -46,6 +47,7 @@
   - include_role:
       name: etcd
       tasks_from: backup.yml
+    static: true
     vars:
       r_etcd_common_backup_tag: pre-migration
       r_etcd_common_backup_sufix_name: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
@@ -73,6 +75,7 @@
   - include_role:
       name: etcd
       tasks_from: disable_etcd.yml
+    static: true
 
 - name: Migrate data on first etcd
   hosts: oo_etcd_to_migrate[0]
@@ -81,6 +84,7 @@
   - include_role:
       name: etcd
       tasks_from: migrate.yml
+    static: true
     vars:
       etcd_peer: "{{ openshift.common.ip }}"
       etcd_url_scheme: "https"
@@ -93,6 +97,7 @@
   - include_role:
       name: etcd
       tasks_from: clean_data.yml
+    static: true
     vars:
       etcd_peer: "{{ openshift.common.ip }}"
       etcd_url_scheme: "https"
@@ -129,6 +134,7 @@
   - include_role:
       name: etcd
       tasks_from: migrate.add_ttls.yml
+    static: true
     vars:
       etcd_peer: "{{ hostvars[groups.oo_etcd_to_migrate.0].openshift.common.ip }}"
       etcd_url_scheme: "https"
@@ -141,6 +147,7 @@
   - include_role:
       name: etcd
       tasks_from: migrate.configure_master.yml
+    static: true
     when: etcd_migration_failed | length == 0
   - debug:
       msg: "Skipping master re-configuration since migration failed."

--- a/playbooks/openshift-etcd/private/redeploy-ca.yml
+++ b/playbooks/openshift-etcd/private/redeploy-ca.yml
@@ -17,9 +17,11 @@
   - include_role:
       name: etcd
       tasks_from: backup_ca_certificates.yml
+    static: true
   - include_role:
       name: etcd
       tasks_from: remove_ca_certificates.yml
+    static: true
 
 - import_playbook: ca.yml
 
@@ -40,6 +42,7 @@
   - include_role:
       name: etcd
       tasks_from: distribute_ca.yml
+    static: true
     vars:
       etcd_sync_cert_dir: "{{ hostvars['localhost'].g_etcd_mktemp.stdout }}"
       etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
@@ -57,6 +60,7 @@
   - include_role:
       name: etcd
       tasks_from: retrieve_ca_certificates.yml
+    static: true
     vars:
       etcd_sync_cert_dir: "{{ hostvars['localhost'].g_etcd_mktemp.stdout }}"
 

--- a/playbooks/openshift-etcd/private/restart.yml
+++ b/playbooks/openshift-etcd/private/restart.yml
@@ -6,6 +6,7 @@
     - include_role:
         name: etcd
         tasks_from: restart.yml
+      static: true
       when:
         - not g_etcd_certificates_expired | default(false) | bool
 
@@ -15,5 +16,6 @@
     - include_role:
         name: etcd
         tasks_from: restart.yml
+      static: true
       when:
         - g_etcd_certificates_expired | default(false) | bool

--- a/playbooks/openshift-etcd/private/scaleup.yml
+++ b/playbooks/openshift-etcd/private/scaleup.yml
@@ -33,6 +33,7 @@
   - include_role:
       name: etcd
       tasks_from: server_certificates.yml
+    static: true
     vars:
       etcd_peers: "{{ groups.oo_new_etcd_to_config | default([], true) }}"
       etcd_certificates_etcd_hosts: "{{ groups.oo_new_etcd_to_config | default([], true) }}"
@@ -79,3 +80,4 @@
   - include_role:
       name: openshift_master
       tasks_from: update_etcd_client_urls.yml
+    static: true

--- a/playbooks/openshift-etcd/private/server_certificates.yml
+++ b/playbooks/openshift-etcd/private/server_certificates.yml
@@ -8,6 +8,7 @@
     - include_role:
         name: etcd
         tasks_from: server_certificates.yml
+      static: true
       vars:
         etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
         etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"

--- a/playbooks/openshift-etcd/private/upgrade_backup.yml
+++ b/playbooks/openshift-etcd/private/upgrade_backup.yml
@@ -7,6 +7,7 @@
   - include_role:
       name: etcd
       tasks_from: backup.yml
+    static: true
     vars:
       r_etcd_common_backup_tag: "{{ etcd_backup_tag }}"
       r_etcd_common_backup_sufix_name: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"

--- a/playbooks/openshift-etcd/private/upgrade_image_members.yml
+++ b/playbooks/openshift-etcd/private/upgrade_image_members.yml
@@ -9,6 +9,7 @@
   - include_role:
       name: etcd
       tasks_from: upgrade_image.yml
+    static: true
     vars:
       r_etcd_upgrade_version: "{{ etcd_upgrade_version }}"
       etcd_peer: "{{ openshift.common.hostname }}"

--- a/playbooks/openshift-etcd/private/upgrade_main.yml
+++ b/playbooks/openshift-etcd/private/upgrade_main.yml
@@ -17,6 +17,7 @@
   - include_role:
       name: etcd
       tasks_from: drop_etcdctl.yml
+    static: true
 
 - name: Perform etcd upgrade
   import_playbook: upgrade_step.yml

--- a/playbooks/openshift-etcd/private/upgrade_rpm_members.yml
+++ b/playbooks/openshift-etcd/private/upgrade_rpm_members.yml
@@ -9,6 +9,7 @@
   - include_role:
       name: etcd
       tasks_from: upgrade_rpm.yml
+    static: true
     vars:
       r_etcd_upgrade_version: "{{ etcd_upgrade_version }}"
       etcd_peer: "{{ openshift.common.hostname }}"

--- a/playbooks/openshift-etcd/private/upgrade_step.yml
+++ b/playbooks/openshift-etcd/private/upgrade_step.yml
@@ -5,6 +5,7 @@
   - include_role:
       name: etcd
       tasks_from: version_detect.yml
+    static: true
 
 - import_playbook: upgrade_rpm_members.yml
   vars:
@@ -57,6 +58,7 @@
   - include_role:
       name: etcd
       tasks_from: upgrade_image.yml
+    static: true
     vars:
       etcd_peer: "{{ openshift.common.hostname }}"
     when:

--- a/playbooks/openshift-glusterfs/private/config.yml
+++ b/playbooks/openshift-glusterfs/private/config.yml
@@ -17,11 +17,13 @@
   - include_role:
       name: openshift_storage_glusterfs
       tasks_from: firewall.yml
+    static: true
     when:
     - openshift_storage_glusterfs_is_native | default(True) | bool
   - include_role:
       name: openshift_storage_glusterfs
       tasks_from: kernel_modules.yml
+    static: true
     when:
     - openshift_storage_glusterfs_is_native | default(True) | bool
 
@@ -31,11 +33,13 @@
   - include_role:
       name: openshift_storage_glusterfs
       tasks_from: firewall.yml
+    static: true
     when:
     - openshift_storage_glusterfs_registry_is_native | default(True) | bool
   - include_role:
       name: openshift_storage_glusterfs
       tasks_from: kernel_modules.yml
+    static: true
     when:
     - openshift_storage_glusterfs_registry_is_native | default(True) | bool
 
@@ -45,6 +49,7 @@
   - name: setup glusterfs
     include_role:
       name: openshift_storage_glusterfs
+    static: true
     when: groups.oo_glusterfs_to_config | default([]) | count > 0
 
 - name: GlusterFS Install Checkpoint End

--- a/playbooks/openshift-hosted/private/openshift_hosted_create_projects.yml
+++ b/playbooks/openshift-hosted/private/openshift_hosted_create_projects.yml
@@ -5,3 +5,4 @@
   - include_role:
       name: openshift_hosted
       tasks_from: create_projects.yml
+    static: true

--- a/playbooks/openshift-hosted/private/openshift_hosted_registry.yml
+++ b/playbooks/openshift-hosted/private/openshift_hosted_registry.yml
@@ -8,6 +8,7 @@
   - include_role:
       name: openshift_hosted
       tasks_from: registry.yml
+    static: true
     when:
     - openshift_hosted_manage_registry | default(True) | bool
     - openshift_hosted_registry_registryurl is defined

--- a/playbooks/openshift-hosted/private/openshift_hosted_registry_storage.yml
+++ b/playbooks/openshift-hosted/private/openshift_hosted_registry_storage.yml
@@ -8,6 +8,7 @@
   - include_role:
       name: openshift_hosted
       tasks_from: registry_storage.yml
+    static: true
     when:
     - openshift_hosted_manage_registry | default(True) | bool
     - openshift_hosted_registry_registryurl is defined

--- a/playbooks/openshift-hosted/private/openshift_hosted_router.yml
+++ b/playbooks/openshift-hosted/private/openshift_hosted_router.yml
@@ -8,6 +8,7 @@
   - include_role:
       name: openshift_hosted
       tasks_from: router.yml
+    static: true
     when:
     - openshift_hosted_manage_router | default(True) | bool
     - openshift_hosted_router_registryurl is defined

--- a/playbooks/openshift-hosted/private/openshift_hosted_wait_for_pods.yml
+++ b/playbooks/openshift-hosted/private/openshift_hosted_wait_for_pods.yml
@@ -8,6 +8,7 @@
   - include_role:
       name: openshift_hosted
       tasks_from: wait_for_pod.yml
+    static: true
     vars:
       l_openshift_hosted_wait_for_pod: "{{ openshift_hosted_router_wait }}"
       l_openshift_hosted_wfp_items: "{{ openshift_hosted_routers }}"
@@ -18,6 +19,7 @@
   - include_role:
       name: openshift_hosted
       tasks_from: wait_for_pod.yml
+    static: true
     vars:
       l_openshift_hosted_wait_for_pod: "{{ openshift_hosted_registry_wait }}"
       l_openshift_hosted_wfp_items: "{{ r_openshift_hosted_registry_list }}"

--- a/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
@@ -118,6 +118,7 @@
   - include_role:
       name: openshift_hosted
       tasks_from: main
+    static: true
     vars:
       openshift_hosted_manage_registry: false
     when:

--- a/playbooks/openshift-logging/private/config.yml
+++ b/playbooks/openshift-logging/private/config.yml
@@ -23,6 +23,7 @@
     - include_role:
         name: openshift_logging
         tasks_from: update_master_config
+      static: true
 
 - name: Logging Install Checkpoint End
   hosts: all

--- a/playbooks/openshift-management/add_many_container_providers.yml
+++ b/playbooks/openshift-management/add_many_container_providers.yml
@@ -30,6 +30,7 @@
   - include_role:
       name: openshift_management
       tasks_from: noop
+    static: true
 
   - name: print each result
     debug:

--- a/playbooks/openshift-management/private/add_container_provider.yml
+++ b/playbooks/openshift-management/private/add_container_provider.yml
@@ -6,3 +6,4 @@
     include_role:
       name: openshift_management
       tasks_from: add_container_provider
+    static: true

--- a/playbooks/openshift-management/private/config.yml
+++ b/playbooks/openshift-management/private/config.yml
@@ -23,6 +23,7 @@
   - name: Run the CFME Setup Role
     include_role:
       name: openshift_management
+    static: true
     vars:
       template_dir: "{{ hostvars[groups.masters.0].r_openshift_management_mktemp.stdout }}"
 

--- a/playbooks/openshift-management/private/uninstall.yml
+++ b/playbooks/openshift-management/private/uninstall.yml
@@ -6,3 +6,4 @@
     include_role:
       name: openshift_management
       tasks_from: uninstall
+    static: true

--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -209,11 +209,13 @@
   - include_role:
       name: kuryr
       tasks_from: master
+    static: true
     when: openshift_use_kuryr | default(false) | bool
 
   - name: Setup the node group config maps
     include_role:
       name: openshift_node_group
+    static: true
     when: openshift_master_bootstrap_enabled | default(false) | bool
     run_once: True
 

--- a/playbooks/openshift-master/private/tasks/restart_services.yml
+++ b/playbooks/openshift-master/private/tasks/restart_services.yml
@@ -2,3 +2,4 @@
 - include_role:
     name: openshift_master
     tasks_from: restart.yml
+  static: true

--- a/playbooks/openshift-metrics/private/config.yml
+++ b/playbooks/openshift-metrics/private/config.yml
@@ -24,6 +24,7 @@
     include_role:
       name: openshift_metrics
       tasks_from: update_master_config.yaml
+    static: true
 
 - name: Metrics Install Checkpoint End
   hosts: all

--- a/playbooks/openshift-node/private/additional_config.yml
+++ b/playbooks/openshift-node/private/additional_config.yml
@@ -60,4 +60,5 @@
   - include_role:
       name: kuryr
       tasks_from: node
+    static: true
     when: openshift_use_kuryr | default(false) | bool

--- a/playbooks/openshift-node/private/image_prep.yml
+++ b/playbooks/openshift-node/private/image_prep.yml
@@ -18,6 +18,7 @@
     - include_role:
         name: openshift_node
         tasks_from: bootstrap.yml
+      static: true
 
 - name: Re-enable excluders
   import_playbook: enable_excluders.yml

--- a/playbooks/openstack/openshift-cluster/prerequisites.yml
+++ b/playbooks/openstack/openshift-cluster/prerequisites.yml
@@ -5,8 +5,10 @@
     include_role:
       name: openshift_openstack
       tasks_from: check-prerequisites.yml
+    static: true
 
   - name: Check network configuration
     include_role:
       name: openshift_openstack
       tasks_from: net_vars_check.yaml
+    static: true

--- a/playbooks/openstack/openshift-cluster/provision.yml
+++ b/playbooks/openstack/openshift-cluster/provision.yml
@@ -6,6 +6,7 @@
     include_role:
       name: openshift_openstack
       tasks_from: provision.yml
+    static: true
 
 
 # NOTE(shadower): Bring in the host groups:
@@ -39,6 +40,7 @@
     include_role:
       name: openshift_openstack
       tasks_from: populate-dns.yml
+    static: true
     when:
     - openshift_openstack_external_nsupdate_keys is defined
     - openshift_openstack_external_nsupdate_keys.private is defined or openshift_openstack_external_nsupdate_keys.public is defined
@@ -51,6 +53,7 @@
   - name: Subscribe RHEL instances
     include_role:
       name: rhel_subscribe
+    static: true
     when:
     - ansible_distribution == "RedHat"
     - rhsub_user is defined
@@ -59,6 +62,7 @@
   - name: Enable required YUM repositories
     include_role:
       name: openshift_repos
+    static: true
     when:
     - ansible_distribution == "RedHat"
     - rh_subscribed is defined
@@ -67,8 +71,10 @@
     include_role:
       name: openshift_openstack
       tasks_from: node-packages.yml
+    static: true
 
   - name: Configure Node
     include_role:
       name: openshift_openstack
       tasks_from: node-configuration.yml
+    static: true

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -10,6 +10,7 @@
   include_role:
     name: etcd
     tasks_from: client_certificates
+  static: true
   when: calico_etcd_ca_cert_file is not defined or calico_etcd_cert_file is not defined or calico_etcd_key_file is not defined or calico_etcd_endpoints is not defined or calico_etcd_cert_dir is not defined
   vars:
     etcd_cert_prefix: calico.etcd-

--- a/roles/openshift_etcd_client_certificates/tasks/main.yml
+++ b/roles/openshift_etcd_client_certificates/tasks/main.yml
@@ -2,3 +2,4 @@
 - include_role:
     name: etcd
     tasks_from: client_certificates
+  static: true

--- a/roles/openshift_logging/tasks/delete_logging.yaml
+++ b/roles/openshift_logging/tasks/delete_logging.yaml
@@ -128,5 +128,6 @@
 ## EventRouter
 - include_role:
     name: openshift_logging_eventrouter
+  static: true
   when:
     not openshift_logging_install_eventrouter | default(false) | bool

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -77,6 +77,7 @@
 # We don't allow scaling down of ES nodes currently
 - include_role:
     name: openshift_logging_elasticsearch
+  static: true
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
@@ -105,6 +106,7 @@
 # Create any new DC that may be required
 - include_role:
     name: openshift_logging_elasticsearch
+  static: true
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
@@ -139,6 +141,7 @@
 
 - include_role:
     name: openshift_logging_elasticsearch
+  static: true
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
@@ -182,6 +185,7 @@
 # Create any new DC that may be required
 - include_role:
     name: openshift_logging_elasticsearch
+  static: true
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
@@ -215,6 +219,7 @@
 ## Kibana
 - include_role:
     name: openshift_logging_kibana
+  static: true
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_kibana_namespace: "{{ openshift_logging_namespace }}"
@@ -228,6 +233,7 @@
 
 - include_role:
     name: openshift_logging_kibana
+  static: true
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_kibana_ops_deployment: true
@@ -258,6 +264,7 @@
 ## Curator
 - include_role:
     name: openshift_logging_curator
+  static: true
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_curator_namespace: "{{ openshift_logging_namespace }}"
@@ -268,6 +275,7 @@
 
 - include_role:
     name: openshift_logging_curator
+  static: true
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_curator_ops_deployment: true
@@ -286,6 +294,7 @@
 ## Mux
 - include_role:
     name: openshift_logging_mux
+  static: true
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_mux_ops_host: "{{ ( openshift_logging_use_ops | bool ) | ternary('logging-es-ops', 'logging-es') }}"
@@ -299,6 +308,7 @@
 ## Fluentd
 - include_role:
     name: openshift_logging_fluentd
+  static: true
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
     openshift_logging_fluentd_ops_host: "{{ ( openshift_logging_use_ops | bool ) | ternary('logging-es-ops', 'logging-es') }}"
@@ -310,6 +320,7 @@
 ## EventRouter
 - include_role:
     name: openshift_logging_eventrouter
+  static: true
   when:
     openshift_logging_install_eventrouter | default(false) | bool
 

--- a/roles/openshift_logging_curator/tasks/main.yaml
+++ b/roles/openshift_logging_curator/tasks/main.yaml
@@ -59,6 +59,7 @@
 - include_role:
     name: openshift_logging
     tasks_from: patch_configmap_files.yaml
+  static: true
   vars:
     configmap_name: "logging-curator"
     configmap_namespace: "logging"

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -184,6 +184,7 @@
 - include_role:
     name: openshift_logging
     tasks_from: patch_configmap_files.yaml
+  static: true
   vars:
     configmap_name: "logging-elasticsearch"
     configmap_namespace: "logging"

--- a/roles/openshift_logging_fluentd/tasks/main.yaml
+++ b/roles/openshift_logging_fluentd/tasks/main.yaml
@@ -120,6 +120,7 @@
 - include_role:
     name: openshift_logging
     tasks_from: patch_configmap_files.yaml
+  static: true
   vars:
     configmap_name: "logging-fluentd"
     configmap_namespace: "logging"

--- a/roles/openshift_logging_mux/tasks/main.yaml
+++ b/roles/openshift_logging_mux/tasks/main.yaml
@@ -98,6 +98,7 @@
 - include_role:
     name: openshift_logging
     tasks_from: patch_configmap_files.yaml
+  static: true
   vars:
     configmap_name: "logging-mux"
     configmap_namespace: "{{ openshift_logging_mux_namespace }}"

--- a/roles/openshift_management/tasks/add_container_provider.yml
+++ b/roles/openshift_management/tasks/add_container_provider.yml
@@ -2,6 +2,7 @@
 - name: Ensure OpenShift facts module is available
   include_role:
     role: openshift_facts
+  static: true
 
 - name: Ensure OpenShift facts are loaded
   openshift_facts:

--- a/roles/openshift_management/tasks/main.yml
+++ b/roles/openshift_management/tasks/main.yml
@@ -10,6 +10,7 @@
 - name: Enable Container Provider Integration
   include_role:
     role: openshift_manageiq
+  static: true
 
 - name: "Ensure the Management '{{ openshift_management_project }}' namespace exists"
   oc_project:

--- a/roles/openshift_management/tasks/storage/nfs.yml
+++ b/roles/openshift_management/tasks/storage/nfs.yml
@@ -8,6 +8,7 @@
       include_role:
         role: openshift_nfs
         tasks_from: setup
+      static: true
       vars:
         l_nfs_base_dir: "{{ openshift_management_storage_nfs_base_dir }}"
 
@@ -15,6 +16,7 @@
       include_role:
         role: openshift_nfs
         tasks_from: create_export
+      static: true
       vars:
         l_nfs_base_dir: "{{ openshift_management_storage_nfs_base_dir }}"
         l_nfs_export_config: "{{ openshift_management_flavor_short }}"
@@ -25,6 +27,7 @@
       include_role:
         role: openshift_nfs
         tasks_from: create_export
+      static: true
       vars:
         l_nfs_base_dir: "{{ openshift_management_storage_nfs_base_dir }}"
         l_nfs_export_config: "{{ openshift_management_flavor_short }}"


### PR DESCRIPTION
In Ansible 2.2, the `include_role` directive came into existence as
a Tech Preview. It is still a Tech Preview through Ansible 2.4
(and in current devel branch), but with a noteable change. The
default behavior switched from `static: true` to `static: false`
because that functionality moved to the newly introduced
`import_role` directive (in order to stay consistent with `include*`
being dynamic in nature and `import* being static in nature).

The dynamic include is considerably more memory intensive as it will
dynamically create a role import for every host in the inventory
list to be used. (Also worth noting, there is at the time of this
writing an object allocation inefficiency in the dynamic include
that can in certain situations amplify this effect considerably)

This change is meant to mitigate the pressure on memory for the
Ansible control host while maintaining compatibility with Ansible
2.3 and Ansible 2.4. (Eventually this should be migrated to use
`import_role` everywhere, but that directive is not present in
Ansible 2.3)

Signed-off-by: Adam Miller <admiller@redhat.com>