### PR TITLE
[WIP] [Openstack] Allow all-in-one openshift clusters

### DIFF
--- a/playbooks/openstack/advanced-configuration.md
+++ b/playbooks/openstack/advanced-configuration.md
@@ -263,15 +263,45 @@ The `openshift_openstack_num_masters`, `openshift_openstack_num_infra` and
 App nodes to create.
 
 The `openshift_openstack_cluster_node_labels` defines custom labels for your openshift
-cluster node groups. It currently supports app and infra node groups.
+cluster node groups. It currently supports groups for masters, cns, app and infra nodes.
 The default value of this variable sets `region: primary` to app nodes and
-`region: infra` to infra nodes.
+`region: infra` to infra nodes. It is unset for the remaining node groups.
 An example of setting a customised label:
 ```
 openshift_openstack_cluster_node_labels:
   app:
     mylabel: myvalue
 ```
+For all-in-one deployments, you may want to define custom labels like that:
+```yaml
+openshift_node_labels:
+  region: default
+  zone: default
+openshift_openstack_cluster_node_labels:
+  app:
+    region: default
+    zone: default
+  infra:
+    region: default
+    zone: default
+  masters:
+    region: default
+    zone: default
+  cns:
+    region: default
+    zone: default
+osm_default_node_selector: "region=default"
+openshift_hosted_router_selector: "region=default"
+openshift_hosted_registry_selector: "region=default"
+openshift_web_console_nodeselector: "region=default"
+template_service_broker_selector: {"region": "default"}
+openshift_router_selector: "region=default"
+openshift_registry_selector: "region=default"
+openshift_prometheus_node_selector: {"region": "default"}
+openshift_hosted_infra_selector: "region=default"
+openshift_schedulable: true
+```
+This enables all pods scheduling and starting on a single (master) node.
 
 The `openshift_openstack_nodes_to_remove` allows you to specify the numerical indexes
 of App nodes that should be removed; for example, ['0', '2'],

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -626,6 +626,12 @@ resources:
                 k8s_type: masters
                 cluster_id: {{ openshift_openstack_stack_name }}
           type:        master
+{% if openshift_openstack_cluster_node_labels.masters is defined %}
+          node_labels:
+{% for k, v in openshift_openstack_cluster_node_labels.masters.items() %}
+            {{ k|e }}: {{ v|e }}
+{% endfor %}
+{% endif %}
           image:       {{ openshift_openstack_master_image }}
           flavor:      {{ openshift_openstack_master_flavor }}
           key_name:    {{ openshift_openstack_keypair_name }}
@@ -655,6 +661,12 @@ resources:
 {% if openshift_openstack_num_etcd|int == 0 %}
             - { get_resource: etcd-secgrp }
 {% endif %}
+{% endif %}
+{% if openshift_openstack_num_infra|int == 0 %}
+            - { get_resource: infra-secgrp }
+{% endif %}
+{% if openshift_openstack_num_cns|int == 0 and openshift_openstack_num_nodes|int == 0 %}
+            - { get_resource: cns-secgrp }
 {% endif %}
             - { get_resource: common-secgrp }
           floating_network:
@@ -837,6 +849,12 @@ resources:
                 k8s_type: cns
                 cluster_id: {{ openshift_openstack_stack_name }}
           type:        cns
+{% if openshift_openstack_cluster_node_labels.cns is defined %}
+          node_labels:
+{% for k, v in openshift_openstack_cluster_node_labels.cns.items() %}
+            {{ k|e }}: {{ v|e }}
+{% endfor %}
+{% endif %}
           image:       {{ openshift_openstack_cns_image }}
           flavor:      {{ openshift_openstack_cns_flavor }}
           key_name:    {{ openshift_openstack_keypair_name }}


### PR DESCRIPTION
Document all-in-one deployments via custom node labes.
Allow to specify node labels for masters and cns groups as well.
Add missing sec groups for all-in-one master.
Autodect adding sec groups for cns, if num masters is 1
and num nodes is 0.

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>