### PR TITLE
roles/openshift-prometheus: fix some prometheus service discovery scraping

### DIFF
--- a/roles/openshift_prometheus/templates/prometheus.j2
+++ b/roles/openshift_prometheus/templates/prometheus.j2
@@ -155,6 +155,7 @@ spec:
         - -cookie-secret-file=/etc/proxy/secrets/session_secret
         - -openshift-ca=/etc/pki/tls/cert.pem
         - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        - -skip-auth-regex=^/metrics
         volumeMounts:
         - mountPath: /etc/tls/private
           name: alerts-tls-secret
@@ -184,9 +185,6 @@ spec:
         volumeMounts:
         - mountPath: /alert-buffer
           name: alerts-data
-        ports:
-        - containerPort: 9099
-          name: alert-buf
 
       # Deploy alertmanager behind oauth alertmanager-proxy
       - name: alertmanager-proxy
@@ -251,9 +249,6 @@ spec:
 {% if openshift_prometheus_alertmanager_cpu_limit is defined and openshift_prometheus_alertmanager_cpu_limit is not none %}
             cpu: "{{ openshift_prometheus_alertmanager_cpu_limit }}"
 {% endif %}
-        ports:
-        - containerPort: 9093
-          name: web
         volumeMounts:
         - mountPath: /etc/alertmanager
           name: alertmanager-config
@@ -262,7 +257,7 @@ spec:
 
       restartPolicy: Always
       volumes:
-      
+
       - name: prometheus-config
         configMap:
           defaultMode: 420
@@ -286,10 +281,10 @@ spec:
           name: alertmanager
       - name: alertmanager-proxy-secret
         secret:
-          secretName: alertmanager-proxy  
+          secretName: alertmanager-proxy
       - name: alertmanager-tls-secret
         secret:
-          secretName: alertmanager-tls 
+          secretName: alertmanager-tls
       - name: alerts-tls-secret
         secret:
           secretName: alerts-tls


### PR DESCRIPTION
- remove containerPort config from alertmanager and alertbuffer so that the prometheus
  kube discovery doesn't try to scrape them
- allow unauthenticated access to /metrics path so and alert buffer can be scraped
- minor whitespace fix

Related origin example PR: https://github.com/openshift/origin/pull/18802