### PR TITLE
WIP create an azure vm and save an image from it

### DIFF
--- a/playbooks/azure/openshift-cluster/build_vhd.yml
+++ b/playbooks/azure/openshift-cluster/build_vhd.yml
@@ -1,0 +1,94 @@
+---
+# Note: this required ansible-galaxy install Azure.azure_modules
+
+# create all the items necessary to make the VM
+
+- name: "Create resource group"
+  hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: "provision resource group"
+    import_role:
+      name: openshift_azure
+      tasks_from: create_resource_group.yml
+
+- name: "Create storage account"
+  hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: "provision storage account"
+    import_role:
+      name: openshift_azure
+      tasks_from: create_storage_account.yml  
+
+- name: Create virtual network
+  hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: "provision virtual network"
+    import_role:
+      name: openshift_azure
+      tasks_from: create_virtual_network.yml  
+
+- name: Add subnet
+  hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: "provision subnet in virtual network"
+    import_role:
+      name: openshift_azure
+      tasks_from: add_subnet_to_virtual_network.yml
+
+- name: Create public ip
+  hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: "provision public ip address"
+    import_role:
+      name: openshift_azure
+      tasks_from: create_public_ip.yml
+
+
+- name: Create security group that allows SSH
+  hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: "provision security group allowing SSH"
+    import_role: 
+      name: openshift_azure
+      tasks_from: create_security_group.yml
+
+- name: Create NIC
+  hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: "provision network interface card"
+    import_role:
+      name: openshift_azure
+      tasks_from: create_nic.yml
+
+
+- name: Create virtual machine
+  hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: "provision vm"
+    import_role:
+      name: openshift_azure
+      tasks_from: create_vm.yml
+
+#
+# TODO: do OpenShifty stuff to the VM
+#
+
+# NOTE: this isn't available until ansible 2.5
+# https://github.com/ansible/ansible/pull/32589
+# installed from https://releases.ansible.com/ansible/rpm/nightly/devel/epel-7-x86_64/
+- name: Create image
+  hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: "create image"
+    import_role:
+      name: openshift_azure
+      tasks_from: create_image_from_vm.yml

--- a/playbooks/azure/openshift-cluster/deprovision.yml
+++ b/playbooks/azure/openshift-cluster/deprovision.yml
@@ -1,0 +1,13 @@
+---
+# Warning, use with caution, this will remove all resources 
+# from the group.
+
+- name: "Create resource group"
+  hosts: localhost 
+  tasks:
+  - name: "rm resource group"
+    import_role:
+      name: openshift_azure
+      tasks_from: rm_resource_group.yml
+
+

--- a/playbooks/azure/openshift-cluster/example_params.yml
+++ b/playbooks/azure/openshift-cluster/example_params.yml
@@ -1,0 +1,35 @@
+---
+# need these to connect with a service principal
+# this didn't seem to work, had to resource to ~/.azure/credentials file
+# client_id: "{{ lookup('env','AZURE_CLIENT_ID') }}"
+# secret: "{{ lookup('env','AZURE_SECRET') }}"
+# subscription_id: "{{ lookup('env','AZURE_SUBSCRIPTION_ID') }}"
+# tenant: "{{ lookup('env','AZURE_TENANT') }}"
+
+# resource group parameters
+openshift_azure_create_resource_group: True
+openshift_azure_resource_group_name: openshifttestgroup
+openshift_azure_resource_location: eastus
+
+# storage account parameters
+openshift_azure_storage_account_type: Standard_LRS
+
+# virtual network parameters
+openshift_azure_virtual_network_address_prefixes: "10.10.0.0/16"
+openshift_azure_subnet_prefix: "10.10.0.0/24"
+
+# base vm parameters
+openshift_azure_vm_name: openshiftbasevm
+openshift_azure_vm_storage_container: "openshiftbasevm.vhd"
+openshift_azure_vm_size: Standard_D1
+openshift_azure_vm_admin_username: "openshift"
+openshift_azure_vm_admin_password: "OpenShift1!"
+
+openshift_azure_vm_offer: RHEL
+openshift_azure_vm_publisher: Redhat
+openshift_azure_vm_sku: '7-RAW'
+openshift_azure_vm_version: latest
+
+# image parameters
+openshift_azure_image_name: openshiftbaseimage
+

--- a/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/add_subnet_to_virtual_network.yml
+++ b/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/add_subnet_to_virtual_network.yml
@@ -1,0 +1,7 @@
+---
+- name: Add subnet
+  azure_rm_subnet:
+    resource_group: "{{ openshift_azure_resource_group_name }}"
+    name: "{{ openshift_azure_resource_group_name }}"
+    address_prefix: "{{ openshift_azure_subnet_prefix }}"
+    virtual_network: "{{ openshift_azure_resource_group_name }}"

--- a/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_image_from_vm.yml
+++ b/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_image_from_vm.yml
@@ -1,0 +1,24 @@
+---
+# taken from tests in https://github.com/ansible/ansible/pull/32589/files
+# not sure if this is completely necessary but initial attempts
+# errored because VM was not generalized and this seems to work around it.
+- name: Deallocate the virtual machine
+  azure_rm_virtualmachine:
+      resource_group: "{{ openshift_azure_resource_group_name }}"
+      name: "{{ openshift_azure_vm_name }}"
+      allocated: no 
+      vm_size: "{{ openshift_azure_vm_size }}"
+
+- name: Start the virtual machine
+  azure_rm_virtualmachine:
+      resource_group: "{{ openshift_azure_resource_group_name }}"
+      name: "{{ openshift_azure_vm_name }}"
+      vm_size: "{{ openshift_azure_vm_size }}"
+
+- name: Create an image from VM
+  azure_rm_image:
+      resource_group: "{{ openshift_azure_resource_group_name }}"
+      source: "https://{{ openshift_azure_resource_group_name }}.blob.core.windows.net/{{ openshift_azure_vm_name }}/{{ openshift_azure_vm_storage_container }}"
+      name: "{{ openshift_azure_image_name }}"
+      os_type: Linux  
+

--- a/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_nic.yml
+++ b/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_nic.yml
@@ -1,0 +1,9 @@
+---
+- name: Create NIC
+  azure_rm_networkinterface:
+    resource_group: "{{ openshift_azure_resource_group_name }}"
+    name: "{{ openshift_azure_resource_group_name }}"
+    virtual_network: "{{ openshift_azure_resource_group_name }}"
+    subnet: "{{ openshift_azure_resource_group_name }}"
+    public_ip_name: "{{ openshift_azure_resource_group_name }}"
+    security_group: "{{ openshift_azure_resource_group_name }}"

--- a/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_public_ip.yml
+++ b/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_public_ip.yml
@@ -1,0 +1,6 @@
+---
+- name: Create public ip
+  azure_rm_publicipaddress:
+    resource_group: "{{ openshift_azure_resource_group_name }}"
+    allocation_method: Static
+    name: "{{ openshift_azure_resource_group_name }}" #this needs to be a better name

--- a/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_resource_group.yml
+++ b/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_resource_group.yml
@@ -1,0 +1,7 @@
+---
+# this passes back provisioning_state when successful, how do I key on that?
+- name: Create Resource Group
+  azure_rm_resourcegroup: 
+    name: "{{ openshift_azure_resource_group_name }}"
+    location: "{{ openshift_azure_resource_location }}"
+  when: openshift_azure_create_resource_group | bool

--- a/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_security_group.yml
+++ b/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_security_group.yml
@@ -1,0 +1,12 @@
+---
+- name: Create security group that allows SSH
+  azure_rm_securitygroup:
+    resource_group: "{{ openshift_azure_resource_group_name }}"
+    name: "{{ openshift_azure_resource_group_name }}"
+    rules:
+      - name: SSH
+        protocol: Tcp
+        destination_port_range: 22
+        access: Allow
+        priority: 101
+        direction: Inbound

--- a/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_storage_account.yml
+++ b/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_storage_account.yml
@@ -1,0 +1,6 @@
+---
+- name: Create storage account
+  azure_rm_storageaccount:
+    resource_group: "{{ openshift_azure_resource_group_name }}"
+    name: "{{ openshift_azure_resource_group_name }}"
+    account_type: "{{ openshift_azure_storage_account_type }}"

--- a/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_virtual_network.yml
+++ b/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_virtual_network.yml
@@ -1,0 +1,5 @@
+- name: Create virtual network
+  azure_rm_virtualnetwork:
+    resource_group: "{{ openshift_azure_resource_group_name }}"
+    name: "{{ openshift_azure_resource_group_name }}"
+    address_prefixes: "{{ openshift_azure_virtual_network_address_prefixes }}"

--- a/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_vm.yml
+++ b/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/create_vm.yml
@@ -1,0 +1,17 @@
+---
+- name: Create virtual machine
+  azure_rm_virtualmachine:
+    resource_group: "{{ openshift_azure_resource_group_name }}"
+    name: "{{ openshift_azure_vm_name }}"
+    vm_size: "{{ openshift_azure_vm_size }}"
+    storage_account: "{{ openshift_azure_resource_group_name }}"
+    storage_container: openshiftbasevm
+    storage_blob: "{{ openshift_azure_vm_storage_container }}"
+    admin_username: "{{ openshift_azure_vm_admin_username }}"
+    admin_password: "{{ openshift_azure_vm_admin_password }}"
+    network_interfaces: "{{ openshift_azure_resource_group_name }}"
+    image:
+      offer: "{{ openshift_azure_vm_offer }}"
+      publisher: "{{ openshift_azure_vm_publisher }}"
+      sku: "{{ openshift_azure_vm_sku }}"
+      version: "{{ openshift_azure_vm_version }}"

--- a/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/rm_resource_group.yml
+++ b/playbooks/azure/openshift-cluster/roles/openshift_azure/tasks/rm_resource_group.yml
@@ -1,0 +1,6 @@
+---
+- name: Delete a resource group
+  azure_rm_resourcegroup:
+    name: "{{ openshift_azure_resource_group_name }}"
+    state: absent
+    force: yes # removes all resources within the group


### PR DESCRIPTION
@kwoodson this creates a RHEL VM then creates a private Azure image from it that other VMs can be started with.  I'm sure the resources are naive but the mechanics are there.  It does not include any node configuration at this point I was hoping that is where I could get some guidance on things we can reuse.  

I'd still be curious if we can use the export task to just save our AWS image but I was hoping this could be a backstop.

It does require Ansible 2.5 to get one of the modules.

cc @dobbymoodge @glennswest @smarterclayton 