### PR TITLE
[openstack] custom user commands for cloud-init

### DIFF
--- a/playbooks/openstack/advanced-configuration.md
+++ b/playbooks/openstack/advanced-configuration.md
@@ -291,15 +291,15 @@ possible, like this `provision_install_custom.yml` example playbook:
 The playbook leverages a two existing provider interfaces: `provision.yml` and
 `install.yml`. For some cases, like SSH keys configuration and coordinated reboots of
 servers, the cloud-init runcmd directive may be a better choice though. User specified
-shell commands for cloud-init need to be lists, for example:
+shell commands for cloud-init need to be either strings or lists, for example:
 ```
 - openshift_openstack_cloud_init_runcmd:
-  - ['echo', 'foo']
-  - ['reboot']
+  - set -vx
+  - systemctl stop sshd # fences off ansible playbooks as we want to reboot later
+  - ['echo', 'foo', '>', '/tmp/foo']
+  - [ ls, /tmp/foo, '||', true ]
+  - reboot # unfences ansible playbooks to continue after reboot
 ```
-The commands should not use JSON escaped characters: `> < & '`. So the command
-`['foo', '>', '"bar"', '<', "'baz'", "&"]` is a bad one, while
-`['echo', '"${HOME}"']` is OK.
 
 **Note** To protect Nova servers from recreating when the user-data changes via
 `openshift_openstack_cloud_init_runcmd`, the

--- a/playbooks/openstack/advanced-configuration.md
+++ b/playbooks/openstack/advanced-configuration.md
@@ -273,9 +273,33 @@ openshift_openstack_cluster_node_labels:
     mylabel: myvalue
 ```
 
-`openshift_openstack_provision_user_commands` allows users to execute
-additional post-provisioning commands for all of the created Nova servers in
-the Heat stack. It configures the `runcmd` directive via cloud-init.
+`openshift_openstack_cloud_init_runcmd` allows users to execute
+shell commands via cloud-init for all of the created Nova servers in
+the Heat stack, before they are available for SSH connections.
+Note that you should better off using custom ansible playbooks whenever
+possible, like this `provision_install_custom.yml` example playbook:
+```
+- import_playbook: openshift-ansible/playbooks/openstack/openshift-cluster/provision.yml
+
+- name: My custom actions
+  hosts: cluster_hosts
+  tasks:
+  - do whatever you want here
+
+- import_playbook: openshift-ansible/playbooks/openstack/openshift-cluster/install.yml
+```
+The playbook leverages a two existing provider interfaces: `provision.yml` and
+`install.yml`. For some cases, like SSH keys configuration and coordinated reboots of
+servers, the cloud-init runcmd directive may be a better choice though. User specified
+shell commands for cloud-init need to be lists, for example:
+```
+- openshift_openstack_cloud_init_runcmd:
+  - ['echo', 'foo']
+  - ['reboot']
+```
+The commands should not use JSON escaped characters: `> < & '`. So the command
+`['foo', '>', '"bar"', '<', "'baz'", "&"]` is a bad one, while
+`['echo', '"${HOME}"']` is OK.
 
 The `openshift_openstack_nodes_to_remove` allows you to specify the numerical indexes
 of App nodes that should be removed; for example, ['0', '2'],

--- a/playbooks/openstack/advanced-configuration.md
+++ b/playbooks/openstack/advanced-configuration.md
@@ -301,6 +301,10 @@ The commands should not use JSON escaped characters: `> < & '`. So the command
 `['foo', '>', '"bar"', '<', "'baz'", "&"]` is a bad one, while
 `['echo', '"${HOME}"']` is OK.
 
+**Note** To protect Nova servers from recreating when the user-data changes via
+`openshift_openstack_cloud_init_runcmd`, the
+`user_data_update_policy` parameter configured to `IGNORE` for Heat resources.
+
 The `openshift_openstack_nodes_to_remove` allows you to specify the numerical indexes
 of App nodes that should be removed; for example, ['0', '2'],
 

--- a/playbooks/openstack/advanced-configuration.md
+++ b/playbooks/openstack/advanced-configuration.md
@@ -273,6 +273,10 @@ openshift_openstack_cluster_node_labels:
     mylabel: myvalue
 ```
 
+`openshift_openstack_provision_user_commands` allows users to execute
+additional post-provisioning commands for all of the created Nova servers in
+the Heat stack. It configures the `runcmd` directive via cloud-init.
+
 The `openshift_openstack_nodes_to_remove` allows you to specify the numerical indexes
 of App nodes that should be removed; for example, ['0', '2'],
 

--- a/playbooks/openstack/advanced-configuration.md
+++ b/playbooks/openstack/advanced-configuration.md
@@ -276,7 +276,7 @@ openshift_openstack_cluster_node_labels:
 `openshift_openstack_cloud_init_runcmd` allows users to execute
 shell commands via cloud-init for all of the created Nova servers in
 the Heat stack, before they are available for SSH connections.
-Note that you should better off using custom ansible playbooks whenever
+Note that you should use custom ansible playbooks whenever
 possible, like this `provision_install_custom.yml` example playbook:
 ```
 - import_playbook: openshift-ansible/playbooks/openstack/openshift-cluster/provision.yml

--- a/playbooks/openstack/advanced-configuration.md
+++ b/playbooks/openstack/advanced-configuration.md
@@ -273,7 +273,7 @@ openshift_openstack_cluster_node_labels:
     mylabel: myvalue
 ```
 
-`openshift_openstack_cloud_init_runcmd` allows users to execute
+`openshift_openstack_provision_user_commands` allows users to execute
 shell commands via cloud-init for all of the created Nova servers in
 the Heat stack, before they are available for SSH connections.
 Note that you should use custom ansible playbooks whenever
@@ -293,7 +293,7 @@ The playbook leverages a two existing provider interfaces: `provision.yml` and
 servers, the cloud-init runcmd directive may be a better choice though. User specified
 shell commands for cloud-init need to be either strings or lists, for example:
 ```
-- openshift_openstack_cloud_init_runcmd:
+- openshift_openstack_provision_user_commands:
   - set -vx
   - systemctl stop sshd # fences off ansible playbooks as we want to reboot later
   - ['echo', 'foo', '>', '/tmp/foo']
@@ -302,7 +302,7 @@ shell commands for cloud-init need to be either strings or lists, for example:
 ```
 
 **Note** To protect Nova servers from recreating when the user-data changes via
-`openshift_openstack_cloud_init_runcmd`, the
+`openshift_openstack_provision_user_commands`, the
 `user_data_update_policy` parameter configured to `IGNORE` for Heat resources.
 
 The `openshift_openstack_nodes_to_remove` allows you to specify the numerical indexes

--- a/roles/openshift_openstack/defaults/main.yml
+++ b/roles/openshift_openstack/defaults/main.yml
@@ -94,6 +94,8 @@ openshift_openstack_etcd_volume_size: 2
 openshift_openstack_lb_volume_size: 5
 openshift_openstack_ephemeral_volumes: false
 
+# User commands for cloud-init executed on all Nova servers provisioned
+openshift_openstack_provision_user_commands: []
 
 # cloud-config
 openshift_openstack_disable_root: true

--- a/roles/openshift_openstack/templates/user_data.j2
+++ b/roles/openshift_openstack/templates/user_data.j2
@@ -13,8 +13,17 @@ write_files:
       Defaults:openshift !requiretty
 
 {% if openshift_openstack_cloud_init_runcmd %}
-runcmd:
+  - path: /root/ansible_install.sh
+    permissions: '0544'
+    content: |
 {% for cmd in openshift_openstack_cloud_init_runcmd %}
-  - {{ cmd|map('string')|list|tojson }}
+{% if cmd is string %}
+      {{ cmd }}
+{% elif cmd is iterable %}
+      {{ cmd|join(' ') }}
+{% endif %}
 {% endfor %}
+
+runcmd:
+  - /root/ansible_install.sh
 {% endif %}

--- a/roles/openshift_openstack/templates/user_data.j2
+++ b/roles/openshift_openstack/templates/user_data.j2
@@ -11,3 +11,10 @@ write_files:
     permissions: 440
     content: |
       Defaults:openshift !requiretty
+
+{% if openshift_openstack_provision_user_commands %}
+runcmd:
+{% for cmd in openshift_openstack_provision_user_commands %}
+  - {{ cmd }}
+{% endfor %}
+{% endif %}

--- a/roles/openshift_openstack/templates/user_data.j2
+++ b/roles/openshift_openstack/templates/user_data.j2
@@ -12,9 +12,9 @@ write_files:
     content: |
       Defaults:openshift !requiretty
 
-{% if openshift_openstack_provision_user_commands %}
+{% if openshift_openstack_cloud_init_runcmd %}
 runcmd:
-{% for cmd in openshift_openstack_provision_user_commands %}
+{% for cmd in openshift_openstack_cloud_init_runcmd %}
   - {{ cmd|map('string')|list|tojson }}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_openstack/templates/user_data.j2
+++ b/roles/openshift_openstack/templates/user_data.j2
@@ -15,6 +15,6 @@ write_files:
 {% if openshift_openstack_provision_user_commands %}
 runcmd:
 {% for cmd in openshift_openstack_provision_user_commands %}
-  - {{ cmd }}
+  - {{ cmd|map('string')|list|tojson }}
 {% endfor %}
 {% endif %}

--- a/roles/openshift_openstack/templates/user_data.j2
+++ b/roles/openshift_openstack/templates/user_data.j2
@@ -12,11 +12,11 @@ write_files:
     content: |
       Defaults:openshift !requiretty
 
-{% if openshift_openstack_cloud_init_runcmd %}
+{% if openshift_openstack_provision_user_commands %}
   - path: /root/ansible_install.sh
     permissions: '0544'
     content: |
-{% for cmd in openshift_openstack_cloud_init_runcmd %}
+{% for cmd in openshift_openstack_provision_user_commands %}
 {% if cmd is string %}
       {{ cmd }}
 {% elif cmd is iterable %}


### PR DESCRIPTION
Allow to specify additional user commands executed on all Nova servers
provisioned via Heat.

An example use case is installing and starting os-collect-config agents
to put Nova servers under the configuration management driven via the
host openstack cloud Heat services. This allows to integrate with another
deployment tools like TripleO.

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>