### PR TITLE
Specify the namespace to "oc process" for better idempotent

### DIFF
--- a/roles/template_service_broker/tasks/deploy.yml
+++ b/roles/template_service_broker/tasks/deploy.yml
@@ -36,7 +36,7 @@
 - name: Apply template file
   shell: >
     {{ openshift_client_binary }} process --config={{ mktemp.stdout }}/admin.kubeconfig
-    -f "{{ mktemp.stdout }}/{{ __tsb_template_file }}"
+    -f "{{ mktemp.stdout }}/{{ __tsb_template_file }}" -n openshift-template-service-broker
     --param API_SERVER_CONFIG="{{ config['content'] | b64decode }}"
     --param IMAGE="{{ template_service_broker_prefix }}{{ template_service_broker_image_name }}:{{ template_service_broker_version }}"
     --param NODE_SELECTOR={{ template_service_broker_selector | to_json | quote }}
@@ -45,7 +45,7 @@
 # reconcile with rbac
 - name: Reconcile with RBAC file
   shell: >
-    {{ openshift_client_binary }} process --config={{ mktemp.stdout }}/admin.kubeconfig -f "{{ mktemp.stdout }}/{{ __tsb_rbac_file }}"
+    {{ openshift_client_binary }} process --config={{ mktemp.stdout }}/admin.kubeconfig -f "{{ mktemp.stdout }}/{{ __tsb_rbac_file }}" -n openshift-template-service-broker
     | {{ openshift_client_binary }} auth reconcile --config={{ mktemp.stdout }}/admin.kubeconfig -f -
 
 # Check that the TSB is running
@@ -69,7 +69,7 @@
 # Register with broker
 - name: Register TSB with broker
   shell: >
-    {{ openshift_client_binary }} process --config={{ mktemp.stdout }}/admin.kubeconfig -f "{{ mktemp.stdout }}/{{ __tsb_broker_file }}" --param CA_BUNDLE="{{ __ca_bundle.content }}" | {{ openshift_client_binary }} apply --config={{ mktemp.stdout }}/admin.kubeconfig -f -
+    {{ openshift_client_binary }} process --config={{ mktemp.stdout }}/admin.kubeconfig -f "{{ mktemp.stdout }}/{{ __tsb_broker_file }}" -n openshift-template-service-broker --param CA_BUNDLE="{{ __ca_bundle.content }}" | {{ openshift_client_binary }} apply --config={{ mktemp.stdout }}/admin.kubeconfig -f -
 
 - file:
     state: absent


### PR DESCRIPTION
* Symptom: If source namespace is not existing when executing some playbooks including this roles, `oc process -f` was failed.

* Related links: https://github.com/openshift/origin/pull/4863               

* You can reproduce the error as follows, 
```
-- Select the "openshift-ansible-service-broker"
# oc project openshift-ansible-service-broker

-- Remove the OAB using ansible playbooks
# ansible-playbook -i ~/.config/openshift/hosts \
  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/service-catalog.yml \
  -e ansible_service_broker_remove=true \
  -e ansible_service_broker_install=false

-- Continuously executing the same command, you can see the failed error messages
# ansible-playbook -i ~/.config/openshift/hosts \
  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/service-catalog.yml \
  -e ansible_service_broker_remove=true \
  -e ansible_service_broker_install=false

...
TASK [template_service_broker : Apply template file] ***********************************************************************************
fatal: [master.example.com]: FAILED! => {"changed": true, "cmd": "oc process -f \"/tmp/tsb-ansible-AABBCC/apiserver-template.yaml\" --param API_SERVER_CONFIG=\"kind: TemplateServiceBrokerConfig\napiVersion: config.templateservicebroker.openshift.io/v1\ntemplateNamespaces:\n- openshift\n\" --param IMAGE=\"registry.access.redhat.com/openshift3/ose:v3.7\" --param NODE_SELECTOR='{\"region\": \"infra\"}' | oc apply -f -", "delta": "0:00:00.244989", "end": "2018-02-20 17:46:30.401475", "msg": "non-zero return code", "rc": 1, "start": "2018-02-20 20:00:30.156486", "stderr": "error: unable to process template\n  namespaces \"openshift-ansible-service-broker\" not found\nerror: no objects passed to apply", "stderr_lines": ["error: unable to process template", "  namespaces \"openshift-ansible-service-broker\" not found", "error: no objects passed to apply"], "stdout": "", "stdout_lines": []}
...
```