### PR TITLE
Fix: change import_role to include_role

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -181,7 +181,9 @@
   changed_when: no
 
 # create diff between current configmap files and our current files
-- import_role:
+# NOTE: include_role must be used instead of import_role because
+# this task file is looped over from another role.
+- include_role:
     name: openshift_logging
     tasks_from: patch_configmap_files.yaml
   vars:


### PR DESCRIPTION
It appears that when one role dynamically imports
another, usage of import_role inside the dynamically
included role is not possible.

If something is included with include_role (dynamic),
all tasks therein must also use include_role (dynamic).