### PR TITLE
Ensure wire-aggregator run on 3.7 upgrades

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade.yml
@@ -39,6 +39,16 @@
   vars:
     master_config_hook: "v3_7/master_config_upgrade.yml"
 
+# this must occur after the control plane is upgraded because systemd service
+# names are changed
+- name: Configure API aggregation on masters
+  hosts: oo_masters_to_config
+  serial: 1
+  roles:
+  - role: openshift_facts
+  tasks:
+  - include_tasks: ../../../openshift-master/tasks/wire_aggregator.yml
+
 # All controllers must be stopped at the same time then restarted
 - name: Cycle all controller services to force new leader election mode
   hosts: oo_masters_to_config

--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -51,6 +51,16 @@
   vars:
     master_config_hook: "v3_7/master_config_upgrade.yml"
 
+# this must occur after the control plane is upgraded because systemd service
+# names are changed
+- name: Configure API aggregation on masters
+  hosts: oo_masters_to_config
+  serial: 1
+  roles:
+  - role: openshift_facts
+  tasks:
+  - include_tasks: ../../../openshift-master/tasks/wire_aggregator.yml
+
 # All controllers must be stopped at the same time then restarted
 - name: Cycle all controller services to force new leader election mode
   hosts: oo_masters_to_config


### PR DESCRIPTION
Wire aggregator needs to be run when moving from
3.6 to 3.7.

This commit ensures wire-aggregator is run on
such upgrades.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1546365