### PR TITLE
Bug 1532787 - Add empty node selector to openshift-web-console namespace

### DIFF
--- a/roles/openshift_web_console/tasks/install.yml
+++ b/roles/openshift_web_console/tasks/install.yml
@@ -18,6 +18,8 @@
   oc_project:
     name: openshift-web-console
     state: present
+    node_selector:
+      - ""
 
 - name: Make temp directory for asset config files
   command: mktemp -d /tmp/console-ansible-XXXXXX


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1532787

/kind bug
/assign @sdodson 
/cc @mffiedler 