### PR TITLE
kernel module loading fix

### DIFF
--- a/playbooks/openshift-glusterfs/private/config.yml
+++ b/playbooks/openshift-glusterfs/private/config.yml
@@ -19,11 +19,6 @@
       tasks_from: firewall.yml
     when:
     - openshift_storage_glusterfs_is_native | default(True) | bool
-  - import_role:
-      name: openshift_storage_glusterfs
-      tasks_from: kernel_modules.yml
-    when:
-    - openshift_storage_glusterfs_is_native | default(True) | bool
 
 - name: Open firewall ports for GlusterFS registry nodes
   hosts: glusterfs_registry
@@ -33,6 +28,10 @@
       tasks_from: firewall.yml
     when:
     - openshift_storage_glusterfs_registry_is_native | default(True) | bool
+
+- name: Load kernel modules for nodes
+  hosts: oo_nodes_to_config
+  tasks:
   - import_role:
       name: openshift_storage_glusterfs
       tasks_from: kernel_modules.yml

--- a/roles/openshift_storage_glusterfs/tasks/kernel_modules.yml
+++ b/roles/openshift_storage_glusterfs/tasks/kernel_modules.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensure device mapper modules loaded
   template:
-    src: glusterfs.conf
+    src: glusterfs.conf.j2
     dest: /etc/modules-load.d/glusterfs.conf
   register: km
 

--- a/roles/openshift_storage_glusterfs/templates/glusterfs.conf
+++ b/roles/openshift_storage_glusterfs/templates/glusterfs.conf
@@ -1,7 +1,0 @@
-#{{ ansible_managed }}
-dm_thin_pool
-dm_snapshot
-dm_mirror
-#glusterblock
-dm_multipath
-target_core_user

--- a/roles/openshift_storage_glusterfs/templates/glusterfs.conf.j2
+++ b/roles/openshift_storage_glusterfs/templates/glusterfs.conf.j2
@@ -1,0 +1,8 @@
+#{{ ansible_managed }}
+dm_thin_pool
+dm_multipath
+target_core_user
+{% if inventory_hostname in groups.glusterfs or inventory_hostname in groups.glusterfs_registry %}
+dm_snapshot
+dm_mirror
+{% endif %}


### PR DESCRIPTION
Load GlusterFS kernel modules on all nodes so we could use iscsi and glusterfs mounts on all nodes when  PVC is requested. 