### PR TITLE
Fix undefined lib_utils_oo_random_word on release-3.7. #7173

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -148,7 +148,7 @@
     dest: "{{ generated_certs_dir }}/passwd.yml"
   vars:
     logging_user_name: "{{ openshift_logging_elasticsearch_prometheus_sa }}"
-    logging_user_passwd: "{{ 16 | lib_utils_oo_random_word | b64encode }}"
+    logging_user_passwd: "{{ 16 | oo_random_word | b64encode }}"
 
 - slurp:
     src: "{{ generated_certs_dir }}/passwd.yml"


### PR DESCRIPTION
Fix undefined lib_utils_oo_random_word on release-3.7 by using oo_random_word (name of function in release 3.7 branch).

Fixes #7173