### PR TITLE
update health check required versions for 3.9

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/__init__.py
+++ b/roles/openshift_health_checker/openshift_checks/__init__.py
@@ -325,6 +325,24 @@ class OpenShiftCheck(object):
 
         return tuple(int(x) for x in components[:2])
 
+    def get_required_version(self, name, version_map):
+        """Return the correct required version(s) for the current (or nearest) OpenShift version."""
+        openshift_version = self.get_major_minor_version()
+
+        earliest = min(version_map)
+        latest = max(version_map)
+        if openshift_version < earliest:
+            return version_map[earliest]
+        if openshift_version > latest:
+            return version_map[latest]
+
+        required_version = version_map.get(openshift_version)
+        if not required_version:
+            msg = "There is no recommended version of {} for the current version of OpenShift ({})"
+            raise OpenShiftCheckException(msg.format(name, ".".join(str(comp) for comp in openshift_version)))
+
+        return required_version
+
     def find_ansible_mount(self, path):
         """Return the mount point for path from ansible_mounts."""
 

--- a/roles/openshift_health_checker/openshift_checks/__init__.py
+++ b/roles/openshift_health_checker/openshift_checks/__init__.py
@@ -5,6 +5,7 @@ Health checks for OpenShift clusters.
 import json
 import operator
 import os
+import re
 import time
 import collections
 
@@ -309,28 +310,20 @@ class OpenShiftCheck(object):
             name_list = name_list.split(',')
         return [name.strip() for name in name_list if name.strip()]
 
-    @staticmethod
-    def get_major_minor_version(openshift_image_tag):
+    def get_major_minor_version(self, openshift_image_tag=None):
         """Parse and return the deployed version of OpenShift as a tuple."""
-        if openshift_image_tag and openshift_image_tag[0] == 'v':
-            openshift_image_tag = openshift_image_tag[1:]
 
-        # map major release versions across releases
-        # to a common major version
-        openshift_major_release_version = {
-            "1": "3",
-        }
+        version = openshift_image_tag or self.get_var("openshift_image_tag")
+        components = [int(component) for component in re.findall(r'\d+', version)]
 
-        components = openshift_image_tag.split(".")
-        if not components or len(components) < 2:
+        if len(components) < 2:
             msg = "An invalid version of OpenShift was found for this host: {}"
-            raise OpenShiftCheckException(msg.format(openshift_image_tag))
+            raise OpenShiftCheckException(msg.format(version))
 
-        if components[0] in openshift_major_release_version:
-            components[0] = openshift_major_release_version[components[0]]
+        # map major release version across releases to OCP major version
+        components[0] = {1: 3}.get(components[0], components[0])
 
-        components = tuple(int(x) for x in components[:2])
-        return components
+        return tuple(int(x) for x in components[:2])
 
     def find_ansible_mount(self, path):
         """Return the mount point for path from ansible_mounts."""

--- a/roles/openshift_health_checker/openshift_checks/ovs_version.py
+++ b/roles/openshift_health_checker/openshift_checks/ovs_version.py
@@ -20,6 +20,8 @@ class OvsVersion(NotContainerizedMixin, OpenShiftCheck):
         (3, 5): ["2.6", "2.7"],
         (3, 6): ["2.6", "2.7", "2.8"],
         (3, 7): ["2.6", "2.7", "2.8"],
+        (3, 8): ["2.6", "2.7", "2.8"],
+        (3, 9): ["2.6", "2.7", "2.8"],
     }
 
     def is_active(self):

--- a/roles/openshift_health_checker/openshift_checks/ovs_version.py
+++ b/roles/openshift_health_checker/openshift_checks/ovs_version.py
@@ -3,7 +3,7 @@ Ansible module for determining if an installed version of Open vSwitch is incomp
 currently installed version of OpenShift.
 """
 
-from openshift_checks import OpenShiftCheck, OpenShiftCheckException
+from openshift_checks import OpenShiftCheck
 from openshift_checks.mixins import NotContainerizedMixin
 
 
@@ -16,10 +16,10 @@ class OvsVersion(NotContainerizedMixin, OpenShiftCheck):
     tags = ["health"]
 
     openshift_to_ovs_version = {
-        "3.7": ["2.6", "2.7", "2.8"],
-        "3.6": ["2.6", "2.7", "2.8"],
-        "3.5": ["2.6", "2.7"],
-        "3.4": "2.4",
+        (3, 4): "2.4",
+        (3, 5): ["2.6", "2.7"],
+        (3, 6): ["2.6", "2.7", "2.8"],
+        (3, 7): ["2.6", "2.7", "2.8"],
     }
 
     def is_active(self):
@@ -40,16 +40,5 @@ class OvsVersion(NotContainerizedMixin, OpenShiftCheck):
         return self.execute_module("rpm_version", args)
 
     def get_required_ovs_version(self):
-        """Return the correct Open vSwitch version for the current OpenShift version"""
-        openshift_version_tuple = self.get_major_minor_version(self.get_var("openshift_image_tag"))
-
-        if openshift_version_tuple < (3, 5):
-            return self.openshift_to_ovs_version["3.4"]
-
-        openshift_version = ".".join(str(x) for x in openshift_version_tuple)
-        ovs_version = self.openshift_to_ovs_version.get(openshift_version)
-        if ovs_version:
-            return self.openshift_to_ovs_version[openshift_version]
-
-        msg = "There is no recommended version of Open vSwitch for the current version of OpenShift: {}"
-        raise OpenShiftCheckException(msg.format(openshift_version))
+        """Return the correct Open vSwitch version(s) for the current OpenShift version."""
+        return self.get_required_version("Open vSwitch", self.openshift_to_ovs_version)

--- a/roles/openshift_health_checker/openshift_checks/package_version.py
+++ b/roles/openshift_health_checker/openshift_checks/package_version.py
@@ -1,6 +1,6 @@
 """Check that available RPM packages match the required versions."""
 
-from openshift_checks import OpenShiftCheck, OpenShiftCheckException
+from openshift_checks import OpenShiftCheck
 from openshift_checks.mixins import NotContainerizedMixin
 
 
@@ -76,36 +76,8 @@ class PackageVersion(NotContainerizedMixin, OpenShiftCheck):
 
     def get_required_ovs_version(self):
         """Return the correct Open vSwitch version(s) for the current OpenShift version."""
-        openshift_version = self.get_major_minor_version()
-
-        earliest = min(self.openshift_to_ovs_version)
-        latest = max(self.openshift_to_ovs_version)
-        if openshift_version < earliest:
-            return self.openshift_to_ovs_version[earliest]
-        if openshift_version > latest:
-            return self.openshift_to_ovs_version[latest]
-
-        ovs_version = self.openshift_to_ovs_version.get(openshift_version)
-        if not ovs_version:
-            msg = "There is no recommended version of Open vSwitch for the current version of OpenShift: {}"
-            raise OpenShiftCheckException(msg.format(".".join(str(comp) for comp in openshift_version)))
-
-        return ovs_version
+        return self.get_required_version("Open vSwitch", self.openshift_to_ovs_version)
 
     def get_required_docker_version(self):
         """Return the correct Docker version(s) for the current OpenShift version."""
-        openshift_version = self.get_major_minor_version()
-
-        earliest = min(self.openshift_to_docker_version)
-        latest = max(self.openshift_to_docker_version)
-        if openshift_version < earliest:
-            return self.openshift_to_docker_version[earliest]
-        if openshift_version > latest:
-            return self.openshift_to_docker_version[latest]
-
-        docker_version = self.openshift_to_docker_version.get(openshift_version)
-        if not docker_version:
-            msg = "There is no recommended version of Docker for the current version of OpenShift: {}"
-            raise OpenShiftCheckException(msg.format(".".join(str(comp) for comp in openshift_version)))
-
-        return docker_version
+        return self.get_required_version("Docker", self.openshift_to_docker_version)

--- a/roles/openshift_health_checker/openshift_checks/package_version.py
+++ b/roles/openshift_health_checker/openshift_checks/package_version.py
@@ -16,6 +16,8 @@ class PackageVersion(NotContainerizedMixin, OpenShiftCheck):
         (3, 5): ["2.6", "2.7"],
         (3, 6): ["2.6", "2.7", "2.8"],
         (3, 7): ["2.6", "2.7", "2.8"],
+        (3, 8): ["2.6", "2.7", "2.8"],
+        (3, 9): ["2.6", "2.7", "2.8"],
     }
 
     openshift_to_docker_version = {
@@ -25,6 +27,9 @@ class PackageVersion(NotContainerizedMixin, OpenShiftCheck):
         (3, 4): "1.12",
         (3, 5): "1.12",
         (3, 6): "1.12",
+        (3, 7): "1.12",
+        (3, 8): "1.12",
+        (3, 9): ["1.12", "1.13"],
     }
 
     def is_active(self):

--- a/roles/openshift_health_checker/test/ovs_version_test.py
+++ b/roles/openshift_health_checker/test/ovs_version_test.py
@@ -1,26 +1,7 @@
 import pytest
 
-from openshift_checks.ovs_version import OvsVersion, OpenShiftCheckException
-
-
-def test_openshift_version_not_supported():
-    def execute_module(*_):
-        return {}
-
-    openshift_release = '111.7.0'
-
-    task_vars = dict(
-        openshift=dict(common=dict()),
-        openshift_release=openshift_release,
-        openshift_image_tag='v' + openshift_release,
-        openshift_deployment_type='origin',
-        openshift_service_type='origin'
-    )
-
-    with pytest.raises(OpenShiftCheckException) as excinfo:
-        OvsVersion(execute_module, task_vars).run()
-
-    assert "no recommended version of Open vSwitch" in str(excinfo.value)
+from openshift_checks.ovs_version import OvsVersion
+from openshift_checks import OpenShiftCheckException
 
 
 def test_invalid_openshift_release_format():

--- a/roles/openshift_health_checker/test/package_version_test.py
+++ b/roles/openshift_health_checker/test/package_version_test.py
@@ -1,6 +1,7 @@
 import pytest
 
-from openshift_checks.package_version import PackageVersion, OpenShiftCheckException
+from openshift_checks.package_version import PackageVersion
+from openshift_checks import OpenShiftCheckException
 
 
 def task_vars_for(openshift_release, deployment_type):

--- a/roles/openshift_health_checker/test/package_version_test.py
+++ b/roles/openshift_health_checker/test/package_version_test.py
@@ -18,7 +18,7 @@ def task_vars_for(openshift_release, deployment_type):
 
 def test_openshift_version_not_supported():
     check = PackageVersion(None, task_vars_for("1.2.3", 'origin'))
-    check.get_openshift_version_tuple = lambda: (3, 4, 1)  # won't be in the dict
+    check.get_major_minor_version = lambda: (3, 4, 1)  # won't be in the dict
 
     with pytest.raises(OpenShiftCheckException) as excinfo:
         check.get_required_ovs_version()


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1534922

A little refactoring in the first commits to reuse code and prevent having to update this for every single release. Then, updating the actual versions for 3.9.