### PR TITLE
Allow for firewalld on atomic host

### DIFF
--- a/roles/os_firewall/tasks/firewalld.yml
+++ b/roles/os_firewall/tasks/firewalld.yml
@@ -2,7 +2,9 @@
 - name: Fail - Firewalld is not supported on Atomic Host
   fail:
     msg: "Firewalld is not supported on Atomic Host"
-  when: r_os_firewall_is_atomic | bool
+  when:
+    - r_os_firewall_is_atomic | bool
+    - not openshift_enable_unsupported_configurations | default(false)
 
 - name: Install firewalld packages
   package:
@@ -10,6 +12,7 @@
     state: present
   register: result
   until: result is succeeded
+  when: not r_os_firewall_is_atomic | bool
 
 - name: Ensure iptables services are not enabled
   systemd:


### PR DESCRIPTION
Right now this is only available on fedora so guard it with
openshift_enable_unsupported_configurations