### PR TITLE
Properly cast crio boolean variables to bool

### DIFF
--- a/roles/container_runtime/tasks/common/post.yml
+++ b/roles/container_runtime/tasks/common/post.yml
@@ -22,5 +22,5 @@
 
 - include_tasks: setup_docker_symlink.yml
   when:
-    - openshift_use_crio
+    - openshift_use_crio | bool
     - dockerstat.stat.islnk is defined and not (dockerstat.stat.islnk | bool)

--- a/roles/container_runtime/tasks/systemcontainer_crio.yml
+++ b/roles/container_runtime/tasks/systemcontainer_crio.yml
@@ -104,4 +104,4 @@
 # 'docker login'
 - include_tasks: common/post.yml
   vars:
-    openshift_docker_alternative_creds: "{{ openshift_use_crio_only }}"
+    openshift_docker_alternative_creds: "{{ openshift_use_crio_only | bool }}"

--- a/roles/openshift_cli/defaults/main.yml
+++ b/roles/openshift_cli/defaults/main.yml
@@ -8,4 +8,4 @@ system_images_registry: "{{ system_images_registry_dict[openshift_deployment_typ
 openshift_use_crio_only: False
 
 l_is_system_container_image: "{{ openshift_use_master_system_container | default(openshift_use_system_containers | default(False)) | bool }}"
-l_use_cli_atomic_image: "{{ openshift_use_crio_only or l_is_system_container_image }}"
+l_use_cli_atomic_image: "{{ (openshift_use_crio_only | bool) or (l_is_system_container_image | bool) }}"

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -169,7 +169,7 @@ oreg_auth_credentials_path: "{{ openshift_node_data_dir }}/.docker"
 oreg_auth_credentials_replace: False
 l_bind_docker_reg_auth: False
 openshift_use_crio: False
-openshift_docker_alternative_creds: "{{ (openshift_docker_use_system_container | default(False) | bool) or (openshift_use_crio_only | default(False)) }}"
+openshift_docker_alternative_creds: "{{ (openshift_docker_use_system_container | default(False) | bool) or (openshift_use_crio_only | default(False) | bool) }}"
 
 openshift_docker_service_name: "{{ 'container-engine' if (openshift_docker_use_system_container | default(False) | bool) else 'docker' }}"
 

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -4,7 +4,7 @@
   when:
     - (not ansible_selinux or ansible_selinux.status != 'enabled')
     - openshift_deployment_type == 'openshift-enterprise'
-    - not openshift_use_crio
+    - not openshift_use_crio | bool
 
 - include_tasks: dnsmasq_install.yml
 - include_tasks: dnsmasq.yml
@@ -50,7 +50,7 @@
     name: cri-o
     enabled: yes
     state: restarted
-  when: openshift_use_crio
+  when: openshift_use_crio | bool
   register: task_result
   failed_when:
     - task_result is failed

--- a/roles/openshift_node/tasks/openvswitch_system_container.yml
+++ b/roles/openshift_node/tasks/openvswitch_system_container.yml
@@ -1,11 +1,11 @@
 ---
 - set_fact:
     l_service_name: "cri-o"
-  when: openshift_use_crio
+  when: openshift_use_crio | bool
 
 - set_fact:
     l_service_name: "{{ openshift_docker_service_name }}"
-  when: not openshift_use_crio
+  when: not openshift_use_crio | bool
 
 - name: Pre-pull OpenVSwitch system container image
   command: >

--- a/roles/openshift_node/templates/node.service.j2
+++ b/roles/openshift_node/templates/node.service.j2
@@ -8,7 +8,7 @@ Wants={{ openshift_docker_service_name }}.service
 Documentation=https://github.com/openshift/origin
 Requires=dnsmasq.service
 After=dnsmasq.service
-{% if openshift_use_crio %}Wants=cri-o.service{% endif %}
+{% if openshift_use_crio | bool %}Wants=cri-o.service{% endif %}
 
 [Service]
 Type=notify

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -14,7 +14,7 @@ imageConfig:
   latest: {{ openshift_node_image_config_latest }}
 kind: NodeConfig
 kubeletArguments: {{  l2_openshift_node_kubelet_args  | default(None) | lib_utils_to_padded_yaml(level=1) }}
-{% if openshift_use_crio %}
+{% if openshift_use_crio | bool %}
   container-runtime:
   - remote
   container-runtime-endpoint:

--- a/roles/openshift_node/templates/openshift.docker.node.dep.service
+++ b/roles/openshift_node/templates/openshift.docker.node.dep.service
@@ -3,7 +3,7 @@ Requires={{ openshift_docker_service_name }}.service
 After={{ openshift_docker_service_name }}.service
 PartOf={{ openshift_service_type }}-node.service
 Before={{ openshift_service_type }}-node.service
-{% if openshift_use_crio %}Wants=cri-o.service{% endif %}
+{% if openshift_use_crio | bool %}Wants=cri-o.service{% endif %}
 
 [Service]
 ExecStart=/bin/bash -c 'if [[ -f /usr/bin/docker-current ]]; \

--- a/roles/openshift_version/tasks/set_version_containerized.yml
+++ b/roles/openshift_version/tasks/set_version_containerized.yml
@@ -21,7 +21,7 @@
   register: cli_image_version
   when:
   - openshift_version is not defined
-  - not openshift_use_crio_only
+  - not openshift_use_crio_only | bool
 
 # Origin latest = pre-release version (i.e. v1.3.0-alpha.1-321-gb095e3a)
 - set_fact:
@@ -30,7 +30,7 @@
   - openshift_version is not defined
   - openshift.common.deployment_type == 'origin'
   - cli_image_version.stdout_lines[0].split('-') | length > 1
-  - not openshift_use_crio_only
+  - not openshift_use_crio_only | bool
 
 - set_fact:
     openshift_version: "{{ cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0][1:] }}"
@@ -45,14 +45,14 @@
   when:
   - openshift_version is defined
   - openshift_version.split('.') | length == 2
-  - not openshift_use_crio_only
+  - not openshift_use_crio_only | bool
 
 - set_fact:
     openshift_version: "{{ cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0:2][1:] | join('-') if openshift.common.deployment_type == 'origin' else cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0][1:] }}"
   when:
   - openshift_version is defined
   - openshift_version.split('.') | length == 2
-  - not openshift_use_crio_only
+  - not openshift_use_crio_only | bool
 
 # TODO: figure out a way to check for the openshift_version when using CRI-O.
 # We should do that using the images in the ostree storage so we don't have


### PR DESCRIPTION
Variables that are specifically booleans should be
cast to bool.  This is because users may sometimes
pass them as string values.  This is particularly
prevalent when using ini-style inventories.

Affected-by: https://github.com/ansible/ansible/issues/34591

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1531592