### PR TITLE
CRI-O, Docker: Use images from the CentOS and Fedora registry

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -115,20 +115,20 @@ l_crio_image: "{{ openshift_crio_systemcontainer_image_override | default(l_crio
 # ----------------------- #
 # systemcontainers_docker #
 # ----------------------- #
-l_crt_docker_image_prepend_dict:
-  Fedora: "registry.fedoraproject.org/latest"
-  Centos: "docker.io/gscrivano"
-  RedHat: "registry.access.redhat.com/openshift3"
+l_crt_docker_image_dict:
+  Fedora: "registry.fedoraproject.org/latest/docker"
+  Centos: "registry.centos.org/projectatomic/docker"
+  RedHat: "registry.access.redhat.com/openshift3/container-engine"
 
 openshift_docker_image_tag_default: "latest"
 l_crt_docker_image_tag_dict:
   openshift-enterprise: "{{ l_openshift_image_tag }}"
   origin: "{{ openshift_docker_image_tag | default(openshift_docker_image_tag_default) }}"
 
-l_docker_image_prepend: "{{ l_crt_docker_image_prepend_dict[ansible_distribution] }}"
+l_docker_image_prepend: "{{ l_crt_docker_image_dict[ansible_distribution] }}"
 l_docker_image_tag: "{{ l_crt_docker_image_tag_dict[openshift_deployment_type] }}"
 
-l_docker_image_default: "{{ l_docker_image_prepend }}/{{ openshift_docker_service_name }}:{{ l_docker_image_tag }}"
+l_docker_image_default: "{{ l_docker_image_prepend }}:{{ l_docker_image_tag }}"
 l_docker_image: "{{ openshift_docker_systemcontainer_image_override | default(l_docker_image_default) }}"
 
 l_is_node_system_container: "{{ (openshift_use_node_system_container | default(openshift_use_system_containers | default(false)) | bool) }}"

--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -101,26 +101,15 @@ l_crt_crio_image_tag_dict:
   openshift-enterprise: "{{ l_openshift_image_tag }}"
   origin: "{{ openshift_crio_image_tag | default(openshift_crio_image_tag_default) }}"
 
-l_crt_crio_image_prepend_dict:
-  openshift-enterprise: "registry.access.redhat.com/openshift3"
-  origin: "docker.io/gscrivano"
-
 l_crt_crio_image_dict:
-  Fedora:
-    crio_image_name: "cri-o-fedora"
-    crio_image_tag: "latest"
-  CentOS:
-    crio_image_name: "cri-o-centos"
-    crio_image_tag: "latest"
-  RedHat:
-    crio_image_name: "cri-o"
-    crio_image_tag: "{{ openshift_crio_image_tag | default(l_crt_crio_image_tag_dict[openshift_deployment_type]) }}"
+  Fedora: "registry.fedoraproject.org/latest/cri-o"
+  CentOS: "registry.centos.org/projectatomic/cri-o"
+  RedHat: "registry.access.redhat.com/openshift3/cri-o"
 
-l_crio_image_prepend: "{{ l_crt_crio_image_prepend_dict[openshift_deployment_type] }}"
-l_crio_image_name: "{{ l_crt_crio_image_dict[ansible_distribution]['crio_image_name'] }}"
-l_crio_image_tag: "{{ l_crt_crio_image_dict[ansible_distribution] }}"
+l_crio_image_name: "{{ l_crt_crio_image_dict[ansible_distribution] }}"
+l_crio_image_tag: "{{ l_crt_crio_image_tag_dict[openshift_deployment_type] }}"
 
-l_crio_image_default: "{{ l_crio_image_prepend }}/{{ l_crio_image_name }}:{{ l_crio_image_tag }}"
+l_crio_image_default: "{{ l_crio_image_name }}:{{ l_crio_image_tag }}"
 l_crio_image: "{{ openshift_crio_systemcontainer_image_override | default(l_crio_image_default) }}"
 
 # ----------------------- #

--- a/roles/lib_utils/library/docker_creds.py
+++ b/roles/lib_utils/library/docker_creds.py
@@ -151,7 +151,7 @@ def write_config(module, docker_config, dest):
     conf_file_path = os.path.join(dest, 'config.json')
     try:
         with open(conf_file_path, 'w') as conf_file:
-            json.dump(docker_config, conf_file, indent=8)
+            json.dump(docker_config.decode(), conf_file, indent=8)
     except IOError as ioerror:
         result = {'failed': True,
                   'changed': False,

--- a/roles/lib_utils/library/docker_creds.py
+++ b/roles/lib_utils/library/docker_creds.py
@@ -135,7 +135,7 @@ def update_config(docker_config, registry, username, password):
         docker_config['auths'][registry] = {}
 
     # base64 encode our username:password string
-    encoded_data = base64.b64encode('{}:{}'.format(username, password))
+    encoded_data = base64.b64encode('{}:{}'.format(username, password).encode())
 
     # check if the same value is already present for idempotency.
     if 'auth' in docker_config['auths'][registry]:


### PR DESCRIPTION
Since these containers are built on the CentOS and Fedora registries, use them by default.

NB: the docker image is not yet synchronized on the Fedora registry, it is going to happen soon since the image built is already available as `candidate-registry.fedoraproject.org/latest/docker:latest`