### PR TITLE
Change the etcd group entries check for 1, 3 or 5 nodes so that it just checks not 0 nodes

### DIFF
--- a/playbooks/common/openshift-cluster/evaluate_groups.yml
+++ b/playbooks/common/openshift-cluster/evaluate_groups.yml
@@ -49,7 +49,7 @@
         upgrade please see https://docs.openshift.com/container-platform/latest/install_config/upgrading/migrating_embedded_etcd.html
         for documentation on how to migrate from embedded to external etcd.
     when:
-    - g_etcd_hosts | default([]) | length not in [5,3,1]
+    - g_etcd_hosts | default([]) | length == 0
     - not openshift_master_unsupported_embedded_etcd | default(False)
     - not (openshift_node_bootstrap | default(False))
 


### PR DESCRIPTION
Backports #7061 

This playbook is called (via std_include.yml) when the scale up playbook for either master or etcd is called.  In the scenario where you are scaling up the number of masters/etcd nodes it is feasible, if not likely, that the number of etcd nodes is not 1, 3 or 5 and this check therefore causes a scale up to fail.

The two example scenarios that are driving this change are:
- You have a cluster with 3 master nodes (each running etcd) and one of those masters fail.  The master node is removed from both the OpenShift cluster and the etcd cluster and the inventory updated to reflect the state of the cluster minus the failed master node.  You would then run the scale up playbook to add a new master / etcd master into the cluster using an inventory containing and etcd group of just 2 nodes.
- As above but the cluster has 5 master nodes.  If you lose a master node and update the inventory to reflect that then the inventory will contain an etcd group with 4 nodes.