### PR TITLE
docker_image_availability: encode error message

### DIFF
--- a/roles/openshift_health_checker/callback_plugins/zz_failure_summary.py
+++ b/roles/openshift_health_checker/callback_plugins/zz_failure_summary.py
@@ -10,7 +10,7 @@ import traceback
 from ansible.plugins.callback import CallbackBase
 from ansible import constants as C
 from ansible.utils.color import stringc
-from ansible.module_utils.six import string_types
+from ansible.module_utils.six import string_types, PY2
 
 
 FAILED_NO_MSG = u'Failed without returning a message.'
@@ -86,6 +86,8 @@ def failure_summary(failures, playbook):
         entries = format_failure(failure)
         summary.append(u'\n{}{}'.format(initial_indent_format.format(i), entries[0]))
         for entry in entries[1:]:
+            if PY2:
+                entry = entry.decode('utf8')
             entry = entry.replace(u'\n', u'\n' + subsequent_extra_indent)
             indented = u'{}{}'.format(subsequent_indent, entry)
             summary.append(indented)
@@ -187,7 +189,7 @@ def format_failure(failure):
     if checks:
         fields += ((u'Details', format_failed_checks(checks)),)
     row_format = '{:10}{}'
-    return [row_format.format(header + u':', body) for header, body in fields]
+    return [row_format.format(header + u':', body.encode('utf8')) if PY2 else body for header, body in fields]
 
 
 def format_failed_checks(checks):

--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -119,6 +119,12 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
             unreachable = [reg for reg, reachable in self.reachable_registries.items() if not reachable]
             unreachable_msg = "Failed connecting to: {}\n".format(", ".join(unreachable))
             blocked_msg = "Blocked registries: {}\n".format(", ".join(self.registries["blocked"]))
+            missing = ",\n    ".join(sorted(unavailable_images))
+            if six.PY2:
+                unreachable_msg = unreachable_msg.encode('utf8')
+                blocked_msg = blocked_msg.encode('utf8')
+                missing = missing.encode('utf8')
+
             msg = (
                 "One or more required container images are not available:\n    {missing}\n"
                 "Checked with: {cmd}\n"
@@ -126,7 +132,7 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
                 "{blocked}"
                 "{unreachable}"
             ).format(
-                missing=",\n    ".join(sorted(unavailable_images)),
+                missing=missing,
                 cmd=self.skopeo_example_command,
                 registries=", ".join(self.registries["configured"]),
                 blocked=blocked_msg if self.registries["blocked"] else "",
@@ -262,6 +268,10 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
                 self.reachable_registries[registry] = self.connect_to_registry(registry)
             if not self.reachable_registries[registry]:
                 continue  # do not keep trying unreachable registries
+
+            if six.PY2:
+                registry = registry.encode('utf8')
+                image = image.encode('utf8')
 
             args = dict(
                 proxyvars=self.skopeo_proxy_vars,


### PR DESCRIPTION
Encode error message when checking for docker image availability
to ensure this works with ansible-playbook and ansible-playbook-3

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1544648

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>