### PR TITLE
Clarify node system container service unit

### DIFF
--- a/roles/container_runtime/tasks/systemcontainer_docker.yml
+++ b/roles/container_runtime/tasks/systemcontainer_docker.yml
@@ -22,7 +22,8 @@
   register: result
   until: result is succeeded
 
-# Make sure docker is disabled. Errors are ignored.
+# Make sure docker.service from docker rpm is disabled. Errors are ignored.
+# docker runs as a system container as 'container-engine' in a later task.
 - name: Disable Docker
   systemd:
     name: docker
@@ -85,8 +86,8 @@
     dest: "{{ docker_conf_dir }}/container-daemon.json"
     src: daemon.json
 
-# Enable and start the container-engine service
-- name: Start the Container Engine service
+# Enable and start the container-engine service (docker as system container)
+- name: Start the container-engine service
   systemd:
     name: "{{ openshift_docker_service_name }}"
     enabled: yes

--- a/roles/openshift_node/tasks/config/install-node-docker-service-file.yml
+++ b/roles/openshift_node/tasks/config/install-node-docker-service-file.yml
@@ -1,8 +1,0 @@
----
-- name: Install Node docker service file
-  template:
-    dest: "/etc/systemd/system/{{ openshift_service_type }}-node.service"
-    src: openshift.docker.node.service
-  notify:
-  - reload systemd units
-  - restart node

--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -1,4 +1,9 @@
 ---
+# system containers create their own service unit files based on templates
+# that are part of the container image.
+# oc_atomic_container will create a systemd service unit file in
+# /etc/systemd/system/origin-node.service (origin) or
+# /etc/systemd/system/atomic-openshift-node.service (enterprise)
 
 - name: Pre-pull node system container image
   command: >


### PR DESCRIPTION
System containers create their own service unit files.
This is not apparent to those unfamiliar with
system containers.

This commit adds comments to assist in troubleshooting
and development.

This commit also removes unused file
install-node-docker-service-file.yml