### PR TITLE
Update to AWS EC2 root vol size so that Health Check tasks pass

### DIFF
--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -98,12 +98,20 @@ openshift_aws_elb_dict:
       proxy_protocol: True
 
 openshift_aws_node_group_config_master_volumes:
+- device_name: /dev/sda1
+  volume_size: 100
+  device_type: gp2
+  delete_on_termination: False
 - device_name: /dev/sdb
   volume_size: 100
   device_type: gp2
   delete_on_termination: False
 
 openshift_aws_node_group_config_node_volumes:
+- device_name: /dev/sda1
+  volume_size: 100
+  device_type: gp2
+  delete_on_termination: True
 - device_name: /dev/sdb
   volume_size: 100
   device_type: gp2


### PR DESCRIPTION
AWS EC2s under the ASG and LaunchConfig are deployed with the default 10gb root vol size.  Heath Checks fail because / filesystem and /var directory is too small.  Health Check wants a minimum of 40Gb.  10Gb is just too small for server operations in general.  Let's increase to 100Gb.  Cost increase for additional EBS storage will be minimal and give plenty of elbow room for normal server operations.
  