### PR TITLE
Don't hardcode the network interface in the openshift_logging_mux role

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -177,6 +177,9 @@ Elasticsearch OPS too, if using an OPS cluster:
   clients will use to connect to mux, and will be used in the TLS server cert
   subject.
 - `openshift_logging_mux_port`: 24284
+- `openshift_logging_mux_external_address`: The IP address that mux will listen
+ on for connections from *external* clients.  Default is the default ipv4
+ interface as reported by the `ansible_default_ipv4` fact.
 - `openshift_logging_mux_cpu_request`: 100m
 - `openshift_logging_mux_memory_limit`: 512Mi
 - `openshift_logging_mux_default_namespaces`: Default `["mux-undefined"]` - the

--- a/roles/openshift_logging_mux/defaults/main.yml
+++ b/roles/openshift_logging_mux/defaults/main.yml
@@ -30,6 +30,7 @@ openshift_logging_mux_allow_external: False
 openshift_logging_use_mux: "{{ openshift_logging_mux_allow_external | default(False) }}"
 openshift_logging_mux_hostname: "{{ 'mux.' ~ openshift_master_default_subdomain }}"
 openshift_logging_mux_port: 24284
+openshift_logging_mux_external_address: "{{ ansible_default_ipv4.address }}"
 # the namespace to use for undefined projects should come first, followed by any
 # additional namespaces to create by default - users will typically not need to set this
 openshift_logging_mux_default_namespaces: ["mux-undefined"]

--- a/roles/openshift_logging_mux/tasks/main.yaml
+++ b/roles/openshift_logging_mux/tasks/main.yaml
@@ -148,7 +148,7 @@
         port: "{{ openshift_logging_mux_port }}"
         targetPort: "mux-forward"
     external_ips:
-      - "{{ ansible_eth0.ipv4.address }}"
+      - "{{ openshift_logging_mux_external_address }}"
   when: openshift_logging_mux_allow_external | bool
 
 - name: Set logging-mux service for internal communication


### PR DESCRIPTION
The openshift_logging_mux role hardcodes the 'eth0' interface alias
for determining the IP address to use for incoming external client
connections.  This will cause the playbook to fail with an undefined
variable error on systems where an 'eth0' interface does not exist.

This patch changes the default IP address for external connections
to use the 'ansible_default_ipv4' fact.  It also allows this to be
overridden by a new 'openshift_logging_mux_external_address' variable.