### PR TITLE
Use curl --noproxy option for internal apiserver access

### DIFF
--- a/roles/openshift_service_catalog/tasks/start_api_server.yml
+++ b/roles/openshift_service_catalog/tasks/start_api_server.yml
@@ -10,7 +10,7 @@
 # wait to see that the apiserver is available
 - name: wait for api server to be ready
   command: >
-    curl -k https://apiserver.kube-service-catalog.svc/healthz
+    curl --noproxy '*' -k https://apiserver.kube-service-catalog.svc/healthz
   args:
     # Disables the following warning:
     # Consider using get_url or uri module rather than running curl


### PR DESCRIPTION
Fix for BZ1544645, Service catalog playbook missing --noproxy '*' when checking api server:

https://bugzilla.redhat.com/1544645