### PR TITLE
[release-3.7] During master upgrade reset loopback config

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -113,6 +113,9 @@
   - name: Remove any legacy systemd units and update systemd units
     include: ../../../../roles/openshift_master/tasks/systemd_units.yml
 
+  - name: Update loopback kubeconfig
+    include: ../../../../roles/openshift_master/tasks/set_loopback_context.yml
+
   - name: Check for ca-bundle.crt
     stat:
       path: "{{ openshift.common.config_base }}/master/ca-bundle.crt"

--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -37,6 +37,10 @@
     - groups.oo_masters_to_config | length > 1 or openshift_version | version_compare('3.7','>=')
   - debug:
       msg: "master service name: {{ master_services }}"
+  - name: Update loopback kubeconfig
+    include_role:
+      name: openshift_master
+      tasks_from: set_loopback_context.yml
   - name: Stop masters
     service:
       name: "{{ item }}"


### PR DESCRIPTION
Backports #7391

At some point in time the install and cert re-deploy playbooks
incorrectly defined the loopback context to point at the load balancer
rather than localhost. This creates a bootstrapping problem where if all
API servers are taken down they cannot be brought back up because the
API servers depend on being able to connect back to themselves during
startup. If the load balancer does not instananeously place the
bootstrapping API server into rotation it will fail.