### PR TITLE
[release-3.6] reconcile registry-console and docker_image_availability

### DIFF
--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -414,10 +414,11 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #    action: append
 
 # OpenShift Registry Console Options
-# Override the console image prefix for enterprise deployments, not used in origin
-# default is "registry.access.redhat.com/openshift3/" and the image appended is "registry-console"
+# Override the console image prefix:
+# origin default is "cockpit/" and the image appended is "kubernetes"
+# enterprise default is "registry.access.redhat.com/openshift3/" and the image appended is "registry-console"
 #openshift_cockpit_deployer_prefix=registry.example.com/myrepo/
-# Override image version, defaults to latest for origin, matches the product version for enterprise
+# Override image version, defaults to latest for origin, vX.Y product version for enterprise
 #openshift_cockpit_deployer_version=1.4.1
 
 # Openshift Registry Options

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -415,9 +415,10 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 
 # OpenShift Registry Console Options
 # Override the console image prefix:
-# origin default is "cockpit/" and the image appended is "kubernetes"
-# enterprise default is "registry.access.redhat.com/openshift3/" and the image appended is "registry-console"
+# origin default is "cockpit/", enterprise default is "openshift3/"
 #openshift_cockpit_deployer_prefix=registry.example.com/myrepo/
+# origin default is "kubernetes", enterprise default is "registry-console"
+#openshift_cockpit_deployer_basename=my-console
 # Override image version, defaults to latest for origin, vX.Y product version for enterprise
 #openshift_cockpit_deployer_version=1.4.1
 

--- a/roles/cockpit-ui/tasks/main.yml
+++ b/roles/cockpit-ui/tasks/main.yml
@@ -37,7 +37,6 @@
       cp {{ openshift_master_config_dir }}/admin.kubeconfig {{ openshift_hosted_kubeconfig }}
     changed_when: False
 
-  # TODO: Need to fix the origin and enterprise templates so that they both respect IMAGE_PREFIX
   - name: Deploy registry-console
     command: >
       {{ openshift.common.client_binary }} new-app --template=registry-console

--- a/roles/cockpit-ui/tasks/main.yml
+++ b/roles/cockpit-ui/tasks/main.yml
@@ -41,6 +41,7 @@
     command: >
       {{ openshift.common.client_binary }} new-app --template=registry-console
       {% if openshift_cockpit_deployer_prefix is defined  %}-p IMAGE_PREFIX="{{ openshift_cockpit_deployer_prefix }}"{% endif %}
+      {% if openshift_cockpit_deployer_basename is defined  %}-p IMAGE_BASENAME="{{ openshift_cockpit_deployer_basename }}"{% endif %}
       {% if openshift_cockpit_deployer_version is defined  %}-p IMAGE_VERSION="{{ openshift_cockpit_deployer_version }}"{% endif %}
       -p OPENSHIFT_OAUTH_PROVIDER_URL="{{ openshift.master.public_api_url }}"
       -p REGISTRY_HOST="{{ docker_registry_route.results[0].spec.host }}"

--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -11,15 +11,15 @@ DEPLOYMENT_IMAGE_INFO = {
     "origin": {
         "namespace": "openshift",
         "name": "origin",
-        "registry_console_template": "${prefix}kubernetes:${version}",
         "registry_console_prefix": "cockpit/",
+        "registry_console_basename": "kubernetes",
         "registry_console_default_version": "latest",
     },
     "openshift-enterprise": {
         "namespace": "openshift3",
         "name": "ose",
-        "registry_console_template": "${prefix}registry-console:${version}",
-        "registry_console_prefix": "registry.access.redhat.com/openshift3/",
+        "registry_console_prefix": "openshift3/",
+        "registry_console_basename": "registry-console",
         "registry_console_default_version": "${short_version}",
     },
 }
@@ -155,7 +155,8 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
         if 'nodes' in host_groups:
             for suffix in NODE_IMAGE_SUFFIXES:
                 required.add(image_url.replace("${component}", suffix).replace("${version}", image_tag))
-            required.add(self._registry_console_image(image_tag, image_info))
+            if self.get_var("osm_use_cockpit", default=True, convert=bool):
+                required.add(self._registry_console_image(image_tag, image_info))
 
         # images for containerized components
         if self.get_var("openshift", "common", "is_containerized"):
@@ -179,6 +180,10 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
             "openshift_cockpit_deployer_prefix",
             default=image_info["registry_console_prefix"],
         )
+        basename = self.get_var(
+            "openshift_cockpit_deployer_basename",
+            default=image_info["registry_console_basename"],
+        )
 
         # enterprise template just uses v3.6, v3.7, etc
         match = re.match(r'v\d+\.\d+', image_tag)
@@ -186,8 +191,7 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
         version = image_info["registry_console_default_version"].replace("${short_version}", short_version)
         version = self.get_var("openshift_cockpit_deployer_version", default=version)
 
-        template = image_info["registry_console_template"]
-        return template.replace('${prefix}', prefix).replace('${version}', version)
+        return prefix + basename + ':' + version
 
     def local_images(self, images):
         """Filter a list of images and return those available locally."""

--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -1,5 +1,6 @@
 """Check that required Docker images are available."""
 
+import re
 from pipes import quote
 from openshift_checks import OpenShiftCheck
 from openshift_checks.mixins import DockerHostMixin
@@ -10,12 +11,16 @@ DEPLOYMENT_IMAGE_INFO = {
     "origin": {
         "namespace": "openshift",
         "name": "origin",
-        "registry_console_image": "cockpit/kubernetes",
+        "registry_console_template": "${prefix}kubernetes:${version}",
+        "registry_console_prefix": "cockpit/",
+        "registry_console_default_version": "latest",
     },
     "openshift-enterprise": {
         "namespace": "openshift3",
         "name": "ose",
-        "registry_console_image": "registry.access.redhat.com/openshift3/registry-console",
+        "registry_console_template": "${prefix}registry-console:${version}",
+        "registry_console_prefix": "registry.access.redhat.com/openshift3/",
+        "registry_console_default_version": "${short_version}",
     },
 }
 
@@ -150,10 +155,7 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
         if 'nodes' in host_groups:
             for suffix in NODE_IMAGE_SUFFIXES:
                 required.add(image_url.replace("${component}", suffix).replace("${version}", image_tag))
-            # The registry-console is for some reason not prefixed with ose- like the other components.
-            # Nor is it versioned the same, so just look for latest.
-            # Also a completely different name is used for Origin.
-            required.add(image_info["registry_console_image"])
+            required.add(self._registry_console_image(image_tag, image_info))
 
         # images for containerized components
         if self.get_var("openshift", "common", "is_containerized"):
@@ -168,6 +170,24 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
                 required.add("registry.access.redhat.com/rhel7/etcd")  # and no image tag
 
         return required
+
+    def _registry_console_image(self, image_tag, image_info):
+        """Returns image with logic to parallel what happens with the registry-console template."""
+        # The registry-console is for some reason not prefixed with ose- like the other components.
+        # Nor is it versioned the same. Also a completely different name is used for Origin.
+        prefix = self.get_var(
+            "openshift_cockpit_deployer_prefix",
+            default=image_info["registry_console_prefix"],
+        )
+
+        # enterprise template just uses v3.6, v3.7, etc
+        match = re.match(r'v\d+\.\d+', image_tag)
+        short_version = match.group() if match else image_tag
+        version = image_info["registry_console_default_version"].replace("${short_version}", short_version)
+        version = self.get_var("openshift_cockpit_deployer_version", default=version)
+
+        template = image_info["registry_console_template"]
+        return template.replace('${prefix}', prefix).replace('${version}', version)
 
     def local_images(self, images):
         """Filter a list of images and return those available locally."""

--- a/roles/openshift_health_checker/test/docker_image_availability_test.py
+++ b/roles/openshift_health_checker/test/docker_image_availability_test.py
@@ -219,7 +219,7 @@ def test_registry_availability(image, registries, connection_test_failed, skopeo
             'foo.io/openshift3/ose-docker-registry:f13ac45',
             'foo.io/openshift3/ose-haproxy-router:f13ac45',
             # registry-console is not constructed/versioned the same as the others.
-            'registry.access.redhat.com/openshift3/registry-console:vtest',
+            'openshift3/registry-console:vtest',
             # containerized images aren't built from oreg_url
             'openshift3/node:vtest',
             'openshift3/openvswitch:vtest',
@@ -263,7 +263,7 @@ def test_required_images(deployment_type, is_containerized, groups, oreg_url, ex
             openshift_deployment_type="openshift-enterprise",
             openshift_image_tag="vtest",
         ),
-        "registry.access.redhat.com/openshift3/registry-console:vtest",
+        "openshift3/registry-console:vtest",
     ), (
         dict(
             openshift_deployment_type="openshift-enterprise",

--- a/roles/openshift_health_checker/test/docker_image_availability_test.py
+++ b/roles/openshift_health_checker/test/docker_image_availability_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from openshift_checks.docker_image_availability import DockerImageAvailability
+from openshift_checks.docker_image_availability import DockerImageAvailability, DEPLOYMENT_IMAGE_INFO
 
 
 @pytest.fixture()
@@ -182,7 +182,7 @@ def test_registry_availability(image, registries, connection_test_failed, skopeo
             'openshift/origin-deployer:vtest',
             'openshift/origin-docker-registry:vtest',
             'openshift/origin-haproxy-router:vtest',
-            'cockpit/kubernetes',  # origin version of registry-console
+            'cockpit/kubernetes:latest',  # origin version of registry-console
         ])
     ),
     (  # set a different URL for images
@@ -192,7 +192,7 @@ def test_registry_availability(image, registries, connection_test_failed, skopeo
             'foo.io/openshift/origin-deployer:vtest',
             'foo.io/openshift/origin-docker-registry:vtest',
             'foo.io/openshift/origin-haproxy-router:vtest',
-            'cockpit/kubernetes',  # AFAICS this is not built from the URL
+            'cockpit/kubernetes:latest',  # AFAICS this is not built from the URL
         ])
     ),
     (
@@ -203,7 +203,7 @@ def test_registry_availability(image, registries, connection_test_failed, skopeo
             'openshift/origin-deployer:vtest',
             'openshift/origin-docker-registry:vtest',
             'openshift/origin-haproxy-router:vtest',
-            'cockpit/kubernetes',
+            'cockpit/kubernetes:latest',
             # containerized component images
             'openshift/origin:vtest',
             'openshift/node:vtest',
@@ -219,7 +219,7 @@ def test_registry_availability(image, registries, connection_test_failed, skopeo
             'foo.io/openshift3/ose-docker-registry:f13ac45',
             'foo.io/openshift3/ose-haproxy-router:f13ac45',
             # registry-console is not constructed/versioned the same as the others.
-            'registry.access.redhat.com/openshift3/registry-console',
+            'registry.access.redhat.com/openshift3/registry-console:vtest',
             # containerized images aren't built from oreg_url
             'openshift3/node:vtest',
             'openshift3/openvswitch:vtest',
@@ -249,6 +249,42 @@ def test_required_images(deployment_type, is_containerized, groups, oreg_url, ex
     )
 
     assert expected == DockerImageAvailability(task_vars=task_vars).required_images()
+
+
+@pytest.mark.parametrize("task_vars, expected", [
+    (
+        dict(
+            openshift_deployment_type="origin",
+            openshift_image_tag="vtest",
+        ),
+        "cockpit/kubernetes:latest",
+    ), (
+        dict(
+            openshift_deployment_type="openshift-enterprise",
+            openshift_image_tag="vtest",
+        ),
+        "registry.access.redhat.com/openshift3/registry-console:vtest",
+    ), (
+        dict(
+            openshift_deployment_type="openshift-enterprise",
+            openshift_image_tag="v3.7.0-alpha.0",
+            openshift_cockpit_deployer_prefix="registry.example.com/spam/",
+        ),
+        "registry.example.com/spam/registry-console:v3.7",
+    ), (
+        dict(
+            openshift_deployment_type="origin",
+            openshift_image_tag="v3.7.0-alpha.0",
+            openshift_cockpit_deployer_prefix="registry.example.com/eggs/",
+            openshift_cockpit_deployer_version="spam",
+        ),
+        "registry.example.com/eggs/kubernetes:spam",
+    ),
+])
+def test_registry_console_image(task_vars, expected):
+    info = DEPLOYMENT_IMAGE_INFO[task_vars["openshift_deployment_type"]]
+    tag = task_vars["openshift_image_tag"]
+    assert expected == DockerImageAvailability(task_vars=task_vars)._registry_console_image(tag, info)
 
 
 def test_containerized_etcd():

--- a/roles/openshift_hosted_templates/files/v3.6/enterprise/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.6/enterprise/registry-console.yaml
@@ -27,7 +27,7 @@ objects:
         spec:
           containers:
             - name: registry-console
-              image: ${IMAGE_PREFIX}registry-console:${IMAGE_VERSION}
+              image: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
               ports:
                 - containerPort: 9090
                   protocol: TCP
@@ -89,7 +89,7 @@ objects:
         - annotations: null
           from:
             kind: DockerImage
-            name: ${IMAGE_PREFIX}registry-console
+            name: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
           name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
@@ -102,7 +102,10 @@ objects:
 parameters:
   - description: 'Specify "registry/repository" prefix for container image; e.g. for "registry.access.redhat.com/openshift3/registry-console:latest", set prefix "registry.access.redhat.com/openshift3/"'
     name: IMAGE_PREFIX
-    value: "registry.access.redhat.com/openshift3/"
+    value: "openshift3/"
+  - description: 'Specify component name for container image; e.g. for "registry.access.redhat.com/openshift3/registry-console:latest", use base name "registry-console"'
+    name: IMAGE_BASENAME
+    value: "registry-console"
   - description: 'Specify image version; e.g. for "registry.access.redhat.com/openshift3/registry-console:v3.6", set version "v3.6"'
     name: IMAGE_VERSION
     value: "v3.6"

--- a/roles/openshift_hosted_templates/files/v3.6/origin/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.6/origin/registry-console.yaml
@@ -27,7 +27,7 @@ objects:
         spec:
           containers:
             - name: registry-console
-              image: ${IMAGE_PREFIX}kubernetes:${IMAGE_VERSION}
+              image: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
               ports:
                 - containerPort: 9090
                   protocol: TCP
@@ -89,7 +89,7 @@ objects:
         - annotations: null
           from:
             kind: DockerImage
-            name: ${IMAGE_PREFIX}kubernetes:${IMAGE_VERSION}
+            name: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
           name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
@@ -103,6 +103,9 @@ parameters:
   - description: 'Specify "registry/namespace" prefix for container image; e.g. for "registry.example.com/cockpit/kubernetes:latest", set prefix "registry.example.com/cockpit/"'
     name: IMAGE_PREFIX
     value: "cockpit/"
+  - description: 'Specify component name for container image; e.g. for "registry.example.com/cockpit/kubernetes:latest", use base name "kubernetes"'
+    name: IMAGE_BASENAME
+    value: "kubernetes"
   - description: 'Specify image version; e.g. for "cockpit/kubernetes:latest", set version "latest"'
     name: IMAGE_VERSION
     value: latest

--- a/roles/openshift_hosted_templates/files/v3.6/origin/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.6/origin/registry-console.yaml
@@ -27,7 +27,7 @@ objects:
         spec:
           containers:
             - name: registry-console
-              image: ${IMAGE_NAME}:${IMAGE_VERSION}
+              image: ${IMAGE_PREFIX}kubernetes:${IMAGE_VERSION}
               ports:
                 - containerPort: 9090
                   protocol: TCP
@@ -89,7 +89,7 @@ objects:
         - annotations: null
           from:
             kind: DockerImage
-            name: ${IMAGE_NAME}
+            name: ${IMAGE_PREFIX}kubernetes:${IMAGE_VERSION}
           name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
@@ -100,9 +100,9 @@ objects:
     redirectURIs:
       - "${COCKPIT_KUBE_URL}"
 parameters:
-  - description: "Container image name"
-    name: IMAGE_NAME
-    value: "cockpit/kubernetes"
+  - description: 'Specify "registry/namespace" prefix for container image; e.g. for "registry.example.com/cockpit/kubernetes:latest", set prefix "registry.example.com/cockpit/"'
+    name: IMAGE_PREFIX
+    value: "cockpit/"
   - description: 'Specify image version; e.g. for "cockpit/kubernetes:latest", set version "latest"'
     name: IMAGE_VERSION
     value: latest


### PR DESCRIPTION
3.6 backport of https://github.com/openshift/openshift-ansible/pull/5829 to address https://bugzilla.redhat.com/show_bug.cgi?id=1537344