### PR TITLE
ansible-quiet.cfg: update callback_plugins path

### DIFF
--- a/utils/etc/ansible-quiet.cfg
+++ b/utils/etc/ansible-quiet.cfg
@@ -30,4 +30,3 @@ deprecation_warnings=False
 # control_path
 
 stdout_callback = openshift_quick_installer
-callback_plugins = /usr/share/ansible_plugins/callback_plugins


### PR DESCRIPTION
This changes the config used by uninstaller to look for a new location of openshift_quick_installer.py

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1548633