### PR TITLE
Label masters with node-role.kubernetes.io/master

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -310,13 +310,8 @@
   - import_role:
       name: openshift_node
       tasks_from: upgrade.yml
-  - name: Set node schedulability
-    oc_adm_manage_node:
-      node: "{{ openshift.node.nodename | lower }}"
-      schedulable: True
-    delegate_to: "{{ groups.oo_first_master.0 }}"
-    retries: 10
-    delay: 5
-    register: node_schedulable
-    until: node_schedulable is succeeded
-    when: node_unschedulable is changed
+  - import_role:
+      name: openshift_manage_node
+      tasks_from: config.yml
+    vars:
+      openshift_master_host: "{{ groups.oo_first_master.0 }}"

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -50,16 +50,11 @@
   - import_role:
       name: openshift_node
       tasks_from: upgrade.yml
-  - name: Set node schedulability
-    oc_adm_manage_node:
-      node: "{{ openshift.node.nodename | lower }}"
-      schedulable: True
-    delegate_to: "{{ groups.oo_first_master.0 }}"
-    retries: 10
-    delay: 5
-    register: node_schedulable
-    until: node_schedulable is succeeded
-    when: node_unschedulable is changed
+  - import_role:
+      name: openshift_manage_node
+      tasks_from: config.yml
+    vars:
+      openshift_master_host: "{{ groups.oo_first_master.0 }}"
 
 - name: Re-enable excluders
   hosts: oo_nodes_to_upgrade:!oo_masters_to_config

--- a/roles/openshift_manage_node/defaults/main.yml
+++ b/roles/openshift_manage_node/defaults/main.yml
@@ -4,3 +4,6 @@ openshift_manage_node_is_master: False
 
 # Default is to be schedulable except for master nodes.
 l_openshift_manage_schedulable: "{{ openshift_schedulable | default(not openshift_manage_node_is_master) }}"
+
+openshift_master_node_labels:
+  node-role.kubernetes.io/master: 'true'

--- a/roles/openshift_manage_node/tasks/config.yml
+++ b/roles/openshift_manage_node/tasks/config.yml
@@ -15,21 +15,13 @@
     name: "{{ openshift.node.nodename }}"
     kind: node
     state: add
-    labels: "{{ openshift_node_labels | lib_utils_oo_dict_to_list_of_dict }}"
+    labels: "{{ l_all_labels | lib_utils_oo_dict_to_list_of_dict }}"
     namespace: default
   when:
     - "'nodename' in openshift.node"
-    - openshift_node_labels | default({}) != {}
+    - l_all_labels != {}
   delegate_to: "{{ openshift_master_host }}"
-
-- name: Label master nodes
-  oc_label:
-    name: "{{ openshift.node.nodename }}"
-    kind: node
-    state: add
-    labels: "{{ openshift_master_node_labels | lib_utils_oo_dict_to_list_of_dict }}"
-    namespace: default
-  when:
-    - "'nodename' in openshift.node"
-    - "'oo_masters_to_config' in group_names"
-  delegate_to: "{{ openshift_master_host }}"
+  vars:
+    l_node_labels: "{{ openshift_node_labels | default({}) }}"
+    l_master_labels: "{{ ('oo_masters_to_config' in group_names) | ternary(openshift_master_node_labels, {}) }}"
+    l_all_labels: "{{ l_node_labels | combine(l_master_labels) }}"

--- a/roles/openshift_manage_node/tasks/config.yml
+++ b/roles/openshift_manage_node/tasks/config.yml
@@ -1,0 +1,35 @@
+---
+- name: Set node schedulability
+  oc_adm_manage_node:
+    node: "{{ openshift.node.nodename | lower }}"
+    schedulable: "{{ 'true' if l_openshift_manage_schedulable | bool else 'false' }}"
+  retries: 10
+  delay: 5
+  register: node_schedulable
+  until: node_schedulable is succeeded
+  when: "'nodename' in openshift.node"
+  delegate_to: "{{ openshift_master_host }}"
+
+- name: Label nodes
+  oc_label:
+    name: "{{ openshift.node.nodename }}"
+    kind: node
+    state: add
+    labels: "{{ openshift_node_labels | lib_utils_oo_dict_to_list_of_dict }}"
+    namespace: default
+  when:
+    - "'nodename' in openshift.node"
+    - openshift_node_labels | default({}) != {}
+  delegate_to: "{{ openshift_master_host }}"
+
+- name: Label master nodes
+  oc_label:
+    name: "{{ openshift.node.nodename }}"
+    kind: node
+    state: add
+    labels: "{{ openshift_master_node_labels | lib_utils_oo_dict_to_list_of_dict }}"
+    namespace: default
+  when:
+    - "'nodename' in openshift.node"
+    - "'oo_masters_to_config' in group_names"
+  delegate_to: "{{ openshift_master_host }}"

--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -34,25 +34,4 @@
   when: "'nodename' in openshift.node"
   delegate_to: "{{ openshift_master_host }}"
 
-- name: Set node schedulability
-  oc_adm_manage_node:
-    node: "{{ openshift.node.nodename | lower }}"
-    schedulable: "{{ 'true' if l_openshift_manage_schedulable | bool else 'false' }}"
-  retries: 10
-  delay: 5
-  register: node_schedulable
-  until: node_schedulable is succeeded
-  when: "'nodename' in openshift.node"
-  delegate_to: "{{ openshift_master_host }}"
-
-- name: Label nodes
-  oc_label:
-    name: "{{ openshift.node.nodename }}"
-    kind: node
-    state: add
-    labels: "{{ openshift_node_labels | lib_utils_oo_dict_to_list_of_dict }}"
-    namespace: default
-  when:
-    - "'nodename' in openshift.node"
-    - openshift_node_labels | default({}) != {}
-  delegate_to: "{{ openshift_master_host }}"
+- include_tasks: config.yml


### PR DESCRIPTION
This is controlled by `openshift_master_node_label` var in openshift_manage_node

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1535673