### PR TITLE
Pause for 10 secs when starting/stopping masters when a new leader is being elected

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade.yml
@@ -45,6 +45,9 @@
     systemd:
       name: "{{ openshift_service_type }}-master-controllers"
       state: stopped
+  - name: need to pause here, otherwise master service can sometimes fail to start
+    pause:
+      seconds: 10
   - name: Start {{ openshift_service_type }}-master-controllers
     systemd:
       name: "{{ openshift_service_type }}-master-controllers"

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
@@ -127,6 +127,9 @@
     systemd:
       name: "{{ openshift_service_type }}-master-controllers"
       state: stopped
+  - name: need to pause here, otherwise master service can sometimes fail to start
+    pause:
+      seconds: 10
   - name: Start {{ openshift_service_type }}-master-controllers
     systemd:
       name: "{{ openshift_service_type }}-master-controllers"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540054