### PR TITLE
During master upgrade reset loopback config

### DIFF
--- a/roles/openshift_master/tasks/upgrade.yml
+++ b/roles/openshift_master/tasks/upgrade.yml
@@ -12,6 +12,8 @@
 
 - include_tasks: systemd_units.yml
 
+- include_tasks: set_loopback_context.yml
+
 - name: Check for ca-bundle.crt
   stat:
     path: "{{ openshift.common.config_base }}/master/ca-bundle.crt"


### PR DESCRIPTION
At some point in time the install and cert re-deploy playbooks
incorrectly defined the loopback context to point at the load balancer
rather than localhost. This creates a bootstrapping problem where if all
API servers are taken down they cannot be brought back up because the
API servers depend on being able to connect back to themselves during
startup. If the load balancer does not instananeously place the
bootstrapping API server into rotation it will fail.