### PR TITLE
Change openshift.common.hostname to inventory_hostname

### DIFF
--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -30,7 +30,7 @@
   # masters, or absent if such is the case.
   - name: Detect if this host is a new master in a scale up
     set_fact:
-      g_openshift_master_is_scaleup: "{{ openshift.common.hostname in ( groups['new_masters'] | default([]) ) }}"
+      g_openshift_master_is_scaleup: "{{ inventory_hostname in ( groups['new_masters'] | default([]) ) }}"
 
   - name: Scaleup Detection
     debug:


### PR DESCRIPTION
This commit corrects possible wrong behavior and
removes relianace on unnecessary openshift_facts
in favor of inventory_hostname.