### PR TITLE
Retrieve node list from API when testing for nodes with selector.

### DIFF
--- a/playbooks/common/private/components.yml
+++ b/playbooks/common/private/components.yml
@@ -14,6 +14,9 @@
 #    include the masters and usually includes infra nodes.
 # 5. The init/main.yml playbook has been invoked
 
+
+- import_playbook: ../../init/collect_schedulable_node_labels.yml
+
 - import_playbook: ../../openshift-glusterfs/private/config.yml
   when: groups.oo_glusterfs_to_config | default([]) | count > 0
 

--- a/playbooks/init/collect_schedulable_node_labels.yml
+++ b/playbooks/init/collect_schedulable_node_labels.yml
@@ -1,0 +1,28 @@
+---
+# Several roles test existing node labels to determine if a component
+# has nodes to be deployed to based on the selectors for the
+# component. This playbook sets "openshift_component_nodes" which
+# contains a list of all nodes. "openshift_component_nodes" is used by
+# the openshift_facts role to update
+# "openshift_schedulable_node_labels" to contain labels for
+# schedulable nodes collected from the API.
+
+- name: Retrieve node list
+  hosts: oo_first_master
+  roles:
+  - lib_openshift
+  post_tasks:
+  - name: Retrieve node list
+    oc_obj:
+      state: list
+      kind: node
+    register: __component_nodes
+  - set_fact:
+      openshift_component_nodes: "{{ __component_nodes['results']['results'][0]['items'] | default([]) }}"
+
+- name: Update openshift_schedulable_node_labels
+  hosts: oo_first_master
+  roles:
+  # Facts must be refreshed s.t. node labels will be included in
+  # openshift_schedulable_node_labels
+  - openshift_facts

--- a/playbooks/openshift-logging/config.yml
+++ b/playbooks/openshift-logging/config.yml
@@ -11,4 +11,6 @@
     l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
+- import_playbook: ../init/collect_schedulable_node_labels.yml
+
 - import_playbook: private/config.yml

--- a/playbooks/openshift-metrics/config.yml
+++ b/playbooks/openshift-metrics/config.yml
@@ -6,5 +6,6 @@
     l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
+- import_playbook: ../init/collect_schedulable_node_labels.yml
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-prometheus/config.yml
+++ b/playbooks/openshift-prometheus/config.yml
@@ -6,5 +6,6 @@
     l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
+- import_playbook: ../init/collect_schedulable_node_labels.yml
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-provisioners/config.yml
+++ b/playbooks/openshift-provisioners/config.yml
@@ -6,5 +6,6 @@
     l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
+- import_playbook: ../init/collect_schedulable_node_labels.yml
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-service-catalog/config.yml
+++ b/playbooks/openshift-service-catalog/config.yml
@@ -6,5 +6,6 @@
     l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
+- import_playbook: ../init/collect_schedulable_node_labels.yml
 
 - import_playbook: private/config.yml

--- a/roles/lib_utils/filter_plugins/oo_filters.py
+++ b/roles/lib_utils/filter_plugins/oo_filters.py
@@ -660,7 +660,7 @@ def map_from_pairs(source, delim="="):
     return dict(item.split(delim) for item in source.split(","))
 
 
-def lib_utils_oo_get_node_labels(source, hostvars=None):
+def lib_utils_oo_get_node_labels(source, hostvars=None, nodes=None):
     ''' Return a list of labels assigned to schedulable nodes '''
     labels = list()
 
@@ -685,6 +685,21 @@ def lib_utils_oo_get_node_labels(source, hostvars=None):
 
         # Get a list of labels from the node
         node_labels = node_vars.get('openshift_node_labels')
+        if node_labels:
+            labels.append(node_labels)
+
+    if nodes is None:
+        nodes = list()
+
+    # Filter out the unschedulable nodes
+    for node in nodes:
+        schedulable = node.get('spec').get('unschedulable')
+        # explicitly marked as unschedulable
+        if schedulable is not None:
+            continue
+
+        # Get a list of labels from the node
+        node_labels = node.get('metadata').get('labels')
         if node_labels:
             labels.append(node_labels)
 

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -101,5 +101,7 @@ openshift_service_type_dict:
 
 openshift_service_type: "{{ openshift_service_type_dict[openshift_deployment_type] }}"
 
+openshift_component_nodes: []
+
 # Create a list of node labels (dict) for schedulable nodes
-openshift_schedulable_node_labels: "{{ groups['oo_nodes_to_config'] | lib_utils_oo_get_node_labels(hostvars) }}"
+openshift_schedulable_node_labels: "{{ groups['oo_nodes_to_config'] | lib_utils_oo_get_node_labels(hostvars, openshift_component_nodes) }}"


### PR DESCRIPTION
Test node labels by retrieving nodes matching selector list from the API instead of inventory. We're setting the node labels via configmap for cluster operator so we need some way to work around checking the static labels from inventory. I will update other similar checks if others agree with this method or we arrive at something different.