### PR TITLE
openshift_checks: repair adhoc list-checks mode

### DIFF
--- a/playbooks/openshift-checks/adhoc.yml
+++ b/playbooks/openshift-checks/adhoc.yml
@@ -11,6 +11,7 @@
   # usage. Running this play only in localhost speeds up execution.
   hosts: localhost
   connection: local
+  gather_facts: false
   roles:
   - openshift_health_checker
   vars:

--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -56,7 +56,7 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
         # ordered list of registries (according to inventory vars) that docker will try for unscoped images
         regs = self.ensure_list("openshift_docker_additional_registries")
         # currently one of these registries is added whether the user wants it or not.
-        deployment_type = self.get_var("openshift_deployment_type")
+        deployment_type = self.get_var("openshift_deployment_type", default="")
         if deployment_type == "origin" and "docker.io" not in regs:
             regs.append("docker.io")
         elif deployment_type == 'openshift-enterprise' and "registry.access.redhat.com" not in regs:


### PR DESCRIPTION
fixes bug https://bugzilla.redhat.com/show_bug.cgi?id=1509157

`docker_image_availability.__init__` was loading a variable that of course
was not defined for localhost, which is how this play runs. Fixed that.
Would be nice if there were a more generic way to solve that class of
problem but I can't think of anything for now that isn't worse.

Also noticed that this play gathers facts for localhost. That's not
necessary for what it's doing, so disabled that.