### PR TITLE
check for empty string when installing ansible deps

### DIFF
--- a/playbooks/common/openshift-cluster/initialize_facts.yml
+++ b/playbooks/common/openshift-cluster/initialize_facts.yml
@@ -105,6 +105,8 @@
       - "{{ 'python3-PyYAML' if ansible_distribution == 'Fedora' else 'PyYAML' }}"
       - "{{ 'python-ipaddress' if ansible_distribution != 'Fedora' else '' }}"
       - yum-utils
+      when:
+      - item != ''
       register: result
       until: result | success
 


### PR DESCRIPTION
With the check the "Ensure openshift-ansible installer package deps are installed" task
fails on Fedora due to trying to install a package named the "" (i.e., the empty string).