### PR TITLE
[WIP] Taint masters to make web console pods run there

### DIFF
--- a/playbooks/openshift-node/private/manage_node.yml
+++ b/playbooks/openshift-node/private/manage_node.yml
@@ -7,6 +7,7 @@
   - role: openshift_manage_node
     openshift_master_host: "{{ groups.oo_first_master.0 }}"
     openshift_manage_node_is_master: "{{ ('oo_masters_to_config' in group_names) | bool }}"
+    openshift_has_dedicated_nodes: "{{ groups['oo_nodes_to_config'] | length != groups['oo_masters_to_config'] | length | bool }}"
   tasks:
   - name: Create group for deployment type
     group_by: key=oo_nodes_deployment_type_{{ openshift.common.deployment_type }}

--- a/roles/openshift_manage_node/defaults/main.yml
+++ b/roles/openshift_manage_node/defaults/main.yml
@@ -3,3 +3,5 @@
 openshift_manage_node_is_master: False
 openshift_master_node_labels:
   node-role.kubernetes.io/master: 'true'
+l_openshift_master_webconsole_taint_noexecute_labels: "{{ openshift_master_webconsole_taint_noexecute_labels | default('webconsole=true') }}"
+l_openshift_master_webconsole_taint_noschedule_labels: "{{ openshift_master_webconsole_taint_noschedule_labels | default('webconsole=true') }}"

--- a/roles/openshift_manage_node/defaults/main.yml
+++ b/roles/openshift_manage_node/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 # openshift_manage_node_is_master is set at the play level.
 openshift_manage_node_is_master: False
+# openshift_has_dedicated_nodes is set on play level, don't taint node if its the only node
+openshift_has_dedicated_nodes: False
 openshift_master_node_labels:
   node-role.kubernetes.io/master: 'true'
-l_openshift_master_webconsole_taint_noexecute_labels: "{{ openshift_master_webconsole_taint_noexecute_labels | default('webconsole=true') }}"
-l_openshift_master_webconsole_taint_noschedule_labels: "{{ openshift_master_webconsole_taint_noschedule_labels | default('webconsole=true') }}"
+l_openshift_master_webconsole_taint_noexecute_labels: "webconsole=true"
+l_openshift_master_webconsole_taint_noschedule_labels: "webconsole=true"

--- a/roles/openshift_manage_node/tasks/config.yml
+++ b/roles/openshift_manage_node/tasks/config.yml
@@ -25,3 +25,12 @@
     l_node_labels: "{{ openshift_node_labels | default({}) }}"
     l_master_labels: "{{ openshift_manage_node_is_master | ternary(openshift_master_node_labels, {}) }}"
     l_all_labels: "{{ l_node_labels | combine(l_master_labels) }}"
+
+- name: Taint master nodes
+  shell: >
+    {{ openshift_client_binary }} adm taint nodes {{ openshift.node.nodename }} {{ item.label }}:{{ item.effect }} --overwrite
+  with_items:
+    - { effect: "NoExecute", label: "{{ l_openshift_master_webconsole_taint_noexecute_labels }}" }
+    - { effect: "NoSchedule", label: "{{ l_openshift_master_webconsole_taint_noschedule_labels }}" }
+  when: "{{ openshift_manage_node_is_master }}"
+  delegate_to: "{{ openshift_master_host }}"

--- a/roles/openshift_manage_node/tasks/config.yml
+++ b/roles/openshift_manage_node/tasks/config.yml
@@ -32,5 +32,7 @@
   with_items:
     - { effect: "NoExecute", label: "{{ l_openshift_master_webconsole_taint_noexecute_labels }}" }
     - { effect: "NoSchedule", label: "{{ l_openshift_master_webconsole_taint_noschedule_labels }}" }
-  when: "{{ openshift_manage_node_is_master }}"
+  when:
+    - openshift_manage_node_is_master
+    - openshift_has_dedicated_nodes
   delegate_to: "{{ openshift_master_host }}"

--- a/roles/openshift_web_console/files/console-template.yaml
+++ b/roles/openshift_web_console/files/console-template.yaml
@@ -76,6 +76,15 @@ objects:
               cpu: 100m
               memory: 100Mi
         nodeSelector: "${{NODE_SELECTOR}}"
+        tolerations:
+        - key: "webconsole"
+          operator: "Equal"
+          value: "true"
+          effect: "NoExecute"
+        - key: "webconsole"
+          operator: "Equal"
+          value: "true"
+          effect: "NoSchedule"
         volumes:
         - name: serving-cert
           secret:


### PR DESCRIPTION
This PR ensures that :
 * masters are schedulable
 * webconsole taints are set to make only web console pods run there
 * skip tainting if no dedicated nodes are available (number of nodes == number of masters)

Note, that this change might break setups with 'openshift_node_labels: region=infra' set globally