### PR TITLE
Revert "use non-deprecated REGISTRY_OPENSHIFT_SERVER_ADDR variable to set the registry hostname"

### DIFF
--- a/roles/openshift_hosted/tasks/registry.yml
+++ b/roles/openshift_hosted/tasks/registry.yml
@@ -43,7 +43,7 @@
 
 - name: Update registry environment variables when pushing via dns
   set_fact:
-    openshift_hosted_registry_env_vars: "{{ openshift_hosted_registry_env_vars | combine({'REGISTRY_OPENSHIFT_SERVER_ADDR':'docker-registry.default.svc:5000'}) }}"
+    openshift_hosted_registry_env_vars: "{{ openshift_hosted_registry_env_vars | combine({'OPENSHIFT_DEFAULT_REGISTRY':'docker-registry.default.svc:5000'}) }}"
   when: openshift_push_via_dns | bool
 
 - name: Update registry proxy settings for dc/docker-registry


### PR DESCRIPTION
Reverts openshift/openshift-ansible#6830

@dmage @legionus the registry does not appear to actually respect this value properly:

```
$ oc logs docker-registry-1-knwnf -n default | grep URL

time="2018-01-28T03:00:12.310853118Z" level=info msg="Using \"172.30.183.222:5000\" as Docker Registry URL" go.version=go1.9.2 instance.id=a82b7ca8-0b55-4567-92ef-2c1744e6074a 

$ oc get pod docker-registry-1-knwnf -o yaml | grep -A 2 ADDR 
--
    - name: REGISTRY_OPENSHIFT_SERVER_ADDR
      value: docker-registry.default.svc:5000
```
