### PR TITLE
[3.7] service catalog: Update API healthz check to use uri module and add noproxy

### DIFF
--- a/roles/openshift_service_catalog/tasks/start_api_server.yml
+++ b/roles/openshift_service_catalog/tasks/start_api_server.yml
@@ -9,14 +9,12 @@
 
 # wait to see that the apiserver is available
 - name: wait for api server to be ready
-  command: >
-    curl -k https://apiserver.kube-service-catalog.svc/healthz
-  args:
-    # Disables the following warning:
-    # Consider using get_url or uri module rather than running curl
-    warn: no
+  uri:
+    url: https://apiserver.kube-service-catalog.svc/healthz
+    validate_certs: no
+    return_content: yes
   register: api_health
-  until: api_health.stdout == 'ok'
-  retries: 120
-  delay: 1
+  until: "'ok' in api_health.content"
+  retries: 60
+  delay: 5
   changed_when: false

--- a/roles/openshift_service_catalog/tasks/start_api_server.yml
+++ b/roles/openshift_service_catalog/tasks/start_api_server.yml
@@ -13,6 +13,8 @@
     url: https://apiserver.kube-service-catalog.svc/healthz
     validate_certs: no
     return_content: yes
+  environment:
+    no_proxy: '*'
   register: api_health
   until: "'ok' in api_health.content"
   retries: 60


### PR DESCRIPTION
Backport of  #7222 and #7262