### PR TITLE
[3.6] openshift_common: don't install base package for versioning during upgrades

### DIFF
--- a/roles/openshift_common/tasks/main.yml
+++ b/roles/openshift_common/tasks/main.yml
@@ -62,7 +62,9 @@
   package:
     name: "{{ openshift.common.service_type }}{{ openshift_pkg_version | default('') | oo_image_tag_to_rpm_version(include_dash=True) }}"
     state: present
-  when: not openshift.common.is_containerized | bool
+  when:
+    - not openshift.common.is_containerized | bool
+    - not openshift_upgrade_target is defined
 
 - name: Set version facts
   openshift_facts:


### PR DESCRIPTION
Base package requires openshift-node, so a newer node package will be
installed even when openshift_pkg_version is set during this task.
Version is determined in openshift_version role via repoquery later on.

The issue doesn't seem to happen on master or release-3.7 branches

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1539021