### PR TITLE
upgrade: skip restart during double upgrade

### DIFF
--- a/playbooks/openshift-master/private/validate_restart.yml
+++ b/playbooks/openshift-master/private/validate_restart.yml
@@ -61,4 +61,6 @@
     - exists.stat.exists and openshift.common.rolling_restart_mode == 'system'
   - set_fact:
       current_host: "{{ exists.stat.exists }}"
-    when: openshift.common.rolling_restart_mode == 'system'
+    when:
+    - "'stat' in exists"
+    - openshift.common.rolling_restart_mode == 'system'


### PR DESCRIPTION
This is an additional fix for #7124 - localhost tasks won't be executed during 
3.7 -> 3.8 upgrade, so this task should be skipped as well

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1549058