### PR TITLE
Use complete version, since v3.7 do not exist

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -35,7 +35,7 @@ openshift_deployment_type=origin
 # use this to lookup the latest exact version of the container images, which is the tag actually used to configure
 # the cluster. For RPM installations we just verify the version detected in your configured repos matches this
 # release.
-openshift_release=v3.7
+openshift_release=v3.7.0
 
 # Specify an exact container image tag to install or configure.
 # WARNING: This value will be used for all hosts in containerized environments, even those that have another version installed.


### PR DESCRIPTION
Since it took me a bit to figure what was wrong with version "v3.7" and why docker couldn't pull the image, I suspect I am not the only ones who would stumble on this after pasting the variable from example configuration.