### PR TITLE
Disables check for RPMs on masters and nodes in openshift_version role during containerized install

### DIFF
--- a/roles/openshift_version/tasks/masters_and_nodes.yml
+++ b/roles/openshift_version/tasks/masters_and_nodes.yml
@@ -13,7 +13,9 @@
     - openshift_version_reinit | default(false)
 
   # block when
-  when: not openshift_is_atomic | bool
+  when:
+  - not openshift_is_atomic | bool
+  - not openshift_is_containerized | bool
 
 # We can't map an openshift_release to full rpm version like we can with containers; make sure
 # the rpm version we looked up matches the release requested and error out if not.


### PR DESCRIPTION
When trying to run the playbooks to deploy a cluster on CentOS machines using a BYO inventory (running the `deploy_cluster.yml` playbook), if one sets `containerized=true` and `openshift_release=3.9` (for example), the playbooks fail when it goes to run the `openshift_version` roles. Resulting in a failure stating: "Package origin not found".

This fix sets now allows for the RPM version check for not only when `openshift_is_atomic` is true (which was there) but also when `openshift_is_containerized` is true. I casted it as a bool however, unsure how necessary it was but saw it used otherwise in the playbooks.

Of note, in my particular case, with `containerized=true` and this fix, I was able to get a cluster up, however, I also needed to add `openshift_disable_check=docker_image_availability` and `enable_excluders=false` under CentOS 7.

Example inventory:

```
openshift-master ansible_host=192.168.1.154
openshift-minion-1 ansible_host=192.168.1.249
openshift-minion-2 ansible_host=192.168.1.233

[OSEv3:children]
masters
nodes
etcd

[OSEv3:vars]
ansible_ssh_user=centos
ansible_become=yes
debug_level=2
ansible_ssh_private_key_file=/root/.ssh/id_vm_rsa
openshift_master_unsupported_embedded_etcd=true 
openshift_disable_check=disk_availability,memory_availability,docker_image_availability
openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
openshift_deployment_type=origin 
containerized=true
openshift_release=3.9
openshift_image_tag=latest
enable_excluders=false

[masters]
openshift-master

[etcd]
openshift-master

[nodes]
openshift-master openshift_node_labels="{'region': 'infra', 'zone': 'default'}" openshift_schedulable=true
openshift-minion-[1:2] openshift_node_labels="{'region': 'primary', 'zone': 'default'}"
```

fixes #6899