### PR TITLE
Redeploy router certificates during upgrade only when secure.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -114,22 +114,26 @@
     openshift_hosted_templates_import_command: replace
 
   post_tasks:
-  # we need to migrate customers to the new pattern of pushing to the registry via dns
-  # Step 1: verify the certificates have the docker registry service name
-  - shell: >
-      echo -n | openssl s_client -showcerts -servername docker-registry.default.svc -connect docker-registry.default.svc:5000  | openssl x509 -text |  grep -A1 'X509v3 Subject Alternative Name:' | grep -Pq 'DNS:docker-registry\.default\.svc(,|$)'
-    register: cert_output
-    changed_when: false
-    failed_when:
-    - cert_output.rc not in [0, 1]
+  # Do not perform these tasks when the registry is insecure.  The default registry is insecure in openshift_hosted/defaults/main.yml
+  - when: not (openshift_docker_hosted_registry_insecure | default(True))
+    block:
+    # we need to migrate customers to the new pattern of pushing to the registry via dns
+    # Step 1: verify the certificates have the docker registry service name
+    - name: shell command to determine if the docker-registry.default.svc is found in the registry certificate
+      shell: >
+        echo -n | openssl s_client -showcerts -servername docker-registry.default.svc -connect docker-registry.default.svc:5000  | openssl x509 -text |  grep -A1 'X509v3 Subject Alternative Name:' | grep -Pq 'DNS:docker-registry\.default\.svc(,|$)'
+      register: cert_output
+      changed_when: false
+      failed_when:
+      - cert_output.rc not in [0, 1]
 
-  # Step 2: Set a fact to be used to determine if we should run the redeploy of registry certs
-  - name: set a fact to include the registry certs playbook if needed
-    set_fact:
-      openshift_hosted_rollout_certs_and_registry: "{{ cert_output.rc == 0  }}"
+    # Step 2: Set a fact to be used to determine if we should run the redeploy of registry certs
+    - name: set a fact to include the registry certs playbook if needed
+      set_fact:
+        openshift_hosted_rollout_certs_and_registry: "{{ cert_output.rc == 0  }}"
 
-# Run the redeploy certs based upon the certificates
-- when: hostvars[groups.oo_first_master.0].openshift_hosted_rollout_certs_and_registry
+# Run the redeploy certs based upon the certificates. Defaults to False for insecure registries
+- when: (hostvars[groups.oo_first_master.0].openshift_hosted_rollout_certs_and_registry | default(False)) | bool
   import_playbook: ../../../openshift-hosted/redeploy-registry-certificates.yml
 
 # Check for warnings to be printed at the end of the upgrade:


### PR DESCRIPTION
Wrap the upgrade logic for redeploying certificates into another block so that insecure registries do not perform any certificate tasks.