### PR TITLE
bug 1540799: openshift_prometheus: update alertmanager config file flag

### DIFF
--- a/roles/openshift_prometheus/templates/prometheus.j2
+++ b/roles/openshift_prometheus/templates/prometheus.j2
@@ -219,7 +219,7 @@ spec:
 
       - name: alertmanager
         args:
-        - -config.file=/etc/alertmanager/alertmanager.yml
+        - --config.file=/etc/alertmanager/alertmanager.yml
         image: "{{ l_openshift_prometheus_alertmanager_image_prefix }}prometheus-alertmanager:{{ l_openshift_prometheus_alertmanager_image_version }}"
         imagePullPolicy: IfNotPresent
         resources:

--- a/roles/openshift_prometheus/vars/default_images.yml
+++ b/roles/openshift_prometheus/vars/default_images.yml
@@ -8,5 +8,5 @@ l_openshift_prometheus_alertbuffer_image_prefix: "{{ openshift_prometheus_alertb
 # image version defaults
 l_openshift_prometheus_image_version: "{{ openshift_prometheus_image_version | default('v2.0.0') }}"
 l_openshift_prometheus_proxy_image_version: "{{ openshift_prometheus_proxy_image_version | default('v1.0.0') }}"
-l_openshift_prometheus_alertmanager_image_version: "{{ openshift_prometheus_alertmanager_image_version | default('v0.9.1') }}"
+l_openshift_prometheus_alertmanager_image_version: "{{ openshift_prometheus_alertmanager_image_version | default('v0.13.0') }}"
 l_openshift_prometheus_alertbuffer_image_version: "{{ openshift_prometheus_alertbuffer_image_version | default('v0.0.2') }}"


### PR DESCRIPTION
Prometheus alertmanager as of 0.13.0 requires double dashes (posix) for
command line flags.  The double dashes should be backwards compat
with earlier versions of alertmanager.