### PR TITLE
[1540108] Ignore openshift_pkg_version during 3.8 upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
@@ -64,6 +64,7 @@
 - import_playbook: ../upgrade_control_plane.yml
   vars:
     openshift_release: '3.8'
+    openshift_pkg_version: ''
   when: hostvars[groups.oo_first_master.0].openshift_currently_installed_version | version_compare('3.8','<')
 
 ## 3.8 upgrade complete we should now be able to upgrade to 3.9


### PR DESCRIPTION
Version 3.8 is an intermediate step when upgrading to 3.9 and
openshift_pkg_version may be set in the inventory for 3.9. This will
ensure there is not a conflict between the intermediate step and the
final version requested.

Bug 1540108
https://bugzilla.redhat.com/show_bug.cgi?id=1540108