### PR TITLE
[1488056] Run node systemd_units.yml during upgrade

### DIFF
--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -1,7 +1,6 @@
 ---
 - name: Update systemd units
   include_tasks: ../systemd_units.yml
-  when: openshift_is_containerized | bool
 
 - name: Update oreg value
   yedit:


### PR DESCRIPTION
Task file can be run for both containerized/non-containerized.  Logic
handles both cases.

Bug 1488056 | https://bugzilla.redhat.com/show_bug.cgi?id=1488056