### PR TITLE
add deprovision playbook for cluster-operator infrastructure

### DIFF
--- a/playbooks/cluster-operator/aws/uninstall_infrastructure.yml
+++ b/playbooks/cluster-operator/aws/uninstall_infrastructure.yml
@@ -1,0 +1,21 @@
+---
+- name: Deprovision infrastructure
+  hosts: localhost
+  tasks:
+  - name: Alert user to variables needed - clusterid
+    debug:
+      msg: "openshift_aws_clusterid={{ openshift_aws_clusterid }}"
+
+  - name: Alert user to variables needed - region
+    debug:
+      msg: "openshift_aws_region={{ openshift_aws_region }}"
+
+- import_playbook: ../../aws/openshift-cluster/uninstall_elb.yml
+
+- import_playbook: ../../aws/openshift-cluster/uninstall_s3.yml
+
+- import_playbook: ../../aws/openshift-cluster/uninstall_sec_group.yml
+
+- import_playbook: ../../aws/openshift-cluster/uninstall_ssh_keypair.yml
+
+- import_playbook: ../../aws/openshift-cluster/uninstall_vpc.yml


### PR DESCRIPTION
use existing playbooks/aws/cluster-operator/* uninstall playbooks to create an uninstall playbook for cluster-operator infrastructure