### PR TITLE
[release-3.6] health checks: tolerate ovs 2.9

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/ovs_version.py
+++ b/roles/openshift_health_checker/openshift_checks/ovs_version.py
@@ -16,8 +16,8 @@ class OvsVersion(NotContainerizedMixin, OpenShiftCheck):
     tags = ["health"]
 
     openshift_to_ovs_version = {
-        "3.7": ["2.6", "2.7", "2.8"],
-        "3.6": ["2.6", "2.7", "2.8"],
+        "3.7": ["2.6", "2.7", "2.8", "2.9"],
+        "3.6": ["2.6", "2.7", "2.8", "2.9"],
         "3.5": ["2.6", "2.7"],
         "3.4": "2.4",
     }

--- a/roles/openshift_health_checker/openshift_checks/package_version.py
+++ b/roles/openshift_health_checker/openshift_checks/package_version.py
@@ -16,8 +16,8 @@ class PackageVersion(NotContainerizedMixin, OpenShiftCheck):
     openshift_to_ovs_version = {
         (3, 4): "2.4",
         (3, 5): ["2.6", "2.7"],
-        (3, 6): ["2.6", "2.7", "2.8"],
-        (3, 7): ["2.6", "2.7", "2.8"],
+        (3, 6): ["2.6", "2.7", "2.8", "2.9"],
+        (3, 7): ["2.6", "2.7", "2.8", "2.9"],
     }
 
     openshift_to_docker_version = {

--- a/roles/openshift_health_checker/test/ovs_version_test.py
+++ b/roles/openshift_health_checker/test/ovs_version_test.py
@@ -63,7 +63,14 @@ def test_ovs_package_version(openshift_release, expected_ovs_version):
 
         return return_value
 
-    result = OvsVersion(execute_module, task_vars).run()
+    check = OvsVersion(execute_module, task_vars)
+    check.openshift_to_ovs_version = {
+        "3.7": ["2.6", "2.7", "2.8"],
+        "3.6": ["2.6", "2.7", "2.8"],
+        "3.5": ["2.6", "2.7"],
+        "3.4": "2.4",
+    }
+    result = check.run()
     assert result is return_value
 
 


### PR DESCRIPTION
backport of #7035