### PR TITLE
[3.7] Add ability to mount volumes into system container nodes

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -1193,6 +1193,18 @@ that result to this filter plugin.
     return secret_name
 
 
+def oo_l_of_d_to_csv(input_list):
+    """Map a list of dictionaries, input_list, into a csv string
+    of json values.
+
+    Example input:
+    [{'var1': 'val1', 'var2': 'val2'}, {'var1': 'val3', 'var2': 'val4'}]
+    Example output:
+    u'{"var1": "val1", "var2": "val2"},{"var1": "val3", "var2": "val4"}'
+    """
+    return ','.join(json.dumps(x) for x in input_list)
+
+
 class FilterModule(object):
     """ Custom ansible filter mapping """
 
@@ -1237,4 +1249,5 @@ class FilterModule(object):
             "oo_contains_rule": oo_contains_rule,
             "oo_selector_to_string_list": oo_selector_to_string_list,
             "oo_filter_sa_secrets": oo_filter_sa_secrets,
+            "oo_l_of_d_to_csv": oo_l_of_d_to_csv
         }

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -7,6 +7,18 @@ r_openshift_node_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }
 openshift_deployment_type: "{{ openshift_deployment_type | default('origin') }}"
 openshift_service_type: "{{ 'origin' if openshift_deployment_type == 'origin' else 'atomic-openshift' }}"
 
+openshift_node_syscon_auth_mounts_l:
+- type: bind
+  source: "{{ oreg_auth_credentials_path }}"
+  destination: "/root/.docker"
+  options:
+  - ro
+  - bind
+
+# If we need to add new mounts in the future, or the user wants to mount data.
+# This should be in the same format as auth_mounts_l above.
+openshift_node_syscon_add_mounts_l: []
+
 openshift_image_tag: ''
 
 default_r_openshift_node_image_prep_packages:

--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -19,4 +19,23 @@
     - "DNS_DOMAIN={{ openshift.common.dns_domain }}"
     - "DOCKER_SERVICE={{ openshift.docker.service_name }}.service"
     - "MASTER_SERVICE={{ openshift.common.service_type }}.service"
+    - 'ADDTL_MOUNTS={{ l_node_syscon_add_mounts2 }}'
     state: latest
+  vars:
+    # We need to evaluate some variables here to ensure
+    # l_bind_docker_reg_auth is evaluated after registry_auth.yml has been
+    # processed.
+
+    # Determine if we want to include auth credentials mount.
+    l_node_syscon_auth_mounts_l: "{{ l_bind_docker_reg_auth | ternary(openshift_node_syscon_auth_mounts_l,[]) }}"
+
+    # Join any user-provided mounts and auth_mounts into a combined list.
+    l_node_syscon_add_mounts_l: "{{ openshift_node_syscon_add_mounts_l | union(l_node_syscon_auth_mounts_l) }}"
+
+    # We must prepend a ',' here to ensure the value is inserted properly into an
+    # existing json list in the container's config.json
+    # oo_l_of_d_to_csv is a custom filter plugin openshift-ansible/filter_plugins/oo_filters.py
+    l_node_syscon_add_mounts: ",{{ l_node_syscon_add_mounts_l | oo_l_of_d_to_csv }}"
+    # if we have just a ',' then both mount lists were empty, we don't want to add
+    # anything to config.json
+    l_node_syscon_add_mounts2: "{{ (l_node_syscon_add_mounts != ',') | bool | ternary(l_node_syscon_add_mounts,'') }}"


### PR DESCRIPTION
This commit adds the ability to mount volumes into
system containerized nodes.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1534933
(cherry picked from commit e18a06d2a14c5933243773f0aca7a891177f3e40)

node: specify bind option to /root/.docker

Without the option, runc fails with "no such device" when trying to
create the mount point.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1534933

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit 63cf5012085994a542ca85b4208f05c955a03aab)