### PR TITLE
Remove master_ha bool checks

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -48,8 +48,6 @@
 # support for optional hooks to be defined.
 - name: Upgrade master
   hosts: oo_masters_to_config
-  vars:
-    openshift_master_ha: "{{ groups.oo_masters_to_config | length > 1 }}"
   serial: 1
   roles:
   - openshift_facts

--- a/playbooks/openshift-master/private/additional_config.yml
+++ b/playbooks/openshift-master/private/additional_config.yml
@@ -16,7 +16,6 @@
   vars:
     cockpit_plugins: "{{ osm_cockpit_plugins | default(['cockpit-kubernetes']) }}"
     etcd_urls: "{{ openshift.master.etcd_urls }}"
-    openshift_master_ha: "{{ groups.oo_masters | length > 1 }}"
     omc_cluster_hosts: "{{ groups.oo_masters | join(' ')}}"
   roles:
   - role: openshift_project_request_template

--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -78,7 +78,6 @@
         console_url: "{{ openshift_master_console_url | default(None) }}"
         console_use_ssl: "{{ openshift_master_console_use_ssl | default(None) }}"
         public_console_url: "{{ openshift_master_public_console_url | default(None) }}"
-        ha: "{{ openshift_master_ha | default(groups.oo_masters | length > 1) }}"
         master_count: "{{ openshift_master_count | default(groups.oo_masters | length) }}"
 
 - name: Inspect state of first master config settings
@@ -166,7 +165,6 @@
   hosts: oo_masters_to_config
   any_errors_fatal: true
   vars:
-    openshift_master_ha: "{{ openshift.master.ha }}"
     openshift_master_count: "{{ openshift.master.master_count }}"
     openshift_master_session_auth_secrets: "{{ hostvars[groups.oo_first_master.0].openshift.master.session_auth_secrets }}"
     openshift_master_session_encryption_secrets: "{{ hostvars[groups.oo_first_master.0].openshift.master.session_encryption_secrets }}"
@@ -186,6 +184,7 @@
   - role: openshift_buildoverrides
   - role: nickhammond.logrotate
   - role: openshift_master
+    openshift_master_ha: "{{ (groups.oo_masters | length > 1) | bool }}"
     openshift_master_hosts: "{{ groups.oo_masters_to_config }}"
     r_openshift_master_clean_install: "{{ hostvars[groups.oo_first_master.0].l_clean_install }}"
     r_openshift_master_etcd3_storage: "{{ hostvars[groups.oo_first_master.0].l_etcd3_enabled }}"

--- a/playbooks/openshift-master/private/restart.yml
+++ b/playbooks/openshift-master/private/restart.yml
@@ -3,16 +3,13 @@
 
 - name: Restart masters
   hosts: oo_masters_to_config
-  vars:
-    openshift_master_ha: "{{ groups.oo_masters_to_config | length > 1 }}"
   serial: 1
-  handlers:
-  - import_tasks: ../../../roles/openshift_master/handlers/main.yml
   roles:
   - openshift_facts
   post_tasks:
   - include_tasks: tasks/restart_hosts.yml
     when: openshift_rolling_restart_mode | default('services') == 'system'
-
-  - include_tasks: tasks/restart_services.yml
+  - import_role:
+      name: openshift_master
+      tasks_from: restart.yml
     when: openshift_rolling_restart_mode | default('services') == 'services'

--- a/playbooks/openshift-master/private/scaleup.yml
+++ b/playbooks/openshift-master/private/scaleup.yml
@@ -8,7 +8,6 @@
   - openshift_facts:
       role: master
       local_facts:
-        ha: "{{ openshift_master_ha | default(groups.oo_masters | length > 1) }}"
         master_count: "{{ openshift_master_count | default(groups.oo_masters | length) }}"
   - name: Update master count
     modify_yaml:

--- a/playbooks/openshift-master/private/tasks/restart_services.yml
+++ b/playbooks/openshift-master/private/tasks/restart_services.yml
@@ -1,4 +1,0 @@
----
-- import_role:
-    name: openshift_master
-    tasks_from: restart.yml

--- a/roles/nuage_master/handlers/main.yaml
+++ b/roles/nuage_master/handlers/main.yaml
@@ -1,9 +1,7 @@
 ---
 - name: restart master api
   systemd: name={{ openshift_service_type }}-master-api state=restarted
-  when: >
-    (openshift_master_ha | bool) and
-    (not master_api_service_status_changed | default(false))
+  when: (not master_api_service_status_changed | default(false))
 
 # TODO: need to fix up ignore_errors here
 # We retry the controllers because the API may not be 100% initialized yet.
@@ -13,7 +11,5 @@
   delay: 5
   register: result
   until: result.rc == 0
-  when: >
-    (openshift_master_ha | bool) and
-    (not master_controllers_service_status_changed | default(false))
+  when: (not master_controllers_service_status_changed | default(false))
   ignore_errors: yes

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -227,7 +227,7 @@
 - pause:
     seconds: 15
   when:
-  - openshift.master.ha | bool
+  - openshift_master_ha | bool
 
 - name: Start and enable master api all masters
   systemd:

--- a/roles/openshift_master/tasks/restart.yml
+++ b/roles/openshift_master/tasks/restart.yml
@@ -3,7 +3,6 @@
   service:
     name: "{{ openshift_service_type }}-master-api"
     state: restarted
-  when: openshift_master_ha | bool
 - name: Wait for master API to come back online
   wait_for:
     host: "{{ openshift.common.hostname }}"
@@ -11,12 +10,10 @@
     delay: 10
     port: "{{ openshift.master.api_port }}"
     timeout: 600
-  when: openshift_master_ha | bool
-- name: Restart master controllers
-  service:
-    name: "{{ openshift_service_type }}-master-controllers"
-    state: restarted
-  # Ignore errrors since it is possible that type != simple for
-  # pre-3.1.1 installations.
-  ignore_errors: true
-  when: openshift_master_ha | bool
+# We retry the controllers because the API may not be 100% initialized yet.
+- name: restart master controllers
+  command: "systemctl restart {{ openshift_service_type }}-master-controllers"
+  retries: 3
+  delay: 5
+  register: result
+  until: result.rc == 0


### PR DESCRIPTION
Most of these checks are no longer applicable to
the tasks on which they are applied.

This commit removes incorrect ha checks to ensure
services are restarted at appropriate times.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1500897