### PR TITLE
Automatic profile setting for tuned 2.9

### DIFF
--- a/roles/tuned/tasks/main.yml
+++ b/roles/tuned/tasks/main.yml
@@ -28,7 +28,12 @@
     when: item.state == 'file'
 
   - name: Make tuned use the recommended tuned profile on restart
-    file: path=/etc/tuned/active_profile state=absent
+    file:
+      path: '{{ item }}'
+      state: absent
+    with_items:
+    - /etc/tuned/active_profile
+    - /etc/tuned/profile_mode
 
   - name: Restart tuned service
     systemd:


### PR DESCRIPTION
Tuned 2.9 introduces automatic and manual profile selection.
If there is file /etc/tuned/profile_mode containing "manual"
on a system with tuned 2.9, without this PR the appropriate OCP
profiles will not be set.  This PR removes the file prior to
tuned restart, in addition to /etc/tuned/active_profile to
make the tuned profile selection automatic.