### PR TITLE
container-engine: move registry_auth.yml before pull

### DIFF
--- a/roles/container_runtime/tasks/systemcontainer_docker.yml
+++ b/roles/container_runtime/tasks/systemcontainer_docker.yml
@@ -42,6 +42,12 @@
 - debug:
     var: l_docker_image
 
+# Do the authentication before pulling the container engine system container
+# as the pull might be from an authenticated registry.
+- include_tasks: registry_auth.yml
+  vars:
+    openshift_docker_alternative_creds: True
+
 # NOTE: no_proxy added as a workaround until https://github.com/projectatomic/atomic/pull/999 is released
 - name: Pre-pull Container Engine System Container image
   command: "atomic pull --storage ostree {{ l_docker_image }}"


### PR DESCRIPTION
so that the atomic pull takes into account the credentials if
required.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>