### PR TITLE
Fix node scaleup plays

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
@@ -14,7 +14,7 @@
 - import_playbook: ../init.yml
   vars:
     l_upgrade_no_switch_firewall_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
-    l_upgrade_non_node_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
 
 - name: Configure the upgrade target for the common upgrade tasks
   hosts: oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -14,7 +14,7 @@
 - import_playbook: ../init.yml
   vars:
     l_upgrade_no_switch_firewall_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
-    l_upgrade_non_node_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
 
 - name: Configure the upgrade target for the common upgrade tasks
   hosts: oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config

--- a/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml
@@ -14,7 +14,7 @@
 - import_playbook: ../init.yml
   vars:
     l_upgrade_no_switch_firewall_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
-    l_upgrade_non_node_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
   when: not skip_version_info | default(false)
 
 - name: Configure the upgrade target for the common upgrade tasks

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
@@ -14,7 +14,7 @@
 - import_playbook: ../init.yml
   vars:
     l_upgrade_no_switch_firewall_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
-    l_upgrade_non_node_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
 
 ## Check to see if they're running 3.7 and if so upgrade them to 3.8 on control plan
 ## If they've specified pkg_version or image_tag preserve that for later use

--- a/playbooks/container-runtime/private/config.yml
+++ b/playbooks/container-runtime/private/config.yml
@@ -1,7 +1,11 @@
 ---
+# l_scale_up_hosts may be passed in via prerequisites.yml during scaleup plays.
+
 - import_playbook: build_container_groups.yml
 
-- hosts: oo_nodes_to_config:oo_hosts_containerized_managed_true
+- hosts: "{{ l_scale_up_hosts | default(l_default_container_runtime_hosts) }}"
+  vars:
+    l_default_container_runtime_hosts: "oo_nodes_to_config:oo_hosts_containerized_managed_true"
   roles:
     - role: container_runtime
   tasks:

--- a/playbooks/container-runtime/private/setup_storage.yml
+++ b/playbooks/container-runtime/private/setup_storage.yml
@@ -1,8 +1,11 @@
 ---
+# l_scale_up_hosts may be passed in via prerequisites.yml during scaleup plays.
+
 - import_playbook: build_container_groups.yml
 
-- hosts: oo_nodes_to_config:oo_hosts_containerized_managed_true
+- hosts: "{{ l_scale_up_hosts | default(l_default_container_storage_hosts) }}"
   vars:
+    l_default_container_storage_hosts: "oo_nodes_to_config:oo_hosts_containerized_managed_true"
     l_chg_temp: "{{ hostvars[groups['oo_first_master'][0]]['openshift_containerized_host_groups'] | default([]) }}"
     l_containerized_host_groups: "{{ (['oo_nodes_to_config'] | union(l_chg_temp)) | join(':') }}"
   # role: container_runtime is necessary  here to bring role default variables

--- a/playbooks/init/base_packages.yml
+++ b/playbooks/init/base_packages.yml
@@ -1,6 +1,8 @@
 ---
+# l_scale_up_hosts may be passed in via prerequisites.yml during scaleup plays.
+
 - name: Install packages necessary for installer
-  hosts: oo_all_hosts
+  hosts: "{{ l_scale_up_hosts | default('oo_all_hosts') }}"
   any_errors_fatal: true
   tasks:
   - when:

--- a/playbooks/init/facts.yml
+++ b/playbooks/init/facts.yml
@@ -5,9 +5,9 @@
   tasks:
 
 - name: Initialize host facts
-  # l_upgrade_non_node_hosts is passed in via play during control-plane-only
-  # upgrades; otherwise oo_all_hosts is used.
-  hosts: "{{ l_upgrade_non_node_hosts | default('oo_all_hosts') }}"
+  # l_init_fact_hosts is passed in via play during control-plane-only
+  # upgrades and scale-up plays; otherwise oo_all_hosts is used.
+  hosts: "{{ l_init_fact_hosts | default('oo_all_hosts') }}"
   tasks:
   - name: load openshift_facts module
     import_role:

--- a/playbooks/init/repos.yml
+++ b/playbooks/init/repos.yml
@@ -1,6 +1,8 @@
 ---
+# l_scale_up_hosts may be passed in via prerequisites.yml during scaleup plays.
+
 - name: Setup yum repositories for all hosts
-  hosts: oo_all_hosts
+  hosts: "{{ l_scale_up_hosts | default('oo_all_hosts') }}"
   gather_facts: no
   tasks:
   - name: subscribe instances to Red Hat Subscription Manager

--- a/playbooks/init/sanity_checks.yml
+++ b/playbooks/init/sanity_checks.yml
@@ -1,4 +1,5 @@
 ---
+# l_sanity_check_hosts may be passed in during scale-up plays
 - name: Verify Requirements
   hosts: oo_first_master
   roles:
@@ -11,5 +12,5 @@
   # Thus, sanity_checks cannot gather new information about any hosts.
   - name: Run variable sanity checks
     sanity_checks:
-      check_hosts: "{{ groups['oo_all_hosts'] }}"
+      check_hosts: "{{ l_sanity_check_hosts | default(groups['oo_all_hosts']) }}"
     run_once: True

--- a/playbooks/openshift-etcd/upgrade.yml
+++ b/playbooks/openshift-etcd/upgrade.yml
@@ -2,6 +2,6 @@
 - import_playbook: ../init/main.yml
   vars:
     skip_verison: True
-    l_upgrade_non_node_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
 
 - import_playbook: private/upgrade_main.yml

--- a/playbooks/openshift-node/scaleup.yml
+++ b/playbooks/openshift-node/scaleup.yml
@@ -13,8 +13,18 @@
     when:
     - g_new_node_hosts | default([]) | length == 0
 
-# Need a better way to do the above check for node without
-# running evaluate_groups and init/main.yml
-- import_playbook: ../init/main.yml
+# if g_new_node_hosts is not empty, oo_nodes_to_config will be set to
+# g_new_node_hosts via evaluate_groups.yml
+
+- import_playbook: ../prerequisites.yml
+  vars:
+    l_scale_up_hosts: "oo_nodes_to_config"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_nodes_to_config"
+    l_sanity_check_hosts: "{{ groups['oo_nodes_to_config'] | union(groups['oo_masters_to_config']) }}"
+
+- import_playbook: ../init/version.yml
+  vars:
+    l_openshift_version_set_hosts: "oo_nodes_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "oo_nodes_to_config"
 
 - import_playbook: private/config.yml

--- a/playbooks/prerequisites.yml
+++ b/playbooks/prerequisites.yml
@@ -1,4 +1,6 @@
 ---
+# l_scale_up_hosts may be passed in via various scaleup plays.
+
 - import_playbook: init/main.yml
   vars:
     skip_verison: True
@@ -12,7 +14,9 @@
 
 # This is required for container runtime for crio, only needs to run once.
 - name: Configure os_firewall
-  hosts: oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_nfs_to_config:oo_nodes_to_config
+  hosts: "{{ l_scale_up_hosts | default(l_default_firewall_hosts) }}"
+  vars:
+    l_default_firewall_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_nfs_to_config:oo_nodes_to_config"
   roles:
   - role: os_firewall
 


### PR DESCRIPTION
Currently, users have no way to run preqrequisites.yml
on just newly added nodes during scaleup.

This commit ensures only the new nodes are changed during
scaleup as well as ensure prerequisites are run.