### PR TITLE
Add key existing check to collect facts for rolebidings

### DIFF
--- a/roles/openshift_logging/library/openshift_logging_facts.py
+++ b/roles/openshift_logging/library/openshift_logging_facts.py
@@ -288,7 +288,7 @@ class OpenshiftLoggingFacts(OCBaseCommand):
             return
         for item in role["subjects"]:
             comp = self.comp(item["name"])
-            if comp is not None and namespace == item["namespace"]:
+            if comp is not None and namespace == item.get("namespace"):
                 self.add_facts_for(comp, "rolebindings", "logging-elasticsearch-view-role", dict())
 
     # pylint: disable=no-self-use, too-many-return-statements

--- a/roles/openshift_logging/library/openshift_logging_facts.py
+++ b/roles/openshift_logging/library/openshift_logging_facts.py
@@ -276,7 +276,7 @@ class OpenshiftLoggingFacts(OCBaseCommand):
             return
         for item in role["subjects"]:
             comp = self.comp(item["name"])
-            if comp is not None and namespace == item["namespace"]:
+            if comp is not None and namespace == item.get("namespace"):
                 self.add_facts_for(comp, "clusterrolebindings", "cluster-readers", dict())
 
 # this needs to end up nested under the service account...


### PR DESCRIPTION
Currently `facts_for_rolebindings()` tries to collect
ClusterRoleBinding facts in logging namespace. But all of the
`subjects` do not have the `namspace` value like[1].

(e.g)
```
- kind: SystemGroup
  name: system:cluster-readers
```

Due to this, `if comp is not None and namespace == item["namespace"]:`
will cause an exception when such item. This patch adds
`"namespace" in item` check before accessing to the
`item["namespace"]`.

[1]
~~~
#  oc get clusterrolebindings/cluster-readers -o yaml 
apiVersion: v1
groupNames:
- system:cluster-readers
kind: ClusterRoleBinding
metadata:
  annotations:
    openshift.io/reconcile-protect: "false"
  creationTimestamp: 2017-11-30T06:10:43Z
  name: cluster-readers
  resourceVersion: "9824"
  selfLink: /oapi/v1/clusterrolebindings/cluster-readers
  uid: 3288302d-d595-11e7-bbc2-001a4a40dca1
roleRef:
  name: cluster-reader
subjects:
- kind: ServiceAccount
  name: management-admin
  namespace: management-infra
- kind: ServiceAccount
  name: router
  namespace: default
- kind: SystemGroup
  name: system:cluster-readers
~~~
  