### PR TITLE
[bz 1508561] default to secure registry and update certificates

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -115,7 +115,7 @@
 
   post_tasks:
   # Do not perform these tasks when the registry is insecure.  The default registry is insecure in openshift_hosted/defaults/main.yml
-  - when: not (openshift_docker_hosted_registry_insecure | default(True))
+  - when: not (openshift_docker_hosted_registry_insecure | default(False))
     block:
     # we need to migrate customers to the new pattern of pushing to the registry via dns
     # Step 1: verify the certificates have the docker registry service name


### PR DESCRIPTION
Inverting the logic to deploy updated registry certificates when insecure is False or is not defined.
https://bugzilla.redhat.com/show_bug.cgi?id=1508561