### PR TITLE
Add prometheus reader role for lightweight privileges.

### DIFF
--- a/roles/openshift_prometheus/defaults/main.yaml
+++ b/roles/openshift_prometheus/defaults/main.yaml
@@ -15,6 +15,7 @@ openshift_prometheus_node_selector: {"region":"infra"}
 openshift_prometheus_service_port: 443
 openshift_prometheus_service_targetport: 8443
 openshift_prometheus_service_name: prometheus
+openshift_prometheus_reader_serviceaccount_name: prometheus-reader
 openshift_prometheus_alerts_service_targetport: 9443
 openshift_prometheus_alerts_service_name: alerts
 openshift_prometheus_alertmanager_service_targetport: 10443

--- a/roles/openshift_prometheus/tasks/install_prometheus.yaml
+++ b/roles/openshift_prometheus/tasks/install_prometheus.yaml
@@ -32,6 +32,13 @@
     namespace: "{{ openshift_prometheus_namespace }}"
   changed_when: no
 
+# serviceaccount reader
+- name: create openshift_prometheus_reader_serviceaccount_name serviceaccount
+  oc_serviceaccount:
+    state: present
+    name: "{{ openshift_prometheus_reader_serviceaccount_name }}"
+    namespace: "{{ openshift_prometheus_namespace }}"
+  changed_when: no
 
 # TODO remove this when annotations are supported by oc_serviceaccount
 - name: annotate serviceaccount
@@ -49,6 +56,15 @@
     resource_kind: cluster-role
     resource_name: cluster-reader
     user: "system:serviceaccount:{{ openshift_prometheus_namespace }}:{{ openshift_prometheus_service_name }}"
+
+# create view role for prometheus-reader serviceaccount
+- name: Set view permissions for prometheus reader
+  oc_adm_policy_user:
+    state: present
+    namespace: "{{ openshift_prometheus_namespace }}"
+    resource_kind: cluster-role
+    resource_name: view
+    user: "system:serviceaccount:{{ openshift_prometheus_namespace }}:{{ openshift_prometheus_reader_serviceaccount_name }}"
 
 
 - name: create services for prometheus


### PR DESCRIPTION
Standardise lightweight service account with read\view privileges as "prometheus-reader", for security best practices.
so that "prometheus-reader" sa token will be available especially for monitor purposes.

the main use-case is to facilitate grafana and prometheus integration CI.