### PR TITLE
configure imagePolicyConfig:allowedRegistriesForImport

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -101,6 +101,8 @@ debug_level=2
 # Configure imagePolicyConfig in the master config
 # See: https://docs.openshift.org/latest/admin_guide/image_policy.html
 #openshift_master_image_policy_config={"maxImagesBulkImportedPerRepository": 3, "disableScheduledImport": true}
+# This setting overrides allowedRegistriesForImport in openshift_master_image_policy_config. By default, all registries are allowed.
+#openshift_master_image_policy_allowed_registries_for_import=["docker.io", "*.docker.io", "*.redhat.com", "gcr.io", "quay.io", "registry.centos.org", "registry.redhat.io", "*.amazonaws.com"]
 
 # Configure master API rate limits for external clients
 #openshift_master_external_ratelimit_qps=200

--- a/roles/lib_utils/test/test_sanity_checks.py
+++ b/roles/lib_utils/test/test_sanity_checks.py
@@ -1,0 +1,48 @@
+'''
+ Unit tests for wildcard
+'''
+import os
+import sys
+
+MODULE_PATH = os.path.realpath(os.path.join(__file__, os.pardir, os.pardir, 'action_plugins'))
+sys.path.insert(0, MODULE_PATH)
+
+# pylint: disable=import-error,wrong-import-position,missing-docstring
+from sanity_checks import is_registry_match   # noqa: E402
+
+
+def test_is_registry_match():
+    '''
+     Test for is_registry_match
+    '''
+    pat_allowall = "*"
+    pat_docker = "docker.io"
+    pat_subdomain = "*.example.com"
+    pat_matchport = "registry:80"
+
+    assert is_registry_match("docker.io/repo/my", pat_allowall)
+    assert is_registry_match("example.com:4000/repo/my", pat_allowall)
+    assert is_registry_match("172.192.222.10:4000/a/b/c", pat_allowall)
+    assert is_registry_match("https://registry.com", pat_allowall)
+    assert is_registry_match("example.com/openshift3/ose-${component}:${version}", pat_allowall)
+
+    assert is_registry_match("docker.io/repo/my", pat_docker)
+    assert is_registry_match("docker.io:443/repo/my", pat_docker)
+    assert is_registry_match("docker.io/openshift3/ose-${component}:${version}", pat_allowall)
+    assert not is_registry_match("example.com:4000/repo/my", pat_docker)
+    assert not is_registry_match("index.docker.io/a/b/c", pat_docker)
+    assert not is_registry_match("https://registry.com", pat_docker)
+    assert not is_registry_match("example.com/openshift3/ose-${component}:${version}", pat_docker)
+
+    assert is_registry_match("apps.foo.example.com/prefix", pat_subdomain)
+    assert is_registry_match("sub.example.com:80", pat_subdomain)
+    assert not is_registry_match("https://example.com:443/prefix", pat_subdomain)
+    assert not is_registry_match("docker.io/library/my", pat_subdomain)
+    assert not is_registry_match("https://hello.example.bar", pat_subdomain)
+
+    assert is_registry_match("registry:80/prefix", pat_matchport)
+    assert is_registry_match("registry/myapp", pat_matchport)
+    assert is_registry_match("registry:443/myap", pat_matchport)
+    assert not is_registry_match("https://example.com:443/prefix", pat_matchport)
+    assert not is_registry_match("docker.io/library/my", pat_matchport)
+    assert not is_registry_match("https://hello.registry/myapp", pat_matchport)

--- a/roles/openshift_hosted/tasks/registry.yml
+++ b/roles/openshift_hosted/tasks/registry.yml
@@ -13,8 +13,13 @@
     openshift_hosted_registry_storage_glusterfs_ips: "{%- set gluster_ips = [] %}{% if groups.glusterfs_registry is defined %}{% for node in groups.glusterfs_registry %}{%- set _ = gluster_ips.append(hostvars[node].glusterfs_ip | default(hostvars[node].openshift.common.ip)) %}{% endfor %}{{ gluster_ips }}{% elif groups.glusterfs is defined %}{% for node in groups.glusterfs %}{%- set _ = gluster_ips.append(hostvars[node].glusterfs_ip | default(hostvars[node].openshift.common.ip)) %}{% endfor %}{{ gluster_ips }}{% else %}{{ openshift_hosted_registry_storage_glusterfs_ips }}{% endif %}"
 
 - name: Update registry environment variables when pushing via dns
+  # OPENSHIFT_DEFAULT_REGISTRY is deprecated - keep until 3.11
   set_fact:
-    openshift_hosted_registry_env_vars: "{{ openshift_hosted_registry_env_vars | combine({'REGISTRY_OPENSHIFT_SERVER_ADDR':'docker-registry.default.svc:5000'}) }}"
+    openshift_hosted_registry_env_vars: "{{ {'OPENSHIFT_DEFAULT_REGISTRY': item,
+                                             'REGISTRY_OPENSHIFT_SERVER_ADDR': item}
+                                           | combine(openshift_hosted_registry_env_vars) }}"
+  with_items:
+  - "docker-registry.default.svc:5000"
   when: openshift_push_via_dns | bool
 
 - name: Update registry proxy settings for dc/docker-registry

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -51,6 +51,7 @@
       admission_plugin_config: "{{openshift_master_admission_plugin_config }}"
       kube_admission_plugin_config: "{{openshift_master_kube_admission_plugin_config | default(None) }}"  # deprecated, merged with admission_plugin_config
       image_policy_config: "{{ openshift_master_image_policy_config | default(None) }}"
+      image_policy_allowed_registries_for_import: "{{ openshift_master_image_policy_allowed_registries_for_import | default(None) }}"
 
 - name: Determine if scheduler config present
   stat:


### PR DESCRIPTION
Currently the allowedRegistriesForImport are not configured by ansible scripts,
which effectively disables whitelisting. This PR sets the default registry
whitelist and allowes for simple overrides.

Related upstream PR: openshift/origin#17783
Related doc PR: openshift/openshift-docs#7788