### PR TITLE
Don't use 'omit' for package module

### DIFF
--- a/playbooks/init/base_packages.yml
+++ b/playbooks/init/base_packages.yml
@@ -16,8 +16,9 @@
       - iproute
       - "{{ 'python3-dbus' if ansible_distribution == 'Fedora' else 'dbus-python' }}"
       - "{{ 'python3-PyYAML' if ansible_distribution == 'Fedora' else 'PyYAML' }}"
-      - "{{ 'python-ipaddress' if ansible_distribution != 'Fedora' else omit }}"
+      - "{{ 'python-ipaddress' if ansible_distribution != 'Fedora' else '' }}"
       - yum-utils
+      when: item != ''
       register: result
       until: result is succeeded
 


### PR DESCRIPTION
'name' param is required and can't be skipped. 'when' is used instead


Fixes #6968