### PR TITLE
bug 1547688.  Annotate ops projects with prefix for data index

### DIFF
--- a/roles/openshift_logging/tasks/annotate_ops_projects.yaml
+++ b/roles/openshift_logging/tasks/annotate_ops_projects.yaml
@@ -5,7 +5,7 @@
     get namespaces -o jsonpath={.items[*].metadata.name} {{ __default_logging_ops_projects | join(' ') }}
   register: __logging_ops_projects
 
-- name: Annotate Operations Projects
+- name: Annotate Operations Projects for ops hostname
   oc_edit:
     kind: ns
     name: "{{ project }}"
@@ -18,3 +18,16 @@
   when:
   - __logging_ops_projects.stderr | length == 0
   - openshift_logging_use_ops | default(false) | bool
+
+- name: Annotate Operations Projects for data prefix
+  oc_edit:
+    kind: ns
+    name: "{{ project }}"
+    separator: '#'
+    content:
+      metadata#annotations#openshift.io/logging.data.prefix: ".operations"
+  with_items: "{{ __logging_ops_projects.stdout.split(' ') }}"
+  loop_control:
+    loop_var: project
+  when:
+  - __logging_ops_projects.stderr | length == 0


### PR DESCRIPTION
This PR fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1547688

(cherry picked from commit 7ccfbfe027a2707feb37563191cd0cbe656aedd9)