### PR TITLE
cockpit-ui: Make it optional

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -475,7 +475,9 @@ debug_level=2
 #
 # Manage the OpenShift Registry (optional)
 #openshift_hosted_manage_registry=true
-
+# Manage the OpenShift Registry Console (optional)
+#openshift_hosted_manage_registry_console=true
+#
 # Registry Storage Options
 #
 # NFS Host Group

--- a/playbooks/openshift-hosted/private/cockpit-ui.yml
+++ b/playbooks/openshift-hosted/private/cockpit-ui.yml
@@ -5,4 +5,5 @@
   - role: cockpit-ui
     when:
     - openshift_hosted_manage_registry | default(true) | bool
+    - openshift_hosted_manage_registry_console | default(true) | bool
     - not (openshift_docker_hosted_registry_insecure | default(false)) | bool


### PR DESCRIPTION
* Added openshift_hosted_manage_registry_console defaulting to true,
making the component optional

Partially fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1425022

@sdodson 