### PR TITLE
crio: docker_gc on by default

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -166,7 +166,7 @@ debug_level=2
 # Enable docker garbage collection when using cri-o
 #openshift_crio_enable_docker_gc=True
 # Node Selectors to run the garbage collection
-#openshift_crio_docker_gc_node_selector: {'runtime': 'cri-o'}
+#openshift_crio_docker_gc_node_selector={'runtime': 'cri-o'}
 
 # Items added, as is, to end of /etc/sysconfig/docker OPTIONS
 # Default value: "--log-driver=journald"

--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -159,12 +159,12 @@ debug_level=2
 # use this option if you are sure you know what you are doing!
 #openshift_docker_systemcontainer_image_override="registry.example.com/container-engine:latest"
 #openshift_crio_systemcontainer_image_override="registry.example.com/cri-o:latest"
-# NOTE: The following crio docker-gc items are tech preview and likely shouldn't be used
-# unless you know what you are doing!!
 # The following two variables are used when openshift_use_crio is True
-# and cleans up after builds that pass through docker.
+# and cleans up after builds that pass through docker. When openshift_use_crio is True
+# these variables are set to the defaults shown. You may override them here.
+# NOTE: You will still need to tag crio nodes with your given label(s)!
 # Enable docker garbage collection when using cri-o
-#openshift_crio_enable_docker_gc=false
+#openshift_crio_enable_docker_gc=True
 # Node Selectors to run the garbage collection
 #openshift_crio_docker_gc_node_selector: {'runtime': 'cri-o'}
 

--- a/playbooks/openshift-hosted/private/config.yml
+++ b/playbooks/openshift-hosted/private/config.yml
@@ -30,7 +30,7 @@
 - import_playbook: install_docker_gc.yml
   when:
   - openshift_use_crio | default(False) | bool
-  - openshift_crio_enable_docker_gc | default(False) | bool
+  - openshift_crio_enable_docker_gc | default(True) | bool
 
 - name: Hosted Install Checkpoint End
   hosts: all

--- a/roles/openshift_docker_gc/defaults/main.yml
+++ b/roles/openshift_docker_gc/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-r_enable_docker_gc: "{{ openshift_crio_enable_docker_gc | default(False) }}"
-r_docker_gc_node_selectors: "{{ openshift_crio_docker_gc_node_selector | default({}) }}"
+r_enable_docker_gc: "{{ openshift_crio_enable_docker_gc | default(True) }}"
+r_docker_gc_node_selectors: "{{ openshift_crio_docker_gc_node_selector | default({'runtime': 'cri-o'}) }}"

--- a/roles/openshift_docker_gc/tasks/main.yaml
+++ b/roles/openshift_docker_gc/tasks/main.yaml
@@ -1,4 +1,12 @@
 ---
+- name: Ensure that docker-gc will have nodes to run on
+  import_role:
+    name: openshift_master
+    tasks_from: ensure_nodes_matching_selector.yml
+  vars:
+    openshift_master_ensure_nodes_selector: "{{ r_docker_gc_node_selectors }}"
+    openshift_master_ensure_nodes_service: docker-gc daemonset
+
 - name: Create docker-gc tempdir
   command: mktemp -d
   register: templates_tmpdir


### PR DESCRIPTION
When using crio the docker_gc functionality will be on by default. Note
that the administrator still will need to tag nodes with the default or
modified label(s) to ensure the ds runs the garbage collection.

See: https://github.com/openshift/openshift-docs/pull/7795#discussion_r170749543

/cc @sferich888 @sdodson 