### PR TITLE
add deprovisioning for ELB (and IAM certs)

### DIFF
--- a/playbooks/aws/openshift-cluster/uninstall_elb.yml
+++ b/playbooks/aws/openshift-cluster/uninstall_elb.yml
@@ -1,0 +1,9 @@
+---
+- name: Delete elb
+  hosts: localhost
+  connection: local
+  tasks:
+  - name: deprovision elb
+    include_role:
+      name: openshift_aws
+      tasks_from: uninstall_elb.yml

--- a/roles/openshift_aws/tasks/elb.yml
+++ b/roles/openshift_aws/tasks/elb.yml
@@ -2,26 +2,8 @@
 - name: "dump the elb listeners for {{ l_elb_dict_item.key }}"
   debug:
     msg: "{{ l_elb_dict_item.value }}"
+    verbosity: 1
 
-- name: "Create ELB {{ l_elb_dict_item.key }}"
-  ec2_elb_lb:
-    name: "{{ item.value.name }}"
-    state: present
-    cross_az_load_balancing: "{{ item.value.cross_az_load_balancing }}"
-    security_group_names: "{{ l_elb_security_groups[l_elb_dict_item.key] }}"
-    idle_timeout: "{{ item.value.idle_timout }}"
-    region: "{{ openshift_aws_region }}"
-    subnets:
-    - "{{ subnetout.subnets[0].id }}"
-    health_check: "{{ item.value.health_check }}"
-    listeners: "{{ item.value.listeners }}"
-    scheme: "{{ (item.key == 'internal') | ternary('internal','internet-facing') }}"
-    tags: "{{ item.value.tags }}"
-    wait: True
-  register: new_elb
+- name: Create ELB(s)
+  include_tasks: elb_single.yml
   with_dict: "{{ l_elb_dict_item.value }}"
-
-- debug:
-    msg: "{{ item }}"
-  with_items:
-  - "{{ new_elb }}"

--- a/roles/openshift_aws/tasks/elb_single.yml
+++ b/roles/openshift_aws/tasks/elb_single.yml
@@ -1,0 +1,34 @@
+---
+- name: "dump the elb listeners for {{ item.key }}"
+  debug:
+    msg: "{{ item.value }}"
+    verbosity: 1
+
+- name: "Create ELB {{ item.value.name }}"
+  ec2_elb_lb:
+    name: "{{ item.value.name }}"
+    state: present
+    cross_az_load_balancing: "{{ item.value.cross_az_load_balancing }}"
+    security_group_names: "{{ l_elb_security_groups[l_elb_dict_item.key] }}"
+    idle_timeout: "{{ item.value.idle_timout }}"
+    region: "{{ openshift_aws_region }}"
+    subnets:
+    - "{{ subnetout.subnets[0].id }}"
+    health_check: "{{ item.value.health_check }}"
+    listeners: "{{ item.value.listeners }}"
+    scheme: "{{ (item.key == 'internal') | ternary('internal','internet-facing') }}"
+    tags: "{{ item.value.tags }}"
+    wait: True
+  register: new_elb
+  retries: 20
+  delay: 5
+  until: new_elb | succeeded
+  ignore_errors: yes
+
+- fail:
+    msg: "couldn't create ELB {{ item.value.name }}"
+  when: not new_elb | succeeded
+
+- debug:
+    msg: "{{ new_elb }}"
+    verbosity: 1

--- a/roles/openshift_aws/tasks/iam_cert.yml
+++ b/roles/openshift_aws/tasks/iam_cert.yml
@@ -18,7 +18,9 @@
   - openshift_aws_iam_cert_key_path != ''
   - openshift_aws_elb_cert_arn == ''
 
-- debug: msg="{{ elb_cert_chain }}"
+- debug:
+    msg: "{{ elb_cert_chain }}"
+    verbosity: 1
 
 - name: set_fact openshift_aws_elb_cert_arn
   set_fact:
@@ -28,8 +30,3 @@
   - openshift_aws_iam_cert_path != ''
   - openshift_aws_iam_cert_key_path != ''
   - openshift_aws_elb_cert_arn == ''
-
-- name: wait for cert to propagate
-  pause:
-    seconds: 5
-  when: elb_cert_chain.changed

--- a/roles/openshift_aws/tasks/uninstall_elb.yml
+++ b/roles/openshift_aws/tasks/uninstall_elb.yml
@@ -1,0 +1,11 @@
+---
+- name: delete elbs
+  ec2_elb_lb:
+    name: "{{ item }}"
+    region: "{{ openshift_aws_region }}"
+    state: absent
+  with_items: "{{ openshift_aws_elb_dict | json_query('*.*.name') | sum(start = []) }}"
+
+- when: openshift_aws_create_iam_cert | bool
+  name: delete the iam_cert for elb certificate
+  include_tasks: uninstall_iam_cert.yml

--- a/roles/openshift_aws/tasks/uninstall_iam_cert.yml
+++ b/roles/openshift_aws/tasks/uninstall_iam_cert.yml
@@ -1,0 +1,25 @@
+---
+- when:
+  - openshift_aws_create_iam_cert | bool
+  - openshift_aws_iam_cert_path != ''
+  - openshift_aws_iam_cert_key_path != ''
+  - openshift_aws_elb_cert_arn == ''
+  block:
+  - name: delete AWS IAM certificates
+    iam_cert23:
+      state: absent
+      name: "{{ openshift_aws_iam_cert_name }}"
+    register: elb_cert_chain
+    retries: 20
+    delay: 10
+    until: elb_cert_chain | succeeded
+    ignore_errors: yes
+
+  - debug:
+      var: elb_cert_chain
+      verbosity: 1
+
+  - name: check for iam cert error
+    fail:
+      msg: "Couldn't delete IAM cert {{ openshift_aws_iam_cert_name }}"
+    when: not elb_cert_chain | succeeded

--- a/roles/openshift_aws/tasks/vpc_and_subnet_id.yml
+++ b/roles/openshift_aws/tasks/vpc_and_subnet_id.yml
@@ -7,7 +7,9 @@
   register: vpcout
 
 - name: debug vcpout
-  debug: var=vpcout
+  debug:
+    var: vpcout
+    verbosity: 1
 
 - name: fetch the default subnet id
   ec2_vpc_subnet_facts:
@@ -18,4 +20,6 @@
   register: subnetout
 
 - name: debug subnetout
-  debug: var=subnetout
+  debug:
+    var: subnetout
+    verbosity: 1


### PR DESCRIPTION
add playbooks to handle deleting ELBs and any IAM certs that may have been created during provisioning.

increase timeout on IAM cert creation to 10 seconds (failures seen previously with 5 second wait).

add some 'verbosity: 1' to limit some of the output during a non-verbose playbook run.