### PR TITLE
docker_upgrade_check: skip repoquery calls on containerized setups

### DIFF
--- a/roles/container_runtime/tasks/docker_upgrade_check.yml
+++ b/roles/container_runtime/tasks/docker_upgrade_check.yml
@@ -21,6 +21,7 @@
   retries: 4
   until: curr_docker_version is succeeded
   changed_when: false
+  when: not openshift_is_atomic | bool
 
 - name: Get latest available version of Docker
   command: >
@@ -29,7 +30,9 @@
   retries: 4
   until: avail_docker_version is succeeded
   # Don't expect docker rpm to be available on hosts that don't already have it installed:
-  when: pkg_check.rc == 0
+  when:
+    - not openshift_is_atomic | bool
+    - pkg_check.rc == 0
   failed_when: false
   changed_when: false
 
@@ -37,9 +40,10 @@
     msg: This playbook requires access to Docker 1.12 or later
   # Disable the 1.12 requirement if the user set a specific Docker version
   when:
-  - docker_version is not defined
-  - docker_upgrade is not defined or docker_upgrade | bool == True
-  - (pkg_check.rc == 0 and (avail_docker_version.stdout == "" or avail_docker_version.stdout is version_compare('1.12','<')))
+    - not openshift_is_atomic | bool
+    - docker_version is not defined
+    - docker_upgrade is not defined or docker_upgrade | bool == True
+    - (pkg_check.rc == 0 and (avail_docker_version.stdout == "" or avail_docker_version.stdout is version_compare('1.12','<')))
 
 # Default l_docker_upgrade to False, we'll set to True if an upgrade is required:
 - set_fact:
@@ -48,14 +52,17 @@
 # Make sure a docker_version is set if none was requested:
 - set_fact:
     docker_version: "{{ avail_docker_version.stdout }}"
-  when: pkg_check.rc == 0 and docker_version is not defined
+  when:
+    - not openshift_is_atomic | bool
+    - pkg_check.rc == 0 and docker_version is not defined
 
 - name: Flag for Docker upgrade if necessary
   set_fact:
     l_docker_upgrade: True
   when:
-  - pkg_check.rc == 0
-  - curr_docker_version.stdout is version_compare(docker_version,'<')
+    - not openshift_is_atomic | bool
+    - pkg_check.rc == 0
+    - curr_docker_version.stdout is version_compare(docker_version,'<')
 
 # Additional checks for Atomic hosts:
 - name: Determine available Docker
@@ -70,5 +77,5 @@
 - fail:
     msg: This playbook requires access to Docker 1.12 or later
   when:
-  - openshift_is_atomic | bool
-  - l_docker_version.avail_version | default(l_docker_version.curr_version, true) is version_compare('1.12','<')
+    - openshift_is_atomic | bool
+    - l_docker_version.avail_version | default(l_docker_version.curr_version, true) is version_compare('1.12','<')


### PR DESCRIPTION
Fedora/CentOS Atomic hosts don't have repoquery installed - also there
is no need to check available Docker rpms in the repos for Atomic

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1527256


Note, that this solution is pretty naive - a better idea would be splitting
the playbooks for rpm and containerized installs for clarity