### PR TITLE
Remove no_log: True from openshift_version calls

### DIFF
--- a/playbooks/init/version.yml
+++ b/playbooks/init/version.yml
@@ -6,7 +6,6 @@
   - include_role:
       name: openshift_version
       tasks_from: first_master.yml
-    no_log: True
   - debug: msg="openshift_pkg_version set to {{ openshift_pkg_version | default('') }}"
 
 # NOTE: We set this even on etcd hosts as they may also later run as masters,


### PR DESCRIPTION
#6519 set `no_log: True` on several plays and tasks in order to prevent logging credentials that come over from the inventory. However that's led to openshift_version role being invoked in a manner that it omits required debugging information like the following. I think we need to be very careful not to apply `no_log: True` at the playbook level and instead only use it on specific tasks that are known to emit sensitive information.

I think it's also worth considering that the ansible logs simply need to be treated as sensitive data and handled appropriately rather than omitting potentially useful debugging data.

```
# ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_9/upgrade.yml

TASK [openshift_version : Get available atomic-openshift version] *************************************************************************************************************************************************
task path: /usr/share/ansible/openshift-ansible/roles/openshift_version/tasks/check_available_rpms.yml:2
Using module file /usr/share/ansible/openshift-ansible/roles/lib_utils/library/repoquery.py

TASK [openshift_version : fail] ***********************************************************************************************************************************************************************************
task path: /usr/share/ansible/openshift-ansible/roles/openshift_version/tasks/check_available_rpms.yml:8
fatal: [host-xxxx.redhat.com]: FAILED! => {
    "censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", 
    "changed": false
}
```