### PR TITLE
Nodes upgrade: run openshift_manage_node role instead of scheduling node

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -50,16 +50,10 @@
   - import_role:
       name: openshift_node
       tasks_from: upgrade.yml
-  - name: Set node schedulability
-    oc_adm_manage_node:
-      node: "{{ openshift.node.nodename | lower }}"
-      schedulable: True
-    delegate_to: "{{ groups.oo_first_master.0 }}"
-    retries: 10
-    delay: 5
-    register: node_schedulable
-    until: node_schedulable is succeeded
-    when: node_unschedulable is changed
+  - import_role:
+      name: openshift_manage_node
+    vars:
+      openshift_master_host: "{{ groups.oo_first_master.0 }}"
 
 - name: Re-enable excluders
   hosts: oo_nodes_to_upgrade:!oo_masters_to_config


### PR DESCRIPTION
This would remove copied code and ensure node has necessary labels added.
Required for https://github.com/openshift/openshift-ansible/pull/6849