### PR TITLE
Bug 1536924: Migrate previous asset config from master-config.yaml

### DIFF
--- a/roles/openshift_web_console/tasks/install.yml
+++ b/roles/openshift_web_console/tasks/install.yml
@@ -21,7 +21,7 @@
     node_selector:
       - ""
 
-- name: Make temp directory for the web console config files
+- name: Make temp directory for web console templates
   command: mktemp -d /tmp/console-ansible-XXXXXX
   register: mktemp
   changed_when: False
@@ -31,7 +31,7 @@
     cp {{ openshift.common.config_base }}/master//admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
   changed_when: false
 
-- name: Copy the web console config template to temp directory
+- name: Copy web console templates to temp directory
   copy:
     src: "{{ __console_files_location }}/{{ item }}"
     dest: "{{ mktemp.stdout }}/{{ item }}"
@@ -40,31 +40,87 @@
     - "{{ __console_rbac_file }}"
     - "{{ __console_config_file }}"
 
-- name: Update the web console config properties
-  yedit:
-    src: "{{ mktemp.stdout }}/{{ __console_config_file }}"
-    edits:
-      - key: clusterInfo#consolePublicURL
-        # Must have a trailing slash
-        value: "{{ openshift.master.public_console_url }}/"
-      - key: clusterInfo#masterPublicURL
-        value: "{{ openshift.master.public_api_url }}"
-      - key: clusterInfo#logoutPublicURL
-        value: "{{ openshift.master.logout_url | default('') }}"
-      - key: features#inactivityTimeoutMinutes
-        value: "{{ openshift_web_console_inactivity_timeout_minutes | default(0) }}"
-      - key: extensions#scriptURLs
-        value: "{{ openshift_web_console_extension_script_urls | default([]) }}"
-      - key: extensions#stylesheetURLs
-        value: "{{ openshift_web_console_extension_stylesheet_urls | default([]) }}"
-      - key: extensions#properties
-        value: "{{ openshift_web_console_extension_properties | default({}) }}"
-    separator: '#'
-    state: present
+# Check if an existing webconsole-config config map exists. If so, use those
+# contents so we don't overwrite changes.
+- name: Read the existing web console config map
+  oc_configmap:
+    namespace: openshift-web-console
+    name: webconsole-config
+    state: list
+  register: webconsole_config_map
+
+- set_fact:
+    existing_config_map_data: "{{ webconsole_config_map.results.results[0].data | default({}) }}"
+
+- name: Copy the existing web console config to temp directory
+  copy:
+    content: "{{ existing_config_map_data['webconsole-config.yaml'] }}"
+    dest: "{{ mktemp.stdout }}/{{ __console_config_file }}"
+  when: existing_config_map_data['webconsole-config.yaml'] is defined
+
+# Generate a new config when a config map is not defined.
+- when: existing_config_map_data['webconsole-config.yaml'] is not defined
+  block:
+    # Migrate the previous master-config.yaml asset config if it exists into the new
+    # web console config config map.
+    - name: Read existing assetConfig in master-config.yaml
+      slurp:
+        src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      register: master_config_output
+
+    - set_fact:
+        config_to_migrate: "{{ master_config_output.content | b64decode | from_yaml }}"
+
+    # Update properties in the config template based on inventory vars when the
+    # asset config does not exist.
+    - name: Set web console config properties from inventory variables
+      yedit:
+        src: "{{ mktemp.stdout }}/{{ __console_config_file }}"
+        edits:
+          - key: clusterInfo#consolePublicURL
+            # Must have a trailing slash
+            value: "{{ openshift.master.public_console_url }}/"
+          - key: clusterInfo#masterPublicURL
+            value: "{{ openshift.master.public_api_url }}"
+          - key: clusterInfo#logoutPublicURL
+            value: "{{ openshift.master.logout_url | default('') }}"
+          - key: features#inactivityTimeoutMinutes
+            value: "{{ openshift_web_console_inactivity_timeout_minutes | default(0) }}"
+          - key: extensions#scriptURLs
+            value: "{{ openshift_web_console_extension_script_urls | default([]) }}"
+          - key: extensions#stylesheetURLs
+            value: "{{ openshift_web_console_extension_stylesheet_urls | default([]) }}"
+          - key: extensions#properties
+            value: "{{ openshift_web_console_extension_properties | default({}) }}"
+        separator: '#'
+        state: present
+      when: config_to_migrate.assetConfig is not defined
+
+    - name: Migrate assetConfig from master-config.yaml
+      yedit:
+        src: "{{ mktemp.stdout }}/{{ __console_config_file }}"
+        edits:
+          - key: clusterInfo#consolePublicURL
+            value: "{{ config_to_migrate.assetConfig.publicURL }}"
+          - key: clusterInfo#masterPublicURL
+            value: "{{ config_to_migrate.assetConfig.masterPublicURL }}"
+          - key: clusterInfo#logoutPublicURL
+            value: "{{ config_to_migrate.assetConfig.logoutURL | default('') }}"
+          - key: clusterInfo#metricsPublicURL
+            value: "{{ config_to_migrate.assetConfig.metricsPublicURL | default('') }}"
+          - key: clusterInfo#loggingPublicURL
+            value: "{{ config_to_migrate.assetConfig.loggingPublicURL | default('') }}"
+          - key: servingInfo#maxRequestsInFlight
+            value: "{{ config_to_migrate.assetConfig.servingInfo.maxRequestsInFlight | default(0) }}"
+          - key: servingInfo#requestTimeoutSeconds
+            value: "{{ config_to_migrate.assetConfig.servingInfo.requestTimeoutSeconds | default(0) }}"
+        separator: '#'
+        state: present
+      when: config_to_migrate.assetConfig is defined
 
 - slurp:
     src: "{{ mktemp.stdout }}/{{ __console_config_file }}"
-  register: config
+  register: updated_console_config
 
 - name: Reconcile with the web console RBAC file
   shell: >
@@ -74,7 +130,7 @@
 - name: Apply the web console template file
   shell: >
     {{ openshift_client_binary }} process -f "{{ mktemp.stdout }}/{{ __console_template_file }}"
-    --param API_SERVER_CONFIG="{{ config['content'] | b64decode }}"
+    --param API_SERVER_CONFIG="{{ updated_console_config['content'] | b64decode }}"
     --param IMAGE="{{ openshift_web_console_prefix }}{{ openshift_web_console_image_name }}:{{ openshift_web_console_version }}"
     --param NODE_SELECTOR={{ openshift_web_console_nodeselector | to_json | quote }}
     --param REPLICA_COUNT="{{ openshift_web_console_replica_count }}"


### PR DESCRIPTION
Copy configuration from master-config.yaml to the openshift-web-console asset config config map.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1536924

TODO:

- [x] Don't overwrite config map if it exists

Follow on:

- [ ] Remove assetConfig from master-config.yaml on upgrades to 3.9
- [ ] Warn about existing extensions that aren't migrated on upgrades

/assign @sdodson 
/hold

cc @jwforres 