### PR TITLE
Fix: e2e tests failing due to :1936/metrics unaccessible.

### DIFF
--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -418,6 +418,10 @@ resources:
           protocol: tcp
           port_range_min: 443
           port_range_max: 443
+        - direction: ingress
+          protocol: tcp
+          port_range_min: 1936
+          port_range_max: 1936
 
   cns-secgrp:
     type: OS::Neutron::SecurityGroup


### PR DESCRIPTION
This PR allows access to tcp/1936 ingress infra-secgrp policy, so that e2e test do not fail looking for router metrics (:1936/metrics).