### PR TITLE
Removing prefix, replacing with cidr, pool_start and pool_end vars

### DIFF
--- a/playbooks/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/all.yml
@@ -85,7 +85,12 @@ openshift_openstack_docker_volume_size: "15"
 ## WARNING: This will delete any data on the volume!
 #openshift_openstack_prepare_and_format_registry_volume: False
 
-openshift_openstack_subnet_prefix: "192.168.99"
+# The Classless Inter-Domain Routing (CIDR) for the OpenStack VM subnet.
+openshift_openstack_subnet_cidr: "192.168.99.0/24"
+# The starting IP address for the OpenStack subnet allocation pool.
+openshift_openstack_pool_start: "192.168.99.3"
+# The ending IP address for the OpenStack subnet allocation pool.
+openshift_openstack_pool_end: "192.168.99.254"
 
 ## Red Hat subscription:
 #rhsub_user: '<username>'

--- a/roles/openshift_openstack/defaults/main.yml
+++ b/roles/openshift_openstack/defaults/main.yml
@@ -55,7 +55,9 @@ openshift_openstack_app_subdomain: "apps"
 # heat vars
 openshift_openstack_clusterid: openshift
 openshift_openstack_stack_name: "{{ openshift_openstack_clusterid }}.{{ openshift_openstack_public_dns_domain }}"
-openshift_openstack_subnet_prefix: "192.168.99"
+openshift_openstack_subnet_cidr: "192.168.99.0/24"
+openshift_openstack_pool_start: "192.168.99.3"
+openshift_openstack_pool_end: "192.168.99.254"
 openshift_openstack_master_hostname: master
 openshift_openstack_infra_hostname: infra-node
 openshift_openstack_cns_hostname: cns

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -78,22 +78,10 @@ resources:
           params:
             cluster_id: {{ openshift_openstack_stack_name }}
       network: { get_resource: net }
-      cidr:
-        str_replace:
-          template: subnet_24_prefix.0/24
-          params:
-            subnet_24_prefix: {{ openshift_openstack_subnet_prefix }}
+      cidr: {{ openshift_openstack_subnet_cidr }}
       allocation_pools:
-        - start:
-            str_replace:
-              template: subnet_24_prefix.3
-              params:
-                subnet_24_prefix: {{ openshift_openstack_subnet_prefix }}
-          end:
-            str_replace:
-              template: subnet_24_prefix.254
-              params:
-                subnet_24_prefix: {{ openshift_openstack_subnet_prefix }}
+        - start: {{ openshift_openstack_pool_start }}
+          end: {{ openshift_openstack_pool_end }}
       dns_nameservers:
 {% for nameserver in openshift_openstack_dns_nameservers %}
         - {{ nameserver }}
@@ -261,7 +249,7 @@ resources:
           protocol: tcp
           port_range_min: 30000
           port_range_max: 32767
-          remote_ip_prefix: "{{ openshift_openstack_subnet_prefix }}.0/24"
+          remote_ip_prefix: "{{ openshift_openstack_subnet_cidr }}"
 {% else %}
   master-secgrp:
     type: OS::Neutron::SecurityGroup
@@ -393,7 +381,7 @@ resources:
           protocol: tcp
           port_range_min: 30000
           port_range_max: 32767
-          remote_ip_prefix: "{{ openshift_openstack_subnet_prefix }}.0/24"
+          remote_ip_prefix: "{{ openshift_openstack_subnet_cidr }}"
 {% endif %}
 
   infra-secgrp:


### PR DESCRIPTION
The heat template was hardcoded with a /24 cidr and that limited customers to 251 ip addresses in the OpenStack subnet. This allows the user to configure the cidr and the allocation pool start and end.

Addresses issue #6829 that I created last week.

@tomassedovic please take a look