### PR TITLE
upgrades: set openshift_client_binary fact when running on oo_first_master host

### DIFF
--- a/playbooks/init/facts.yml
+++ b/playbooks/init/facts.yml
@@ -100,3 +100,5 @@
       # We need to setup openshift_client_binary here for special uses of delegate_to in
       # later roles and plays.
       first_master_client_binary: "{{  openshift_client_binary }}"
+      #Some roles may require this to be set for first master
+      openshift_client_binary: "{{ openshift_client_binary }}"


### PR DESCRIPTION
This sets openshift_client_binary var for the first master,
as some roles use this var along with first_master_client_binary.

Not sure if its worth setting this var for the faulty roles instead though.

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>