### PR TITLE
[bug 1543256] Fix redeploy router from openshift_hosted refactor.

### DIFF
--- a/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
@@ -117,9 +117,7 @@
 
   - import_role:
       name: openshift_hosted
-      tasks_from: main
-    vars:
-      openshift_hosted_manage_registry: false
+      tasks_from: router.yml
     when:
     - l_router_dc.rc == 0
     - l_router_svc.rc == 0


### PR DESCRIPTION
It appears that after a recent refactor of `openshift_hosted` role the `redeploy-router-certificates.yml` was not calling the `router.yml` required to re-roll the certificates.

https://bugzilla.redhat.com/attachment.cgi?id=1401169
