### PR TITLE
CRI-O: base crio socket on openshift version

### DIFF
--- a/roles/container_runtime/templates/crio.conf.j2
+++ b/roles/container_runtime/templates/crio.conf.j2
@@ -27,7 +27,11 @@ storage_option = [
 [crio.api]
 
 # listen is the path to the AF_LOCAL socket on which crio will listen.
+{% if openshift.common.version_gte_3_9 %}
 listen = "/var/run/crio/crio.sock"
+{% else %}
+listen = "/var/run/crio.sock"
+{% endif %}
 
 # stream_address is the IP address on which the stream server will listen
 stream_address = ""

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -18,9 +18,17 @@ kubeletArguments: {{  l2_openshift_node_kubelet_args  | default(None) | lib_util
   container-runtime:
   - remote
   container-runtime-endpoint:
+{% if openshift.common.version_gte_3_9 %}
   - /var/run/crio/crio.sock
+{% else %}
+  - /var/run/crio.sock
+{% endif %}
   image-service-endpoint:
+{% if openshift.common.version_gte_3_9 %}
   - /var/run/crio/crio.sock
+{% else %}
+  - /var/run/crio.sock
+{% endif %}
   node-labels:
   - router=true
   - registry=true


### PR DESCRIPTION
This is needed by the CI cause right now, we're running tests against 3.7 code base and it fails to connect to the _old_ socket at `/var/run/crio.sock`. We need this in order to ensure compatibility in the CI. This build is an example of a failing 3.7 build because the socket path is the new one but 3.7 (and 3.8) code base expect the old one: https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/18559/test_pull_request_origin_extended_conformance_crio/4191/

@giuseppe PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>