### PR TITLE
Add var for catalog controller to enable async bindings

### DIFF
--- a/roles/openshift_service_catalog/defaults/main.yml
+++ b/roles/openshift_service_catalog/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 openshift_service_catalog_remove: false
 openshift_service_catalog_nodeselector: {"openshift-infra": "apiserver"}
+openshift_service_catalog_async_bindings_enabled: false
 
 openshift_use_openshift_sdn: True
 # os_sdn_network_plugin_name: "{% if openshift_use_openshift_sdn %}redhat/openshift-ovs-subnet{% else %}{% endif %}"

--- a/roles/openshift_service_catalog/templates/controller_manager.j2
+++ b/roles/openshift_service_catalog/templates/controller_manager.j2
@@ -8,7 +8,7 @@ spec:
   selector:
     matchLabels:
       app: controller-manager
-  strategy:
+  updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
     type: RollingUpdate
@@ -38,6 +38,10 @@ spec:
         - "5m"
         - --feature-gates
         - OriginatingIdentity=true
+{% if openshift_service_catalog_async_bindings_enabled | bool %}
+        - --feature-gates
+        - AsyncBindingOperations=true
+{% endif %}
         image: {{ openshift_service_catalog_image_prefix }}service-catalog:{{ openshift_service_catalog_image_version }}
         command: ["/usr/bin/service-catalog"]
         imagePullPolicy: Always


### PR DESCRIPTION
New variable is called
'openshift_service_catalog_async_bindings_enabled' and is set to false
by default.

Also, fixed a typo in the controller template for the DaemonSet update
strategy, which caused the strategy to be set to OnDelete rather than
the intended RollingUpdate.