### PR TITLE
upgrades: use openshift_version as a regexp when checking openshift.common.version

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/config.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/config.yml
@@ -60,7 +60,7 @@
   - fail: msg="Master running {{ openshift.common.version }} must be upgraded to {{ openshift_version }} before node upgrade can be run."
     when:
     - l_upgrade_nodes_only | default(False) | bool
-    - openshift.common.version != openshift_version
+    - not openshift.common.version | match(openshift_version)
 
 # If we're only upgrading nodes, skip this.
 - import_playbook: ../../../../openshift-master/private/validate_restart.yml


### PR DESCRIPTION
This would fix errors like 'Master running 3.9.0 must be upgraded to
3.9* before node upgrade can be run' during the upgrade

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>