### PR TITLE
Fix GlusterFS Hosted Registry - Deploy PersistentVolumeClaim definitions failure

### DIFF
--- a/roles/openshift_persistent_volumes/templates/persistent-volume-claim.yml.j2
+++ b/roles/openshift_persistent_volumes/templates/persistent-volume-claim.yml.j2
@@ -12,7 +12,7 @@ items:
     resources:
       requests:
         storage: "{{ claim.capacity }}"
-{% if claim.storageclass is not None %}
+{% if claim.storageclass is not none %}
     storageClassName: "{{ claim.storageclass }}"
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Fix by replacing None by lowercase none in pvc template. 

Fixes #7167 