### PR TITLE
Copy files from openshift_master_generated_config_dir instead using hardlinks

### DIFF
--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -88,11 +88,10 @@
   delegate_to: "{{ openshift_ca_host }}"
   run_once: true
 
-- file:
+- copy:
     src: "/etc/origin/master/{{ item }}"
     dest: "{{ openshift_master_generated_config_dir }}/{{ item }}"
-    state: hard
-    force: true
+    remote_src: yes
   with_items:
   - admin.crt
   - admin.key


### PR DESCRIPTION
Fixes #7075

Tested in a release-3.7 branch on a existing 3.7 cluster.