### PR TITLE
cri-o: export variables defined in crio-network

### DIFF
--- a/roles/container_runtime/templates/crio-network.j2
+++ b/roles/container_runtime/templates/crio-network.j2
@@ -1,9 +1,9 @@
 {% if 'http_proxy' in openshift.common %}
-HTTP_PROXY={{ openshift.common.http_proxy }}
+export HTTP_PROXY={{ openshift.common.http_proxy }}
 {% endif %}
 {% if 'https_proxy' in openshift.common %}
-HTTPS_PROXY={{ openshift.common.https_proxy }}
+export HTTPS_PROXY={{ openshift.common.https_proxy }}
 {% endif %}
 {% if 'no_proxy' in openshift.common %}
-NO_PROXY={{ openshift.common.no_proxy }}
+export NO_PROXY={{ openshift.common.no_proxy }}
 {% endif %}


### PR DESCRIPTION
so that the cri-o process can use them.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1529478

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>