### PR TITLE
catalog: fix typo in daemonset update strategy

### DIFF
--- a/roles/openshift_service_catalog/templates/controller_manager.j2
+++ b/roles/openshift_service_catalog/templates/controller_manager.j2
@@ -8,7 +8,7 @@ spec:
   selector:
     matchLabels:
       app: controller-manager
-  strategy:
+  updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
     type: RollingUpdate


### PR DESCRIPTION
This is a backported fix from master.