### PR TITLE
Bug 1524805- ServiceCatalog now works disconnected

### DIFF
--- a/roles/openshift_service_catalog/templates/api_server.j2
+++ b/roles/openshift_service_catalog/templates/api_server.j2
@@ -49,7 +49,7 @@ spec:
         - OriginatingIdentity=true
         image: {{ openshift_service_catalog_image_prefix }}service-catalog:{{ openshift_service_catalog_image_version }}
         command: ["/usr/bin/service-catalog"]
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: apiserver
         ports:
         - containerPort: 6443

--- a/roles/openshift_service_catalog/templates/controller_manager.j2
+++ b/roles/openshift_service_catalog/templates/controller_manager.j2
@@ -44,7 +44,7 @@ spec:
 {% endif %}
         image: {{ openshift_service_catalog_image_prefix }}service-catalog:{{ openshift_service_catalog_image_version }}
         command: ["/usr/bin/service-catalog"]
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: controller-manager
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Change imagePullPolicy for service catalog from Always to IfNotPresent,
      allowing service catalog to install in a disconnected setting

https://bugzilla.redhat.com/show_bug.cgi?id=1524805