### PR TITLE
Install web console on upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -1,7 +1,13 @@
 ---
-###############################################################################
-# Post upgrade - Upgrade default router, default registry and examples
-###############################################################################
+####################################################################################
+# Post upgrade - Upgrade web console, default router, default registry, and examples
+####################################################################################
+- name: Upgrade web console
+  hosts: oo_first_master
+  roles:
+  - role: openshift_web_console
+    when: openshift_web_console_install | default(true) | bool
+
 - name: Upgrade default router and default registry
   hosts: oo_first_master
   vars:


### PR DESCRIPTION
Pared down PR that just installs the web console in post_control_plane upgrade. Leaving #6676 open for now to work on migrating asset config from master-config.yaml.

/assign @sdodson 
@jwforres 