### PR TITLE
Fix service catalog upgrade from 3.6

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
@@ -123,6 +123,13 @@
   vars:
     master_config_hook: "v3_7/master_config_upgrade.yml"
 
+# this must occur after the control plane is upgraded because systemd service
+# names are changed
+- name: Configure API aggregation on masters
+  hosts: oo_masters_to_config
+  tasks:
+  - include: ../../../openshift-master/tasks/wire_aggregator.yml
+
 # All controllers must be stopped at the same time then restarted
 - name: Cycle all controller services to force new leader election mode
   hosts: oo_masters_to_config

--- a/playbooks/common/openshift-master/tasks/wire_aggregator.yml
+++ b/playbooks/common/openshift-master/tasks/wire_aggregator.yml
@@ -142,10 +142,11 @@
     state: absent
   changed_when: False
 
-- name: Setup extension file for service console UI
-  template:
-    src: ../templates/openshift-ansible-catalog-console.js
+# setup extension file for service console UI
+- lineinfile:
     dest: /etc/origin/master/openshift-ansible-catalog-console.js
+    line: "window.OPENSHIFT_CONSTANTS.TEMPLATE_SERVICE_BROKER_ENABLED={{ 'true' if (template_service_broker_install | default(True)) else 'false' }}"
+    create: yes
 
 - name: Update master config
   yedit:
@@ -178,12 +179,21 @@
       value: false
   register: yedit_output
 
+# this is needed for repopulating during upgrade, so delete before restart
+- name: Delete apiserver extensionconfigmap
+  oc_configmap:
+    state: absent
+    name: extension-apiserver-authentication
+    namespace: kube-system
+  when:
+  - openshift_version | version_compare('3.7','<')
+  - openshift_upgrade_target | version_compare('3.7','>=')
+
 #restart master serially here
 - name: restart master api
   systemd: name={{ openshift.common.service_type }}-master-api state=restarted
   when:
   - yedit_output.changed
-  - openshift.master.cluster_method == 'native'
 
 # We retry the controllers because the API may not be 100% initialized yet.
 - name: restart master controllers

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1927,7 +1927,7 @@ class OpenShiftFacts(object):
                                       console_use_ssl=True,
                                       console_path='/console',
                                       console_port='8443', etcd_use_ssl=True,
-                                      etcd_hosts='', etcd_port='4001',
+                                      etcd_hosts='', etcd_port='2379',
                                       portal_net='172.30.0.0/16',
                                       embedded_etcd=True, embedded_kube=True,
                                       embedded_dns=True,


### PR DESCRIPTION
This enables the aggregator (for all upgrades), which is required for
service catalog to function as expected.

---

Still working one last remaining issue.