### PR TITLE
`containerized` deployment fixes

### DIFF
--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -10,7 +10,7 @@ r_etcd_common_embedded_etcd: false
 
 osm_etcd_image: 'registry.access.redhat.com/rhel7/etcd'
 etcd_image_dict:
-  origin: "registry.fedoraproject.org/latest/etcd"
+  origin: "registry.fedoraproject.org/f27/etcd"
   openshift-enterprise: "{{ osm_etcd_image }}"
 etcd_image: "{{ etcd_image_dict[openshift_deployment_type | default('origin')] }}"
 

--- a/roles/openshift_version/tasks/masters_and_nodes.yml
+++ b/roles/openshift_version/tasks/masters_and_nodes.yml
@@ -10,7 +10,7 @@
     # Both versions have the same string representation
     when: rpm_results.results.versions.available_versions.0 != openshift_version
   # block when
-  when: not openshift_is_atomic | bool
+  when: not ( openshift_is_containerized or openshift_is_atomic ) | bool
 
 # We can't map an openshift_release to full rpm version like we can with containers; make sure
 # the rpm version we looked up matches the release requested and error out if not.


### PR DESCRIPTION
Resolves -
https://bugzilla.redhat.com/show_bug.cgi?id=1552225
https://github.com/openshift/openshift-ansible/issues/6756

Allows for a fully containerized deployment. The `registry.fedoraproject.org/latest/etcd` image doesn't appear to exist in the fedora registry.  Using the f27 etcd release instead works well.

Deployed v3.9 successfully with these vars:
```
openshift_deployment_type=origin
openshift_release=v3.9
openshift_image_tag=v3.9.0
containerized=true
enable_excluders=false
```