### PR TITLE
Fix upgrade-control plane post_control_plane.yml

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -134,7 +134,7 @@
 
 # Run the redeploy certs based upon the certificates. Defaults to False for insecure registries
 - when: (hostvars[groups.oo_first_master.0].openshift_hosted_rollout_certs_and_registry | default(False)) | bool
-  import_playbook: ../../../openshift-hosted/redeploy-registry-certificates.yml
+  import_playbook: ../../../openshift-hosted/private/redeploy-registry-certificates.yml
 
 # Check for warnings to be printed at the end of the upgrade:
 - name: Clean up and display warnings


### PR DESCRIPTION
An entry-point playbook was imported by mistake.
This caused common init code to run again, which
is undesireable.

This commit changes the import to use the corresponding
'private' play which does not call the init code.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1542855