### PR TITLE
[release-3.7] Require minimum Ansible version 2.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ you are not running a stable release.
     ***
 
     Requirements:
-    - Ansible >= 2.3.0.0
+    - Ansible >= 2.3.2.0
     - Jinja >= 2.7
     - pyOpenSSL
     - python-lxml

--- a/callback_plugins/aa_version_requirement.py
+++ b/callback_plugins/aa_version_requirement.py
@@ -29,7 +29,7 @@ else:
 
 
 # Set to minimum required Ansible version
-REQUIRED_VERSION = '2.3.0.0'
+REQUIRED_VERSION = '2.3.2.0'
 DESCRIPTION = "Supported versions: %s or newer" % REQUIRED_VERSION
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.3.1.0
+ansible==2.3.2.0
 boto==2.34.0
 click==6.7
 pyOpenSSL==16.2.0


### PR DESCRIPTION
Require Ansible 2.3.2 due to Python recursion errors