### PR TITLE
ignore 'users' field in oc_group module

### DIFF
--- a/roles/lib_openshift/library/oc_group.py
+++ b/roles/lib_openshift/library/oc_group.py
@@ -1485,7 +1485,7 @@ class OCGroup(OpenShiftCLI):
 
     def needs_update(self):
         ''' verify an update is needed '''
-        return not Utils.check_def_equal(self.config.data, self.group.yaml_dict, skip_keys=[], debug=True)
+        return not Utils.check_def_equal(self.config.data, self.group.yaml_dict, skip_keys=['users'], debug=True)
 
     # pylint: disable=too-many-return-statements,too-many-branches
     @staticmethod

--- a/roles/lib_openshift/src/class/oc_group.py
+++ b/roles/lib_openshift/src/class/oc_group.py
@@ -59,7 +59,7 @@ class OCGroup(OpenShiftCLI):
 
     def needs_update(self):
         ''' verify an update is needed '''
-        return not Utils.check_def_equal(self.config.data, self.group.yaml_dict, skip_keys=[], debug=True)
+        return not Utils.check_def_equal(self.config.data, self.group.yaml_dict, skip_keys=['users'], debug=True)
 
     # pylint: disable=too-many-return-statements,too-many-branches
     @staticmethod


### PR DESCRIPTION
oc_group doesn't manage the list of users assigned to a group (oc_user does).

so when doing an
oc_group:
  state: present
  name: groupA

on a pre-existing group 'groupA' with already defined users, oc_group would detect a difference and blow away the existing users

fix this by adding 'users' to the list of fields to ignore when determining whether there are object differences