### PR TITLE
Determine which host is the etcd CA host

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
@@ -92,25 +92,3 @@
         state: started
         enabled: yes
       with_items: "{{ master_services }}"
-
-# Until openshift-ansible is determining which host is the CA host we
-# must (unfortunately) ensure that the first host in the etcd group is
-# the etcd CA host.
-# https://bugzilla.redhat.com/show_bug.cgi?id=1469358
-- name: Verify we can proceed on first etcd
-  hosts: oo_first_etcd
-  gather_facts: no
-  tasks:
-  - name: Ensure CA exists on first etcd
-    stat:
-      path: /etc/etcd/generated_certs
-    register: __etcd_ca_stat
-
-  - fail:
-      msg: >
-        In order to correct an etcd certificate signing problem
-        upgrading may require re-generating etcd certificates. Please
-        ensure that the /etc/etcd/generated_certs directory exists on
-        the first host defined in your [etcd] group.
-    when:
-    - not __etcd_ca_stat.stat.exists | bool

--- a/playbooks/openshift-etcd/private/ca.yml
+++ b/playbooks/openshift-etcd/private/ca.yml
@@ -10,7 +10,6 @@
       tasks_from: ca.yml
     vars:
       etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"
-      etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
       etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"
     when:
     - etcd_ca_setup | default(True) | bool

--- a/playbooks/openshift-etcd/private/certificates-backup.yml
+++ b/playbooks/openshift-etcd/private/certificates-backup.yml
@@ -1,6 +1,6 @@
 ---
 - name: Backup and remove generated etcd certificates
-  hosts: oo_first_etcd
+  hosts: oo_etcd_to_config
   any_errors_fatal: true
   tasks:
   - import_role:

--- a/playbooks/openshift-etcd/private/config.yml
+++ b/playbooks/openshift-etcd/private/config.yml
@@ -22,7 +22,6 @@
   - role: openshift_clock
   - role: openshift_etcd
     etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"
-    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
     etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"
   - role: nickhammond.logrotate
 

--- a/playbooks/openshift-etcd/private/master_etcd_certificates.yml
+++ b/playbooks/openshift-etcd/private/master_etcd_certificates.yml
@@ -5,9 +5,7 @@
   roles:
     - role: openshift_etcd_facts
     - role: openshift_etcd_client_certificates
-      etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
       etcd_cert_subdir: "openshift-master-{{ openshift.common.hostname }}"
       etcd_cert_config_dir: "{{ openshift.common.config_base }}/master"
       etcd_cert_prefix: "master.etcd-"
-      openshift_ca_host: "{{ groups.oo_first_master.0 }}"
       when: groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config

--- a/playbooks/openshift-etcd/private/redeploy-ca.yml
+++ b/playbooks/openshift-etcd/private/redeploy-ca.yml
@@ -45,7 +45,6 @@
       tasks_from: distribute_ca.yml
     vars:
       etcd_sync_cert_dir: "{{ hostvars['localhost'].g_etcd_mktemp.stdout }}"
-      etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
 
 - import_playbook: restart.yml
   # Do not restart etcd when etcd certificates were previously expired.

--- a/playbooks/openshift-etcd/private/scaleup.yml
+++ b/playbooks/openshift-etcd/private/scaleup.yml
@@ -12,8 +12,6 @@
   hosts: oo_new_etcd_to_config
   serial: 1
   any_errors_fatal: true
-  vars:
-    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
   pre_tasks:
   - name: Add new etcd members to cluster
     command: >
@@ -42,7 +40,6 @@
   - role: openshift_etcd
     when: etcd_add_check.rc == 0
     etcd_peers: "{{ groups.oo_etcd_to_config | union(groups.oo_new_etcd_to_config)| default([], true) }}"
-    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
     etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"
     etcd_initial_cluster_state: "existing"
     etcd_initial_cluster: "{{ etcd_add_check.stdout_lines[3] | regex_replace('ETCD_INITIAL_CLUSTER=','') | regex_replace('\"','') }}"
@@ -66,8 +63,6 @@
   hosts: oo_masters_to_config
   serial: 1
   vars:
-    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
     openshift_master_etcd_hosts: "{{ hostvars
                                      | lib_utils_oo_select_keys(groups['oo_etcd_to_config'] | union(groups['oo_new_etcd_to_config'] | default([]) ))
                                      | lib_utils_oo_collect('openshift.common.hostname')

--- a/playbooks/openshift-etcd/private/server_certificates.yml
+++ b/playbooks/openshift-etcd/private/server_certificates.yml
@@ -9,6 +9,5 @@
         name: etcd
         tasks_from: server_certificates.yml
       vars:
-        etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
         etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"
         etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"

--- a/playbooks/openshift-master/private/scaleup.yml
+++ b/playbooks/openshift-master/private/scaleup.yml
@@ -46,7 +46,7 @@
 
 - import_playbook: set_network_facts.yml
 
-- import_playbook: ../../openshift-etcd/private/certificates.yml
+- import_playbook: ../../openshift-etcd/private/master_etcd_certificates.yml
 
 - import_playbook: config.yml
 

--- a/playbooks/openshift-node/private/etcd_client_config.yml
+++ b/playbooks/openshift-node/private/etcd_client_config.yml
@@ -6,6 +6,5 @@
   - role: openshift_etcd_facts
   - role: openshift_etcd_client_certificates
     etcd_cert_prefix: flannel.etcd-
-    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
     etcd_cert_subdir: "openshift-node-{{ openshift.common.hostname }}"
     etcd_cert_config_dir: "{{ openshift.common.config_base }}/node"

--- a/roles/lib_utils/filter_plugins/oo_filters.py
+++ b/roles/lib_utils/filter_plugins/oo_filters.py
@@ -126,7 +126,7 @@ def lib_utils_oo_collect(data_list, attribute=None, filters=None):
             raise errors.AnsibleFilterError(
                 "lib_utils_oo_collect expects filter to be a dict")
         retval.extend([get_attr(d, attribute) for d in data if (
-            all([d.get(key, None) == filters[key] for key in filters]))])
+            all([get_attr(d, key) == filters[key] for key in filters]))])
     else:
         retval.extend([get_attr(d, attribute) for d in data])
 

--- a/roles/openshift_etcd_facts/defaults/main.yml
+++ b/roles/openshift_etcd_facts/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+etcd_ca_host_group: "oo_etcd_to_config"

--- a/roles/openshift_etcd_facts/tasks/main.yml
+++ b/roles/openshift_etcd_facts/tasks/main.yml
@@ -1,1 +1,2 @@
 ---
+- import_tasks: set_etcd_ca_host.yml

--- a/roles/openshift_etcd_facts/tasks/set_etcd_ca_host.yml
+++ b/roles/openshift_etcd_facts/tasks/set_etcd_ca_host.yml
@@ -1,0 +1,44 @@
+---
+- name: Check for CA indicator files
+  stat:
+    path: "{{ item.0 }}"
+  delegate_to: "{{ item.1 }}"
+  with_nested:
+  - - /etc/etcd/ca
+    - /etc/etcd/generated_certs
+  - "{{ groups[etcd_ca_host_group] }}"
+  register: __etcd_ca_host_stat
+  run_once: true
+
+# Collect ansible_host (inventory hostname) of hosts with /etc/etcd/ca
+# and /etc/etcd/generated_certs directories.
+- set_fact:
+    __etcd_ca_dir_hosts: "{{ __etcd_ca_host_stat.results
+                             | lib_utils_oo_collect('_ansible_delegated_vars.ansible_host',
+                                                    filters={'stat.path':'/etc/etcd/ca','stat.exists':True}) }}"
+    __etcd_generated_certs_dir_hosts: "{{ __etcd_ca_host_stat.results
+                                          | lib_utils_oo_collect('_ansible_delegated_vars.ansible_host',
+                                                                 filters={'stat.path':'/etc/etcd/generated_certs','stat.exists':True}) }}"
+  run_once: true
+
+# __etcd_ca_hosts is the intersection of hosts which have /etc/etcd/ca
+# and /etc/etcd/generated_certs directories.
+- set_fact:
+    __etcd_ca_hosts: "{{ __etcd_ca_dir_hosts | intersect(__etcd_generated_certs_dir_hosts) }}"
+  run_once: true
+
+# __etcd_ca_hosts should only contain one host. If more than one host
+# is able to be an etcd CA host then we will use the first.
+- set_fact:
+    etcd_ca_host: "{{ __etcd_ca_hosts[0] }}"
+  when:
+  - __etcd_ca_hosts | length > 0
+  - etcd_ca_host is not defined
+
+# No etcd_ca_host was found in __etcd_ca_hosts. This is probably a
+# fresh installation so we will default to the first member of the
+# etcd host group.
+- set_fact:
+    etcd_ca_host: "{{ groups[etcd_ca_host_group].0 }}"
+  when:
+  - etcd_ca_host is not defined


### PR DESCRIPTION
Tested by installing a cluster & re-ordering the etcd host group. `etcd_ca_host` should remain the same.

```
---
- import_playbook: init/evaluate_groups.yml

- hosts: oo_masters_to_config
  gather_facts: no
  tasks:
  - import_role:
      name: openshift_etcd_facts
      tasks_from: set_etcd_ca_host.yml
  - debug: var=etcd_ca_host
```