### PR TITLE
Dump verbose curl output and API logs when API doesn't become available.

### DIFF
--- a/roles/openshift_master/tasks/check_master_api_is_ready.yml
+++ b/roles/openshift_master/tasks/check_master_api_is_ready.yml
@@ -12,3 +12,36 @@
   delay: 1
   run_once: true
   changed_when: false
+  failed_when: false
+
+- name: "Collect verbose curl output when API didn't become available"
+  command: >-
+    curl --verbose --tlsv1.2
+    --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+    {{ openshift.master.api_url }}/healthz/ready
+  register: l_api_available_verbose_output
+  failed_when: false
+
+- name: "Collect API logs when API didn't become available"
+  command: journalctl --no-pager -n 100 -u {{ openshift_service_type }}-master-api
+  register: l_api_log_output
+  when:
+  - l_api_available_output.stdout != 'ok'
+
+- name: "Dump verbose curl output when the API didn't become available"
+  debug:
+    msg: "{{ l_api_available_verbose_output.stderr_lines }}"
+  when: l_api_available_output.stdout != 'ok'
+
+- name: "Dump API logs when the API didn't become availabale"
+  debug:
+    msg: "{{ l_api_log_output.stdout_lines }}"
+  when:
+  - l_api_available_output.stdout != 'ok'
+
+- fail:
+    msg: >
+      API did not become available. Verbose curl output and API logs
+      have been collected above to assist with debugging.
+  when:
+  - l_api_available_output.stdout != 'ok'

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -193,13 +193,11 @@
 
 - include_tasks: set_loopback_context.yml
 
-- name: Start and enable master api on first master
+- name: Start and enable master api
   systemd:
     name: "{{ openshift_service_type }}-master-api"
     enabled: yes
     state: started
-  when:
-  - inventory_hostname == openshift_master_hosts[0]
   register: l_start_result
   until: not (l_start_result is failed)
   retries: 1
@@ -212,38 +210,7 @@
 
 - set_fact:
     master_api_service_status_changed: "{{ l_start_result is changed }}"
-  when:
-  - inventory_hostname == openshift_master_hosts[0]
 
-- pause:
-    seconds: 15
-  when:
-  - openshift_master_ha | bool
-
-- name: Start and enable master api all masters
-  systemd:
-    name: "{{ openshift_service_type }}-master-api"
-    enabled: yes
-    state: started
-  when:
-  - inventory_hostname != openshift_master_hosts[0]
-  register: l_start_result
-  until: not (l_start_result is failed)
-  retries: 1
-  delay: 60
-
-- name: Dump logs from master-api if it failed
-  command: journalctl --no-pager -n 100 -u {{ openshift_service_type }}-master-api
-  when:
-  - l_start_result is failed
-
-- set_fact:
-    master_api_service_status_changed: "{{ l_start_result is changed }}"
-  when:
-  - inventory_hostname != openshift_master_hosts[0]
-
-# A separate wait is required here for native HA since notifies will
-# be resolved after all tasks in the role.
 - include_tasks: check_master_api_is_ready.yml
   when:
   - master_api_service_status_changed | bool


### PR DESCRIPTION
Doing this for CI but would also be helpful as we receive a lot of issues on this task.

Ex: https://gist.github.com/abutcher/8f6edcd159741ca06188cd99cf8468d0

Also starting the API in parallel while I'm here.