### PR TITLE
Sort web console events for easier debugging

### DIFF
--- a/roles/openshift_web_console/tasks/install.yml
+++ b/roles/openshift_web_console/tasks/install.yml
@@ -189,7 +189,7 @@
       msg: "{{ console_pods.stdout_lines }}"
   - name: Get events in the openshift-web-console namespace
     command: >
-      {{ openshift_client_binary }} get events --config={{ mktemp.stdout }}/admin.kubeconfig -n openshift-web-console
+      {{ openshift_client_binary }} get events --config={{ mktemp.stdout }}/admin.kubeconfig --sort-by='.metadata.creationTimestamp' -n openshift-web-console
     register: console_events
     ignore_errors: true
   - debug:
@@ -208,7 +208,7 @@
     name: "{{ mktemp.stdout }}"
   changed_when: False
 
-- name: Report console errors
+- name: Web console install failed
   fail:
-    msg: Console install failed.
+    msg: Web console install failed
   when: console_health.stdout != 'ok'


### PR DESCRIPTION
When the console install fails, the install prints events from the
openshift-web-console namespace for troubleshooting. They're not sorted,
however. This makes it difficult to debug, particularly since the "First
Seen" column only has minute granularity, so it's not clear what order
things happened.

Sort the events by creation timestamp when printed.

/assign @sdodson 