### PR TITLE
Fix typo in hawkular-cassandra RC

### DIFF
--- a/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
@@ -35,7 +35,7 @@ spec:
         ports:
         - name: cql-port
           containerPort: 9042
-        - name: thift-port
+        - name: thrift-port
           containerPort: 9160
         - name: tcp-port
           containerPort: 7000


### PR DESCRIPTION
This typo makes that the endpoint hawkular-cassandra object misses the port 9160/tcp. If the endpoint port is missing some SDN vendor's implementation won't do the load balancing.