### PR TITLE
Require Ansible 2.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install base dependencies:
 
 Requirements:
 
-- Ansible >= 2.4.1.0
+- Ansible >= 2.4.3.0
 - Jinja >= 2.7
 - pyOpenSSL
 - python-lxml

--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -17,7 +17,7 @@ URL:            https://github.com/openshift/openshift-ansible
 Source0:        https://github.com/openshift/openshift-ansible/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-Requires:      ansible >= 2.4.1
+Requires:      ansible >= 2.4.3
 Requires:      python2
 Requires:      python-six
 Requires:      tar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.4.1.0
+ansible==2.4.3.0
 boto==2.34.0
 click==6.7
 pyOpenSSL==16.2.0

--- a/roles/lib_utils/callback_plugins/aa_version_requirement.py
+++ b/roles/lib_utils/callback_plugins/aa_version_requirement.py
@@ -29,7 +29,7 @@ else:
 
 
 # Set to minimum required Ansible version
-REQUIRED_VERSION = '2.4.1.0'
+REQUIRED_VERSION = '2.4.3.0'
 DESCRIPTION = "Supported versions: %s or newer" % REQUIRED_VERSION
 
 


### PR DESCRIPTION
Several Ansible bugs effecting OpenShift-Ansible have been resolved in Ansible 2.4.3.  We should require this for Release 3.9.

Trello: https://trello.com/c/7mBMZ4pQ/610-1-validate-ansible-243-with-openshift-ansible