### PR TITLE
Don't deploy the console if disabled or registry subtype

### DIFF
--- a/playbooks/init/basic_facts.yml
+++ b/playbooks/init/basic_facts.yml
@@ -67,3 +67,11 @@
       first_master_client_binary: "{{  openshift_client_binary }}"
       #Some roles may require this to be set for first master
       openshift_client_binary: "{{ openshift_client_binary }}"
+
+- name: Disable web console if required
+  hosts: oo_masters_to_config
+  gather_facts: no
+  tasks:
+  - set_fact:
+      openshift_web_console_install: False
+    when: openshift_deployment_subtype == 'registry' or ( osm_disabled_features is defined and 'WebConsole' in osm_disabled_features )


### PR DESCRIPTION
Whenever openshift_deployment_subtype == registry or the console is explicitly listed as a disabled feature don't deploy.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1538974