### PR TITLE
Add app label to console deployment pod template

### DIFF
--- a/roles/openshift_web_console/files/console-template.yaml
+++ b/roles/openshift_web_console/files/console-template.yaml
@@ -42,6 +42,7 @@ objects:
       metadata:
         name: webconsole
         labels:
+          app: openshift-web-console
           webconsole: "true"
       spec:
         serviceAccountName: webconsole


### PR DESCRIPTION
Small change to sync the console template with the origin repo. This makes sure the replica sets and pods have the same app=openshift-web-console label.

https://github.com/openshift/origin/blob/master/install/origin-web-console/console-template.yaml#L45