### PR TITLE
Updating AMI copying tags to no longer default to parent AMI.

### DIFF
--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -34,6 +34,8 @@ openshift_aws_launch_config_bootstrap_token: ''
 
 openshift_aws_users: []
 
+openshift_aws_copy_base_ami_tags: False
+
 openshift_aws_ami_tags:
   bootstrap: "true"
   openshift-created: "true"

--- a/roles/openshift_aws/tasks/seal_ami.yml
+++ b/roles/openshift_aws/tasks/seal_ami.yml
@@ -10,18 +10,20 @@
   delay: 3
   until: instancesout.instances|length > 0
 
-- name: fetch the ami used to create the instance
-  ec2_ami_find:
-    region: "{{ openshift_aws_region }}"
-    ami_id: "{{ instancesout.instances[0]['image_id'] }}"
-  register: original_ami_out
-  retries: 20
-  delay: 3
-  until: original_ami_out.results|length > 0
+- when: openshift_aws_copy_base_ami_tags | default(False) | bool
+  block:
+  - name: fetch the ami used to create the instance
+    ec2_ami_find:
+      region: "{{ openshift_aws_region }}"
+      ami_id: "{{ instancesout.instances[0]['image_id'] }}"
+    register: original_ami_out
+    retries: 20
+    delay: 3
+    until: original_ami_out.results|length > 0
 
-- name: combine the tags of the original ami with newly created ami
-  set_fact:
-    l_openshift_aws_ami_tags: "{{ original_ami_out.results[0]['tags'] | combine(openshift_aws_ami_tags) }}"
+  - name: combine the tags of the original ami with newly created ami
+    set_fact:
+      l_openshift_aws_ami_tags: "{{ original_ami_out.results[0]['tags'] | combine(openshift_aws_ami_tags) }}"
 
 - name: bundle ami
   ec2_ami:
@@ -30,7 +32,7 @@
     state: present
     description: "This was provisioned {{ ansible_date_time.iso8601 }}"
     name: "{{ openshift_aws_ami_name }}"
-    tags: "{{ l_openshift_aws_ami_tags }}"
+    tags: "{{ l_openshift_aws_ami_tags if l_openshift_aws_ami_tags is defined and l_openshift_aws_ami_tags != {} else openshift_aws_ami_tags }}"
     wait: yes
   register: amioutput
 


### PR DESCRIPTION
During a chat with @mtnbikenc, we discovered that the AMI building script copies the base AMI's tags and places them on the newly created AMI.  This is a useful feature when carrying tags forward from an instance and is used by @mwoodson during CICD's build process.

However this breaks when we want to build from an already built CI's AMI.  This copies the same tags which in turn places the newly created AMI into the returned search results for the CI process.

I have placed a variable to enable CICD workflow `openshift_aws_copy_base_ami_tags: False` so they continue to work.  This will require the above variable to be set to `True` and passed in via inventory.



