### PR TITLE
Remove invalid `storage.azure.realm` from registry config

### DIFF
--- a/roles/openshift_hosted/templates/registry_config.j2
+++ b/roles/openshift_hosted/templates/registry_config.j2
@@ -34,7 +34,6 @@ storage:
     accountname: {{ openshift_hosted_registry_storage_azure_blob_accountname }}
     accountkey: {{ openshift_hosted_registry_storage_azure_blob_accountkey }}
     container: {{ openshift_hosted_registry_storage_azure_blob_container }}
-    realm: {{ openshift_hosted_registry_storage_azure_blob_realm }}
 {% elif openshift_hosted_registry_storage_provider | default('') == 'swift' %}
   swift:
     authurl: {{ openshift_hosted_registry_storage_swift_authurl }}

--- a/roles/openshift_hosted/templates/registry_config.j2
+++ b/roles/openshift_hosted/templates/registry_config.j2
@@ -34,6 +34,9 @@ storage:
     accountname: {{ openshift_hosted_registry_storage_azure_blob_accountname }}
     accountkey: {{ openshift_hosted_registry_storage_azure_blob_accountkey }}
     container: {{ openshift_hosted_registry_storage_azure_blob_container }}
+{% if openshift_hosted_registry_storage_azure_blob_realm is defined %}
+    realm: {{ openshift_hosted_registry_storage_azure_blob_realm }}
+{% endif %}
 {% elif openshift_hosted_registry_storage_provider | default('') == 'swift' %}
   swift:
     authurl: {{ openshift_hosted_registry_storage_swift_authurl }}


### PR DESCRIPTION
Neither official [docker registry docs](https://docs.docker.com/registry/configuration/#storage) nor [openshift docs](https://docs.openshift.org/latest/install_config/storage_examples/azure_blob_docker_registry_example.html#azure-blob-docker-registry-registry-config) require the `realm` option.