### PR TITLE
openshift_node: Remove master from aws node building

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -112,7 +112,7 @@ l_is_openvswitch_system_container: "{{ (openshift_use_openvswitch_system_contain
 openshift_image_tag: ''
 
 default_r_openshift_node_image_prep_packages:
-- "{{ openshift_service_type }}-master"
+#- "{{ openshift_service_type }}-master"
 - "{{ openshift_service_type }}-node"
 - "{{ openshift_service_type }}-docker-excluder"
 - "{{ openshift_service_type }}-sdn-ovs"

--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -43,13 +43,13 @@
 #    line: "{% raw %}ExecStart=/usr/bin/openshift start node --bootstrap --kubeconfig=${KUBECONFIG} $OPTIONS{% endraw %}"
 #    regexp: "^ExecStart=.*"
 
-- name: "disable {{ openshift_service_type }}-node and {{ openshift_service_type }}-master services"
+- name: "disable {{ openshift_service_type }}-node"  # and {{ openshift_service_type }}-master services"
   systemd:
     name: "{{ item }}"
     enabled: no
   with_items:
   - "{{ openshift_service_type }}-node.service"
-  - "{{ openshift_service_type }}-master.service"
+#  - "{{ openshift_service_type }}-master.service"
 
 - name: Check for RPM generated config marker file .config_managed
   stat:


### PR DESCRIPTION
Since it is expected to be re-added at some point in the future the lines
have been commented out rather than deleted.

