### PR TITLE
cri-o: set proxy variables

### DIFF
--- a/roles/container_runtime/tasks/systemcontainer_crio.yml
+++ b/roles/container_runtime/tasks/systemcontainer_crio.yml
@@ -81,6 +81,11 @@
     dest: /etc/cni/net.d/openshift-sdn.conf
     src: 80-openshift-sdn.conf.j2
 
+- name: Create /etc/sysconfig/crio-network
+  template:
+    dest: /etc/sysconfig/crio-network
+    src: crio-network.j2
+
 - name: Start the CRI-O service
   systemd:
     name: "cri-o"

--- a/roles/container_runtime/tasks/systemcontainer_crio.yml
+++ b/roles/container_runtime/tasks/systemcontainer_crio.yml
@@ -81,6 +81,12 @@
     dest: /etc/cni/net.d/openshift-sdn.conf
     src: 80-openshift-sdn.conf.j2
 
+- name: Create /etc/sysconfig/crio-storage
+  copy:
+    content: ""
+    dest: /etc/sysconfig/crio-storage
+    force: no
+
 - name: Create /etc/sysconfig/crio-network
   template:
     dest: /etc/sysconfig/crio-network

--- a/roles/container_runtime/templates/crio-network.j2
+++ b/roles/container_runtime/templates/crio-network.j2
@@ -1,0 +1,9 @@
+{% if 'http_proxy' in openshift.common %}
+HTTP_PROXY={{ openshift.common.http_proxy }}
+{% endif %}
+{% if 'https_proxy' in openshift.common %}
+HTTPS_PROXY={{ openshift.common.https_proxy }}
+{% endif %}
+{% if 'no_proxy' in openshift.common %}
+NO_PROXY={{ openshift.common.no_proxy }}
+{% endif %}


### PR DESCRIPTION
Make CRI-O honor HTTP_PROXY/HTTPS_PROXY/NO_PROXY.

This change https://github.com/kubernetes-incubator/cri-o/pull/1245 in the system container is required