### PR TITLE
container-engine: support ADDTL_MOUNTS

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -107,6 +107,18 @@ container_runtime_crio_additional_mounts: []
 
 l_crio_additional_mounts: "{{ ',' + (container_runtime_crio_additional_mounts | lib_utils_oo_l_of_d_to_csv) if container_runtime_crio_additional_mounts != [] else '' }}"
 
+# this is a list of dictionaries of mounts
+# container_runtime_docker_additional_mounts:
+# - destination: /test
+#   source: /var/test
+#   options:
+#   - rw
+#   - mode=755
+#   type: bind
+container_runtime_docker_additional_mounts: []
+
+l_docker_additional_mounts: "{{ ',' + (container_runtime_docker_additional_mounts | lib_utils_oo_l_of_d_to_csv) if container_runtime_docker_additional_mounts != [] else '' }}"
+
 openshift_crio_image_tag_default: "latest"
 
 l_crt_crio_image_tag_dict:

--- a/roles/container_runtime/tasks/systemcontainer_docker.yml
+++ b/roles/container_runtime/tasks/systemcontainer_docker.yml
@@ -71,6 +71,8 @@
     name: "{{ openshift_docker_service_name }}"
     image: "{{ l_docker_image }}"
     state: latest
+    values:
+      - "ADDTL_MOUNTS={{ l_docker_additional_mounts }}"
 
 - name: Configure Container Engine Service File
   template:


### PR DESCRIPTION
Add support for additional mount points as we already do with CRI-O.

It still need a change in the Docker system container:

https://github.com/projectatomic/atomic-system-containers/pull/167

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>