### PR TITLE
Make broker pods run correct versions on upgrade 

### DIFF
--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -212,16 +212,7 @@
       - ReadWriteOnce
     volume_capacity: 1G
 
-- name: Search for existing Ansible Service Broker deployment config
-  oc_obj:
-    name: asb
-    namespace: openshift-ansible-service-broker
-    kind: DeploymentConfig
-    state: list
-  register: asb_dc
-
-- name: Create Ansible Service Broker deployment config
-  when: asb_dc.results.results.0 | length == 0
+- name: Set Ansible Service Broker deployment config
   oc_obj:
     force: yes
     name: asb

--- a/roles/template_service_broker/files/apiserver-template.yaml
+++ b/roles/template_service_broker/files/apiserver-template.yaml
@@ -71,6 +71,8 @@ objects:
           configMap:
             defaultMode: 420
             name: apiserver-config
+    updateStrategy:
+      type: RollingUpdate
 
 # to create the config for the TSB
 - apiVersion: v1


### PR DESCRIPTION
This ensures that the DeploymentConfig for the ansible service broker is
updated on upgrade (in addition to first install). Since the deployment config
was already using a strategy type of rolling, removing the skip
condition was all that was necessary to launch updated pods.

In the case of the template service broker the daemonset was correctly being
updated with the new image version, but the update strategy was using the
default OnDelete. Changing the strategy to RollingUpdate ensures the
apiserver pod is upgraded as well.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1551115
