### PR TITLE
[3.7] etcd migrate: instead of scaleup playbook etcd server should be started back

### DIFF
--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -126,7 +126,77 @@
     set_fact:
       r_etcd_migrate_success: true
 
-- include: ./scaleup.yml
+- name: Gather facts for migrated nodes
+  hosts: oo_etcd_to_config:oo_new_etcd_to_config
+  roles:
+  - openshift_etcd_facts
+  post_tasks:
+  - set_fact:
+      etcd_hostname: "{{ etcd_hostname }}"
+      etcd_ip: "{{ etcd_ip }}"
+
+- name: Re-configure etcd and bring the cluster up
+  hosts: oo_new_etcd_to_config
+  serial: 1
+  any_errors_fatal: true
+  vars:
+    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
+    etcd_peer_port: 2380
+    etcd_client_port: 2379
+    etcd_conf_dir: '/etc/etcd'
+    etcd_conf_file: "{{ etcd_conf_dir }}/etcd.conf"
+    etcd_peer_ca_file: "{{ etcd_conf_dir }}/ca.crt"
+    etcd_peer_cert_file: "{{ etcd_conf_dir }}/peer.crt"
+    etcd_peer_key_file: "{{ etcd_conf_dir }}/peer.key"
+    etcd_peer_url_scheme: "https"
+  tasks:
+  - name: Add new etcd members to cluster
+    command: >
+      /usr/bin/etcdctl --cert-file {{ etcd_peer_cert_file }}
+                       --key-file {{ etcd_peer_key_file }}
+                       --ca-file {{ etcd_peer_ca_file }}
+                       -C {{ etcd_peer_url_scheme }}://{{ hostvars[etcd_ca_host].etcd_hostname }}:{{ etcd_client_port }}
+                       member add {{ etcd_hostname }} {{ etcd_peer_url_scheme }}://{{ etcd_ip }}:{{ etcd_peer_port }}
+    delegate_to: "{{ etcd_ca_host }}"
+    failed_when:
+    - etcd_add_check.rc == 1
+    - ("peerURL exists" not in etcd_add_check.stderr)
+    register: etcd_add_check
+    retries: 12
+    delay: 10
+    until: etcd_add_check.rc == 0
+  - name: Set ETCD_INITIAL_CLUSTER_STATE=existing on migrated etcd host
+    lineinfile:
+      regexp: ^ETCD_INITIAL_CLUSTER_STATE=
+      line: "ETCD_INITIAL_CLUSTER_STATE=existing"
+      dest: /etc/etcd/etcd.conf
+  - name: Set ETCD_INITIAL_CLUSTER  on migrated etcd host
+    lineinfile:
+      regexp: ^ETCD_INITIAL_CLUSTER=
+      line: "ETCD_INITIAL_CLUSTER={{ initial_etcd_cluster }}"
+      dest: /etc/etcd/etcd.conf
+    vars:
+      initial_etcd_cluster: "{{ etcd_add_check.stdout_lines[3] | regex_replace('ETCD_INITIAL_CLUSTER=','') | regex_replace('\"','') }}"
+  - name: restart etcd
+    systemd:
+      name: "{{ l_etcd_service }}"
+      state: started
+    vars:
+      l_etcd_service: "{{ 'etcd_container' if openshift.common.is_containerized else 'etcd' }}"
+  - name: Pause for 30 secs to let etcd come up and sync data
+    pause: seconds=30
+  - name: Verify cluster is stable
+    command: >
+      /usr/bin/etcdctl --cert-file {{ etcd_peer_cert_file }}
+                      --key-file {{ etcd_peer_key_file }}
+                      --ca-file {{ etcd_peer_ca_file }}
+                      -C {{ etcd_peer_url_scheme }}://{{ hostvars[etcd_ca_host].etcd_hostname }}:{{ etcd_client_port }}
+                      cluster-health
+    register: scaleup_health
+    retries: 3
+    delay: 30
+    until: scaleup_health.rc == 0
+    delegate_to: "{{ etcd_ca_host }}"
 
 - name: Gate on etcd migration
   hosts: oo_masters_to_config


### PR DESCRIPTION
Backport of #7226
Replaces #7297

Verified to be working on 3.7 cluster