### PR TITLE
Fix grafana role node selector check

### DIFF
--- a/roles/openshift_grafana/README.md
+++ b/roles/openshift_grafana/README.md
@@ -23,7 +23,7 @@ defined:
 
 | Name                                         | Default value     | Description                                  |
 |----------------------------------------------|-------------------|----------------------------------------------|
-| openshift_grafana_namespace                  | grafana           | Default grafana namespace                    |
+| openshift_grafana_namespace                  | openshift-grafana | Default grafana namespace                    |
 | openshift_grafana_timeout                    | 300               | Default pod wait timeout                     |
 | openshift_grafana_prometheus_namespace       | openshift-metrics | Default prometheus namespace                 |
 | openshift_grafana_prometheus_serviceaccount  | promethus         | Prometheus service account                   |

--- a/roles/openshift_grafana/defaults/main.yaml
+++ b/roles/openshift_grafana/defaults/main.yaml
@@ -1,7 +1,7 @@
 ---
 
 openshift_grafana_state: present
-openshift_grafana_namespace: grafana
+openshift_grafana_namespace: openshift-grafana
 openshift_grafana_pod_timeout: 300
 openshift_grafana_prometheus_namespace: "{{ openshift_prometheus_namespace | default('openshift-metrics') }}"
 openshift_grafana_prometheus_serviceaccount: prometheus

--- a/roles/openshift_grafana/tasks/install_grafana.yaml
+++ b/roles/openshift_grafana/tasks/install_grafana.yaml
@@ -1,11 +1,12 @@
 ---
 
 - name: Ensure that Grafana has nodes to run on
-  fail:
-    msg: |-
-      No schedulable nodes found matching node selector for Grafana - '{{ grafana_node_selector }}'
-  when:
-  - openshift_schedulable_node_labels  | lib_utils_oo_has_no_matching_selector(grafana_node_selector)
+  import_role:
+    name: openshift_master
+    tasks_from: ensure_nodes_matching_selector.yml
+  vars:
+    openshift_master_ensure_nodes_selector: "{{ grafana_node_selector | map_to_pairs }}"
+    openshift_master_ensure_nodes_service: Grafana
 
 - name: Create grafana namespace
   oc_project:


### PR DESCRIPTION
Apply the changes introduced in #7241 to the grafana role, i.e. use the matching selector task instead of the removed lib_utils_oo_has_no_matching_selector filter to check for node availability.

Fixes #7375