### PR TITLE
Add GCS object storage to hosts.example

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -553,6 +553,12 @@ debug_level=2
 #openshift_hosted_registry_storage_s3_cloudfront_baseurl=https://myendpoint.cloudfront.net/
 #openshift_hosted_registry_storage_s3_cloudfront_privatekeyfile=/full/path/to/secret.pem
 #openshift_hosted_registry_storage_s3_cloudfront_keypairid=yourpairid
+#
+# GCS Storage Bucket
+#openshift_hosted_registry_storage_provider=gcs
+#openshift_hosted_registry_storage_gcs_bucket=bucket01
+#openshift_hosted_registry_storage_gcs_keyfile=test.key
+#openshift_hosted_registry_storage_gcs_rootdirectory=/registry
 
 # Metrics deployment
 # See: https://docs.openshift.com/enterprise/latest/install_config/cluster_metrics.html


### PR DESCRIPTION
QE noticed that when deploying to GCE the defaults storage provider gladly provides an RWO volume which means that the registry cannot be upgraded in a rolling manner or be scaled to multiple pods.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1548654