### PR TITLE
[release-3.6] Migrate to static:true for include_role

### DIFF
--- a/playbooks/common/openshift-cfme/config.yml
+++ b/playbooks/common/openshift-cfme/config.yml
@@ -22,6 +22,7 @@
     include_role:
       name: openshift_cfme
       tasks_from: tune_masters
+    static: true
 
 - name: Setup CFME
   hosts: oo_first_master
@@ -42,3 +43,4 @@
       name: openshift_cfme
     vars:
       template_dir: "{{ hostvars[groups.masters.0].r_openshift_cfme_mktemp.stdout }}"
+    static: true

--- a/playbooks/common/openshift-cfme/uninstall.yml
+++ b/playbooks/common/openshift-cfme/uninstall.yml
@@ -6,3 +6,4 @@
     include_role:
       name: openshift_cfme
       tasks_from: uninstall
+    static: true

--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -63,10 +63,12 @@
     - include_role:
         name: openshift_logging
         tasks_from: update_master_config
+      static: true
     when: openshift_hosted_logging_deploy | default(false) | bool
 
   - block:
     - include_role:
         name: openshift_metrics
         tasks_from: update_master_config
+      static: true
     when: openshift_hosted_metrics_deploy | default(false) | bool

--- a/playbooks/common/openshift-cluster/openshift_logging.yml
+++ b/playbooks/common/openshift-cluster/openshift_logging.yml
@@ -13,4 +13,5 @@
     - include_role:
         name: openshift_logging
         tasks_from: update_master_config
+      static: true
     when: openshift_logging_install_logging | default(false) | bool

--- a/playbooks/common/openshift-cluster/openshift_metrics.yml
+++ b/playbooks/common/openshift-cluster/openshift_metrics.yml
@@ -14,3 +14,4 @@
     include_role:
       name: openshift_metrics
       tasks_from: update_master_config.yaml
+    static: true

--- a/playbooks/common/openshift-cluster/service_catalog.yml
+++ b/playbooks/common/openshift-cluster/service_catalog.yml
@@ -11,6 +11,7 @@
         tasks_from: wire_aggregator
       vars:
         first_master: "{{ groups.oo_first_master[0] }}"
+      static: true
 
 - name: Service Catalog
   hosts: oo_first_master

--- a/playbooks/common/openshift-cluster/upgrades/etcd/main.yml
+++ b/playbooks/common/openshift-cluster/upgrades/etcd/main.yml
@@ -18,6 +18,7 @@
       name: etcd_common
     vars:
       r_etcd_common_action: drop_etcdctl
+    static: true
 
 - name: Perform etcd upgrade
   include: ./upgrade.yml

--- a/playbooks/common/openshift-cluster/upgrades/etcd/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/etcd/upgrade.yml
@@ -110,3 +110,4 @@
     when:
     - ansible_distribution == 'Fedora'
     - not openshift.common.is_containerized | bool
+    static: true

--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -16,7 +16,7 @@
   - name: Load lib_openshift modules
     include_role:
       name: lib_openshift
-    static: yes
+    static: true
 
   - name: Collect all routers
     oc_obj:

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -9,6 +9,7 @@
     name: docker
     tasks_from: registry_auth.yml
   when: oreg_auth_user is defined
+  static: true
 
 - name: Verify containers are available for upgrade
   command: >

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -337,7 +337,7 @@
   - name: Load lib_openshift modules
     include_role:
       name: lib_openshift
-    static: yes
+    static: true
 
   # TODO: To better handle re-trying failed upgrades, it would be nice to check if the node
   # or docker actually needs an upgrade before proceeding. Perhaps best to save this until

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -10,7 +10,7 @@
   - name: Load lib_openshift modules
     include_role:
       name: lib_openshift
-    static: yes
+    static: true
 
   # TODO: To better handle re-trying failed upgrades, it would be nice to check if the node
   # or docker actually needs an upgrade before proceeding. Perhaps best to save this until

--- a/playbooks/common/openshift-etcd/scaleup.yml
+++ b/playbooks/common/openshift-etcd/scaleup.yml
@@ -70,3 +70,4 @@
                                        | oo_collect('openshift.common.hostname')
                                        | default(none, true) }}"
       openshift_master_etcd_port: "{{ (etcd_client_port | default('2379')) if (groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config) else none }}"
+    static: true

--- a/playbooks/common/openshift-glusterfs/config.yml
+++ b/playbooks/common/openshift-glusterfs/config.yml
@@ -32,6 +32,7 @@
       tasks_from: kernel_modules.yml
     when:
     - openshift_storage_glusterfs_is_native | default(True) | bool
+    static: true
 
 - name: Open firewall ports for GlusterFS registry nodes
   hosts: glusterfs_registry
@@ -55,6 +56,7 @@
       tasks_from: kernel_modules.yml
     when:
     - openshift_storage_glusterfs_registry_is_native | default(True) | bool
+    static: true
 
 - name: Configure GlusterFS
   hosts: oo_first_master

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -16,6 +16,7 @@
     r_etcd_common_action: drop_etcdctl
   when:
   - openshift_etcd_etcdctl_profile | default(true) | bool
+  static: true
 
 - block:
   - name: Pull etcd container

--- a/roles/openshift_node_upgrade/tasks/main.yml
+++ b/roles/openshift_node_upgrade/tasks/main.yml
@@ -177,3 +177,4 @@
 
 - include_role:
     name: openshift_node_dnsmasq
+  static: true


### PR DESCRIPTION
In Ansible 2.2, the include_role directive came into existence as
a Tech Preview. It is still a Tech Preview through Ansible 2.4
(and in current devel branch), but with a noteable change. The
default behavior switched from static: true to static: false
because that functionality moved to the newly introduced
import_role directive (in order to stay consistent with include*
being dynamic in nature and `import* being static in nature).

The dynamic include is considerably more memory intensive as it will
dynamically create a role import for every host in the inventory
list to be used. (Also worth noting, there is at the time of this
writing an object allocation inefficiency in the dynamic include
that can in certain situations amplify this effect considerably)

This change is meant to mitigate the pressure on memory for the
Ansible control host while maintaining compatibility with Ansible
2.3 and Ansible 2.4. (Eventually this should be migrated to use
import_role everywhere, but that directive is not present in
Ansible 2.3)

Backports #6599