### PR TITLE
Updating deprecations to use callback plugin

### DIFF
--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -6,11 +6,3 @@
 - import_playbook: openshift-node/private/config.yml
 
 - import_playbook: common/private/components.yml
-
-- name: Print deprecated variable warning message if necessary
-  hosts: oo_first_master
-  gather_facts: no
-  tasks:
-  - debug: msg="{{__deprecation_message}}"
-    when:
-    - __deprecation_message | default ('') | length > 0

--- a/roles/installer_checkpoint/callback_plugins/installer_checkpoint.py
+++ b/roles/installer_checkpoint/callback_plugins/installer_checkpoint.py
@@ -127,6 +127,10 @@ class CallbackModule(CallbackBase):
                         self._display.display(
                             '\tThis phase can be restarted by running: {}'.format(
                                 phase_attributes[phase]['playbook']))
+                    if 'message' in stats.custom['_run'][phase]:
+                        self._display.display(
+                            '\t{}'.format(
+                                stats.custom['_run'][phase]['message']))
 
         self._display.display("", screen_only=True)
 

--- a/roles/openshift_sanitize_inventory/tasks/deprecations.yml
+++ b/roles/openshift_sanitize_inventory/tasks/deprecations.yml
@@ -2,15 +2,18 @@
 
 - name: Check for usage of deprecated variables
   set_fact:
-    __deprecation_message: "{{ __deprecation_message | default([]) }} + ['{{ __deprecation_header }} {{ item }} is a deprecated variable and will be no longer be used in the next minor release. Please update your inventory accordingly.']"
+    __deprecation_message: "{{ __deprecation_message | default( __deprecation_header ) }} \n\t{{ item }}"
   when:
   - hostvars[inventory_hostname][item] is defined
   with_items: "{{ __warn_deprecated_vars }}"
 
 - block:
   - debug: msg="{{__deprecation_message}}"
-  - pause:
-      seconds: "{{ 10 }}"
+  - run_once: true
+    set_stats:
+      data:
+        installer_phase_initialize:
+          message: "{{ __deprecation_message }}"
   when:
   - __deprecation_message | default ('') | length > 0
 

--- a/roles/openshift_sanitize_inventory/vars/main.yml
+++ b/roles/openshift_sanitize_inventory/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 
-__deprecation_header: "[DEPRECATION WARNING]:"
+__deprecation_header: "[DEPRECATION WARNING]: The following are deprecated variables and will be no longer be used in the next minor release. Please update your inventory accordingly."
 
 # this is a list of variables that we will be deprecating within the next minor release, this list should be expected to change from release to release
 __warn_deprecated_vars:


### PR DESCRIPTION
Instead of just pausing during the run and relying on users to see it, instead format and print the deprecated variables at the end of play instead like this:
```
Initialization             : Complete (0:00:23)
	[DEPRECATION WARNING]: The following are deprecated variables and will be no longer be used in the next minor release. Please update your inventory accordingly. 
	openshift_hosted_logging_deploy 
	openshift_hosted_metrics_deployer_prefix
```

The plugin changes are the same as the changes made in https://github.com/openshift/openshift-ansible/pull/6734