### PR TITLE
Add max-time option to curl to avoid long running ansible

### DIFF
--- a/playbooks/openshift-master/private/scaleup.yml
+++ b/playbooks/openshift-master/private/scaleup.yml
@@ -21,7 +21,7 @@
     notify: verify api server
   - name: verify api server
     command: >
-      curl --silent --tlsv1.2
+      curl --silent --tlsv1.2 --max-time 2
       --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
       {{ openshift.master.api_url }}/healthz/ready
     args:

--- a/roles/openshift_control_plane/handlers/main.yml
+++ b/roles/openshift_control_plane/handlers/main.yml
@@ -13,7 +13,7 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent --tlsv1.2
+    curl --silent --tlsv1.2 --max-time 2
     --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
     {{ openshift.master.api_url }}/healthz/ready
   args:

--- a/roles/openshift_control_plane/tasks/check_master_api_is_ready.yml
+++ b/roles/openshift_control_plane/tasks/check_master_api_is_ready.yml
@@ -3,7 +3,7 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent --tlsv1.2
+    curl --silent --tlsv1.2 --max-time 2
     --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
     {{ openshift.master.api_url }}/healthz/ready
   register: l_api_available_output

--- a/roles/openshift_logging/handlers/main.yml
+++ b/roles/openshift_logging/handlers/main.yml
@@ -11,7 +11,7 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent --tlsv1.2
+    curl --silent --tlsv1.2 --max-time 2
     --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
     {{ openshift.master.api_url }}/healthz/ready
   args:

--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -6,7 +6,7 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent --tlsv1.2
+    curl --silent --tlsv1.2 --max-time 2
     --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
     {{ openshift_node_master_api_url }}/healthz/ready
   args:

--- a/roles/openshift_metrics/handlers/main.yml
+++ b/roles/openshift_metrics/handlers/main.yml
@@ -11,7 +11,7 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent --tlsv1.2
+    curl --silent --tlsv1.2 --max-time 2
     --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
     {{ openshift.master.api_url }}/healthz/ready
   args:

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -54,7 +54,8 @@
       # Using curl here since the uri module requires python-httplib2 and
       # wait_for port doesn't provide health information.
       command: >
-        curl --silent --tlsv1.2 --cacert {{ openshift.common.config_base }}/node/ca.crt
+        curl --silent --tlsv1.2 --max-time 2
+        --cacert {{ openshift.common.config_base }}/node/ca.crt
         {{ openshift_node_master_api_url }}/healthz/ready
       args:
         # Disables the following warning:


### PR DESCRIPTION
When curl command is executed to check services health with `retries:
120` and `delay: 1`, it looks like it takes `120 sec` at a
maximum until it gives up. However, in case that peer does not reply
and makes timeout due to some issue, curl takes around 1 min
(=connection timeout) to fail, so `120(sec) * 1(min) = 2 hours` in
total. It takes too long until users wait for the end of ansible.

To solve this failed after long running ansible, this patch adds
`--max-time 2` to curl command to timeout.