### PR TITLE
Glusterfs wipe makes playbook fail if etcd servers are not nodes

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
@@ -22,7 +22,7 @@
     kind: node
     state: absent
     labels: "{{ glusterfs_nodeselector | lib_utils_oo_dict_to_list_of_dict }}"
-  with_items: "{{ groups.all }}"
+  with_items: "{{ groups.nodes }}"
   when: "'openshift' in hostvars[item] and glusterfs_wipe"
 
 - name: Delete pre-existing GlusterFS config


### PR DESCRIPTION
Var hostvars[item].openshift has not any value when we use external etcd hosts because external etcd hosts are not nodes.

Ansible output:
```
TASK [openshift_storage_glusterfs : Unlabel any existing GlusterFS nodes] *****************************************************************************************************************************************
ok: [master1.example.es] => (item=master1.example.es)
ok: [master1.example.es] => (item=master2.example.es)
ok: [master1.example.es] => (item=etcd1.example.es)
ok: [master1.example.es] => (item=etcd2.example.es)
ok: [master1.example.es] => (item=etcd3.example.es)
ok: [master1.example.es] => (item=infra1.example.es)
ok: [master1.example.es] => (item=infra2.example.es)
ok: [master1.example.es] => (item=infra3.example.es)
ok: [master1.example.es] => (item=app1.example.es)
ok: [master1.example.es] => (item=app2.example.es)
ok: [master1.example.es] => (item=app3.example.es)
ok: [master1.example.es] => (item=glusterfs1.example.es)
ok: [master1.example.es] => (item=glusterfs2.example.es)
ok: [master1.example.es] => (item=glusterfs3.example.es)
fatal: [master1.example.es]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'openshift'\n\nThe error appears to have been in '/usr/share/ansible/openshift-ansible/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml': line 19, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Unlabel any existing GlusterFS nodes\n  ^ here\n\nexception type: <class 'ansible.errors.AnsibleUndefinedVariable'>\nexception: 'dict object' has no attribute 'openshift'"}
to retry, use: --limit @/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-glusterfs/config.retry
```

This tasks must be executed only on nodes.