### PR TITLE
Fix upgrade verify_upgrade_targets

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -43,7 +43,7 @@
     fail:
       msg: "OpenShift {{ avail_openshift_version }} is available, but {{ openshift_upgrade_target }} or greater is required"
     when:
-    - (openshift_pkg_version | default('-0.0', True)).split('-')[1] is version_compare(openshift_release, '<')
+    - (openshift_pkg_version | default('-0.0', True)).split('-')[1] is version_compare(openshift_upgrade_target, '<')
 
 - name: Fail when openshift version does not meet minium requirement for Origin upgrade
   fail:


### PR DESCRIPTION
verify_upgrade_targets.yml compares available
openshift package versions to openshift_release.

This commit changes openshift_release in that
comparison to openshift_upgrade_target, which is
a more appropriate variable here.

openshift_upgrade_target is always defined via
set_fact during upgrades, whereas openshift_release
is not.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1547898