### PR TITLE
Normalize the time we wait for pods to 5s * 60 retries

### DIFF
--- a/roles/openshift_service_catalog/tasks/start_api_server.yml
+++ b/roles/openshift_service_catalog/tasks/start_api_server.yml
@@ -17,6 +17,6 @@
     warn: no
   register: api_health
   until: api_health.stdout == 'ok'
-  retries: 120
-  delay: 1
+  retries: 60
+  delay: 5
   changed_when: false

--- a/roles/openshift_web_console/tasks/install.yml
+++ b/roles/openshift_web_console/tasks/install.yml
@@ -153,8 +153,8 @@
     warn: no
   register: console_health
   until: console_health.stdout == 'ok'
-  retries: 120
-  delay: 1
+  retries: 60
+  delay: 5
   changed_when: false
 
 - name: Remove temp directory

--- a/roles/template_service_broker/tasks/install.yml
+++ b/roles/template_service_broker/tasks/install.yml
@@ -71,8 +71,8 @@
     warn: no
   register: api_health
   until: api_health.stdout == 'ok'
-  retries: 120
-  delay: 1
+  retries: 60
+  delay: 5
   changed_when: false
 
 - set_fact:


### PR DESCRIPTION
A few people have run into situations where it takes longer than 120seconds for the webconsole to start up so lets be a bit more foregiving and allow for up to 5 minutes in scenarios where we're waiting for pods.
