### PR TITLE
add steps in bootstrap playbook to handle updating aws.conf file

### DIFF
--- a/playbooks/aws/provisioning-inventory.example.ini
+++ b/playbooks/aws/provisioning-inventory.example.ini
@@ -9,6 +9,7 @@ etcd
 ################################################################################
 # openshift_deployment_type is required for installation
 openshift_deployment_type=origin
+openshift_cloudprovider_kind=aws
 
 openshift_master_bootstrap_enabled=True
 openshift_master_api_port=443

--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -67,8 +67,8 @@
   - "/etc/docker/certs.d/docker-registry.default.svc:5000"
 
 - name: laydown the bootstrap.yml file for on boot configuration
-  copy:
-    src: bootstrap.yml
+  template:
+    src: bootstrap.yml.j2
     dest: /root/openshift_bootstrap/bootstrap.yml
 
 - name: symlink master ca for docker-registry

--- a/roles/openshift_node/templates/bootstrap.yml.j2
+++ b/roles/openshift_node/templates/bootstrap.yml.j2
@@ -1,3 +1,4 @@
+{% raw %}
 #!/usr/bin/ansible-playbook
 ---
 - hosts: localhost
@@ -61,3 +62,22 @@
       with_items:
       - line: "BOOTSTRAP_CONFIG_NAME=node-config-{{ openshift_group_type }}"
         regexp: "^BOOTSTRAP_CONFIG_NAME=.*"
+{% endraw %}
+
+{% if openshift_cloudprovider_kind | default('') == 'aws' %}
+  # need to update aws.conf file if the instance has come up in a new region
+  - name: set up aws.conf
+    block:
+    - name: get current AZ
+      uri:
+        url: http://169.254.169.254/latest/meta-data/placement/availability-zone
+        return_content: yes
+      register: aws_out
+
+    - name: set AZ in aws.conf
+      ini_file:
+        path: /etc/origin/cloudprovider/aws.conf
+        section: Global
+        option: Zone
+        value: "{% raw %}{{ aws_out.content }}{% endraw %}"
+{% endif %}


### PR DESCRIPTION
when bringing up an instance with an AMI built in a different region the aws.conf reflects the original region/AZ that the AMI was built in

add steps in the bootstrap.yml playbook (conditionally included for AWS) to handle updating aws.conf

update example AWS inventory file to specify the openshift_cloudprovider_kind variable (to 'aws')