### PR TITLE
CRI-O: expose metrics port on node

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -47,6 +47,8 @@ r_crio_os_firewall_deny: []
 r_crio_os_firewall_allow:
 - service: crio
   port: 10010/tcp
+- service: crio
+  port: 4242/tcp
 
 
 openshift_docker_is_node_or_master: "{{ True if inventory_hostname in (groups['oo_masters_to_config']|default([])) or inventory_hostname in (groups['oo_nodes_to_config']|default([])) else False | bool }}"


### PR DESCRIPTION
we need to expose the crio metrics port (4242) so outside node we can grab metrics

@jeremyeder @mrunalp @giuseppe PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>