### PR TITLE
Create hawkular-metrics cluster role binding to watch namespaces

### DIFF
--- a/roles/openshift_metrics/tasks/generate_rolebindings.yaml
+++ b/roles/openshift_metrics/tasks/generate_rolebindings.yaml
@@ -13,3 +13,36 @@
     - kind: ServiceAccount
       name: hawkular
   changed_when: no
+
+- name: generate hawkular-metrics cluster role binding for the hawkular service account
+  template:
+    src: rolebinding.j2
+    dest: "{{ mktemp.stdout }}/templates/hawkular-cluster-rolebinding.yaml"
+  vars:
+    cluster: True
+    obj_name: hawkular-namespace-watcher
+    labels:
+      metrics-infra: hawkular
+    roleRef:
+      kind: ClusterRole
+      name: hawkular-metrics
+    subjects:
+    - kind: ServiceAccount
+      name: hawkular
+      namespace: "{{openshift_metrics_project}}"
+  changed_when: no
+
+- name: generate the hawkular cluster role
+  template:
+    src: hawkular_metrics_role.j2
+    dest: "{{ mktemp.stdout }}/templates/hawkular-cluster-role.yaml"
+  changed_when: no
+
+- name: Set hawkular cluster roles
+  oc_obj:
+    name: hawkular-metrics
+    namespace: "{{ openshift_metrics_project }}"
+    kind: clusterrole
+    files:
+    - "{{ mktemp.stdout }}/templates/hawkular-cluster-role.yaml"
+    delete_after: true

--- a/roles/openshift_metrics/templates/hawkular_metrics_role.j2
+++ b/roles/openshift_metrics/templates/hawkular_metrics_role.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  name: hawkular-metrics
+  labels:
+    metrics-infra: hawkular-metrics
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - get
+  - watch


### PR DESCRIPTION
This commit creates the hawkular-metrics cluster role binding that is needed to watch namespaces. See [BZ 1479989](https://bugzilla.redhat.com/show_bug.cgi?id=1479989) for details.