### PR TITLE
container-engine: move registry_auth.yml before pull

### DIFF
--- a/roles/docker/tasks/systemcontainer_docker.yml
+++ b/roles/docker/tasks/systemcontainer_docker.yml
@@ -121,6 +121,12 @@
     - debug:
         var: l_docker_image
 
+# Since docker is running as a system container, docker login will fail to create
+# credentials.  Use alternate method if requiring authenticated registries.
+- include: registry_auth.yml
+  vars:
+    openshift_docker_alternative_creds: True
+
 # NOTE: no_proxy added as a workaround until https://github.com/projectatomic/atomic/pull/999 is released
 - name: Pre-pull Container Engine System Container image
   command: "atomic pull --storage ostree {{ l_docker_image }}"
@@ -183,9 +189,3 @@
     docker_service_status_changed: "{{ r_docker_systemcontainer_docker_start_result | changed }}"
 
 - meta: flush_handlers
-
-# Since docker is running as a system container, docker login will fail to create
-# credentials.  Use alternate method if requiring authenticated registries.
-- include: registry_auth.yml
-  vars:
-    openshift_docker_alternative_creds: True


### PR DESCRIPTION
so that the atomic pull takes into account the credentials if
required.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1505744

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>