### PR TITLE
Upgrade playbook improvements

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -96,6 +96,12 @@
   - include_tasks: "{{ openshift_master_upgrade_hook }}"
     when: openshift_master_upgrade_hook is defined
 
+  - name: Disable master controller
+    service:
+      name: "{{ openshift_service_type }}-master-controllers"
+      enabled: false
+    when: openshift.common.rolling_restart_mode == 'system'
+
   - include_tasks: ../../../openshift-master/private/tasks/restart_hosts.yml
     when: openshift.common.rolling_restart_mode == 'system'
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade.yml
@@ -2,54 +2,6 @@
 #
 # Full Control Plane + Nodes Upgrade
 #
-- import_playbook: ../init.yml
+- import_playbook: upgrade_control_plane.yml
 
-- name: Configure the upgrade target for the common upgrade tasks
-  hosts: oo_all_hosts
-  tasks:
-  - set_fact:
-      openshift_upgrade_target: '3.9'
-      openshift_upgrade_min: '3.7'
-      openshift_release: '3.9'
-
-- import_playbook: ../pre/config.yml
-  vars:
-    l_upgrade_repo_hosts: "oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config:oo_lb_to_config"
-    l_upgrade_no_proxy_hosts: "oo_masters_to_config:oo_nodes_to_upgrade"
-    l_upgrade_health_check_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
-    l_upgrade_verify_targets_hosts: "oo_masters_to_config:oo_nodes_to_upgrade"
-    l_upgrade_docker_target_hosts: "oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config"
-    l_upgrade_excluder_hosts: "oo_nodes_to_config:oo_masters_to_config"
-    openshift_protect_installed_version: False
-
-- import_playbook: validator.yml
-
-- name: Flag pre-upgrade checks complete for hosts without errors
-  hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
-  tasks:
-  - set_fact:
-      pre_upgrade_complete: True
-
-# Pre-upgrade completed
-
-- import_playbook: ../upgrade_control_plane.yml
-
-# All controllers must be stopped at the same time then restarted
-- name: Cycle all controller services to force new leader election mode
-  hosts: oo_masters_to_config
-  gather_facts: no
-  roles:
-  - role: openshift_facts
-  tasks:
-  - name: Stop {{ openshift_service_type }}-master-controllers
-    systemd:
-      name: "{{ openshift_service_type }}-master-controllers"
-      state: stopped
-  - name: Start {{ openshift_service_type }}-master-controllers
-    systemd:
-      name: "{{ openshift_service_type }}-master-controllers"
-      state: started
-
-- import_playbook: ../upgrade_nodes.yml
-
-- import_playbook: ../post_control_plane.yml
+- import_playbook: upgrade_nodes.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
@@ -123,14 +123,16 @@
   roles:
   - role: openshift_facts
   tasks:
-  - name: Stop {{ openshift_service_type }}-master-controllers
-    systemd:
+  - name: Restart master controllers to force new leader election mode
+    service:
       name: "{{ openshift_service_type }}-master-controllers"
-      state: stopped
-  - name: Start {{ openshift_service_type }}-master-controllers
-    systemd:
+      state: restart
+    when: openshift.common.rolling_restart_mode == 'service'
+  - name: Re-enable master controllers to force new leader election mode
+    service:
       name: "{{ openshift_service_type }}-master-controllers"
-      state: started
+      enabled: true
+    when: openshift.common.rolling_restart_mode == 'system'
 
 - import_playbook: ../post_control_plane.yml
 


### PR DESCRIPTION
Two changes in this PR:

 * Avoid duplication in upgrade.yml - it now would simply run upgrade_control_plane and upgrade_nodes playbooks
 * Restart controllers instead of start/stop if restart mode is 'services'
 * For 'system' restart mode controllers are disabled before master upgrade and re-enabled after upgrades are finished