### PR TITLE
docker storage setup for ami building

### DIFF
--- a/playbooks/aws/provisioning_vars.yml.example
+++ b/playbooks/aws/provisioning_vars.yml.example
@@ -93,6 +93,11 @@ openshift_aws_ssh_key_name: # myuser_key
 # --------- #
 # Variables in this section apply to building a node AMI for use in your
 # openshift cluster.
+# openshift-ansible will perform the container runtime storage setup when specified
+# The current storage setup with require a drive if using a separate storage device
+# for the container runtime.
+container_runtime_docker_storage_type: overlay2
+container_runtime_docker_storage_setup_device: /dev/xvdb
 
 # must specify a base_ami when building an AMI
 openshift_aws_base_ami: # ami-12345678

--- a/roles/openshift_aws/tasks/provision_instance.yml
+++ b/roles/openshift_aws/tasks/provision_instance.yml
@@ -42,5 +42,5 @@
 
 - name: add host to nodes
   add_host:
-    groups: nodes
+    groups: nodes,g_new_node_hosts
     name: "{{ instancesout.instances[0].public_dns_name }}"


### PR DESCRIPTION
add host to g_new_node_hosts so that plays run against the AMI instance

update example vars so that overlay2 is used by default for docker storage