### PR TITLE
Fix gcp variable warnings

### DIFF
--- a/roles/openshift_cloud_provider/tasks/gce.yml
+++ b/roles/openshift_cloud_provider/tasks/gce.yml
@@ -1,11 +1,13 @@
 ---
 - name: check variables are passed
   fail:
-    msg: "Ensure correct variables are defined for gcp. {{ item }}"
-  when: item == ''
+    msg: "Ensure correct variables are defined for gcp. {{ item.name }}"
+  when: item.value == ''
   with_items:
-  - "{{ openshift_gcp_project }}"
-  - "{{ openshift_gcp_prefix }}"
+  - name: openshift_gcp_project
+    value: "{{ openshift_gcp_project }}"
+  - name: openshift_gcp_prefix
+    value: "{{ openshift_gcp_prefix }}"
 
 # Work around ini_file create option in 2.2 which defaults to no
 - name: Create cloud config file


### PR DESCRIPTION
This commit ensures that user get better information
regarding variables that need to be defined in
inventory when using gcp.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1541589