### PR TITLE
Update deployment and apiserver with new certs

### DIFF
--- a/roles/openshift_service_catalog/tasks/generate_certs.yml
+++ b/roles/openshift_service_catalog/tasks/generate_certs.yml
@@ -59,11 +59,6 @@
     src: "{{ generated_certs_dir }}/ca.crt"
   register: apiserver_ca
 
-- shell: >
-    {{ openshift_client_binary }} --config=/etc/origin/master/admin.kubeconfig get apiservices.apiregistration.k8s.io/v1beta1.servicecatalog.k8s.io -n kube-service-catalog || echo "not found"
-  register: get_apiservices
-  changed_when: no
-
 - name: Create api service
   oc_obj:
     state: present
@@ -86,4 +81,3 @@
           caBundle: "{{ apiserver_ca.content }}"
           groupPriorityMinimum: 20
           versionPriority: 10
-  when: "'not found' in get_apiservices.stdout"

--- a/roles/openshift_service_catalog/tasks/install.yml
+++ b/roles/openshift_service_catalog/tasks/install.yml
@@ -179,6 +179,8 @@
     etcd_servers: "{{ openshift.master.etcd_urls | join(',') }}"
     etcd_cafile: "{{ '/etc/origin/master/master.etcd-ca.crt' if etcd_ca_crt.stat.exists else '/etc/origin/master/ca-bundle.crt' }}"
     node_selector: "{{ openshift_service_catalog_nodeselector | default ({'openshift-infra': 'apiserver'}) }}"
+    # apiserver_ca is defined in generate_certs.yml
+    ca_hash: "{{ apiserver_ca.content|hash('sha1') }}"
 
 - name: Set Service Catalog API Server daemonset
   oc_obj:

--- a/roles/openshift_service_catalog/templates/api_server.j2
+++ b/roles/openshift_service_catalog/templates/api_server.j2
@@ -14,6 +14,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        ca_hash: {{ ca_hash }}
       labels:
         app: apiserver
     spec:


### PR DESCRIPTION
Since new certificates are generated for every run, the apiservice
caBundle needs updating in order to have the on disk CA match what is in
Kubernetes.

Because the secrets are updated, the daemonset needs to do a rolling
update for the apiserver to pick up the new certs. Implemented here is
an added annotation to the api server such that the update occurs
automatically when the CA is changed.

---

There may be a better way to make the rolling update occur without adding an annotation, such as within ansible itself (I just didn't know how to do that). Also, I think that probably the controller needs to be updated too in order to ensure staying in sync with the api server.
Edit: I did not think that doing "oc apply" would cause the daemonset to pick up a change since the yaml may be exactly the same, but if it does then the annotation part can definitely be changed.