### PR TITLE
start_api_server: service catalog healthcheck doesn't require proxy

### DIFF
--- a/roles/openshift_service_catalog/tasks/start_api_server.yml
+++ b/roles/openshift_service_catalog/tasks/start_api_server.yml
@@ -13,6 +13,8 @@
     url: https://apiserver.kube-service-catalog.svc/healthz
     validate_certs: no
     return_content: yes
+  environment:
+    no_proxy: '*'
   register: api_health
   until: "'ok' in api_health.content"
   retries: 60


### PR DESCRIPTION
This change would restore no_proxy param set by #7125 and reverted by #7222

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1544645