### PR TITLE
Add init/main.yml to etc-upgrade

### DIFF
--- a/playbooks/openshift-etcd/upgrade.yml
+++ b/playbooks/openshift-etcd/upgrade.yml
@@ -1,4 +1,7 @@
 ---
-- import_playbook: ../init/evaluate_groups.yml
+- import_playbook: ../init/main.yml
+  vars:
+    skip_verison: True
+    l_upgrade_non_node_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
 
 - import_playbook: private/upgrade_main.yml


### PR DESCRIPTION
Currently, etcd upgrade playbook only calls
evaluate_groups to limit the number of tasks
that are run against nodes during initialization.

Recently, changes have been added to allow skipping
of most node tasks via providing variablized host
groups during initialization code.

This commit allows etcd upgrades to use common
init code to ensure necessary facts are defined
and proper variables are sanity checked.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1527771