### PR TITLE
Fix base_packages ordering

### DIFF
--- a/playbooks/init/base_packages.yml
+++ b/playbooks/init/base_packages.yml
@@ -1,4 +1,5 @@
 ---
+# Nothing in this file can depend on version!
 - name: Install packages necessary for installer
   hosts: oo_all_hosts
   any_errors_fatal: true

--- a/playbooks/init/main.yml
+++ b/playbooks/init/main.yml
@@ -15,6 +15,8 @@
 
 - import_playbook: evaluate_groups.yml
 
+- import_playbook: base_packages.yml
+
 - import_playbook: facts.yml
 
 - import_playbook: version.yml

--- a/playbooks/prerequisites.yml
+++ b/playbooks/prerequisites.yml
@@ -8,8 +8,6 @@
 
 - import_playbook: init/repos.yml
 
-- import_playbook: init/base_packages.yml
-
 # This is required for container runtime for crio, only needs to run once.
 - name: Configure os_firewall
   hosts: oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_nfs_to_config:oo_nodes_to_config


### PR DESCRIPTION
The modules called by facts playbook require yaml.

```
TASK [Gather Cluster facts] *************************************************************************************************************************************************************
task path: /home/ewolinetz/git/openshift-ansible/playbooks/init/facts.yml:59
Using module file /home/ewolinetz/git/openshift-ansible/roles/openshift_facts/library/openshift_facts.py
-- snip --- 
<n01.example.com> (0, 'Traceback (most recent call last):\r\n  File "/tmp/ansible_z4Ee9y/ansible_module_openshift_facts.py", line 15, in <module>\r\n    import yaml\r\nImportError: No module named yaml\r\n', 'Shared connection to n01.example.com closed.\r\n')
fatal: [n01.example.com]: FAILED! => {
    "changed": false, 
    "module_stderr": "Shared connection to n01.example.com closed.\r\n", 
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_z4Ee9y/ansible_module_openshift_facts.py\", line 15, in <module>\r\n    import yaml\r\nImportError: No module named yaml\r\n", 
    "msg": "MODULE FAILURE", 
    "rc": 0
}
```

CC @ewolinetz 
/assign mtnbikenc