### PR TITLE
failure_summary: make sure msg is always a string

### DIFF
--- a/roles/openshift_health_checker/callback_plugins/zz_failure_summary.py
+++ b/roles/openshift_health_checker/callback_plugins/zz_failure_summary.py
@@ -175,6 +175,8 @@ def format_failure(failure):
     play = failure['play']
     task = failure['task']
     msg = failure['msg']
+    if not isinstance(msg, string_types):
+        msg = str(msg)
     checks = failure['checks']
     fields = (
         (u'Hosts', host),


### PR DESCRIPTION
Some tasks may return a dict in the msg. In that case `stringc` will
fail to colorize it (with "AttributeError: <msg type> object has no
attribute 'split'" error.