### PR TITLE
Ensure that node names are lowerecased before matching

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
@@ -31,7 +31,7 @@
       with_items: " {{ groups['oo_nodes_to_config'] }}"
       when:
       - hostvars[item].openshift is defined
-      - hostvars[item].openshift.common.hostname in nodes_to_upgrade.results.results[0]['items'] | map(attribute='metadata.name') | list
+      - hostvars[item].openshift.common.hostname | lower in nodes_to_upgrade.results.results[0]['items'] | map(attribute='metadata.name') | list
       changed_when: false
 
   # Build up the oo_nodes_to_upgrade group, use the list filtered by label if


### PR DESCRIPTION
The name field is always lowercase whereas the nodename may not have
been in the past. Ensure that we lowercase it before looking for
matching nodes.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1396350