### PR TITLE
Build containerized host group dynamically

### DIFF
--- a/playbooks/container-runtime/private/build_container_groups.yml
+++ b/playbooks/container-runtime/private/build_container_groups.yml
@@ -1,0 +1,6 @@
+---
+- name: create oo_hosts_containerized_managed_true host group
+  hosts: oo_all_hosts:!oo_nodes_to_config
+  tasks:
+  - group_by:
+      key: oo_hosts_containerized_managed_{{ (containerized | default(False)) | ternary('true','false') }}

--- a/playbooks/container-runtime/private/config.yml
+++ b/playbooks/container-runtime/private/config.yml
@@ -1,10 +1,7 @@
 ---
-- hosts: "{{ l_containerized_host_groups }}"
-  vars:
-    l_chg_temp: "{{ hostvars[groups['oo_first_master'][0]]['openshift_containerized_host_groups'] | default([]) }}"
-    l_containerized_host_groups: "{{ (['oo_nodes_to_config'] | union(l_chg_temp)) | join(':') }}"
-  # role: container_runtime is necessary  here to bring role default variables
-  # into the play scope.
+- import_playbook: build_container_groups.yml
+
+- hosts: oo_nodes_to_config:oo_hosts_containerized_managed_true
   roles:
     - role: container_runtime
   tasks:

--- a/playbooks/container-runtime/private/setup_storage.yml
+++ b/playbooks/container-runtime/private/setup_storage.yml
@@ -1,5 +1,7 @@
 ---
-- hosts: "{{ l_containerized_host_groups }}"
+- import_playbook: build_container_groups.yml
+
+- hosts: oo_nodes_to_config:oo_hosts_containerized_managed_true
   vars:
     l_chg_temp: "{{ hostvars[groups['oo_first_master'][0]]['openshift_containerized_host_groups'] | default([]) }}"
     l_containerized_host_groups: "{{ (['oo_nodes_to_config'] | union(l_chg_temp)) | join(':') }}"

--- a/test/tox-inventory.txt
+++ b/test/tox-inventory.txt
@@ -13,6 +13,7 @@ oo_first_etcd
 oo_etcd_hosts_to_backup
 oo_etcd_hosts_to_upgrade
 oo_etcd_to_migrate
+oo_hosts_containerized_managed_true
 oo_masters
 oo_masters_to_config
 oo_first_master
@@ -102,4 +103,7 @@ localhost
 localhost
 
 [glusterfs_registry]
+localhost
+
+[oo_hosts_containerized_managed_true]
 localhost


### PR DESCRIPTION
Currently, we are using some inventory variables
to determine what host groups should be considered
containerized.

This is problematic and has several edge cases.

This commit removes the variable l_containerized_host_groups
and builds a dynamic group of hosts named
'oo_hosts_containerized_managed_true' based on the value of
'containerized'