### PR TITLE
Fix misaligned ports for sg,elb,api

### DIFF
--- a/playbooks/aws/provisioning_vars.yml.example
+++ b/playbooks/aws/provisioning_vars.yml.example
@@ -21,6 +21,12 @@ openshift_release: # v3.7
 # This will be dependent on the version provided by the yum repository
 openshift_pkg_version: # -3.7.0
 
+# OpenShift api port
+# Fulfills a chicken/egg scenario with how Ansible treats host inventory file
+# and extra_vars.  This is used for SecurityGroups, ELB Listeners as well as
+# an override to installer inventory openshift_master_api_port key
+# openshift_master_api_port: 8443
+
 # specify a clusterid
 # This value is also used as the default value for many other components.
 #openshift_aws_clusterid: default

--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -42,60 +42,77 @@ openshift_aws_ami_tags:
 openshift_aws_s3_mode: create
 openshift_aws_s3_bucket_name: "{{ openshift_aws_clusterid }}-docker-registry"
 
-openshift_aws_elb_health_check:
-  ping_protocol: tcp
-  ping_port: 443
-  response_timeout: 5
-  interval: 30
-  unhealthy_threshold: 2
-  healthy_threshold: 2
-
 openshift_aws_elb_basename: "{{ openshift_aws_clusterid }}"
-openshift_aws_elb_name_dict:
-  master:
-    external: "{{ openshift_aws_elb_basename }}-master-external"
-    internal: "{{ openshift_aws_elb_basename }}-master-internal"
-  infra:
-    external: "{{ openshift_aws_elb_basename }}-infra"
-
-openshift_aws_elb_idle_timout: 400
-
-openshift_aws_elb_cert_arn: ''
 
 openshift_aws_elb_dict:
   master:
     external:
-    - protocol: tcp
-      load_balancer_port: 80
-      instance_protocol: ssl
-      instance_port: 443
-    - protocol: ssl
-      load_balancer_port: 443
-      instance_protocol: ssl
-      instance_port: 443
-      # ssl certificate required for https or ssl
-      ssl_certificate_id: "{{ openshift_aws_elb_cert_arn }}"
+      cross_az_load_balancing: False
+      health_check:
+        ping_protocol: tcp
+        ping_port: "{{ openshift_master_api_port | default(8443) }}"
+        response_timeout: 5
+        interval: 30
+        unhealthy_threshold: 2
+        healthy_threshold: 2
+      idle_timout: 400
+      listeners:
+      - protocol: tcp
+        load_balancer_port: 80
+        instance_protocol: ssl
+        instance_port: "{{ openshift_master_api_port | default(8443) }}"
+      - protocol: ssl
+        load_balancer_port: "{{ openshift_master_api_port | default(8443) }}"
+        instance_protocol: ssl
+        instance_port: "{{ openshift_master_api_port | default(8443) }}"
+        ssl_certificate_id: ''
+      name: "{{ openshift_aws_elb_basename }}-master-external"
+      tags: "{{ openshift_aws_kube_tags }}"
     internal:
-    - protocol: tcp
-      load_balancer_port: 80
-      instance_protocol: tcp
-      instance_port: 80
-    - protocol: tcp
-      load_balancer_port: 443
-      instance_protocol: tcp
-      instance_port: 443
+      cross_az_load_balancing: False
+      health_check:
+        ping_protocol: tcp
+        ping_port: "{{ openshift_master_api_port | default(8443) }}"
+        response_timeout: 5
+        interval: 30
+        unhealthy_threshold: 2
+        healthy_threshold: 2
+      idle_timout: 400
+      listeners:
+      - protocol: tcp
+        load_balancer_port: 80
+        instance_protocol: tcp
+        instance_port: 80
+      - protocol: tcp
+        load_balancer_port: "{{ openshift_master_api_port | default(8443) }}"
+        instance_protocol: tcp
+        instance_port: "{{ openshift_master_api_port | default(8443) }}"
+      name: "{{ openshift_aws_elb_basename }}-master-internal"
+      tags: "{{ openshift_aws_kube_tags }}"
   infra:
     external:
-    - protocol: tcp
-      load_balancer_port: 80
-      instance_protocol: tcp
-      instance_port: 443
-      proxy_protocol: True
-    - protocol: tcp
-      load_balancer_port: 443
-      instance_protocol: tcp
-      instance_port: 443
-      proxy_protocol: True
+      cross_az_load_balancing: False
+      health_check:
+        ping_protocol: tcp
+        ping_port: 443
+        response_timeout: 5
+        interval: 30
+        unhealthy_threshold: 2
+        healthy_threshold: 2
+      idle_timout: 400
+      listeners:
+      - protocol: tcp
+        load_balancer_port: 80
+        instance_protocol: tcp
+        instance_port: 443
+        proxy_protocol: True
+      - protocol: tcp
+        load_balancer_port: 443
+        instance_protocol: tcp
+        instance_port: 443
+        proxy_protocol: True
+      name: "{{ openshift_aws_elb_basename }}-infra"
+      tags: "{{ openshift_aws_kube_tags }}"
 
 openshift_aws_node_group_config_master_volumes:
 - device_name: /dev/sda1
@@ -172,7 +189,7 @@ openshift_aws_master_group_config:
     iam_role: "{{ openshift_aws_iam_role_name }}"
     policy_name: "{{ openshift_aws_iam_role_policy_name }}"
     policy_json: "{{ openshift_aws_iam_role_policy_json }}"
-    elbs: "{{ openshift_aws_elb_name_dict['master'].keys()| map('extract', openshift_aws_elb_name_dict['master']) | list }}"
+    elbs: "{{ openshift_aws_elb_dict | json_query('master.[*][0][*].name') }}"
 
 openshift_aws_node_group_config:
   # The 'compute' key is always required here.
@@ -205,10 +222,7 @@ openshift_aws_node_group_config:
     iam_role: "{{ openshift_aws_iam_role_name }}"
     policy_name: "{{ openshift_aws_iam_role_policy_name }}"
     policy_json: "{{ openshift_aws_iam_role_policy_json }}"
-    elbs: "{{ openshift_aws_elb_name_dict['infra'].keys()| map('extract', openshift_aws_elb_name_dict['infra']) | list }}"
-
-openshift_aws_elb_tags: "{{ openshift_aws_kube_tags }}"
-openshift_aws_elb_az_load_balancing: False
+    elbs: "{{ openshift_aws_elb_dict | json_query('infra.[*][0][*].name') }}"
 
 # build_instance_tags is a custom filter in role lib_utils
 openshift_aws_kube_tags: "{{ openshift_aws_clusterid | build_instance_tags }}"
@@ -253,8 +267,8 @@ openshift_aws_node_security_groups:
       to_port: 80
       cidr_ip: 0.0.0.0/0
     - proto: tcp
-      from_port: 443
-      to_port: 443
+      from_port: "{{ openshift_master_api_port | default(8443) }}"
+      to_port: "{{ openshift_master_api_port | default(8443) }}"
       cidr_ip: 0.0.0.0/0
   compute:
     name: "{{ openshift_aws_clusterid }}_compute"
@@ -268,8 +282,8 @@ openshift_aws_node_security_groups:
       to_port: 80
       cidr_ip: 0.0.0.0/0
     - proto: tcp
-      from_port: 443
-      to_port: 443
+      from_port: "{{ openshift_master_api_port | default(8443) }}"
+      to_port: "{{ openshift_master_api_port | default(8443) }}"
       cidr_ip: 0.0.0.0/0
     - proto: tcp
       from_port: 30000

--- a/roles/openshift_aws/tasks/elb.yml
+++ b/roles/openshift_aws/tasks/elb.yml
@@ -5,18 +5,18 @@
 
 - name: "Create ELB {{ l_elb_dict_item.key }}"
   ec2_elb_lb:
-    name: "{{ l_openshift_aws_elb_name_dict[l_elb_dict_item.key][item.key] }}"
+    name: "{{ item.value.name }}"
     state: present
-    cross_az_load_balancing: "{{ openshift_aws_elb_az_load_balancing }}"
+    cross_az_load_balancing: "{{ item.value.cross_az_load_balancing }}"
     security_group_names: "{{ l_elb_security_groups[l_elb_dict_item.key] }}"
-    idle_timeout: "{{ openshift_aws_elb_idle_timout }}"
+    idle_timeout: "{{ item.value.idle_timout }}"
     region: "{{ openshift_aws_region }}"
     subnets:
     - "{{ subnetout.subnets[0].id }}"
-    health_check: "{{ openshift_aws_elb_health_check }}"
-    listeners: "{{ item.value }}"
+    health_check: "{{ item.value.health_check }}"
+    listeners: "{{ item.value.listeners }}"
     scheme: "{{ (item.key == 'internal') | ternary('internal','internet-facing') }}"
-    tags: "{{ openshift_aws_elb_tags }}"
+    tags: "{{ item.value.tags }}"
     wait: True
   register: new_elb
   with_dict: "{{ l_elb_dict_item.value }}"

--- a/roles/openshift_aws/tasks/master_facts.yml
+++ b/roles/openshift_aws/tasks/master_facts.yml
@@ -3,7 +3,7 @@
   ec2_elb_facts:
     region: "{{ openshift_aws_region }}"
     names:
-    - "{{ openshift_aws_elb_name_dict['master']['internal'] }}"
+    - "{{ openshift_aws_elb_dict['master']['internal']['name'] }}"
   delegate_to: localhost
   register: elbs
 

--- a/roles/openshift_aws/tasks/provision_elb.yml
+++ b/roles/openshift_aws/tasks/provision_elb.yml
@@ -10,6 +10,5 @@
   with_dict: "{{ openshift_aws_elb_dict }}"
   vars:
     l_elb_security_groups: "{{ openshift_aws_elb_security_groups }}"
-    l_openshift_aws_elb_name_dict: "{{ openshift_aws_elb_name_dict }}"
   loop_control:
     loop_var: l_elb_dict_item


### PR DESCRIPTION
Fix to issue [6867](https://github.com/openshift/openshift-ansible/issues/6867)

The scope of this patch widened slightly to consolidate some AWS ELB vars/dicts into the single dictionary due to Health check being sourced by all ELBs.  By default health check needs to ping 8443  for master ELBS and 443 for infra ELBs.  Consolidating allows for changes to the behavior of one ELB without affecting the others.

@sdodson @kwoodson 