### PR TITLE
Install base_packages earlier

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -5,7 +5,8 @@
     g_new_master_hosts: []
     g_new_node_hosts: []
 
-- import_playbook: ../../../init/facts.yml
+- import_playbook: ../../../init/basic_facts.yml
+- import_playbook: ../../../init/cluster_facts.yml
 
 - name: Ensure firewall is not switched during upgrade
   hosts: "{{ l_upgrade_no_switch_firewall_hosts | default('oo_all_hosts') }}"

--- a/playbooks/init/basic_facts.yml
+++ b/playbooks/init/basic_facts.yml
@@ -4,15 +4,13 @@
   any_errors_fatal: true
   tasks:
 
-- name: Initialize host facts
+- name: Initialize basic host facts
   # l_init_fact_hosts is passed in via play during control-plane-only
   # upgrades and scale-up plays; otherwise oo_all_hosts is used.
   hosts: "{{ l_init_fact_hosts | default('oo_all_hosts') }}"
+  roles:
+  - role: openshift_facts
   tasks:
-  - name: load openshift_facts module
-    import_role:
-      name: openshift_facts
-
   # TODO: Should this role be refactored into health_checks??
   - name: Run openshift_sanitize_inventory to set variables
     import_role:
@@ -57,41 +55,6 @@
         that:
         - l_atomic_docker_version.stdout | replace('"', '') is version_compare('1.12','>=')
         msg: Installation on Atomic Host requires Docker 1.12 or later. Please upgrade and restart the Atomic Host.
-
-  - name: Gather Cluster facts
-    openshift_facts:
-      role: common
-      local_facts:
-        deployment_type: "{{ openshift_deployment_type }}"
-        deployment_subtype: "{{ openshift_deployment_subtype | default(None) }}"
-        hostname: "{{ openshift_hostname | default(None) }}"
-        ip: "{{ openshift_ip | default(None) }}"
-        public_hostname: "{{ openshift_public_hostname | default(None) }}"
-        public_ip: "{{ openshift_public_ip | default(None) }}"
-        portal_net: "{{ openshift_portal_net | default(openshift_master_portal_net) | default(None) }}"
-        http_proxy: "{{ openshift_http_proxy | default(None) }}"
-        https_proxy: "{{ openshift_https_proxy | default(None) }}"
-        no_proxy: "{{ openshift_no_proxy | default(None) }}"
-        generate_no_proxy_hosts: "{{ openshift_generate_no_proxy_hosts | default(True) }}"
-
-  - name: Set fact of no_proxy_internal_hostnames
-    openshift_facts:
-      role: common
-      local_facts:
-        no_proxy_internal_hostnames: "{{ hostvars | lib_utils_oo_select_keys(groups['oo_nodes_to_config']
-                                             | union(groups['oo_masters_to_config'])
-                                             | union(groups['oo_etcd_to_config'] | default([])))
-                                         | lib_utils_oo_collect('openshift.common.hostname') | default([]) | join (',')
-                                         }}"
-    when:
-    - openshift_http_proxy is defined or openshift_https_proxy is defined
-    - openshift_generate_no_proxy_hosts | default(True) | bool
-
-  - name: Initialize openshift.node.sdn_mtu
-    openshift_facts:
-      role: node
-      local_facts:
-        sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
 
 - name: Initialize special first-master variables
   hosts: oo_first_master

--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -1,0 +1,42 @@
+---
+- name: Initialize cluster facts
+  # l_init_fact_hosts is passed in via play during control-plane-only
+  # upgrades and scale-up plays; otherwise oo_all_hosts is used.
+  hosts: "{{ l_init_fact_hosts | default('oo_all_hosts') }}"
+  roles:
+  - role: openshift_facts
+  tasks:
+  - name: Gather Cluster facts
+    openshift_facts:
+      role: common
+      local_facts:
+        deployment_type: "{{ openshift_deployment_type }}"
+        deployment_subtype: "{{ openshift_deployment_subtype | default(None) }}"
+        hostname: "{{ openshift_hostname | default(None) }}"
+        ip: "{{ openshift_ip | default(None) }}"
+        public_hostname: "{{ openshift_public_hostname | default(None) }}"
+        public_ip: "{{ openshift_public_ip | default(None) }}"
+        portal_net: "{{ openshift_portal_net | default(openshift_master_portal_net) | default(None) }}"
+        http_proxy: "{{ openshift_http_proxy | default(None) }}"
+        https_proxy: "{{ openshift_https_proxy | default(None) }}"
+        no_proxy: "{{ openshift_no_proxy | default(None) }}"
+        generate_no_proxy_hosts: "{{ openshift_generate_no_proxy_hosts | default(True) }}"
+
+  - name: Set fact of no_proxy_internal_hostnames
+    openshift_facts:
+      role: common
+      local_facts:
+        no_proxy_internal_hostnames: "{{ hostvars | lib_utils_oo_select_keys(groups['oo_nodes_to_config']
+                                             | union(groups['oo_masters_to_config'])
+                                             | union(groups['oo_etcd_to_config'] | default([])))
+                                         | lib_utils_oo_collect('openshift.common.hostname') | default([]) | join (',')
+                                         }}"
+    when:
+    - openshift_http_proxy is defined or openshift_https_proxy is defined
+    - openshift_generate_no_proxy_hosts | default(True) | bool
+
+  - name: Initialize openshift.node.sdn_mtu
+    openshift_facts:
+      role: node
+      local_facts:
+        sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"

--- a/playbooks/init/main.yml
+++ b/playbooks/init/main.yml
@@ -1,4 +1,7 @@
 ---
+# skip_verison and l_install_base_packages are passed in via prerequistes.yml.
+# skip_sanity_checks is passed in via openshift-node/private/image_prep.yml
+
 - name: Initialization Checkpoint Start
   hosts: all
   gather_facts: false
@@ -15,7 +18,13 @@
 
 - import_playbook: evaluate_groups.yml
 
-- import_playbook: facts.yml
+- import_playbook: basic_facts.yml
+
+# base_packages needs to be setup for openshift_facts.py to run correctly.
+- import_playbook: base_packages.yml
+  when: l_install_base_packages | default(False) | bool
+
+- import_playbook: cluster_facts.yml
 
 - import_playbook: version.yml
   when: not (skip_verison | default(False))

--- a/playbooks/openstack/openshift-cluster/provision.yml
+++ b/playbooks/openstack/openshift-cluster/provision.yml
@@ -26,8 +26,8 @@
   - name: Gather facts for the new nodes
     setup:
 
-- name: set common facts
-  import_playbook: ../../init/facts.yml
+- import_playbook: ../../init/basic_facts.yml
+- import_playbook: ../../init/cluster_facts.yml
 
 
 # TODO(shadower): consider splitting this up so people can stop here

--- a/playbooks/prerequisites.yml
+++ b/playbooks/prerequisites.yml
@@ -4,13 +4,12 @@
 - import_playbook: init/main.yml
   vars:
     skip_verison: True
+    l_install_base_packages: True
 
 - import_playbook: init/validate_hostnames.yml
   when: not (skip_validate_hostnames | default(False))
 
 - import_playbook: init/repos.yml
-
-- import_playbook: init/base_packages.yml
 
 # This is required for container runtime for crio, only needs to run once.
 - name: Configure os_firewall


### PR DESCRIPTION
Currently, openshift_facts requires pyyaml to be installed.
This package is installed via init/base_packages.yml, which
is currently called after init/facts.yml.  This results
in a situation where installs will fail due to missing
python dependency.

This commit splits init/facts.yml into two, and
allows base_packages.yml to be run before the
openshift_facts.py plugin is executed.