### PR TITLE
Add kuryr-kubernetes external lock_path

### DIFF
--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -665,3 +665,10 @@ data:
 
     # Minimun interval (in seconds) between pool updates (integer value)
     ports_pool_update_frequency = {{ kuryr_openstack_pool_update_frequency | default(20) }}
+
+    [oslo_concurrency]
+
+    #
+    # From kuryr_kubernetes
+    #
+    lock_path = {{ kuryr_openstack_lock_path | default('/var/kuryr-lock') }}


### PR DESCRIPTION
* Lock path is now configurable to run cni daemon without error.

With devstack-based installation, kuryr conf is properly configured for oslo_concurrency.
However, with byo installation, without this configuration it occurs kuryr daemon down.

Signed-off-by: Eunsoo Park <esevan.park@samsung.com>