### PR TITLE
Update API healthz check to use uri module

### DIFF
--- a/roles/openshift_service_catalog/tasks/start_api_server.yml
+++ b/roles/openshift_service_catalog/tasks/start_api_server.yml
@@ -9,14 +9,12 @@
 
 # wait to see that the apiserver is available
 - name: wait for api server to be ready
-  command: >
-    curl --noproxy '*' -k https://apiserver.kube-service-catalog.svc/healthz
-  args:
-    # Disables the following warning:
-    # Consider using get_url or uri module rather than running curl
-    warn: no
+  uri:
+    url: https://apiserver.kube-service-catalog.svc/healthz
+    validate_certs: no
+    return_content: yes
   register: api_health
-  until: api_health.stdout == 'ok'
+  until: "'ok' in api_health.content"
   retries: 60
   delay: 5
   changed_when: false


### PR DESCRIPTION
This should prevent issues with curl getting upset with certs that have the same serial number and name.

See https://github.com/openshift/origin/pull/18405

/assign @sdodson 