### PR TITLE
Cast string to dict in lib_utils_oo_dict_to_keqv_list

### DIFF
--- a/roles/lib_utils/filter_plugins/oo_filters.py
+++ b/roles/lib_utils/filter_plugins/oo_filters.py
@@ -4,6 +4,7 @@
 """
 Custom filters for use in openshift-ansible
 """
+import ast
 import json
 import os
 import pdb
@@ -248,6 +249,15 @@ def lib_utils_oo_dict_to_keqv_list(data):
         Return data:
         ['a=1', 'b=2']
     """
+    if not isinstance(data, dict):
+        try:
+            # This will attempt to convert something that looks like a string
+            # representation of a dictionary (including json) into a dictionary.
+            data = ast.literal_eval(data)
+        except ValueError:
+            msg = "|failed expects first param is a dict. Got {}. Type: {}"
+            msg = msg.format(str(data), str(type(data)))
+            raise errors.AnsibleFilterError(msg)
     return ['='.join(str(e) for e in x) for x in data.items()]
 
 


### PR DESCRIPTION
Due to bug in ansible not treating host-vars and group-vars
exactly the same when evaluating a string to see if
it should be cast as a dictionary, some users experience
a failure of lib_utils_oo_dict_to_keqv_list due to
the module receiving a string instead of a dictionary.

This commit attempts to create a string from a
dictionary if the dictionary is not provided.

Ansible bug report: https://github.com/ansible/ansible/issues/36544

Fixes: https://github.com/openshift/openshift-ansible/issues/6897
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1542099