### PR TITLE
Revert openshift_portal_net

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -15,7 +15,7 @@ openshift_docker_service_name: "{{ 'container-engine' if (openshift_docker_use_s
 
 openshift_docker_hosted_registry_insecure: False  # bool
 
-openshift_docker_hosted_registry_network: "{{ openshift_portal_net }}"
+openshift_docker_hosted_registry_network: "{{ openshift.common.portal_net }}"
 
 openshift_docker_additional_registries: []
 openshift_docker_blocked_registries: []


### PR DESCRIPTION
Revert usage of openshift_portal_net back to
openshift.common.portal_net

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1546919