### PR TITLE
hosts.example: use 3.9 versions in sample inventory file

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -51,7 +51,7 @@ openshift_deployment_type=origin
 # use this to lookup the latest exact version of the container images, which is the tag actually used to configure
 # the cluster. For RPM installations we just verify the version detected in your configured repos matches this
 # release.
-openshift_release=v3.7
+openshift_release=v3.9
 
 # default subdomain to use for exposed routes, you should have wildcard dns
 # for *.apps.test.example.com that points at your infra nodes which will run
@@ -73,12 +73,12 @@ debug_level=2
 # Specify an exact container image tag to install or configure.
 # WARNING: This value will be used for all hosts in containerized environments, even those that have another version installed.
 # This could potentially trigger an upgrade and downtime, so be careful with modifying this value after the cluster is set up.
-#openshift_image_tag=v3.7.0
+#openshift_image_tag=v3.9.0
 
 # Specify an exact rpm version to install or configure.
 # WARNING: This value will be used for all hosts in RPM based environments, even those that have another version installed.
 # This could potentially trigger an upgrade and downtime, so be careful with modifying this value after the cluster is set up.
-#openshift_pkg_version=-3.7.0
+#openshift_pkg_version=-3.9.0
 
 # This enables all the system containers except for docker:
 #openshift_use_system_containers=False
@@ -609,10 +609,10 @@ debug_level=2
 #openshift_metrics_hawkular_hostname=hawkular-metrics.example.com
 # Configure the prefix and version for the component images
 #openshift_metrics_image_prefix=docker.io/openshift/origin-
-#openshift_metrics_image_version=v3.7
+#openshift_metrics_image_version=v3.9
 # when openshift_deployment_type=='openshift-enterprise'
 #openshift_metrics_image_prefix=registry.access.redhat.com/openshift3/
-#openshift_metrics_image_version=v3.7
+#openshift_metrics_image_version=v3.9
 #
 # StorageClass
 # openshift_storageclass_name=gp2
@@ -671,10 +671,10 @@ debug_level=2
 #openshift_logging_es_cluster_size=1
 # Configure the prefix and version for the component images
 #openshift_logging_image_prefix=docker.io/openshift/origin-
-#openshift_logging_image_version=v3.7.0
+#openshift_logging_image_version=v3.9.0
 # when openshift_deployment_type=='openshift-enterprise'
 #openshift_logging_image_prefix=registry.access.redhat.com/openshift3/
-#openshift_logging_image_version=3.7.0
+#openshift_logging_image_version=3.9.0
 
 # Prometheus deployment
 #
@@ -809,9 +809,9 @@ debug_level=2
 #openshift_master_console_port=8443
 
 # set exact RPM version (include - prefix)
-#openshift_pkg_version=-3.6.0
+#openshift_pkg_version=-3.9.0
 # you may also specify version and release, ie:
-#openshift_pkg_version=-3.7.0-0.126.0.git.0.9351aae.el7
+#openshift_pkg_version=-3.9.0-0.126.0.git.0.9351aae.el7
 
 # Configure custom ca certificate
 #openshift_master_ca_certificate={'certfile': '/path/to/ca.crt', 'keyfile': '/path/to/ca.key'}
@@ -968,10 +968,10 @@ debug_level=2
 #openshift_service_catalog_image_prefix=docker.io/openshift/origin-
 #openshift_service_catalog_image_prefix=registry.access.redhat.com/openshift3/ose-
 # Force a specific image version to use when pulling the service catalog image
-#openshift_service_catalog_image_version=v3.7
+#openshift_service_catalog_image_version=v3.9
 
 # TSB image tag
-#template_service_broker_version='v3.7'
+#template_service_broker_version='v3.9'
 
 # Configure one of more namespaces whose templates will be served by the TSB
 #openshift_template_service_broker_namespaces=['openshift']


### PR DESCRIPTION
Replace all occurrences of `3.7` with `3.9` in hosts.example

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1549406