### PR TITLE
oc_obj: fail in state=list when return code != 0.

### DIFF
--- a/roles/lib_openshift/library/oc_obj.py
+++ b/roles/lib_openshift/library/oc_obj.py
@@ -1612,6 +1612,8 @@ class OCObject(OpenShiftCLI):
         # Get
         #####
         if state == 'list':
+            if api_rval['returncode'] != 0:
+                return {'changed': False, 'failed': True, 'msg': api_rval}
             return {'changed': False, 'results': api_rval, 'state': state}
 
         ########

--- a/roles/lib_openshift/src/class/oc_obj.py
+++ b/roles/lib_openshift/src/class/oc_obj.py
@@ -126,6 +126,8 @@ class OCObject(OpenShiftCLI):
         # Get
         #####
         if state == 'list':
+            if api_rval['returncode'] != 0:
+                return {'changed': False, 'failed': True, 'msg': api_rval}
             return {'changed': False, 'results': api_rval, 'state': state}
 
         ########


### PR DESCRIPTION
The `oc_obj` module supports the `field_selector` parameter now and if you were to use the master branch's `oc_obj` module with a `field_selector` parameter against a 3.7 client (`--field-selector` is new in 3.9) you might get an error like this because listing nodes failed but the `oc_obj` module didn't report that it had failed.

```
TASK [openshift_master : Ensure that Heapster has nodes to run on] ******************************************************************************************************

fatal: [openshift-master]: FAILED! => {"failed": true, "msg": "Unexpected templating type error occurred on ({{  __schedulable_nodes_matching_selector['results']['results'][0]['items'] | default([]) | length != 0 }}): object of type 'builtin_function_or_method' has no len()"}

        to retry, use: --limit @/openshift-ansible/playbooks/openshift-metrics/config.retry
```

Instead of carrying on, I'd like to bubble the error up so that folks have an idea where to look when they hit this. The output reminds me of vomit but `"Error: unknown flag: --field-selector"` can be found at the front of stderr.

```
TASK [Retrieve list of schedulable nodes matching selector] ******************************************************************************************************************************************************************************************************************************
Wednesday 28 February 2018  14:59:57 -0500 (0:00:00.970)       0:00:01.095 **** 
fatal: [master1.abutcher.com]: FAILED! => {"changed": false, "msg": {"cmd": "/usr/bin/oc get node --selector=region=infra --field-selector=spec.unschedulable!=true -o json -n default", "results": [{}], "returncode": 1, "stderr": "Error: unknown flag: --field-selector\n\n\nUsage:\n  oc get [(-o|--output=)json|yaml|wide|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=...] (TYPE [NAME | -l label] | TYPE/NAME ...) [flags] [options]\n\nExamples:\n  # List all pods in ps output format.\n  oc get pods\n  \n  # List a single replication controller with specified ID in ps output format.\n  oc get rc redis\n  \n  # List all pods and show more details about them.\n  oc get -o wide pods\n  \n  # List a single pod in JSON output format.\n  oc get -o json pod redis-pod\n  \n  # Return only the status value of the specified pod.\n  oc get -o template pod redis-pod --template={{.currentState.status}}\n\nOptions:\n      --all-namespaces=false: If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.\n      --allow-missing-template-keys=true: If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.\n      --experimental-use-openapi-print-columns=false: If true, use x-kubernetes-print-column metadata (if present) from openapi schema for displaying a resource.\n      --export=false: If true, use 'export' for the resources.  Exported resources are stripped of cluster-specific information.\n  -f, --filename=[]: Filename, directory, or URL to files identifying the resource to get from a server.\n      --ignore-not-found=false: Treat \"resource not found\" as a successful retrieval.\n      --include-extended-apis=true: If true, include definitions of new APIs via calls to the API server. [default true]\n  -L, --label-columns=[]: Accepts a comma separated list of labels that are going to be presented as columns. Names are case-sensitive. You can also use multiple flag options like -L label1 -L label2...\n      --no-headers=false: When using the default or custom-column output format, don't print headers (default print headers).\n  -o, --output='': Output format. One of: json|yaml|wide|name|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See custom columns [http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].\n      --raw='': Raw URI to request from the server.  Uses the transport specified by the kubeconfig file.\n  -R, --recursive=false: Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.\n      --schema-cache-dir='~/.kube/schema': If non-empty, load/store cached API schemas in this directory, default is '$HOME/.kube/schema'\n  -l, --selector='': Selector (label query) to filter on, supports '=', '==', and '!='.\n  -a, --show-all=true: When printing, show all resources (false means hide terminated pods.)\n      --show-kind=false: If present, list the resource type for the requested object(s).\n      --show-labels=false: When printing, show all labels as the last column (default hide labels column)\n      --sort-by='': If non-empty, sort list types using this field specification.  The field specification is expressed as a JSONPath expression (e.g. '{.metadata.name}'). The field in the API resource specified by this JSONPath expression must be an integer or a string.\n      --template='': Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].\n  -w, --watch=false: After listing/getting the requested object, watch for changes.\n      --watch-only=false: Watch for changes to the requested object(s), without listing/getting first.\n\nUse \"oc options\" for a list of global command-line options (applies to all commands).\n\n", "stdout": ""}}
        to retry, use: --limit @/home/abutcher/rhat/openshift-ansible/playbooks/test.retry
```

Note that `oc_obj` still [hides/ignores errors when the kind of object listed isn't found](https://github.com/openshift/openshift-ansible/blob/49c91c4f180901ff44a34220c58e36a20bd3cb8a/roles/lib_openshift/library/oc_obj.py#L1516-L1517).