### PR TITLE
etcd_scaleup: use inventory_hostname when etcd ca host is being picked

### DIFF
--- a/roles/openshift_etcd_facts/tasks/set_etcd_ca_host.yml
+++ b/roles/openshift_etcd_facts/tasks/set_etcd_ca_host.yml
@@ -14,10 +14,10 @@
 # and /etc/etcd/generated_certs directories.
 - set_fact:
     __etcd_ca_dir_hosts: "{{ __etcd_ca_host_stat.results
-                             | lib_utils_oo_collect('_ansible_delegated_vars.ansible_host',
+                             | lib_utils_oo_collect('_ansible_delegated_vars.inventory_hostname',
                                                     filters={'stat.path':'/etc/etcd/ca','stat.exists':True}) }}"
     __etcd_generated_certs_dir_hosts: "{{ __etcd_ca_host_stat.results
-                                          | lib_utils_oo_collect('_ansible_delegated_vars.ansible_host',
+                                          | lib_utils_oo_collect('_ansible_delegated_vars.inventory_hostname',
                                                                  filters={'stat.path':'/etc/etcd/generated_certs','stat.exists':True}) }}"
   run_once: true
 


### PR DESCRIPTION
This would fix etcd scaleup playbook when inventory uses custom hostnames, e.g.:

```
new_etcd:
  hosts:
    new-etcd-node:
      ansible_host: ec2-54-173-186-97.compute-1.amazonaws.com
```