### PR TITLE
[3.7] Clean up host-local IPAM data while nodes are drained

### DIFF
--- a/roles/openshift_node_upgrade/tasks/main.yml
+++ b/roles/openshift_node_upgrade/tasks/main.yml
@@ -104,6 +104,12 @@
     path: "/var/lib/dockershim/sandbox/"
     state: absent
 
+# https://bugzilla.redhat.com/show_bug.cgi?id=1518912
+- name: Clean up IPAM data
+  file:
+    path: "/var/lib/cni/networks/openshift-sdn/"
+    state: absent
+
 - name: Upgrade openvswitch
   package:
     name: openvswitch


### PR DESCRIPTION
Manual rebase of #6426; the tasks were reorganized somewhere between 3.7 and master so the automated cherrypick failed.

@sdodson 
