### PR TITLE
Fix way openshift_openstack_nodes_to_remove parameter is parsed

### DIFF
--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -672,7 +672,7 @@ resources:
     properties:
       count: {{ openshift_openstack_num_nodes }}
       removal_policies:
-      - resource_list: {{ openshift_openstack_nodes_to_remove }}
+      - resource_list: {{ openshift_openstack_nodes_to_remove | to_json }}
       resource_def:
         type: server.yaml
         properties:


### PR DESCRIPTION
This fixes the openshift_openstack_nodes_to_remove parameter to use to_json.