### PR TITLE
package_version check: stop looking for docker

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/package_version.py
+++ b/roles/openshift_health_checker/openshift_checks/package_version.py
@@ -20,15 +20,6 @@ class PackageVersion(NotContainerizedMixin, OpenShiftCheck):
         (3, 7): ["2.6", "2.7", "2.8", "2.9"],
     }
 
-    openshift_to_docker_version = {
-        (3, 1): "1.8",
-        (3, 2): "1.10",
-        (3, 3): "1.10",
-        (3, 4): "1.12",
-        (3, 5): "1.12",
-        (3, 6): "1.12",
-    }
-
     # map major OpenShift release versions across releases to a common major version
     map_major_release_version = {
         1: 3,
@@ -52,11 +43,6 @@ class PackageVersion(NotContainerizedMixin, OpenShiftCheck):
                 {
                     "name": "openvswitch",
                     "version": self.get_required_ovs_version(),
-                    "check_multi": False,
-                },
-                {
-                    "name": "docker",
-                    "version": self.get_required_docker_version(),
                     "check_multi": False,
                 },
                 {
@@ -96,24 +82,6 @@ class PackageVersion(NotContainerizedMixin, OpenShiftCheck):
             raise OpenShiftCheckException(msg.format(".".join(str(comp) for comp in openshift_version)))
 
         return ovs_version
-
-    def get_required_docker_version(self):
-        """Return the correct Docker version(s) for the current OpenShift version."""
-        openshift_version = self.get_openshift_version_tuple()
-
-        earliest = min(self.openshift_to_docker_version)
-        latest = max(self.openshift_to_docker_version)
-        if openshift_version < earliest:
-            return self.openshift_to_docker_version[earliest]
-        if openshift_version > latest:
-            return self.openshift_to_docker_version[latest]
-
-        docker_version = self.openshift_to_docker_version.get(openshift_version)
-        if not docker_version:
-            msg = "There is no recommended version of Docker for the current version of OpenShift: {}"
-            raise OpenShiftCheckException(msg.format(".".join(str(comp) for comp in openshift_version)))
-
-        return docker_version
 
     def get_openshift_version_tuple(self):
         """Return received image tag as a normalized (X, Y) minor version tuple."""

--- a/roles/openshift_health_checker/test/package_version_test.py
+++ b/roles/openshift_health_checker/test/package_version_test.py
@@ -21,10 +21,6 @@ def test_openshift_version_not_supported():
         check.get_required_ovs_version()
     assert "no recommended version of Open vSwitch" in str(excinfo.value)
 
-    with pytest.raises(OpenShiftCheckException) as excinfo:
-        check.get_required_docker_version()
-    assert "no recommended version of Docker" in str(excinfo.value)
-
 
 def test_invalid_openshift_release_format():
     task_vars = dict(
@@ -65,33 +61,6 @@ def test_package_version(openshift_release):
         return return_value
 
     check = PackageVersion(execute_module, task_vars_for(openshift_release, 'origin'))
-    result = check.run()
-    assert result == return_value
-
-
-@pytest.mark.parametrize('deployment_type,openshift_release,expected_docker_version', [
-    ("origin", "3.5", "1.12"),
-    ("origin", "1.3", "1.10"),
-    ("origin", "1.1", "1.8"),
-    ("openshift-enterprise", "3.4", "1.12"),
-    ("openshift-enterprise", "3.2", "1.10"),
-    ("openshift-enterprise", "3.1", "1.8"),
-])
-def test_docker_package_version(deployment_type, openshift_release, expected_docker_version):
-
-    return_value = {"foo": object()}
-
-    def execute_module(module_name=None, module_args=None, *_):
-        assert module_name == 'aos_version'
-        assert "package_list" in module_args
-
-        for pkg in module_args["package_list"]:
-            if pkg["name"] == "docker":
-                assert pkg["version"] == expected_docker_version
-
-        return return_value
-
-    check = PackageVersion(execute_module, task_vars_for(openshift_release, deployment_type))
     result = check.run()
     assert result == return_value
 


### PR DESCRIPTION
Removes the part of the check that ensures the available Docker version
matches the OpenShift version to be installed, because we can't really
determine the available Docker version.

At the time that this check runs, the excluders have likely not been
run. With the release of docker-1.13, versions prior to OpenShift 3.9
will not be compatible, and we will be relying on the docker excluder to
ensure openshift-ansible does not install it. But as the check looks at
the state of yum to see what would be installed, and the exclusion is
not in place, the check cannot accurately determine if the docker-1.13
it sees is going to be installed, or if something compatible will be.
Rather than give a bogus error when 1.13 is released, or add some
horrible hack, just stop looking at docker.