### PR TITLE
failed_when lists are implicitely ANDs, not ORs

### DIFF
--- a/roles/openshift_metrics/tasks/oc_apply.yaml
+++ b/roles/openshift_metrics/tasks/oc_apply.yaml
@@ -16,9 +16,7 @@
     apply -f {{ file_name }}
     -n {{namespace}}
   register: generation_apply
-  failed_when:
-    - "'error' in generation_apply.stderr"
-    - "generation_apply.rc != 0"
+  failed_when: "'error' in generation_apply.stderr or (generation_apply.rc | int != 0)"
   changed_when: no
 
 - name: Determine change status of {{file_content.kind}} {{file_content.metadata.name}}
@@ -30,7 +28,5 @@
   register: version_changed
   vars:
     init_version: "{{ (generation_init is defined) | ternary(generation_init.stdout, '0') }}"
-  failed_when:
-    - "'error' in version_changed.stderr"
-    - "version_changed.rc != 0"
+  failed_when: "'error' in version_changed.stderr or version_changed.rc | int != 0"
   changed_when: version_changed.stdout | int  > init_version | int

--- a/roles/openshift_provisioners/tasks/oc_apply.yaml
+++ b/roles/openshift_provisioners/tasks/oc_apply.yaml
@@ -15,9 +15,7 @@
     apply -f {{ file_name }}
     -n {{ namespace }}
   register: generation_apply
-  failed_when:
-    - "'error' in generation_apply.stderr"
-    - "generation_apply.rc != 0"
+  failed_when: "'error' in generation_apply.stderr or generation_apply.rc != 0"
   changed_when: no
 
 - name: Determine change status of {{file_content.kind}} {{file_content.metadata.name}}
@@ -38,9 +36,7 @@
     delete -f {{ file_name }}
     -n {{ namespace }}
   register: generation_delete
-  failed_when:
-    - "'error' in generation_delete.stderr"
-    - "generation_delete.rc != 0"
+  failed_when: "'error' in generation_delete.stderr or generation_delete.rc != 0"
   changed_when: generation_delete.rc == 0
   when: generation_apply.rc != 0
 
@@ -50,8 +46,6 @@
     apply -f {{ file_name }}
     -n {{ namespace }}
   register: generation_apply
-  failed_when:
-    - "'error' in generation_apply.stderr"
-    - "generation_apply.rc != 0"
+  failed_when: "'error' in generation_apply.stderr or generation_apply.rc | int != 0"
   changed_when: generation_apply.rc == 0
   when: generation_apply.rc != 0


### PR DESCRIPTION
For some reason I believed `failed_when` lists are considered to be ORs, but it turns out these are ANDs.

Fixes bug 1534538
Relates to #6751