### PR TITLE
Add support for instance_ids to ELB provisioner

### DIFF
--- a/roles/openshift_aws/tasks/elb_single.yml
+++ b/roles/openshift_aws/tasks/elb_single.yml
@@ -15,6 +15,7 @@
     subnets:
     - "{{ subnetout.subnets[0].id }}"
     health_check: "{{ item.value.health_check }}"
+    instance_ids: "{{ item.value.instance_ids | default(omit) }}"
     listeners: "{{ item.value.listeners }}"
     scheme: "{{ (item.key == 'internal') | ternary('internal','internet-facing') }}"
     tags: "{{ item.value.tags }}"


### PR DESCRIPTION
This allows member instance_ids to optionally be added to an ELB at the time it is provisioned.