### PR TITLE
Master scheduler upgrade cleanup

### DIFF
--- a/roles/lib_utils/lookup_plugins/openshift_master_facts_default_predicates.py
+++ b/roles/lib_utils/lookup_plugins/openshift_master_facts_default_predicates.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 
-import re
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
@@ -9,24 +8,12 @@ class LookupModule(LookupBase):
     # pylint: disable=too-many-branches,too-many-statements,too-many-arguments
 
     def run(self, terms, variables=None, regions_enabled=True, short_version=None,
-            deployment_type=None, **kwargs):
+            **kwargs):
 
         predicates = []
 
-        if short_version is None or deployment_type is None:
-            if 'openshift' not in variables:
-                raise AnsibleError("This lookup module requires openshift_facts to be run prior to use")
-
-        if deployment_type is None:
-            if 'common' not in variables['openshift'] or 'deployment_type' not in variables['openshift']['common']:
-                raise AnsibleError("This lookup module requires that the deployment_type be set")
-
-            deployment_type = variables['openshift']['common']['deployment_type']
-
         if short_version is None:
-            if 'short_version' in variables['openshift']['common']:
-                short_version = variables['openshift']['common']['short_version']
-            elif 'openshift_release' in variables:
+            if 'openshift_release' in variables:
                 release = variables['openshift_release']
                 if release.startswith('v'):
                     short_version = release[1:]
@@ -39,18 +26,9 @@ class LookupModule(LookupBase):
             else:
                 # pylint: disable=line-too-long
                 raise AnsibleError("Either OpenShift needs to be installed or openshift_release needs to be specified")
-        if deployment_type == 'origin':
-            if short_version not in ['1.1', '1.2', '1.3', '1.4', '1.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'latest']:
-                raise AnsibleError("Unknown short_version %s" % short_version)
-        elif deployment_type == 'openshift-enterprise':
-            if short_version not in ['3.1', '3.2', '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'latest']:
-                raise AnsibleError("Unknown short_version %s" % short_version)
-        else:
-            raise AnsibleError("Unknown deployment_type %s" % deployment_type)
 
-        if deployment_type == 'origin':
-            # convert short_version to enterprise short_version
-            short_version = re.sub('^1.', '3.', short_version)
+        if short_version not in ['3.6', '3.7', '3.8', '3.9', '3.10', 'latest']:
+            raise AnsibleError("Unknown short_version %s" % short_version)
 
         if short_version == 'latest':
             short_version = '3.10'
@@ -58,50 +36,7 @@ class LookupModule(LookupBase):
         # Predicates ordered according to OpenShift Origin source:
         # origin/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
 
-        if short_version == '3.1':
-            predicates.extend([
-                {'name': 'PodFitsHostPorts'},
-                {'name': 'PodFitsResources'},
-                {'name': 'NoDiskConflict'},
-                {'name': 'MatchNodeSelector'},
-            ])
-
-        if short_version == '3.2':
-            predicates.extend([
-                {'name': 'PodFitsHostPorts'},
-                {'name': 'PodFitsResources'},
-                {'name': 'NoDiskConflict'},
-                {'name': 'NoVolumeZoneConflict'},
-                {'name': 'MatchNodeSelector'},
-                {'name': 'MaxEBSVolumeCount'},
-                {'name': 'MaxGCEPDVolumeCount'}
-            ])
-
-        if short_version == '3.3':
-            predicates.extend([
-                {'name': 'NoDiskConflict'},
-                {'name': 'NoVolumeZoneConflict'},
-                {'name': 'MaxEBSVolumeCount'},
-                {'name': 'MaxGCEPDVolumeCount'},
-                {'name': 'GeneralPredicates'},
-                {'name': 'PodToleratesNodeTaints'},
-                {'name': 'CheckNodeMemoryPressure'}
-            ])
-
-        if short_version == '3.4':
-            predicates.extend([
-                {'name': 'NoDiskConflict'},
-                {'name': 'NoVolumeZoneConflict'},
-                {'name': 'MaxEBSVolumeCount'},
-                {'name': 'MaxGCEPDVolumeCount'},
-                {'name': 'GeneralPredicates'},
-                {'name': 'PodToleratesNodeTaints'},
-                {'name': 'CheckNodeMemoryPressure'},
-                {'name': 'CheckNodeDiskPressure'},
-                {'name': 'MatchInterPodAffinity'}
-            ])
-
-        if short_version in ['3.5', '3.6']:
+        if short_version in ['3.6']:
             predicates.extend([
                 {'name': 'NoVolumeZoneConflict'},
                 {'name': 'MaxEBSVolumeCount'},

--- a/roles/lib_utils/lookup_plugins/openshift_master_facts_default_priorities.py
+++ b/roles/lib_utils/lookup_plugins/openshift_master_facts_default_priorities.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 
-import re
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
@@ -9,24 +8,12 @@ class LookupModule(LookupBase):
     # pylint: disable=too-many-branches,too-many-statements,too-many-arguments
 
     def run(self, terms, variables=None, zones_enabled=True, short_version=None,
-            deployment_type=None, **kwargs):
+            **kwargs):
 
         priorities = []
 
-        if short_version is None or deployment_type is None:
-            if 'openshift' not in variables:
-                raise AnsibleError("This lookup module requires openshift_facts to be run prior to use")
-
-        if deployment_type is None:
-            if 'common' not in variables['openshift'] or 'deployment_type' not in variables['openshift']['common']:
-                raise AnsibleError("This lookup module requires that the deployment_type be set")
-
-            deployment_type = variables['openshift']['common']['deployment_type']
-
         if short_version is None:
-            if 'short_version' in variables['openshift']['common']:
-                short_version = variables['openshift']['common']['short_version']
-            elif 'openshift_release' in variables:
+            if 'openshift_release' in variables:
                 release = variables['openshift_release']
                 if release.startswith('v'):
                     short_version = release[1:]
@@ -40,58 +27,13 @@ class LookupModule(LookupBase):
                 # pylint: disable=line-too-long
                 raise AnsibleError("Either OpenShift needs to be installed or openshift_release needs to be specified")
 
-        if deployment_type == 'origin':
-            if short_version not in ['1.1', '1.2', '1.3', '1.4', '1.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'latest']:
-                raise AnsibleError("Unknown short_version %s" % short_version)
-        elif deployment_type == 'openshift-enterprise':
-            if short_version not in ['3.1', '3.2', '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'latest']:
-                raise AnsibleError("Unknown short_version %s" % short_version)
-        else:
-            raise AnsibleError("Unknown deployment_type %s" % deployment_type)
-
-        if deployment_type == 'origin':
-            # convert short_version to origin short_version
-            short_version = re.sub('^1.', '3.', short_version)
+        if short_version not in ['3.6', '3.7', '3.8', '3.9', '3.10', 'latest']:
+            raise AnsibleError("Unknown short_version %s" % short_version)
 
         if short_version == 'latest':
             short_version = '3.10'
 
-        if short_version == '3.1':
-            priorities.extend([
-                {'name': 'LeastRequestedPriority', 'weight': 1},
-                {'name': 'BalancedResourceAllocation', 'weight': 1},
-                {'name': 'SelectorSpreadPriority', 'weight': 1}
-            ])
-
-        if short_version == '3.2':
-            priorities.extend([
-                {'name': 'LeastRequestedPriority', 'weight': 1},
-                {'name': 'BalancedResourceAllocation', 'weight': 1},
-                {'name': 'SelectorSpreadPriority', 'weight': 1},
-                {'name': 'NodeAffinityPriority', 'weight': 1}
-            ])
-
-        if short_version == '3.3':
-            priorities.extend([
-                {'name': 'LeastRequestedPriority', 'weight': 1},
-                {'name': 'BalancedResourceAllocation', 'weight': 1},
-                {'name': 'SelectorSpreadPriority', 'weight': 1},
-                {'name': 'NodeAffinityPriority', 'weight': 1},
-                {'name': 'TaintTolerationPriority', 'weight': 1}
-            ])
-
-        if short_version == '3.4':
-            priorities.extend([
-                {'name': 'LeastRequestedPriority', 'weight': 1},
-                {'name': 'BalancedResourceAllocation', 'weight': 1},
-                {'name': 'SelectorSpreadPriority', 'weight': 1},
-                {'name': 'NodePreferAvoidPodsPriority', 'weight': 10000},
-                {'name': 'NodeAffinityPriority', 'weight': 1},
-                {'name': 'TaintTolerationPriority', 'weight': 1},
-                {'name': 'InterPodAffinityPriority', 'weight': 1}
-            ])
-
-        if short_version in ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']:
+        if short_version in ['3.6', '3.7', '3.8', '3.9', '3.10']:
             priorities.extend([
                 {'name': 'SelectorSpreadPriority', 'weight': 1},
                 {'name': 'InterPodAffinityPriority', 'weight': 1},

--- a/roles/lib_utils/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/lib_utils/test/openshift_master_facts_default_predicates_tests.py
@@ -4,46 +4,7 @@ import pytest
 # Predicates ordered according to OpenShift Origin source:
 # origin/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
 
-DEFAULT_PREDICATES_1_1 = [
-    {'name': 'PodFitsHostPorts'},
-    {'name': 'PodFitsResources'},
-    {'name': 'NoDiskConflict'},
-    {'name': 'MatchNodeSelector'},
-]
-
-DEFAULT_PREDICATES_1_2 = [
-    {'name': 'PodFitsHostPorts'},
-    {'name': 'PodFitsResources'},
-    {'name': 'NoDiskConflict'},
-    {'name': 'NoVolumeZoneConflict'},
-    {'name': 'MatchNodeSelector'},
-    {'name': 'MaxEBSVolumeCount'},
-    {'name': 'MaxGCEPDVolumeCount'}
-]
-
-DEFAULT_PREDICATES_1_3 = [
-    {'name': 'NoDiskConflict'},
-    {'name': 'NoVolumeZoneConflict'},
-    {'name': 'MaxEBSVolumeCount'},
-    {'name': 'MaxGCEPDVolumeCount'},
-    {'name': 'GeneralPredicates'},
-    {'name': 'PodToleratesNodeTaints'},
-    {'name': 'CheckNodeMemoryPressure'}
-]
-
-DEFAULT_PREDICATES_1_4 = [
-    {'name': 'NoDiskConflict'},
-    {'name': 'NoVolumeZoneConflict'},
-    {'name': 'MaxEBSVolumeCount'},
-    {'name': 'MaxGCEPDVolumeCount'},
-    {'name': 'GeneralPredicates'},
-    {'name': 'PodToleratesNodeTaints'},
-    {'name': 'CheckNodeMemoryPressure'},
-    {'name': 'CheckNodeDiskPressure'},
-    {'name': 'MatchInterPodAffinity'}
-]
-
-DEFAULT_PREDICATES_1_5 = [
+DEFAULT_PREDICATES_3_6 = [
     {'name': 'NoVolumeZoneConflict'},
     {'name': 'MaxEBSVolumeCount'},
     {'name': 'MaxGCEPDVolumeCount'},
@@ -54,8 +15,6 @@ DEFAULT_PREDICATES_1_5 = [
     {'name': 'CheckNodeMemoryPressure'},
     {'name': 'CheckNodeDiskPressure'},
 ]
-
-DEFAULT_PREDICATES_3_6 = DEFAULT_PREDICATES_1_5
 
 DEFAULT_PREDICATES_3_7 = [
     {'name': 'NoVolumeZoneConflict'},
@@ -99,26 +58,11 @@ REGION_PREDICATE = {
 }
 
 TEST_VARS = [
-    ('1.1', 'origin', DEFAULT_PREDICATES_1_1),
-    ('3.1', 'openshift-enterprise', DEFAULT_PREDICATES_1_1),
-    ('1.2', 'origin', DEFAULT_PREDICATES_1_2),
-    ('3.2', 'openshift-enterprise', DEFAULT_PREDICATES_1_2),
-    ('1.3', 'origin', DEFAULT_PREDICATES_1_3),
-    ('3.3', 'openshift-enterprise', DEFAULT_PREDICATES_1_3),
-    ('1.4', 'origin', DEFAULT_PREDICATES_1_4),
-    ('3.4', 'openshift-enterprise', DEFAULT_PREDICATES_1_4),
-    ('1.5', 'origin', DEFAULT_PREDICATES_1_5),
-    ('3.5', 'openshift-enterprise', DEFAULT_PREDICATES_1_5),
-    ('3.6', 'origin', DEFAULT_PREDICATES_3_6),
-    ('3.6', 'openshift-enterprise', DEFAULT_PREDICATES_3_6),
-    ('3.7', 'origin', DEFAULT_PREDICATES_3_7),
-    ('3.7', 'openshift-enterprise', DEFAULT_PREDICATES_3_7),
-    ('3.8', 'origin', DEFAULT_PREDICATES_3_8),
-    ('3.8', 'openshift-enterprise', DEFAULT_PREDICATES_3_8),
-    ('3.9', 'origin', DEFAULT_PREDICATES_3_9),
-    ('3.9', 'openshift-enterprise', DEFAULT_PREDICATES_3_9),
-    ('3.10', 'origin', DEFAULT_PREDICATES_3_10),
-    ('3.10', 'openshift-enterprise', DEFAULT_PREDICATES_3_10),
+    ('3.6', DEFAULT_PREDICATES_3_6),
+    ('3.7', DEFAULT_PREDICATES_3_7),
+    ('3.8', DEFAULT_PREDICATES_3_8),
+    ('3.9', DEFAULT_PREDICATES_3_9),
+    ('3.10', DEFAULT_PREDICATES_3_10),
 ]
 
 
@@ -137,10 +81,9 @@ def test_openshift_version(predicates_lookup, openshift_version_fixture, regions
 
 @pytest.fixture(params=TEST_VARS)
 def openshift_version_fixture(request, facts):
-    version, deployment_type, default_predicates = request.param
+    version, default_predicates = request.param
     version += '.1'
     facts['openshift_version'] = version
-    facts['openshift']['common']['deployment_type'] = deployment_type
     return facts, default_predicates
 
 
@@ -151,22 +94,8 @@ def test_openshift_release(predicates_lookup, openshift_release_fixture, regions
 
 @pytest.fixture(params=TEST_VARS)
 def openshift_release_fixture(request, facts, release_mod):
-    release, deployment_type, default_predicates = request.param
+    release, default_predicates = request.param
     facts['openshift_release'] = release_mod(release)
-    facts['openshift']['common']['deployment_type'] = deployment_type
-    return facts, default_predicates
-
-
-def test_short_version(predicates_lookup, short_version_fixture, regions_enabled):
-    facts, default_predicates = short_version_fixture
-    assert_ok(predicates_lookup, default_predicates, variables=facts, regions_enabled=regions_enabled)
-
-
-@pytest.fixture(params=TEST_VARS)
-def short_version_fixture(request, facts):
-    short_version, deployment_type, default_predicates = request.param
-    facts['openshift']['common']['short_version'] = short_version
-    facts['openshift']['common']['deployment_type'] = deployment_type
     return facts, default_predicates
 
 
@@ -179,33 +108,5 @@ def test_short_version_kwarg(predicates_lookup, short_version_kwarg_fixture, reg
 
 @pytest.fixture(params=TEST_VARS)
 def short_version_kwarg_fixture(request, facts):
-    short_version, deployment_type, default_predicates = request.param
-    facts['openshift']['common']['deployment_type'] = deployment_type
+    short_version, default_predicates = request.param
     return facts, short_version, default_predicates
-
-
-def test_deployment_type_kwarg(predicates_lookup, deployment_type_kwarg_fixture, regions_enabled):
-    facts, deployment_type, default_predicates = deployment_type_kwarg_fixture
-    assert_ok(
-        predicates_lookup, default_predicates, variables=facts,
-        regions_enabled=regions_enabled, deployment_type=deployment_type)
-
-
-@pytest.fixture(params=TEST_VARS)
-def deployment_type_kwarg_fixture(request, facts):
-    short_version, deployment_type, default_predicates = request.param
-    facts['openshift']['common']['short_version'] = short_version
-    return facts, deployment_type, default_predicates
-
-
-def test_short_version_deployment_type_kwargs(
-        predicates_lookup, short_version_deployment_type_kwargs_fixture, regions_enabled):
-    short_version, deployment_type, default_predicates = short_version_deployment_type_kwargs_fixture
-    assert_ok(
-        predicates_lookup, default_predicates, regions_enabled=regions_enabled,
-        short_version=short_version, deployment_type=deployment_type)
-
-
-@pytest.fixture(params=TEST_VARS)
-def short_version_deployment_type_kwargs_fixture(request):
-    return request.param

--- a/roles/lib_utils/test/openshift_master_facts_default_priorities_tests.py
+++ b/roles/lib_utils/test/openshift_master_facts_default_priorities_tests.py
@@ -1,38 +1,7 @@
 import pytest
 
 
-DEFAULT_PRIORITIES_1_1 = [
-    {'name': 'LeastRequestedPriority', 'weight': 1},
-    {'name': 'BalancedResourceAllocation', 'weight': 1},
-    {'name': 'SelectorSpreadPriority', 'weight': 1}
-]
-
-DEFAULT_PRIORITIES_1_2 = [
-    {'name': 'LeastRequestedPriority', 'weight': 1},
-    {'name': 'BalancedResourceAllocation', 'weight': 1},
-    {'name': 'SelectorSpreadPriority', 'weight': 1},
-    {'name': 'NodeAffinityPriority', 'weight': 1}
-]
-
-DEFAULT_PRIORITIES_1_3 = [
-    {'name': 'LeastRequestedPriority', 'weight': 1},
-    {'name': 'BalancedResourceAllocation', 'weight': 1},
-    {'name': 'SelectorSpreadPriority', 'weight': 1},
-    {'name': 'NodeAffinityPriority', 'weight': 1},
-    {'name': 'TaintTolerationPriority', 'weight': 1}
-]
-
-DEFAULT_PRIORITIES_1_4 = [
-    {'name': 'LeastRequestedPriority', 'weight': 1},
-    {'name': 'BalancedResourceAllocation', 'weight': 1},
-    {'name': 'SelectorSpreadPriority', 'weight': 1},
-    {'name': 'NodePreferAvoidPodsPriority', 'weight': 10000},
-    {'name': 'NodeAffinityPriority', 'weight': 1},
-    {'name': 'TaintTolerationPriority', 'weight': 1},
-    {'name': 'InterPodAffinityPriority', 'weight': 1}
-]
-
-DEFAULT_PRIORITIES_1_5 = [
+DEFAULT_PRIORITIES_3_6 = [
     {'name': 'SelectorSpreadPriority', 'weight': 1},
     {'name': 'InterPodAffinityPriority', 'weight': 1},
     {'name': 'LeastRequestedPriority', 'weight': 1},
@@ -41,8 +10,6 @@ DEFAULT_PRIORITIES_1_5 = [
     {'name': 'NodeAffinityPriority', 'weight': 1},
     {'name': 'TaintTolerationPriority', 'weight': 1}
 ]
-
-DEFAULT_PRIORITIES_3_6 = DEFAULT_PRIORITIES_1_5
 
 DEFAULT_PRIORITIES_3_10 = DEFAULT_PRIORITIES_3_9 = DEFAULT_PRIORITIES_3_8 = DEFAULT_PRIORITIES_3_7 = DEFAULT_PRIORITIES_3_6
 
@@ -57,26 +24,11 @@ ZONE_PRIORITY = {
 }
 
 TEST_VARS = [
-    ('1.1', 'origin', DEFAULT_PRIORITIES_1_1),
-    ('3.1', 'openshift-enterprise', DEFAULT_PRIORITIES_1_1),
-    ('1.2', 'origin', DEFAULT_PRIORITIES_1_2),
-    ('3.2', 'openshift-enterprise', DEFAULT_PRIORITIES_1_2),
-    ('1.3', 'origin', DEFAULT_PRIORITIES_1_3),
-    ('3.3', 'openshift-enterprise', DEFAULT_PRIORITIES_1_3),
-    ('1.4', 'origin', DEFAULT_PRIORITIES_1_4),
-    ('3.4', 'openshift-enterprise', DEFAULT_PRIORITIES_1_4),
-    ('1.5', 'origin', DEFAULT_PRIORITIES_1_5),
-    ('3.5', 'openshift-enterprise', DEFAULT_PRIORITIES_1_5),
-    ('3.6', 'origin', DEFAULT_PRIORITIES_3_6),
-    ('3.6', 'openshift-enterprise', DEFAULT_PRIORITIES_3_6),
-    ('3.7', 'origin', DEFAULT_PRIORITIES_3_7),
-    ('3.7', 'openshift-enterprise', DEFAULT_PRIORITIES_3_7),
-    ('3.8', 'origin', DEFAULT_PRIORITIES_3_8),
-    ('3.8', 'openshift-enterprise', DEFAULT_PRIORITIES_3_8),
-    ('3.9', 'origin', DEFAULT_PRIORITIES_3_9),
-    ('3.9', 'openshift-enterprise', DEFAULT_PRIORITIES_3_9),
-    ('3.10', 'origin', DEFAULT_PRIORITIES_3_10),
-    ('3.10', 'openshift-enterprise', DEFAULT_PRIORITIES_3_10)
+    ('3.6', DEFAULT_PRIORITIES_3_6),
+    ('3.7', DEFAULT_PRIORITIES_3_7),
+    ('3.8', DEFAULT_PRIORITIES_3_8),
+    ('3.9', DEFAULT_PRIORITIES_3_9),
+    ('3.10', DEFAULT_PRIORITIES_3_10)
 ]
 
 
@@ -95,10 +47,9 @@ def test_openshift_version(priorities_lookup, openshift_version_fixture, zones_e
 
 @pytest.fixture(params=TEST_VARS)
 def openshift_version_fixture(request, facts):
-    version, deployment_type, default_priorities = request.param
+    version, default_priorities = request.param
     version += '.1'
     facts['openshift_version'] = version
-    facts['openshift']['common']['deployment_type'] = deployment_type
     return facts, default_priorities
 
 
@@ -109,22 +60,8 @@ def test_openshift_release(priorities_lookup, openshift_release_fixture, zones_e
 
 @pytest.fixture(params=TEST_VARS)
 def openshift_release_fixture(request, facts, release_mod):
-    release, deployment_type, default_priorities = request.param
+    release, default_priorities = request.param
     facts['openshift_release'] = release_mod(release)
-    facts['openshift']['common']['deployment_type'] = deployment_type
-    return facts, default_priorities
-
-
-def test_short_version(priorities_lookup, short_version_fixture, zones_enabled):
-    facts, default_priorities = short_version_fixture
-    assert_ok(priorities_lookup, default_priorities, variables=facts, zones_enabled=zones_enabled)
-
-
-@pytest.fixture(params=TEST_VARS)
-def short_version_fixture(request, facts):
-    short_version, deployment_type, default_priorities = request.param
-    facts['openshift']['common']['short_version'] = short_version
-    facts['openshift']['common']['deployment_type'] = deployment_type
     return facts, default_priorities
 
 
@@ -137,33 +74,5 @@ def test_short_version_kwarg(priorities_lookup, short_version_kwarg_fixture, zon
 
 @pytest.fixture(params=TEST_VARS)
 def short_version_kwarg_fixture(request, facts):
-    short_version, deployment_type, default_priorities = request.param
-    facts['openshift']['common']['deployment_type'] = deployment_type
+    short_version, default_priorities = request.param
     return facts, short_version, default_priorities
-
-
-def test_deployment_type_kwarg(priorities_lookup, deployment_type_kwarg_fixture, zones_enabled):
-    facts, deployment_type, default_priorities = deployment_type_kwarg_fixture
-    assert_ok(
-        priorities_lookup, default_priorities, variables=facts,
-        zones_enabled=zones_enabled, deployment_type=deployment_type)
-
-
-@pytest.fixture(params=TEST_VARS)
-def deployment_type_kwarg_fixture(request, facts):
-    short_version, deployment_type, default_priorities = request.param
-    facts['openshift']['common']['short_version'] = short_version
-    return facts, deployment_type, default_priorities
-
-
-def test_short_version_deployment_type_kwargs(
-        priorities_lookup, short_version_deployment_type_kwargs_fixture, zones_enabled):
-    short_version, deployment_type, default_priorities = short_version_deployment_type_kwargs_fixture
-    assert_ok(
-        priorities_lookup, default_priorities, zones_enabled=zones_enabled,
-        short_version=short_version, deployment_type=deployment_type)
-
-
-@pytest.fixture(params=TEST_VARS)
-def short_version_deployment_type_kwargs_fixture(request):
-    return request.param

--- a/roles/openshift_master/tasks/upgrade/upgrade_predicates.yml
+++ b/roles/openshift_master/tasks/upgrade/upgrade_predicates.yml
@@ -1,0 +1,45 @@
+---
+# Handle case where openshift_master_predicates is defined
+- when: openshift_master_scheduler_predicates | default(none) is not none
+  block:
+  - name: openshift_master_scheduler_predicates is defined
+    debug:
+      msg: "openshift_master_scheduler_predicates is defined"
+
+  - name: openshift_master_scheduler_predicates is set to defaults from an earlier release
+    debug:
+      msg: "WARNING: openshift_master_scheduler_predicates is set to defaults from an earlier release of OpenShift current defaults are: {{ openshift_master_scheduler_default_predicates }}"
+    when: openshift_master_scheduler_predicates in osm_older_predicates + osm_older_predicates_no_region + [osm_prev_predicates] + [osm_prev_predicates_no_region]
+
+  - name: openshift_master_scheduler_predicates does not match current defaults
+    debug:
+      msg: "WARNING: openshift_master_scheduler_predicates does not match current defaults of: {{ openshift_master_scheduler_default_predicates }}"
+    when: openshift_master_scheduler_predicates != openshift_master_scheduler_default_predicates
+
+# Handle cases where openshift_master_predicates is not defined
+- when: openshift_master_scheduler_predicates | default(none) is none
+  block:
+  - name: openshift_master_scheduler_predicates is not defined
+    debug:
+      msg: "openshift_master_scheduler_predicates is not defined"
+
+  - name: existing scheduler config does not match previous known defaults
+    debug:
+      msg: "WARNING: existing scheduler config does not match previous known defaults automated upgrade of scheduler config is disabled.\nexisting scheduler predicates: {{ openshift_master_scheduler_current_predicates }}\ncurrent scheduler default predicates are: {{ openshift_master_scheduler_default_predicates }}"
+    when:
+    - openshift_master_scheduler_current_predicates != openshift_master_scheduler_default_predicates
+    - openshift_master_scheduler_current_predicates not in osm_older_predicates + [osm_prev_predicates]
+
+  - name: set_fact openshift_upgrade_scheduler_predicates 1
+    set_fact:
+      openshift_upgrade_scheduler_predicates: "{{ openshift_master_scheduler_default_predicates }}"
+    when:
+    - openshift_master_scheduler_current_predicates != openshift_master_scheduler_default_predicates
+    - openshift_master_scheduler_current_predicates in osm_older_predicates + [osm_prev_predicates]
+
+  - name: set_fact openshift_upgrade_scheduler_predicates 2
+    set_fact:
+      openshift_upgrade_scheduler_predicates: "{{ osm_default_predicates_no_region }}"
+    when:
+    - openshift_master_scheduler_current_predicates != osm_default_predicates_no_region
+    - openshift_master_scheduler_current_predicates in osm_older_predicates_no_region + [osm_prev_predicates_no_region]

--- a/roles/openshift_master/tasks/upgrade/upgrade_priorities.yml
+++ b/roles/openshift_master/tasks/upgrade/upgrade_priorities.yml
@@ -1,0 +1,45 @@
+---
+# Handle case where openshift_master_priorities is defined
+- when: openshift_master_scheduler_priorities | default(none) is not none
+  block:
+  - name: openshift_master_scheduler_priorities is defined
+    debug:
+      msg: "openshift_master_scheduler_priorities is defined"
+
+  - name: openshift_master_scheduler_priorities is set to defaults from an earlier release of OpenShift
+    debug:
+      msg: "WARNING: openshift_master_scheduler_priorities is set to defaults from an earlier release of OpenShift current defaults are: {{ openshift_master_scheduler_default_priorities }}"
+    when: openshift_master_scheduler_priorities in osm_older_priorities + osm_older_priorities_no_zone + [osm_prev_priorities] + [osm_prev_priorities_no_zone]
+
+  - name: openshift_master_scheduler_priorities does not match current defaults
+    debug:
+      msg: "WARNING: openshift_master_scheduler_priorities does not match current defaults of: {{ openshift_master_scheduler_default_priorities }}"
+    when: openshift_master_scheduler_priorities != openshift_master_scheduler_default_priorities
+
+# Handle cases where openshift_master_priorities is not defined
+- when: openshift_master_scheduler_priorities | default(none) is none
+  block:
+  - name: openshift_master_scheduler_priorities is not defined
+    debug:
+      msg: "openshift_master_scheduler_priorities is not defined"
+
+  - name: existing scheduler config does not match previous known defaults
+    debug:
+      msg: "WARNING: existing scheduler config does not match previous known defaults automated upgrade of scheduler config is disabled.\nexisting scheduler priorities: {{ openshift_master_scheduler_current_priorities }}\ncurrent scheduler default priorities are: {{ openshift_master_scheduler_default_priorities }}"
+    when:
+    - openshift_master_scheduler_current_priorities != openshift_master_scheduler_default_priorities
+    - openshift_master_scheduler_current_priorities not in osm_older_priorities + [osm_prev_priorities]
+
+  - name: set_fact openshift_upgrade_scheduler_priorities 1
+    set_fact:
+      openshift_upgrade_scheduler_priorities: "{{ openshift_master_scheduler_default_priorities }}"
+    when:
+    - openshift_master_scheduler_current_priorities != openshift_master_scheduler_default_priorities
+    - openshift_master_scheduler_current_priorities in osm_older_priorities + [osm_prev_priorities]
+
+  - name: set_fact openshift_upgrade_scheduler_priorities 2
+    set_fact:
+      openshift_upgrade_scheduler_priorities: "{{ osm_default_priorities_no_zone }}"
+    when:
+    - openshift_master_scheduler_current_priorities != osm_default_priorities_no_zone
+    - openshift_master_scheduler_current_priorities in osm_older_priorities_no_zone + [osm_prev_priorities_no_zone]

--- a/roles/openshift_master/tasks/upgrade/upgrade_scheduler.yml
+++ b/roles/openshift_master/tasks/upgrade/upgrade_scheduler.yml
@@ -1,175 +1,24 @@
 ---
 # Upgrade predicates
-- vars:
-    # openshift_master_facts_default_predicates is a custom lookup plugin in
-    # role lib_utils
-    prev_predicates: "{{ lookup('openshift_master_facts_default_predicates', short_version=openshift_upgrade_min, deployment_type=openshift_deployment_type) }}"
-    prev_predicates_no_region: "{{ lookup('openshift_master_facts_default_predicates', short_version=openshift_upgrade_min, deployment_type=openshift_deployment_type, regions_enabled=False) }}"
-    default_predicates_no_region: "{{ lookup('openshift_master_facts_default_predicates', regions_enabled=False) }}"
-    # older_predicates are the set of predicates that have previously been
-    # hard-coded into openshift_facts
-    older_predicates:
-    - - name: MatchNodeSelector
-      - name: PodFitsResources
-      - name: PodFitsPorts
-      - name: NoDiskConflict
-      - name: NoVolumeZoneConflict
-      - name: MaxEBSVolumeCount
-      - name: MaxGCEPDVolumeCount
-      - name: Region
-        argument:
-          serviceAffinity:
-            labels:
-            - region
-    - - name: MatchNodeSelector
-      - name: PodFitsResources
-      - name: PodFitsPorts
-      - name: NoDiskConflict
-      - name: NoVolumeZoneConflict
-      - name: Region
-        argument:
-          serviceAffinity:
-            labels:
-            - region
-    - - name: MatchNodeSelector
-      - name: PodFitsResources
-      - name: PodFitsPorts
-      - name: NoDiskConflict
-      - name: Region
-        argument:
-          serviceAffinity:
-            labels:
-            - region
-    # older_predicates_no_region are the set of predicates that have previously
-    # been hard-coded into openshift_facts, with the Region predicate removed
-    older_predicates_no_region:
-    - - name: MatchNodeSelector
-      - name: PodFitsResources
-      - name: PodFitsPorts
-      - name: NoDiskConflict
-      - name: NoVolumeZoneConflict
-      - name: MaxEBSVolumeCount
-      - name: MaxGCEPDVolumeCount
-    - - name: MatchNodeSelector
-      - name: PodFitsResources
-      - name: PodFitsPorts
-      - name: NoDiskConflict
-      - name: NoVolumeZoneConflict
-    - - name: MatchNodeSelector
-      - name: PodFitsResources
-      - name: PodFitsPorts
-      - name: NoDiskConflict
-  block:
-
-  # Handle case where openshift_master_predicates is defined
-  - block:
-    - debug:
-        msg: "WARNING: openshift_master_scheduler_predicates is set to defaults from an earlier release of OpenShift current defaults are: {{ openshift_master_scheduler_default_predicates }}"
-      when: openshift_master_scheduler_predicates in older_predicates + older_predicates_no_region + [prev_predicates] + [prev_predicates_no_region]
-
-    - debug:
-        msg: "WARNING: openshift_master_scheduler_predicates does not match current defaults of: {{ openshift_master_scheduler_default_predicates }}"
-      when: openshift_master_scheduler_predicates != openshift_master_scheduler_default_predicates
-    when: openshift_master_scheduler_predicates | default(none) is not none
-
-  # Handle cases where openshift_master_predicates is not defined
-  - block:
-    - debug:
-        msg: "WARNING: existing scheduler config does not match previous known defaults automated upgrade of scheduler config is disabled.\nexisting scheduler predicates: {{ openshift_master_scheduler_current_predicates }}\ncurrent scheduler default predicates are: {{ openshift_master_scheduler_default_predicates }}"
-      when:
-      - openshift_master_scheduler_current_predicates != openshift_master_scheduler_default_predicates
-      - openshift_master_scheduler_current_predicates not in older_predicates + [prev_predicates]
-
-    - set_fact:
-        openshift_upgrade_scheduler_predicates: "{{ openshift_master_scheduler_default_predicates }}"
-      when:
-      - openshift_master_scheduler_current_predicates != openshift_master_scheduler_default_predicates
-      - openshift_master_scheduler_current_predicates in older_predicates + [prev_predicates]
-
-    - set_fact:
-        openshift_upgrade_scheduler_predicates: "{{ default_predicates_no_region }}"
-      when:
-      - openshift_master_scheduler_current_predicates != default_predicates_no_region
-      - openshift_master_scheduler_current_predicates in older_predicates_no_region + [prev_predicates_no_region]
-
-    when: openshift_master_scheduler_predicates | default(none) is none
-
+- include_tasks: upgrade_predicates.yml
 
 # Upgrade priorities
-- vars:
-    prev_priorities: "{{ lookup('openshift_master_facts_default_priorities', short_version=openshift_upgrade_min, deployment_type=openshift_deployment_type) }}"
-    prev_priorities_no_zone: "{{ lookup('openshift_master_facts_default_priorities', short_version=openshift_upgrade_min, deployment_type=openshift_deployment_type, zones_enabled=False) }}"
-    default_priorities_no_zone: "{{ lookup('openshift_master_facts_default_priorities', zones_enabled=False) }}"
-    # older_priorities are the set of priorities that have previously been
-    # hard-coded into openshift_facts
-    older_priorities:
-    - - name: LeastRequestedPriority
-        weight: 1
-      - name: SelectorSpreadPriority
-        weight: 1
-      - name: Zone
-        weight: 2
-        argument:
-          serviceAntiAffinity:
-            label: zone
-    # older_priorities_no_region are the set of priorities that have previously
-    # been hard-coded into openshift_facts, with the Zone priority removed
-    older_priorities_no_zone:
-    - - name: LeastRequestedPriority
-        weight: 1
-      - name: SelectorSpreadPriority
-        weight: 1
-  block:
-
-  # Handle case where openshift_master_priorities is defined
-  - block:
-    - debug:
-        msg: "WARNING: openshift_master_scheduler_priorities is set to defaults from an earlier release of OpenShift current defaults are: {{ openshift_master_scheduler_default_priorities }}"
-      when: openshift_master_scheduler_priorities in older_priorities + older_priorities_no_zone + [prev_priorities] + [prev_priorities_no_zone]
-
-    - debug:
-        msg: "WARNING: openshift_master_scheduler_priorities does not match current defaults of: {{ openshift_master_scheduler_default_priorities }}"
-      when: openshift_master_scheduler_priorities != openshift_master_scheduler_default_priorities
-    when: openshift_master_scheduler_priorities | default(none) is not none
-
-  # Handle cases where openshift_master_priorities is not defined
-  - block:
-    - debug:
-        msg: "WARNING: existing scheduler config does not match previous known defaults automated upgrade of scheduler config is disabled.\nexisting scheduler priorities: {{ openshift_master_scheduler_current_priorities }}\ncurrent scheduler default priorities are: {{ openshift_master_scheduler_default_priorities }}"
-      when:
-      - openshift_master_scheduler_current_priorities != openshift_master_scheduler_default_priorities
-      - openshift_master_scheduler_current_priorities not in older_priorities + [prev_priorities]
-
-    - set_fact:
-        openshift_upgrade_scheduler_priorities: "{{ openshift_master_scheduler_default_priorities }}"
-      when:
-      - openshift_master_scheduler_current_priorities != openshift_master_scheduler_default_priorities
-      - openshift_master_scheduler_current_priorities in older_priorities + [prev_priorities]
-
-    - set_fact:
-        openshift_upgrade_scheduler_priorities: "{{ default_priorities_no_zone }}"
-      when:
-      - openshift_master_scheduler_current_priorities != default_priorities_no_zone
-      - openshift_master_scheduler_current_priorities in older_priorities_no_zone + [prev_priorities_no_zone]
-
-    when: openshift_master_scheduler_priorities | default(none) is none
-
+- include_tasks: upgrade_priorities.yml
 
 # Update scheduler
-- vars:
-    scheduler_config:
+- name: Update scheduler config
+  copy:
+    content: "{{ upgrade_scheduler_config | to_nice_json }}"
+    dest: "{{ openshift_master_scheduler_conf }}"
+    backup: true
+  when: >
+    openshift_upgrade_scheduler_predicates is defined or
+    openshift_upgrade_scheduler_priorities is defined
+  vars:
+    upgrade_scheduler_config:
       kind: Policy
       apiVersion: v1
       predicates: "{{ openshift_upgrade_scheduler_predicates
                       | default(openshift_master_scheduler_current_predicates) }}"
       priorities: "{{ openshift_upgrade_scheduler_priorities
                       | default(openshift_master_scheduler_current_priorities) }}"
-  block:
-  - name: Update scheduler config
-    copy:
-      content: "{{ scheduler_config | to_nice_json }}"
-      dest: "{{ openshift_master_scheduler_conf }}"
-      backup: true
-  when: >
-    openshift_upgrade_scheduler_predicates is defined or
-    openshift_upgrade_scheduler_priorities is defined

--- a/roles/openshift_master/tasks/upgrade_predicates.yml
+++ b/roles/openshift_master/tasks/upgrade_predicates.yml
@@ -1,0 +1,45 @@
+---
+# Handle case where openshift_master_predicates is defined
+- when: openshift_master_scheduler_predicates | default(none) is not none
+  block:
+  - name: openshift_master_scheduler_predicates is defined
+    debug:
+      msg: "openshift_master_scheduler_predicates is defined"
+
+  - name: openshift_master_scheduler_predicates is set to defaults from an earlier release
+    debug:
+      msg: "WARNING: openshift_master_scheduler_predicates is set to defaults from an earlier release of OpenShift current defaults are: {{ openshift_master_scheduler_default_predicates }}"
+    when: openshift_master_scheduler_predicates in osm_older_predicates + osm_older_predicates_no_region + [osm_prev_predicates] + [osm_prev_predicates_no_region]
+
+  - name: openshift_master_scheduler_predicates does not match current defaults
+    debug:
+      msg: "WARNING: openshift_master_scheduler_predicates does not match current defaults of: {{ openshift_master_scheduler_default_predicates }}"
+    when: openshift_master_scheduler_predicates != openshift_master_scheduler_default_predicates
+
+# Handle cases where openshift_master_predicates is not defined
+- when: openshift_master_scheduler_predicates | default(none) is none
+  block:
+  - name: openshift_master_scheduler_predicates is not defined
+    debug:
+      msg: "openshift_master_scheduler_predicates is not defined"
+
+  - name: existing scheduler config does not match previous known defaults
+    debug:
+      msg: "WARNING: existing scheduler config does not match previous known defaults automated upgrade of scheduler config is disabled.\nexisting scheduler predicates: {{ openshift_master_scheduler_current_predicates }}\ncurrent scheduler default predicates are: {{ openshift_master_scheduler_default_predicates }}"
+    when:
+    - openshift_master_scheduler_current_predicates != openshift_master_scheduler_default_predicates
+    - openshift_master_scheduler_current_predicates not in osm_older_predicates + [osm_prev_predicates]
+
+  - name: set_fact openshift_upgrade_scheduler_predicates 1
+    set_fact:
+      openshift_upgrade_scheduler_predicates: "{{ openshift_master_scheduler_default_predicates }}"
+    when:
+    - openshift_master_scheduler_current_predicates != openshift_master_scheduler_default_predicates
+    - openshift_master_scheduler_current_predicates in osm_older_predicates + [osm_prev_predicates]
+
+  - name: set_fact openshift_upgrade_scheduler_predicates 2
+    set_fact:
+      openshift_upgrade_scheduler_predicates: "{{ osm_default_predicates_no_region }}"
+    when:
+    - openshift_master_scheduler_current_predicates != osm_default_predicates_no_region
+    - openshift_master_scheduler_current_predicates in osm_older_predicates_no_region + [osm_prev_predicates_no_region]

--- a/roles/openshift_master/vars/main.yml
+++ b/roles/openshift_master/vars/main.yml
@@ -1,0 +1,82 @@
+---
+# openshift_master_facts_default_predicates is a custom lookup plugin in
+# role lib_utils
+osm_prev_predicates: "{{ lookup('openshift_master_facts_default_predicates', short_version=openshift_upgrade_min, deployment_type=openshift_deployment_type) }}"
+osm_prev_predicates_no_region: "{{ lookup('openshift_master_facts_default_predicates', short_version=openshift_upgrade_min, deployment_type=openshift_deployment_type, regions_enabled=False) }}"
+osm_default_predicates_no_region: "{{ lookup('openshift_master_facts_default_predicates', regions_enabled=False) }}"
+# osm_older_predicates are the set of predicates that have previously been
+# hard-coded into openshift_facts
+osm_older_predicates:
+- - name: MatchNodeSelector
+  - name: PodFitsResources
+  - name: PodFitsPorts
+  - name: NoDiskConflict
+  - name: NoVolumeZoneConflict
+  - name: MaxEBSVolumeCount
+  - name: MaxGCEPDVolumeCount
+  - name: Region
+    argument:
+      serviceAffinity:
+        labels:
+        - region
+- - name: MatchNodeSelector
+  - name: PodFitsResources
+  - name: PodFitsPorts
+  - name: NoDiskConflict
+  - name: NoVolumeZoneConflict
+  - name: Region
+    argument:
+      serviceAffinity:
+        labels:
+        - region
+- - name: MatchNodeSelector
+  - name: PodFitsResources
+  - name: PodFitsPorts
+  - name: NoDiskConflict
+  - name: Region
+    argument:
+      serviceAffinity:
+        labels:
+        - region
+# osm_older_predicates_no_region are the set of predicates that have previously
+# been hard-coded into openshift_facts, with the Region predicate removed
+osm_older_predicates_no_region:
+- - name: MatchNodeSelector
+  - name: PodFitsResources
+  - name: PodFitsPorts
+  - name: NoDiskConflict
+  - name: NoVolumeZoneConflict
+  - name: MaxEBSVolumeCount
+  - name: MaxGCEPDVolumeCount
+- - name: MatchNodeSelector
+  - name: PodFitsResources
+  - name: PodFitsPorts
+  - name: NoDiskConflict
+  - name: NoVolumeZoneConflict
+- - name: MatchNodeSelector
+  - name: PodFitsResources
+  - name: PodFitsPorts
+  - name: NoDiskConflict
+
+osm_prev_priorities: "{{ lookup('openshift_master_facts_default_priorities', short_version=openshift_upgrade_min, deployment_type=openshift_deployment_type) }}"
+osm_prev_priorities_no_zone: "{{ lookup('openshift_master_facts_default_priorities', short_version=openshift_upgrade_min, deployment_type=openshift_deployment_type, zones_enabled=False) }}"
+osm_default_priorities_no_zone: "{{ lookup('openshift_master_facts_default_priorities', zones_enabled=False) }}"
+# osm_older_priorities are the set of priorities that have previously been
+# hard-coded into openshift_facts
+osm_older_priorities:
+- - name: LeastRequestedPriority
+    weight: 1
+  - name: SelectorSpreadPriority
+    weight: 1
+  - name: Zone
+    weight: 2
+    argument:
+      serviceAntiAffinity:
+        label: zone
+# osm_older_priorities_no_region are the set of priorities that have previously
+# been hard-coded into openshift_facts, with the Zone priority removed
+osm_older_priorities_no_zone:
+- - name: LeastRequestedPriority
+    weight: 1
+  - name: SelectorSpreadPriority
+    weight: 1


### PR DESCRIPTION
Master scheduler upgrade cleanup

This commit cleans up nested blocks which are hard
to read, gives names to all tasks so we can
debug the output better.

This commit also removes openshift.common.short_version
from predicate/priority lookup plugins as that data
may be stale.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1549971