### PR TITLE
node: specify bind option to /root/.docker

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -83,6 +83,7 @@ openshift_node_syscon_auth_mounts_l:
   destination: "/root/.docker"
   options:
   - ro
+  - bind
 
 # If we need to add new mounts in the future, or the user wants to mount data.
 # This should be in the same format as auth_mounts_l above.


### PR DESCRIPTION
Without the option, runc fails with "no such device" when trying to
create the mount point.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1534933

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>