### PR TITLE
[release-1.5] Migrate to static:true for include_role

### DIFF
--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -61,10 +61,12 @@
     - include_role:
         name: openshift_logging
         tasks_from: update_master_config
+      static: true
     when: openshift_hosted_logging_deploy | default(false) | bool
 
   - block:
     - include_role:
         name: openshift_metrics
         tasks_from: update_master_config
+      static: true
     when: openshift_hosted_metrics_deploy | default(false) | bool

--- a/playbooks/common/openshift-cluster/openshift_logging.yml
+++ b/playbooks/common/openshift-cluster/openshift_logging.yml
@@ -14,3 +14,4 @@
         name: openshift_logging
         tasks_from: update_master_config
     when: openshift_logging_install_logging | default(false) | bool
+    static: true

--- a/playbooks/common/openshift-cluster/openshift_metrics.yml
+++ b/playbooks/common/openshift-cluster/openshift_metrics.yml
@@ -13,4 +13,5 @@
     - include_role:
         name: openshift_metrics
         tasks_from: update_master_config
+      static: true
     when: openshift_metrics_install_metrics | default(false) | bool

--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -14,7 +14,7 @@
   - name: Load lib_openshift modules
     include_role:
       name: lib_openshift
-    static: yes
+    static: true
 
   - name: Collect all routers
     oc_obj:

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -12,6 +12,7 @@
     name: docker
     tasks_from: registry_auth.yml
   when: oreg_auth_user is defined
+  static: true
 
 - name: Verify containers are available for upgrade
   command: >

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -257,7 +257,7 @@
   - name: Load lib_openshift modules
     include_role:
       name: lib_openshift
-    static: yes
+    static: true
 
   # TODO: To better handle re-trying failed upgrades, it would be nice to check if the node
   # or docker actually needs an upgrade before proceeding. Perhaps best to save this until

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -10,7 +10,7 @@
   - name: Load lib_openshift modules
     include_role:
       name: lib_openshift
-    static: yes
+    static: true
 
   # TODO: To better handle re-trying failed upgrades, it would be nice to check if the node
   # or docker actually needs an upgrade before proceeding. Perhaps best to save this until


### PR DESCRIPTION
In Ansible 2.2, the include_role directive came into existence as
a Tech Preview. It is still a Tech Preview through Ansible 2.4
(and in current devel branch), but with a noteable change. The
default behavior switched from static: true to static: false
because that functionality moved to the newly introduced
import_role directive (in order to stay consistent with include*
being dynamic in nature and `import* being static in nature).

The dynamic include is considerably more memory intensive as it will
dynamically create a role import for every host in the inventory
list to be used. (Also worth noting, there is at the time of this
writing an object allocation inefficiency in the dynamic include
that can in certain situations amplify this effect considerably)

This change is meant to mitigate the pressure on memory for the
Ansible control host while maintaining compatibility with Ansible
2.3 and Ansible 2.4. (Eventually this should be migrated to use
import_role everywhere, but that directive is not present in
Ansible 2.3)

Backports #6599