### PR TITLE
golden-image: Allow AH golden images

### DIFF
--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -6,6 +6,7 @@
   with_items: "{{ r_openshift_node_image_prep_packages }}"
   register: result
   until: result is succeeded
+  when: not openshift_is_atomic
 
 - name: create the directory for node
   file:


### PR DESCRIPTION
As it turned out there really only seems to be a small change in the code (on top of the [pre-work](https://github.com/openshift/openshift-ansible/pull/7057) removing master code from golden image path) to get AH golden images. This change let me run through the entire modification process without errors. Note: I didn't change anything in the AWS portion of the code as, from what I can tell, there would be no changes needed to provision or seal the AMI.

Updated Inventory Variables:
  - ``openshift_use_system_containers=True``
  - ``openshift_docker_use_system_container=True``

See the following for AWS ID's:

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/release_notes/amazon_machine_image_ids