### PR TITLE
[3.7] Allow journald_vars_to_replace to set

### DIFF
--- a/roles/openshift_master/tasks/journald.yml
+++ b/roles/openshift_master/tasks/journald.yml
@@ -14,7 +14,7 @@
     regexp: '^(\#| )?{{ item.var }}=\s*.*?$'
     replace: ' {{ item.var }}={{ item.val }}'
     backup: yes
-  with_items: "{{ journald_vars_to_replace | default([]) }}"
+  with_items: "{{ journald_vars_to_replace | default(journald_vars_to_replace_defaults) }}"
   when: journald_conf_file.stat.exists
   register: journald_update
 

--- a/roles/openshift_master/vars/main.yml
+++ b/roles/openshift_master/vars/main.yml
@@ -26,7 +26,7 @@ openshift_master_is_scaleup_host: False
 # syslog or wall, using 8GB of disk space maximum, using 10MB journal
 # files, keeping only a days worth of logs per journal file, and
 # retaining journal files no longer than a month.
-journald_vars_to_replace:
+journald_vars_to_replace_defaults:
 - { var: Storage, val: persistent }
 - { var: Compress, val: yes }
 - { var: SyncIntervalSec, val: 1s }


### PR DESCRIPTION
Currently in 3.7 branch, journald_vars_to_replace
is in openshift_master/vars/main.yml.  This will
disallow inventory variables to set the value for
journald_vars_to_replace.

This commit adds the variable journald_vars_to_replace_defaults
to vars/main.yml and uses that as the default value
for journald_vars_to_replace.  This will allow
users to override journald_vars_to_replace with inventory
variables.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1542887