### PR TITLE
logging: allow fluentd to determine cri-o

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -219,7 +219,7 @@ Elasticsearch OPS too, if using an OPS cluster:
 - `openshift_logging_fluentd_remote_syslog_use_record`: Set `true` to use the severity and facility from the record, defaults to `false`
 - `openshift_logging_fluentd_remote_syslog_payload_key`: If string is specified, use this field from the record as the payload on the syslog message
 
-The corresponding openshift\_logging\_mux\_* parameters are below.
+The corresponding `openshift_logging_mux_*` parameters are below.
 
 - `openshift_logging_mux_remote_syslog`: Set `true` to enable remote syslog forwarding, defaults to `false`
 - `openshift_logging_mux_remote_syslog_host`: Required, hostname or IP of remote syslog server
@@ -230,6 +230,19 @@ The corresponding openshift\_logging\_mux\_* parameters are below.
 - `openshift_logging_mux_remote_syslog_tag_key`: If string specified, use this field from the record to set the key field on the syslog message
 - `openshift_logging_mux_remote_syslog_use_record`: Set `true` to use the severity and facility from the record, defaults to `false`
 - `openshift_logging_mux_remote_syslog_payload_key`: If string is specified, use this field from the record as the payload on the syslog message
+
+Cri-o Formatted Container Logs
+------------------------------
+In order to enable cri-o logs parsing, the `openshift_logging_fluentd` role
+mounts `node-config.yaml` from the host to the fluentd container to this path:
+```
+/etc/origin/node/node-config.yaml
+```
+
+Fluentd pod on startup automatically determines from the `node-config.yaml`
+whether to setup `in_tail` plugin to parse cri-o formatted logs in
+`/var/log/containers/*` based on the
+`kubeletArguments -> container-runtime-endpoint` value.
 
 Image update procedure
 ----------------------

--- a/roles/openshift_logging_fluentd/templates/2.x/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/2.x/fluentd.j2
@@ -79,6 +79,9 @@ spec:
         - name: dockerdaemoncfg
           mountPath: /etc/docker
           readOnly: true
+        - name: originnodecfg 
+          mountPath: /etc/origin/node
+          readOnly: true
         - name: filebufferstorage
           mountPath: /var/lib/fluentd
 {% if openshift_logging_mux_client_mode is defined and
@@ -234,6 +237,9 @@ spec:
       - name: dockercfg
         hostPath:
           path: /etc/sysconfig/docker
+      - name: originnodecfg 
+        hostPath:
+          path: /etc/origin/node
       - name: dockerdaemoncfg
         hostPath:
           path: /etc/docker


### PR DESCRIPTION
Allow fluentd to try to determine if OpenShift is running cri-o from `etc/origin/node/node-config.yaml` config file where `kubeletArguments -> container-runtime-endpoint` contains `cri-o`

cc: @mrunalp , @jcantrill , @richm 