### PR TITLE
Bug 1536262: Default console and TSB node selector to openshift_hosted_infra_selector

### DIFF
--- a/roles/openshift_web_console/defaults/main.yml
+++ b/roles/openshift_web_console/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-# TODO: This is temporary and will be updated to use taints and tolerations so that the console runs on the masters
-openshift_web_console_nodeselector: {"region":"infra"}
+openshift_web_console_nodeselector: "{{ openshift_hosted_infra_selector | default('region=infra') | map_from_pairs }}"

--- a/roles/template_service_broker/defaults/main.yml
+++ b/roles/template_service_broker/defaults/main.yml
@@ -3,4 +3,4 @@
 template_service_broker_remove: False
 template_service_broker_install: True
 openshift_template_service_broker_namespaces: ['openshift']
-template_service_broker_selector: { "region": "infra" }
+template_service_broker_selector: "{{ openshift_hosted_infra_selector | default('region=infra') | map_from_pairs }}"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1536262
Fixes #6805

/kind bug
/assign @sdodson 

@jupierce You should no longer need to set `openshift_web_console_nodeselector` when this merges.
@bparees @jim-minter FYI, I switched the TSB default as well.
