### PR TITLE
add master deprovisioning

### DIFF
--- a/playbooks/aws/openshift-cluster/uninstall.yml
+++ b/playbooks/aws/openshift-cluster/uninstall.yml
@@ -1,0 +1,10 @@
+---
+- import_playbook: uninstall_nodes.yml
+
+- import_playbook: uninstall_masters.yml
+
+- import_playbook: uninstall_s3.yml
+
+- import_playbook: uninstall_elb.yml
+
+- import_playbook: uninstall_prerequisites.yml

--- a/playbooks/aws/openshift-cluster/uninstall_masters.yml
+++ b/playbooks/aws/openshift-cluster/uninstall_masters.yml
@@ -1,8 +1,6 @@
 ---
-- name: delete the node scale groups
+- name: Alert user to variables needed
   hosts: localhost
-  connection: local
-  gather_facts: yes
   tasks:
   - name: Alert user to variables needed - clusterid
     debug:
@@ -12,7 +10,10 @@
     debug:
       msg: "openshift_aws_region={{ openshift_aws_region }}"
 
-  - name: delete the node groups
+- name: Delete the master node group
+  hosts: localhost
+  tasks:
+  - name: delete masters
     import_role:
       name: openshift_aws
-      tasks_from: uninstall_nodes.yml
+      tasks_from: uninstall_masters.yml

--- a/roles/openshift_aws/tasks/uninstall_masters.yml
+++ b/roles/openshift_aws/tasks/uninstall_masters.yml
@@ -1,0 +1,8 @@
+---
+- name: scale group deletion for master
+  include_tasks: uninstall_node_group.yml
+  with_items: "{{ openshift_aws_master_group }}"
+  vars:
+    l_node_group_config: "{{ openshift_aws_master_group_config }}"
+  loop_control:
+    loop_var: openshift_aws_node_group

--- a/roles/openshift_aws/tasks/uninstall_node_group.yml
+++ b/roles/openshift_aws/tasks/uninstall_node_group.yml
@@ -17,13 +17,19 @@
     msg: "{{ asgs }}"
     verbosity: 1
 
-- name: save launch config and scale group names
-  set_fact:
-    l_delete_sg_launch_config_name: "{{ asgs.results[0].launch_config_name }}"
-    l_delete_sg_name: "{{ asgs.results[0].auto_scaling_group_name }}"
+# if re-running deprovisioning, the scale group/launch config may have already
+# been removed
+- name: delete launch configs and scale groups
+  when: asgs.results|length == 1
+  block:
 
-- when: openshift_aws_create_scale_group
-  include_tasks: uninstall_scale_group.yml
+  - name: save launch config and scale group names
+    set_fact:
+      l_delete_sg_launch_config_name: "{{ asgs.results[0].launch_config_name }}"
+      l_delete_sg_name: "{{ asgs.results[0].auto_scaling_group_name }}"
 
-- when: openshift_aws_create_launch_config
-  include_tasks: uninstall_launch_config.yml
+  - when: openshift_aws_create_scale_group
+    include_tasks: uninstall_scale_group.yml
+
+  - when: openshift_aws_create_launch_config
+    include_tasks: uninstall_launch_config.yml

--- a/roles/openshift_aws/tasks/uninstall_security_group.yml
+++ b/roles/openshift_aws/tasks/uninstall_security_group.yml
@@ -5,6 +5,16 @@
     name: "{{ item.value.name}}"
     region: "{{ openshift_aws_region }}"
   with_dict: "{{ openshift_aws_node_security_groups }}"
+  register: sg_delete_result
+  retries: 20
+  delay: 10
+  until: sg_delete_result | succeeded
+  ignore_errors: yes
+
+- name: check for sg delete error
+  fail:
+    msg: "Couldn't delete SGs {{ openshift_aws_node_security_groups }}"
+  when: not sg_delete_result | succeeded
 
 - name: delete the k8s sgs for the node group
   oo_ec2_group:
@@ -12,3 +22,13 @@
     name: "{{ item.value.name }}_k8s"
     region: "{{ openshift_aws_region }}"
   with_dict: "{{ openshift_aws_node_security_groups }}"
+  register: sg_delete_result
+  retries: 20
+  delay: 10
+  until: sg_delete_result | succeeded
+  ignore_errors: yes
+
+- name: check for k8s sg delete error
+  fail:
+    msg: "Couldn't delete SGs {{ openshift_aws_node_security_groups }}"
+  when: not sg_delete_result | succeeded


### PR DESCRIPTION
add tasks to remove master scale group and launch config

add retries to security group removal (takes a while before all AWS object references are really gone)

handle re-running deprovisioning when some objects may have already been deleted

add a high-level uninstall.yml playbook that runs through nodes, master, elbs, security groups, s3, etc deprovisioning

remove default values for deprovisioning