### PR TITLE
Log troubleshooting info when console install fails

### DIFF
--- a/roles/openshift_web_console/tasks/install.yml
+++ b/roles/openshift_web_console/tasks/install.yml
@@ -167,9 +167,48 @@
   retries: 60
   delay: 5
   changed_when: false
+  # Ignore errors so we can log troubleshooting info on failures.
+  ignore_errors: yes
+
+# Log the result of `oc status`, `oc get pods`, `oc get events`, and `oc logs deployment/webconsole` for troubleshooting failures.
+- when: console_health.stdout != 'ok'
+  block:
+  - name: Check status in the openshift-web-console namespace
+    command: >
+      {{ openshift_client_binary }} status --config={{ mktemp.stdout }}/admin.kubeconfig -n openshift-web-console
+    register: console_status
+    ignore_errors: true
+  - debug:
+      msg: "{{ console_status.stdout_lines }}"
+  - name: Get pods in the openshift-web-console namespace
+    command: >
+      {{ openshift_client_binary }} get pods --config={{ mktemp.stdout }}/admin.kubeconfig -n openshift-web-console -o wide
+    register: console_pods
+    ignore_errors: true
+  - debug:
+      msg: "{{ console_pods.stdout_lines }}"
+  - name: Get events in the openshift-web-console namespace
+    command: >
+      {{ openshift_client_binary }} get events --config={{ mktemp.stdout }}/admin.kubeconfig -n openshift-web-console
+    register: console_events
+    ignore_errors: true
+  - debug:
+      msg: "{{ console_events.stdout_lines }}"
+  - name: Get console pod logs
+    command: >
+      {{ openshift_client_binary }} logs deployment/webconsole --tail=50 --config={{ mktemp.stdout }}/admin.kubeconfig -n openshift-web-console
+    register: console_log
+    ignore_errors: true
+  - debug:
+      msg: "{{ console_log.stdout_lines }}"
 
 - name: Remove temp directory
   file:
     state: absent
     name: "{{ mktemp.stdout }}"
   changed_when: False
+
+- name: Report console errors
+  fail:
+    msg: Console install failed.
+  when: console_health.stdout != 'ok'


### PR DESCRIPTION
Show the results of the following commands for troubleshooting console
errors when install fails:

* `oc status -n openshift-web-console`
* `oc get pods -n openshift-web-console -o wide`
* `oc get events -n openshift-web-console`
* `oc logs deployment/webconsole --tail=50 -n openshift-web-console`

/assign @sdodson 
@jwforres FYI