### PR TITLE
[1542368] Fix openshift_version and openshift_image_tag

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
@@ -27,17 +27,10 @@
       openshift_upgrade_min: '3.7'
       openshift_release: '3.8'
       _requested_pkg_version: "{{ openshift_pkg_version if openshift_pkg_version is defined else omit }}"
-      openshift_pkg_version: ''
+      openshift_pkg_version: '-3.8'
       _requested_image_tag: "{{ openshift_image_tag if openshift_image_tag is defined else omit }}"
-      l_double_upgrade_cp: True
+      openshift_image_tag: 'v3.8'
     when: hostvars[groups.oo_first_master.0].openshift_currently_installed_version | version_compare('3.8','<')
-
-  - name: set l_force_image_tag_to_version = True
-    set_fact:
-      # Need to set this during 3.8 upgrade to ensure image_tag is set correctly
-      # to match 3.8 version
-      l_force_image_tag_to_version: True
-    when: _requested_image_tag is defined
 
 - import_playbook: ../pre/config.yml
   # These vars a meant to exclude oo_nodes from plays that would otherwise include
@@ -54,13 +47,6 @@
     openshift_protect_installed_version: False
   when: hostvars[groups.oo_first_master.0].openshift_currently_installed_version | version_compare('3.8','<')
 
-- name: Flag pre-upgrade checks complete for hosts without errors 3.8
-  hosts: oo_masters_to_config:oo_etcd_to_config
-  tasks:
-  - set_fact:
-      pre_upgrade_complete: True
-    when: hostvars[groups.oo_first_master.0].openshift_currently_installed_version | version_compare('3.8','<')
-
 # Pre-upgrade completed
 
 - name: Intermediate 3.8 Upgrade
@@ -72,26 +58,12 @@
 - name: Configure the upgrade target for the common upgrade tasks 3.9
   hosts: oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config
   tasks:
-  - meta: clear_facts
   - set_fact:
       openshift_upgrade_target: '3.9'
       openshift_upgrade_min: '3.8'
       openshift_release: '3.9'
       openshift_pkg_version: "{{ _requested_pkg_version if _requested_pkg_version is defined else '' }}"
-  # Set the user's specified image_tag for 3.9 upgrade if it was provided.
-  - set_fact:
-      openshift_image_tag: "{{ _requested_image_tag }}"
-      l_force_image_tag_to_version: False
-    when: _requested_image_tag is defined
-  # If the user didn't specify an image_tag, we need to force update image_tag
-  # because it will have already been set during 3.8.  If we aren't running
-  # a double upgrade, then we can preserve image_tag because it will still
-  # be the user provided value.
-  - set_fact:
-      l_force_image_tag_to_version: True
-    when:
-    - l_double_upgrade_cp is defined and l_double_upgrade_cp
-    - _requested_image_tag is not defined
+      openshift_image_tag: "{{ _requested_image_tag if _requested_image_tag is defined else '' }}"
 
 - import_playbook: ../pre/config.yml
   # These vars a meant to exclude oo_nodes from plays that would otherwise include
@@ -107,12 +79,6 @@
     l_upgrade_excluder_hosts: "oo_masters_to_config"
     openshift_protect_installed_version: False
     openshift_version_reinit: True
-
-- name: Flag pre-upgrade checks complete for hosts without errors
-  hosts: oo_masters_to_config:oo_etcd_to_config
-  tasks:
-  - set_fact:
-      pre_upgrade_complete: True
 
 - import_playbook: ../upgrade_control_plane.yml
 

--- a/playbooks/init/version.yml
+++ b/playbooks/init/version.yml
@@ -6,7 +6,6 @@
   - include_role:
       name: openshift_version
       tasks_from: first_master.yml
-  - debug: msg="openshift_pkg_version set to {{ openshift_pkg_version | default('') }}"
 
 # NOTE: We set this even on etcd hosts as they may also later run as masters,
 # and we don't want to install wrong version of docker and have to downgrade

--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -158,6 +158,8 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
         host_groups = self.get_var("group_names")
         # containerized etcd may not have openshift_image_tag, see bz 1466622
         image_tag = self.get_var("openshift_image_tag", default="latest")
+        if image_tag == '':
+            image_tag = 'latest'
         image_info = DEPLOYMENT_IMAGE_INFO[deployment_type]
 
         # template for images that run on top of OpenShift

--- a/roles/openshift_version/defaults/main.yml
+++ b/roles/openshift_version/defaults/main.yml
@@ -11,3 +11,5 @@ openshift_use_crio_only: False
 
 l_first_master_version_task_file: "{{ openshift_is_containerized | ternary('first_master_containerized_version.yml', 'first_master_rpm_version.yml') }}"
 l_force_image_tag_to_version: False
+
+openshift_version_reinit: false

--- a/roles/openshift_version/tasks/check_available_rpms.yml
+++ b/roles/openshift_version/tasks/check_available_rpms.yml
@@ -1,10 +1,27 @@
 ---
-- name: Get available {{ openshift_service_type}} version
+- name: Get available openshift_service_type version
   repoquery:
-    name: "{{ openshift_service_type}}{{ '-' ~ openshift_release ~ '*' if openshift_release is defined else '' }}"
+    name: "{{ openshift_service_type }}{{ '-' ~ openshift_release ~ '*' if openshift_release is defined else '' }}"
     ignore_excluders: true
   register: rpm_results
 
-- fail:
-    msg: "Package {{ openshift_service_type}} not found"
+- name: Fail when Package openshift_service_type not found
+  fail:
+    msg: "The requested service type package {{ openshift_service_type }} or version {{ '-' ~ openshift_release ~ '*' if openshift_release is defined else '' }} was not found"
   when: not rpm_results.results.package_found
+
+- name: Abort when the release requested does not match the available RPM version.
+  vars:
+    l_rpm_version: "{{ rpm_results.results.versions.available_versions.0 }}"
+  when:
+  - openshift_version is defined
+  assert:
+    that:
+    - l_rpm_version.startswith(openshift_version) | bool
+    msg: >
+      You requested openshift version {{ openshift_version }}, which is not matched by
+      the latest OpenShift RPM we detected as {{ openshift_service_type }}-{{ l_rpm_version }}
+      on host {{ inventory_hostname }}.
+      We will only install the latest RPMs, so please ensure you are getting the release
+      you expect. You may need to adjust your Ansible inventory, modify the repositories
+      available on the host, or run the appropriate OpenShift upgrade playbook.

--- a/roles/openshift_version/tasks/first_master.yml
+++ b/roles/openshift_version/tasks/first_master.yml
@@ -13,20 +13,15 @@
 
 - include_tasks: "{{ l_first_master_version_task_file }}"
 
-- block:
-  - debug:
-      msg: "openshift_pkg_version was not defined. Falling back to -{{ openshift_version }}"
-  - set_fact:
-      openshift_pkg_version: -{{ openshift_version }}
-  when:
-  - openshift_pkg_version is not defined or openshift_pkg_version == ""
-  - openshift_upgrade_target is not defined
+# The end result of these variables is quite important so make sure they are displayed and logged:
+- debug:
+    var: openshift_release
 
-- block:
-  - debug:
-      msg: "openshift_image_tag set to v{{ openshift_version }}"
-  - set_fact:
-      openshift_image_tag: v{{ openshift_version }}
-  when: >
-    openshift_image_tag is not defined or openshift_image_tag == ""
-    or l_force_image_tag_to_version | bool
+- debug:
+    var: openshift_version
+
+- debug:
+    var: openshift_image_tag
+
+- debug:
+    var: openshift_pkg_version

--- a/roles/openshift_version/tasks/first_master_containerized_version.yml
+++ b/roles/openshift_version/tasks/first_master_containerized_version.yml
@@ -1,4 +1,5 @@
 ---
+# If provided, openshift_image_tag is preferred over openshift_release
 - name: Set containerized version to configure if openshift_image_tag specified
   set_fact:
     # Expects a leading "v" in inventory, strip it off here unless
@@ -7,61 +8,85 @@
   when:
   - openshift_image_tag is defined
   - openshift_image_tag != ""
-  - openshift_version is not defined
-  - not (openshift_version_reinit | default(false))
+  - openshift_version is not defined or openshift_version_reinit | bool
 
 - name: Set containerized version to configure if openshift_release specified
   set_fact:
     openshift_version: "{{ openshift_release }}"
   when:
   - openshift_release is defined
-  - openshift_version is not defined
+  - openshift_image_tag is not defined or openshift_image_tag == ""
+  - openshift_version is not defined or openshift_version_reinit | bool
 
-- name: Lookup latest containerized version if no version specified
-  command: >
-    docker run --rm {{ openshift_cli_image }}:latest version
-  register: cli_image_version
-  when:
-  - openshift_version is not defined or openshift_version_reinit | default(false)
-  - not openshift_use_crio_only
+# Fall back to looking up the latest image available in configured registries
+- when: openshift_version is not defined
+  block:
+  - name: Lookup latest containerized version if no version specified
+    command: >
+      docker run --rm {{ openshift_cli_image }}:latest version
+    register: cli_image_version
+    when:
+    - not openshift_use_crio_only
 
-# Origin latest = pre-release version (i.e. v1.3.0-alpha.1-321-gb095e3a)
-- set_fact:
-    openshift_version: "{{ (cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0:2] | join('-'))[1:] }}"
-  when:
-  - openshift_version is not defined
-  - openshift.common.deployment_type == 'origin'
-  - cli_image_version.stdout_lines[0].split('-') | length > 1
-  - not openshift_use_crio_only
+  # Origin latest = pre-release version (i.e. v1.3.0-alpha.1-321-gb095e3a)
+  - name: Set openshift_version to latest containerized version found (Origin)
+    set_fact:
+      openshift_version: "{{ (cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0:2] | join('-'))[1:] }}"
+    when:
+    - openshift.common.deployment_type == 'origin'
+    - cli_image_version.stdout_lines[0].split('-') | length > 1
+    - not openshift_use_crio_only
 
-- set_fact:
-    openshift_version: "{{ cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0][1:] }}"
-  when: openshift_version is not defined or openshift_version_reinit | default(false)
+  - name: Set openshift_version to latest containerized version found (OCP)
+    set_fact:
+      openshift_version: "{{ cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0][1:] }}"
 
 # If we got an openshift_version like "3.2", lookup the latest 3.2 container version
 # and use that value instead.
-- name: Set precise containerized version to configure if openshift_release specified
-  command: >
-    docker run --rm {{ openshift_cli_image }}:v{{ openshift_version }} version
-  register: cli_image_version
-  when:
+- when:
   - openshift_version is defined
   - openshift_version.split('.') | length == 2
-  - not openshift_use_crio_only
+  block:
+  # TODO: figure out a way to check for the openshift_version when using CRI-O.
+  # We should do that using the images in the ostree storage so we don't have
+  # to pull them again.
+  - name: Lookup precise containerized version to configure if openshift_release specified
+    command: >
+      docker run --rm {{ openshift_cli_image }}:v{{ openshift_version }} version
+    register: cli_image_version
+    when:
+    - not openshift_use_crio_only
 
-- set_fact:
-    openshift_version: "{{ cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0:2][1:] | join('-') if openshift.common.deployment_type == 'origin' else cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0][1:] }}"
-  when:
-  - openshift_version is defined
-  - openshift_version.split('.') | length == 2
-  - not openshift_use_crio_only
-
-# TODO: figure out a way to check for the openshift_version when using CRI-O.
-# We should do that using the images in the ostree storage so we don't have
-# to pull them again.
+  - name: Set openshift_version to precise containerized version found
+    set_fact:
+      openshift_version: "{{ cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0:2][1:] | join('-') if openshift.common.deployment_type == 'origin' else cli_image_version.stdout_lines[0].split(' ')[1].split('-')[0][1:] }}"
+    when:
+    - not openshift_use_crio_only
 
 # We finally have the specific version. Now we clean up any strange
 # dangly +c0mm1t-offset tags in the version. See also,
 # openshift_facts.py
-- set_fact:
+- name: Remove any commit offset tags from openshift_version
+  set_fact:
     openshift_version: "{{ openshift_version | lib_utils_oo_chomp_commit_offset }}"
+
+- name: Set openshift_image_tag to match openshift_version found if openshift_image_tag was not provided
+  set_fact:
+    openshift_image_tag: v{{ openshift_version }}
+  when: >
+    openshift_image_tag is not defined or openshift_image_tag == ""
+    or (openshift_image_tag is defined and openshift_image_tag.split('.') | length == 2)
+
+- name: Set openshift_pkg_version to match openshift_version
+  set_fact:
+    openshift_pkg_version: -{{ openshift_version }}
+  when: >
+    openshift_pkg_version is not defined or openshift_pkg_version == ""
+    or openshift_version not in openshift_pkg_version
+#    or (openshift_pkg_version is defined and openshift_pkg_version.split('.') | length == 2)
+
+- name: Check for available RPMs
+  include_tasks: check_available_rpms.yml
+  vars:
+    openshift_version: "{{ openshift_pkg_version[1:].split('-')[0] }}"
+  when: not openshift_is_atomic | bool

--- a/roles/openshift_version/tasks/first_master_rpm_version.yml
+++ b/roles/openshift_version/tasks/first_master_rpm_version.yml
@@ -1,4 +1,5 @@
 ---
+# If provided, openshift_pkg_version is preferred over openshift_release
 - name: Set rpm version to configure if openshift_pkg_version specified
   set_fact:
     # Expects a leading "-" in inventory, strip it off here, and remove trailing release,
@@ -6,16 +7,36 @@
   when:
   - openshift_pkg_version is defined
   - openshift_pkg_version != ""
-  - openshift_version is not defined
-  - not (openshift_version_reinit | default(false))
+  - openshift_version is not defined or openshift_version_reinit | bool
 
-# These tasks should only be run against masters and nodes
-- name: Set openshift_version for rpm installation
+- name: Set rpm version to configure if openshift_release specified
+  set_fact:
+    openshift_version: "{{ openshift_release }}"
+  when:
+  - openshift_release is defined
+  - openshift_pkg_version is not defined or openshift_pkg_version == ""
+  - openshift_version is not defined or openshift_version_reinit | bool
+
+- name: Check for available RPMs
   include_tasks: check_available_rpms.yml
 
-- set_fact:
+# Fall back to the rpm package found in configured repositories
+- name: Set openshift_version to rpm version found
+  set_fact:
     openshift_version: "{{ rpm_results.results.versions.available_versions.0 }}"
-  when: openshift_version is not defined or ( openshift_version_reinit | default(false) )
-- set_fact:
+  when:
+  - openshift_version is not defined or (openshift_version is defined and openshift_version.split('.') | length == 2)
+
+- name: Set openshift_pkg_version to rpm version found if openshift_pkg_version was not specified
+  set_fact:
     openshift_pkg_version: "-{{ rpm_results.results.versions.available_versions.0 }}"
-  when: openshift_version_reinit | default(false)
+  when: >
+    openshift_pkg_version is not defined or openshift_pkg_version == ""
+    or (openshift_pkg_version is defined and openshift_pkg_version.split('.') | length == 2)
+
+- name: Set openshift_image_tag to match openshift_version
+  set_fact:
+    openshift_image_tag: v{{ openshift_version }}
+  when: >
+    openshift_image_tag is not defined or openshift_image_tag == ""
+    or openshift_version not in openshift_image_tag

--- a/roles/openshift_version/tasks/masters_and_nodes.yml
+++ b/roles/openshift_version/tasks/masters_and_nodes.yml
@@ -1,42 +1,20 @@
 ---
 # These tasks should only be run against masters and nodes
 
-- block:
-  - name: Check openshift_version for rpm installation
-    include_tasks: check_available_rpms.yml
-  - name: Fail if rpm version and docker image version are different
-    fail:
-      msg: "OCP rpm version {{ rpm_results.results.versions.available_versions.0 }} is different from OCP image version {{ openshift_version }}"
-    # Both versions have the same string representation
-    when:
-    - openshift_version not in rpm_results.results.versions.available_versions.0
-    - openshift_version_reinit | default(false)
-
-  # block when
+# RPM and Containerized installs
+- name: Check openshift_version for rpm installation
+  include_tasks: check_available_rpms.yml
   when: not openshift_is_atomic | bool
 
-# We can't map an openshift_release to full rpm version like we can with containers; make sure
-# the rpm version we looked up matches the release requested and error out if not.
-- name: For an RPM install, abort when the release requested does not match the available version.
-  when:
-  - not openshift_is_containerized | bool
-  - openshift_release is defined
-  assert:
-    that:
-    - l_rpm_version.startswith(openshift_release) | bool
-    msg: |-
-      You requested openshift_release {{ openshift_release }}, which is not matched by
-      the latest OpenShift RPM we detected as {{ openshift_service_type }}-{{ l_rpm_version }}
-      on host {{ inventory_hostname }}.
-      We will only install the latest RPMs, so please ensure you are getting the release
-      you expect. You may need to adjust your Ansible inventory, modify the repositories
-      available on the host, or run the appropriate OpenShift upgrade playbook.
-  vars:
-    l_rpm_version: "{{ rpm_results.results.versions.available_versions.0 }}"
+# The end result of these variables is quite important so make sure they are displayed and logged:
+- debug:
+    var: openshift_release
 
-# The end result of these three variables is quite important so make sure they are displayed and logged:
-- debug: var=openshift_release
+- debug:
+    var: openshift_version
 
-- debug: var=openshift_image_tag
+- debug:
+    var: openshift_image_tag
 
-- debug: var=openshift_pkg_version
+- debug:
+    var: openshift_pkg_version


### PR DESCRIPTION
openshift_image_tag was not being properly set because openshift_version
was already set from the intermediate 3.8 upgrade.  This was causing
containerized installs to not use openshift_image_tag provided in the
inventory.

Bug 1542368 | https://bugzilla.redhat.com/show_bug.cgi?id=1542368