### PR TITLE
Fix etcd scaleup playbook

### DIFF
--- a/playbooks/container-runtime/private/build_container_groups.yml
+++ b/playbooks/container-runtime/private/build_container_groups.yml
@@ -1,6 +1,8 @@
 ---
+# l_build_container_groups_hosts is passed in via prerequisites.yml during
+# etcd scaleup plays.
 - name: create oo_hosts_containerized_managed_true host group
-  hosts: oo_all_hosts:!oo_nodes_to_config
+  hosts: "{{ l_build_container_groups_hosts | default('oo_all_hosts:!oo_nodes_to_config') }}"
   tasks:
   - group_by:
       key: oo_hosts_containerized_managed_{{ (openshift_is_containerized | default(False)) | ternary('true','false') }}

--- a/playbooks/container-runtime/private/config.yml
+++ b/playbooks/container-runtime/private/config.yml
@@ -1,9 +1,11 @@
 ---
 # l_scale_up_hosts may be passed in via prerequisites.yml during scaleup plays.
+# l_etcd_scale_up_hosts may be passed in via prerequisites.yml during etcd
+# scaleup plays.
 
 - import_playbook: build_container_groups.yml
 
-- hosts: "{{ l_scale_up_hosts | default(l_default_container_runtime_hosts) }}"
+- hosts: "{{ l_etcd_scale_up_hosts | default(l_scale_up_hosts) | default(l_default_container_runtime_hosts) }}"
   vars:
     l_default_container_runtime_hosts: "oo_nodes_to_config:oo_hosts_containerized_managed_true"
   roles:

--- a/playbooks/container-runtime/private/setup_storage.yml
+++ b/playbooks/container-runtime/private/setup_storage.yml
@@ -1,9 +1,11 @@
 ---
 # l_scale_up_hosts may be passed in via prerequisites.yml during scaleup plays.
+# l_etcd_scale_up_hosts may be passed in via prerequisites.yml during etcd
+# scaleup plays.
 
 - import_playbook: build_container_groups.yml
 
-- hosts: "{{ l_scale_up_hosts | default(l_default_container_storage_hosts) }}"
+- hosts: "{{ l_etcd_scale_up_hosts | default(l_scale_up_hosts) | default(l_default_container_storage_hosts) }}"
   vars:
     l_default_container_storage_hosts: "oo_nodes_to_config:oo_hosts_containerized_managed_true"
     l_chg_temp: "{{ hostvars[groups['oo_first_master'][0]]['openshift_containerized_host_groups'] | default([]) }}"

--- a/playbooks/openshift-etcd/scaleup.yml
+++ b/playbooks/openshift-etcd/scaleup.yml
@@ -1,4 +1,51 @@
 ---
+- import_playbook: ../init/evaluate_groups.yml
+
+- name: Ensure there are new_etcd
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - fail:
+      msg: >
+        Detected no new_etcd in inventory. Please add hosts to the
+        new_etcd host group to add etcd hosts.
+    when:
+    - g_new_etcd_hosts | default([]) | length == 0
+
+  - fail:
+      msg: >
+        Detected new_etcd host is member of new_masters or new_nodes.  Please
+        run playbooks/openshift-master/scaleup.yml or
+        playbooks/openshift-node/scaleup.yml before running this play.
+    when: >
+      inventory_hostname in (groups['new_masters'] | default([]))
+      or inventory_hostname in (groups['new_nodes'] | default([]))
+
+# We only need to run this if etcd is being installed on a standalone host;
+# If etcd is part of master or node group, there's no need to
+# re-run prerequisites
+- import_playbook: ../prerequisites.yml
+  vars:
+    # We need to ensure container_runtime is only processed for containerized
+    # etcd hosts by setting l_build_container_groups_hosts and l_etcd_scale_up_hosts
+    l_build_container_groups_hosts: "oo_new_etcd_to_config"
+    l_etcd_scale_up_hosts: "oo_hosts_containerized_managed_true"
+    l_scale_up_hosts: "oo_new_etcd_to_config"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_new_etcd_to_config"
+    l_sanity_check_hosts: "{{ groups['oo_new_etcd_to_config'] | union(groups['oo_masters_to_config']) | union(groups['oo_etcd_to_config']) }}"
+  when:
+  - inventory_hostname not in groups['oo_masters']
+  - inventory_hostname not in groups['oo_nodes_to_config']
+
+# If this etcd host is part of a master or node, we don't need to run
+# prerequisites, we can just init facts as normal.
 - import_playbook: ../init/main.yml
+  vars:
+    skip_verison: True
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_new_etcd_to_config"
+  when:
+  - inventory_hostname in groups['oo_masters']
+  - inventory_hostname in groups['oo_nodes_to_config']
 
 - import_playbook: private/scaleup.yml


### PR DESCRIPTION
Currently, etcd scaleup playbook has no way to account
for newly added prerequisites.yml play.

This commit allows adding new etcd hosts via scaleup play
and accounts for etcd hosts that are standalone or part
of nodes or masters group.