### PR TITLE
Ensure atomic_proxies are configured with docker

### DIFF
--- a/playbooks/container-runtime/private/build_container_groups.yml
+++ b/playbooks/container-runtime/private/build_container_groups.yml
@@ -3,4 +3,4 @@
   hosts: oo_all_hosts:!oo_nodes_to_config
   tasks:
   - group_by:
-      key: oo_hosts_containerized_managed_{{ (containerized | default(False)) | ternary('true','false') }}
+      key: oo_hosts_containerized_managed_{{ (openshift_is_containerized | default(False)) | ternary('true','false') }}

--- a/roles/container_runtime/tasks/package_docker.yml
+++ b/roles/container_runtime/tasks/package_docker.yml
@@ -1,6 +1,17 @@
 ---
 - include_tasks: common/pre.yml
 
+# In some cases, some services may be run as containers and docker may still
+# be installed via rpm.
+- include_tasks: common/atomic_proxy.yml
+  when:
+  - >
+    (openshift_use_system_containers | default(False)) | bool
+    or (openshift_use_etcd_system_container | default(False)) | bool
+    or (openshift_use_openvswitch_system_container | default(False)) | bool
+    or (openshift_use_node_system_container | default(False)) | bool
+    or (openshift_use_master_system_container | default(False)) | bool
+
 - name: Get current installed Docker version
   command: "{{ repoquery_installed }} --qf '%{version}' docker"
   when: not openshift_is_atomic | bool


### PR DESCRIPTION
In some setups, system containers may be used
in conjunction with package_docker.

This commit ensures that the atomic
proxies are configured while using package_docker
and containerized components.

This commit also ensures containerized_groups
are based on openshift_is_containerized instead
of 'containerized' variable directly to
account for possible use of atomic hosts which
users may not specify containerized in inventory
directly.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1535323