### PR TITLE
Expose router stats port when prometheus is installed

### DIFF
--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -62,7 +62,10 @@ openshift_hosted_router_certificate: {}
 openshift_hosted_router_create_certificate: True
 
 r_openshift_hosted_router_os_firewall_deny: []
-r_openshift_hosted_router_os_firewall_allow: []
+r_openshift_hosted_router_os_firewall_allow:
+- service: Router Statistics Port
+  port: "{{ stats_port }}/tcp"
+  cond: "{{ openshift_prometheus_state == 'present' }}"
 
 ############
 # Registry #

--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -26,6 +26,7 @@ openshift_cluster_domain: 'cluster.local'
 ##########
 r_openshift_hosted_router_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
 r_openshift_hosted_router_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
+r_openshift_hosted_router_prometheus_enabled: "{{ openshift_prometheus_state == 'present' | default(True) }}"
 
 openshift_hosted_router_selector: "{{ openshift_router_selector | default(openshift_hosted_infra_selector) }}"
 openshift_hosted_router_namespace: 'default'
@@ -65,7 +66,7 @@ r_openshift_hosted_router_os_firewall_deny: []
 r_openshift_hosted_router_os_firewall_allow:
 - service: Router Statistics Port
   port: "{{ stats_port }}/tcp"
-  cond: "{{ openshift_prometheus_state == 'present' }}"
+  cond: "{{ r_openshift_hosted_router_prometheus_enabled }}"
 
 ############
 # Registry #

--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -26,7 +26,7 @@ openshift_cluster_domain: 'cluster.local'
 ##########
 r_openshift_hosted_router_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
 r_openshift_hosted_router_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
-r_openshift_hosted_router_prometheus_enabled: "{{ openshift_prometheus_state == 'present' | default(True) }}"
+r_openshift_hosted_router_prometheus_enabled: "{{ openshift_prometheus_state is defined and openshift_prometheus_state == 'present' | default(True) }}"
 
 openshift_hosted_router_selector: "{{ openshift_router_selector | default(openshift_hosted_infra_selector) }}"
 openshift_hosted_router_namespace: 'default'


### PR DESCRIPTION
Today prometheus is configured out of the box to try and scrape the openshift hosted router stats/metrics endpoint however it is unable to do so because the firewall on each physical node is not permitting this port to exposed.

This change exposes the firewall port when prometheus is installed (default here is True corresponding to `openshift_prometheus_state` default state of `present` )

Currently getting: `Get http://<ip of node hosting router>:1936/metrics: dial tcp <ip of node hosting router>:1936: getsockopt: no route to host`

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1552235