### PR TITLE
Glusterfs block storage ansible support

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -137,6 +137,7 @@ default_r_openshift_node_image_prep_packages:
 - yum-utils
 # gluster
 - glusterfs-fuse
+- device-mapper-multipath
 # nfs
 - nfs-utils
 - flannel

--- a/roles/openshift_node/tasks/storage_plugins/iscsi.yml
+++ b/roles/openshift_node/tasks/storage_plugins/iscsi.yml
@@ -1,6 +1,32 @@
 ---
 - name: Install iSCSI storage plugin dependencies
-  package: name=iscsi-initiator-utils state=present
+  package:
+    name: "{{ item }}"
+    state: present
   when: not openshift_is_atomic | bool
   register: result
   until: result is succeeded
+  with_items:
+    - iscsi-initiator-utils
+    - device-mapper-multipath
+
+- name: restart services
+  systemd:
+    name: "{{ item }}"
+    state: started
+    enabled: True
+  with_items:
+    - multipathd
+    - rpcbind
+
+- name: Template multipath configuration
+  template:
+    dest: "/etc/multipath.conf"
+    src: multipath.conf.j2
+    backup: true
+  when: not openshift_is_atomic | bool
+
+#enable multipath
+- name: Enable multipath
+  command: "mpathconf --enable"
+  when: not openshift_is_atomic | bool

--- a/roles/openshift_node/templates/multipath.conf.j2
+++ b/roles/openshift_node/templates/multipath.conf.j2
@@ -1,0 +1,15 @@
+# LIO iSCSI
+# TODO: Add env variables for tweaking
+devices {
+        device {
+                vendor "LIO-ORG"
+                user_friendly_names "yes" 
+                path_grouping_policy "failover"
+                path_selector "round-robin 0"
+                failback immediate
+                path_checker "tur"
+                prio "const"
+                no_path_retry 120
+                rr_weight "uniform"
+        }
+}

--- a/roles/openshift_storage_glusterfs/README.md
+++ b/roles/openshift_storage_glusterfs/README.md
@@ -73,49 +73,51 @@ Role Variables
 This role has the following variables that control the integration of a
 GlusterFS cluster into a new or existing OpenShift cluster:
 
-| Name                                             | Default value           | Description                             |
-|--------------------------------------------------|-------------------------|-----------------------------------------|
-| openshift_storage_glusterfs_timeout              | 300                     | Seconds to wait for pods to become ready
-| openshift_storage_glusterfs_namespace            | 'glusterfs'             | Namespace/project in which to create GlusterFS resources
-| openshift_storage_glusterfs_is_native            | True                    | GlusterFS should be containerized
-| openshift_storage_glusterfs_name                 | 'storage'               | A name to identify the GlusterFS cluster, which will be used in resource names
-| openshift_storage_glusterfs_nodeselector         | 'glusterfs=storage-host'| Selector to determine which nodes will host GlusterFS pods in native mode. **NOTE:** The label value is taken from the cluster name
-| openshift_storage_glusterfs_use_default_selector | False                   | Whether to use a default node selector for the GlusterFS namespace/project. If False, the namespace/project will have no restricting node selector. If True, uses pre-existing or default (e.g. osm_default_node_selector) node selectors. **NOTE:** If True, nodes which will host GlusterFS pods must already have the additional labels.
-| openshift_storage_glusterfs_storageclass         | True                    | Automatically create a StorageClass for each GlusterFS cluster
-| openshift_storage_glusterfs_storageclass_default | False                   | Sets the StorageClass for each GlusterFS cluster as default
-| openshift_storage_glusterfs_image                | 'gluster/gluster-centos'| Container image to use for GlusterFS pods, enterprise default is 'rhgs3/rhgs-server-rhel7'
-| openshift_storage_glusterfs_version              | 'latest'                | Container image version to use for GlusterFS pods
-| openshift_storage_glusterfs_block_deploy         | True                    | Deploy glusterblock provisioner service
-| openshift_storage_glusterfs_block_image          | 'gluster/glusterblock-provisioner'| Container image to use for glusterblock-provisioner pod, enterprise default is 'rhgs3/rhgs-gluster-block-prov-rhel7'
-| openshift_storage_glusterfs_block_version        | 'latest'                | Container image version to use for glusterblock-provisioner pod
-| openshift_storage_glusterfs_block_host_vol_create| True                    | Automatically create GlusterFS volumes to host glusterblock volumes. **NOTE:** If this is False, block-hosting volumes will need to be manually created before glusterblock volumes can be provisioned
-| openshift_storage_glusterfs_block_host_vol_size  | 100                     | Size, in GB, of GlusterFS volumes that will be automatically create to host glusterblock volumes if not enough space is available for a glusterblock volume create request. **NOTE:** This value is effectively an upper limit on the size of glusterblock volumes unless you manually create larger GlusterFS block-hosting volumes
-| openshift_storage_glusterfs_block_host_vol_max   | 15                      | Max number of GlusterFS volumes to host glusterblock volumes
-| openshift_storage_glusterfs_s3_deploy            | True                    | Deploy gluster-s3 service
-| openshift_storage_glusterfs_s3_image             | 'gluster/gluster-object'| Container image to use for gluster-s3 pod, enterprise default is 'rhgs3/rhgs-gluster-s3-server-rhel7'
-| openshift_storage_glusterfs_s3_version           | 'latest'                | Container image version to use for gluster=s3 pod
-| openshift_storage_glusterfs_s3_account           | Undefined               | S3 account name for the S3 service, required for S3 service deployment
-| openshift_storage_glusterfs_s3_user              | Undefined               | S3 user name for the S3 service, required for S3 service deployment
-| openshift_storage_glusterfs_s3_password          | Undefined               | S3 user password for the S3 service, required for S3 service deployment
-| openshift_storage_glusterfs_s3_pvc               | Dynamic                 | Name of the GlusterFS-backed PVC which will be used for S3 object data storage, generated from the cluster name and S3 account by default
-| openshift_storage_glusterfs_s3_pvc_size          | "2Gi"                   | Size, in Gi, of the GlusterFS-backed PVC which will be used for S3 object data storage
-| openshift_storage_glusterfs_s3_meta_pvc          | Dynamic                 | Name of the GlusterFS-backed PVC which will be used for S3 object metadata storage, generated from the cluster name and S3 account by default
-| openshift_storage_glusterfs_s3_meta_pvc_size     | "1Gi"                   | Size, in Gi, of the GlusterFS-backed PVC which will be used for S3 object metadata storage
-| openshift_storage_glusterfs_wipe                 | False                   | Destroy any existing GlusterFS resources and wipe storage devices. **WARNING: THIS WILL DESTROY ANY DATA ON THOSE DEVICES.**
-| openshift_storage_glusterfs_heketi_is_native     | True                    | heketi should be containerized
-| openshift_storage_glusterfs_heketi_cli           | 'heketi-cli'            | Command/Path to invoke the heketi-cli tool **NOTE:** Change this only for **non-native heketi** if heketi-cli is not in the global `$PATH` of the machine running openshift-ansible
-| openshift_storage_glusterfs_heketi_image         | 'heketi/heketi'         | Container image to use for heketi pods, enterprise default is 'rhgs3/rhgs-volmanager-rhel7'
-| openshift_storage_glusterfs_heketi_version       | 'latest'                | Container image version to use for heketi pods
-| openshift_storage_glusterfs_heketi_admin_key     | auto-generated          | String to use as secret key for performing heketi commands as admin
-| openshift_storage_glusterfs_heketi_user_key      | auto-generated          | String to use as secret key for performing heketi commands as user that can only view or modify volumes
-| openshift_storage_glusterfs_heketi_topology_load | True                    | Load the GlusterFS topology information into heketi
-| openshift_storage_glusterfs_heketi_url           | Undefined               | When heketi is native, this sets the hostname portion of the final heketi route URL. When heketi is external, this is the FQDN or IP address to the heketi service.
-| openshift_storage_glusterfs_heketi_port          | 8080                    | TCP port for external heketi service **NOTE:** This has no effect in native mode
-| openshift_storage_glusterfs_heketi_executor      | 'kubernetes'            | Selects how a native heketi service will manage GlusterFS nodes: 'kubernetes' for native nodes, 'ssh' for external nodes
-| openshift_storage_glusterfs_heketi_ssh_port      | 22                      | SSH port for external GlusterFS nodes via native heketi
-| openshift_storage_glusterfs_heketi_ssh_user      | 'root'                  | SSH user for external GlusterFS nodes via native heketi
-| openshift_storage_glusterfs_heketi_ssh_sudo      | False                   | Whether to sudo (if non-root user) for SSH to external GlusterFS nodes via native heketi
-| openshift_storage_glusterfs_heketi_ssh_keyfile   | Undefined               | Path to a private key file for use with SSH connections to external GlusterFS nodes via native heketi **NOTE:** This must be an absolute path
+| Name                                                   | Default value           | Description                             |
+|--------------------------------------------------------|-------------------------|-----------------------------------------|
+| openshift_storage_glusterfs_timeout                    | 300                     | Seconds to wait for pods to become ready
+| openshift_storage_glusterfs_namespace                  | 'glusterfs'             | Namespace/project in which to create GlusterFS resources
+| openshift_storage_glusterfs_is_native                  | True                    | GlusterFS should be containerized
+| openshift_storage_glusterfs_name                       | 'storage'               | A name to identify the GlusterFS cluster, which will be used in resource names
+| openshift_storage_glusterfs_nodeselector               | 'glusterfs=storage-host'| Selector to determine which nodes will host GlusterFS pods in native mode. **NOTE:** The label value is taken from the cluster name
+| openshift_storage_glusterfs_use_default_selector       | False                   | Whether to use a default node selector for the GlusterFS namespace/project. If False, the namespace/project will have no restricting node selector. If True, uses pre-existing or default (e.g. osm_default_node_selector) node selectors. **NOTE:** If True, nodes which will host GlusterFS pods must already have the additional labels.
+| openshift_storage_glusterfs_storageclass               | True                    | Automatically create a StorageClass for each GlusterFS cluster
+| openshift_storage_glusterfs_storageclass_default       | False                   | Sets the StorageClass for each GlusterFS cluster as default
+| openshift_storage_glusterfs_image                      | 'gluster/gluster-centos'| Container image to use for GlusterFS pods, enterprise default is 'rhgs3/rhgs-server-rhel7'
+| openshift_storage_glusterfs_version                    | 'latest'                | Container image version to use for GlusterFS pods
+| openshift_storage_glusterfs_block_deploy               | True                    | Deploy glusterblock provisioner service
+| openshift_storage_glusterfs_block_image                | 'gluster/glusterblock-provisioner'| Container image to use for glusterblock-provisioner pod, enterprise default is 'rhgs3/rhgs-gluster-block-prov-rhel7'
+| openshift_storage_glusterfs_block_version              | 'latest'                | Container image version to use for glusterblock-provisioner pod
+| openshift_storage_glusterfs_block_host_vol_create      | True                    | Automatically create GlusterFS volumes to host glusterblock volumes. **NOTE:** If this is False, block-hosting volumes will need to be manually created before glusterblock volumes can be provisioned
+| openshift_storage_glusterfs_block_host_vol_size        | 100                     | Size, in GB, of GlusterFS volumes that will be automatically create to host glusterblock volumes if not enough space is available for a glusterblock volume create request. **NOTE:** This value is effectively an upper limit on the size of glusterblock volumes unless you manually create larger GlusterFS block-hosting volumes
+| openshift_storage_glusterfs_block_host_vol_max         | 15                      | Max number of GlusterFS volumes to host glusterblock volumes
+| openshift_storage_glusterfs_block_storageclass         | False                   | Automatically create a StorageClass for each Gluster Block cluster
+| openshift_storage_glusterfs_block_storageclass_default | False                   | Sets the StorageClass for each Gluster Block cluster as default
+| openshift_storage_glusterfs_s3_deploy                  | True                    | Deploy gluster-s3 service
+| openshift_storage_glusterfs_s3_image                   | 'gluster/gluster-object'| Container image to use for gluster-s3 pod, enterprise default is 'rhgs3/rhgs-gluster-s3-server-rhel7'
+| openshift_storage_glusterfs_s3_version                 | 'latest'                | Container image version to use for gluster=s3 pod
+| openshift_storage_glusterfs_s3_account                 | Undefined               | S3 account name for the S3 service, required for S3 service deployment
+| openshift_storage_glusterfs_s3_user                    | Undefined               | S3 user name for the S3 service, required for S3 service deployment
+| openshift_storage_glusterfs_s3_password                | Undefined               | S3 user password for the S3 service, required for S3 service deployment
+| openshift_storage_glusterfs_s3_pvc                     | Dynamic                 | Name of the GlusterFS-backed PVC which will be used for S3 object data storage, generated from the cluster name and S3 account by default
+| openshift_storage_glusterfs_s3_pvc_size                | "2Gi"                   | Size, in Gi, of the GlusterFS-backed PVC which will be used for S3 object data storage
+| openshift_storage_glusterfs_s3_meta_pvc                | Dynamic                 | Name of the GlusterFS-backed PVC which will be used for S3 object metadata storage, generated from the cluster name and S3 account by default
+| openshift_storage_glusterfs_s3_meta_pvc_size           | "1Gi"                   | Size, in Gi, of the GlusterFS-backed PVC which will be used for S3 object metadata storage
+| openshift_storage_glusterfs_wipe                       | False                   | Destroy any existing GlusterFS resources and wipe storage devices. **WARNING: THIS WILL DESTROY ANY DATA ON THOSE DEVICES.**
+| openshift_storage_glusterfs_heketi_is_native           | True                    | heketi should be containerized
+| openshift_storage_glusterfs_heketi_cli                 | 'heketi-cli'            | Command/Path to invoke the heketi-cli tool **NOTE:** Change this only for **non-native heketi** if heketi-cli is not in the global `$PATH` of the machine running openshift-ansible
+| openshift_storage_glusterfs_heketi_image               | 'heketi/heketi'         | Container image to use for heketi pods, enterprise default is 'rhgs3/rhgs-volmanager-rhel7'
+| openshift_storage_glusterfs_heketi_version             | 'latest'                | Container image version to use for heketi pods
+| openshift_storage_glusterfs_heketi_admin_key           | auto-generated          | String to use as secret key for performing heketi commands as admin
+| openshift_storage_glusterfs_heketi_user_key            | auto-generated          | String to use as secret key for performing heketi commands as user that can only view or modify volumes
+| openshift_storage_glusterfs_heketi_topology_load       | True                    | Load the GlusterFS topology information into heketi
+| openshift_storage_glusterfs_heketi_url                 | Undefined               | When heketi is native, this sets the hostname portion of the final heketi route URL. When heketi is external, this is the FQDN or IP address to the heketi service.
+| openshift_storage_glusterfs_heketi_port                | 8080                    | TCP port for external heketi service **NOTE:** This has no effect in native mode
+| openshift_storage_glusterfs_heketi_executor            | 'kubernetes'            | Selects how a native heketi service will manage GlusterFS nodes: 'kubernetes' for native nodes, 'ssh' for external nodes
+| openshift_storage_glusterfs_heketi_ssh_port            | 22                      | SSH port for external GlusterFS nodes via native heketi
+| openshift_storage_glusterfs_heketi_ssh_user            | 'root'                  | SSH user for external GlusterFS nodes via native heketi
+| openshift_storage_glusterfs_heketi_ssh_sudo            | False                   | Whether to sudo (if non-root user) for SSH to external GlusterFS nodes via native heketi
+| openshift_storage_glusterfs_heketi_ssh_keyfile         | Undefined               | Path to a private key file for use with SSH connections to external GlusterFS nodes via native heketi **NOTE:** This must be an absolute path
 | openshift_storage_glusterfs_heketi_fstab         | '/var/lib/heketi/fstab' | When heketi is native, sets the path to the fstab file on the GlusterFS nodes to update on LVM volume mounts, changes to '/etc/fstab/' when the heketi executor is 'ssh' **NOTE:** This should not need to be changed
 | openshift_storage_glusterfs_heketi_wipe          | False                   | Destroy any existing heketi resources, defaults to the value of `openshift_storage_glusterfs_wipe`
 
@@ -126,14 +128,16 @@ registry. These variables start with the prefix
 values in their corresponding non-registry variables. The following variables
 are an exception:
 
-| Name                                                      | Default value         | Description                             |
-|-----------------------------------------------------------|-----------------------|-----------------------------------------|
-| openshift_storage_glusterfs_registry_namespace            | registry namespace    | Default is to use the hosted registry's namespace, otherwise 'glusterfs'
-| openshift_storage_glusterfs_registry_name                 | 'registry'            | This allows for the logical separation of the registry GlusterFS cluster from other GlusterFS clusters
-| openshift_storage_glusterfs_registry_storageclass         | False                 | It is recommended to not create a StorageClass for GlusterFS clusters serving registry storage, so as to avoid performance penalties
-| openshift_storage_glusterfs_registry_storageclass_default | False                 | Sets the StorageClass for each GlusterFS cluster as default
-| openshift_storage_glusterfs_registry_heketi_admin_key     | auto-generated        | Separate from the above
-| openshift_storage_glusterfs_registry_heketi_user_key      | auto-generated        | Separate from the above
+| Name                                                            | Default value         | Description                             |
+|-----------------------------------------------------------------|-----------------------|-----------------------------------------|
+| openshift_storage_glusterfs_registry_namespace                  | registry namespace    | Default is to use the hosted registry's namespace, otherwise 'glusterfs'
+| openshift_storage_glusterfs_registry_name                       | 'registry'            | This allows for the logical separation of the registry GlusterFS cluster from other GlusterFS clusters
+| openshift_storage_glusterfs_registry_storageclass               | False                 | It is recommended to not create a StorageClass for GlusterFS clusters serving registry storage, so as to avoid performance penalties
+| openshift_storage_glusterfs_registry_storageclass_default       | False                 | Sets the StorageClass for each GlusterFS cluster as default
+| openshift_storage_glusterfs_registry_block_storageclass         | False                 | It is recommended to not create a StorageClass for Gluster Block clusters serving registry storage, so as to avoid performance penalties
+| openshift_storage_glusterfs_registry_block_storageclass_default | False                 | Sets the StorageClass for each Gluster Block cluster as default
+| openshift_storage_glusterfs_registry_heketi_admin_key           | auto-generated        | Separate from the above
+| openshift_storage_glusterfs_registry_heketi_user_key            | auto-generated        | Separate from the above
 
 Additionally, this role's behavior responds to several registry-specific variables in the [openshift_hosted role](../openshift_hosted/README.md):
 

--- a/roles/openshift_storage_glusterfs/defaults/main.yml
+++ b/roles/openshift_storage_glusterfs/defaults/main.yml
@@ -14,6 +14,8 @@ openshift_storage_glusterfs_block_version: 'latest'
 openshift_storage_glusterfs_block_host_vol_create: True
 openshift_storage_glusterfs_block_host_vol_size: 100
 openshift_storage_glusterfs_block_host_vol_max: 15
+openshift_storage_glusterfs_block_storageclass: False
+openshift_storage_glusterfs_block_storageclass_default: False
 openshift_storage_glusterfs_s3_deploy: True
 openshift_storage_glusterfs_s3_image: "{{ 'rhgs3/rhgs-gluster-s3-server-rhel7' | quote if openshift_deployment_type == 'openshift-enterprise' else 'gluster/gluster-object' | quote }}"
 openshift_storage_glusterfs_s3_version: 'latest'
@@ -61,6 +63,8 @@ openshift_storage_glusterfs_registry_block_version: "{{ openshift_storage_gluste
 openshift_storage_glusterfs_registry_block_host_vol_create: "{{ openshift_storage_glusterfs_block_host_vol_create }}"
 openshift_storage_glusterfs_registry_block_host_vol_size: "{{ openshift_storage_glusterfs_block_host_vol_size }}"
 openshift_storage_glusterfs_registry_block_host_vol_max: "{{ openshift_storage_glusterfs_block_host_vol_max }}"
+openshift_storage_glusterfs_registry_block_storageclass: False
+openshift_storage_glusterfs_registry_block_storageclass_default: False
 openshift_storage_glusterfs_registry_s3_deploy: "{{ openshift_storage_glusterfs_s3_deploy }}"
 openshift_storage_glusterfs_registry_s3_image: "{{ openshift_storage_glusterfs_s3_image }}"
 openshift_storage_glusterfs_registry_s3_version: "{{ openshift_storage_glusterfs_s3_version }}"
@@ -103,3 +107,9 @@ r_openshift_storage_glusterfs_os_firewall_allow:
   port: "24008/tcp"
 - service: glusterfs_bricks
   port: "49152-49251/tcp"
+- service: glusterblockd
+  port: "24010/tcp"
+- service: iscsi-targets
+  port: "3260/tcp"
+- service: rpcbind
+  port: "111/tcp"

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
@@ -315,5 +315,31 @@
 - include_tasks: glusterblock_deploy.yml
   when: glusterfs_block_deploy
 
+- block:
+  - name: Create heketi block secret
+    oc_secret:
+      namespace: "{{ glusterfs_namespace }}"
+      state: present
+      name: "heketi-{{ glusterfs_name }}-admin-secret-block"
+      type: "gluster.org/glusterblock"
+      force: True
+      contents:
+      - path: key
+        data: "{{ glusterfs_heketi_admin_key }}"
+    when: glusterfs_heketi_admin_key is defined
+  - name: Generate Gluster Block StorageClass file
+    template:
+      src: "{{ openshift.common.examples_content_version }}/gluster-block-storageclass.yml.j2"
+      dest: "{{ mktemp.stdout }}/gluster-block-storageclass.yml"
+
+  - name: Create Gluster Block StorageClass
+    oc_obj:
+      state: present
+      kind: storageclass
+      name: "glusterfs-{{ glusterfs_name }}-block"
+      files:
+      - "{{ mktemp.stdout }}/gluster-block-storageclass.yml"
+  when: glusterfs_block_storageclass
+
 - include_tasks: gluster_s3_deploy.yml
   when: glusterfs_s3_deploy

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_config.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_config.yml
@@ -17,6 +17,8 @@
     glusterfs_block_host_vol_create: "{{ openshift_storage_glusterfs_block_host_vol_create }}"
     glusterfs_block_host_vol_size: "{{ openshift_storage_glusterfs_block_host_vol_size }}"
     glusterfs_block_host_vol_max: "{{ openshift_storage_glusterfs_block_host_vol_max }}"
+    glusterfs_block_storageclass: "{{ openshift_storage_glusterfs_block_storageclass | bool }}"
+    glusterfs_block_storageclass_default: "{{ openshift_storage_glusterfs_block_storageclass_default | bool }}"
     glusterfs_s3_deploy: "{{ openshift_storage_glusterfs_s3_deploy | bool }}"
     glusterfs_s3_image: "{{ openshift_storage_glusterfs_s3_image }}"
     glusterfs_s3_version: "{{ openshift_storage_glusterfs_s3_version }}"

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_registry.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_registry.yml
@@ -17,6 +17,8 @@
     glusterfs_block_host_vol_create: "{{ openshift_storage_glusterfs_registry_block_host_vol_create }}"
     glusterfs_block_host_vol_size: "{{ openshift_storage_glusterfs_registry_block_host_vol_size }}"
     glusterfs_block_host_vol_max: "{{ openshift_storage_glusterfs_registry_block_host_vol_max }}"
+    glusterfs_block_storageclass: "{{ openshift_storage_glusterfs_registry_block_storageclass | bool }}"
+    glusterfs_block_storageclass_default: "{{ openshift_storage_glusterfs_registry_block_storageclass_default | bool }}"
     glusterfs_s3_deploy: "{{ openshift_storage_glusterfs_registry_s3_deploy | bool }}"
     glusterfs_s3_image: "{{ openshift_storage_glusterfs_registry_s3_image }}"
     glusterfs_s3_version: "{{ openshift_storage_glusterfs_registry_s3_version }}"

--- a/roles/openshift_storage_glusterfs/templates/glusterfs.conf
+++ b/roles/openshift_storage_glusterfs/templates/glusterfs.conf
@@ -2,3 +2,6 @@
 dm_thin_pool
 dm_snapshot
 dm_mirror
+#glusterblock
+dm_multipath
+target_core_user

--- a/roles/openshift_storage_glusterfs/templates/v3.7/gluster-block-storageclass.yml.j2
+++ b/roles/openshift_storage_glusterfs/templates/v3.7/gluster-block-storageclass.yml.j2
@@ -1,0 +1,19 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: glusterfs-{{ glusterfs_name }}-block
+{% if glusterfs_block_storageclass_default is defined and glusterfs_block_storageclass_default %}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+{% endif %}
+provisioner: gluster.org/glusterblock
+parameters:
+  resturl: "http://{% if glusterfs_heketi_is_native %}{{ glusterfs_heketi_route }}{% else %}{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}{% endif %}"
+  restuser: "admin"
+  chapauthenabled: "true"
+  hacount: "3"
+{% if glusterfs_heketi_admin_key is defined %}
+  restsecretnamespace: "{{ glusterfs_namespace }}"
+  restsecretname: "heketi-{{ glusterfs_name }}-admin-secret-block"
+{%- endif -%}

--- a/roles/openshift_storage_glusterfs/templates/v3.8/gluster-block-storageclass.yml.j2
+++ b/roles/openshift_storage_glusterfs/templates/v3.8/gluster-block-storageclass.yml.j2
@@ -1,0 +1,19 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: glusterfs-{{ glusterfs_name }}-block
+{% if glusterfs_block_storageclass_default is defined and glusterfs_block_storageclass_default %}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+{% endif %}
+provisioner: gluster.org/glusterblock
+parameters:
+  resturl: "http://{% if glusterfs_heketi_is_native %}{{ glusterfs_heketi_route }}{% else %}{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}{% endif %}"
+  restuser: "admin"
+  chapauthenabled: "true"
+  hacount: "3"
+{% if glusterfs_heketi_admin_key is defined %}
+  restsecretnamespace: "{{ glusterfs_namespace }}"
+  restsecretname: "heketi-{{ glusterfs_name }}-admin-secret-block"
+{%- endif -%}

--- a/roles/openshift_storage_glusterfs/templates/v3.9/gluster-block-storageclass.yml.j2
+++ b/roles/openshift_storage_glusterfs/templates/v3.9/gluster-block-storageclass.yml.j2
@@ -1,0 +1,19 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: glusterfs-{{ glusterfs_name }}-block
+{% if glusterfs_block_storageclass_default is defined and glusterfs_block_storageclass_default %}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+{% endif %}
+provisioner: gluster.org/glusterblock
+parameters:
+  resturl: "http://{% if glusterfs_heketi_is_native %}{{ glusterfs_heketi_route }}{% else %}{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}{% endif %}"
+  restuser: "admin"
+  chapauthenabled: "true"
+  hacount: "3"
+{% if glusterfs_heketi_admin_key is defined %}
+  restsecretnamespace: "{{ glusterfs_namespace }}"
+  restsecretname: "heketi-{{ glusterfs_name }}-admin-secret-block"
+{%- endif -%}


### PR DESCRIPTION
GlusterBlock support in our ansible for glusterfs role

TODO:

- [ ] checking if only one SC is set default
- [ ] validate if mpath on nodes is configured
- [ ] add check for rhel vs atomic
- [x] make sure rpcbind is running and enabled BEFORE we even start glusterfs pods
- [x] enable mpath 
- [ ] validate kernel module availability

@ckyriakidou
@jarrpa 
