### PR TITLE
Only try to yaml.load a file if it ends in .yml or .yaml in logging facts

### DIFF
--- a/roles/openshift_logging/library/openshift_logging_facts.py
+++ b/roles/openshift_logging/library/openshift_logging_facts.py
@@ -208,9 +208,10 @@ class OpenshiftLoggingFacts(OCBaseCommand):
     def facts_from_configmap(self, comp, kind, name, config_key, yaml_file=None):
         '''Extracts facts in logging namespace from configmap'''
         if yaml_file is not None:
-            config_facts = yaml.load(yaml_file)
-            self.facts[comp][kind][name][config_key] = config_facts
-            self.facts[comp][kind][name]["raw"] = yaml_file
+            if config_key.endswith(".yml") or config_key.endswith(".yaml"):
+                config_facts = yaml.load(yaml_file)
+                self.facts[comp][kind][name][config_key] = config_facts
+                self.facts[comp][kind][name][config_key]["raw"] = yaml_file
 
     def facts_for_configmaps(self, namespace):
         ''' Gathers facts for configmaps in logging namespace '''


### PR DESCRIPTION
Addresses error seen in https://bugzilla.redhat.com/show_bug.cgi?id=1543625
Also prevents us from seeing this when rerunning a deployment for es5.x branch.

When we are trying to load a configmap file to parse it for facts based on the values, we should only parse if it is a yaml or yml file.

Note: if someone created a configmap entry with key that matched that, but wasn't a yaml file, it would still fail... not sure if that can be helped.