### PR TITLE
Docker version's output is not in YAML format.

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -834,7 +834,7 @@ def get_docker_version_info():
     """ Parses and returns the docker version info """
     result = None
     if is_service_running('docker') or is_service_running('container-engine'):
-        version_info = yaml.safe_load(get_version_output('/usr/bin/docker', 'version'))
+        version_info = json.loads(get_version_output('/usr/bin/docker', 'version', '--format', '\'{{json .}}\''))
         if 'Server' in version_info:
             result = {
                 'api_version': version_info['Server']['API version'],


### PR DESCRIPTION
The default docker version's output doesn't follow the YAML format and there is nothing in the documentation about the default output format.
But docker version provides an official "json" output.
Update OpenShift to handle the json output.