### PR TITLE
[3.7] Revert "GlusterFS: Remove image option from heketi command"

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/heketi_deploy_part2.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_deploy_part2.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create heketi DB volume
-  command: "{{ glusterfs_heketi_client }} setup-openshift-heketi-storage --listfile /tmp/heketi-storage.json"
+  command: "{{ glusterfs_heketi_client }} setup-openshift-heketi-storage --image {{ glusterfs_heketi_image}}:{{ glusterfs_heketi_version }} --listfile /tmp/heketi-storage.json"
   register: setup_storage
 
 - name: Copy heketi-storage list


### PR DESCRIPTION
Cherry-pick of #6938 for 3.7 branch.

This reverts commit 3d3853836d71c37a9c81aea8e606c94052439789 which was
supposedly a fix for an issue with topology initialization, but that
turned out to be a separate issue fixed in commit
b8879b5c6731bd51e590b470b1a51fce73db0ee1. By default "heketi-cli
setup-openshift-heketi-storage" uses the "heketi/heketi:dev" image
while, for OpenShift Container Platform installations, the default image
for all other operations is "rhgs3/rhgs-volmanager-rhel7". In
environments where only a limited set of Docker registries is available,
i.e. only the Red Hat registry but not Docker Hub, using
"heketi/heketi:dev" does not work or would require manual intervention.

The discussion surrounding the removal of "--image" in PR#5769 involved
statements that "--image" was removed from Heketi. As of January 30,
2018 the master branch contains the option, as does the upstream Docker
image (Heketi version v5.0.0-225-gffb9fea) and the aforementioned
"rhgs3/rhgs-volmanager-rhel7" image.

Tested with OpenShift Container Platform 3.7.23.