### PR TITLE
Bug 1541946- waiting for master reboot now works behind bastion 

### DIFF
--- a/playbooks/openshift-master/private/tasks/restart_hosts.yml
+++ b/playbooks/openshift-master/private/tasks/restart_hosts.yml
@@ -7,26 +7,10 @@
   ignore_errors: true
   become: yes
 
-# WARNING: This process is riddled with weird behavior.
-
-# Workaround for https://github.com/ansible/ansible/issues/21269
-- set_fact:
-    wait_for_host: "{{ ansible_host }}"
-
-# Ansible's blog documents this *without* the port, which appears to now
-# just wait until the timeout value and then proceed without checking anything.
-# port is now required.
-#
-# However neither ansible_ssh_port or ansible_port are reliably defined, likely
-# only if overridden. Assume a default of 22.
 - name: Wait for master to restart
-  local_action:
-    module: wait_for
-      host="{{ wait_for_host }}"
-      state=started
-      delay=10
-      timeout=600
-      port="{{ ansible_port | default(ansible_ssh_port | default(22,boolean=True),boolean=True) }}"
+  wait_for_connection:
+    delay: 10
+    timeout: 600
 
 # Now that ssh is back up we can wait for API on the remote system,
 # avoiding some potential connection issues from local system:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1541946

I made this change because [this ansible PR](https://github.com/ansible/ansible/pull/28450) makes it seem like if we switch to the `wait_for_connection` module we can avoid a lot of the jankiness referenced in the removed code. If I'm interpreting the ansible change properly, this should make it use the full ssh config, proxy jumps and all, without any workarounds. 

I've marked it WIP because I'm still trying to test and make sure that this works.