### PR TITLE
Provide a mechanism for disabling the variable deprecation tests

### DIFF
--- a/roles/openshift_sanitize_inventory/tasks/main.yml
+++ b/roles/openshift_sanitize_inventory/tasks/main.yml
@@ -2,6 +2,8 @@
 # We should print out deprecations prior to any failures so that if a play does fail for other reasons
 # the user would also be aware of any deprecated variables they should note to adjust
 - include_tasks: deprecations.yml
+  when:
+    - openshift_deprecations_test | default(true) | bool
 
 - name: Standardize on latest variable names
   set_fact:


### PR DESCRIPTION
When scaling a cluster running the deprecation tests has a significant performance effect.  Provide a mechanism to disable them so that once people have verified that they're not using deprecated variables they don't have to incur the performance penalty on a regular basis:

```
Wednesday 14 February 2018  09:25:39 +0000 (0:00:02.253)       0:23:57.560 **** 
=============================================================================== 
openshift_sanitize_inventory : Check for usage of deprecated variables - 455.00s
Gather Cluster facts and set is_containerized if needed ---------------- 73.32s
openshift_excluder : Install docker excluder - yum --------------------- 39.61s
openshift_sanitize_inventory : conditional_set_fact -------------------- 31.98s
openshift_sanitize_inventory : conditional_set_fact -------------------- 28.00s
Gathering Facts -------------------------------------------------------- 18.93s
openshift_sanitize_inventory : set_fact -------------------------------- 18.26s
Gathering Facts -------------------------------------------------------- 17.56s
Ensure openshift-ansible installer package deps are installed ---------- 16.86s
openshift_docker_facts : Set docker facts ------------------------------ 14.14s
openshift_docker_facts : Set docker facts ------------------------------ 13.03s
tuned : Ensure files are populated from templates ---------------------- 12.87s
initialize_facts set_fact on openshift_docker_hosted_registry_network -- 12.55s
openshift_node_certificates : Generate the node server certificate ----- 11.93s
openshift_node_certificates : Generate the node client config ---------- 11.02s
openshift_node : Start and enable node --------------------------------- 10.75s
openshift_repos : openshift_repos detect ostree ------------------------ 10.17s
openshift_node_certificates : Check status of node certificates -------- 10.12s
os_firewall : need to pause here, otherwise the iptables service starting can sometimes cause ssh to fail -- 10.11s
openshift_node_facts : Set node facts ---------------------------------- 10.03s
Playbook run took 0 days, 0 hours, 23 minutes, 57 seconds
```