### PR TITLE
cri-o: configure oci-umount with CRI-O paths

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -159,3 +159,8 @@ l_is_node_system_container: "{{ (openshift_use_node_system_container | default(o
 
 l_crio_use_new_var_sock: "{{  (l_openshift_image_tag == 'latest') or (l_openshift_image_tag | version_compare('3.9', '>='))  | bool }}"
 l_crio_var_sock: "{{ l_crio_use_new_var_sock | ternary('/var/run/crio/crio.sock', '/var/run/crio.sock') }}"
+
+container_runtime_oci_umounts:
+- '/var/lib/containers/storage/*'
+- '/run/containers/storage/*'
+- '/var/lib/origin/*'

--- a/roles/container_runtime/tasks/systemcontainer_crio.yml
+++ b/roles/container_runtime/tasks/systemcontainer_crio.yml
@@ -94,6 +94,12 @@
     dest: /etc/sysconfig/crio-network
     src: crio-network.j2
 
+- name: Configure oci umount for CRI-O
+  lineinfile:
+    dest: /etc/oci-umount.conf
+    line: '{{ item }}'
+  with_items: "{{ container_runtime_oci_umounts }}"
+
 - name: Start the CRI-O service
   systemd:
     name: "cri-o"


### PR DESCRIPTION
Configure the file from the installer until
https://github.com/projectatomic/oci-umount/pull/37 is not part of a
release.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>