### PR TITLE
skip search for an ami if openshift_aws_ami_map provides one

### DIFF
--- a/roles/openshift_aws/tasks/build_node_group.yml
+++ b/roles/openshift_aws/tasks/build_node_group.yml
@@ -2,7 +2,9 @@
 # When openshift_aws_use_custom_ami is '' then
 # we retrieve the latest build AMI.
 # Then set openshift_aws_ami to the ami.
-- when: openshift_aws_ami == ''
+- when:
+  - openshift_aws_ami == ''
+  - openshift_aws_node_group.group not in openshift_aws_ami_map
   block:
   - name: fetch recently created AMI
     ec2_ami_find:


### PR DESCRIPTION
if we define openshift_aws_ami_map with appropriate entries for the various node group types, they will include an ami id to use

it is okay for openshift_aws_ami to be empty in the case that openshift_aws_aws_map has an entry for the node group we're setting up

change the ami detection to skip if openshift_aws_ami_map already has an ami for us