### PR TITLE
Use explicit broker version for v3.7

### DIFF
--- a/roles/ansible_service_broker/vars/default_images.yml
+++ b/roles/ansible_service_broker/vars/default_images.yml
@@ -1,7 +1,7 @@
 ---
 
 __ansible_service_broker_image_prefix: ansibleplaybookbundle/origin-
-__ansible_service_broker_image_tag: latest
+__ansible_service_broker_image_tag: v3.7
 
 __ansible_service_broker_etcd_image_prefix: quay.io/coreos/
 __ansible_service_broker_etcd_image_tag: latest


### PR DESCRIPTION
The current latest image for the broker is built targeting 3.9 and has broken the 3.7 installation. This locks it to the correct version.