### PR TITLE
[3.7] Check that rc != 0 for steps with 'failed_when'

### DIFF
--- a/roles/calico_master/tasks/main.yml
+++ b/roles/calico_master/tasks/main.yml
@@ -23,7 +23,7 @@
     -f {{ mktemp.stdout }}/calico-policy-controller.yml
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
   register: calico_create_output
-  failed_when: ('already exists' not in calico_create_output.stderr) and ('created' not in calico_create_output.stdout)
+  failed_when: "('already exists' not in calico_create_output.stderr) and ('created' not in calico_create_output.stdout) and calico_create_output.rc != 0"
   changed_when: ('created' in calico_create_output.stdout)
 
 - name: Calico Master | Delete temp directory

--- a/roles/openshift_expand_partition/tasks/main.yml
+++ b/roles/openshift_expand_partition/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: Determine if growpart is installed
   command: "rpm -q cloud-utils-growpart"
   register: has_growpart
-  failed_when: has_growpart.cr != 0 and 'package cloud-utils-growpart is not installed' not in has_growpart.stdout
+  failed_when: has_growpart.rc != 0 and 'package cloud-utils-growpart is not installed' not in has_growpart.stdout
   changed_when: false
   when: openshift.common.is_containerized | bool
 

--- a/roles/openshift_metrics/tasks/oc_apply.yaml
+++ b/roles/openshift_metrics/tasks/oc_apply.yaml
@@ -16,7 +16,9 @@
     apply -f {{ file_name }}
     -n {{namespace}}
   register: generation_apply
-  failed_when: "'error' in generation_apply.stderr"
+  failed_when:
+    - "'error' in generation_apply.stderr"
+    - "generation_apply.rc != 0"
   changed_when: no
 
 - name: Determine change status of {{file_content.kind}} {{file_content.metadata.name}}
@@ -28,5 +30,7 @@
   register: version_changed
   vars:
     init_version: "{{ (generation_init is defined) | ternary(generation_init.stdout, '0') }}"
-  failed_when: "'error' in version_changed.stderr"
+  failed_when:
+    - "'error' in version_changed.stderr"
+    - "version_changed.rc != 0"
   changed_when: version_changed.stdout | int  > init_version | int

--- a/roles/openshift_provisioners/tasks/oc_apply.yaml
+++ b/roles/openshift_provisioners/tasks/oc_apply.yaml
@@ -15,7 +15,9 @@
     apply -f {{ file_name }}
     -n {{ namespace }}
   register: generation_apply
-  failed_when: "'error' in generation_apply.stderr"
+  failed_when:
+    - "'error' in generation_apply.stderr"
+    - "generation_apply.rc != 0"
   changed_when: no
 
 - name: Determine change status of {{file_content.kind}} {{file_content.metadata.name}}
@@ -36,7 +38,9 @@
     delete -f {{ file_name }}
     -n {{ namespace }}
   register: generation_delete
-  failed_when: "'error' in generation_delete.stderr"
+  failed_when:
+    - "'error' in generation_delete.stderr"
+    - "generation_delete.rc != 0"
   changed_when: generation_delete.rc == 0
   when: generation_apply.rc != 0
 
@@ -46,6 +50,8 @@
     apply -f {{ file_name }}
     -n {{ namespace }}
   register: generation_apply
-  failed_when: "'error' in generation_apply.stderr"
+  failed_when:
+    - "'error' in generation_apply.stderr"
+    - "generation_apply.rc != 0"
   changed_when: generation_apply.rc == 0
   when: generation_apply.rc != 0


### PR DESCRIPTION
Some parts don't check the result rc at all, some check that 'error' is present there.
Instead the safest way is to check for both

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1534538

Backport of https://github.com/openshift/openshift-ansible/pull/6751 to 3.7