### PR TITLE
Update etcd to 3.1

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/etcd/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/etcd/upgrade.yml
@@ -105,6 +105,24 @@
   - include: containerized_tasks.yml
     when: etcd_container_version.stdout | default('99') | version_compare('3.0','<') and openshift.common.is_containerized | bool
 
+- name: Upgrade RPM hosts to 3.1
+  hosts: etcd_hosts_to_upgrade
+  serial: 1
+  vars:
+    upgrade_version: '3.1'
+  tasks:
+  - include: rhel_tasks.yml
+    when: etcd_rpm_version.stdout | default('99') | version_compare('3.1','<') and ansible_distribution == 'RedHat' and not openshift.common.is_containerized | bool
+
+- name: Upgrade containerized hosts to 3.1.3
+  hosts: etcd_hosts_to_upgrade
+  serial: 1
+  vars:
+    upgrade_version: 3.1.3
+  tasks:
+  - include: containerized_tasks.yml
+    when: etcd_container_version.stdout | default('99') | version_compare('3.1.3','<') and openshift.common.is_containerized | bool
+
 - name: Upgrade fedora to latest
   hosts: etcd_hosts_to_upgrade
   serial: 1


### PR DESCRIPTION
Updating the etcd to `3.1.*` in `3.5` as requested by https://bugzilla.redhat.com/show_bug.cgi?id=1421587

@sdodson does it still make sense to fix it via z-stream?