### PR TITLE
Detect config changes in console liveness probe

### DIFF
--- a/roles/openshift_web_console/files/console-template.yaml
+++ b/roles/openshift_web_console/files/console-template.yaml
@@ -67,10 +67,17 @@ objects:
               port: 8443
               scheme: HTTPS
           livenessProbe:
-            httpGet:
-              path: /
-              port: 8443
-              scheme: HTTPS
+            exec:
+              command:
+                - /bin/sh
+                - -i
+                - -c
+                - |-
+                  if [[ ! -f /tmp/webconsole-config.hash ]]; then \
+                    md5sum /var/webconsole-config/webconsole-config.yaml > /tmp/webconsole-config.hash; \
+                  elif [[ $(md5sum /var/webconsole-config/webconsole-config.yaml) != $(cat /tmp/webconsole-config.hash) ]]; then \
+                    exit 1; \
+                  fi && curl -k -f https://0.0.0.0:8443/console/
           resources:
             requests:
               cpu: 100m

--- a/roles/openshift_web_console/tasks/update_console_config.yml
+++ b/roles/openshift_web_console/tasks/update_console_config.yml
@@ -5,9 +5,6 @@
 # `value` properties in the same format as `yedit` module `edits`. Only
 # properties passed are updated. The separator for nested properties is `#`.
 #
-# Note that this triggers a redeployment on the console and a brief downtime
-# since it uses a `Recreate` strategy.
-#
 # Example usage:
 #
 # - include_role:
@@ -55,13 +52,9 @@
       state: present
       from_file:
         webconsole-config.yaml: "{{ mktemp_console.stdout }}/webconsole-config.yaml"
-    register: update_console_config_map
 
   - name: Remove temp directory
     file:
       state: absent
       name: "{{ mktemp_console.stdout }}"
     changed_when: False
-
-  - include_tasks: rollout_console.yml
-    when: update_console_config_map.changed | bool


### PR DESCRIPTION
Use an md5sum to check if the console config has changed and
automatically restart the container.

See https://github.com/openshift/origin/pull/18411

/assign @sdodson 
/cc @jwforres 