### PR TITLE
upgrades: use openshift_node_use_openshift_sdn when trying to pre-pull the image

### DIFF
--- a/roles/openshift_node/tasks/upgrade/containerized_upgrade_pull.yml
+++ b/roles/openshift_node/tasks/upgrade/containerized_upgrade_pull.yml
@@ -10,6 +10,6 @@
     docker pull {{ osn_ovs_image }}:{{ openshift_image_tag }}
   register: pull_result
   changed_when: "'Downloaded newer image' in pull_result.stdout"
-  when: openshift_use_openshift_sdn | bool
+  when: openshift_node_use_openshift_sdn | bool
 
 - include_tasks: ../container_images.yml


### PR DESCRIPTION
This affects 3.8/3.9 upgrades for containerized hosts, if nodes are separate from master.  