### PR TITLE
Add defaults for openshift_pkg_version

### DIFF
--- a/playbooks/init/version.yml
+++ b/playbooks/init/version.yml
@@ -6,7 +6,7 @@
   - include_role:
       name: openshift_version
       tasks_from: first_master.yml
-  - debug: msg="openshift_pkg_version set to {{ openshift_pkg_version }}"
+  - debug: msg="openshift_pkg_version set to {{ openshift_pkg_version | default('') }}"
 
 # NOTE: We set this even on etcd hosts as they may also later run as masters,
 # and we don't want to install wrong version of docker and have to downgrade
@@ -16,7 +16,7 @@
   vars:
     l_default_version_set_hosts: "oo_etcd_to_config:oo_nodes_to_config:oo_masters_to_config:!oo_first_master"
     l_first_master_openshift_version: "{{ hostvars[groups.oo_first_master.0].openshift_version }}"
-    l_first_master_openshift_pkg_version: "{{ hostvars[groups.oo_first_master.0].openshift_pkg_version }}"
+    l_first_master_openshift_pkg_version: "{{ hostvars[groups.oo_first_master.0].openshift_pkg_version | default('') }}"
     l_first_master_openshift_image_tag: "{{ hostvars[groups.oo_first_master.0].openshift_image_tag}}"
   tasks:
   - set_fact:

--- a/roles/openshift_master/tasks/upgrade/rpm_upgrade.yml
+++ b/roles/openshift_master/tasks/upgrade/rpm_upgrade.yml
@@ -12,11 +12,11 @@
   package: name={{ master_pkgs | join(',') }} state=present
   vars:
     master_pkgs:
-      - "{{ openshift_service_type }}{{ openshift_pkg_version }}"
-      - "{{ openshift_service_type }}-master{{ openshift_pkg_version }}"
-      - "{{ openshift_service_type }}-node{{ openshift_pkg_version }}"
-      - "{{ openshift_service_type }}-sdn-ovs{{ openshift_pkg_version }}"
-      - "{{ openshift_service_type }}-clients{{ openshift_pkg_version }}"
-      - "tuned-profiles-{{ openshift_service_type }}-node{{ openshift_pkg_version }}"
+      - "{{ openshift_service_type }}{{ openshift_pkg_version | default('') }}"
+      - "{{ openshift_service_type }}-master{{ openshift_pkg_version | default('') }}"
+      - "{{ openshift_service_type }}-node{{ openshift_pkg_version | default('') }}"
+      - "{{ openshift_service_type }}-sdn-ovs{{ openshift_pkg_version | default('') }}"
+      - "{{ openshift_service_type }}-clients{{ openshift_pkg_version | default('') }}"
+      - "tuned-profiles-{{ openshift_service_type }}-node{{ openshift_pkg_version | default('') }}"
   register: result
   until: result is succeeded

--- a/roles/openshift_node/tasks/upgrade/rpm_upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade/rpm_upgrade.yml
@@ -12,7 +12,7 @@
   until: result is succeeded
   vars:
     openshift_node_upgrade_rpm_list:
-      - "{{ openshift_service_type }}-node{{ openshift_pkg_version }}"
+      - "{{ openshift_service_type }}-node{{ openshift_pkg_version | default('') }}"
       - "PyYAML"
       - "dnsmasq"
 

--- a/roles/openshift_node/tasks/upgrade/rpm_upgrade_install.yml
+++ b/roles/openshift_node/tasks/upgrade/rpm_upgrade_install.yml
@@ -14,6 +14,6 @@
   until: result is succeeded
   vars:
     openshift_node_upgrade_rpm_list:
-      - "{{ openshift_service_type }}-node{{ openshift_pkg_version }}"
+      - "{{ openshift_service_type }}-node{{ openshift_pkg_version | default('') }}"
       - "PyYAML"
       - "openvswitch"


### PR DESCRIPTION
This variable may or may not be defined by the users.

During deployments, it will be set to '-{{ openshift_version }}'
if undefined.

During upgrades, it will remain undefined.

This commit ensures that if the variable is undefined,
empty strings '' are set.