### PR TITLE
Adding a validity period to the Nuage CA certificate

### DIFF
--- a/roles/nuage_ca/tasks/main.yaml
+++ b/roles/nuage_ca/tasks/main.yaml
@@ -32,7 +32,7 @@
   delegate_to: "{{ nuage_ca_master }}"
 
 - name: Create CA crt
-  command: openssl req -new -x509 -key "{{ nuage_ca_key }}" -out "{{ nuage_ca_crt }}" -subj "/CN=nuage-signer"
+  command: openssl req -new -x509 -key "{{ nuage_ca_key }}" -out "{{ nuage_ca_crt }}" -subj "/CN=nuage-signer" -days {{ nuage_mon_cert_validity_period }}
   run_once: true
   delegate_to: "{{ nuage_ca_master }}"
   when: nuage_ca_crt_check.stat.exists is defined and nuage_ca_crt_check.stat.exists == False


### PR DESCRIPTION
The Nuage CA is setup without specifying the proper validity period,
causing the CA to be valid for only 30 days. As a result, any
certificate generated with this CA will only be valid for 30 days.
These certificates are used by the Nuage integration with OpenShift.