### PR TITLE
Fix service catalog upgrade from 3.6

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
@@ -34,6 +34,13 @@
 
 # Pre-upgrade completed
 
+- name: Configure API aggregation on masters
+  hosts: oo_masters_to_config
+  tasks:
+  - set_fact:
+      cluster_method: "{{ openshift_master_cluster_method | default('native') }}"
+  - include: ../../../openshift-master/private/tasks/wire_aggregator.yml
+
 - import_playbook: ../upgrade_control_plane.yml
   vars:
     master_config_hook: "v3_7/master_config_upgrade.yml"

--- a/playbooks/openshift-master/private/tasks/wire_aggregator.yml
+++ b/playbooks/openshift-master/private/tasks/wire_aggregator.yml
@@ -142,10 +142,11 @@
     state: absent
   changed_when: False
 
-- name: Setup extension file for service console UI
-  template:
-    src: ../templates/openshift-ansible-catalog-console.js
-    dest: /etc/origin/master/openshift-ansible-catalog-console.js
+# setup extension file for service console UI
+- lineinfile:
+    dest=/etc/origin/master/openshift-ansible-catalog-console.js
+    line="window.OPENSHIFT_CONSTANTS.TEMPLATE_SERVICE_BROKER_ENABLED={{ 'true' if (template_service_broker_install | default(True)) else 'false' }}"
+    create=yes
 
 - name: Update master config
   yedit:
@@ -183,6 +184,13 @@
   systemd: name={{ openshift_service_type }}-master-api state=restarted
   when:
   - yedit_output.changed
+
+# this needs to be repopulated during upgrade
+- name: Delete apiserver extensionconfigmap
+  oc_configmap:
+    state: absent
+    name: extension-apiserver-authentication
+    namespace: kube-system
 
 # We retry the controllers because the API may not be 100% initialized yet.
 - name: restart master controllers

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1416,7 +1416,7 @@ class OpenShiftFacts(object):
                                       console_use_ssl=True,
                                       console_path='/console',
                                       console_port='8443', etcd_use_ssl=True,
-                                      etcd_hosts='', etcd_port='4001',
+                                      etcd_hosts='', etcd_port='2379',
                                       portal_net='172.30.0.0/16',
                                       embedded_kube=True,
                                       embedded_dns=True,


### PR DESCRIPTION
This enables the aggregator (for all upgrades), which is required for
service catalog to function as expected.

---

Note that this has only been tested in the release-3.7 branch, which is slightly different. I think this could be refactored slightly to move the aggregator config file out of private directory and rely upon the javascript file no longer needing a file template. I'm a bit perplexed why the default etcd port needed changing, so hopefully this isn't a problem.