### PR TITLE
Allow rcpbind for CNS block in cns-secgrp (openshift_openstack).

### DIFF
--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -598,6 +598,11 @@ resources:
           params:
             cluster_id: {{ openshift_openstack_stack_name }}
       rules:
+        # Allow rcpbind for CNS block
+        - direction: ingress
+          protocol: tcp
+          port_range_min: 111
+          port_range_max: 111
         # glusterfs_sshd
         - direction: ingress
           protocol: tcp


### PR DESCRIPTION
The security policy blocks RPC bind between CNS nodes.  This change allows 111/TCP ingress rule in cns-secgrp policy.

@ekuric, ptal