### PR TITLE
[3.7] Readd etcd openshift_facts

### DIFF
--- a/roles/openshift_etcd_facts/tasks/main.yml
+++ b/roles/openshift_etcd_facts/tasks/main.yml
@@ -1,1 +1,4 @@
 ---
+- openshift_facts:
+    role: etcd
+    local_facts: {}


### PR DESCRIPTION
Restore call to openshift_facts because
several etcd variables require openshift.x to be
present.

This branch is too far off with master to cherrypick
fixes.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1538446