### PR TITLE
[release-3.7] Don't restart docker when re-deploying node certs

### DIFF
--- a/playbooks/byo/openshift-cluster/redeploy-node-certificates.yml
+++ b/playbooks/byo/openshift-cluster/redeploy-node-certificates.yml
@@ -14,3 +14,5 @@
     openshift_certificates_redeploy: true
 
 - include: ../../common/openshift-node/restart.yml
+  vars:
+    openshift_node_restart_docker_required: False

--- a/playbooks/common/openshift-node/restart.yml
+++ b/playbooks/common/openshift-node/restart.yml
@@ -15,6 +15,7 @@
     until: not l_docker_restart_docker_in_node_result | failed
     retries: 3
     delay: 30
+    when: openshift_node_restart_docker_required | default(True)
 
   - name: Update docker facts
     openshift_facts:


### PR DESCRIPTION
This is only necessary when the CA has been replaced.

Backports #6855 