### PR TITLE
[1537872] Adding seboolean for virt_use_samba

### DIFF
--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -180,6 +180,7 @@
   - role: openshift_master_facts
   - role: openshift_clock
   - role: openshift_cloud_provider
+    when: openshift_cloudprovider_kind is defined
   - role: openshift_builddefaults
   - role: openshift_buildoverrides
   - role: nickhammond.logrotate

--- a/playbooks/openshift-node/private/configure_nodes.yml
+++ b/playbooks/openshift-node/private/configure_nodes.yml
@@ -12,6 +12,7 @@
   roles:
   - role: openshift_clock
   - role: openshift_cloud_provider
+    when: openshift_cloudprovider_kind is defined
   - role: openshift_node
   - role: tuned
   - role: nickhammond.logrotate

--- a/playbooks/openshift-node/private/containerized_nodes.yml
+++ b/playbooks/openshift-node/private/containerized_nodes.yml
@@ -14,6 +14,7 @@
   roles:
   - role: openshift_clock
   - role: openshift_cloud_provider
+    when: openshift_cloudprovider_kind is defined
   - role: openshift_node
     openshift_ca_host: "{{ groups.oo_first_master.0 }}"
   - role: nickhammond.logrotate

--- a/roles/openshift_cloud_provider/tasks/azure.yml
+++ b/roles/openshift_cloud_provider/tasks/azure.yml
@@ -1,0 +1,6 @@
+---
+- name: set seboolean for samba use
+  seboolean:
+    name: virt_use_samba
+    state: yes
+    persistent: yes

--- a/roles/openshift_cloud_provider/tasks/main.yml
+++ b/roles/openshift_cloud_provider/tasks/main.yml
@@ -9,16 +9,6 @@
   file:
     path: "{{ openshift.common.config_base }}/cloudprovider"
     state: directory
-  when: has_cloudprovider | bool
 
-- include_tasks: openstack.yml
-  when: cloudprovider_is_openstack | bool
-
-- include_tasks: aws.yml
-  when: cloudprovider_is_aws | bool
-
-- include_tasks: gce.yml
-  when: cloudprovider_is_gce | bool
-
-- include_tasks: vsphere.yml
-  when: cloudprovider_is_vsphere | bool
+- name: include the defined cloud provider files
+  include_tasks: "{{ openshift_cloudprovider_kind }}.yml"

--- a/roles/openshift_cloud_provider/vars/main.yml
+++ b/roles/openshift_cloud_provider/vars/main.yml
@@ -1,6 +1,0 @@
----
-has_cloudprovider: "{{ openshift_cloudprovider_kind | default(None) != None }}"
-cloudprovider_is_aws: "{{ has_cloudprovider | bool and openshift_cloudprovider_kind == 'aws' }}"
-cloudprovider_is_openstack: "{{ has_cloudprovider | bool and openshift_cloudprovider_kind == 'openstack' }}"
-cloudprovider_is_gce: "{{ has_cloudprovider | bool and openshift_cloudprovider_kind == 'gce' }}"
-cloudprovider_is_vsphere: "{{ has_cloudprovider | bool and openshift_cloudprovider_kind == 'vsphere' }}"


### PR DESCRIPTION
Adding an seboolean for bz: https://bugzilla.redhat.com/show_bug.cgi?id=1537872
This will require `openshift_cloudprovider_kind: azure` inventory variable be set.