### PR TITLE
Default logging namespace to openshift-logging

### DIFF
--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -9,7 +9,7 @@ r_openshift_hosted_use_calico: "{{ r_openshift_hosted_use_calico_default }}"
 openshift_default_projects:
   default:
     default_node_selector: ''
-  logging:
+  openshift-logging:
     default_node_selector: ''
   openshift-infra:
     default_node_selector: ''

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -2,7 +2,6 @@
 openshift_logging_use_ops: False
 openshift_logging_master_url: "https://kubernetes.default.svc.{{ openshift.common.dns_domain }}"
 openshift_logging_master_public_url: "{{ 'https://' + openshift_master_cluster_public_hostname | default(openshift.common.public_hostname) + ':' ~ (openshift_master_api_port | default('8443', true)) }}"
-openshift_logging_namespace: logging
 openshift_logging_nodeselector: null
 openshift_logging_labels: {}
 openshift_logging_label_key: ""

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -2,7 +2,7 @@
 - name: Gather OpenShift Logging Facts
   openshift_logging_facts:
     oc_bin: "{{openshift_client_binary}}"
-    openshift_logging_namespace: "{{openshift_logging_namespace}}"
+    openshift_logging_namespace: "{{ openshift_logging_namespace }}"
 
 ## This is include vs import because we need access to group/inventory variables
 - include_tasks: set_defaults_from_current.yml

--- a/roles/openshift_logging/tasks/main.yaml
+++ b/roles/openshift_logging/tasks/main.yaml
@@ -19,13 +19,44 @@
   check_mode: no
   become: false
 
+- oc_obj:
+    state: list
+    kind: dc
+    all_namespaces: true
+    selector: "logging-infra,provider=openshift"
+  register: _logging_dcs
+
+- assert:
+    that:
+    - _logging_dcs.results.results[0]['items'] | map(attribute='metadata.namespace') | list | unique | count <= 1
+    msg: "Found aggregated logging deploymentconfigs in multiple namespaces which is not supported"
+  when:
+  - _logging_dcs is defined
+  - _logging_dcs.results | count > 0
+
+- set_fact:
+    _logging_namespace: "{{ _logging_dcs.results.results[0]['items'] | map(attribute='metadata.namespace') | list | unique | join('') }}"
+  when:
+  - _logging_dcs is defined
+  - _logging_dcs.results | count > 0
+  - _logging_dcs.results.results | count > 0
+
+- debug:
+    msg: "Using the namespace '{{ _logging_namespace }}' which has an existing deployment"
+  when:
+  - _logging_namespace is defined
+  - _logging_namespace | count > 0
+
+- set_fact:
+    openshift_logging_namespace: "{{ _logging_namespace if _logging_namespace else 'openshift-logging' }}"
+
 - include_tasks: install_logging.yaml
   when:
-    - openshift_logging_install_logging | default(false) | bool
+  - openshift_logging_install_logging | default(false) | bool
 
 - include_tasks: delete_logging.yaml
   when:
-    - not openshift_logging_install_logging | default(false) | bool
+  - not openshift_logging_install_logging | default(false) | bool
 
 - name: Cleaning up local temp dir
   local_action: file path="{{local_tmp.stdout}}" state=absent

--- a/roles/openshift_logging/vars/main.yaml
+++ b/roles/openshift_logging/vars/main.yaml
@@ -7,4 +7,4 @@ es_ops_recover_expected_nodes: "{{openshift_logging_es_ops_cluster_size | int}}"
 
 es_log_appenders: ['file', 'console']
 
-__default_logging_ops_projects: ['default', 'openshift', 'openshift-infra', 'kube-system']
+__default_logging_ops_projects: ['default', 'openshift', 'openshift-infra', 'kube-system', 'openshift-logging']

--- a/roles/openshift_sanitize_inventory/vars/main.yml
+++ b/roles/openshift_sanitize_inventory/vars/main.yml
@@ -62,6 +62,7 @@ __warn_deprecated_vars:
   - 'openshift_hosted_logging_storage_access_modes'
   - 'openshift_hosted_logging_deployer_prefix'
   - 'openshift_hosted_logging_deployer_version'
+  - 'openshift_logging_namespace'
   # metrics
   - 'openshift_hosted_metrics_deploy'
   - 'openshift_hosted_metrics_storage_kind'


### PR DESCRIPTION
This PR

* Modifies the default logging namespace
* Uses the existing namespace if logging is already deployed
* Makes no effort to try and move the logging deployment

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1535300

@smarterclayton it should would be nice to have a utility to move PV's....