### PR TITLE
Changing default of openshift_logging_public_master_url to use opensh…

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 openshift_logging_use_ops: False
 openshift_logging_master_url: "https://kubernetes.default.svc.{{ openshift.common.dns_domain }}"
-openshift_logging_master_public_url: "{{ 'https://' + openshift.common.public_hostname + ':' ~ (openshift_master_api_port | default('8443', true)) }}"
+openshift_logging_master_public_url: "{{ 'https://' + openshift_master_cluster_public_hostname | default(openshift.common.public_hostname) + ':' ~ (openshift_master_api_port | default('8443', true)) }}"
 openshift_logging_namespace: logging
 openshift_logging_nodeselector: null
 openshift_logging_labels: {}


### PR DESCRIPTION
…ift_master_cluster_public_hostname if available

Addresses: https://bugzilla.redhat.com/show_bug.cgi?id=1547944

Leaving `openshift.common.public_hostname` as there isn't a `openshift.master.public_hostname` always.