### PR TITLE
Upgrade to migrate to using push to DNS for registries.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -113,6 +113,22 @@
     registry_url: "{{ openshift.master.registry_url }}"
     openshift_hosted_templates_import_command: replace
 
+  post_tasks:
+  # we need to migrate customers to the new pattern of pushing to the registry via dns
+  # Step 1: verify the certificates have the docker registry service name
+  - shell: >
+      echo -n | openssl s_client -showcerts -servername docker-registry.default.svc -connect docker-registry.default.svc:5000  | openssl x509 -text |  grep -A1 'X509v3 Subject Alternative Name:' | grep -Pq 'DNS:docker-registry\.default\.svc(,|$)'
+    register: cert_output
+
+  # Step 2: Set a fact to be used to determine if we should run the redeploy of registry certs
+  - name: set a fact to include the registry certs playbook if needed
+    set_fact:
+      openshift_hosted_rollout_certs_and_registry: "{{ cert_output.rc == 0  }}"
+
+# Run the redeploy certs based upon the certificates
+- when: hostvars[groups.oo_first_master.0].openshift_hosted_rollout_certs_and_registry
+  import_playbook: ../../../openshift-hosted/redeploy-registry-certificates.yml
+
 # Check for warnings to be printed at the end of the upgrade:
 - name: Clean up and display warnings
   hosts: oo_masters_to_config

--- a/playbooks/openshift-hosted/deploy_registry.yml
+++ b/playbooks/openshift-hosted/deploy_registry.yml
@@ -1,0 +1,4 @@
+---
+- import_playbook: ../init/main.yml
+
+- import_playbook: private/openshift_hosted_registry.yml

--- a/playbooks/openshift-hosted/deploy_router.yml
+++ b/playbooks/openshift-hosted/deploy_router.yml
@@ -1,0 +1,4 @@
+---
+- import_playbook: ../init/main.yml
+
+- import_playbook: private/openshift_hosted_router.yml

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -137,17 +137,8 @@
   - item.clientCA | default('') != ''
   with_items: "{{ openshift.master.identity_providers }}"
 
-# This is an ugly hack to verify settings are in a file without modifying them with lineinfile.
-# The template file will stomp any other settings made.
-- block:
-  - name: check whether our docker-registry setting exists in the env file
-    command: "awk '/^OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000/' /etc/sysconfig/{{ openshift_service_type }}-master"
-    failed_when: false
-    changed_when: false
-    register: l_already_set
-
-  - set_fact:
-      openshift_push_via_dns: "{{ openshift.common.version_gte_3_6 or (l_already_set.stdout is defined and l_already_set.stdout is match('OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000')) }}"
+- name: Include push_via_dns.yml
+  include_tasks: push_via_dns.yml
 
 - name: Set fact of all etcd host IPs
   openshift_facts:

--- a/roles/openshift_master/tasks/push_via_dns.yml
+++ b/roles/openshift_master/tasks/push_via_dns.yml
@@ -1,0 +1,13 @@
+---
+# This is an ugly hack to verify settings are in a file without modifying them with lineinfile.
+# The template file will stomp any other settings made.
+- when: openshift_push_via_dns is not defined
+  block:
+  - name: check whether our docker-registry setting exists in the env file
+    shell: "awk '/^OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000/' /etc/sysconfig/{{ openshift_service_type }}-master*"
+    failed_when: false
+    changed_when: false
+    register: l_already_set
+
+  - set_fact:
+      openshift_push_via_dns: "{{ openshift.common.version_gte_3_6 or (l_already_set.stdout is defined and l_already_set.stdout is match('OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000')) }}"

--- a/roles/openshift_master/tasks/systemd_units.yml
+++ b/roles/openshift_master/tasks/systemd_units.yml
@@ -1,6 +1,8 @@
 ---
 # systemd_units.yml is included both in the openshift_master role and in the upgrade
 # playbooks.
+- name: include push_via_dns.yml tasks
+  include_tasks: push_via_dns.yml
 
 - name: Set HA Service Info for containerized installs
   set_fact:
@@ -9,7 +11,8 @@
   when:
   - openshift_is_containerized | bool
 
-- include_tasks: registry_auth.yml
+- name: include registry_auth tasks
+  include_tasks: registry_auth.yml
 
 - name: Disable the legacy master service if it exists
   systemd:


### PR DESCRIPTION
This is the beginning of the migration to push to docker-registry by DNS.  This migrates users by rerolling their certificates and then redeploying the registry so that hosts can push to the registries with the newly created certificates.