### PR TITLE
Add cloud config variables to the sample inventory

### DIFF
--- a/playbooks/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/all.yml
@@ -124,3 +124,7 @@ ansible_user: openshift
 #    region: primary
 #  infra:
 #    region: infra
+
+## cloud config
+openshift_openstack_disable_root: true
+openshift_openstack_user: openshift


### PR DESCRIPTION
This commit adds openshift_openstack_disable_root and openshift_openstack_user
vars to the openstack sample inventory.
Ref: https://github.com/openshift/openshift-ansible/pull/6988