### PR TITLE
CRI-O: use /var/run/crio/crio.sock for >=3.9

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -145,3 +145,6 @@ l_docker_image_default: "{{ l_docker_image_prepend }}:{{ l_docker_image_tag }}"
 l_docker_image: "{{ openshift_docker_systemcontainer_image_override | default(l_docker_image_default) }}"
 
 l_is_node_system_container: "{{ (openshift_use_node_system_container | default(openshift_use_system_containers | default(false)) | bool) }}"
+
+l_crio_use_new_var_sock: "{{  (l_openshift_image_tag == 'latest') or (l_openshift_image_tag | version_compare('3.9', '>='))  | bool }}"
+l_crio_var_sock: "{{ l_crio_use_new_var_sock | ternary('/var/run/crio/crio.sock', '/var/run/crio.sock') }}"

--- a/roles/container_runtime/templates/crio.conf.j2
+++ b/roles/container_runtime/templates/crio.conf.j2
@@ -27,7 +27,7 @@ storage_option = [
 [crio.api]
 
 # listen is the path to the AF_LOCAL socket on which crio will listen.
-listen = "/var/run/crio/crio.sock"
+listen = "{{ l_crio_var_sock }}"
 
 # stream_address is the IP address on which the stream server will listen
 stream_address = ""

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -195,6 +195,8 @@ oreg_auth_credentials_path: "{{ openshift_node_data_dir }}/.docker"
 oreg_auth_credentials_replace: False
 l_bind_docker_reg_auth: False
 openshift_use_crio: False
+l_crio_use_new_var_sock: "{{ openshift_version | version_compare('3.9', '>=') }}"
+l_crio_var_sock: "{{ l_crio_use_new_var_sock | ternary('/var/run/crio/crio.sock', '/var/run/crio.sock') }}"
 openshift_docker_alternative_creds: "{{ (openshift_docker_use_system_container | default(False) | bool) or (openshift_use_crio_only | default(False) | bool) }}"
 
 openshift_docker_service_name: "{{ 'container-engine' if (openshift_docker_use_system_container | default(False) | bool) else 'docker' }}"

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -18,9 +18,9 @@ kubeletArguments: {{  l2_openshift_node_kubelet_args  | default(None) | lib_util
   container-runtime:
   - remote
   container-runtime-endpoint:
-  - /var/run/crio/crio.sock
+  - {{ l_crio_var_sock }}
   image-service-endpoint:
-  - /var/run/crio/crio.sock
+  - {{ l_crio_var_sock }}
   node-labels:
   - router=true
   - registry=true


### PR DESCRIPTION
a replacement for: https://github.com/openshift/openshift-ansible/pull/7126

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>