### PR TITLE
ntpd/chronyd will now be started before node/master services

### DIFF
--- a/roles/openshift_loadbalancer/templates/haproxy.docker.service.j2
+++ b/roles/openshift_loadbalancer/templates/haproxy.docker.service.j2
@@ -1,5 +1,7 @@
 [Unit]
 After={{ openshift_docker_service_name }}.service
+After=chronyd.service
+After=ntpd.service
 Requires={{ openshift_docker_service_name }}.service
 PartOf={{ openshift_docker_service_name }}.service
 

--- a/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-api.service.j2
+++ b/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-api.service.j2
@@ -5,6 +5,8 @@ After=etcd_container.service
 Wants=etcd_container.service
 Before={{ openshift_service_type }}-node.service
 After={{ openshift_docker_service_name }}.service
+After=chronyd.service
+After=ntpd.service
 PartOf={{ openshift_docker_service_name }}.service
 Requires={{ openshift_docker_service_name }}.service
 

--- a/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.service.j2
+++ b/roles/openshift_master/templates/native-cluster/atomic-openshift-master-api.service.j2
@@ -3,6 +3,8 @@ Description=Atomic OpenShift Master API
 Documentation=https://github.com/openshift/origin
 After=network-online.target
 After=etcd.service
+After=chronyd.service
+After=ntpd.service
 Before={{ openshift_service_type }}-node.service
 Requires=network-online.target
 

--- a/roles/openshift_node/templates/node.service.j2
+++ b/roles/openshift_node/templates/node.service.j2
@@ -1,6 +1,8 @@
 [Unit]
 Description=OpenShift Node
 After={{ openshift_docker_service_name }}.service
+After=chronyd.service
+After=ntpd.service
 Wants=openvswitch.service
 After=ovsdb-server.service
 After=ovs-vswitchd.service

--- a/roles/openshift_node/templates/openshift.docker.node.service
+++ b/roles/openshift_node/templates/openshift.docker.node.service
@@ -1,6 +1,8 @@
 [Unit]
 After={{ openshift_service_type }}-master.service
 After={{ openshift_docker_service_name }}.service
+After=chronyd.service
+After=ntpd.service
 After=openvswitch.service
 PartOf={{ openshift_docker_service_name }}.service
 Requires={{ openshift_docker_service_name }}.service


### PR DESCRIPTION
Fixes openshift/origin#18699

@sdodson - I didn't add it to the controllers because it looks like they already require the master API. I can add them as well if you prefer though.