### PR TITLE
[release-3.6] During master upgrade reset loopback config and etcd migration

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -97,6 +97,9 @@
   - name: Update systemd units
     include: ../../../../roles/openshift_master/tasks/systemd_units.yml
 
+  - name: Update loopback kubeconfig
+    include: ../../../../roles/openshift_master/tasks/set_loopback_context.yml
+
   - name: Check for ca-bundle.crt
     stat:
       path: "{{ openshift.common.config_base }}/master/ca-bundle.crt"

--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -32,6 +32,10 @@
     - (openshift_master_cluster_method is defined and openshift_master_cluster_method == "native") or openshift.common.is_master_system_container | bool
   - debug:
       msg: "master service name: {{ master_services }}"
+  - name: Update loopback kubeconfig
+    include_role:
+      name: openshift_master
+      tasks_from: set_loopback_context.yml
   - name: Stop masters
     service:
       name: "{{ item }}"


### PR DESCRIPTION
Backport #7391 

At some point in time the install and cert re-deploy playbooks
incorrectly defined the loopback context to point at the load balancer
rather than localhost. This creates a bootstrapping problem where if all
API servers are taken down they cannot be brought back up because the
API servers depend on being able to connect back to themselves during
startup. If the load balancer does not instananeously place the
bootstrapping API server into rotation it will fail.

Also, we need to do this during the etcd v2 to v3 migration because during that playbook we shut down all API servers.