### PR TITLE
un-hardcode default subnet az

### DIFF
--- a/playbooks/aws/provisioning_vars.yml.example
+++ b/playbooks/aws/provisioning_vars.yml.example
@@ -41,11 +41,27 @@ openshift_pkg_version: # -3.7.0
 # a vpc, set this to false.
 #openshift_aws_create_vpc: true
 
+# when openshift_aws_create_vpc is true (the default), the VPC defined in
+# openshift_aws_vpc will be created
+#openshift_aws_vpc:
+#  name: "{{ openshift_aws_vpc_name }}"
+#  cidr: 172.31.0.0/16
+#  subnets:
+#    us-east-1:
+#    - cidr: 172.31.48.0/20
+#      az: "us-east-1c"
+#      default_az: true
+#    - cidr: 172.31.32.0/20
+#      az: "us-east-1e"
+#    - cidr: 172.31.16.0/20
+#      az: "us-east-1a"
+
 # Name of the vpc.  Needs to be set if using a pre-existing vpc.
 #openshift_aws_vpc_name: "{{ openshift_aws_clusterid }}"
 
 # Name of the subnet in the vpc to use.  Needs to be set if using a pre-existing
-# vpc + subnet.
+# vpc + subnet. Otherwise will use the subnet with 'default_az' set (see above
+# example VPC structure)
 #openshift_aws_subnet_az:
 
 # -------------- #

--- a/roles/lib_utils/filter_plugins/openshift_aws_filters.py
+++ b/roles/lib_utils/filter_plugins/openshift_aws_filters.py
@@ -67,8 +67,24 @@ class FilterModule(object):
 
         return tags
 
+    @staticmethod
+    def get_default_az(subnets):
+        ''' From a list of subnets/AZs in a specific region (from the VPC
+            structure), return the AZ that has the key/value
+            'default_az=True.' '''
+
+        for subnet in subnets:
+            if subnet.get('default_az'):
+                return subnet['az']
+
+        # if there was none marked with default_az=True, just return the first
+        # one. (this does mean we could possible return an item that has
+        # default_az=False set
+        return subnets[0]['az']
+
     def filters(self):
         ''' returns a mapping of filters to methods '''
         return {'build_instance_tags': self.build_instance_tags,
+                'get_default_az': self.get_default_az,
                 'scale_groups_match_capacity': self.scale_groups_match_capacity,
                 'scale_groups_serial': self.scale_groups_serial}

--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -274,8 +274,6 @@ openshift_aws_node_security_groups:
 openshift_aws_vpc_tags:
   Name: "{{ openshift_aws_vpc_name }}"
 
-openshift_aws_subnet_az: us-east-1c
-
 openshift_aws_vpc:
   name: "{{ openshift_aws_vpc_name }}"
   cidr: 172.31.0.0/16
@@ -283,10 +281,13 @@ openshift_aws_vpc:
     us-east-1:
     - cidr: 172.31.48.0/20
       az: "us-east-1c"
+      default_az: true
     - cidr: 172.31.32.0/20
       az: "us-east-1e"
     - cidr: 172.31.16.0/20
       az: "us-east-1a"
+
+openshift_aws_subnet_az: "{{ openshift_aws_vpc.subnets[openshift_aws_region] | get_default_az }}"
 
 openshift_aws_node_run_bootstrap_startup: True
 openshift_aws_node_user_data: ''


### PR DESCRIPTION
allow defining 'default_az' for one of the subnets in the vpc structure, and pull that default_az and set it to openshift_aws_subnet_az.
    
this should allow one less variable to be defined/overridded when using non-default (us-east-1) regions