### PR TITLE
Add missing dependency on openshift_facts

### DIFF
--- a/roles/openshift_hosted_templates/meta/main.yml
+++ b/roles/openshift_hosted_templates/meta/main.yml
@@ -13,3 +13,4 @@ galaxy_info:
   - cloud
 dependencies:
 - role: lib_utils
+- role: openshift_facts


### PR DESCRIPTION
Fixes the following but I see other roles that don't include openshift_facts dependency so I wonder if there's a better solution.

```
+ /usr/bin/ansible-playbook -e openshift_install_examples=false -e openshift_upgrade_pre_authorization_migration_enabled=false -e openshift_upgrade_pre_storage_migration_enabled=false -e openshift_upgrade_post_storage_migration_enabled=false -e openshift_disable_check=disk_availability,docker_storage,memory_availability,package_version,docker_image_availability -e osm_cluster_network_cidr=10.128.0.0/14 -e osm_host_subnet_length=9 -e openshift_portal_net=172.30.0.0/16 -e etcd_quota_backend_bytes=4294967296 -M playbooks/byo/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml

...

  1. Hosts:    master-1
     Play:     Upgrade default router and default registry
     Task:     Create or update hosted templates
     Message:  The task includes an option with an undefined variable. The error was: 'openshift_client_binary' is undefined
               
               The error appears to have been in 'roles/openshift_hosted_templates/tasks/main.yml': line 53, column 3, but may
               be elsewhere in the file depending on the exact syntax problem.
               
               The offending line appears to be:
               
               
               - name: Create or update hosted templates
                 ^ here
               
               exception type: <class 'ansible.errors.AnsibleUndefinedVariable'>
               exception: 'openshift_client_binary' is undefined
```