### PR TITLE
extend targetted scale group remover

### DIFF
--- a/playbooks/aws/openshift-cluster/uninstall_specific_scale_group.yml
+++ b/playbooks/aws/openshift-cluster/uninstall_specific_scale_group.yml
@@ -1,0 +1,19 @@
+---
+# set openshift_aws_asgs_to_remove for any SGs you want deleted
+- name: delete specified scale groups
+  hosts: localhost
+  connection: local
+  gather_facts: yes
+  tasks:
+  - name: Alert user to variables needed - clusterid
+    debug:
+      msg: "openshift_aws_clusterid={{ openshift_aws_clusterid }}"
+
+  - name: Alert user to variables needed - region
+    debug:
+      msg: "openshift_aws_region={{ openshift_aws_region }}"
+
+  - name: delete the scale groups
+    import_role:
+      name: openshift_aws
+      tasks_from: remove_scale_group.yml

--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -325,3 +325,5 @@ openshift_aws_enable_uninstall_shared_objects: False
 # name in the meantime). Default to just emptying the contents of the S3
 # bucket if we've been asked to create the bucket during provisioning.
 openshift_aws_really_delete_s3_bucket: False
+# Protect master scale groups from deletion by default
+openshift_aws_protect_masters_from_deletion: True

--- a/roles/openshift_aws/tasks/remove_scale_group.yml
+++ b/roles/openshift_aws/tasks/remove_scale_group.yml
@@ -10,14 +10,29 @@
   with_items: "{{ openshift_aws_current_asgs if openshift_aws_current_asgs != [] else openshift_aws_asgs_to_remove }}"
   register: qasg
 
-- name: remove non-master scale groups
+- set_fact:
+    l_asgs_to_remove: []
+
+- name: protect masters from deletion
+  set_fact:
+    l_asgs_to_remove: "{{ [item.results[0]] | union(l_asgs_to_remove) }}"
+  with_items: "{{ qasg.results }}"
+  when:
+  - item.results != []
+  - "'master' not in item.results[0].auto_scaling_group_name"
+  - openshift_aws_protect_masters_from_deletion
+
+- debug:
+    var: l_asgs_to_remove
+  verbosity: 1
+
+- name: remove scale groups
   ec2_asg:
     region: "{{ openshift_aws_region }}"
     state: absent
     name: "{{ item.auto_scaling_group_name }}"
-  when: "'master'  not in item.auto_scaling_group_name"
   register: asg_results
-  with_items: "{{ qasg | json_query('results[*]') | sum(attribute='results', start=[]) }}"
+  with_items: "{{ l_asgs_to_remove }}"
   async: 600
   poll: 0
 
@@ -28,3 +43,10 @@
   with_items: "{{ asg_results.results }}"
   until: jobs_results.finished
   retries: 200
+
+- name: remove launch configs
+  ec2_lc:
+    name: "{{ item.launch_configuration_name }}"
+    state: absent
+    region: "{{ openshift_aws_region }}"
+  with_items: "{{ l_asgs_to_remove }}"


### PR DESCRIPTION
modify remove_scale_group.yml to remove launch configs associated with the to-be-deleted scale groups

remove hard-coded master protection and make it conditional on openshift_aws_protect_masters_from_deletion (default True)

allow calling of remove_scale_group.yml from playbooks/aws/openshift-cluster/*