### PR TITLE
include elasticsearch container name

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/logging/elasticsearch.py
+++ b/roles/openshift_health_checker/openshift_checks/logging/elasticsearch.py
@@ -170,7 +170,7 @@ class Elasticsearch(LoggingCheck):
         """
         errors = []
         for pod_name in pods_by_name.keys():
-            df_cmd = 'exec {} -- df --output=ipcent,pcent /elasticsearch/persistent'.format(pod_name)
+            df_cmd = '-c elasticsearch exec {} -- df --output=ipcent,pcent /elasticsearch/persistent'.format(pod_name)
             disk_output = self.exec_oc(df_cmd, [], save_as_name='get_pv_diskspace.json')
             lines = disk_output.splitlines()
             # expecting one header looking like 'IUse% Use%' and one body line


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1534988

Addresses cases where the elasticsearch pod with multiple containers does not have the `elasticsearch` container as its first one.

cc @sosiouxme 