### PR TITLE
Bug 1536651 - logging-mux not working in 3.7.z when logging installed…

### DIFF
--- a/roles/openshift_logging_fluentd/defaults/main.yml
+++ b/roles/openshift_logging_fluentd/defaults/main.yml
@@ -49,6 +49,10 @@ openshift_logging_fluentd_aggregating_cert_path: none
 openshift_logging_fluentd_aggregating_key_path: none
 openshift_logging_fluentd_aggregating_passphrase: none
 
+# set openshift_logging_use_mux=maximal by default.
+# if the cluster is not configured with mux, this default value is going to be ignored.
+openshift_logging_mux_client_mode: "maximal"
+
 ### Deprecating in 3.6
 # following can be uncommented to provide values for configmaps -- take care when providing file contents as it may cause your cluster to not operate correctly
 #fluentd_config_contents:


### PR DESCRIPTION
… with openshift_logging_use_mux=true

To set MUX_CLIENT_MODE to maximal by default for the mux client, changing the
/etc/fluent/muxkeys mounting condition so that if openshift_logging_use_mux
or openshift_logging_mux_allow_external is set to true, /etc/fluent/muxkeys
is mounted on the collector fluentd.

This openshift-ansible pr is needed for https://github.com/openshift/origin-aggregated-logging/pull/960