### PR TITLE
Setup docker excluder if requested before container_runtime is installed

### DIFF
--- a/playbooks/container-runtime/private/config.yml
+++ b/playbooks/container-runtime/private/config.yml
@@ -12,6 +12,12 @@
     - role: container_runtime
   tasks:
     - import_role:
+        name: openshift_excluder
+        tasks_from: enable.yml
+      vars:
+        r_openshift_excluder_action: enable
+        r_openshift_excluder_enable_openshift_excluder: false
+    - import_role:
         name: container_runtime
         tasks_from: package_docker.yml
       when:


### PR DESCRIPTION
That would prevent possible container runtime upgrades during cluster
config

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540800

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>