### PR TITLE
Add GPG keys in the base image and don't install docker

### DIFF
--- a/playbooks/gcp/openshift-cluster/build_base_image.yml
+++ b/playbooks/gcp/openshift-cluster/build_base_image.yml
@@ -90,6 +90,8 @@
       repo_gpgcheck: no
       state: present
     when: ansible_os_family == "RedHat"
+  - name: Accept GPG keys for the repos
+    command: yum -q makecache -y --disablerepo='*' --enablerepo='google-cloud,jdetiber-qemu-user-static'
   - name: Install qemu-user-static
     package:
       name: qemu-user-static
@@ -121,7 +123,6 @@
     with_items:
     # required by Ansible
     - PyYAML
-    - docker
     - google-compute-engine
     - google-compute-engine-init
     - google-config


### PR DESCRIPTION
Base image fails to accept the keys.