### PR TITLE
Fix setup-openshift-heketi-storage image

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/heketi_deploy_part2.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_deploy_part2.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create heketi DB volume
-  command: "{{ glusterfs_heketi_client }} setup-openshift-heketi-storage --listfile /tmp/heketi-storage.json"
+  command: "{{ glusterfs_heketi_client }} setup-openshift-heketi-storage --listfile /tmp/heketi-storage.json --image {{ glusterfs_heketi_image }}:{{ glusterfs_heketi_version }}"
   register: setup_storage
 
 - name: Copy heketi-storage list


### PR DESCRIPTION
Addresses issue: https://github.com/openshift/openshift-ansible/issues/7036

The setup-openshift-heketi-storage command creates a job/pod resource without specifying an image. It then uses the heketi/heketi:dev image that is hardcoded into the binary.