### PR TITLE
Commit to solve multi-az problem

### DIFF
--- a/playbooks/aws/provisioning_vars.yml.example
+++ b/playbooks/aws/provisioning_vars.yml.example
@@ -44,9 +44,8 @@ openshift_pkg_version: # -3.7.0
 # Name of the vpc.  Needs to be set if using a pre-existing vpc.
 #openshift_aws_vpc_name: "{{ openshift_aws_clusterid }}"
 
-# Name of the subnet in the vpc to use.  Needs to be set if using a pre-existing
-# vpc + subnet.
-#openshift_aws_subnet_az:
+# Number of Availability Zones/networks to make available to AWS AutoScale Group
+#openshift_aws_asg_master_az_count: 1
 
 # -------------- #
 # Security Group #

--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -272,19 +272,18 @@ openshift_aws_node_security_groups:
 openshift_aws_vpc_tags:
   Name: "{{ openshift_aws_vpc_name }}"
 
-openshift_aws_subnet_az: us-east-1c
+openshift_aws_asg_master_az_count: 1
 
 openshift_aws_vpc:
   name: "{{ openshift_aws_vpc_name }}"
   cidr: 172.31.0.0/16
   subnets:
-    us-east-1:
-    - cidr: 172.31.48.0/20
-      az: "us-east-1c"
-    - cidr: 172.31.32.0/20
-      az: "us-east-1e"
-    - cidr: 172.31.16.0/20
-      az: "us-east-1a"
+  - az: us-east-1a
+    cidr: 172.31.16.0/20
+  - az: us-east-1c
+    cidr: 172.31.48.0/20
+  - az: us-east-1e
+    cidr: 172.31.32.0/20
 
 openshift_aws_node_run_bootstrap_startup: True
 openshift_aws_node_user_data: ''

--- a/roles/openshift_aws/tasks/scale_group.yml
+++ b/roles/openshift_aws/tasks/scale_group.yml
@@ -3,6 +3,12 @@
   set_fact:
     l_node_group_name: "{{ openshift_aws_node_group.name }} {{ l_deployment_serial }}"
 
+- fail:
+    msg:
+      - "AWS ASG az count is greater than available az/subnets"
+      - "Please set openshift_aws_asg_az_count accordingly"
+  when: openshift_aws_asg_master_az_count > (subnetout.subnets | map(attribute='az') | list | length)
+
 - name: Create the scale group
   ec2_asg:
     name: "{{ l_node_group_name }}"
@@ -16,12 +22,12 @@
     termination_policies: "{{ l_node_group_config[openshift_aws_node_group.group].termination_policy if 'termination_policy' in  l_node_group_config[openshift_aws_node_group.group] else omit }}"
     load_balancers: "{{ l_node_group_config[openshift_aws_node_group.group].elbs if 'elbs' in l_node_group_config[openshift_aws_node_group.group] else omit }}"
     wait_for_instances: "{{ l_node_group_config[openshift_aws_node_group.group].wait_for_instances | default(False)}}"
-    vpc_zone_identifier: "{{ subnetout.subnets[0].id }}"
+    vpc_zone_identifier: "{{ subnetout.subnets[:openshift_aws_asg_master_az_count] | map(attribute='id') | list }}"
     replace_instances: "{{ openshift_aws_node_group_replace_instances if openshift_aws_node_group_replace_instances != [] else omit }}"
     replace_all_instances: "{{ omit if openshift_aws_node_group_replace_instances != []
                                     else (l_node_group_config[openshift_aws_node_group.group].replace_all_instances | default(omit)) }}"
     tags:
-    - "{{ openshift_aws_node_group_config_tags
+      - "{{ openshift_aws_node_group_config_tags
           | combine(openshift_aws_node_group.tags)
           | combine({'deployment_serial': l_deployment_serial, 'ami': openshift_aws_ami_map[openshift_aws_node_group.group] | default(openshift_aws_ami)}) }}"
 

--- a/roles/openshift_aws/tasks/vpc_and_subnet_id.yml
+++ b/roles/openshift_aws/tasks/vpc_and_subnet_id.yml
@@ -13,7 +13,7 @@
   ec2_vpc_subnet_facts:
     region: "{{ openshift_aws_region }}"
     filters:
-      "availability_zone": "{{ openshift_aws_subnet_az }}"
+      "availability_zone": "{{ openshift_aws_vpc.subnets | map(attribute='az') | list }}"
       vpc-id: "{{ vpcout.vpcs[0].id }}"
   register: subnetout
 


### PR DESCRIPTION
First step in solving the multiaz problem.  This commit will allow the AWS ASG to transition from single az to multi az based a key value in the var file.  openshift_aws_subnet_az key value is dropped as it is no longer needed.  I cosmetically reordered the default subnets list also.