### PR TITLE
Set default image to openshift_release

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -934,6 +934,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # Force a specific image version to use when pulling the service catalog image
 #openshift_service_catalog_image_version=v3.7
 
+# TSB image tag
+#template_service_broker_version='v3.7'
+
 # Configure one of more namespaces whose templates will be served by the TSB
 #openshift_template_service_broker_namespaces=['openshift']
 

--- a/roles/ansible_service_broker/vars/openshift-enterprise.yml
+++ b/roles/ansible_service_broker/vars/openshift-enterprise.yml
@@ -1,7 +1,7 @@
 ---
 
 __ansible_service_broker_image_prefix: registry.access.redhat.com/openshift3/ose-
-__ansible_service_broker_image_tag: v3.7
+__ansible_service_broker_image_tag: "{{ openshift_image_tag }}"
 
 __ansible_service_broker_etcd_image_prefix: registry.access.redhat.com/rhel7/
 __ansible_service_broker_etcd_image_tag: latest
@@ -14,6 +14,6 @@ __ansible_service_broker_registry_url: "https://registry.access.redhat.com"
 __ansible_service_broker_registry_user: null
 __ansible_service_broker_registry_password: null
 __ansible_service_broker_registry_organization: null
-__ansible_service_broker_registry_tag: v3.7
+__ansible_service_broker_registry_tag: "{{ openshift_image_tag }}"
 __ansible_service_broker_registry_whitelist:
   - '.*-apb$'

--- a/roles/openshift_logging_curator/vars/default_images.yml
+++ b/roles/openshift_logging_curator/vars/default_images.yml
@@ -1,3 +1,3 @@
 ---
 __openshift_logging_curator_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_logging_curator_image_version: "{{ openshift_logging_image_version | default('latest') }}"
+__openshift_logging_curator_image_version: "{{ openshift_logging_image_version | default(openshift_image_tag) }}"

--- a/roles/openshift_logging_curator/vars/openshift-enterprise.yml
+++ b/roles/openshift_logging_curator/vars/openshift-enterprise.yml
@@ -1,3 +1,3 @@
 ---
 __openshift_logging_curator_image_prefix: "{{ openshift_logging_image_prefix | default('registry.access.redhat.com/openshift3/') }}"
-__openshift_logging_curator_image_version: "{{ openshift_logging_image_version | default ('v3.7') }}"
+__openshift_logging_curator_image_version: "{{ openshift_logging_image_version | default (openshift_image_tag) }}"

--- a/roles/openshift_logging_elasticsearch/vars/openshift-enterprise.yml
+++ b/roles/openshift_logging_elasticsearch/vars/openshift-enterprise.yml
@@ -1,5 +1,5 @@
 ---
 __openshift_logging_elasticsearch_image_prefix: "{{ openshift_logging_image_prefix | default('registry.access.redhat.com/openshift3/') }}"
-__openshift_logging_elasticsearch_image_version: "{{ openshift_logging_image_version | default ('v3.7') }}"
+__openshift_logging_elasticsearch_image_version: "{{ openshift_logging_image_version | default (openshift_image_tag) }}"
 __openshift_logging_elasticsearch_proxy_image_prefix: "{{ openshift_logging_image_prefix | default('registry.access.redhat.com/openshift3/') }}"
-__openshift_logging_elasticsearch_proxy_image_version: "{{ openshift_logging_image_version | default ('v3.7') }}"
+__openshift_logging_elasticsearch_proxy_image_version: "{{ openshift_logging_image_version | default (openshift_image_tag) }}"

--- a/roles/openshift_logging_eventrouter/vars/openshift-enterprise.yml
+++ b/roles/openshift_logging_eventrouter/vars/openshift-enterprise.yml
@@ -1,3 +1,3 @@
 ---
 __openshift_logging_eventrouter_image_prefix: "{{ openshift_logging_image_prefix | default('registry.access.redhat.com/openshift3/') }}"
-__openshift_logging_eventrouter_image_version: "{{ openshift_logging_image_version | default ('v3.7') }}"
+__openshift_logging_eventrouter_image_version: "{{ openshift_logging_image_version | default (openshift_image_tag) }}"

--- a/roles/openshift_logging_fluentd/vars/openshift-enterprise.yml
+++ b/roles/openshift_logging_fluentd/vars/openshift-enterprise.yml
@@ -1,3 +1,3 @@
 ---
 __openshift_logging_fluentd_image_prefix: "{{ openshift_logging_image_prefix | default('registry.access.redhat.com/openshift3/') }}"
-__openshift_logging_fluentd_image_version: "{{ openshift_logging_image_version | default ('v3.7') }}"
+__openshift_logging_fluentd_image_version: "{{ openshift_logging_image_version | default (openshift_image_tag) }}"

--- a/roles/openshift_logging_kibana/vars/openshift-enterprise.yml
+++ b/roles/openshift_logging_kibana/vars/openshift-enterprise.yml
@@ -1,5 +1,5 @@
 ---
 __openshift_logging_kibana_image_prefix: "{{ openshift_logging_image_prefix | default('registry.access.redhat.com/openshift3/') }}"
-__openshift_logging_kibana_image_version: "{{ openshift_logging_image_version | default ('v3.7') }}"
+__openshift_logging_kibana_image_version: "{{ openshift_logging_image_version | default (openshift_image_tag) }}"
 __openshift_logging_kibana_proxy_image_prefix: "{{ openshift_logging_image_prefix | default('registry.access.redhat.com/openshift3/') }}"
-__openshift_logging_kibana_proxy_image_version: "{{ openshift_logging_image_version | default ('v3.7') }}"
+__openshift_logging_kibana_proxy_image_version: "{{ openshift_logging_image_version | default (openshift_image_tag) }}"

--- a/roles/openshift_logging_mux/vars/openshift-enterprise.yml
+++ b/roles/openshift_logging_mux/vars/openshift-enterprise.yml
@@ -1,3 +1,3 @@
 ---
 __openshift_logging_mux_image_prefix: "{{ openshift_logging_image_prefix | default('registry.access.redhat.com/openshift3/') }}"
-__openshift_logging_mux_image_version: "{{ openshift_logging_image_version | default ('v3.7') }}"
+__openshift_logging_mux_image_version: "{{ openshift_logging_image_version | default (openshift_image_tag) }}"

--- a/roles/openshift_metrics/vars/default_images.yml
+++ b/roles/openshift_metrics/vars/default_images.yml
@@ -1,3 +1,3 @@
 ---
 __openshift_metrics_image_prefix: "docker.io/openshift/origin-"
-__openshift_metrics_image_version: "latest"
+__openshift_metrics_image_version: "{{ openshift_image_tag }}"

--- a/roles/openshift_metrics/vars/openshift-enterprise.yml
+++ b/roles/openshift_metrics/vars/openshift-enterprise.yml
@@ -1,3 +1,3 @@
 ---
 __openshift_metrics_image_prefix: "registry.access.redhat.com/openshift3/"
-__openshift_metrics_image_version: "v3.7"
+__openshift_metrics_image_version: "{{ openshift_image_tag }}"

--- a/roles/openshift_prometheus/vars/openshift-enterprise.yml
+++ b/roles/openshift_prometheus/vars/openshift-enterprise.yml
@@ -6,7 +6,7 @@ l_openshift_prometheus_alertmanager_image_prefix: "{{ openshift_prometheus_alter
 l_openshift_prometheus_alertbuffer_image_prefix: "{{ openshift_prometheus_alertbuffer_image_prefix | default(l_openshift_prometheus_image_prefix) }}"
 
 # image version defaults
-l_openshift_prometheus_image_version: "{{ openshift_prometheus_image_version | default('v3.7') }}"
-l_openshift_prometheus_proxy_image_version: "{{ openshift_prometheus_proxy_image_version | default('v3.7') }}"
-l_openshift_prometheus_alertmanager_image_version: "{{ openshift_prometheus_alertmanager_image_version | default('v3.7') }}"
-l_openshift_prometheus_alertbuffer_image_version: "{{ openshift_prometheus_alertbuffer_image_version | default('v3.7') }}"
+l_openshift_prometheus_image_version: "{{ openshift_prometheus_image_version | default(openshift_image_tag) }}"
+l_openshift_prometheus_proxy_image_version: "{{ openshift_prometheus_proxy_image_version | default(openshift_image_tag) }}"
+l_openshift_prometheus_alertmanager_image_version: "{{ openshift_prometheus_alertmanager_image_version | default(openshift_image_tag) }}"
+l_openshift_prometheus_alertbuffer_image_version: "{{ openshift_prometheus_alertbuffer_image_version | default(openshift_image_tag) }}"

--- a/roles/openshift_service_catalog/vars/default_images.yml
+++ b/roles/openshift_service_catalog/vars/default_images.yml
@@ -1,3 +1,3 @@
 ---
 __openshift_service_catalog_image_prefix: "docker.io/openshift/origin-"
-__openshift_service_catalog_image_version: "latest"
+__openshift_service_catalog_image_version: "{{ openshift_service_catalog_image_version | default(openshift_image_tag) }}"

--- a/roles/openshift_service_catalog/vars/openshift-enterprise.yml
+++ b/roles/openshift_service_catalog/vars/openshift-enterprise.yml
@@ -1,3 +1,3 @@
 ---
 __openshift_service_catalog_image_prefix: "registry.access.redhat.com/openshift3/ose-"
-__openshift_service_catalog_image_version: "v3.7"
+__openshift_service_catalog_image_version: "{{ openshift_service_catalog_image_version | default(openshift_image_tag) }}"

--- a/roles/openshift_web_console/vars/default_images.yml
+++ b/roles/openshift_web_console/vars/default_images.yml
@@ -1,4 +1,4 @@
 ---
 __openshift_web_console_prefix: "docker.io/openshift/origin-"
-__openshift_web_console_version: "latest"
+__openshift_web_console_version: "{{ openshift_image_tag }}"
 __openshift_web_console_image_name: "web-console"

--- a/roles/openshift_web_console/vars/openshift-enterprise.yml
+++ b/roles/openshift_web_console/vars/openshift-enterprise.yml
@@ -1,4 +1,4 @@
 ---
 __openshift_web_console_prefix: "registry.access.redhat.com/openshift3/ose-"
-__openshift_web_console_version: "v3.9"
+__openshift_web_console_version: "{{ openshift_image_tag }}"
 __openshift_web_console_image_name: "web-console"

--- a/roles/template_service_broker/vars/default_images.yml
+++ b/roles/template_service_broker/vars/default_images.yml
@@ -1,4 +1,4 @@
 ---
 __template_service_broker_prefix: "docker.io/openshift/origin-"
-__template_service_broker_version: "latest"
+__template_service_broker_version: "{{ openshift_image_tag }}"
 __template_service_broker_image_name: "template-service-broker"

--- a/roles/template_service_broker/vars/openshift-enterprise.yml
+++ b/roles/template_service_broker/vars/openshift-enterprise.yml
@@ -1,4 +1,4 @@
 ---
 __template_service_broker_prefix: "registry.access.redhat.com/openshift3/ose-"
-__template_service_broker_version: "v3.7"
+__template_service_broker_version: "{{ openshift_image_tag }}"
 __template_service_broker_image_name: "template-service-broker"


### PR DESCRIPTION
Previously `v3.7` was hardcoded as a default value, instead `openshift_release` should be used.

A new var is introduced - `openshift_template_service_broker_image_tag`, similar to vars for other services.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1530183

TODO:
* [x] Make sure all images have a variable for image prefix
* [x] Figure out if `latest` is a good default for origin images
* [ ] Set correct `openshift_image_tag` in CI inventory for tests to pass