### PR TITLE
Bug 1512825 - add mux pod failed for Serial number 02 has already been issued

### DIFF
--- a/roles/openshift_logging/tasks/generate_certs.yaml
+++ b/roles/openshift_logging/tasks/generate_certs.yaml
@@ -19,7 +19,7 @@
   command: >
     {{ openshift_client_binary }} adm --config={{ mktemp.stdout }}/admin.kubeconfig ca create-signer-cert
     --key={{generated_certs_dir}}/ca.key --cert={{generated_certs_dir}}/ca.crt
-    --serial={{generated_certs_dir}}/ca.serial.txt --name=logging-signer-test
+    --serial={{generated_certs_dir}}/ca.serial.txt --name=logging-signer-test --overwrite=false
   check_mode: no
   when:
     - not ca_key_file.stat.exists

--- a/roles/openshift_logging/tasks/procure_server_certs.yaml
+++ b/roles/openshift_logging/tasks/procure_server_certs.yaml
@@ -30,7 +30,7 @@
      {{ openshift_client_binary }} adm --config={{ mktemp.stdout }}/admin.kubeconfig ca create-server-cert
      --key={{generated_certs_dir}}/{{cert_info.procure_component}}.key --cert={{generated_certs_dir}}/{{cert_info.procure_component}}.crt
      --hostnames={{cert_info.hostnames|quote}} --signer-cert={{generated_certs_dir}}/ca.crt --signer-key={{generated_certs_dir}}/ca.key
-     --signer-serial={{generated_certs_dir}}/ca.serial.txt
+     --signer-serial={{generated_certs_dir}}/ca.serial.txt --overwrite=false
   check_mode: no
   when:
   - cert_info.hostnames is defined


### PR DESCRIPTION
According to mkhan@redhat.com, to run the "oc adm ca create-server-cert" command
line with --signer-serial option, the following changes need to be made.
1. adding --overwrite=false
2. <ca.serial.txt> should contain only [0-9A-F]*.
   (no trailing newlines are allowed for now)

This patch solves 1.