### PR TITLE
Quick installer: deprecate upgrades

### DIFF
--- a/utils/src/ooinstall/cli_installer.py
+++ b/utils/src/ooinstall/cli_installer.py
@@ -938,91 +938,10 @@ def uninstall(ctx):
 @click.pass_context
 # pylint: disable=too-many-statements,too-many-branches
 def upgrade(ctx, latest_minor, next_major):
-    oo_cfg = ctx.obj['oo_cfg']
-
-    if len(oo_cfg.deployment.hosts) == 0:
-        click.echo("No hosts defined in: %s" % oo_cfg.config_path)
-        sys.exit(1)
-
-    variant = oo_cfg.settings['variant']
-    if find_variant(variant)[0] is None:
-        click.echo("%s is not a supported variant for upgrade." % variant)
-        sys.exit(0)
-
-    old_version = oo_cfg.settings['variant_version']
-
-    try:
-        mapping = UPGRADE_MAPPINGS[old_version]
-    except KeyError:
-        click.echo('No upgrades available for %s %s' % (variant, old_version))
-        sys.exit(0)
-
-    message = """
-        This tool will help you upgrade your existing OpenShift installation.
-        Currently running: %s %s
-"""
-    click.echo(message % (variant, old_version))
-
-    # Map the dynamic upgrade options to the playbook to run for each.
-    # Index offset by 1.
-    # List contains tuples of booleans for (latest_minor, next_major)
-    selections = []
-    if not (latest_minor or next_major):
-        i = 0
-        if 'minor_playbook' in mapping:
-            click.echo("(%s) Update to latest %s" % (i + 1, old_version))
-            selections.append((True, False))
-            i += 1
-        if 'major_playbook' in mapping:
-            click.echo("(%s) Upgrade to next release: %s" % (i + 1, mapping['major_version']))
-            selections.append((False, True))
-            i += 1
-
-        response = click.prompt("\nChoose an option from above",
-                                type=click.Choice(list(map(str, range(1, len(selections) + 1)))))
-        latest_minor, next_major = selections[int(response) - 1]
-
-    if next_major:
-        if 'major_playbook' not in mapping:
-            click.echo("No major upgrade supported for %s %s with this version "
-                       "of atomic-openshift-utils." % (variant, old_version))
-            sys.exit(0)
-        playbook = mapping['major_playbook']
-        new_version = mapping['major_version']
-        # Update config to reflect the version we're targeting, we'll write
-        # to disk once Ansible completes successfully, not before.
-        oo_cfg.settings['variant_version'] = new_version
-        if oo_cfg.settings['variant'] == 'enterprise':
-            oo_cfg.settings['variant'] = 'openshift-enterprise'
-
-    if latest_minor:
-        if 'minor_playbook' not in mapping:
-            click.echo("No minor upgrade supported for %s %s with this version "
-                       "of atomic-openshift-utils." % (variant, old_version))
-            sys.exit(0)
-        playbook = mapping['minor_playbook']
-        new_version = old_version
-
-    click.echo("OpenShift will be upgraded from %s %s to latest %s %s on the following hosts:\n" % (
-        variant, old_version, oo_cfg.settings['variant'], new_version))
-    for host in oo_cfg.deployment.hosts:
-        click.echo("  * %s" % host.connect_to)
-
-    if not ctx.obj['unattended']:
-        # Prompt interactively to confirm:
-        if not click.confirm("\nDo you want to proceed?"):
-            click.echo("Upgrade cancelled.")
-            sys.exit(0)
-
-    retcode = openshift_ansible.run_upgrade_playbook(oo_cfg.deployment.hosts,
-                                                     playbook,
-                                                     ctx.obj['verbose'])
-    if retcode > 0:
-        click.echo("Errors encountered during upgrade, please check %s." %
-                   oo_cfg.settings['ansible_log_path'])
-    else:
-        oo_cfg.save_to_disk()
-        click.echo("Upgrade completed! Rebooting all hosts is recommended.")
+    click.echo("Upgrades are no longer supported by this version of installer")
+    click.echo("Please see the documentation for manual upgrade:")
+    click.echo("https://docs.openshift.com/container-platform/latest/install_config/upgrading/automated_upgrades.html")
+    sys.exit(1)
 
 
 @click.command()

--- a/utils/src/ooinstall/openshift_ansible.py
+++ b/utils/src/ooinstall/openshift_ansible.py
@@ -321,21 +321,3 @@ def run_uninstall_playbook(hosts, verbose=False):
         facts_env['ANSIBLE_CONFIG'] = CFG.settings['ansible_quiet_config']
 
     return run_ansible(playbook, inventory_file, facts_env, verbose)
-
-
-def run_upgrade_playbook(hosts, playbook, verbose=False):
-    playbook = os.path.join(CFG.settings['ansible_playbook_directory'],
-                            'playbooks/byo/openshift-cluster/upgrades/{}'.format(playbook))
-
-    # TODO: Upgrade inventory for upgrade?
-    inventory_file = generate_inventory(hosts)
-    facts_env = os.environ.copy()
-    if 'ansible_log_path' in CFG.settings:
-        facts_env['ANSIBLE_LOG_PATH'] = CFG.settings['ansible_log_path']
-    if 'ansible_config' in CFG.settings:
-        facts_env['ANSIBLE_CONFIG'] = CFG.settings['ansible_config']
-    # override the ansible config for our main playbook run
-    if 'ansible_quiet_config' in CFG.settings:
-        facts_env['ANSIBLE_CONFIG'] = CFG.settings['ansible_quiet_config']
-
-    return run_ansible(playbook, inventory_file, facts_env, verbose)


### PR DESCRIPTION
Output a link to manual deprecate docs when `atomic-openshift-installer
upgrade` is called