### PR TITLE
Remove obsolete properties from console config map

### DIFF
--- a/files/origin-components/console-config.yaml
+++ b/files/origin-components/console-config.yaml
@@ -6,13 +6,10 @@ clusterInfo:
   logoutPublicURL: ""
   masterPublicURL: https://127.0.0.1:8443
   metricsPublicURL: ""
-# TODO: The new extensions properties cannot be set until
-# origin-web-console-server has been updated with the API changes since
-# `extensions` in the old asset config was an array.
-#extensions:
-#  scriptURLs: []
-#  stylesheetURLs: []
-#  properties: null
+extensions:
+  scriptURLs: []
+  stylesheetURLs: []
+  properties: null
 features:
   inactivityTimeoutMinutes: 0
 servingInfo:
@@ -24,19 +21,3 @@ servingInfo:
   maxRequestsInFlight: 0
   namedCertificates: null
   requestTimeoutSeconds: 0
-
-# START deprecated properties
-# These properties have been renamed and will be removed from the install
-# in a future pull. Keep both the old and new properties for now so that
-# the install is not broken while the origin-web-console image is updated.
-extensionDevelopment: false
-extensionProperties: null
-extensionScripts: null
-extensionStylesheets: null
-extensions: null
-loggingPublicURL: ""
-logoutURL: ""
-masterPublicURL: https://127.0.0.1:8443
-metricsPublicURL: ""
-publicURL: https://127.0.0.1:8443/console/
-# END deprecated properties

--- a/roles/openshift_logging/tasks/delete_logging.yaml
+++ b/roles/openshift_logging/tasks/delete_logging.yaml
@@ -138,6 +138,6 @@
     tasks_from: update_console_config.yml
   vars:
     console_config_edits:
-      - key: loggingPublicURL
+      - key: clusterInfo#loggingPublicURL
         value: ""
   when: openshift_web_console_install | default(true) | bool

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -326,9 +326,4 @@
     console_config_edits:
     - key: clusterInfo#loggingPublicURL
       value: "https://{{ openshift_logging_kibana_hostname }}"
-    # Continue to set the old deprecated property until the
-    # origin-web-console image is updated for the new name.
-    # This will be removed in a future pull.
-    - key: loggingPublicURL
-      value: "https://{{ openshift_logging_kibana_hostname }}"
   when: openshift_web_console_install | default(true) | bool

--- a/roles/openshift_metrics/tasks/install_metrics.yaml
+++ b/roles/openshift_metrics/tasks/install_metrics.yaml
@@ -79,11 +79,6 @@
     console_config_edits:
       - key: clusterInfo#metricsPublicURL
         value: "https://{{ openshift_metrics_hawkular_hostname}}/hawkular/metrics"
-      # Continue to set the old deprecated property until the
-      # origin-web-console image is updated for the new name.
-      # This will be removed in a future pull.
-      - key: metricsPublicURL
-        value: "https://{{ openshift_metrics_hawkular_hostname}}/hawkular/metrics"
   when: openshift_web_console_install | default(true) | bool
 
 - command: >

--- a/roles/openshift_metrics/tasks/uninstall_metrics.yaml
+++ b/roles/openshift_metrics/tasks/uninstall_metrics.yaml
@@ -26,6 +26,6 @@
     tasks_from: update_console_config.yml
   vars:
     console_config_edits:
-      - key: metricsPublicURL
+      - key: clusterInfo#metricsPublicURL
         value: ""
   when: openshift_web_console_install | default(true) | bool

--- a/roles/openshift_web_console/tasks/install.yml
+++ b/roles/openshift_web_console/tasks/install.yml
@@ -48,29 +48,12 @@
         value: "{{ openshift.master.logout_url | default('') }}"
       - key: features#inactivityTimeoutMinutes
         value: "{{ openshift_web_console_inactivity_timeout_minutes | default(0) }}"
-
-      # TODO: The new extensions properties cannot be set until
-      # origin-web-console-server has been updated with the API changes since
-      # `extensions` in the old asset config was an array.
-
-      # - key: extensions#scriptURLs
-      #   value: "{{ openshift_web_console_extension_script_urls | default([]) }}"
-      # - key: extensions#stylesheetURLs
-      #   value: "{{ openshift_web_console_extension_stylesheet_urls | default([]) }}"
-      # - key: extensions#properties
-      #   value: "{{ openshift_web_console_extension_properties | default({}) }}"
-
-      # DEPRECATED PROPERTIES
-      # These properties have been renamed and will be removed from the install
-      # in a future pull. Keep both the old and new properties for now so that
-      # the install is not broken while the origin-web-console image is updated.
-      - key: publicURL
-        # Must have a trailing slash
-        value: "{{ openshift.master.public_console_url }}/"
-      - key: logoutURL
-        value: "{{ openshift.master.logout_url | default('') }}"
-      - key: masterPublicURL
-        value: "{{ openshift.master.public_api_url }}"
+      - key: extensions#scriptURLs
+        value: "{{ openshift_web_console_extension_script_urls | default([]) }}"
+      - key: extensions#stylesheetURLs
+        value: "{{ openshift_web_console_extension_stylesheet_urls | default([]) }}"
+      - key: extensions#properties
+        value: "{{ openshift_web_console_extension_properties | default({}) }}"
     separator: '#'
     state: present
 


### PR DESCRIPTION
Stop writing deprecated config to the console config map.

/hold

This can't be merged until https://github.com/openshift/origin-web-console-server/pull/20 merges.
Follow on to https://github.com/openshift/openshift-ansible/pull/6730