### PR TITLE
[release-3.7] Correct ability to override openshift_management_app_template

### DIFF
--- a/roles/openshift_management/defaults/main.yml
+++ b/roles/openshift_management/defaults/main.yml
@@ -15,6 +15,8 @@ openshift_management_pod_rollout_retries: 30
 #
 # Choose 'miq-template' for a podified database install
 # Choose 'miq-template-ext-db' for an external database install
+# TODO: Swap this var declaration once CFME is fully supported
+#openshift_management_app_template: "{{ 'cfme-template' if openshift_deployment_type == 'openshift-enterprise' else 'miq-template' }}"
 openshift_management_app_template: miq-template
 # If you are using the miq-template-ext-db template then you must add
 # the required database parameters to the

--- a/roles/openshift_management/tasks/accounts.yml
+++ b/roles/openshift_management/tasks/accounts.yml
@@ -5,14 +5,14 @@
   oc_serviceaccount:
     namespace: "{{ openshift_management_project }}"
     state: present
-    name: "{{ openshift_management_flavor_short }}{{ item.name }}"
+    name: "{{ __openshift_management_flavor_short }}{{ item.name }}"
   with_items:
     - "{{ __openshift_system_account_sccs }}"
 
 - name: Ensure the CFME system accounts have all the required SCCs
   oc_adm_policy_user:
     namespace: "{{ openshift_management_project }}"
-    user: "system:serviceaccount:{{ openshift_management_project }}:{{ openshift_management_flavor_short }}{{ item.name }}"
+    user: "system:serviceaccount:{{ openshift_management_project }}:{{ __openshift_management_flavor_short }}{{ item.name }}"
     resource_kind: scc
     resource_name: "{{ item.resource_name }}"
   with_items:
@@ -21,7 +21,7 @@
 - name: Ensure the CFME system accounts have the required roles
   oc_adm_policy_user:
     namespace: "{{ openshift_management_project }}"
-    user: "system:serviceaccount:{{ openshift_management_project }}:{{ openshift_management_flavor_short }}{{ item.name }}"
+    user: "system:serviceaccount:{{ openshift_management_project }}:{{ __openshift_management_flavor_short }}{{ item.name }}"
     resource_kind: role
     resource_name: "{{ item.resource_name }}"
   with_items:

--- a/roles/openshift_management/tasks/main.yml
+++ b/roles/openshift_management/tasks/main.yml
@@ -72,15 +72,15 @@
 # CREATE APP
 - name: Note the correct ext-db template name
   set_fact:
-    openshift_management_template_name: "{{ openshift_management_flavor }}-ext-db"
+    openshift_management_template_name: "{{ __openshift_management_flavor }}-ext-db"
   when:
-    - openshift_management_app_template in ['miq-template-ext-db', 'cfme-template-ext-db']
+    - __openshift_management_use_ext_db
 
 - name: Note the correct podified db template name
   set_fact:
-    openshift_management_template_name: "{{ openshift_management_flavor }}"
+    openshift_management_template_name: "{{ __openshift_management_flavor }}"
   when:
-    - openshift_management_app_template in ['miq-template', 'cfme-template']
+    - not __openshift_management_use_ext_db
 
 - name: Ensure the Management App is created
   oc_process:
@@ -90,7 +90,7 @@
     params: "{{ openshift_management_template_parameters }}"
 
 - name: Wait for the app to come up. May take several minutes, 30s check intervals, {{ openshift_management_pod_rollout_retries }} retries
-  command: "oc logs {{ openshift_management_flavor }}-0 -n {{ openshift_management_project }}"
+  command: "oc logs {{ __openshift_management_flavor }}-0 -n {{ openshift_management_project }}"
   register: app_seeding_logs
   until: app_seeding_logs.stdout.find('Server starting complete') != -1
   delay: 30

--- a/roles/openshift_management/tasks/storage/create_nfs_pvs.yml
+++ b/roles/openshift_management/tasks/storage/create_nfs_pvs.yml
@@ -12,7 +12,7 @@
   when:
     - openshift_management_template_parameters.APPLICATION_VOLUME_CAPACITY is not defined
 
-- when: openshift_management_app_template in ['miq-template', 'cfme-template']
+- when: not __openshift_management_use_ext_db
   block:
     - name: Note the DB PV Size from Template Parameters
       set_fact:
@@ -31,7 +31,7 @@
     namespace: "{{ openshift_management_project }}"
     state: list
     kind: pv
-    name: "{{ openshift_management_flavor_short }}-app"
+    name: "{{ __openshift_management_flavor_short }}-app"
   register: miq_app_pv_check
 
 - name: Check if the Management DB PV has been created
@@ -39,15 +39,15 @@
     namespace: "{{ openshift_management_project }}"
     state: list
     kind: pv
-    name: "{{ openshift_management_flavor_short }}-db"
+    name: "{{ __openshift_management_flavor_short }}-db"
   register: miq_db_pv_check
   when:
-    - openshift_management_app_template in ['miq-template', 'cfme-template']
+    - not __openshift_management_use_ext_db
 
 - name: Ensure the Management App PV is created
   oc_process:
     namespace: "{{ openshift_management_project }}"
-    template_name: "{{ openshift_management_flavor }}-app-pv"
+    template_name: "{{ __openshift_management_flavor }}-app-pv"
     create: True
     params:
       PV_SIZE: "{{ openshift_management_app_pv_size }}"
@@ -58,12 +58,12 @@
 - name: Ensure the Management DB PV is created
   oc_process:
     namespace: "{{ openshift_management_project }}"
-    template_name: "{{ openshift_management_flavor }}-db-pv"
+    template_name: "{{ __openshift_management_flavor }}-db-pv"
     create: True
     params:
       PV_SIZE: "{{ openshift_management_db_pv_size }}"
       BASE_PATH: "{{ openshift_management_storage_nfs_base_dir }}"
       NFS_HOST: "{{ openshift_management_nfs_server }}"
   when:
-    - openshift_management_app_template in ['miq-template', 'cfme-template']
+    - not __openshift_management_use_ext_db
     - miq_db_pv_check.results.results == [{}]

--- a/roles/openshift_management/tasks/storage/nfs.yml
+++ b/roles/openshift_management/tasks/storage/nfs.yml
@@ -18,8 +18,8 @@
         tasks_from: create_export
       vars:
         l_nfs_base_dir: "{{ openshift_management_storage_nfs_base_dir }}"
-        l_nfs_export_config: "{{ openshift_management_flavor_short }}"
-        l_nfs_export_name: "{{ openshift_management_flavor_short }}-app"
+        l_nfs_export_config: "{{ __openshift_management_flavor_short }}"
+        l_nfs_export_name: "{{ __openshift_management_flavor_short }}-app"
         l_nfs_options: "*(rw,no_root_squash,no_wdelay)"
       static: true
 
@@ -29,11 +29,11 @@
         tasks_from: create_export
       vars:
         l_nfs_base_dir: "{{ openshift_management_storage_nfs_base_dir }}"
-        l_nfs_export_config: "{{ openshift_management_flavor_short }}"
-        l_nfs_export_name: "{{ openshift_management_flavor_short }}-db"
+        l_nfs_export_config: "{{ __openshift_management_flavor_short }}"
+        l_nfs_export_name: "{{ __openshift_management_flavor_short }}-db"
         l_nfs_options: "*(rw,no_root_squash,no_wdelay)"
       when:
-        - openshift_management_app_template in ['miq-template', 'cfme-template']
+        - not __openshift_management_use_ext_db
       static: true
 
   delegate_to: "{{ openshift_management_nfs_server }}"

--- a/roles/openshift_management/tasks/template.yml
+++ b/roles/openshift_management/tasks/template.yml
@@ -13,59 +13,59 @@
 
 ######################################################################
 # STANDARD PODIFIED DATABASE TEMPLATE
-- when: openshift_management_app_template in ['miq-template', 'cfme-template']
+- when: not __openshift_management_use_ext_db
   block:
   - name: Check if the Management Server template has been created already
     oc_obj:
       namespace: "{{ openshift_management_project }}"
       state: list
       kind: template
-      name: "{{ openshift_management_flavor }}"
+      name: "{{ __openshift_management_flavor }}"
     register: miq_server_check
 
   - when: miq_server_check.results.results == [{}]
     block:
     - name: Copy over Management Server template
       copy:
-        src: "templates/{{ openshift_management_flavor }}/{{ openshift_management_flavor_short }}-template.yaml"
+        src: "templates/{{ __openshift_management_flavor }}/{{ __openshift_management_flavor_short }}-template.yaml"
         dest: "{{ template_dir }}/"
 
     - name: Ensure Management Server Template is created
       oc_obj:
         namespace: "{{ openshift_management_project }}"
-        name: "{{ openshift_management_flavor }}"
+        name: "{{ __openshift_management_flavor }}"
         state: present
         kind: template
         files:
-        - "{{ template_dir }}/{{ openshift_management_flavor_short }}-template.yaml"
+        - "{{ template_dir }}/{{ __openshift_management_flavor_short }}-template.yaml"
 
 ######################################################################
 # EXTERNAL DATABASE TEMPLATE
-- when: openshift_management_app_template in ['miq-template-ext-db', 'cfme-template-ext-db']
+- when: __openshift_management_use_ext_db
   block:
   - name: Check if the Management Ext-DB Server template has been created already
     oc_obj:
       namespace: "{{ openshift_management_project }}"
       state: list
       kind: template
-      name: "{{ openshift_management_flavor }}-ext-db"
+      name: "{{ __openshift_management_flavor }}-ext-db"
     register: miq_ext_db_server_check
 
   - when: miq_ext_db_server_check.results.results == [{}]
     block:
     - name: Copy over Management Ext-DB Server template
       copy:
-        src: "templates/{{ openshift_management_flavor }}/{{openshift_management_flavor_short}}-template-ext-db.yaml"
+        src: "templates/{{ __openshift_management_flavor }}/{{__openshift_management_flavor_short}}-template-ext-db.yaml"
         dest: "{{ template_dir }}/"
 
     - name: Ensure Management Ext-DB Server Template is created
       oc_obj:
         namespace: "{{ openshift_management_project }}"
-        name: "{{ openshift_management_flavor }}-ext-db"
+        name: "{{ __openshift_management_flavor }}-ext-db"
         state: present
         kind: template
         files:
-        - "{{ template_dir }}/{{ openshift_management_flavor_short }}-template-ext-db.yaml"
+        - "{{ template_dir }}/{{ __openshift_management_flavor_short }}-template-ext-db.yaml"
 
 # End app template creation.
 ######################################################################
@@ -79,50 +79,50 @@
     namespace: "{{ openshift_management_project }}"
     state: list
     kind: template
-    name: "{{ openshift_management_flavor }}-app-pv"
+    name: "{{ __openshift_management_flavor }}-app-pv"
   register: miq_app_pv_check
 
 - when: miq_app_pv_check.results.results == [{}]
   block:
   - name: Copy over Management App PV template
     copy:
-      src: "templates/{{ openshift_management_flavor }}/{{ openshift_management_flavor_short }}-pv-server-example.yaml"
+      src: "templates/{{ __openshift_management_flavor }}/{{ __openshift_management_flavor_short }}-pv-server-example.yaml"
       dest: "{{ template_dir }}/"
 
   - name: Ensure Management App PV Template is created
     oc_obj:
       namespace: "{{ openshift_management_project }}"
-      name: "{{ openshift_management_flavor }}-app-pv"
+      name: "{{ __openshift_management_flavor }}-app-pv"
       state: present
       kind: template
       files:
-      - "{{ template_dir }}/{{ openshift_management_flavor_short }}-pv-server-example.yaml"
+      - "{{ template_dir }}/{{ __openshift_management_flavor_short }}-pv-server-example.yaml"
 
 #---------------------------------------------------------------------
 
 # Required for database if the installation is fully podified
-- when: openshift_management_app_template in ['miq-template', 'cfme-template']
+- when: not __openshift_management_use_ext_db
   block:
   - name: Check if the Management DB PV template has been created already
     oc_obj:
       namespace: "{{ openshift_management_project }}"
       state: list
       kind: template
-      name: "{{ openshift_management_flavor }}-db-pv"
+      name: "{{ __openshift_management_flavor }}-db-pv"
     register: miq_db_pv_check
 
   - when: miq_db_pv_check.results.results == [{}]
     block:
     - name: Copy over Management DB PV template
       copy:
-        src: "templates/{{ openshift_management_flavor }}/{{ openshift_management_flavor_short }}-pv-db-example.yaml"
+        src: "templates/{{ __openshift_management_flavor }}/{{ __openshift_management_flavor_short }}-pv-db-example.yaml"
         dest: "{{ template_dir }}/"
 
     - name: Ensure Management DB PV Template is created
       oc_obj:
         namespace: "{{ openshift_management_project }}"
-        name: "{{ openshift_management_flavor }}-db-pv"
+        name: "{{ __openshift_management_flavor }}-db-pv"
         state: present
         kind: template
         files:
-        - "{{ template_dir }}/{{ openshift_management_flavor_short }}-pv-db-example.yaml"
+        - "{{ template_dir }}/{{ __openshift_management_flavor_short }}-pv-db-example.yaml"

--- a/roles/openshift_management/tasks/validate.yml
+++ b/roles/openshift_management/tasks/validate.yml
@@ -100,4 +100,4 @@
       'openshift_management_template_parameters'"
   with_items: "{{ __openshift_management_required_db_conn_params }}"
   when:
-    - openshift_management_app_template in ['miq-template-ext-db', 'cfme-template-ext-db']
+    - __openshift_management_use_ext_db

--- a/roles/openshift_management/vars/main.yml
+++ b/roles/openshift_management/vars/main.yml
@@ -30,14 +30,18 @@ __openshift_management_db_parameters:
   - DATABASE_PORT
   - DATABASE_NAME
 
-# # Commented out until we can support both CFME and MIQ
-# # openshift_management_flavor: "{{ 'cloudforms' if openshift_deployment_type == 'openshift-enterprise' else 'manageiq' }}"
-#openshift_management_flavor: cloudforms
-openshift_management_flavor: manageiq
-# TODO: Make this conditional as well based on the prior variable
-# # openshift_management_flavor_short: "{{ 'cfme' if openshift_deployment_type == 'openshift-enterprise' else 'miq' }}"
-# openshift_management_flavor_short: cfme
-openshift_management_flavor_short: miq
+__openshift_management_flavors:
+  miq:
+    short: miq
+    long: manageiq
+  cfme:
+    short: cfme
+    long: cloudforms
+
+__openshift_management_flavor: "{{ __openshift_management_flavors[openshift_management_app_template.split('-')[0]]['long'] }}"
+__openshift_management_flavor_short: "{{ __openshift_management_flavors[openshift_management_app_template.split('-')[0]]['short'] }}"
+
+__openshift_management_use_ext_db: "{{ true if 'ext-db' in openshift_management_app_template else false }}"
 
 ######################################################################
 # ACCOUNTING


### PR DESCRIPTION
Backports #6925

* Converted 'flavor' logic to be based on app template
* Converted 'ext-db' logic to use var based on app template
* Prepended role private vars with '__' for consistency

Bug 1540246
https://bugzilla.redhat.com/show_bug.cgi?id=1540246