### PR TITLE
Fix hosted registry upgrade bug

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -12,87 +12,16 @@
 
 - name: Upgrade default router and default registry
   hosts: oo_first_master
-  vars:
-    registry_image: "{{  openshift.master.registry_url | replace( '${component}', 'docker-registry' )  |
-                         replace ( '${version}', openshift_image_tag ) }}"
-    router_image: "{{ openshift.master.registry_url | replace( '${component}', 'haproxy-router' ) |
-                      replace ( '${version}', openshift_image_tag ) }}"
-    registry_console_image: "{{ openshift.master.registry_url | regex_replace ( '(origin|ose)-\\${component}', 'registry-console') |
-                                replace ( '${version}', 'v' ~ openshift.common.short_version ) }}"
-
   pre_tasks:
-  - name: Load lib_openshift modules
-    import_role:
-      name: lib_openshift
-
-  - name: Collect all routers
-    oc_obj:
-      state: list
-      kind: pods
-      all_namespaces: True
-      selector: 'router'
-    register: all_routers
-
-  - set_fact:
-      haproxy_routers: "{{ all_routers.results.results[0]['items'] |
-                           lib_utils_oo_pods_match_component(openshift_deployment_type, 'haproxy-router') |
-                           lib_utils_oo_select_keys_from_list(['metadata']) }}"
-    when:
-    - all_routers.results.returncode == 0
-
-  - set_fact: haproxy_routers=[]
-    when:
-    - all_routers.results.returncode != 0
-
-  - name: Update router image to current version
-    oc_edit:
-      kind: dc
-      name: "{{ item['labels']['deploymentconfig'] }}"
-      namespace: "{{ item['namespace'] }}"
-      content:
-        spec.template.spec.containers[0].image: "{{ router_image }}"
-    with_items: "{{ haproxy_routers }}"
-    when:
-    - all_routers.results.returncode == 0
-
-  - name: Check for default registry
-    oc_obj:
-      state: list
-      kind: dc
-      name: docker-registry
-    register: _default_registry
-
-  - name: Update registry image to current version
-    oc_edit:
-      kind: dc
-      name: docker-registry
-      namespace: default
-      content:
-        spec.template.spec.containers[0].image: "{{ registry_image }}"
-    when:
-    - _default_registry.results.results[0] != {}
-
-  - name: Check for registry-console
-    oc_obj:
-      state: list
-      kind: dc
-      name: registry-console
-    register: _registry_console
-    when:
-    - openshift.common.deployment_type != 'origin'
-
-  - name: Update registry-console image to current version
-    oc_edit:
-      kind: dc
-      name: registry-console
-      namespace: default
-      content:
-        spec.template.spec.containers[0].image: "{{ registry_console_image }}"
-    when:
-    - openshift.common.deployment_type != 'origin'
-    - _registry_console.results.results[0] != {}
+  - import_role:
+      name: openshift_hosted
+      tasks_from: upgrade_routers.yml
+  - import_role:
+      name: openshift_hosted
+      tasks_from: upgrade_registry.yml
 
   roles:
+  - lib_utils
   - openshift_manageiq
   - role: openshift_project_request_template
     when: openshift_project_request_template_manage
@@ -107,10 +36,8 @@
   # Update the existing templates
   - role: openshift_examples
     when: openshift_install_examples | default(true) | bool
-    registry_url: "{{ openshift.master.registry_url }}"
     openshift_examples_import_command: replace
   - role: openshift_hosted_templates
-    registry_url: "{{ openshift.master.registry_url }}"
     openshift_hosted_templates_import_command: replace
 
   post_tasks:

--- a/playbooks/openshift-glusterfs/private/registry.yml
+++ b/playbooks/openshift-glusterfs/private/registry.yml
@@ -9,12 +9,5 @@
 
 - name: Create Hosted Resources
   hosts: oo_first_master
-  tags:
-  - hosted
-  pre_tasks:
-  - set_fact:
-      openshift_hosted_router_registryurl: "{{ hostvars[groups.oo_first_master.0].openshift.master.registry_url }}"
-      openshift_hosted_registry_registryurl: "{{ hostvars[groups.oo_first_master.0].openshift.master.registry_url }}"
-    when: "'master' in hostvars[groups.oo_first_master.0].openshift and 'registry_url' in hostvars[groups.oo_first_master.0].openshift.master"
   roles:
   - role: openshift_hosted

--- a/playbooks/openshift-master/private/additional_config.yml
+++ b/playbooks/openshift-master/private/additional_config.yml
@@ -22,9 +22,7 @@
     when: openshift_project_request_template_manage
   - role: openshift_examples
     when: openshift_install_examples | default(true) | bool
-    registry_url: "{{ openshift.master.registry_url }}"
   - role: openshift_hosted_templates
-    registry_url: "{{ openshift.master.registry_url }}"
   - role: openshift_manageiq
     when: openshift_use_manageiq | default(true) | bool
   - role: cockpit
@@ -32,7 +30,7 @@
     - not openshift_is_atomic | bool
     - openshift_deployment_type == 'openshift-enterprise'
     - osm_use_cockpit is undefined or osm_use_cockpit | bool
-    - openshift.common.deployment_subtype != 'registry'
+    - openshift_deployment_subtype != 'registry'
   - role: flannel_register
     when: openshift_use_flannel | default(false) | bool
 

--- a/roles/openshift_examples/defaults/main.yml
+++ b/roles/openshift_examples/defaults/main.yml
@@ -26,5 +26,9 @@ cockpit_ui_base: "{{ examples_base }}/infrastructure-templates/enterprise"
 
 
 openshift_examples_import_command: "create"
-registry_url: ""
-registry_host: "{{ registry_url.split('/')[0] if '.' in registry_url.split('/')[0] else '' }}"
+registry_host: "{{ openshift_examples_registryurl.split('/')[0] if '.' in openshift_examples_registryurl.split('/')[0] else '' }}"
+
+openshift_hosted_images_dict:
+  origin: 'openshift/origin-${component}:${version}'
+  openshift-enterprise: 'openshift3/ose-${component}:${version}'
+openshift_examples_registryurl: "{{ oreg_url_master | default(oreg_url) | default(openshift_hosted_images_dict[openshift_deployment_type]) }}"

--- a/roles/openshift_hosted/tasks/upgrade_registry.yml
+++ b/roles/openshift_hosted/tasks/upgrade_registry.yml
@@ -1,0 +1,43 @@
+---
+- name: Check for default registry
+  oc_obj:
+    state: list
+    kind: dc
+    name: docker-registry
+  register: _default_registry
+
+- name: Update registry image to current version
+  oc_edit:
+    kind: dc
+    name: docker-registry
+    namespace: default
+    content:
+      spec.template.spec.containers[0].image: "{{ l_osh_registry_image }}"
+  vars:
+    l_osh_registry_image: "{{ openshift_hosted_registry_registryurl | replace( '${component}', 'docker-registry' )  |
+                           replace ( '${version}', openshift_image_tag ) }}"
+  when:
+  - _default_registry.results.results[0] != {}
+
+- name: Check for registry-console
+  oc_obj:
+    state: list
+    kind: dc
+    name: registry-console
+  register: _registry_console
+  when:
+  - openshift_deployment_type != 'origin'
+
+- name: Update registry-console image to current version
+  oc_edit:
+    kind: dc
+    name: registry-console
+    namespace: default
+    content:
+      spec.template.spec.containers[0].image: "{{ l_osh_registry_console_image }}"
+  vars:
+    l_osh_registry_console_image: "{{ openshift_hosted_registry_registryurl | regex_replace ( '(origin|ose)-\\${component}', 'registry-console') |
+                                      replace ( '${version}', 'v' ~ openshift_upgrade_target ) }}"
+  when:
+  - openshift_deployment_type != 'origin'
+  - _registry_console.results.results[0] != {}

--- a/roles/openshift_hosted/tasks/upgrade_routers.yml
+++ b/roles/openshift_hosted/tasks/upgrade_routers.yml
@@ -1,0 +1,33 @@
+---
+- name: Collect all routers
+  oc_obj:
+    state: list
+    kind: pods
+    all_namespaces: True
+    selector: 'router'
+  register: all_routers
+
+- set_fact:
+    haproxy_routers: "{{ all_routers.results.results[0]['items'] |
+                         lib_utils_oo_pods_match_component(openshift_deployment_type, 'haproxy-router') |
+                         lib_utils_oo_select_keys_from_list(['metadata']) }}"
+  when:
+  - all_routers.results.returncode == 0
+
+- set_fact: haproxy_routers=[]
+  when:
+  - all_routers.results.returncode != 0
+
+- name: Update router image to current version
+  oc_edit:
+    kind: dc
+    name: "{{ item['labels']['deploymentconfig'] }}"
+    namespace: "{{ item['namespace'] }}"
+    content:
+      spec.template.spec.containers[0].image: "{{ l_osh_router_image }}"
+  with_items: "{{ haproxy_routers }}"
+  vars:
+    l_osh_router_image: "{{ openshift_hosted_router_registryurl | replace( '${component}', 'haproxy-router' ) |
+                            replace ( '${version}', openshift_image_tag ) }}"
+  when:
+  - all_routers.results.returncode == 0


### PR DESCRIPTION
During 3.9 upgrade, openshift.common.short_version
may be stale.

This commit refactors hosted component upgrade to
use openshift_target_version and cleans up
variables and tasks.