### PR TITLE
Run openshift_version for image prep

### DIFF
--- a/playbooks/init/version.yml
+++ b/playbooks/init/version.yml
@@ -1,7 +1,7 @@
 ---
 # NOTE: requires openshift_facts be run
 - name: Determine openshift_version to configure on first master
-  hosts: oo_first_master
+  hosts: "{{ l_openshift_version_determine_hosts | default('oo_first_master') }}"
   tasks:
   - include_role:
       name: openshift_version

--- a/playbooks/openshift-node/private/image_prep.yml
+++ b/playbooks/openshift-node/private/image_prep.yml
@@ -6,6 +6,13 @@
     skip_sanity_checks: True
     skip_validate_hostnames: True
 
+- name: determine version
+  import_playbook: ../../init/version.yml
+  vars:
+    l_openshift_version_determine_hosts: "oo_nodes_to_config"
+    l_openshift_version_set_hosts: "all:!all"
+    l_openshift_version_check_hosts: "all:!all"
+
 - name: run node config setup
   import_playbook: setup.yml
 


### PR DESCRIPTION
This commit ensures we determine openshift_version
value during image_prep.

Needed-by: https://github.com/openshift/openshift-ansible/pull/7179