### PR TITLE
[bz 1543256] Remove redeploy after the roll has executed.

### DIFF
--- a/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
@@ -125,12 +125,6 @@
     - ('service.alpha.openshift.io/serving-cert-secret-name') not in router_service_annotations
     - ('service.alpha.openshift.io/serving-cert-signed-by') not in router_service_annotations
 
-  - name: Redeploy router
-    command: >
-      {{ openshift_client_binary }} rollout latest dc/router
-      --config={{ router_cert_redeploy_tempdir.stdout }}/admin.kubeconfig
-      -n default
-
   - name: Delete temp directory
     file:
       name: "{{ router_cert_redeploy_tempdir.stdout }}"


### PR DESCRIPTION
Remove the rollout once the router.yml from openshift_hosted has been called.  This was causing 2 separate deployments in succession. 

https://bugzilla.redhat.com/show_bug.cgi?id=1543256