### PR TITLE
Symlink kubectl to oc instead of openshift

### DIFF
--- a/roles/lib_utils/library/openshift_container_binary_sync.py
+++ b/roles/lib_utils/library/openshift_container_binary_sync.py
@@ -107,7 +107,7 @@ class BinarySyncer(object):
             self._sync_binary('oc')
 
         # Ensure correct symlinks created:
-        self._sync_symlink('kubectl', 'openshift')
+        self._sync_symlink('kubectl', 'oc')
 
         # Remove old oadm binary
         if os.path.exists(os.path.join(self.bin_dir, 'oadm')):


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1538933

@sdodson @juanvallejo FYI