### PR TITLE
Enabling log_path in ansible.cfg to log in "/tmp/ansible.log".

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,7 +7,7 @@
 
 [defaults]
 # Set the log_path
-#log_path = /tmp/ansible.log
+log_path = /tmp/ansible.log
 
 # Additional default options for OpenShift Ansible
 forks = 20


### PR DESCRIPTION
Enabling log_path let's us to better analyze the tasks and the time it takes to complete them. 

[edit]