### PR TITLE
typo in systemd module usage

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -64,7 +64,7 @@
   tasks:
   - systemd:
       name: "{{ item }}"
-      status: stopped
+      state: stopped
     with_items:
     - "{{ openshift.common.service_type }}-master if groups.oo_masters_to_config | length == 1 else omit"
     - "{{ openshift.common.service_type }}-master-api if groups.oo_masters_to_config | length != 1 else omit"


### PR DESCRIPTION
Status is not valid state as per http://docs.ansible.com/ansible/latest/systemd_module.html
