### PR TITLE
run kube controllers in a separate process

### DIFF
--- a/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-controllers.service.j2
+++ b/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-controllers.service.j2
@@ -22,12 +22,39 @@ ExecStart=/usr/bin/docker run --rm --privileged --net=host \
   {% if l_bind_docker_reg_auth | default(False) %} -v {{ oreg_auth_credentials_path }}:/root/.docker:ro{% endif %}\
   {{ osm_image }}:${IMAGE_VERSION} start master controllers \
   --config=${CONFIG_FILE} $OPTIONS
+ExecStartPre=-/usr/bin/docker rm -f {{ openshift_service_type}}-master-kube-controllers
+ExecStart=/usr/bin/docker run --rm --privileged --net=host \
+  --name {{ openshift_service_type }}-master-kube-controllers \
+  --env-file=/etc/sysconfig/{{ openshift_service_type }}-master-kube-controllers \
+  -v {{ r_openshift_master_data_dir }}:{{ r_openshift_master_data_dir }} \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v {{ openshift.common.config_base }}:{{ openshift.common.config_base }} \
+  {% if openshift_cloudprovider_kind | default('') != '' -%} -v {{ openshift.common.config_base }}/cloudprovider:{{ openshift.common.config_base}}/cloudprovider {% endif -%} \
+  -v /etc/pki:/etc/pki:ro \
+  {% if l_bind_docker_reg_auth | default(False) %} -v {{ oreg_auth_credentials_path }}:/root/.docker:ro{% endif %}\
+  {{ osm_image }}:${IMAGE_VERSION} start master controllers \
+  --controllers="*" --controllers=-ttl --controllers=-bootstrapsigner --controllers=-tokencleaner --controllers=-horizontalpodautoscaling --controllers=-serviceaccount-token \
+  --service-account-private-key-file=openshift.local.config/master/serviceaccounts.private.key \
+  --root-ca-file=openshift.local.config/master/ca-bundle.crt \
+  --kubeconfig=openshift.local.config/master/openshift-master.kubeconfig \
+  --pod-eviction-timeout=5m \
+  --enable-dynamic-provisioning=true \
+  --port=-1 \
+  --use-service-account-credentials=true \
+  --cluster-signing-cert-file="" \
+  --cluster-signing-key-file="" \
+  --leader-elect \
+  --leader-elect-retry-period=3s \
+  --leader-elect-resource-lock=configmaps \
+  --openshift-config=${CONFIG_FILE}
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop {{ openshift_service_type }}-master-controllers
+ExecStop=/usr/bin/docker stop {{ openshift_service_type }}-master-kube-controllers
 LimitNOFILE=131072
 LimitCORE=infinity
 WorkingDirectory={{ r_openshift_master_data_dir }}
 SyslogIdentifier={{ openshift_service_type }}-master-controllers
+SyslogIdentifier={{ openshift_service_type }}-master-kube-controllers
 Restart=always
 RestartSec=5s
 

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.service.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-controllers.service.j2
@@ -11,6 +11,21 @@ Type=notify
 EnvironmentFile=/etc/sysconfig/{{ openshift_service_type }}-master-controllers
 Environment=GOTRACEBACK=crash
 ExecStart=/usr/bin/openshift start master controllers --config=${CONFIG_FILE} $OPTIONS
+ExecStart=/usr/bin/hyperkube kube-controller-manager \
+  --controllers="*" --controllers=-ttl --controllers=-bootstrapsigner --controllers=-tokencleaner --controllers=-horizontalpodautoscaling --controllers=-serviceaccount-token \
+  --service-account-private-key-file=openshift.local.config/master/serviceaccounts.private.key \
+  --root-ca-file=openshift.local.config/master/ca-bundle.crt \
+  --kubeconfig=openshift.local.config/master/openshift-master.kubeconfig \
+  --pod-eviction-timeout=5m \
+  --enable-dynamic-provisioning=true \
+  --port=-1 \
+  --use-service-account-credentials=true \
+  --cluster-signing-cert-file="" \
+  --cluster-signing-key-file="" \
+  --leader-elect \
+  --leader-elect-retry-period=3s \
+  --leader-elect-resource-lock=configmaps \
+  --openshift-config=${CONFIG_FILE}
 LimitNOFILE=131072
 LimitCORE=infinity
 WorkingDirectory={{ r_openshift_master_data_dir }}
@@ -20,3 +35,5 @@ RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target
+
+


### PR DESCRIPTION
This adds a new exec start for our master-controllers service to launch the kube-controller-manager in the same unit.  This is a compromise between the desired static pods and the current (and unmaintainable) two processes in a single process using separate leases.  This keeps from requiring re-education on how to restart controllers for 3.9, while still allowing separate controller PIDs to go with the separate leases.  We'll also get separate health and metrics, but we don't have those yet.

@smarterclayton @derekwaynecarr @eparis @liggitt as we've discussed separately.  Also, are we ready for `openshift start master` to become "best effort" and spawn the kube controller managers for 3.9 or will we go for broke and remove it?
@sdodson This gives us something to talk about.  How can I improve it?


Can't merge until https://github.com/openshift/origin/pull/18100