### PR TITLE
persistent volume: fix template to support python3

### DIFF
--- a/roles/openshift_persistent_volumes/templates/persistent-volume.yml.j2
+++ b/roles/openshift_persistent_volumes/templates/persistent-volume.yml.j2
@@ -17,5 +17,5 @@ items:
     capacity:
       storage: "{{ volume.capacity }}"
     accessModes: {{ volume.access_modes | to_padded_yaml(2, 2) }}
-    {{ volume.storage.keys()[0] }}: {{ volume.storage[volume.storage.keys()[0]] | to_padded_yaml(3, 2) }}
+    {{ (volume.storage.keys() | list)[0] }}: {{ volume.storage[(volume.storage.keys() | list)[0]] | to_padded_yaml(3, 2) }}
 {% endfor %}


### PR DESCRIPTION
This ensures python3 won't crash when generating a PV yaml from template due to 
dictitems.

This is already resolved in master in https://github.com/openshift/openshift-ansible/commit/f09d144550651c9cb5151c128049819e0122352c

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>