### PR TITLE
[3.7] wire_aggregator: skip openshift_upgrade_target version check if its undefined

### DIFF
--- a/playbooks/common/openshift-master/tasks/wire_aggregator.yml
+++ b/playbooks/common/openshift-master/tasks/wire_aggregator.yml
@@ -187,6 +187,7 @@
     namespace: kube-system
   when:
   - openshift_version | version_compare('3.7','<')
+  - openshift_upgrade_target is defined
   - openshift_upgrade_target | version_compare('3.7','>=')
 
 #restart master serially here


### PR DESCRIPTION
During 3.7 install openshift_upgrade_target is not defined, so this check 
should be skipped

Related to #7233