### PR TITLE
Add openshift_gcp_multizone bool

### DIFF
--- a/roles/openshift_cloud_provider/defaults/main.yml
+++ b/roles/openshift_cloud_provider/defaults/main.yml
@@ -2,3 +2,4 @@
 openshift_gcp_project: ''
 openshift_gcp_prefix: ''
 openshift_gcp_network_name: "{{ openshift_gcp_prefix }}network"
+openshift_gcp_multizone: False

--- a/roles/openshift_cloud_provider/tasks/gce.yml
+++ b/roles/openshift_cloud_provider/tasks/gce.yml
@@ -28,4 +28,4 @@
   - { key: 'network-name', value: '{{ openshift_gcp_network_name }}' }
   - { key: 'node-tags', value: '{{ openshift_gcp_prefix }}ocp' }
   - { key: 'node-instance-prefix', value: '{{ openshift_gcp_prefix }}' }
-  - { key: 'multizone', value: 'false' }
+  - { key: 'multizone', value: '{{ openshift_gcp_multizone | string }}' }

--- a/roles/openshift_gcp/defaults/main.yml
+++ b/roles/openshift_gcp/defaults/main.yml
@@ -56,3 +56,5 @@ openshift_gcp_node_group_config:
 
 openshift_gcp_startup_script_file: ''
 openshift_gcp_user_data_file: ''
+
+openshift_gcp_multizone: False

--- a/roles/openshift_gcp/tasks/node_cloud_config.yml
+++ b/roles/openshift_gcp/tasks/node_cloud_config.yml
@@ -9,4 +9,4 @@
     - { key: 'network-name', value: '{{ openshift_gcp_network_name }}' }
     - { key: 'node-tags', value: '{{ openshift_gcp_prefix }}ocp' }
     - { key: 'node-instance-prefix', value: '{{ openshift_gcp_prefix }}' }
-    - { key: 'multizone', value: 'false' }
+    - { key: 'multizone', value: '{{ openshift_gcp_multizone | string }}' }


### PR DESCRIPTION
Add openshift_gcp_multizone bool that defaults
to False to enable users to support multizone
deployments on gcp.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1542843