### PR TITLE
[3.7] Remove master ha_bool checks 3.7

### DIFF
--- a/playbooks/common/openshift-master/restart.yml
+++ b/playbooks/common/openshift-master/restart.yml
@@ -3,12 +3,7 @@
 
 - name: Restart masters
   hosts: oo_masters_to_config
-  vars:
-    openshift_master_ha: "{{ groups.oo_masters_to_config | length > 1 }}"
   serial: 1
-  handlers:
-  - include: ../../../roles/openshift_master/handlers/main.yml
-    static: yes
   roles:
   - openshift_facts
   post_tasks:

--- a/playbooks/common/openshift-master/restart_services.yml
+++ b/playbooks/common/openshift-master/restart_services.yml
@@ -3,7 +3,7 @@
   service:
     name: "{{ openshift.common.service_type }}-master-api"
     state: restarted
-  when: openshift_master_ha | bool
+
 - name: Wait for master API to come back online
   wait_for:
     host: "{{ openshift.common.hostname }}"
@@ -11,12 +11,11 @@
     delay: 10
     port: "{{ openshift.master.api_port }}"
     timeout: 600
-  when: openshift_master_ha | bool
-- name: Restart master controllers
-  service:
-    name: "{{ openshift.common.service_type }}-master-controllers"
-    state: restarted
-  # Ignore errrors since it is possible that type != simple for
-  # pre-3.1.1 installations.
-  ignore_errors: true
-  when: openshift_master_ha | bool
+
+# We retry the controllers because the API may not be 100% initialized yet.
+- name: restart master controllers
+  command: "systemctl restart {{ openshift.common.service_type }}-master-controllers"
+  retries: 3
+  delay: 5
+  register: result
+  until: result.rc == 0


### PR DESCRIPTION
This commit removes incorrect ha checks to ensure
services are restarted at appropriate times.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1500897