### PR TITLE
Fix for support multi-cluster heketi's topology

### DIFF
--- a/roles/openshift_storage_glusterfs/templates/v1.5/topology.json.j2
+++ b/roles/openshift_storage_glusterfs/templates/v1.5/topology.json.j2
@@ -2,7 +2,7 @@
   "clusters": [
 {%- set clusters = {} -%}
 {%- for node in glusterfs_nodes -%}
-  {%- set cluster = hostvars[node].glusterfs_cluster if 'glusterfs_cluster' in node else '1' -%}
+  {%- set cluster = hostvars[node].glusterfs_cluster if 'glusterfs_cluster' in hostvars[node] else '1' -%}
   {%- if cluster in clusters -%}
     {%- set _dummy = clusters[cluster].append(node) -%}
   {%- else -%}

--- a/roles/openshift_storage_glusterfs/templates/v3.6/topology.json.j2
+++ b/roles/openshift_storage_glusterfs/templates/v3.6/topology.json.j2
@@ -2,7 +2,7 @@
   "clusters": [
 {%- set clusters = {} -%}
 {%- for node in glusterfs_nodes -%}
-  {%- set cluster = hostvars[node].glusterfs_cluster if 'glusterfs_cluster' in node else '1' -%}
+  {%- set cluster = hostvars[node].glusterfs_cluster if 'glusterfs_cluster' in hostvars[node] else '1' -%}
   {%- if cluster in clusters -%}
     {%- set _dummy = clusters[cluster].append(node) -%}
   {%- else -%}


### PR DESCRIPTION
Tested in my setup:
```
[glusterfs]
10.101.17.98 glusterfs_devices='["/dev/disk/by-id/virtio-3fd9672b-bc84-42b8-b"]'  glusterfs_hostname=dev-geogluster034-master-1 glusterfs_ip=192.168.102.21  glusterfs_cluster=111
10.101.17.10 glusterfs_devices='["/dev/disk/by-id/virtio-ed63bbc3-79f2-48e7-9"]'  glusterfs_hostname=dev-geogluster034-master-2 glusterfs_ip=192.168.102.209  glusterfs_cluster=111
10.101.17.106 glusterfs_devices='["/dev/disk/by-id/virtio-55dcba94-b698-4516-8"]'  glusterfs_hostname=dev-geogluster034-master-3 glusterfs_ip=192.168.102.210  glusterfs_cluster=111
10.101.17.92 glusterfs_devices='["/dev/disk/by-id/virtio-f5aee008-7df4-4591-a"]'  glusterfs_hostname=dev-geogluster034-master-4 glusterfs_ip=192.168.102.206   glusterfs_cluster=222
10.101.17.100 glusterfs_devices='["/dev/disk/by-id/virtio-969407a8-a3b8-43bf-9"]'  glusterfs_hostname=dev-geogluster034-master-5 glusterfs_ip=192.168.102.207  glusterfs_cluster=222
10.101.17.99 glusterfs_devices='["/dev/disk/by-id/virtio-5b61d02c-71d4-4e8d-a"]'  glusterfs_hostname=dev-geogluster034-master-6 glusterfs_ip=192.168.102.208   glusterfs_cluster=222

```
was created 2 separate clusters

This is a back-port for  PR https://github.com/openshift/openshift-ansible/pull/7163 