### PR TITLE
Limit host scope during plays

### DIFF
--- a/playbooks/container-runtime/config.yml
+++ b/playbooks/container-runtime/config.yml
@@ -1,6 +1,8 @@
 ---
 - import_playbook: ../init/main.yml
   vars:
-    skip_verison: True
+    skip_version: True
+    l_openshift_version_set_hosts: "all:!all"
+    l_openshift_version_check_hosts: "all:!all"
 
 - import_playbook: private/config.yml

--- a/playbooks/container-runtime/setup_storage.yml
+++ b/playbooks/container-runtime/setup_storage.yml
@@ -1,6 +1,8 @@
 ---
 - import_playbook: ../init/main.yml
   vars:
-    skip_verison: True
+    skip_version: True
+    l_openshift_version_set_hosts: "all:!all"
+    l_openshift_version_check_hosts: "all:!all"
 
 - import_playbook: private/setup_storage.yml

--- a/playbooks/init/main.yml
+++ b/playbooks/init/main.yml
@@ -1,5 +1,5 @@
 ---
-# skip_verison and l_install_base_packages are passed in via prerequistes.yml.
+# skip_version and l_install_base_packages are passed in via prerequistes.yml.
 # skip_sanity_checks is passed in via openshift-node/private/image_prep.yml
 
 - name: Initialization Checkpoint Start
@@ -27,7 +27,7 @@
 - import_playbook: cluster_facts.yml
 
 - import_playbook: version.yml
-  when: not (skip_verison | default(False))
+  when: not (skip_version | default(False))
 
 - import_playbook: sanity_checks.yml
   when: not (skip_sanity_checks | default(False))

--- a/playbooks/openshift-etcd/certificates.yml
+++ b/playbooks/openshift-etcd/certificates.yml
@@ -1,5 +1,11 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    skip_version: True
+    l_openshift_version_set_hosts: "all:!all"
+    l_openshift_version_check_hosts: "all:!all"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 
 - import_playbook: private/ca.yml
 

--- a/playbooks/openshift-etcd/config.yml
+++ b/playbooks/openshift-etcd/config.yml
@@ -1,4 +1,10 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    skip_version: True
+    l_openshift_version_set_hosts: "all:!all"
+    l_openshift_version_check_hosts: "all:!all"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-etcd/embedded2external.yml
+++ b/playbooks/openshift-etcd/embedded2external.yml
@@ -1,4 +1,10 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    skip_version: True
+    l_openshift_version_set_hosts: "all:!all"
+    l_openshift_version_check_hosts: "all:!all"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 
 - import_playbook: private/embedded2external.yml

--- a/playbooks/openshift-etcd/migrate.yml
+++ b/playbooks/openshift-etcd/migrate.yml
@@ -1,4 +1,10 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    skip_version: True
+    l_openshift_version_set_hosts: "all:!all"
+    l_openshift_version_check_hosts: "all:!all"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 
 - import_playbook: private/migrate.yml

--- a/playbooks/openshift-etcd/redeploy-ca.yml
+++ b/playbooks/openshift-etcd/redeploy-ca.yml
@@ -1,4 +1,10 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    skip_version: True
+    l_openshift_version_set_hosts: "all:!all"
+    l_openshift_version_check_hosts: "all:!all"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 
 - import_playbook: private/redeploy-ca.yml

--- a/playbooks/openshift-etcd/redeploy-certificates.yml
+++ b/playbooks/openshift-etcd/redeploy-certificates.yml
@@ -1,5 +1,11 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    skip_version: True
+    l_openshift_version_set_hosts: "all:!all"
+    l_openshift_version_check_hosts: "all:!all"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 
 - import_playbook: private/redeploy-certificates.yml
 

--- a/playbooks/openshift-etcd/restart.yml
+++ b/playbooks/openshift-etcd/restart.yml
@@ -1,4 +1,10 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    skip_version: True
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_openshift_version_set_hosts: "all:!all"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 
 - import_playbook: private/restart.yml

--- a/playbooks/openshift-etcd/scaleup.yml
+++ b/playbooks/openshift-etcd/scaleup.yml
@@ -43,8 +43,10 @@
 # prerequisites, we can just init facts as normal.
 - import_playbook: ../init/main.yml
   vars:
-    skip_verison: True
+    skip_version: True
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_new_etcd_to_config"
+    l_openshift_version_set_hosts: "all:!all"
+    l_openshift_version_check_hosts: "all:!all"
   when:
   - inventory_hostname in groups['oo_masters']
   - inventory_hostname in groups['oo_nodes_to_config']

--- a/playbooks/openshift-etcd/upgrade.yml
+++ b/playbooks/openshift-etcd/upgrade.yml
@@ -1,7 +1,9 @@
 ---
 - import_playbook: ../init/main.yml
   vars:
-    skip_verison: True
+    skip_version: True
+    l_openshift_version_set_hosts: "all:!all"
+    l_openshift_version_check_hosts: "all:!all"
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
     l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 

--- a/playbooks/openshift-glusterfs/config.yml
+++ b/playbooks/openshift-glusterfs/config.yml
@@ -1,4 +1,9 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config:oo_glusterfs_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] | union(groups['oo_glusterfs_to_config']) }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-glusterfs/registry.yml
+++ b/playbooks/openshift-glusterfs/registry.yml
@@ -1,4 +1,9 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config:oo_glusterfs_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] | union(groups['oo_glusterfs_to_config']) }}"
 
 - import_playbook: private/registry.yml

--- a/playbooks/openshift-grafana/config.yml
+++ b/playbooks/openshift-grafana/config.yml
@@ -1,4 +1,9 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-hosted/config.yml
+++ b/playbooks/openshift-hosted/config.yml
@@ -1,4 +1,9 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-hosted/deploy_registry.yml
+++ b/playbooks/openshift-hosted/deploy_registry.yml
@@ -1,4 +1,9 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/openshift_hosted_registry.yml

--- a/playbooks/openshift-hosted/deploy_router.yml
+++ b/playbooks/openshift-hosted/deploy_router.yml
@@ -1,4 +1,9 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/openshift_hosted_router.yml

--- a/playbooks/openshift-hosted/redeploy-registry-certificates.yml
+++ b/playbooks/openshift-hosted/redeploy-registry-certificates.yml
@@ -1,4 +1,9 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/redeploy-registry-certificates.yml

--- a/playbooks/openshift-hosted/redeploy-router-certificates.yml
+++ b/playbooks/openshift-hosted/redeploy-router-certificates.yml
@@ -1,4 +1,9 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/redeploy-router-certificates.yml

--- a/playbooks/openshift-loadbalancer/config.yml
+++ b/playbooks/openshift-loadbalancer/config.yml
@@ -1,4 +1,9 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config:oo_lb_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] | union(groups['oo_lb_to_config']) }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-logging/config.yml
+++ b/playbooks/openshift-logging/config.yml
@@ -5,5 +5,10 @@
 # currently supported method.
 #
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-management/config.yml
+++ b/playbooks/openshift-management/config.yml
@@ -1,4 +1,9 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-metrics/config.yml
+++ b/playbooks/openshift-metrics/config.yml
@@ -1,4 +1,10 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
+
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-nfs/config.yml
+++ b/playbooks/openshift-nfs/config.yml
@@ -1,4 +1,10 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config:oo_nfs_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] | union(groups['oo_nfs_to_config']) }}"
+
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-prometheus/config.yml
+++ b/playbooks/openshift-prometheus/config.yml
@@ -1,4 +1,10 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
+
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-provisioners/config.yml
+++ b/playbooks/openshift-provisioners/config.yml
@@ -1,4 +1,10 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
+
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-service-catalog/config.yml
+++ b/playbooks/openshift-service-catalog/config.yml
@@ -1,4 +1,10 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
+
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-web-console/config.yml
+++ b/playbooks/openshift-web-console/config.yml
@@ -1,4 +1,9 @@
 ---
 - import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/prerequisites.yml
+++ b/playbooks/prerequisites.yml
@@ -3,8 +3,10 @@
 
 - import_playbook: init/main.yml
   vars:
-    skip_verison: True
+    skip_version: True
     l_install_base_packages: True
+    l_openshift_version_set_hosts: "all:!all"
+    l_openshift_version_check_hosts: "all:!all"
 
 - import_playbook: init/validate_hostnames.yml
   when: not (skip_validate_hostnames | default(False))


### PR DESCRIPTION
Many plays only target a select subset of hosts,
especially oo_first_master for components such
as logging and registry.

This commit limits the scope of most plays to
eliminate unnecessary task execution on node
groups.  This will result in great time
savings for large deployments.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1516526