### PR TITLE
[1509853] Allow for overriding hosted registry_url variables

### DIFF
--- a/playbooks/openshift-hosted/private/openshift_hosted_registry.yml
+++ b/playbooks/openshift-hosted/private/openshift_hosted_registry.yml
@@ -2,12 +2,8 @@
 - name: Create Hosted Resources - registry
   hosts: oo_first_master
   tasks:
-  - set_fact:
-      openshift_hosted_registry_registryurl: "{{ hostvars[groups.oo_first_master.0].openshift.master.registry_url }}"
-    when: "'master' in hostvars[groups.oo_first_master.0].openshift and 'registry_url' in hostvars[groups.oo_first_master.0].openshift.master"
   - import_role:
       name: openshift_hosted
       tasks_from: registry.yml
     when:
     - openshift_hosted_manage_registry | default(True) | bool
-    - openshift_hosted_registry_registryurl is defined

--- a/playbooks/openshift-hosted/private/openshift_hosted_router.yml
+++ b/playbooks/openshift-hosted/private/openshift_hosted_router.yml
@@ -2,12 +2,8 @@
 - name: Create Hosted Resources - router
   hosts: oo_first_master
   tasks:
-  - set_fact:
-      openshift_hosted_router_registryurl: "{{ hostvars[groups.oo_first_master.0].openshift.master.registry_url }}"
-    when: "'master' in hostvars[groups.oo_first_master.0].openshift and 'registry_url' in hostvars[groups.oo_first_master.0].openshift.master"
   - import_role:
       name: openshift_hosted
       tasks_from: router.yml
     when:
     - openshift_hosted_manage_router | default(True) | bool
-    - openshift_hosted_router_registryurl is defined

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -8,10 +8,6 @@ openshift_cli_image_dict:
 repoquery_cmd: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --latest-limit 1 -d 0', 'repoquery --plugins') }}"
 repoquery_installed: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --latest-limit 1 -d 0 --disableexcludes=all --installed', 'repoquery --plugins --installed') }}"
 
-openshift_hosted_images_dict:
-  origin: 'openshift/origin-${component}:${version}'
-  openshift-enterprise: 'openshift3/ose-${component}:${version}'
-
 openshift_cli_image: "{{ osm_image | default(openshift_cli_image_dict[openshift_deployment_type]) }}"
 
 # osm_default_subdomain is an old migrated fact, can probably be removed.

--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -21,6 +21,10 @@ openshift_config_base: "/etc/origin"
 openshift_master_config_dir: "{{ openshift.common.config_base | default(openshift_config_base) }}/master"
 openshift_cluster_domain: 'cluster.local'
 
+openshift_hosted_images_dict:
+  origin: 'openshift/origin-${component}:${version}'
+  openshift-enterprise: 'openshift3/ose-${component}:${version}'
+
 ##########
 # Router #
 ##########
@@ -43,7 +47,7 @@ openshift_hosted_router_edits:
   value: 21600
   action: put
 
-openshift_hosted_router_registryurl: "{{ openshift_hosted_images_dict[openshift_deployment_type] }}"
+openshift_hosted_router_registryurl: "{{ oreg_url_master | default(oreg_url) | default(openshift_hosted_images_dict[openshift_deployment_type]) }}"
 openshift_hosted_routers:
 - name: router
   replicas: "{{ replicas | default(1) }}"
@@ -69,7 +73,7 @@ r_openshift_hosted_router_os_firewall_allow: []
 ############
 
 openshift_hosted_registry_selector: "{{ openshift_registry_selector | default(openshift_hosted_infra_selector) }}"
-openshift_hosted_registry_registryurl: "{{ openshift_hosted_images_dict[openshift_deployment_type] }}"
+openshift_hosted_registry_registryurl: "{{ oreg_url_master | default(oreg_url) | default(openshift_hosted_images_dict[openshift_deployment_type]) }}"
 openshift_hosted_registry_routecertificates: {}
 openshift_hosted_registry_routetermination: "passthrough"
 


### PR DESCRIPTION
In rare cases the router or registry registryurl variables may need to
be set to values other than the first master registry_url value. This
change allows these variables to be set in the inventory (undocumented).

openshift_hosted_router_registryurl
openshift_hosted_registry_registryurl

Bug 1509853 | https://bugzilla.redhat.com/show_bug.cgi?id=1509853