### PR TITLE
3.9 upgrade: fix typos in restart masters procedure

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
@@ -125,8 +125,8 @@
   - name: Restart master controllers to force new leader election mode
     service:
       name: "{{ openshift_service_type }}-master-controllers"
-      state: restart
-    when: openshift.common.rolling_restart_mode == 'service'
+      state: restarted
+    when: openshift.common.rolling_restart_mode == 'services'
   - name: Re-enable master controllers to force new leader election mode
     service:
       name: "{{ openshift_service_type }}-master-controllers"


### PR DESCRIPTION
* 'rolling_restart_mode' should be 'services', not 'service'
* use 'state: restarted' to properly restart services

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540054

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>