### PR TITLE
Removing ability to change default cassandra_pvc_prefix based on metr…

### DIFF
--- a/roles/openshift_metrics/defaults/main.yaml
+++ b/roles/openshift_metrics/defaults/main.yaml
@@ -54,7 +54,7 @@ openshift_metrics_master_url: https://kubernetes.default.svc
 openshift_metrics_node_id: nodename
 openshift_metrics_project: openshift-infra
 
-openshift_metrics_cassandra_pvc_prefix: "{{ openshift_metrics_storage_volume_name | default('metrics-cassandra') }}"
+openshift_metrics_cassandra_pvc_prefix: metrics-cassandra
 openshift_metrics_cassandra_pvc_access: "{{ openshift_metrics_storage_access_modes | default(['ReadWriteOnce']) }}"
 
 openshift_metrics_hawkular_user_write_access: False


### PR DESCRIPTION
…ics volume name

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1539382
There isn't a reason to change the pvc name to match the volume name.