### PR TITLE
Upgrades: pass openshift_manage_node_is_master to master nodes during upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -340,3 +340,4 @@
       tasks_from: config.yml
     vars:
       openshift_master_host: "{{ groups.oo_first_master.0 }}"
+      openshift_manage_node_is_master: true


### PR DESCRIPTION
This ensures required labels for master would be set.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1534917
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1535673