### PR TITLE
[1540537] Add base package installation to upgrade playbooks

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -6,6 +6,7 @@
     g_new_node_hosts: []
 
 - import_playbook: ../../../init/basic_facts.yml
+- import_playbook: ../../../init/base_packages.yml
 - import_playbook: ../../../init/cluster_facts.yml
 
 - name: Ensure firewall is not switched during upgrade

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
@@ -15,6 +15,7 @@
   vars:
     l_upgrade_no_switch_firewall_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_base_packages_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
 
 ## Check to see if they're running 3.7 and if so upgrade them to 3.8 on control plan
 ## If they've specified pkg_version or image_tag preserve that for later use

--- a/playbooks/init/base_packages.yml
+++ b/playbooks/init/base_packages.yml
@@ -1,8 +1,9 @@
 ---
-# l_scale_up_hosts may be passed in via prerequisites.yml during scaleup plays.
+# l_base_packages_hosts may be passed in via prerequisites.yml during scaleup plays
+# and upgrade_control_plane.yml upgrade plays.
 
 - name: Install packages necessary for installer
-  hosts: "{{ l_scale_up_hosts | default('oo_all_hosts') }}"
+  hosts: "{{ l_base_packages_hosts | default('oo_all_hosts') }}"
   any_errors_fatal: true
   tasks:
   - when:

--- a/playbooks/openshift-etcd/scaleup.yml
+++ b/playbooks/openshift-etcd/scaleup.yml
@@ -32,6 +32,7 @@
     l_build_container_groups_hosts: "oo_new_etcd_to_config"
     l_etcd_scale_up_hosts: "oo_hosts_containerized_managed_true"
     l_scale_up_hosts: "oo_new_etcd_to_config"
+    l_base_packages_hosts: "oo_new_etcd_to_config"
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_new_etcd_to_config"
     l_sanity_check_hosts: "{{ groups['oo_new_etcd_to_config'] | union(groups['oo_masters_to_config']) | union(groups['oo_etcd_to_config']) }}"
   when:

--- a/playbooks/openshift-master/scaleup.yml
+++ b/playbooks/openshift-master/scaleup.yml
@@ -32,6 +32,7 @@
 - import_playbook: ../prerequisites.yml
   vars:
     l_scale_up_hosts: "oo_nodes_to_config:oo_masters_to_config"
+    l_base_packages_hosts: "oo_nodes_to_config:oo_masters_to_config"
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_nodes_to_config"
     l_sanity_check_hosts: "{{ groups['oo_nodes_to_config'] | union(groups['oo_masters_to_config']) }}"
 

--- a/playbooks/openshift-node/scaleup.yml
+++ b/playbooks/openshift-node/scaleup.yml
@@ -27,6 +27,7 @@
 - import_playbook: ../prerequisites.yml
   vars:
     l_scale_up_hosts: "oo_nodes_to_config"
+    l_base_packages_hosts: "oo_nodes_to_config"
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_nodes_to_config"
     l_sanity_check_hosts: "{{ groups['oo_nodes_to_config'] | union(groups['oo_masters_to_config']) }}"
 


### PR DESCRIPTION
Hosts will need python ipaddress module installed if it was not
installed during initial installation.

Bug 1540537
https://bugzilla.redhat.com/show_bug.cgi?id=1540537