### PR TITLE
Rollout console after template service broker install

### DIFF
--- a/roles/openshift_web_console/tasks/rollout_console.yml
+++ b/roles/openshift_web_console/tasks/rollout_console.yml
@@ -1,0 +1,20 @@
+---
+- name: Check if console deployment exists
+  oc_obj:
+    kind: deployments
+    name: webconsole
+    namespace: openshift-web-console
+    state: list
+  register: console_deployment
+
+# There's currently no command to trigger a rollout for a k8s deployment
+# without changing the pod spec. Add an annotation to force a rollout.
+- name: Rollout updated web console deployment
+  oc_edit:
+    kind: deployments
+    name: webconsole
+    namespace: openshift-web-console
+    separator: '#'
+    content:
+      spec#template#metadata#annotations#installer-triggered-rollout: "{{ ansible_date_time.iso8601_micro }}"
+  when: console_deployment.results.results.0 | length > 0

--- a/roles/openshift_web_console/tasks/update_console_config.yml
+++ b/roles/openshift_web_console/tasks/update_console_config.yml
@@ -58,14 +58,4 @@
   changed_when: False
 
 # TODO: Only rollout if config has changed.
-# There's currently no command to trigger a rollout for a k8s deployment
-# without changing the pod spec. Add an annotation to force a rollout after
-# the config map has been edited.
-- name: Rollout updated web console deployment
-  oc_edit:
-    kind: deployments
-    name: webconsole
-    namespace: openshift-web-console
-    separator: '#'
-    content:
-      spec#template#metadata#annotations#installer-triggered-rollout: "{{ ansible_date_time.iso8601_micro }}"
+- include_tasks: rollout_console.yml

--- a/roles/template_service_broker/tasks/install.yml
+++ b/roles/template_service_broker/tasks/install.yml
@@ -85,3 +85,9 @@
     state: absent
     name: "{{ mktemp.stdout }}"
   changed_when: False
+
+- name: Rollout console so it discovers the template service broker is installed
+  include_role:
+    name: openshift_web_console
+    tasks_from: rollout_console.yml
+  when: openshift_web_console_install | default(true) | bool

--- a/roles/template_service_broker/tasks/remove.yml
+++ b/roles/template_service_broker/tasks/remove.yml
@@ -31,3 +31,9 @@
     state: absent
     name: "{{ mktemp.stdout }}"
   changed_when: False
+
+- name: Rollout console so it discovers the template service broker is removed
+  include_role:
+    name: openshift_web_console
+    tasks_from: rollout_console.yml
+  when: openshift_web_console_install | default(true) | bool


### PR DESCRIPTION
The console will discover if the broker is running, but only on startup.
Trigger a rollout so that the console sees the change.

/assign @sdodson 
cc @jwforres @deads2k @bparees 