### PR TITLE
Allow for blank StorageClass in PVC creation

### DIFF
--- a/roles/lib_utils/action_plugins/generate_pv_pvcs_list.py
+++ b/roles/lib_utils/action_plugins/generate_pv_pvcs_list.py
@@ -118,10 +118,16 @@ class ActionModule(ActionBase):
                     create_pvc = self._templar.template(create_pvc)
                     if kind != 'object' and create_pv and create_pvc:
                         volume, size, _, access_modes = self.build_common(varname=varname)
+                        storageclass = self.task_vars.get(str(varname) + '_storageclass')
+                        if storageclass:
+                            storageclass = self._templar.template(storageclass)
+                        elif storageclass is None and kind != 'dynamic':
+                            storageclass = ''
                         return dict(
                             name="{0}-claim".format(volume),
                             capacity=size,
-                            access_modes=access_modes)
+                            access_modes=access_modes,
+                            storageclass=storageclass)
         return None
 
     def run(self, tmp=None, task_vars=None):

--- a/roles/openshift_persistent_volumes/templates/persistent-volume-claim.yml.j2
+++ b/roles/openshift_persistent_volumes/templates/persistent-volume-claim.yml.j2
@@ -12,4 +12,7 @@ items:
     resources:
       requests:
         storage: "{{ claim.capacity }}"
+{% if claim.storageclass is not None %}
+    storageClassName: "{{ claim.storageclass }}"
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
In the case where a default StorageClass is already defined and a PV's
storage kind is not 'dynamic', allows for the storageClassName of the
associated PVC to be blank so as to not use the default SC.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1544387

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>