### PR TITLE
Fix broken softlink

### DIFF
--- a/roles/openshift_certificate_expiry/examples/playbooks
+++ b/roles/openshift_certificate_expiry/examples/playbooks
@@ -1,1 +1,1 @@
-../../../playbooks/certificate_expiry
+../../../playbooks/openshift-checks/certificate_expiry


### PR DESCRIPTION
I think d3fefc32a727fe3c13159c4e9fe4399f35b487a8 moved dirs and failed to correct the symlinks inside