### PR TITLE
Update user-data for FQDN instance hostnames

### DIFF
--- a/roles/openshift_aws/templates/user_data.j2
+++ b/roles/openshift_aws/templates/user_data.j2
@@ -20,6 +20,9 @@ runcmd:
 - [ ansible-playbook, /root/openshift_bootstrap/bootstrap.yml]
 {%     endif %}
 {%     if openshift_aws_node_group.group != 'master' %}
+{# Restarting systemd-hostnamed ensures that instances will have FQDN
+hostnames following network restart. #}
+- [ systemctl, restart, systemd-hostnamed]
 - [ systemctl, restart, NetworkManager]
 - [ systemctl, enable, {% if openshift_deployment_type == 'openshift-enterprise' %}atomic-openshift{% else %}origin{% endif %}-node]
 - [ systemctl, start, {% if openshift_deployment_type == 'openshift-enterprise' %}atomic-openshift{% else %}origin{% endif %}-node]

--- a/roles/openshift_node/files/bootstrap.yml
+++ b/roles/openshift_node/files/bootstrap.yml
@@ -61,11 +61,3 @@
       with_items:
       - line: "BOOTSTRAP_CONFIG_NAME=node-config-{{ openshift_group_type }}"
         regexp: "^BOOTSTRAP_CONFIG_NAME=.*"
-
-    - name: "Start the {{ openshift_service_type }}-node service"
-      systemd:
-        daemon_reload: yes
-        state: restarted
-        enabled: True
-        name: "{{ openshift_service_type }}-node"
-        no_block: true


### PR DESCRIPTION
* Remove node service start from bootstrap.yml. We start and enable the node service in user-data and we want the node service to start after NetworkManager so that the instance will have its final hostname.
* Restart systemd-hostnamed before restarting NetworkManager. In testing this has ensured that instances receive an FQDN hostname which is required for kube.