### PR TITLE
Fix openshift-webconsole version check

### DIFF
--- a/playbooks/common/private/components.yml
+++ b/playbooks/common/private/components.yml
@@ -20,9 +20,7 @@
 - import_playbook: ../../openshift-hosted/private/config.yml
 
 - import_playbook: ../../openshift-web-console/private/config.yml
-  when:
-    - openshift_web_console_install | default(true) | bool
-    - openshift.common.version_gte_3_9
+  when: openshift_web_console_install | default(true) | bool
 
 - import_playbook: ../../openshift-metrics/private/config.yml
   when: openshift_metrics_install_metrics | default(false) | bool

--- a/playbooks/openshift-web-console/private/config.yml
+++ b/playbooks/openshift-web-console/private/config.yml
@@ -13,10 +13,13 @@
 
 - name: Web Console
   hosts: oo_first_master
-  roles:
-  - openshift_web_console
   vars:
     first_master: "{{ groups.oo_first_master[0] }}"
+  tasks:
+  - debug: msg="{{ openshift_version | version_compare('3.9', '>=') }}"
+  - import_role:
+      name: openshift_web_console
+    when: openshift_version | version_compare('3.9', '>=')
 
 - name: Web Console Install Checkpoint End
   hosts: all


### PR DESCRIPTION
Install checkpoint callback doesn't import
openshift_facts, thus gte_39 bool will fail.

This boolean was applied via common/components.yml.

Putting a boolean on an import_playbook statement
applies the boolean to all tasks inside the imported
playbook.  This resulted in checkpoint callback failing
as openshift_facts might not have been run against
a host in 'all' group and trigger an undefined.

This commit moves boolean to inside private/config
of openshift-webconsole to be more inline with
what we do in openshift-hotsed.