### PR TITLE
Revert "Bug 1512825 - add mux pod failed for Serial number 02 has already been issued"

### DIFF
--- a/roles/openshift_logging/tasks/generate_certs.yaml
+++ b/roles/openshift_logging/tasks/generate_certs.yaml
@@ -19,7 +19,7 @@
   command: >
     {{ openshift_client_binary }} adm --config={{ mktemp.stdout }}/admin.kubeconfig ca create-signer-cert
     --key={{generated_certs_dir}}/ca.key --cert={{generated_certs_dir}}/ca.crt
-    --serial={{generated_certs_dir}}/ca.serial.txt --name=logging-signer-test --overwrite=false
+    --serial={{generated_certs_dir}}/ca.serial.txt --name=logging-signer-test
   check_mode: no
   when:
     - not ca_key_file.stat.exists

--- a/roles/openshift_logging/tasks/procure_server_certs.yaml
+++ b/roles/openshift_logging/tasks/procure_server_certs.yaml
@@ -30,7 +30,7 @@
      {{ openshift_client_binary }} adm --config={{ mktemp.stdout }}/admin.kubeconfig ca create-server-cert
      --key={{generated_certs_dir}}/{{cert_info.procure_component}}.key --cert={{generated_certs_dir}}/{{cert_info.procure_component}}.crt
      --hostnames={{cert_info.hostnames|quote}} --signer-cert={{generated_certs_dir}}/ca.crt --signer-key={{generated_certs_dir}}/ca.key
-     --signer-serial={{generated_certs_dir}}/ca.serial.txt --overwrite=false
+     --signer-serial={{generated_certs_dir}}/ca.serial.txt
   check_mode: no
   when:
   - cert_info.hostnames is defined


### PR DESCRIPTION
@sdodson @nhosoi This reverts #6798 as we are not changing the default in origin https://github.com/openshift/origin/pull/18405.

This reverts commit ac23e6e362d8758032c1dd573d0ff6a958445df5.

That commit introduced a backwards incompatible change to how the commands run.  This undoes that.  The original change was not required to prevent overwriting of the serial file.

Bug 1512825