### PR TITLE
logging: fix oc cluster up ansible_default_ipv4.address and systemctl

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -8,7 +8,7 @@ USER root
 COPY images/installer/origin-extra-root /
 
 # install ansible and deps
-RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl java-1.8.0-openjdk-headless python2-passlib httpd-tools openssh-clients origin-clients" \
+RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl java-1.8.0-openjdk-headless python2-passlib httpd-tools openssh-clients origin-clients iproute" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
  && EPEL_PKGS="ansible python2-boto python2-boto3 python2-crypto google-cloud-sdk-183.0.0 which python2-pip.noarch" \
  && yum install -y epel-release \

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -343,7 +343,7 @@
 
 
 - include_tasks: update_master_config.yaml
-  when: not openshift_version_gte_3_9
+  when: __openshift_oc_cluster_up is not defined and not openshift_version_gte_3_9
 
 # Update asset config in openshift-web-console namespace
 - name: Add Kibana route information to web console asset config


### PR DESCRIPTION
Command `oc cluster up --logging` creates `openshift-ansible` container inside the `logging` namespace. Running the playbook inside a container creates a few issues that are not present when running ansible on host.

1) Adding iproute package to the openshift-ansible image:
Ansible uses common user-space utilities for determining default facts. The `ansible_default_ipv4.address` fact is populated using utilites from `iproute` package, and this fact is used for populating openshift IP in `roles/openshift_facts/library/openshift_facts.py`.

2) Adding `__openshift_oc_cluster_up` test when trying to update master config:
`openshift_logging` role used to populate `assetConfig.loggingPublicURL` in the origin master-config file. In order for origin-master to respect this change, it needed to `systemctl restart origin-master-api` but given the playbook runs inside a container, we don't have `systemctl` available there.

**FIXES** an issue in openshift-ansible https://github.com/openshift/openshift-ansible/issues/7006

@ewolinetz , @jcantrill: please could you comment or suggest a better approach?