### PR TITLE
Add clusterResourceOverridesEnabled to console config

### DIFF
--- a/files/origin-components/console-config.yaml
+++ b/files/origin-components/console-config.yaml
@@ -12,6 +12,7 @@ extensions:
   properties: null
 features:
   inactivityTimeoutMinutes: 0
+  clusterResourceOverridesEnabled: false
 servingInfo:
   bindAddress: 0.0.0.0:8443
   bindNetwork: tcp4

--- a/roles/openshift_web_console/tasks/install.yml
+++ b/roles/openshift_web_console/tasks/install.yml
@@ -86,6 +86,8 @@
             value: "{{ openshift.master.logout_url | default('') }}"
           - key: features#inactivityTimeoutMinutes
             value: "{{ openshift_web_console_inactivity_timeout_minutes | default(0) }}"
+          - key: features#clusterResourceOverridesEnabled
+            value: "{{ openshift_web_console_cluster_resource_overrides_enabled | default(false) }}"
           - key: extensions#scriptURLs
             value: "{{ openshift_web_console_extension_script_urls | default([]) }}"
           - key: extensions#stylesheetURLs


### PR DESCRIPTION
Adds clusterResourceOverridesEnabled flag to console install.

See https://github.com/openshift/api/pull/32
See https://github.com/openshift/origin/pull/18231

/assign @sdodson 
/cc @jwforres