### PR TITLE
Allow for using an external openvswitch

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -113,6 +113,7 @@ system_images_registry_dict:
   origin: "docker.io"
 
 system_images_registry: "{{ system_images_registry_dict[openshift_deployment_type | default('origin')] }}"
+openshift_use_external_openvswitch: False
 l_is_openvswitch_system_container: "{{ (openshift_use_openvswitch_system_container | default(openshift_use_system_containers | default(false)) | bool) }}"
 
 openshift_image_tag: ''

--- a/roles/openshift_node/tasks/container_images.yml
+++ b/roles/openshift_node/tasks/container_images.yml
@@ -9,6 +9,7 @@
   when:
   - openshift_node_use_openshift_sdn | bool
   - l_is_openvswitch_system_container | bool
+  - not openshift_use_external_openvswitch | bool
 
 - name: Pre-pull openvswitch image
   command: >
@@ -18,3 +19,4 @@
   when:
   - openshift_node_use_openshift_sdn | bool
   - not l_is_openvswitch_system_container | bool
+  - not openshift_use_external_openvswitch | bool

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -15,11 +15,14 @@
 
   - name: include ovs service environment file
     include_tasks: config/install-ovs-service-env-file.yml
+    when:
+    - not openshift_use_external_openvswitch | bool
 
   - include_tasks: config/install-ovs-docker-service-file.yml
     when:
     - openshift_node_use_openshift_sdn | bool
     - not l_is_openvswitch_system_container | bool
+    - not openshift_use_external_openvswitch | bool
 
 - include_tasks: config/configure-node-settings.yml
 - include_tasks: config/configure-proxy-settings.yml


### PR DESCRIPTION
This commit allows for relying on an existing openvswitch deployment for the Openshift SDN. This is particularly useful for environments where the openvswitch deployment is shared by multiple services or managed by external resources.

As an example, we're looking into using `TripleO` - on OpenStack deployment tool - as the tool to provision and prepare the baremetal nodes where OpenShift and OpenStack will run. TripleO lays down the network infrastructure, which is then consumed in these nodes.  Instead of re-deploying openvswitch in containers, which currently destroys the existing configuration, openshift-ansible could allow for re-using the existing openvswitch instance.