### PR TITLE
Fix etcd scaleup plays

### DIFF
--- a/playbooks/openshift-etcd/scaleup.yml
+++ b/playbooks/openshift-etcd/scaleup.yml
@@ -45,6 +45,7 @@
   vars:
     skip_version: True
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_new_etcd_to_config"
+    l_sanity_check_hosts: "{{ groups['oo_new_etcd_to_config'] | union(groups['oo_masters_to_config']) | union(groups['oo_etcd_to_config']) }}"
     l_openshift_version_set_hosts: "all:!all"
     l_openshift_version_check_hosts: "all:!all"
   when:


### PR DESCRIPTION
This commit ensures that only the proper host groups
have sanity checks run during etcd scaleup.

This commit also adds additional debugging statements
to sanity_checks.py to make it easier to debug when
an error occurs.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1543771