### PR TITLE
Use rollout instead of deploy (deprecated)

### DIFF
--- a/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml
@@ -88,8 +88,7 @@
 
   - name: Redeploy docker registry
     command: >
-      {{ openshift_client_binary }} deploy dc/docker-registry
-      --latest
+      {{ openshift_client_binary }} rollout latest dc/docker-registry
       --config={{ mktemp.stdout }}/admin.kubeconfig
       -n default
 

--- a/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
@@ -129,8 +129,7 @@
 
   - name: Redeploy router
     command: >
-      {{ openshift_client_binary }} deploy dc/router
-      --latest
+      {{ openshift_client_binary }} rollout latest dc/router
       --config={{ router_cert_redeploy_tempdir.stdout }}/admin.kubeconfig
       -n default
 


### PR DESCRIPTION

```
TASK [Redeploy docker registry] **************************************************************************************************************
task path: /home/rteague/git/clusters/aws-c2/openshift-ansible/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml:89
Friday 02 February 2018  15:35:09 -0500 (0:00:01.593)       0:18:51.955 ******* 
2018-02-02 15:35:10,072 p=9089 u=rteague |  changed: [ec2-54-83-132-196.compute-1.amazonaws.com] => 
{"changed": true,
 "cmd": ["oc", "deploy", "dc/docker-registry", "--latest", "--config=/tmp/openshift-ansible-R4iFPs/admin.kubeconfig", "-n", "default"],
 "delta": "0:00:00.226802",
 "end": "2018-02-02 20:35:10.035377",
 "rc": 0,
 "start": "2018-02-02 20:35:09.808575",
 "stderr": "Command \"deploy\" is deprecated, Use the `rollout latest` and `rollout cancel` commands instead.\nFlag --latest has been deprecated, use 'oc rollout latest' instead",
 "stderr_lines": ["Command \"deploy\" is deprecated, Use the `rollout latest` and `rollout cancel` commands instead.", "Flag --latest has been deprecated, use 'oc rollout latest' instead"],
 "stdout": "Started deployment #3\nUse 'oc logs -f dc/docker-registry' to track its progress.",
 "stdout_lines": ["Started deployment #3", "Use 'oc logs -f dc/docker-registry' to track its progress."]}
```