### PR TITLE
add cinder mountpoint to inventory

### DIFF
--- a/playbooks/openstack/inventory.py
+++ b/playbooks/openstack/inventory.py
@@ -61,6 +61,7 @@ def base_openshift_inventory(cluster_hosts):
 
     return inventory
 
+
 def get_docker_storage_mountpoints(volumes):
     '''Check volumes to see if they're being used for docker storage'''
     docker_storage_mountpoints = {}
@@ -72,6 +73,7 @@ def get_docker_storage_mountpoints(volumes):
                 else:
                     docker_storage_mountpoints[attachment.server_id] = [attachment.device]
     return docker_storage_mountpoints
+
 
 def build_inventory():
     '''Build the dynamic inventory.'''
@@ -139,6 +141,7 @@ def build_inventory():
 
         inventory['_meta']['hostvars'][server.name] = hostvars
     return inventory
+
 
 if __name__ == '__main__':
     print(json.dumps(build_inventory(), indent=4, sort_keys=True))

--- a/roles/openshift_openstack/templates/docker-storage-setup-dm.j2
+++ b/roles/openshift_openstack/templates/docker-storage-setup-dm.j2
@@ -1,4 +1,8 @@
+{% if docker_storage_volume_mountpoints is defined %}
+DEVS="{{ docker_storage_volume_mountpoints }}"
+{% else %}
 DEVS="{{ openshift_openstack_container_storage_setup.docker_dev }}"
+{% endif %}
 VG="{{ openshift_openstack_container_storage_setup.docker_vg }}"
 DATA_SIZE="{{ openshift_openstack_container_storage_setup.docker_data_size }}"
 EXTRA_DOCKER_STORAGE_OPTIONS="--storage-opt dm.basesize={{ openshift_openstack_container_storage_setup.docker_dm_basesize }}"

--- a/roles/openshift_openstack/templates/docker-storage-setup-dm.j2
+++ b/roles/openshift_openstack/templates/docker-storage-setup-dm.j2
@@ -1,5 +1,5 @@
-{% if docker_storage_volume_mountpoints is defined %}
-DEVS="{{ docker_storage_volume_mountpoints }}"
+{% if docker_storage_mountpoints is defined %}
+DEVS="{{ docker_storage_mountpoints }}"
 {% else %}
 DEVS="{{ openshift_openstack_container_storage_setup.docker_dev }}"
 {% endif %}

--- a/roles/openshift_openstack/templates/docker-storage-setup-overlayfs.j2
+++ b/roles/openshift_openstack/templates/docker-storage-setup-overlayfs.j2
@@ -1,4 +1,8 @@
+{% if docker_storage_volume_mountpoints is defined %}
+DEVS="{{ docker_storage_volume_mountpoints }}"
+{% else %}
 DEVS="{{ openshift_openstack_container_storage_setup.docker_dev }}"
+{% endif %}
 VG="{{ openshift_openstack_container_storage_setup.docker_vg }}"
 DATA_SIZE="{{ openshift_openstack_container_storage_setup.docker_data_size }}"
 STORAGE_DRIVER=overlay2

--- a/roles/openshift_openstack/templates/docker-storage-setup-overlayfs.j2
+++ b/roles/openshift_openstack/templates/docker-storage-setup-overlayfs.j2
@@ -1,5 +1,5 @@
-{% if docker_storage_volume_mountpoints is defined %}
-DEVS="{{ docker_storage_volume_mountpoints }}"
+{% if docker_storage_mountpoints is defined %}
+DEVS="{{ docker_storage_mountpoints }}"
 {% else %}
 DEVS="{{ openshift_openstack_container_storage_setup.docker_dev }}"
 {% endif %}

--- a/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
@@ -269,5 +269,4 @@ resources:
     properties:
       volume_id: { get_resource: cinder_volume }
       instance_uuid: { get_resource: server }
-      mountpoint: /dev/sdb
 {% endif %}

--- a/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
@@ -261,6 +261,8 @@ resources:
     properties:
       size: { get_param: volume_size }
       availability_zone: { get_param: availability_zone }
+      metadata:
+        purpose: openshift_docker_storage
 
   volume_attachment:
     type: OS::Cinder::VolumeAttachment


### PR DESCRIPTION
Although the heat templates specify /dev/sdb as a mountpoint for cinder volumes, openstack does not always respect that setting. This PR updates inventory.py to figure out the correct mountpoint from the openstack API; and passes that information into the docker-storage-setup.