### PR TITLE
Fix etcd upgrade sanity

### DIFF
--- a/playbooks/openshift-etcd/upgrade.yml
+++ b/playbooks/openshift-etcd/upgrade.yml
@@ -3,5 +3,6 @@
   vars:
     skip_verison: True
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 
 - import_playbook: private/upgrade_main.yml


### PR DESCRIPTION
This builds off of https://github.com/openshift/openshift-ansible/pull/6784

    Fix etcd-upgrade sanity checks
    
    This commit ensures that only oo_etcd_to_config and
    oo_masters_to_config are checked during sanity_checks.
    
    This will prevent hosts that have not had facts gathered
    (such as nodes) will not be processed for correct inventory
    and runtime facts.
    
    Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1536317
