### PR TITLE
[3.6] openshift_checks: Add OVS versions for OCP 3.7

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/ovs_version.py
+++ b/roles/openshift_health_checker/openshift_checks/ovs_version.py
@@ -16,7 +16,8 @@ class OvsVersion(NotContainerizedMixin, OpenShiftCheck):
     tags = ["health"]
 
     openshift_to_ovs_version = {
-        "3.6": ["2.6", "2.7"],
+        "3.7": ["2.6", "2.7", "2.8"],
+        "3.6": ["2.6", "2.7", "2.8"],
         "3.5": ["2.6", "2.7"],
         "3.4": "2.4",
     }

--- a/roles/openshift_health_checker/openshift_checks/package_version.py
+++ b/roles/openshift_health_checker/openshift_checks/package_version.py
@@ -16,7 +16,8 @@ class PackageVersion(NotContainerizedMixin, OpenShiftCheck):
     openshift_to_ovs_version = {
         (3, 4): "2.4",
         (3, 5): ["2.6", "2.7"],
-        (3, 6): ["2.6", "2.7"],
+        (3, 6): ["2.6", "2.7", "2.8"],
+        (3, 7): ["2.6", "2.7", "2.8"],
     }
 
     openshift_to_docker_version = {

--- a/roles/openshift_health_checker/test/ovs_version_test.py
+++ b/roles/openshift_health_checker/test/ovs_version_test.py
@@ -38,8 +38,9 @@ def test_invalid_openshift_release_format():
 
 
 @pytest.mark.parametrize('openshift_release,expected_ovs_version', [
+    ("3.7", ["2.6", "2.7", "2.8"]),
     ("3.5", ["2.6", "2.7"]),
-    ("3.6", ["2.6", "2.7"]),
+    ("3.6", ["2.6", "2.7", "2.8"]),
     ("3.4", "2.4"),
     ("3.3", "2.4"),
     ("1.0", "2.4"),


### PR DESCRIPTION
Backport of https://github.com/openshift/openshift-ansible/pull/6023

Update the ovs_version check with the allowed Open vSwitch versions for OCP
3.7. Add OVS 2.8 to the allowed versions for OCP 3.6 as well.

Fixes 3.6 bug https://bugzilla.redhat.com/show_bug.cgi?id=1528383