### PR TITLE
Using label instead of maintainer instructions

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -1,7 +1,5 @@
 FROM centos:7
 
-MAINTAINER OpenShift Team <dev@lists.openshift.redhat.com>
-
 USER root
 
 # Add origin repo for including the oc client
@@ -16,7 +14,8 @@ RUN INSTALL_PKGS="python-lxml pyOpenSSL python2-cryptography openssl java-1.8.0-
  && rpm -V $INSTALL_PKGS $EPEL_PKGS \
  && yum clean all
 
-LABEL name="openshift/origin-ansible" \
+LABEL maintainer="OpenShift Team <dev@lists.openshift.redhat.com>" \
+      name="openshift/origin-ansible" \
       summary="OpenShift's installation and configuration tool" \
       description="A containerized openshift-ansible image to let you run playbooks to install, upgrade, maintain and check an OpenShift cluster" \
       url="https://github.com/openshift/openshift-ansible" \

--- a/images/installer/Dockerfile.rhel7
+++ b/images/installer/Dockerfile.rhel7
@@ -1,7 +1,5 @@
 FROM rhel7.3:7.3-released
 
-MAINTAINER OpenShift Team <dev@lists.openshift.redhat.com>
-
 USER root
 
 # Playbooks, roles, and their dependencies are installed from packages.
@@ -13,7 +11,8 @@ RUN INSTALL_PKGS="atomic-openshift-utils atomic-openshift-clients python-boto op
  && rpm -q $INSTALL_PKGS \
  && yum clean all
 
-LABEL name="openshift3/ose-ansible" \
+LABEL maintainer="OpenShift Team <dev@lists.openshift.redhat.com>" \
+      name="openshift3/ose-ansible" \
       summary="OpenShift's installation and configuration tool" \
       description="A containerized openshift-ansible image to let you run playbooks to install, upgrade, maintain and check an OpenShift cluster" \
       url="https://github.com/openshift/openshift-ansible" \


### PR DESCRIPTION
Since docker v1.13.0 the `MAINTAINER` instruction is deprecated: formerly was a limited label and Docker docs encourage to use `LABEL`.