### PR TITLE
Bug 1549220 - configmap still exist after running uninstall playbook for logging

### DIFF
--- a/roles/openshift_logging/tasks/delete_logging.yaml
+++ b/roles/openshift_logging/tasks/delete_logging.yaml
@@ -104,6 +104,7 @@
   with_items:
     - logging-curator
     - logging-elasticsearch
+    - logging-elasticsearch-ops
     - logging-fluentd
     - logging-mux
 


### PR DESCRIPTION
Adding logging-elasticsearch-ops to delete configmaps item.