### PR TITLE
Create default storageclass for cloudprovider openstack

### DIFF
--- a/playbooks/common/openshift-cluster/openshift_hosted.yml
+++ b/playbooks/common/openshift-cluster/openshift_hosted.yml
@@ -27,7 +27,7 @@
       logging_elasticsearch_ops_cluster_size: "{{ openshift_hosted_logging_elasticsearch_ops_cluster_size | default(1) }}"
   roles:
   - role: openshift_default_storage_class
-    when: openshift_cloudprovider_kind is defined and (openshift_cloudprovider_kind == 'aws' or openshift_cloudprovider_kind == 'gce')
+    when: openshift_cloudprovider_kind is defined and (openshift_cloudprovider_kind == 'aws' or openshift_cloudprovider_kind == 'gce' or openshift_cloudprovider_kind == 'openstack')
   - role: openshift_hosted
   - role: openshift_metrics
     when: openshift_hosted_metrics_deploy | default(false) | bool

--- a/roles/openshift_default_storage_class/defaults/main.yml
+++ b/roles/openshift_default_storage_class/defaults/main.yml
@@ -13,7 +13,11 @@ openshift_storageclass_defaults:
     parameters:
       type: pd-standard
 
+  openstack:
+    name: sc-cinder
+    provisioner: cinder
+
 openshift_storageclass_default: "true"
 openshift_storageclass_name: "{{ openshift_storageclass_defaults[openshift_cloudprovider_kind]['name'] }}"
 openshift_storageclass_provisioner: "{{ openshift_storageclass_defaults[openshift_cloudprovider_kind]['provisioner'] }}"
-openshift_storageclass_parameters: "{{ openshift_storageclass_defaults[openshift_cloudprovider_kind]['parameters'] }}"
+openshift_storageclass_parameters: "{{ openshift_storageclass_defaults[openshift_cloudprovider_kind]['parameters'] | default({}) }}"

--- a/roles/openshift_default_storage_class/tasks/main.yml
+++ b/roles/openshift_default_storage_class/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# Install default storage classes in GCE & AWS
+# Install default storage classes in GCE & AWS & OPENSTACK
 - name: Ensure storageclass object
   oc_storageclass:
     name: "{{ openshift_storageclass_name }}"


### PR DESCRIPTION
Hi, I backported the generation of default storage class for Openstack when Openstack cloud-provider is activated for release 3.6.