### PR TITLE
Allow to configure bindNetwork for node and master

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1210,6 +1210,7 @@ class OpenShiftFacts(object):
                                       embedded_kube=True,
                                       embedded_dns=True,
                                       bind_addr='0.0.0.0',
+                                      bind_network='tcp4',
                                       session_max_seconds=3600,
                                       session_name='ssn',
                                       session_secrets_file='',

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -27,7 +27,7 @@ assetConfig:
 {% endif %}
   servingInfo:
     bindAddress: {{ openshift.master.bind_addr }}:{{ openshift.master.console_port }}
-    bindNetwork: tcp4
+    bindNetwork: {{ openshift.master.bind_network }}
     certFile: master.server.crt
     clientCA: ""
     keyFile: master.server.key
@@ -69,7 +69,7 @@ disabledFeatures: {{ l_osm_disabled_features_list | to_json }}
 {% if openshift.master.embedded_dns | bool %}
 dnsConfig:
   bindAddress: {{ openshift.master.bind_addr }}:{{ openshift_master_dns_port }}
-  bindNetwork: tcp4
+  bindNetwork: {{ openshift.master.bind_network }}
 {% endif %}
 etcdClientInfo:
   ca: master.etcd-ca.crt
@@ -204,7 +204,7 @@ serviceAccountConfig:
   - serviceaccounts.public.key
 servingInfo:
   bindAddress: {{ openshift.master.bind_addr }}:{{ openshift.master.api_port }}
-  bindNetwork: tcp4
+  bindNetwork: {{ openshift.master.bind_network }}
   certFile: master.server.crt
   clientCA: ca.crt
   keyFile: master.server.key

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -48,6 +48,7 @@
       embedded_kube: "{{ openshift_master_embedded_kube | default(None) }}"
       embedded_dns: "{{ openshift_master_embedded_dns | default(None) }}"
       bind_addr: "{{ openshift_master_bind_addr | default(None) }}"
+      bind_network: "{{ openshift_master_bind_network | default(None) }}"
       pod_eviction_timeout: "{{ openshift_master_pod_eviction_timeout | default(None) }}"
       session_max_seconds: "{{ openshift_master_session_max_seconds | default(None) }}"
       session_name: "{{ openshift_master_session_name | default(None) }}"

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -45,6 +45,7 @@ nodeName: {{ openshift.node.nodename }}
 podManifestConfig:
 servingInfo:
   bindAddress: 0.0.0.0:10250
+  bindNetwork: {{ openshift_node_bind_network | default('tcp4') }}
   certFile: server.crt
   clientCA: ca.crt
   keyFile: server.key

--- a/roles/openshift_node_group/defaults/main.yml
+++ b/roles/openshift_node_group/defaults/main.yml
@@ -30,3 +30,4 @@ openshift_node_group_network_plugin: "{{ openshift_node_group_network_plugin_def
 openshift_node_group_node_data_dir_default: "{{ openshift_data_dir | default('/var/lib/origin') }}"
 openshift_node_group_node_data_dir: "{{ openshift_node_group_node_data_dir_default }}"
 openshift_node_group_network_mtu: "{{ openshift_node_sdn_mtu | default(8951) | int }}"
+openshift_node_group_bind_network: "{{ openshift_node_bind_network | default('tcp4') }}"

--- a/roles/openshift_node_group/templates/node-config.yaml.j2
+++ b/roles/openshift_node_group/templates/node-config.yaml.j2
@@ -34,7 +34,7 @@ kubeletArguments:
   - /etc/origin/cloudprovider/{{ openshift_node_group_cloud_provider }}.conf
   cloud-provider:
   - {{ openshift_node_group_cloud_provider }}
-  node-labels: 
+  node-labels:
   - "{{ openshift_node_group_labels | join(',') }}"
   enable-controller-attach-detach:
   - 'true'
@@ -50,7 +50,7 @@ networkConfig:
 networkPluginName: {{ openshift_node_group_network_plugin }}
 servingInfo:
   bindAddress: 0.0.0.0:10250
-  bindNetwork: tcp4
+  bindNetwork: {{ openshift_node_group_bind_network }}
   clientCA: client-ca.crt
 volumeConfig:
   localQuota:


### PR DESCRIPTION
Via new Ansible variables `openshift_node_bind_network` and `openshift_master_bind_network`

Previously openshift-ansible would harcode use of `tcp4`, but binding to `tcp6` as well is desirable in some dual-stack deployments. The default remains `tcp4`.