### PR TITLE
Update CloudForms 4.6 templates for configmap mount and GA image location

### DIFF
--- a/roles/openshift_examples/files/examples/v3.7/cfme-templates/cfme-backup-job.yaml
+++ b/roles/openshift_examples/files/examples/v3.7/cfme-templates/cfme-backup-job.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: postgresql
-        image: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-postgresql:latest
+        image: registry.access.redhat.com/cloudforms46/cfme-openshift-postgresql:latest
         command:
         - "/opt/rh/cfme-container-scripts/backup_db"
         env:

--- a/roles/openshift_examples/files/examples/v3.7/cfme-templates/cfme-restore-job.yaml
+++ b/roles/openshift_examples/files/examples/v3.7/cfme-templates/cfme-restore-job.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: postgresql
-        image: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-postgresql:latest
+        image: registry.access.redhat.com/cloudforms46/cfme-openshift-postgresql:latest
         command:
         - "/opt/rh/cfme-container-scripts/restore_db"
         env:

--- a/roles/openshift_examples/files/examples/v3.7/cfme-templates/cfme-template-ext-db.yaml
+++ b/roles/openshift_examples/files/examples/v3.7/cfme-templates/cfme-template-ext-db.yaml
@@ -866,7 +866,7 @@ parameters:
 - name: MEMCACHED_IMG_NAME
   displayName: Memcached Image Name
   description: This is the Memcached image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-memcached
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-memcached
 - name: MEMCACHED_IMG_TAG
   displayName: Memcached Image Tag
   description: This is the Memcached image tag/version requested to deploy.
@@ -874,11 +874,11 @@ parameters:
 - name: FRONTEND_APPLICATION_IMG_NAME
   displayName: Frontend Application Image Name
   description: This is the Frontend Application image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-app-ui
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-app-ui
 - name: BACKEND_APPLICATION_IMG_NAME
   displayName: Backend Application Image Name
   description: This is the Backend Application image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-app
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-app
 - name: FRONTEND_APPLICATION_IMG_TAG
   displayName: Front end Application Image Tag
   description: This is the CloudForms Frontend Application image tag/version requested to deploy.
@@ -890,7 +890,7 @@ parameters:
 - name: ANSIBLE_IMG_NAME
   displayName: Ansible Image Name
   description: This is the Ansible image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-embedded-ansible
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-embedded-ansible
 - name: ANSIBLE_IMG_TAG
   displayName: Ansible Image Tag
   description: This is the Ansible image tag/version requested to deploy.
@@ -926,7 +926,7 @@ parameters:
 - name: HTTPD_IMG_NAME
   displayName: Apache httpd Image Name
   description: This is the httpd image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-httpd
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-httpd
 - name: HTTPD_IMG_TAG
   displayName: Apache httpd Image Tag
   description: This is the httpd image tag/version requested to deploy.

--- a/roles/openshift_examples/files/examples/v3.7/cfme-templates/cfme-template.yaml
+++ b/roles/openshift_examples/files/examples/v3.7/cfme-templates/cfme-template.yaml
@@ -639,7 +639,7 @@ objects:
           - name: cfme-pgdb-volume
             mountPath: "/var/lib/pgsql/data"
           - name: cfme-pg-configs
-            mountPath: "${POSTGRESQL_CONFIG_DIR}"
+            mountPath: "/opt/app-root/src/postgresql-config/"
           env:
           - name: POSTGRESQL_USER
             value: "${DATABASE_USER}"
@@ -654,8 +654,6 @@ objects:
             value: "${POSTGRESQL_MAX_CONNECTIONS}"
           - name: POSTGRESQL_SHARED_BUFFERS
             value: "${POSTGRESQL_SHARED_BUFFERS}"
-          - name: POSTGRESQL_CONFIG_DIR
-            value: "${POSTGRESQL_CONFIG_DIR}"
           resources:
             requests:
               memory: "${POSTGRESQL_MEM_REQ}"
@@ -928,10 +926,6 @@ parameters:
   displayName: Memcached Slab Page Size
   description: Memcached size of each slab page.
   value: 1m
-- name: POSTGRESQL_CONFIG_DIR
-  displayName: PostgreSQL Configuration Overrides
-  description: Directory used to store PostgreSQL configuration overrides.
-  value: "/var/lib/pgsql/conf.d"
 - name: POSTGRESQL_MAX_CONNECTIONS
   displayName: PostgreSQL Max Connections
   description: PostgreSQL maximum number of database connections allowed.

--- a/roles/openshift_examples/files/examples/v3.7/cfme-templates/cfme-template.yaml
+++ b/roles/openshift_examples/files/examples/v3.7/cfme-templates/cfme-template.yaml
@@ -1024,7 +1024,7 @@ parameters:
 - name: POSTGRESQL_IMG_NAME
   displayName: PostgreSQL Image Name
   description: This is the PostgreSQL image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-postgresql
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-postgresql
 - name: POSTGRESQL_IMG_TAG
   displayName: PostgreSQL Image Tag
   description: This is the PostgreSQL image tag/version requested to deploy.
@@ -1032,7 +1032,7 @@ parameters:
 - name: MEMCACHED_IMG_NAME
   displayName: Memcached Image Name
   description: This is the Memcached image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-memcached
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-memcached
 - name: MEMCACHED_IMG_TAG
   displayName: Memcached Image Tag
   description: This is the Memcached image tag/version requested to deploy.
@@ -1040,11 +1040,11 @@ parameters:
 - name: FRONTEND_APPLICATION_IMG_NAME
   displayName: Frontend Application Image Name
   description: This is the Frontend Application image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-app-ui
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-app-ui
 - name: BACKEND_APPLICATION_IMG_NAME
   displayName: Backend Application Image Name
   description: This is the Backend Application image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-app
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-app
 - name: FRONTEND_APPLICATION_IMG_TAG
   displayName: Front end Application Image Tag
   description: This is the CloudForms Frontend Application image tag/version requested to deploy.
@@ -1056,7 +1056,7 @@ parameters:
 - name: ANSIBLE_IMG_NAME
   displayName: Ansible Image Name
   description: This is the Ansible image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-embedded-ansible
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-embedded-ansible
 - name: ANSIBLE_IMG_TAG
   displayName: Ansible Image Tag
   description: This is the Ansible image tag/version requested to deploy.
@@ -1097,7 +1097,7 @@ parameters:
 - name: HTTPD_IMG_NAME
   displayName: Apache httpd Image Name
   description: This is the httpd image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-httpd
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-httpd
 - name: HTTPD_IMG_TAG
   displayName: Apache httpd Image Tag
   description: This is the httpd image tag/version requested to deploy.

--- a/roles/openshift_examples/files/examples/v3.9/cfme-templates/cfme-backup-job.yaml
+++ b/roles/openshift_examples/files/examples/v3.9/cfme-templates/cfme-backup-job.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: postgresql
-        image: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-postgresql:latest
+        image: registry.access.redhat.com/cloudforms46/cfme-openshift-postgresql:latest
         command:
         - "/opt/rh/cfme-container-scripts/backup_db"
         env:

--- a/roles/openshift_examples/files/examples/v3.9/cfme-templates/cfme-restore-job.yaml
+++ b/roles/openshift_examples/files/examples/v3.9/cfme-templates/cfme-restore-job.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: postgresql
-        image: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-postgresql:latest
+        image: registry.access.redhat.com/cloudforms46/cfme-openshift-postgresql:latest
         command:
         - "/opt/rh/cfme-container-scripts/restore_db"
         env:

--- a/roles/openshift_examples/files/examples/v3.9/cfme-templates/cfme-template-ext-db.yaml
+++ b/roles/openshift_examples/files/examples/v3.9/cfme-templates/cfme-template-ext-db.yaml
@@ -866,7 +866,7 @@ parameters:
 - name: MEMCACHED_IMG_NAME
   displayName: Memcached Image Name
   description: This is the Memcached image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-memcached
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-memcached
 - name: MEMCACHED_IMG_TAG
   displayName: Memcached Image Tag
   description: This is the Memcached image tag/version requested to deploy.
@@ -874,11 +874,11 @@ parameters:
 - name: FRONTEND_APPLICATION_IMG_NAME
   displayName: Frontend Application Image Name
   description: This is the Frontend Application image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-app-ui
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-app-ui
 - name: BACKEND_APPLICATION_IMG_NAME
   displayName: Backend Application Image Name
   description: This is the Backend Application image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-app
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-app
 - name: FRONTEND_APPLICATION_IMG_TAG
   displayName: Front end Application Image Tag
   description: This is the CloudForms Frontend Application image tag/version requested to deploy.
@@ -890,7 +890,7 @@ parameters:
 - name: ANSIBLE_IMG_NAME
   displayName: Ansible Image Name
   description: This is the Ansible image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-embedded-ansible
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-embedded-ansible
 - name: ANSIBLE_IMG_TAG
   displayName: Ansible Image Tag
   description: This is the Ansible image tag/version requested to deploy.
@@ -926,7 +926,7 @@ parameters:
 - name: HTTPD_IMG_NAME
   displayName: Apache httpd Image Name
   description: This is the httpd image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-httpd
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-httpd
 - name: HTTPD_IMG_TAG
   displayName: Apache httpd Image Tag
   description: This is the httpd image tag/version requested to deploy.

--- a/roles/openshift_examples/files/examples/v3.9/cfme-templates/cfme-template.yaml
+++ b/roles/openshift_examples/files/examples/v3.9/cfme-templates/cfme-template.yaml
@@ -639,7 +639,7 @@ objects:
           - name: cfme-pgdb-volume
             mountPath: "/var/lib/pgsql/data"
           - name: cfme-pg-configs
-            mountPath: "${POSTGRESQL_CONFIG_DIR}"
+            mountPath: "/opt/app-root/src/postgresql-config/"
           env:
           - name: POSTGRESQL_USER
             value: "${DATABASE_USER}"
@@ -654,8 +654,6 @@ objects:
             value: "${POSTGRESQL_MAX_CONNECTIONS}"
           - name: POSTGRESQL_SHARED_BUFFERS
             value: "${POSTGRESQL_SHARED_BUFFERS}"
-          - name: POSTGRESQL_CONFIG_DIR
-            value: "${POSTGRESQL_CONFIG_DIR}"
           resources:
             requests:
               memory: "${POSTGRESQL_MEM_REQ}"
@@ -928,10 +926,6 @@ parameters:
   displayName: Memcached Slab Page Size
   description: Memcached size of each slab page.
   value: 1m
-- name: POSTGRESQL_CONFIG_DIR
-  displayName: PostgreSQL Configuration Overrides
-  description: Directory used to store PostgreSQL configuration overrides.
-  value: "/var/lib/pgsql/conf.d"
 - name: POSTGRESQL_MAX_CONNECTIONS
   displayName: PostgreSQL Max Connections
   description: PostgreSQL maximum number of database connections allowed.

--- a/roles/openshift_examples/files/examples/v3.9/cfme-templates/cfme-template.yaml
+++ b/roles/openshift_examples/files/examples/v3.9/cfme-templates/cfme-template.yaml
@@ -1024,7 +1024,7 @@ parameters:
 - name: POSTGRESQL_IMG_NAME
   displayName: PostgreSQL Image Name
   description: This is the PostgreSQL image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-postgresql
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-postgresql
 - name: POSTGRESQL_IMG_TAG
   displayName: PostgreSQL Image Tag
   description: This is the PostgreSQL image tag/version requested to deploy.
@@ -1032,7 +1032,7 @@ parameters:
 - name: MEMCACHED_IMG_NAME
   displayName: Memcached Image Name
   description: This is the Memcached image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-memcached
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-memcached
 - name: MEMCACHED_IMG_TAG
   displayName: Memcached Image Tag
   description: This is the Memcached image tag/version requested to deploy.
@@ -1040,11 +1040,11 @@ parameters:
 - name: FRONTEND_APPLICATION_IMG_NAME
   displayName: Frontend Application Image Name
   description: This is the Frontend Application image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-app-ui
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-app-ui
 - name: BACKEND_APPLICATION_IMG_NAME
   displayName: Backend Application Image Name
   description: This is the Backend Application image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-app
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-app
 - name: FRONTEND_APPLICATION_IMG_TAG
   displayName: Front end Application Image Tag
   description: This is the CloudForms Frontend Application image tag/version requested to deploy.
@@ -1056,7 +1056,7 @@ parameters:
 - name: ANSIBLE_IMG_NAME
   displayName: Ansible Image Name
   description: This is the Ansible image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-embedded-ansible
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-embedded-ansible
 - name: ANSIBLE_IMG_TAG
   displayName: Ansible Image Tag
   description: This is the Ansible image tag/version requested to deploy.
@@ -1097,7 +1097,7 @@ parameters:
 - name: HTTPD_IMG_NAME
   displayName: Apache httpd Image Name
   description: This is the httpd image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-httpd
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-httpd
 - name: HTTPD_IMG_TAG
   displayName: Apache httpd Image Tag
   description: This is the httpd image tag/version requested to deploy.

--- a/roles/openshift_management/files/templates/cloudforms/cfme-backup-job.yaml
+++ b/roles/openshift_management/files/templates/cloudforms/cfme-backup-job.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: postgresql
-        image: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-postgresql:latest
+        image: registry.access.redhat.com/cloudforms46/cfme-openshift-postgresql:latest
         command:
         - "/opt/rh/cfme-container-scripts/backup_db"
         env:

--- a/roles/openshift_management/files/templates/cloudforms/cfme-restore-job.yaml
+++ b/roles/openshift_management/files/templates/cloudforms/cfme-restore-job.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: postgresql
-        image: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-postgresql:latest
+        image: registry.access.redhat.com/cloudforms46/cfme-openshift-postgresql:latest
         command:
         - "/opt/rh/cfme-container-scripts/restore_db"
         env:

--- a/roles/openshift_management/files/templates/cloudforms/cfme-template-ext-db.yaml
+++ b/roles/openshift_management/files/templates/cloudforms/cfme-template-ext-db.yaml
@@ -866,7 +866,7 @@ parameters:
 - name: MEMCACHED_IMG_NAME
   displayName: Memcached Image Name
   description: This is the Memcached image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-memcached
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-memcached
 - name: MEMCACHED_IMG_TAG
   displayName: Memcached Image Tag
   description: This is the Memcached image tag/version requested to deploy.
@@ -874,11 +874,11 @@ parameters:
 - name: FRONTEND_APPLICATION_IMG_NAME
   displayName: Frontend Application Image Name
   description: This is the Frontend Application image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-app-ui
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-app-ui
 - name: BACKEND_APPLICATION_IMG_NAME
   displayName: Backend Application Image Name
   description: This is the Backend Application image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-app
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-app
 - name: FRONTEND_APPLICATION_IMG_TAG
   displayName: Front end Application Image Tag
   description: This is the CloudForms Frontend Application image tag/version requested to deploy.
@@ -890,7 +890,7 @@ parameters:
 - name: ANSIBLE_IMG_NAME
   displayName: Ansible Image Name
   description: This is the Ansible image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-embedded-ansible
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-embedded-ansible
 - name: ANSIBLE_IMG_TAG
   displayName: Ansible Image Tag
   description: This is the Ansible image tag/version requested to deploy.
@@ -926,7 +926,7 @@ parameters:
 - name: HTTPD_IMG_NAME
   displayName: Apache httpd Image Name
   description: This is the httpd image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-httpd
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-httpd
 - name: HTTPD_IMG_TAG
   displayName: Apache httpd Image Tag
   description: This is the httpd image tag/version requested to deploy.

--- a/roles/openshift_management/files/templates/cloudforms/cfme-template.yaml
+++ b/roles/openshift_management/files/templates/cloudforms/cfme-template.yaml
@@ -639,7 +639,7 @@ objects:
           - name: cfme-pgdb-volume
             mountPath: "/var/lib/pgsql/data"
           - name: cfme-pg-configs
-            mountPath: "${POSTGRESQL_CONFIG_DIR}"
+            mountPath: "/opt/app-root/src/postgresql-config/"
           env:
           - name: POSTGRESQL_USER
             value: "${DATABASE_USER}"
@@ -654,8 +654,6 @@ objects:
             value: "${POSTGRESQL_MAX_CONNECTIONS}"
           - name: POSTGRESQL_SHARED_BUFFERS
             value: "${POSTGRESQL_SHARED_BUFFERS}"
-          - name: POSTGRESQL_CONFIG_DIR
-            value: "${POSTGRESQL_CONFIG_DIR}"
           resources:
             requests:
               memory: "${POSTGRESQL_MEM_REQ}"
@@ -928,10 +926,6 @@ parameters:
   displayName: Memcached Slab Page Size
   description: Memcached size of each slab page.
   value: 1m
-- name: POSTGRESQL_CONFIG_DIR
-  displayName: PostgreSQL Configuration Overrides
-  description: Directory used to store PostgreSQL configuration overrides.
-  value: "/var/lib/pgsql/conf.d"
 - name: POSTGRESQL_MAX_CONNECTIONS
   displayName: PostgreSQL Max Connections
   description: PostgreSQL maximum number of database connections allowed.

--- a/roles/openshift_management/files/templates/cloudforms/cfme-template.yaml
+++ b/roles/openshift_management/files/templates/cloudforms/cfme-template.yaml
@@ -1024,7 +1024,7 @@ parameters:
 - name: POSTGRESQL_IMG_NAME
   displayName: PostgreSQL Image Name
   description: This is the PostgreSQL image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-postgresql
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-postgresql
 - name: POSTGRESQL_IMG_TAG
   displayName: PostgreSQL Image Tag
   description: This is the PostgreSQL image tag/version requested to deploy.
@@ -1032,7 +1032,7 @@ parameters:
 - name: MEMCACHED_IMG_NAME
   displayName: Memcached Image Name
   description: This is the Memcached image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-memcached
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-memcached
 - name: MEMCACHED_IMG_TAG
   displayName: Memcached Image Tag
   description: This is the Memcached image tag/version requested to deploy.
@@ -1040,11 +1040,11 @@ parameters:
 - name: FRONTEND_APPLICATION_IMG_NAME
   displayName: Frontend Application Image Name
   description: This is the Frontend Application image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-app-ui
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-app-ui
 - name: BACKEND_APPLICATION_IMG_NAME
   displayName: Backend Application Image Name
   description: This is the Backend Application image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-app
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-app
 - name: FRONTEND_APPLICATION_IMG_TAG
   displayName: Front end Application Image Tag
   description: This is the CloudForms Frontend Application image tag/version requested to deploy.
@@ -1056,7 +1056,7 @@ parameters:
 - name: ANSIBLE_IMG_NAME
   displayName: Ansible Image Name
   description: This is the Ansible image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-embedded-ansible
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-embedded-ansible
 - name: ANSIBLE_IMG_TAG
   displayName: Ansible Image Tag
   description: This is the Ansible image tag/version requested to deploy.
@@ -1097,7 +1097,7 @@ parameters:
 - name: HTTPD_IMG_NAME
   displayName: Apache httpd Image Name
   description: This is the httpd image name requested to deploy.
-  value: registry.access.redhat.com/cloudforms46-beta/cfme-openshift-httpd
+  value: registry.access.redhat.com/cloudforms46/cfme-openshift-httpd
 - name: HTTPD_IMG_TAG
   displayName: Apache httpd Image Tag
   description: This is the httpd image tag/version requested to deploy.


### PR DESCRIPTION
- Change templates to mount the configmap into the directory the new image expects.
https://github.com/ManageIQ/manageiq-pods/pull/264

- Changed image location from Beta to GA (images won't become available until CF 4.6 goes GA)