### PR TITLE
Add OpenStack heat checks

### DIFF
--- a/roles/openshift_openstack/tasks/provision.yml
+++ b/roles/openshift_openstack/tasks/provision.yml
@@ -4,6 +4,16 @@
   when:
   - openshift_openstack_stack_state == 'present'
 
+- name: check for openstack client
+  command: openstack
+  register: openstack_cli_exists
+  ignore_errors: True
+
+- name: validate the Heat template
+  command: openstack orchestration template validate -t {{ stack_template_path }}
+  register: template_validation_output
+  when: openstack_cli_exists|succeeded
+
 - name: Handle the Stack (create/delete)
   ignore_errors: False
   register: stack_create

--- a/roles/openshift_openstack/tasks/provision.yml
+++ b/roles/openshift_openstack/tasks/provision.yml
@@ -15,13 +15,31 @@
   when: openstack_cli_exists|succeeded
 
 - name: Handle the Stack (create/delete)
-  ignore_errors: False
+  ignore_errors: True
   register: stack_create
   os_stack:
     name: "{{ openshift_openstack_stack_name }}"
     state: "{{ openshift_openstack_stack_state }}"
     template: "{{ stack_template_path | default(omit) }}"
     wait: yes
+
+- name: get errors in stack creation, if any
+  command: openstack stack failures list {{ openshift_openstack_stack_name }}
+  register: stack_create_failures
+  when:
+  - openstack_cli_exists|succeeded
+  - stack_create|failed
+
+- name: show errors in stack creation, if any
+  debug: var=stack_create_failures
+  when:
+  - openstack_cli_exists|succeeded
+  - stack_create|failed
+
+- fail:
+    msg: Stack creation failed
+  when:
+  - stack_create|failed
 
 - name: Add the new nodes to the inventory
   meta: refresh_inventory


### PR DESCRIPTION
If the openstack client is present:
 * validates the templates
 * show a clearer stack failure summary if the stack fails to create