### PR TITLE
Only run no_log on task that scrapes all inventory variables

### DIFF
--- a/playbooks/init/basic_facts.yml
+++ b/playbooks/init/basic_facts.yml
@@ -15,7 +15,6 @@
   - name: Run openshift_sanitize_inventory to set variables
     import_role:
       name: openshift_sanitize_inventory
-    no_log: True
 
   - name: Detecting Operating System from ostree_booted
     stat:

--- a/roles/openshift_sanitize_inventory/tasks/deprecations.yml
+++ b/roles/openshift_sanitize_inventory/tasks/deprecations.yml
@@ -1,11 +1,13 @@
 ---
-
+# Since this task scrapes all inventory variables which may contain sensitive bits
+# mark it no_log
 - name: Check for usage of deprecated variables
   check_deprecated:
     facts: "{{ hostvars[inventory_hostname] }}"
     vars: "{{ __warn_deprecated_vars }}"
     header: "{{ __deprecation_header }}"
   register: dep_check
+  no_log: true
 
 - block:
   - debug: msg="{{ dep_check.msg }}"


### PR DESCRIPTION
Also, not much we can do to prevent sensitive bits from leaking when run at -vvv. Even before this change the fact gathering dumps every inventory variable.