### PR TITLE
Open AWS security group port range tcp/9000-10000

### DIFF
--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -244,6 +244,11 @@ openshift_aws_node_security_groups:
       from_port: all
       to_port: all
       group_name: "{{ openshift_aws_clusterid }}"
+    - proto: tcp
+      from_port: 9000
+      to_port: 10000
+      group_name: "{{ openshift_aws_clusterid }}"
+
   master:
     name: "{{ openshift_aws_clusterid }}_master"
     desc: "{{ openshift_aws_clusterid }} master instances"


### PR DESCRIPTION
Ports tcp/9000-10000 have been designated for intra-cluster
services, such as prometheus node_exporter (tcp/9100) where
infra nodes must be able to scrape targets on all nodes,
including master, infra and compute nodes.
This range is reserved for this service type.

Signed-off-by: Aaron Weitekamp <aweiteka@redhat.com>