### PR TITLE
Use wait_for_connection to validate ssh transport is alive

### DIFF
--- a/playbooks/gcp/openshift-cluster/build_image.yml
+++ b/playbooks/gcp/openshift-cluster/build_image.yml
@@ -62,6 +62,12 @@
       timeout: 120
     with_items: "{{ gce.instance_data }}"
 
+- name: Wait for full SSH connection
+  hosts: nodes
+  gather_facts: no
+  tasks:
+  - wait_for_connection:
+
 - hosts: nodes
   tasks:
   - name: Set facts


### PR DESCRIPTION
Possible fix for https://github.com/openshift/origin/issues/18360

```
TASK [add host to nodes] *******************************************************
Wednesday 07 February 2018  18:53:27 +0000 (0:00:12.290)       0:00:18.665 **** 
changed: [localhost] => (item={u'status': u'RUNNING', u'network': u'default', u'zone': u'us-east1-c', u'tags': [u'build-image-instance'], u'image': u'rhel-7-v20180129', u'disks': [u'ci-prtest-fa08ce7-515-build-image-instance'], u'name': u'ci-prtest-fa08ce7-515-build-image-instance', u'public_ip': u'104.196.162.237', u'private_ip': u'10.142.0.2', u'machine_type': u'n1-standard-1', u'subnetwork': u'default', u'metadata': {}})

TASK [Wait for instance to respond to SSH] *************************************
Wednesday 07 February 2018  18:53:27 +0000 (0:00:00.038)       0:00:18.704 **** 
ok: [localhost] => (item={u'status': u'RUNNING', u'network': u'default', u'zone': u'us-east1-c', u'tags': [u'build-image-instance'], u'image': u'rhel-7-v20180129', u'disks': [u'ci-prtest-fa08ce7-515-build-image-instance'], u'name': u'ci-prtest-fa08ce7-515-build-image-instance', u'public_ip': u'104.196.162.237', u'private_ip': u'10.142.0.2', u'machine_type': u'n1-standard-1', u'subnetwork': u'default', u'metadata': {}})

PLAY [nodes] *******************************************************************

TASK [Gathering Facts] *********************************************************
Wednesday 07 February 2018  18:53:39 +0000 (0:00:11.387)       0:00:30.091 **** 
fatal: [104.196.162.237]: UNREACHABLE! => {"changed": false, "msg": "SSH Error: data could not be sent to remote host \"104.196.162.237\". Make sure this host can be reached over ssh", "unreachable": true}

PLAY RECAP *********************************************************************
104.196.162.237            : ok=0    changed=0    unreachable=1    failed=0   
localhost                  : ok=5    changed=3    unreachable=0    failed=0   
```