### PR TITLE
Set a default for required vsphere variable

### DIFF
--- a/roles/openshift_default_storage_class/defaults/main.yml
+++ b/roles/openshift_default_storage_class/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# Must not be blank if you're using vsphere
+openshift_cloudprovider_vsphere_datacenter: ''
+
 openshift_storageclass_defaults:
   aws:
     provisioner: aws-ebs

--- a/roles/openshift_sanitize_inventory/tasks/main.yml
+++ b/roles/openshift_sanitize_inventory/tasks/main.yml
@@ -61,3 +61,17 @@
   when:
     - template_service_broker_remove | default(false) | bool
     - template_service_broker_install | default(true) | bool
+
+- name: Ensure that all requires vsphere configuration variables are set
+  fail:
+    msg: >
+      When the vSphere cloud provider is configured you must define all of these variables:
+      openshift_cloudprovider_vsphere_username, openshift_cloudprovider_vsphere_password,
+      openshift_cloudprovider_vsphere_host, openshift_cloudprovider_vsphere_datacenter,
+      openshift_cloudprovider_vsphere_datastore, openshift_cloudprovider_vsphere_folder
+    when:
+      - openshift_cloudprovider_kind is defined
+      - openshift_cloudprovider_kind == 'vsphere'
+      - ( openshift_cloudprovider_vsphere_username is undefined or openshift_cloudprovider_vsphere_password is undefined or
+          openshift_cloudprovider_vsphere_host is undefined or openshift_cloudprovider_vsphere_datacenter is undefined or
+          openshift_cloudprovider_vsphere_datastore is undefined or openshift_cloudprovider_vsphere_folder )


### PR DESCRIPTION
Check for required variables in sanitize inventory

Fixes the following when a different cloud provider is configured.
```
Failure summary:


  1. Hosts:    ci-prtest-fa08ce7-288-ig-m-fnhz
     Play:     Create Hosted Resources - openshift_default_storage_class
     Task:     Ensure storageclass object
     Message:  The task includes an option with an undefined variable. The error was: {{ openshift_storageclass_defaults[openshift_cloudprovider_kind]['name'] }}: {u'gce': {u'name': u'standard', u'parameters': {u'type': u'pd-standard'}, u'provisioner': u'gce-pd'}, u'vsphere': {u'name': u'standard', u'parameters': {u'datastore': u'{{ openshift_cloudprovider_vsphere_datacenter }}'}, u'provisioner': u'vsphere-volume'}, u'aws': {u'name': u'gp2', u'parameters': {u'encrypted': u'false', u'kmsKeyId': u'', u'type': u'gp2'}, u'provisioner': u'aws-ebs'}, u'openstack': {u'name': u'standard', u'parameters': {u'fstype': u'xfs'}, u'provisioner': u'cinder'}}: 'openshift_cloudprovider_vsphere_datacenter' is undefined
               
               The error appears to have been in '/usr/share/ansible/openshift-ansible/roles/openshift_default_storage_class/tasks/main.yml': line 3, column 3, but may
               be elsewhere in the file depending on the exact syntax problem.
               
               The offending line appears to be:
               
               # Install default storage classes in GCE & AWS & OPENSTACK
               - name: Ensure storageclass object
                 ^ here
               
               exception type: <class 'ansible.errors.AnsibleUndefinedVariable'>
               exception: {{ openshift_storageclass_defaults[openshift_cloudprovider_kind]['name'] }}: {u'gce': {u'name': u'standard', u'parameters': {u'type': u'pd-standard'}, u'provisioner': u'gce-pd'}, u'vsphere': {u'name': u'standard', u'parameters': {u'datastore': u'{{ openshift_cloudprovider_vsphere_datacenter }}'}, u'provisioner': u'vsphere-volume'}, u'aws': {u'name': u'gp2', u'parameters': {u'encrypted': u'false', u'kmsKeyId': u'', u'type': u'gp2'}, u'provisioner': u'aws-ebs'}, u'openstack': {u'name': u'standard', u'parameters': {u'fstype': u'xfs'}, u'provisioner': u'cinder'}}: 'openshift_cloudprovider_vsphere_datacenter' is undefined
```