### PR TITLE
hosts.example: openshift_dns_ip should be node-specific

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -838,8 +838,14 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # interface other than the default network interface.
 #openshift_set_node_ip=True
 
-# Configure dnsIP in the node config
-#openshift_dns_ip=172.30.0.1
+# Configure dnsIP in the node config.
+# This setting overrides the bind IP address used by each node's dnsmasq.
+# By default, this value is set to the IP which ansible uses to connect to the node.
+# Only update this variable if you need to bind dnsmasq on a different interface
+#
+# Example:
+# [nodes]
+# node.example.com openshift_dns_ip=172.30.0.1
 
 # Configure node kubelet arguments. pods-per-core is valid in OpenShift Origin 1.3 or OpenShift Container Platform 3.3 and later.
 #openshift_node_kubelet_args={'pods-per-core': ['10'], 'max-pods': ['250'], 'image-gc-high-threshold': ['85'], 'image-gc-low-threshold': ['80']}


### PR DESCRIPTION
Node-specific IPs should not be set globally

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1507044