### PR TITLE
Use openshift_is_containerized instead of openshift_is_atomic when working with packages

### DIFF
--- a/roles/etcd/tasks/auxiliary/drop_etcdctl.yml
+++ b/roles/etcd/tasks/auxiliary/drop_etcdctl.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install etcd for etcdctl
   package: name=etcd{{ '-' + etcd_version if etcd_version is defined else '' }} state=present
-  when: not openshift_is_atomic | bool
+  when: not openshift_is_containerized | bool
   register: result
   until: result is succeeded
 


### PR DESCRIPTION
This ensures 'containerized' setting is taken into account, so that a
non-Atomic system without enabled repos can install containerized
openshift


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1533131