### PR TITLE
Moving python-passlib assert to package manager

### DIFF
--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -1,13 +1,8 @@
 ---
-- local_action: shell python -c 'import passlib' 2>/dev/null || echo not installed
-  register: passlib_result
-  become: false
-
-- name: Check that python-passlib is available on the control host
-  assert:
-    that:
-      - "'not installed' not in passlib_result.stdout"
-    msg: "python-passlib rpm must be installed on control host"
+- name: Install Passlib Package
+  yum:
+    name: python-passlib
+  state: present
 
 - name: Set default image variables based on openshift_deployment_type
   include_vars: "{{ item }}"


### PR DESCRIPTION
With the previous Assert `shell python -c 'import passlib2' 2>/dev/null || echo not installed`, the package was installed but it couldn't be corrected detected on Fedora 27 and RHEL 7.4.

Fedora 27:
> [user@fedora ~]# sudo dnf install python-passlib
> [user@fedora ~]# Package python2-passlib-1.7.0-5.fc27.noarch is already installed
> [user@fedora ~]# shell python -c 'import passlib' 2>/dev/null || echo not installed

> [user@fedora]  not installed


RHEL 7.4:

> [root@rhel ~]# yum install python-passlib
> [root@rhel ~]# The package python-passlib-1.6.5-2.el7.noarch is already installed and on latest version
> [root@rhel ~]# shell python -c 'import passlib' 2>/dev/null || echo not installed
not installed

Delegating it to package manager should install if it is not installed and not break the playbook flow.