### PR TITLE
Change openshift_release to openshift_upgrade_target in upgrade

### DIFF
--- a/roles/openshift_master/tasks/upgrade/rpm_upgrade.yml
+++ b/roles/openshift_master/tasks/upgrade/rpm_upgrade.yml
@@ -11,7 +11,7 @@
 - name: Upgrade master packages - yum
   command:
     yum install -y {{ master_pkgs | join(' ') }} \
-    {{ ' --exclude *' ~ openshift_service_type ~ '*3.9*' if openshift_release | version_compare('3.9','<') else '' }}
+    {{ ' --exclude *' ~ openshift_service_type ~ '*3.9*' if openshift_upgrade_target | version_compare('3.9','<') else '' }}
   vars:
     master_pkgs:
       - "{{ openshift_service_type }}{{ openshift_pkg_version | default('') }}"


### PR DESCRIPTION
openshift_release is not always defined.

We should check openshift_upgrade_target in tasks
during upgrades for a more reliable variable.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1548485