### PR TITLE
Remove old assetConfig from master-config.yaml

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
@@ -12,3 +12,5 @@
 # You can run the upgrade_nodes.yml playbook after this to upgrade these components separately.
 #
 - import_playbook: ../../../../common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+
+- import_playbook: ../../../../openshift-master/private/restart.yml

--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -6,7 +6,9 @@
   hosts: oo_first_master
   roles:
   - role: openshift_web_console
-    when: openshift_web_console_install | default(true) | bool
+    when:
+    - openshift_web_console_install | default(true) | bool
+    - openshift_upgrade_target is version_compare('3.9','>=')
 
 - name: Upgrade default router and default registry
   hosts: oo_first_master

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
@@ -112,3 +112,9 @@
       state: started
 
 - import_playbook: ../post_control_plane.yml
+
+- hosts: oo_masters
+  tasks:
+  - import_role:
+      name: openshift_web_console
+      tasks_from: remove_old_asset_config

--- a/playbooks/openshift-master/private/tasks/wire_aggregator.yml
+++ b/playbooks/openshift-master/private/tasks/wire_aggregator.yml
@@ -142,11 +142,6 @@
     state: absent
   changed_when: False
 
-- name: Setup extension file for service console UI
-  template:
-    src: ../templates/openshift-ansible-catalog-console.js
-    dest: /etc/origin/master/openshift-ansible-catalog-console.js
-
 - name: Update master config
   yedit:
     state: present
@@ -166,8 +161,6 @@
       value: [X-Remote-Group]
     - key: authConfig.requestHeader.extraHeaderPrefixes
       value: [X-Remote-Extra-]
-    - key: assetConfig.extensionScripts
-      value: [/etc/origin/master/openshift-ansible-catalog-console.js]
     - key: kubernetesMasterConfig.apiServerArguments.runtime-config
       value: [apis/settings.k8s.io/v1alpha1=true]
     - key: admissionConfig.pluginConfig.PodPreset.configuration.kind
@@ -178,37 +171,50 @@
       value: false
   register: yedit_output
 
+# Only add the catalog extension script if not 3.9. From 3.9 on, the console
+# can discover if template service broker is running.
+- when: not openshift.common.version_gte_3_9
+  block:
+  - name: Setup extension file for service console UI
+    template:
+      src: ../templates/openshift-ansible-catalog-console.js
+      dest: /etc/origin/master/openshift-ansible-catalog-console.js
+
+  - name: Update master config
+    yedit:
+      state: present
+      src: /etc/origin/master/master-config.yaml
+      key: assetConfig.extensionScripts
+      value: [/etc/origin/master/openshift-ansible-catalog-console.js]
+    register: yedit_asset_config_output
+
 #restart master serially here
-- name: restart master api
-  systemd: name={{ openshift_service_type }}-master-api state=restarted
-  when:
-  - yedit_output.changed
+- when: yedit_output.changed or (yedit_asset_config_output is defined and yedit_asset_config_output.changed)
+  block:
+  - name: restart master api
+    systemd: name={{ openshift_service_type }}-master-api state=restarted
 
-# We retry the controllers because the API may not be 100% initialized yet.
-- name: restart master controllers
-  command: "systemctl restart {{ openshift_service_type }}-master-controllers"
-  retries: 3
-  delay: 5
-  register: result
-  until: result.rc == 0
-  when:
-  - yedit_output.changed
+  # We retry the controllers because the API may not be 100% initialized yet.
+  - name: restart master controllers
+    command: "systemctl restart {{ openshift_service_type }}-master-controllers"
+    retries: 3
+    delay: 5
+    register: result
+    until: result.rc == 0
 
-- name: Verify API Server
-  # Using curl here since the uri module requires python-httplib2 and
-  # wait_for port doesn't provide health information.
-  command: >
-    curl --silent --tlsv1.2
-    --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
-    {{ openshift.master.api_url }}/healthz/ready
-  args:
-    # Disables the following warning:
-    # Consider using get_url or uri module rather than running curl
-    warn: no
-  register: api_available_output
-  until: api_available_output.stdout == 'ok'
-  retries: 120
-  delay: 1
-  changed_when: false
-  when:
-  - yedit_output.changed
+  - name: Verify API Server
+    # Using curl here since the uri module requires python-httplib2 and
+    # wait_for port doesn't provide health information.
+    command: >
+      curl --silent --tlsv1.2
+      --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+      {{ openshift.master.api_url }}/healthz/ready
+    args:
+      # Disables the following warning:
+      # Consider using get_url or uri module rather than running curl
+      warn: no
+    register: api_available_output
+    until: api_available_output.stdout == 'ok'
+    retries: 120
+    delay: 1
+    changed_when: false

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -314,8 +314,8 @@
     openshift_logging_install_eventrouter | default(false) | bool
 
 
-# TODO: Remove when asset config is removed from master-config.yaml
 - include_tasks: update_master_config.yaml
+  when: not openshift.common.version_gte_3_9
 
 # Update asset config in openshift-web-console namespace
 - name: Add Kibana route information to web console asset config

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -5,6 +5,7 @@ admissionConfig:
 apiLevels:
 - v1
 apiVersion: v1
+{% if not openshift.common.version_gte_3_9 %}
 assetConfig:
   logoutURL: "{{ openshift.master.logout_url | default('') }}"
   masterPublicURL: {{ openshift.master.public_api_url }}
@@ -40,6 +41,8 @@ assetConfig:
 {% for cipher_suite in openshift_master_cipher_suites %}
     - {{ cipher_suite }}
 {% endfor %}
+{% endif %}
+# assetconfig end
 {% endif %}
 {% if openshift.master.audit_config | default(none) is not none %}
 auditConfig:{{ openshift.master.audit_config | lib_utils_to_padded_yaml(level=1) }}

--- a/roles/openshift_metrics/tasks/install_metrics.yaml
+++ b/roles/openshift_metrics/tasks/install_metrics.yaml
@@ -67,8 +67,8 @@
   with_items: "{{ hawkular_agent_object_defs.results }}"
   when: openshift_metrics_install_hawkular_agent | bool
 
-# TODO: Remove when asset config is removed from master-config.yaml
 - include_tasks: update_master_config.yaml
+  when: not openshift.common.version_gte_3_9
 
 # Update asset config in openshift-web-console namespace
 - name: Add metrics route information to web console asset config

--- a/roles/openshift_web_console/tasks/remove_old_asset_config.yml
+++ b/roles/openshift_web_console/tasks/remove_old_asset_config.yml
@@ -1,0 +1,19 @@
+---
+# Remove the obsolete assetConfig stanza from master-config.yaml. Since the
+# web console has been split out into a separate deployment, those settings
+# are no longer used.
+- name: Remove assetConfig from master-config.yaml
+  yedit:
+    state: absent
+    src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+    key: assetConfig
+
+# This file was written by wire_aggregator.yml. It is no longer needed since
+# the web console now discovers if the template service broker is running on
+# startup. Remove the file if it exists.
+- name: Remove obsolete web console / service catalog extension file
+  file:
+    state: absent
+    # Hard-code the path instead of using `openshift.common.config_base` since
+    # the path is hard-coded in wire_aggregator.yml.
+    path: /etc/origin/master/openshift-ansible-catalog-console.js


### PR DESCRIPTION
`assetConfig` is no longer used in 3.9 now that the console is split into its own pod.

- Don't write `assetConfig` on new 3.9 installs
- Remove `assetConfig` on upgrades to 3.9
- Stop writing logging and metrics URLs to assetConfig for 3.9

/assign @sdodson 
@jwforres 