### PR TITLE
Fix OpenStack readme

### DIFF
--- a/playbooks/openstack/README.md
+++ b/playbooks/openstack/README.md
@@ -184,7 +184,7 @@ resources:
 
 ```bash
 $ ansible-playbook --user openshift \
-  -i openshift-ansible/playbooks/openstack/inventory.py
+  -i openshift-ansible/playbooks/openstack/inventory.py \
   -i inventory \
   openshift-ansible/playbooks/openstack/openshift-cluster/provision_install.yml
 ```


### PR DESCRIPTION
The ansible-playbook command in the OpenStack readme is missing a
trailing backslash after the dynamic inventory. This prevents being able
to copy/paste the command into the terminal and just run it as is.