### PR TITLE
Parameterize user and disable_root options in cloud config

### DIFF
--- a/roles/openshift_openstack/defaults/main.yml
+++ b/roles/openshift_openstack/defaults/main.yml
@@ -93,3 +93,8 @@ openshift_openstack_node_volume_size: "{{ openshift_openstack_docker_volume_size
 openshift_openstack_etcd_volume_size: 2
 openshift_openstack_lb_volume_size: 5
 openshift_openstack_ephemeral_volumes: false
+
+
+# cloud-config
+openshift_openstack_disable_root: true
+openshift_openstack_user: openshift

--- a/roles/openshift_openstack/templates/user_data.j2
+++ b/roles/openshift_openstack/templates/user_data.j2
@@ -1,9 +1,9 @@
 #cloud-config
-disable_root: true
+disable_root: {{ openshift_openstack_disable_root }}
 
 system_info:
   default_user:
-    name: openshift
+    name: {{ openshift_openstack_user }}
     sudo: ["ALL=(ALL) NOPASSWD: ALL"]
 
 write_files:


### PR DESCRIPTION
This commit will allow the user to login as root. By default the
user is set to openshift and disable_root is set to true.