### PR TITLE
Fix master and node system container variables

### DIFF
--- a/roles/openshift_master/tasks/system_container.yml
+++ b/roles/openshift_master/tasks/system_container.yml
@@ -18,6 +18,8 @@
     state: latest
     values:
     - COMMAND=api
+    - "NODE_SERVICE={{ openshift_service_type }}-node.service"
+    - "DOCKER_SERVICE={{ openshift_docker_service_name }}.service"
 
 - name: Install or Update HA controller master system container
   oc_atomic_container:
@@ -26,3 +28,5 @@
     state: latest
     values:
     - COMMAND=controllers
+    - "NODE_SERVICE={{ openshift_service_type }}-node.service"
+    - "DOCKER_SERVICE={{ openshift_docker_service_name }}.service"

--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -13,7 +13,7 @@
     values:
     - "DNS_DOMAIN={{ openshift.common.dns_domain }}"
     - "DOCKER_SERVICE={{ openshift_docker_service_name }}.service"
-    - "MASTER_SERVICE={{ openshift_service_type }}.service"
+    - "MASTER_SERVICE={{ openshift_service_type }}-master-controllers.service"
     - 'ADDTL_MOUNTS={{ l_node_syscon_add_mounts2 }}'
     state: latest
   vars:


### PR DESCRIPTION
This commit corrects service names and adds
DOCKER_SERVICE variable to openshift_master
system container creation.

This will ensure services will restart correctly
and in the proper order.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1542324