### PR TITLE
Conditionally create pvcs for metrics depending on whether or not it …

### DIFF
--- a/roles/openshift_metrics/tasks/generate_cassandra_pvcs.yaml
+++ b/roles/openshift_metrics/tasks/generate_cassandra_pvcs.yaml
@@ -1,0 +1,46 @@
+---
+- name: Check to see if PVC already exists
+  oc_obj:
+    state: list
+    kind: pvc
+    name: "{{ openshift_metrics_cassandra_pvc_prefix }}-{{ metrics_pvc_index }}"
+    namespace: "{{ openshift_metrics_project }}"
+  register: _metrics_pvc
+
+# _metrics_pvc.results.results | length > 0 returns a false positive
+# so we check for the presence of 'stderr' to determine if the obj exists or not
+# the RC for existing and not existing is both 0
+- when:
+    - _metrics_pvc.results.stderr is defined
+  block:
+    - name: generate hawkular-cassandra persistent volume claims
+      template:
+        src: pvc.j2
+        dest: "{{ mktemp.stdout }}/templates/hawkular-cassandra-pvc{{ metrics_pvc_index }}.yaml"
+      vars:
+        obj_name: "{{ openshift_metrics_cassandra_pvc_prefix }}-{{ metrics_pvc_index }}"
+        labels:
+          metrics-infra: hawkular-cassandra
+        access_modes: "{{ openshift_metrics_cassandra_pvc_access | list }}"
+        size: "{{ openshift_metrics_cassandra_pvc_size }}"
+        pv_selector: "{{ openshift_metrics_cassandra_pv_selector }}"
+        storage_class_name: "{{ openshift_metrics_cassanda_pvc_storage_class_name | default('', true) }}"
+      when:
+        - openshift_metrics_cassandra_storage_type != 'emptydir'
+        - openshift_metrics_cassandra_storage_type != 'dynamic'
+      changed_when: false
+
+    - name: generate hawkular-cassandra persistent volume claims (dynamic)
+      template:
+        src: pvc.j2
+        dest: "{{ mktemp.stdout }}/templates/hawkular-cassandra-pvc{{ metrics_pvc_index }}.yaml"
+      vars:
+        obj_name: "{{ openshift_metrics_cassandra_pvc_prefix }}-{{ metrics_pvc_index }}"
+        labels:
+          metrics-infra: hawkular-cassandra
+        access_modes: "{{ openshift_metrics_cassandra_pvc_access | list }}"
+        size: "{{ openshift_metrics_cassandra_pvc_size }}"
+        pv_selector: "{{ openshift_metrics_cassandra_pv_selector }}"
+        storage_class_name: "{{ openshift_metrics_cassanda_pvc_storage_class_name | default('', true) }}"
+      when: openshift_metrics_cassandra_storage_type == 'dynamic'
+      changed_when: false

--- a/roles/openshift_metrics/tasks/install_cassandra.yaml
+++ b/roles/openshift_metrics/tasks/install_cassandra.yaml
@@ -25,36 +25,7 @@
 - set_fact: openshift_metrics_cassandra_pvc_prefix="hawkular-metrics"
   when: "not openshift_metrics_cassandra_pvc_prefix or openshift_metrics_cassandra_pvc_prefix == ''"
 
-- name: generate hawkular-cassandra persistent volume claims
-  template:
-    src: pvc.j2
-    dest: "{{ mktemp.stdout }}/templates/hawkular-cassandra-pvc{{ item }}.yaml"
-  vars:
-    obj_name: "{{ openshift_metrics_cassandra_pvc_prefix }}-{{ item }}"
-    labels:
-      metrics-infra: hawkular-cassandra
-    access_modes: "{{ openshift_metrics_cassandra_pvc_access | list }}"
-    size: "{{ openshift_metrics_cassandra_pvc_size }}"
-    pv_selector: "{{ openshift_metrics_cassandra_pv_selector }}"
-    storage_class_name: "{{ openshift_metrics_cassanda_pvc_storage_class_name | default('', true) }}"
+- include_tasks: generate_cassandra_pvcs.yaml
   with_sequence: count={{ openshift_metrics_cassandra_replicas }}
-  when:
-  - openshift_metrics_cassandra_storage_type != 'emptydir'
-  - openshift_metrics_cassandra_storage_type != 'dynamic'
-  changed_when: false
-
-- name: generate hawkular-cassandra persistent volume claims (dynamic)
-  template:
-    src: pvc.j2
-    dest: "{{ mktemp.stdout }}/templates/hawkular-cassandra-pvc{{ item }}.yaml"
-  vars:
-    obj_name: "{{ openshift_metrics_cassandra_pvc_prefix }}-{{ item }}"
-    labels:
-      metrics-infra: hawkular-cassandra
-    access_modes: "{{ openshift_metrics_cassandra_pvc_access | list }}"
-    size: "{{ openshift_metrics_cassandra_pvc_size }}"
-    pv_selector: "{{ openshift_metrics_cassandra_pv_selector }}"
-    storage_class_name: "{{ openshift_metrics_cassanda_pvc_storage_class_name | default('', true) }}"
-  with_sequence: count={{ openshift_metrics_cassandra_replicas }}
-  when: openshift_metrics_cassandra_storage_type == 'dynamic'
-  changed_when: false
+  loop_control:
+    loop_var: metrics_pvc_index


### PR DESCRIPTION
…already exists

This is similar to the logic we implemented in logging to prevent messages like:
"The PersistentVolumeClaim "metrics-cassandra-3" is invalid: spec: Forbidden: field is immutable after creation"

If the pvc already exists we won't generate a template for it to later oc apply.

This is to address https://bugzilla.redhat.com/show_bug.cgi?id=1540729