### PR TITLE
Protect master installed version during node upgrades

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/config.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/config.yml
@@ -49,7 +49,7 @@
     # to a more specific version, respecting openshift_image_tag and openshift_pkg_version if
     # defined, and overriding the normal behavior of protecting the installed version
     openshift_release: "{{ openshift_upgrade_target }}"
-    openshift_protect_installed_version: False
+    # openshift_protect_installed_version is passed n via upgrade_control_plane.yml
     # l_openshift_version_set_hosts is passed via upgrade_control_plane.yml
     # l_openshift_version_check_hosts is passed via upgrade_control_plane.yml
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade.yml
@@ -23,6 +23,7 @@
     l_upgrade_verify_targets_hosts: "oo_masters_to_config:oo_nodes_to_upgrade"
     l_upgrade_docker_target_hosts: "oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config"
     l_upgrade_excluder_hosts: "oo_nodes_to_config:oo_masters_to_config"
+    openshift_protect_installed_version: False
 
 - import_playbook: validator.yml
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_6/upgrade_control_plane.yml
@@ -35,6 +35,7 @@
     l_upgrade_verify_targets_hosts: "oo_masters_to_config"
     l_upgrade_docker_target_hosts: "oo_masters_to_config:oo_etcd_to_config"
     l_upgrade_excluder_hosts: "oo_masters_to_config"
+    openshift_protect_installed_version: False
 
 - import_playbook: validator.yml
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
@@ -23,6 +23,7 @@
     l_upgrade_verify_targets_hosts: "oo_masters_to_config:oo_nodes_to_upgrade"
     l_upgrade_docker_target_hosts: "oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config"
     l_upgrade_excluder_hosts: "oo_nodes_to_config:oo_masters_to_config"
+    openshift_protect_installed_version: False
 
 - import_playbook: validator.yml
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -35,6 +35,7 @@
     l_upgrade_verify_targets_hosts: "oo_masters_to_config"
     l_upgrade_docker_target_hosts: "oo_masters_to_config:oo_etcd_to_config"
     l_upgrade_excluder_hosts: "oo_masters_to_config"
+    openshift_protect_installed_version: False
 
 - import_playbook: validator.yml
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade.yml
@@ -23,6 +23,7 @@
     l_upgrade_verify_targets_hosts: "oo_masters_to_config:oo_nodes_to_upgrade"
     l_upgrade_docker_target_hosts: "oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config"
     l_upgrade_excluder_hosts: "oo_nodes_to_config:oo_masters_to_config"
+    openshift_protect_installed_version: False
 
 - import_playbook: validator.yml
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_8/upgrade_control_plane.yml
@@ -36,6 +36,7 @@
     l_upgrade_verify_targets_hosts: "oo_masters_to_config"
     l_upgrade_docker_target_hosts: "oo_masters_to_config:oo_etcd_to_config"
     l_upgrade_excluder_hosts: "oo_masters_to_config"
+    openshift_protect_installed_version: False
 
 - import_playbook: validator.yml
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade.yml
@@ -20,6 +20,7 @@
     l_upgrade_verify_targets_hosts: "oo_masters_to_config:oo_nodes_to_upgrade"
     l_upgrade_docker_target_hosts: "oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config"
     l_upgrade_excluder_hosts: "oo_nodes_to_config:oo_masters_to_config"
+    openshift_protect_installed_version: False
 
 - import_playbook: validator.yml
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
@@ -41,6 +41,7 @@
     l_upgrade_verify_targets_hosts: "oo_masters_to_config"
     l_upgrade_docker_target_hosts: "oo_masters_to_config:oo_etcd_to_config"
     l_upgrade_excluder_hosts: "oo_masters_to_config"
+    openshift_protect_installed_version: False
   when: hostvars[groups.oo_first_master.0].openshift_currently_installed_version | version_compare('3.8','<')
 
 - name: Flag pre-upgrade checks complete for hosts without errors 3.8
@@ -82,6 +83,7 @@
     l_upgrade_verify_targets_hosts: "oo_masters_to_config"
     l_upgrade_docker_target_hosts: "oo_masters_to_config:oo_etcd_to_config"
     l_upgrade_excluder_hosts: "oo_masters_to_config"
+    openshift_protect_installed_version: False
 
 - name: Flag pre-upgrade checks complete for hosts without errors
   hosts: oo_masters_to_config:oo_etcd_to_config


### PR DESCRIPTION
Master version is unprotected during all upgrades.

During node-only upgrades, master version should
remain protected to ensure correct image tag is
set for node upgrades.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1536839