### PR TITLE
Force the conversion to dict for openshift_node_labels

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -27,7 +27,7 @@ openshift_dns_ip: "{{ ansible_default_ipv4['address'] }}"
 openshift_node_env_vars: {}
 
 # Create list of 'k=v' pairs.
-l_node_kubelet_node_labels: "{{ openshift_node_labels | default({}) | lib_utils_oo_dict_to_keqv_list }}"
+l_node_kubelet_node_labels: "{{ openshift_node_labels | default({}) | from_yaml | lib_utils_oo_dict_to_keqv_list }}"
 
 openshift_node_kubelet_args_dict:
   aws:


### PR DESCRIPTION
Without those, on a deployment using ansible 2.4 (or devel branch), it fail
with:

    Message:  The conditional check '('config' in l2_openshift_node_kubelet_args)
    | bool' failed. The error was: {{ l_node_kubelet_args_default |
    combine(l_openshift_node_kubelet_args, recursive=True) }}: {{
    openshift_node_kubelet_args_dict[openshift_cloudprovider_kind | default('undefined')] }}:
    {u'openstack': {u'cloud-config': [u"{{ openshift_config_base ~
    '/cloudprovider/openstack.conf' }}"], u'node-labels': u'{{ l_node_kubelet_node_labels }}',
    u'cloud-provider': [u'openstack']}, u'gce': {u'cloud-config': [u"{{ openshift_config_base ~
    '/cloudprovider/gce.conf' }}"], u'node-labels': u'{{ l_node_kubelet_node_labels }}',
    u'cloud-provider': [u'gce']}, u'aws': {u'cloud-config': [u"{{ openshift_config_base ~
    '/cloudprovider/aws.conf' }}"], u'node-labels': u'{{ l_node_kubelet_node_labels }}',
    u'cloud-provider': [u'aws']}, u'undefined': {u'node-labels': u'{{ l_node_kubelet_node_labels }}'}}:
    {{ openshift_node_labels | default({}) | lib_utils_oo_dict_to_keqv_list }}:
    'unicode' object has no attribute 'items'

It seems that since ansible no longer convert automatically variable to dict.