### PR TITLE
Support creating OpenStack Cinder registry volume

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -440,32 +440,30 @@ You can create one by running:
 openstack volume create --size <volume size in gb> <volume name>
 ```
 
-The volume needs to have a file system created before you put it to
-use.
+Alternatively, the playbooks can create the volume created automatically if you
+specify its name and size.
 
-Once the volume is created, [set up OpenStack credentials](#openstack-credential-configuration),
-and then set the following in `inventory/group_vars/OSEv3.yml`:
+In either case, you have to [set up OpenStack
+credentials](#openstack-credential-configuration), and then set the following
+in `inventory/group_vars/OSEv3.yml`:
 
 * `openshift_hosted_registry_storage_kind`: openstack
 * `openshift_hosted_registry_storage_access_modes`: ['ReadWriteOnce']
 * `openshift_hosted_registry_storage_openstack_filesystem`: xfs
-* `openshift_hosted_registry_storage_openstack_volumeID`: e0ba2d73-d2f9-4514-a3b2-a0ced507fa05
 * `openshift_hosted_registry_storage_volume_size`: 10Gi
 
-The **Cinder volume ID**, **filesystem** and **volume size** variables
-must correspond to the values in your volume. The volume ID must be
-the **UUID** of the Cinder volume, *not its name*.
-
-The volume can also be formatted if you configure it in
-`inventory/group_vars/all.yml`:
-
-* openshift_openstack_prepare_and_format_registry_volume: true
-
-Note that formatting **will destroy any data that's currently on the volume**!
-
-If you already have a provisioned OpenShift cluster, you can also run the
-registry setup playbook directly:
+For a volume *you created*, you must also specify its **UUID** (it must be
+the UUID, not the volume's name):
 
 ```
-ansible-playbook -i inventory playbooks/provisioning/openstack/prepare-and-format-cinder-volume.yaml
+openshift_hosted_registry_storage_openstack_volumeID: e0ba2d73-d2f9-4514-a3b2-a0ced507fa05
 ```
+
+If you want the volume *created automatically*, set the desired name instead:
+
+```
+openshift_hosted_registry_storage_volume_name: registry
+```
+
+The volume will be formatted automaticaly and it will be mounted to one of the
+infra nodes when the registry pod gets started.

--- a/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -27,17 +27,13 @@ openshift_hosted_registry_wait: True
 #openshift_hosted_registry_storage_kind: openstack
 #openshift_hosted_registry_storage_access_modes: ['ReadWriteOnce']
 #openshift_hosted_registry_storage_openstack_filesystem: xfs
-
-## NOTE(shadower): This won't work until the openshift-ansible issue #5657 is fixed:
-## https://github.com/openshift/openshift-ansible/issues/5657
-## If you're using the `openshift_openstack_cinder_hosted_registry_name` option from
-## `all.yml`, uncomment these lines:
-#openshift_hosted_registry_storage_openstack_volumeID: "{{ lookup('os_cinder', openshift_openstack_cinder_hosted_registry_name).id }}"
-#openshift_hosted_registry_storage_volume_size: "{{ openshift_openstack_cinder_hosted_registry_size_gb }}Gi"
-
-## If you're using a Cinder volume you've set up yourself, uncomment these lines:
-#openshift_hosted_registry_storage_openstack_volumeID: e0ba2d73-d2f9-4514-a3b2-a0ced507fa05
 #openshift_hosted_registry_storage_volume_size: 10Gi
+
+## If you want a Cinder volume created automaticaly, uncomment this:
+#openshift_hosted_registry_storage_volume_name: registry
+
+## If you're using a Cinder volume you've set up yourself, uncomment this:
+#openshift_hosted_registry_storage_openstack_volumeID: e0ba2d73-d2f9-4514-a3b2-a0ced507fa05
 
 
 # NOTE(shadower): the hostname check seems to always fail because the

--- a/playbooks/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/all.yml
@@ -126,17 +126,6 @@ openshift_openstack_docker_volume_size: "15"
 #openshift_openstack_master_server_group_policies: [anti-affinity]
 #openshift_openstack_infra_server_group_policies: [anti-affinity]
 
-## Create a Cinder volume and use it for the OpenShift registry.
-## NOTE: the openstack credentials and hosted registry options must be set in OSEv3.yml!
-#openshift_openstack_cinder_hosted_registry_name: cinder-registry
-#openshift_openstack_cinder_hosted_registry_size_gb: 10
-
-## Set up a filesystem on the cinder volume specified in `OSEv3.yaml`.
-## You need to specify the file system and volume ID in OSEv3 via
-## `openshift_hosted_registry_storage_openstack_filesystem` and
-## `openshift_hosted_registry_storage_openstack_volumeID`.
-## WARNING: This will delete any data on the volume!
-#openshift_openstack_prepare_and_format_registry_volume: False
 
 # The Classless Inter-Domain Routing (CIDR) for the OpenStack VM subnet.
 openshift_openstack_subnet_cidr: "192.168.99.0/24"

--- a/roles/openshift_openstack/tasks/create-registry-volume.yml
+++ b/roles/openshift_openstack/tasks/create-registry-volume.yml
@@ -1,0 +1,10 @@
+---
+- name: Create the Cinder Registry volume
+  os_volume:
+    display_name: "{{ cinder_registry_volume_name }}"
+    size: "{{ cinder_registry_volume_size }}"
+    display_description: "Storage for the OpenShift registry"
+  register: cinder_registry_volume
+  vars:
+    cinder_registry_volume_name: "{{ hostvars[groups.infra_hosts.0].openshift_hosted_registry_storage_volume_name }}"
+    cinder_registry_volume_size: "{{ hostvars[groups.infra_hosts.0].openshift_hosted_registry_storage_volume_size | regex_replace('[A-Z]i$') }}"

--- a/roles/openshift_openstack/tasks/provision.yml
+++ b/roles/openshift_openstack/tasks/provision.yml
@@ -98,5 +98,11 @@
   when:
   - openshift_openstack_stack_state == 'present'
 
-# TODO(shadower): create the registry and PV Cinder volumes if specified
-# and include the `prepare-and-format-cinder-volume` tasks to set it up
+- name: Create the Cinder volume for OpenShift Registry
+  include_tasks: create-registry-volume.yml
+  when:
+  - groups.infra_hosts is defined
+  - groups.infra_hosts.0 is defined
+  - hostvars[groups.infra_hosts.0].openshift_hosted_registry_storage_volume_name is defined
+  - hostvars[groups.infra_hosts.0].openshift_hosted_registry_storage_volume_size is defined
+  - hostvars[groups.infra_hosts.0].openshift_hosted_registry_storage_openstack_volumeID is not defined


### PR DESCRIPTION
This adds an option to have the playbooks create (or re-use previously created) Cinder volume for the registry automatically. The OpetStack documentation is updated correspondingly.