### PR TITLE
dynamic inventory bug when group exists but its empty

### DIFF
--- a/roles/openshift_hosted/tasks/storage/glusterfs.yml
+++ b/roles/openshift_hosted/tasks/storage/glusterfs.yml
@@ -35,7 +35,7 @@
   mount:
     state: mounted
     fstype: glusterfs
-    src: "{% if 'glusterfs_registry' in groups %}{% set node = groups.glusterfs_registry[0] %}{% elif 'glusterfs' in groups %}{% set node = groups.glusterfs[0] %}{% endif %}{% if openshift_hosted_registry_storage_glusterfs_ips is defined and openshift_hosted_registry_storage_glusterfs_ips|length > 0 %}{{ openshift_hosted_registry_storage_glusterfs_ips[0] }}{% elif 'glusterfs_hostname' in hostvars[node] %}{{ hostvars[node].glusterfs_hostname }}{% elif 'openshift' in hostvars[node] %}{{ hostvars[node].openshift.node.nodename }}{% else %}{{ node }}{% endif %}:/{{ openshift_hosted_registry_storage_glusterfs_path }}"
+    src: "{% if 'glusterfs_registry' in groups and groups['glusterfs_registry'] | length > 0  %}{% set node = groups.glusterfs_registry[0] %}{% elif 'glusterfs' in groups and groups['glusterfs'] | length > 0 %}{% set node = groups.glusterfs[0] %}{% endif %}{% if openshift_hosted_registry_storage_glusterfs_ips is defined and openshift_hosted_registry_storage_glusterfs_ips|length > 0 %}{{ openshift_hosted_registry_storage_glusterfs_ips[0] }}{% elif 'glusterfs_hostname' in hostvars[node] %}{{ hostvars[node].glusterfs_hostname }}{% elif 'openshift' in hostvars[node] %}{{ hostvars[node].openshift.node.nodename }}{% else %}{{ node }}{% endif %}:/{{ openshift.hosted.registry.storage.glusterfs.path }}"
     name: "{{ mktemp.stdout }}"
 
 - name: Set registry volume permissions

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_registry.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_registry.yml
@@ -48,7 +48,7 @@
     glusterfs_heketi_ssh_sudo: "{{ openshift_storage_glusterfs_registry_heketi_ssh_sudo | bool }}"
     glusterfs_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_registry_heketi_ssh_keyfile }}"
     glusterfs_heketi_fstab: "{{ openshift_storage_glusterfs_registry_heketi_fstab }}"
-    glusterfs_nodes: "{% if groups.glusterfs_registry is defined %}{% set nodes = groups.glusterfs_registry %}{% elif 'groups.glusterfs' is defined %}{% set nodes = groups.glusterfs %}{% else %}{% set nodes = '[]' %}{% endif %}{{ nodes }}"
+    glusterfs_nodes: "{% if groups.glusterfs_registry is defined and groups['glusterfs_registry'] | length > 0 %}{% set nodes = groups.glusterfs_registry %}{% elif 'groups.glusterfs' is defined and groups['glusterfs'] | length > 0 %}{% set nodes = groups.glusterfs %}{% else %}{% set nodes = '[]' %}{% endif %}{{ nodes }}"
 
 - include_tasks: glusterfs_common.yml
   when:


### PR DESCRIPTION
@jarrpa output from my test for the gluster block

I use dynamic inventory. And the result of this is that ansible see all possible groups available, but some of them are empty [1]. Because group exists, fist condition is evaluated as true and it fails with the array is an empty error...  
```
...
'all': [u'54.144.5.175',                                                                                                                                                                                          
         u'52.200.175.54',                                                                                                                                                                                         
         u'54.237.208.252',                                                                                                                                                                                        
         u'52.55.224.72',                                                                                                                                                                                          
         u'52.207.103.246',                                                                                                                                                                                        
         u'34.227.95.191',                                                                                                                                                                                         
         u'34.238.127.160'],                                                                                                                                                                                       
 u'bastion': [u'34.227.95.191'],                                                                                                                                                                                   
 u'bastion.0': [u'34.227.95.191'],                                                                                                                                                                                 
 u'etcd': [u'34.238.127.160'],                                                                                                                                                                                     
 u'glusterfs': [u'52.200.175.54', u'52.207.103.246', u'54.144.5.175'],                                                                                                                                             
 u'glusterfs.0': [u'52.200.175.54'],                                                                                                                                                                               
 u'glusterfs.1': [u'52.207.103.246'],                                                                                                                                                                              
 u'glusterfs.2': [u'54.144.5.175'],                                                                                                                                                                                
 u'glusterfs_registry': [],                                                                                                                                                                                        
 u'infra': [u'52.55.224.72'],                                                                                                                                                                                      
 u'infra.0': [u'52.55.224.72'],
 u'masters': [u'34.238.127.160'],
 u'masters.0': [u'34.238.127.160'],
...
```