### PR TITLE
Change default etcd port to 2379

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1425,7 +1425,7 @@ class OpenShiftFacts(object):
                                       console_use_ssl=True,
                                       console_path='/console',
                                       console_port='8443', etcd_use_ssl=True,
-                                      etcd_hosts='', etcd_port='4001',
+                                      etcd_hosts='', etcd_port='2379',
                                       portal_net='172.30.0.0/16',
                                       embedded_kube=True,
                                       embedded_dns=True,


### PR DESCRIPTION
This has already been done in the 3.7 branch. I saw a system with
catalog configured to use port 4001 for the etcd port upon upgrade, so
fix this here too.