### PR TITLE
Add python2-crypto dependency for gce dynamic inventory

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -28,6 +28,7 @@ Requires:      java-1.8.0-openjdk-headless
 Requires:      httpd-tools
 Requires:      libselinux-python
 Requires:      python-passlib
+Requires:      python2-crypto
 
 %description
 Openshift and Atomic Enterprise Ansible


### PR DESCRIPTION
I'd prefer this over #6982 because it will also cover rpm based installs of openshift-ansible