### PR TITLE
install base_packages on oo_all_hosts

### DIFF
--- a/playbooks/init/base_packages.yml
+++ b/playbooks/init/base_packages.yml
@@ -1,6 +1,6 @@
 ---
-- name: Ensure that all non-node hosts are accessible
-  hosts: oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_nfs_to_config
+- name: Install packages necessary for installer
+  hosts: oo_all_hosts
   any_errors_fatal: true
   tasks:
   - when:


### PR DESCRIPTION
This commit ensures base packages are installed
for oo_all_hosts, which is what we were doing previously.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1530516
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1528945