### PR TITLE
Remove unused symlink

### DIFF
--- a/roles/openshift_hosted/tasks/storage/registry_config.j2
+++ b/roles/openshift_hosted/tasks/storage/registry_config.j2
@@ -1,1 +1,0 @@
-../../../templates/registry_config.j2


### PR DESCRIPTION
The symlink didn't go anywhere so removing it shouldn't produce any problems.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1533658