### PR TITLE
ansible-quite: set callback_plugins path

### DIFF
--- a/utils/etc/ansible-quiet.cfg
+++ b/utils/etc/ansible-quiet.cfg
@@ -29,4 +29,5 @@ deprecation_warnings=False
 # ssh_args - set if provided by user (cli)
 # control_path
 
+callback_plugins = /usr/share/ansible/openshift-ansible/roles/lib_utils/callback_plugins
 stdout_callback = openshift_quick_installer


### PR DESCRIPTION
Specify lib_utils callback plugins explicitely, as this role gets imported 
too late to set correct callback_plugins path

Related to #7300
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1548633