### PR TITLE
Ensure that the aggregator is wired up

### DIFF
--- a/playbooks/openshift-service-catalog/private/config.yml
+++ b/playbooks/openshift-service-catalog/private/config.yml
@@ -11,6 +11,14 @@
           status: "In Progress"
           start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
+- name: Configure API Aggregation on masters
+  hosts: oo_masters
+  serial: 1
+  roles:
+  - role: openshift_facts
+  tasks:
+  - include_tasks: tasks/wire_aggregator.yml
+
 - name: Service Catalog
   hosts: oo_first_master
   roles:


### PR DESCRIPTION
When installing service catalog on an existing cluster this task needs
to be included in the playbook run.

https://bugzilla.redhat.com/show_bug.cgi?id=1523298