### PR TITLE
Migrate to import_role for static role inclusion

### DIFF
--- a/docs/proposals/crt_management_proposal.md
+++ b/docs/proposals/crt_management_proposal.md
@@ -30,7 +30,7 @@ configure, restart, or change the container runtime as much as feasible.
 ## Design
 
 The container_runtime role should be comprised of 3 'pseudo-roles' which will be
-consumed using include_role; each component area should be enabled/disabled with
+consumed using import_role; each component area should be enabled/disabled with
 a boolean value, defaulting to true.
 
 I call them 'pseudo-roles' because they are more or less independent functional
@@ -46,15 +46,15 @@ an abundance of roles), and make things as modular as possible.
 # container_runtime_setup.yml
 - hosts: "{{ openshift_runtime_manage_hosts | default('oo_nodes_to_config') }}"
   tasks:
-    - include_role:
+    - import_role:
         name: container_runtime
         tasks_from: install.yml
       when: openshift_container_runtime_install | default(True) | bool
-    - include_role:
+    - import_role:
         name: container_runtime
         tasks_from: storage.yml
       when: openshift_container_runtime_storage | default(True) | bool
-    - include_role:
+    - import_role:
         name: container_runtime
         tasks_from: configure.yml
       when: openshift_container_runtime_configure | default(True) | bool

--- a/docs/proposals/role_decomposition.md
+++ b/docs/proposals/role_decomposition.md
@@ -115,12 +115,12 @@ providing the location of the generated certificates to the individual roles.
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
 
 ## Elasticsearch
-- include_role:
+- import_role:
     name: openshift_logging_elasticsearch
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
 
-- include_role:
+- import_role:
     name: openshift_logging_elasticsearch
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -130,7 +130,7 @@ providing the location of the generated certificates to the individual roles.
 
 
 ## Kibana
-- include_role:
+- import_role:
     name: openshift_logging_kibana
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -144,7 +144,7 @@ providing the location of the generated certificates to the individual roles.
     openshift_logging_kibana_es_port: "{{ openshift_logging_es_port }}"
     openshift_logging_kibana_image_pull_secret: "{{ openshift_logging_image_pull_secret }}"
 
-- include_role:
+- import_role:
     name: openshift_logging_kibana
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -173,7 +173,7 @@ providing the location of the generated certificates to the individual roles.
 
 
 ## Curator
-- include_role:
+- import_role:
     name: openshift_logging_curator
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -183,7 +183,7 @@ providing the location of the generated certificates to the individual roles.
     openshift_logging_curator_image_version: "{{ openshift_logging_image_version }}"
     openshift_logging_curator_image_pull_secret: "{{ openshift_logging_image_pull_secret }}"
 
-- include_role:
+- import_role:
     name: openshift_logging_curator
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -201,7 +201,7 @@ providing the location of the generated certificates to the individual roles.
 
 
 ## Fluentd
-- include_role:
+- import_role:
     name: openshift_logging_fluentd
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"

--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -408,7 +408,7 @@ Atomic OpenShift Utilities includes
 - Update prometheus to 2.0.0 GA (zgalor@redhat.com)
 - remove schedulable from openshift_facts (mgugino@redhat.com)
 - inventory: Add example for service catalog vars (smilner@redhat.com)
-- Correct usage of include_role (rteague@redhat.com)
+- Correct usage of import_role (rteague@redhat.com)
 - Remove openshift.common.cli_image (mgugino@redhat.com)
 - Fix openshift_env fact creation within openshift_facts. (abutcher@redhat.com)
 - Combine openshift_node and openshift_node_dnsmasq (mgugino@redhat.com)
@@ -1001,7 +1001,7 @@ Atomic OpenShift Utilities includes
 - Renaming csr to bootstrap for consistency. (kwoodson@redhat.com)
 - Add master config upgrade hook to upgrade-all plays (mgugino@redhat.com)
 - Remove 'Not Started' status from playbook checkpoint (rteague@redhat.com)
-- Force include_role to static for loading openshift_facts module
+- Force import_role to static for loading openshift_facts module
   (rteague@redhat.com)
 - Make openshift-ansible depend on all subpackages (sdodson@redhat.com)
 - Refactor health check playbooks (rteague@redhat.com)
@@ -3729,9 +3729,9 @@ Atomic OpenShift Utilities includes
 - run node upgrade if master is node as part of the control plan upgrade only
   (jchaloup@redhat.com)
 - Appease yamllint (sdodson@redhat.com)
-- Adding include_role to block to resolve when eval (ewolinet@redhat.com)
+- Adding import_role to block to resolve when eval (ewolinet@redhat.com)
 - Updating oc_apply to use command instead of shell (ewolinet@redhat.com)
-- Wrap openshift_hosted_logging include_role within a block.
+- Wrap openshift_hosted_logging import_role within a block.
   (abutcher@redhat.com)
 - Adding unit test.  Fixed redudant calls to get. (kwoodson@redhat.com)
 - Fixing doc and generating new label with updated base. (kwoodson@redhat.com)

--- a/playbooks/adhoc/openshift_hosted_logging_efk.yaml
+++ b/playbooks/adhoc/openshift_hosted_logging_efk.yaml
@@ -10,7 +10,7 @@
   - set_fact:
       openshift_logging_kibana_hostname: "{{ openshift_hosted_logging_hostname | default('kibana.' ~ openshift_master_default_subdomain }}"
   tasks:
-  - include_role:
+  - import_role:
       name: openshift_logging
       tasks_from: update_master_config
     when: openshift_hosted_logging_deploy | default(false) | bool

--- a/playbooks/aws/openshift-cluster/install.yml
+++ b/playbooks/aws/openshift-cluster/install.yml
@@ -2,7 +2,7 @@
 - name: Setup the master node group
   hosts: localhost
   tasks:
-  - include_role:
+  - import_role:
       name: openshift_aws
       tasks_from: setup_master_group.yml
 
@@ -11,7 +11,7 @@
   gather_facts: no
   remote_user: root
   tasks:
-  - include_role:
+  - import_role:
       name: openshift_aws
       tasks_from: master_facts.yml
 

--- a/playbooks/aws/openshift-cluster/provision.yml
+++ b/playbooks/aws/openshift-cluster/provision.yml
@@ -12,6 +12,6 @@
       msg: "openshift_aws_region={{ openshift_aws_region | default('us-east-1') }}"
 
   - name: provision cluster
-    include_role:
+    import_role:
       name: openshift_aws
       tasks_from: provision.yml

--- a/playbooks/aws/openshift-cluster/provision_instance.yml
+++ b/playbooks/aws/openshift-cluster/provision_instance.yml
@@ -7,6 +7,6 @@
   gather_facts: no
   tasks:
   - name: create an instance and prepare for ami
-    include_role:
+    import_role:
       name: openshift_aws
       tasks_from: provision_instance.yml

--- a/playbooks/aws/openshift-cluster/provision_nodes.yml
+++ b/playbooks/aws/openshift-cluster/provision_nodes.yml
@@ -13,6 +13,6 @@
       msg: "openshift_aws_region={{ openshift_aws_region | default('us-east-1') }}"
 
   - name: create the node groups
-    include_role:
+    import_role:
       name: openshift_aws
       tasks_from: provision_nodes.yml

--- a/playbooks/aws/openshift-cluster/provision_sec_group.yml
+++ b/playbooks/aws/openshift-cluster/provision_sec_group.yml
@@ -7,7 +7,7 @@
   gather_facts: no
   tasks:
   - name: create security groups
-    include_role:
+    import_role:
       name: openshift_aws
       tasks_from: security_group.yml
     when: openshift_aws_create_security_groups | default(True) | bool

--- a/playbooks/aws/openshift-cluster/provision_ssh_keypair.yml
+++ b/playbooks/aws/openshift-cluster/provision_ssh_keypair.yml
@@ -4,7 +4,7 @@
   gather_facts: no
   tasks:
   - name: create an instance and prepare for ami
-    include_role:
+    import_role:
       name: openshift_aws
       tasks_from: ssh_keys.yml
     vars:

--- a/playbooks/aws/openshift-cluster/provision_vpc.yml
+++ b/playbooks/aws/openshift-cluster/provision_vpc.yml
@@ -4,7 +4,7 @@
   gather_facts: no
   tasks:
   - name: create a vpc
-    include_role:
+    import_role:
       name: openshift_aws
       tasks_from: vpc.yml
     when: openshift_aws_create_vpc | default(True) | bool

--- a/playbooks/aws/openshift-cluster/seal_ami.yml
+++ b/playbooks/aws/openshift-cluster/seal_ami.yml
@@ -7,6 +7,6 @@
   become: no
   tasks:
   - name: seal the ami
-    include_role:
+    import_role:
       name: openshift_aws
       tasks_from: seal_ami.yml

--- a/playbooks/common/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -16,7 +16,7 @@
       msg: Cannot upgrade Docker on Atomic operating systems.
     when: openshift_is_atomic | bool
 
-  - include_role:
+  - import_role:
       name: container_runtime
       tasks_from: docker_upgrade_check.yml
     when: docker_upgrade is not defined or docker_upgrade | bool

--- a/playbooks/common/openshift-cluster/upgrades/pre/config.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/config.yml
@@ -72,6 +72,6 @@
 - name: Verify docker upgrade targets
   hosts: "{{ l_upgrade_docker_target_hosts }}"
   tasks:
-  - include_role:
+  - import_role:
       name: container_runtime
       tasks_from: docker_upgrade_check.yml

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -5,7 +5,7 @@
   when: openshift.common.version is not defined
 
 - name: Update oreg_auth docker login credentials if necessary
-  include_role:
+  import_role:
     name: container_runtime
     tasks_from: registry_auth.yml
   when: oreg_auth_user is defined

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -50,7 +50,7 @@
     openshift_master_ha: "{{ groups.oo_masters_to_config | length > 1 }}"
   serial: 1
   tasks:
-  - include_role:
+  - import_role:
       name: openshift_facts
 
   # Run the pre-upgrade hook if defined:
@@ -60,7 +60,7 @@
   - include_tasks: "{{ openshift_master_upgrade_pre_hook }}"
     when: openshift_master_upgrade_pre_hook is defined
 
-  - include_role:
+  - import_role:
       name: openshift_master
       tasks_from: upgrade.yml
 
@@ -301,7 +301,7 @@
   roles:
   - openshift_facts
   post_tasks:
-  - include_role:
+  - import_role:
       name: openshift_node
       tasks_from: upgrade.yml
     vars:

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -4,7 +4,7 @@
   roles:
   - role: openshift_facts
   tasks:
-  - include_role:
+  - import_role:
       name: openshift_node
       tasks_from: upgrade_pre.yml
     vars:
@@ -43,7 +43,7 @@
     delay: 60
 
   post_tasks:
-  - include_role:
+  - import_role:
       name: openshift_node
       tasks_from: upgrade.yml
     vars:
@@ -62,7 +62,7 @@
 - name: Re-enable excluders
   hosts: oo_nodes_to_upgrade:!oo_masters_to_config
   tasks:
-  - include_role:
+  - import_role:
       name: openshift_excluder
     vars:
       r_openshift_excluder_action: enable

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_scale_group.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_scale_group.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   tasks:
   - name: build upgrade scale groups
-    include_role:
+    import_role:
       name: openshift_aws
       tasks_from: upgrade_node_group.yml
 
@@ -61,6 +61,6 @@
   hosts: localhost
   tasks:
   - name: clean up scale group
-    include_role:
+    import_role:
       name: openshift_aws
       tasks_from: remove_scale_group.yml

--- a/playbooks/container-runtime/private/config.yml
+++ b/playbooks/container-runtime/private/config.yml
@@ -8,19 +8,19 @@
   roles:
     - role: container_runtime
   tasks:
-    - include_role:
+    - import_role:
         name: container_runtime
         tasks_from: package_docker.yml
       when:
         - not openshift_docker_use_system_container | bool
         - not openshift_use_crio_only | bool
-    - include_role:
+    - import_role:
         name: container_runtime
         tasks_from: systemcontainer_docker.yml
       when:
         - openshift_docker_use_system_container | bool
         - not openshift_use_crio_only | bool
-    - include_role:
+    - import_role:
         name: container_runtime
         tasks_from: systemcontainer_crio.yml
       when:

--- a/playbooks/container-runtime/private/setup_storage.yml
+++ b/playbooks/container-runtime/private/setup_storage.yml
@@ -8,7 +8,7 @@
   roles:
     - role: container_runtime
   tasks:
-    - include_role:
+    - import_role:
         name: container_runtime
         tasks_from: docker_storage_setup_overlay.yml
       when:

--- a/playbooks/gcp/provision.yml
+++ b/playbooks/gcp/provision.yml
@@ -6,7 +6,7 @@
   tasks:
 
   - name: provision a GCP cluster in the specified project
-    include_role:
+    import_role:
       name: openshift_gcp
 
 - name: run the cluster deploy

--- a/playbooks/init/facts.yml
+++ b/playbooks/init/facts.yml
@@ -13,7 +13,7 @@
 
   # TODO: Should this role be refactored into health_checks??
   - name: Run openshift_sanitize_inventory to set variables
-    include_role:
+    import_role:
       name: openshift_sanitize_inventory
 
   - name: Detecting Operating System from ostree_booted

--- a/playbooks/init/repos.yml
+++ b/playbooks/init/repos.yml
@@ -4,7 +4,7 @@
   gather_facts: no
   tasks:
   - name: subscribe instances to Red Hat Subscription Manager
-    include_role:
+    import_role:
       name: rhel_subscribe
     when:
     - ansible_distribution == 'RedHat'
@@ -12,5 +12,5 @@
     - rhsub_user is defined
     - rhsub_pass is defined
   - name: initialize openshift repos
-    include_role:
+    import_role:
       name: openshift_repos

--- a/playbooks/openshift-etcd/private/ca.yml
+++ b/playbooks/openshift-etcd/private/ca.yml
@@ -5,7 +5,7 @@
   - role: openshift_clock
   - role: openshift_etcd_facts
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: ca.yml
     vars:

--- a/playbooks/openshift-etcd/private/certificates-backup.yml
+++ b/playbooks/openshift-etcd/private/certificates-backup.yml
@@ -3,10 +3,10 @@
   hosts: oo_first_etcd
   any_errors_fatal: true
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: backup_generated_certificates.yml
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: remove_generated_certificates.yml
 
@@ -14,6 +14,6 @@
   hosts: oo_etcd_to_config
   any_errors_fatal: true
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: backup_server_certificates.yml

--- a/playbooks/openshift-etcd/private/embedded2external.yml
+++ b/playbooks/openshift-etcd/private/embedded2external.yml
@@ -18,7 +18,7 @@
   - role: openshift_facts
   tasks:
   - name: Check the master API is ready
-    include_role:
+    import_role:
       name: openshift_master
       tasks_from: check_master_api_is_ready.yml
   - set_fact:
@@ -31,8 +31,8 @@
       name: "{{ master_service }}"
       state: stopped
   # 2. backup embedded etcd
-  # Can't use with_items with include_role: https://github.com/ansible/ansible/issues/21285
-  - include_role:
+  # Can't use with_items with import_role: https://github.com/ansible/ansible/issues/21285
+  - import_role:
       name: etcd
       tasks_from: backup.yml
     vars:
@@ -40,7 +40,7 @@
       r_etcd_common_embedded_etcd: "{{ true }}"
       r_etcd_common_backup_sufix_name: "{{ embedded_etcd_backup_suffix }}"
 
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: backup.archive.yml
     vars:
@@ -56,7 +56,7 @@
 - name: Backup etcd client certificates for master host
   hosts: oo_first_master
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: backup_master_etcd_certificates.yml
 
@@ -73,10 +73,10 @@
   hosts: oo_etcd_to_config[0]
   gather_facts: no
   pre_tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: disable_etcd.yml
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: clean_data.yml
 
@@ -91,7 +91,7 @@
     changed_when: False
     become: no
 
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: backup.fetch.yml
     vars:
@@ -101,7 +101,7 @@
       r_etcd_common_backup_sufix_name: "{{ hostvars[groups.oo_first_master.0].embedded_etcd_backup_suffix }}"
     delegate_to: "{{ groups.oo_first_master[0] }}"
 
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: backup.copy.yml
     vars:
@@ -122,14 +122,14 @@
 - name: Force new etcd cluster
   hosts: oo_etcd_to_config[0]
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: backup.unarchive.yml
     vars:
       r_etcd_common_backup_tag: pre-migrate
       r_etcd_common_backup_sufix_name: "{{ hostvars[groups.oo_first_master.0].embedded_etcd_backup_suffix }}"
 
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: backup.force_new_cluster.yml
     vars:
@@ -143,7 +143,7 @@
 - name: Configure master to use external etcd
   hosts: oo_first_master
   tasks:
-  - include_role:
+  - import_role:
       name: openshift_master
       tasks_from: configure_external_etcd.yml
     vars:

--- a/playbooks/openshift-etcd/private/migrate.yml
+++ b/playbooks/openshift-etcd/private/migrate.yml
@@ -15,7 +15,7 @@
 - name: Run pre-checks
   hosts: oo_etcd_to_migrate
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: migrate.pre_check.yml
     vars:
@@ -43,7 +43,7 @@
   roles:
   - role: openshift_facts
   post_tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: backup.yml
     vars:
@@ -70,7 +70,7 @@
   hosts: oo_etcd_to_migrate
   gather_facts: no
   pre_tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: disable_etcd.yml
 
@@ -78,7 +78,7 @@
   hosts: oo_etcd_to_migrate[0]
   gather_facts: no
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: migrate.yml
     vars:
@@ -90,7 +90,7 @@
   hosts: oo_etcd_to_migrate[1:]
   gather_facts: no
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: clean_data.yml
     vars:
@@ -126,7 +126,7 @@
 - name: Add TTLs on the first master
   hosts: oo_first_master[0]
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: migrate.add_ttls.yml
     vars:
@@ -138,7 +138,7 @@
 - name: Configure masters if etcd data migration is succesfull
   hosts: oo_masters_to_config
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: migrate.configure_master.yml
     when: etcd_migration_failed | length == 0

--- a/playbooks/openshift-etcd/private/redeploy-ca.yml
+++ b/playbooks/openshift-etcd/private/redeploy-ca.yml
@@ -14,10 +14,10 @@
 - name: Backup existing etcd CA certificate directories
   hosts: oo_etcd_to_config
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: backup_ca_certificates.yml
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: remove_ca_certificates.yml
 
@@ -37,7 +37,7 @@
 - name: Distribute etcd CA to etcd hosts
   hosts: oo_etcd_to_config
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: distribute_ca.yml
     vars:
@@ -54,7 +54,7 @@
 - name: Retrieve etcd CA certificate
   hosts: oo_first_etcd
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: retrieve_ca_certificates.yml
     vars:

--- a/playbooks/openshift-etcd/private/restart.yml
+++ b/playbooks/openshift-etcd/private/restart.yml
@@ -3,7 +3,7 @@
   hosts: oo_etcd_to_config
   serial: 1
   tasks:
-    - include_role:
+    - import_role:
         name: etcd
         tasks_from: restart.yml
       when:
@@ -12,7 +12,7 @@
 - name: Restart etcd
   hosts: oo_etcd_to_config
   tasks:
-    - include_role:
+    - import_role:
         name: etcd
         tasks_from: restart.yml
       when:

--- a/playbooks/openshift-etcd/private/scaleup.yml
+++ b/playbooks/openshift-etcd/private/scaleup.yml
@@ -30,7 +30,7 @@
     retries: 3
     delay: 10
     until: etcd_add_check.rc == 0
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: server_certificates.yml
     vars:
@@ -76,6 +76,6 @@
   roles:
   - role: openshift_master_facts
   post_tasks:
-  - include_role:
+  - import_role:
       name: openshift_master
       tasks_from: update_etcd_client_urls.yml

--- a/playbooks/openshift-etcd/private/server_certificates.yml
+++ b/playbooks/openshift-etcd/private/server_certificates.yml
@@ -5,7 +5,7 @@
   roles:
     - role: openshift_etcd_facts
   post_tasks:
-    - include_role:
+    - import_role:
         name: etcd
         tasks_from: server_certificates.yml
       vars:

--- a/playbooks/openshift-etcd/private/upgrade_backup.yml
+++ b/playbooks/openshift-etcd/private/upgrade_backup.yml
@@ -4,7 +4,7 @@
   roles:
   - role: openshift_etcd_facts
   post_tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: backup.yml
     vars:

--- a/playbooks/openshift-etcd/private/upgrade_image_members.yml
+++ b/playbooks/openshift-etcd/private/upgrade_image_members.yml
@@ -6,7 +6,7 @@
   hosts: oo_etcd_hosts_to_upgrade
   serial: 1
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: upgrade_image.yml
     vars:

--- a/playbooks/openshift-etcd/private/upgrade_main.yml
+++ b/playbooks/openshift-etcd/private/upgrade_main.yml
@@ -14,7 +14,7 @@
 - name: Drop etcdctl profiles
   hosts: oo_etcd_hosts_to_upgrade
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: drop_etcdctl.yml
 

--- a/playbooks/openshift-etcd/private/upgrade_rpm_members.yml
+++ b/playbooks/openshift-etcd/private/upgrade_rpm_members.yml
@@ -6,7 +6,7 @@
   hosts: oo_etcd_hosts_to_upgrade
   serial: 1
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: upgrade_rpm.yml
     vars:

--- a/playbooks/openshift-etcd/private/upgrade_step.yml
+++ b/playbooks/openshift-etcd/private/upgrade_step.yml
@@ -2,7 +2,7 @@
 - name: Determine etcd version
   hosts: oo_etcd_hosts_to_upgrade
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: version_detect.yml
 
@@ -54,7 +54,7 @@
   hosts: oo_etcd_hosts_to_upgrade
   serial: 1
   tasks:
-  - include_role:
+  - import_role:
       name: etcd
       tasks_from: upgrade_image.yml
     vars:

--- a/playbooks/openshift-glusterfs/private/config.yml
+++ b/playbooks/openshift-glusterfs/private/config.yml
@@ -14,12 +14,12 @@
 - name: Open firewall ports for GlusterFS nodes
   hosts: glusterfs
   tasks:
-  - include_role:
+  - import_role:
       name: openshift_storage_glusterfs
       tasks_from: firewall.yml
     when:
     - openshift_storage_glusterfs_is_native | default(True) | bool
-  - include_role:
+  - import_role:
       name: openshift_storage_glusterfs
       tasks_from: kernel_modules.yml
     when:
@@ -28,12 +28,12 @@
 - name: Open firewall ports for GlusterFS registry nodes
   hosts: glusterfs_registry
   tasks:
-  - include_role:
+  - import_role:
       name: openshift_storage_glusterfs
       tasks_from: firewall.yml
     when:
     - openshift_storage_glusterfs_registry_is_native | default(True) | bool
-  - include_role:
+  - import_role:
       name: openshift_storage_glusterfs
       tasks_from: kernel_modules.yml
     when:
@@ -43,7 +43,7 @@
   hosts: oo_first_master
   tasks:
   - name: setup glusterfs
-    include_role:
+    import_role:
       name: openshift_storage_glusterfs
     when: groups.oo_glusterfs_to_config | default([]) | count > 0
 

--- a/playbooks/openshift-hosted/private/install_docker_gc.yml
+++ b/playbooks/openshift-hosted/private/install_docker_gc.yml
@@ -3,5 +3,5 @@
   hosts: oo_first_master
   gather_facts: false
   tasks:
-    - include_role:
+    - import_role:
         name: openshift_docker_gc

--- a/playbooks/openshift-hosted/private/openshift_hosted_create_projects.yml
+++ b/playbooks/openshift-hosted/private/openshift_hosted_create_projects.yml
@@ -2,6 +2,6 @@
 - name: Create Hosted Resources - openshift projects
   hosts: oo_first_master
   tasks:
-  - include_role:
+  - import_role:
       name: openshift_hosted
       tasks_from: create_projects.yml

--- a/playbooks/openshift-hosted/private/openshift_hosted_registry.yml
+++ b/playbooks/openshift-hosted/private/openshift_hosted_registry.yml
@@ -5,7 +5,7 @@
   - set_fact:
       openshift_hosted_registry_registryurl: "{{ hostvars[groups.oo_first_master.0].openshift.master.registry_url }}"
     when: "'master' in hostvars[groups.oo_first_master.0].openshift and 'registry_url' in hostvars[groups.oo_first_master.0].openshift.master"
-  - include_role:
+  - import_role:
       name: openshift_hosted
       tasks_from: registry.yml
     when:

--- a/playbooks/openshift-hosted/private/openshift_hosted_registry_storage.yml
+++ b/playbooks/openshift-hosted/private/openshift_hosted_registry_storage.yml
@@ -5,7 +5,7 @@
 - name: Poll for hosted pod deployments
   hosts: oo_first_master
   tasks:
-  - include_role:
+  - import_role:
       name: openshift_hosted
       tasks_from: registry_storage.yml
     when:

--- a/playbooks/openshift-hosted/private/openshift_hosted_router.yml
+++ b/playbooks/openshift-hosted/private/openshift_hosted_router.yml
@@ -5,7 +5,7 @@
   - set_fact:
       openshift_hosted_router_registryurl: "{{ hostvars[groups.oo_first_master.0].openshift.master.registry_url }}"
     when: "'master' in hostvars[groups.oo_first_master.0].openshift and 'registry_url' in hostvars[groups.oo_first_master.0].openshift.master"
-  - include_role:
+  - import_role:
       name: openshift_hosted
       tasks_from: router.yml
     when:

--- a/playbooks/openshift-hosted/private/openshift_hosted_wait_for_pods.yml
+++ b/playbooks/openshift-hosted/private/openshift_hosted_wait_for_pods.yml
@@ -5,7 +5,7 @@
 - name: Poll for hosted pod deployments
   hosts: oo_first_master
   tasks:
-  - include_role:
+  - import_role:
       name: openshift_hosted
       tasks_from: wait_for_pod.yml
     vars:
@@ -15,7 +15,7 @@
     - openshift_hosted_manage_router | default(True) | bool
     - openshift_hosted_router_registryurl is defined
 
-  - include_role:
+  - import_role:
       name: openshift_hosted
       tasks_from: wait_for_pod.yml
     vars:

--- a/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
@@ -115,7 +115,7 @@
     - ('service.alpha.openshift.io/serving-cert-secret-name') not in router_service_annotations
     - ('service.alpha.openshift.io/serving-cert-signed-by') not in router_service_annotations
 
-  - include_role:
+  - import_role:
       name: openshift_hosted
       tasks_from: main
     vars:

--- a/playbooks/openshift-logging/private/config.yml
+++ b/playbooks/openshift-logging/private/config.yml
@@ -20,7 +20,7 @@
   hosts: oo_masters:!oo_first_master
   tasks:
   - block:
-    - include_role:
+    - import_role:
         name: openshift_logging
         tasks_from: update_master_config
 

--- a/playbooks/openshift-management/add_many_container_providers.yml
+++ b/playbooks/openshift-management/add_many_container_providers.yml
@@ -27,7 +27,7 @@
     register: results
 
   # Include openshift_management for access to filter_plugins.
-  - include_role:
+  - import_role:
       name: openshift_management
       tasks_from: noop
 

--- a/playbooks/openshift-management/private/add_container_provider.yml
+++ b/playbooks/openshift-management/private/add_container_provider.yml
@@ -3,6 +3,6 @@
   hosts: oo_first_master
   tasks:
   - name: Run the Management Integration Tasks
-    include_role:
+    import_role:
       name: openshift_management
       tasks_from: add_container_provider

--- a/playbooks/openshift-management/private/config.yml
+++ b/playbooks/openshift-management/private/config.yml
@@ -21,7 +21,7 @@
 
   tasks:
   - name: Run the CFME Setup Role
-    include_role:
+    import_role:
       name: openshift_management
     vars:
       template_dir: "{{ hostvars[groups.masters.0].r_openshift_management_mktemp.stdout }}"

--- a/playbooks/openshift-management/private/uninstall.yml
+++ b/playbooks/openshift-management/private/uninstall.yml
@@ -3,6 +3,6 @@
   hosts: masters[0]
   tasks:
   - name: Run the CFME Uninstall Role Tasks
-    include_role:
+    import_role:
       name: openshift_management
       tasks_from: uninstall

--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -206,13 +206,13 @@
   - role: calico_master
     when: openshift_use_calico | default(false) | bool
   tasks:
-  - include_role:
+  - import_role:
       name: kuryr
       tasks_from: master
     when: openshift_use_kuryr | default(false) | bool
 
   - name: Setup the node group config maps
-    include_role:
+    import_role:
       name: openshift_node_group
     when: openshift_master_bootstrap_enabled | default(false) | bool
     run_once: True

--- a/playbooks/openshift-master/private/tasks/restart_services.yml
+++ b/playbooks/openshift-master/private/tasks/restart_services.yml
@@ -1,4 +1,4 @@
 ---
-- include_role:
+- import_role:
     name: openshift_master
     tasks_from: restart.yml

--- a/playbooks/openshift-metrics/private/config.yml
+++ b/playbooks/openshift-metrics/private/config.yml
@@ -21,7 +21,7 @@
   serial: 1
   tasks:
   - name: Setup the non-first masters configs
-    include_role:
+    import_role:
       name: openshift_metrics
       tasks_from: update_master_config.yaml
 

--- a/playbooks/openshift-node/private/additional_config.yml
+++ b/playbooks/openshift-node/private/additional_config.yml
@@ -57,7 +57,7 @@
 - name: Configure Kuryr node
   hosts: oo_nodes_use_kuryr
   tasks:
-  - include_role:
+  - import_role:
       name: kuryr
       tasks_from: node
     when: openshift_use_kuryr | default(false) | bool

--- a/playbooks/openshift-node/private/image_prep.yml
+++ b/playbooks/openshift-node/private/image_prep.yml
@@ -15,7 +15,7 @@
 - name: node bootstrap config
   hosts: oo_nodes_to_config:!oo_containerized_master_nodes
   tasks:
-    - include_role:
+    - import_role:
         name: openshift_node
         tasks_from: bootstrap.yml
 

--- a/playbooks/openstack/openshift-cluster/prerequisites.yml
+++ b/playbooks/openstack/openshift-cluster/prerequisites.yml
@@ -2,11 +2,11 @@
 - hosts: localhost
   tasks:
   - name: Check dependencies and OpenStack prerequisites
-    include_role:
+    import_role:
       name: openshift_openstack
       tasks_from: check-prerequisites.yml
 
   - name: Check network configuration
-    include_role:
+    import_role:
       name: openshift_openstack
       tasks_from: net_vars_check.yaml

--- a/playbooks/openstack/openshift-cluster/provision.yml
+++ b/playbooks/openstack/openshift-cluster/provision.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   tasks:
   - name: provision cluster
-    include_role:
+    import_role:
       name: openshift_openstack
       tasks_from: provision.yml
 
@@ -36,7 +36,7 @@
   hosts: localhost
   tasks:
   - name: Populate DNS entries
-    include_role:
+    import_role:
       name: openshift_openstack
       tasks_from: populate-dns.yml
     when:
@@ -49,7 +49,7 @@
   gather_facts: yes
   tasks:
   - name: Subscribe RHEL instances
-    include_role:
+    import_role:
       name: rhel_subscribe
     when:
     - ansible_distribution == "RedHat"
@@ -57,18 +57,18 @@
     - rhsub_pass is defined
 
   - name: Enable required YUM repositories
-    include_role:
+    import_role:
       name: openshift_repos
     when:
     - ansible_distribution == "RedHat"
     - rh_subscribed is defined
 
   - name: Install dependencies
-    include_role:
+    import_role:
       name: openshift_openstack
       tasks_from: node-packages.yml
 
   - name: Configure Node
-    include_role:
+    import_role:
       name: openshift_openstack
       tasks_from: node-configuration.yml

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -7,7 +7,7 @@
   - not (calico_etcd_cert_dir is defined and calico_etcd_ca_cert_file is defined and calico_etcd_cert_file is defined and calico_etcd_key_file is defined and calico_etcd_endpoints is defined)
 
 - name: Calico Node | Generate OpenShift-etcd certs
-  include_role:
+  import_role:
     name: etcd
     tasks_from: client_certificates
   when: calico_etcd_ca_cert_file is not defined or calico_etcd_cert_file is not defined or calico_etcd_key_file is not defined or calico_etcd_endpoints is not defined or calico_etcd_cert_dir is not defined

--- a/roles/container_runtime/README.md
+++ b/roles/container_runtime/README.md
@@ -5,7 +5,7 @@ Ensures docker package or system container is installed, and optionally raises t
 
 container-daemon.json items may be found at https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file
 
-This role is designed to be used with include_role and tasks_from.
+This role is designed to be used with import_role and tasks_from.
 
 Entry points
 ------------
@@ -30,7 +30,7 @@ Example Playbook
 
     - hosts: servers
       tasks:
-      - include_role: container_runtime
+      - import_role: container_runtime
         tasks_from: package_docker.yml
 
 License

--- a/roles/container_runtime/tasks/common/post.yml
+++ b/roles/container_runtime/tasks/common/post.yml
@@ -11,7 +11,7 @@
 - meta: flush_handlers
 
 # This needs to run after docker is restarted to account for proxy settings.
-# registry_auth is called directly with include_role in some places, so we
+# registry_auth is called directly with import_role in some places, so we
 # have to put it in the root of the tasks/ directory.
 - include_tasks: ../registry_auth.yml
 

--- a/roles/container_runtime/tasks/main.yml
+++ b/roles/container_runtime/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-# This role is meant to be used with include_role and tasks_from.
+# This role is meant to be used with import_role and tasks_from.

--- a/roles/lib_utils/callback_plugins/openshift_quick_installer.py
+++ b/roles/lib_utils/callback_plugins/openshift_quick_installer.py
@@ -192,7 +192,7 @@ The only thing we change here is adding `log_only=True` to the
         """
         delegated_vars = result._result.get('_ansible_delegated_vars', None)
         self._clean_results(result._result, result._task.action)
-        if result._task.action in ('include', 'include_role'):
+        if result._task.action in ('include', 'import_role'):
             return
         elif result._result.get('changed', False):
             if delegated_vars:
@@ -220,7 +220,7 @@ The only thing we change here is adding `log_only=True` to the
     def v2_runner_item_on_ok(self, result):
         """Print out task results for items you're iterating over"""
         delegated_vars = result._result.get('_ansible_delegated_vars', None)
-        if result._task.action in ('include', 'include_role'):
+        if result._task.action in ('include', 'import_role'):
             return
         elif result._result.get('changed', False):
             msg = 'changed'

--- a/roles/openshift_aws/README.md
+++ b/roles/openshift_aws/README.md
@@ -7,9 +7,9 @@ This role contains many task-areas to provision resources and perform actions
 against an AWS account for the purposes of dynamically building an openshift
 cluster.
 
-This role is primarily intended to be used with "include_role" and "tasks_from".
+This role is primarily intended to be used with "import_role" and "tasks_from".
 
-include_role can be called from the tasks section in a play.  See example
+import_role can be called from the tasks section in a play.  See example
 playbook below for reference.
 
 These task-areas are:
@@ -40,7 +40,7 @@ Example Playbook
 ----------------
 
 ```yaml
-- include_role:
+- import_role:
     name: openshift_aws
     tasks_from: vpc.yml
   vars:

--- a/roles/openshift_cluster_autoscaler/README.md
+++ b/roles/openshift_cluster_autoscaler/README.md
@@ -28,7 +28,7 @@ Example Playbook
   remote_user: root
   tasks:
   - name: include role autoscaler
-    include_role:
+    import_role:
       name: openshift_cluster_autoscaler
     vars:
       openshift_clusterid: opstest

--- a/roles/openshift_etcd_client_certificates/tasks/main.yml
+++ b/roles/openshift_etcd_client_certificates/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
-- include_role:
+- import_role:
     name: etcd
     tasks_from: client_certificates

--- a/roles/openshift_hosted/tasks/main.yml
+++ b/roles/openshift_hosted/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-# This role is intended to be used with include_role.
-# include_role:
+# This role is intended to be used with import_role.
+# import_role:
 #   name:  openshift_hosted
 #   tasks_from: "{{ item }}"
 # with_items:

--- a/roles/openshift_logging/tasks/delete_logging.yaml
+++ b/roles/openshift_logging/tasks/delete_logging.yaml
@@ -126,7 +126,7 @@
     - __logging_ops_projects.stderr | length == 0
 
 ## EventRouter
-- include_role:
+- import_role:
     name: openshift_logging_eventrouter
   when:
     not openshift_logging_install_eventrouter | default(false) | bool

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -75,7 +75,7 @@
     elasticsearch_storage_type: "{{ openshift_logging_elasticsearch_storage_type | default('pvc' if ( openshift_logging_es_pvc_dynamic | bool or openshift_hosted_logging_storage_kind | default('') == 'nfs' or openshift_logging_es_pvc_size | length > 0)  else 'emptydir') }}"
 
 # We don't allow scaling down of ES nodes currently
-- include_role:
+- import_role:
     name: openshift_logging_elasticsearch
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -103,7 +103,7 @@
   - openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count > 0
 
 # Create any new DC that may be required
-- include_role:
+- import_role:
     name: openshift_logging_elasticsearch
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -137,7 +137,7 @@
   when:
   - openshift_logging_use_ops | bool
 
-- include_role:
+- import_role:
     name: openshift_logging_elasticsearch
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -180,7 +180,7 @@
   - openshift_logging_facts.elasticsearch_ops.deploymentconfigs.keys() | count > 0
 
 # Create any new DC that may be required
-- include_role:
+- import_role:
     name: openshift_logging_elasticsearch
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -213,7 +213,7 @@
 
 
 ## Kibana
-- include_role:
+- import_role:
     name: openshift_logging_kibana
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -226,7 +226,7 @@
     openshift_logging_kibana_image_pull_secret: "{{ openshift_logging_image_pull_secret }}"
 
 
-- include_role:
+- import_role:
     name: openshift_logging_kibana
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -256,7 +256,7 @@
 - include_tasks: annotate_ops_projects.yaml
 
 ## Curator
-- include_role:
+- import_role:
     name: openshift_logging_curator
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -266,7 +266,7 @@
     openshift_logging_curator_master_url: "{{ openshift_logging_master_url }}"
     openshift_logging_curator_image_pull_secret: "{{ openshift_logging_image_pull_secret }}"
 
-- include_role:
+- import_role:
     name: openshift_logging_curator
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -284,7 +284,7 @@
   - openshift_logging_use_ops | bool
 
 ## Mux
-- include_role:
+- import_role:
     name: openshift_logging_mux
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -297,7 +297,7 @@
 
 
 ## Fluentd
-- include_role:
+- import_role:
     name: openshift_logging_fluentd
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -308,7 +308,7 @@
 
 
 ## EventRouter
-- include_role:
+- import_role:
     name: openshift_logging_eventrouter
   when:
     openshift_logging_install_eventrouter | default(false) | bool

--- a/roles/openshift_logging_curator/tasks/main.yaml
+++ b/roles/openshift_logging_curator/tasks/main.yaml
@@ -56,7 +56,7 @@
     dest: "{{ tempdir }}/curator.yml"
   changed_when: no
 
-- include_role:
+- import_role:
     name: openshift_logging
     tasks_from: patch_configmap_files.yaml
   vars:

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -181,7 +181,7 @@
   changed_when: no
 
 # create diff between current configmap files and our current files
-- include_role:
+- import_role:
     name: openshift_logging
     tasks_from: patch_configmap_files.yaml
   vars:

--- a/roles/openshift_logging_fluentd/tasks/main.yaml
+++ b/roles/openshift_logging_fluentd/tasks/main.yaml
@@ -117,7 +117,7 @@
     src: secure-forward.conf
     dest: "{{ tempdir }}/secure-forward.conf"
 
-- include_role:
+- import_role:
     name: openshift_logging
     tasks_from: patch_configmap_files.yaml
   vars:

--- a/roles/openshift_logging_mux/tasks/main.yaml
+++ b/roles/openshift_logging_mux/tasks/main.yaml
@@ -95,7 +95,7 @@
     dest: "{{mktemp.stdout}}/secure-forward-mux.conf"
   changed_when: no
 
-- include_role:
+- import_role:
     name: openshift_logging
     tasks_from: patch_configmap_files.yaml
   vars:

--- a/roles/openshift_management/tasks/add_container_provider.yml
+++ b/roles/openshift_management/tasks/add_container_provider.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure OpenShift facts module is available
-  include_role:
+  import_role:
     role: openshift_facts
 
 - name: Ensure OpenShift facts are loaded

--- a/roles/openshift_management/tasks/main.yml
+++ b/roles/openshift_management/tasks/main.yml
@@ -8,7 +8,7 @@
 # This creates a service account allowing Container Provider
 # integration (managing OCP/Origin via MIQ/Management)
 - name: Enable Container Provider Integration
-  include_role:
+  import_role:
     role: openshift_manageiq
 
 - name: "Ensure the Management '{{ openshift_management_project }}' namespace exists"

--- a/roles/openshift_management/tasks/storage/nfs.yml
+++ b/roles/openshift_management/tasks/storage/nfs.yml
@@ -5,14 +5,14 @@
 - name: Setting up NFS storage
   block:
     - name: Include the NFS Setup role tasks
-      include_role:
+      import_role:
         role: openshift_nfs
         tasks_from: setup
       vars:
         l_nfs_base_dir: "{{ openshift_management_storage_nfs_base_dir }}"
 
     - name: Create the App export
-      include_role:
+      import_role:
         role: openshift_nfs
         tasks_from: create_export
       vars:
@@ -22,7 +22,7 @@
         l_nfs_options: "*(rw,no_root_squash,no_wdelay)"
 
     - name: Create the DB export
-      include_role:
+      import_role:
         role: openshift_nfs
         tasks_from: create_export
       vars:

--- a/roles/openshift_nfs/tasks/create_export.yml
+++ b/roles/openshift_nfs/tasks/create_export.yml
@@ -3,7 +3,7 @@
 #
 # Include signature
 #
-# include_role:
+# import_role:
 #   role: openshift_nfs
 #   tasks_from: create_export
 # vars:

--- a/roles/os_firewall/README.md
+++ b/roles/os_firewall/README.md
@@ -32,7 +32,7 @@ Use iptables:
 ---
 - hosts: servers
   task:
-  - include_role:
+  - import_role:
       name: os_firewall
     vars:
       os_firewall_use_firewalld: false
@@ -44,7 +44,7 @@ Use firewalld:
 - hosts: servers
   vars:
   tasks:
-  - include_role:
+  - import_role:
       name: os_firewall
     vars:
       os_firewall_use_firewalld: true


### PR DESCRIPTION
In Ansible 2.2, the include_role directive came into existence as
a Tech Preview. It is still a Tech Preview through Ansible 2.4
(and in current devel branch), but with a noteable change. The
default behavior switched from static: true to static: false
because that functionality moved to the newly introduced
import_role directive (in order to stay consistent with include*
being dynamic in nature and `import* being static in nature).

The dynamic include is considerably more memory intensive as it will
dynamically create a role import for every host in the inventory
list to be used. (Also worth noting, there is at the time of this
writing an object allocation inefficiency in the dynamic include
that can in certain situations amplify this effect considerably)

This change is meant to mitigate the pressure on memory for the
Ansible control host.

We need to evaluate where it makes sense to dynamically include roles
and revert back to dynamic inclusion if and where it makes sense to do
so.

In older branches which do not require Ansible 2.4 we'll add `static: true`
to preserve compatibility with Ansible 2.3.
  