### PR TITLE
Add containerized check for openshift_ca role

### DIFF
--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -19,7 +19,9 @@
 
 - name: Reload generated facts
   openshift_facts:
-  when: hostvars[openshift_ca_host].install_result | changed
+  when:
+    - not openshift.common.is_containerized | bool
+    - hostvars[openshift_ca_host].install_result | changed
 
 - name: Create openshift_ca_config_dir if it does not exist
   file:


### PR DESCRIPTION
As said in #6973, I had an issue using the scaleup playbook on a centos atomic master. 
I added a check that was used in the previous task to keep it consistent. 

Please let me know if you need anything from me.

Fixes #6973 