### PR TITLE
Refactor openshift.common.version to openshift_current_version

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -12,7 +12,7 @@
 - name: Ensure firewall is not switched during upgrade
   hosts: "{{ l_upgrade_no_switch_firewall_hosts | default('oo_all_hosts') }}"
   vars:
-    openshift_master_installed_version: "{{ hostvars[groups.oo_first_master.0].openshift.common.version }}"
+    openshift_master_installed_version: "{{ hostvars[groups.oo_first_master.0].openshift_current_version }}"
   tasks:
   - name: set currently installed version
     set_fact:

--- a/playbooks/common/openshift-cluster/upgrades/pre/config.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/config.yml
@@ -61,10 +61,10 @@
 - name: Verify masters are already upgraded
   hosts: oo_masters_to_config
   tasks:
-  - fail: msg="Master running {{ openshift.common.version }} must be upgraded to {{ openshift_version }} before node upgrade can be run."
+  - fail: msg="Master running {{ openshift_current_version }} must be upgraded to {{ openshift_version }} before node upgrade can be run."
     when:
     - l_upgrade_nodes_only | default(False) | bool
-    - not openshift.common.version | match(openshift_version)
+    - not (openshift_current_version | default('0.0') | match(openshift_version))
 
 # If we're only upgrading nodes, skip this.
 - import_playbook: ../../../../openshift-master/private/validate_restart.yml

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -2,7 +2,7 @@
 - name: Fail when OpenShift is not installed
   fail:
     msg: Verify OpenShift is already installed
-  when: openshift.common.version is not defined
+  when: openshift_current_version is not defined
 
 - name: Update oreg_auth docker login credentials if necessary
   import_role:
@@ -50,4 +50,4 @@
     msg: "This upgrade playbook must be run against OpenShift {{ openshift_upgrade_min }} or later"
   when:
   - openshift_deployment_type == 'origin'
-  - openshift.common.version is version_compare(openshift_upgrade_min,'<')
+  - openshift_current_version is version_compare(openshift_upgrade_min,'<')

--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -5,7 +5,14 @@
   hosts: "{{ l_init_fact_hosts | default('oo_all_hosts') }}"
   roles:
   - role: openshift_facts
+  - role: lib_utils
   tasks:
+  - name: get openshift_current_version
+    # get_current_openshift_version is a custom module in lib_utils
+    # this will set_fact openshift_current_version
+    get_current_openshift_version:
+      deployment_type: "{{ openshift_deployment_type }}"
+
   - name: Gather Cluster facts
     openshift_facts:
       role: common

--- a/playbooks/init/version.yml
+++ b/playbooks/init/version.yml
@@ -1,12 +1,18 @@
 ---
-# NOTE: requires openshift_facts be run
 - name: Determine openshift_version to configure on first master
   hosts: "{{ l_openshift_version_determine_hosts | default('oo_first_master') }}"
   tasks:
   - include_role:
       name: openshift_version
       tasks_from: first_master.yml
+
   - debug: msg="openshift_pkg_version set to {{ openshift_pkg_version | default('') }}"
+
+  # set_version_facts is a custom module in lib_utils
+  # this will set_fact booleans for openshift_verison
+  - name: set openshift_version booleans (first master)
+    set_version_facts:
+      version: "{{ openshift_current_version | default(openshift_version) }}"
 
 # NOTE: We set this even on etcd hosts as they may also later run as masters,
 # and we don't want to install wrong version of docker and have to downgrade
@@ -31,3 +37,9 @@
   - include_role:
       name: openshift_version
       tasks_from: masters_and_nodes.yml
+
+  # set_version_facts is a custom module in lib_utils
+  # this will set_fact booleans for openshift_verison
+  - name: set openshift_version booleans (masters and nodes)
+    set_version_facts:
+      version: "{{ openshift_current_version | default(openshift_version) }}"

--- a/playbooks/openshift-logging/private/config.yml
+++ b/playbooks/openshift-logging/private/config.yml
@@ -55,7 +55,7 @@
   - include_role:
       name: openshift_logging
       tasks_from: update_master_config
-    when: not openshift.common.version_gte_3_9
+    when: not openshift_version_gte_3_9
 
 - name: Logging Install Checkpoint End
   hosts: all

--- a/playbooks/openshift-master/private/tasks/wire_aggregator.yml
+++ b/playbooks/openshift-master/private/tasks/wire_aggregator.yml
@@ -173,7 +173,7 @@
 
 # Only add the catalog extension script if not 3.9. From 3.9 on, the console
 # can discover if template service broker is running.
-- when: not openshift.common.version_gte_3_9
+- when: not openshift_version_gte_3_9
   block:
   - name: Setup extension file for service console UI
     template:

--- a/playbooks/openshift-metrics/private/config.yml
+++ b/playbooks/openshift-metrics/private/config.yml
@@ -25,7 +25,7 @@
     import_role:
       name: openshift_metrics
       tasks_from: update_master_config.yaml
-    when: not openshift.common.version_gte_3_9
+    when: not openshift_version_gte_3_9
 
 - name: Metrics Install Checkpoint End
   hosts: all

--- a/roles/lib_utils/action_plugins/set_version_facts.py
+++ b/roles/lib_utils/action_plugins/set_version_facts.py
@@ -1,0 +1,74 @@
+"""
+Ansible action plugin to set version facts
+"""
+
+# pylint: disable=no-name-in-module, import-error, wrong-import-order
+from distutils.version import LooseVersion
+from ansible.plugins.action import ActionBase
+
+
+# pylint: disable=too-many-statements
+def set_version_facts_if_unset(version):
+    """ Set version facts. This currently includes common.version and
+        common.version_gte_3_x
+
+        Args:
+            version (string): version of openshift installed/to install
+        Returns:
+            dict: the facts dict updated with version facts.
+    """
+    facts = {}
+    if version and version != "latest":
+        version = LooseVersion(version)
+        version_gte_3_7 = version >= LooseVersion('3.7')
+        version_gte_3_8 = version >= LooseVersion('3.8')
+        version_gte_3_9 = version >= LooseVersion('3.9')
+        version_gte_3_10 = version >= LooseVersion('3.10')
+        version_gte_3_11 = version >= LooseVersion('3.11')
+    else:
+        # 'Latest' version is set to True, 'Next' versions set to False
+        version_gte_3_7 = True
+        version_gte_3_8 = True
+        version_gte_3_9 = True
+        version_gte_3_10 = True
+        version_gte_3_11 = False
+    facts['openshift_version_gte_3_7'] = version_gte_3_7
+    facts['openshift_version_gte_3_8'] = version_gte_3_8
+    facts['openshift_version_gte_3_9'] = version_gte_3_9
+    facts['openshift_version_gte_3_10'] = version_gte_3_10
+    facts['openshift_version_gte_3_11'] = version_gte_3_11
+
+    if version_gte_3_11:
+        examples_content_version = 'v3.11'
+    elif version_gte_3_10:
+        examples_content_version = 'v3.10'
+    elif version_gte_3_9:
+        examples_content_version = 'v3.9'
+    elif version_gte_3_8:
+        examples_content_version = 'v3.8'
+    else:
+        examples_content_version = 'v3.7'
+
+    facts['openshift_examples_content_version'] = examples_content_version
+
+    return facts
+
+
+# pylint: disable=too-few-public-methods
+class ActionModule(ActionBase):
+    """Action plugin to set version facts"""
+
+    def run(self, tmp=None, task_vars=None):
+        """Run set_version_facts"""
+        result = super(ActionModule, self).run(tmp, task_vars)
+        # Ignore settting self.task_vars outside of init.
+        # pylint: disable=W0201
+        self.task_vars = task_vars or {}
+
+        result["changed"] = False
+        result["failed"] = False
+        result["msg"] = "Version facts set"
+
+        version = self._task.args.get('version')
+        result["ansible_facts"] = set_version_facts_if_unset(version)
+        return result

--- a/roles/lib_utils/library/get_current_openshift_version.py
+++ b/roles/lib_utils/library/get_current_openshift_version.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+# pylint: disable=missing-docstring
+#
+# Copyright 2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+DOCUMENTATION = '''
+---
+module: get_current_openshift_version
+
+short_description: Discovers installed openshift version on masters and nodes
+
+version_added: "2.4"
+
+description:
+    - This module checks various files and program outputs to get the
+      currently installed openshfit version
+
+options:
+    deployment_type:
+        description:
+            - openshift_deployment_type
+        required: true
+
+
+author:
+    - "Michael Gugino <mgugino@redhat.com>"
+'''
+
+EXAMPLES = '''
+- name: Set openshift_current_version
+  get_current_openshift_version:
+    deployment_type: openshift_deployment_type
+'''
+
+
+def chomp_commit_offset(version):
+    """Chomp any "+git.foo" commit offset string from the given `version`
+    and return the modified version string.
+
+Ex:
+- chomp_commit_offset(None)                 => None
+- chomp_commit_offset(1337)                 => "1337"
+- chomp_commit_offset("v3.4.0.15+git.derp") => "v3.4.0.15"
+- chomp_commit_offset("v3.4.0.15")          => "v3.4.0.15"
+- chomp_commit_offset("v1.3.0+52492b4")     => "v1.3.0"
+    """
+    if version is None:
+        return version
+    else:
+        # Stringify, just in case it's a Number type. Split by '+' and
+        # return the first split. No concerns about strings without a
+        # '+', .split() returns an array of the original string.
+        return str(version).split('+')[0]
+
+
+def get_container_openshift_version(deployment_type):
+    """
+    If containerized, see if we can determine the installed version via the
+    systemd environment files.
+    """
+    service_type_dict = {'origin': 'origin',
+                         'openshift-enterprise': 'atomic-openshift'}
+    service_type = service_type_dict[deployment_type]
+
+    for filename in ['/etc/sysconfig/%s-master-controllers', '/etc/sysconfig/%s-node']:
+        env_path = filename % service_type
+        if not os.path.exists(env_path):
+            continue
+
+        with open(env_path) as env_file:
+            for line in env_file:
+                if line.startswith("IMAGE_VERSION="):
+                    tag = line[len("IMAGE_VERSION="):].strip()
+                    # Remove leading "v" and any trailing release info, we just want
+                    # a version number here:
+                    no_v_version = tag[1:] if tag[0] == 'v' else tag
+                    version = no_v_version.split("-")[0]
+                    return version
+    return None
+
+
+def parse_openshift_version(output):
+    """ Apply provider facts to supplied facts dict
+
+        Args:
+            string: output of 'openshift version'
+        Returns:
+            string: the version number
+    """
+    versions = dict(e.split(' v') for e in output.splitlines() if ' v' in e)
+    ver = versions.get('openshift', '')
+    # Remove trailing build number and commit hash from older versions, we need to return a straight
+    # w.x.y.z version here for use as openshift_version throughout the playbooks/roles. (i.e. 3.1.1.6-64-g80b61da)
+    ver = ver.split('-')[0]
+    return ver
+
+
+def get_openshift_version(module, deployment_type):
+    """ Get current version of openshift on the host.
+
+        Checks a variety of ways ranging from fastest to slowest.
+
+        Args:
+            facts (dict): existing facts
+
+        Returns:
+            version: the current openshift version
+    """
+    version = None
+
+    if os.path.isfile('/usr/bin/openshift'):
+        _, output, _ = module.run_command(['/usr/bin/openshift', 'version'])  # noqa: F405
+        version = parse_openshift_version(output)
+    else:
+        version = get_container_openshift_version(deployment_type)
+
+    return chomp_commit_offset(version)
+
+
+def run_module():
+    '''Run this module'''
+    module_args = dict(
+        deployment_type=dict(type='str', required=True)
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    # First, create our dest dir if necessary
+    deployment_type = module.params['deployment_type']
+    changed = False
+    ansible_facts = {}
+
+    current_version = get_openshift_version(module, deployment_type)
+    if current_version is not None:
+        ansible_facts = {'openshift_current_version': current_version}
+
+    # Passing back ansible_facts will set_fact the values.
+    result = {'changed': changed, 'ansible_facts': ansible_facts}
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/openshift_examples/defaults/main.yml
+++ b/roles/openshift_examples/defaults/main.yml
@@ -6,7 +6,7 @@ openshift_examples_load_db_templates: true
 openshift_examples_load_xpaas: "{{ openshift_deployment_type != 'origin' }}"
 openshift_examples_load_quickstarts: true
 
-content_version: "{{ openshift.common.examples_content_version }}"
+content_version: "{{ openshift_examples_content_version }}"
 
 examples_base: "{{ openshift.common.config_base if openshift_is_containerized | bool else '/usr/share/openshift' }}/examples"
 image_streams_base: "{{ examples_base }}/image-streams"

--- a/roles/openshift_hosted/tasks/storage/glusterfs_endpoints.yml
+++ b/roles/openshift_hosted/tasks/storage/glusterfs_endpoints.yml
@@ -7,12 +7,12 @@
 
 - name: Generate GlusterFS registry endpoints
   template:
-    src: "{{ openshift.common.examples_content_version }}/glusterfs-registry-endpoints.yml.j2"
+    src: "{{ openshift_examples_content_version }}/glusterfs-registry-endpoints.yml.j2"
     dest: "{{ mktempHosted.stdout }}/glusterfs-registry-endpoints.yml"
 
 - name: Generate GlusterFS registry service
   template:
-    src: "{{ openshift.common.examples_content_version }}/glusterfs-registry-service.yml.j2"
+    src: "{{ openshift_examples_content_version }}/glusterfs-registry-service.yml.j2"
     dest: "{{ mktempHosted.stdout }}/glusterfs-registry-service.yml"
 
 - name: Create GlusterFS registry service and endpoint

--- a/roles/openshift_hosted_templates/defaults/main.yml
+++ b/roles/openshift_hosted_templates/defaults/main.yml
@@ -2,7 +2,7 @@
 hosted_base: "{{ openshift.common.config_base if openshift_is_containerized | bool else '/usr/share/openshift' }}/hosted"
 hosted_deployment_type: "{{ 'origin' if openshift_deployment_type == 'origin' else 'enterprise' }}"
 
-content_version: "{{ openshift.common.examples_content_version }}"
+content_version: "{{ openshift_examples_content_version }}"
 
 registry_url: ""
 registry_host: "{{ registry_url.split('/')[0] if '.' in registry_url.split('/')[0] else '' }}"

--- a/roles/openshift_logging/tasks/delete_logging.yaml
+++ b/roles/openshift_logging/tasks/delete_logging.yaml
@@ -142,4 +142,4 @@
         value: ""
   when:
     - openshift_web_console_install | default(true) | bool
-    - openshift.common.version_gte_3_9
+    - openshift_version_gte_3_9

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -343,7 +343,7 @@
 
 
 - include_tasks: update_master_config.yaml
-  when: not openshift.common.version_gte_3_9
+  when: not openshift_version_gte_3_9
 
 # Update asset config in openshift-web-console namespace
 - name: Add Kibana route information to web console asset config
@@ -356,4 +356,4 @@
       value: "https://{{ openshift_logging_kibana_hostname }}"
   when:
   - openshift_web_console_install | default(true) | bool
-  - openshift.common.version_gte_3_9
+  - openshift_version_gte_3_9

--- a/roles/openshift_master/tasks/push_via_dns.yml
+++ b/roles/openshift_master/tasks/push_via_dns.yml
@@ -10,4 +10,4 @@
     register: l_already_set
 
   - set_fact:
-      openshift_push_via_dns: "{{ openshift.common.version_gte_3_6 or (l_already_set.stdout is defined and l_already_set.stdout is match('OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000')) }}"
+      openshift_push_via_dns: True

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -5,7 +5,7 @@ admissionConfig:
 apiLevels:
 - v1
 apiVersion: v1
-{% if not openshift.common.version_gte_3_9 %}
+{% if not openshift_version_gte_3_9 %}
 assetConfig:
   logoutURL: "{{ openshift.master.logout_url | default('') }}"
   masterPublicURL: {{ openshift.master.public_api_url }}
@@ -100,7 +100,7 @@ kubeletClientInfo:
 {% if openshift.master.embedded_kube | bool %}
 kubernetesMasterConfig:
   apiServerArguments: {{ openshift.master.api_server_args | default(None) | lib_utils_to_padded_yaml( level=2 ) }}
-{% if r_openshift_master_etcd3_storage or ( r_openshift_master_clean_install and openshift.common.version_gte_3_6 ) %}
+{% if r_openshift_master_etcd3_storage or r_openshift_master_clean_install %}
     storage-backend:
     - etcd3
     storage-media-type:
@@ -137,7 +137,7 @@ masterPublicURL: {{ openshift.master.public_api_url }}
 networkConfig:
   clusterNetworkCIDR: {{ openshift.master.sdn_cluster_network_cidr }}
   hostSubnetLength: {{ openshift.master.sdn_host_subnet_length }}
-{% if openshift.common.version_gte_3_7 | bool %}
+{% if openshift_version_gte_3_7 | bool %}
   clusterNetworks:
   - cidr: {{ openshift.master.sdn_cluster_network_cidr }}
     hostSubnetLength: {{ openshift.master.sdn_host_subnet_length }}

--- a/roles/openshift_metrics/tasks/install_metrics.yaml
+++ b/roles/openshift_metrics/tasks/install_metrics.yaml
@@ -68,7 +68,7 @@
   when: openshift_metrics_install_hawkular_agent | bool
 
 - include_tasks: update_master_config.yaml
-  when: not openshift.common.version_gte_3_9
+  when: not openshift_version_gte_3_9
 
 # Update asset config in openshift-web-console namespace
 - name: Add metrics route information to web console asset config
@@ -81,7 +81,7 @@
         value: "https://{{ openshift_metrics_hawkular_hostname}}/hawkular/metrics"
   when:
     - openshift_web_console_install | default(true) | bool
-    - openshift.common.version_gte_3_9
+    - openshift_version_gte_3_9
 
 - command: >
     {{openshift_client_binary}}

--- a/roles/openshift_metrics/tasks/uninstall_metrics.yaml
+++ b/roles/openshift_metrics/tasks/uninstall_metrics.yaml
@@ -30,4 +30,4 @@
         value: ""
   when:
     - openshift_web_console_install | default(true) | bool
-    - openshift.common.version_gte_3_9
+    - openshift_version_gte_3_9

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -1,9 +1,7 @@
 allowDisabledDocker: false
 apiVersion: v1
-{% if openshift.common.version_gte_3_6 %}
 dnsBindAddress: 127.0.0.1:53
 dnsRecursiveResolvConf: /etc/origin/node/resolv.conf
-{% endif %}
 dnsDomain: {{ openshift.common.dns_domain }}
 dnsIP: {{ openshift_dns_ip }}
 dockerConfig:

--- a/roles/openshift_storage_glusterfs/tasks/gluster_s3_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/gluster_s3_deploy.yml
@@ -26,7 +26,7 @@
 
 - name: Copy gluster-s3 PVCs template file
   copy:
-    src: "{{ openshift.common.examples_content_version }}/{{ item }}"
+    src: "{{ openshift_examples_content_version }}/{{ item }}"
     dest: "{{ mktemp.stdout }}/{{ item }}"
   with_items:
   - "gluster-s3-pvcs-template.yml"
@@ -69,7 +69,7 @@
 
 - name: Copy gluster-s3 template file
   copy:
-    src: "{{ openshift.common.examples_content_version }}/{{ item }}"
+    src: "{{ openshift_examples_content_version }}/{{ item }}"
     dest: "{{ mktemp.stdout }}/{{ item }}"
   with_items:
   - "gluster-s3-template.yml"

--- a/roles/openshift_storage_glusterfs/tasks/glusterblock_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterblock_deploy.yml
@@ -26,7 +26,7 @@
 
 - name: Copy initial glusterblock provisioner resource file
   copy:
-    src: "{{ openshift.common.examples_content_version }}/{{ item }}"
+    src: "{{ openshift_examples_content_version }}/{{ item }}"
     dest: "{{ mktemp.stdout }}/{{ item }}"
   with_items:
   - "glusterblock-provisioner.yml"

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
@@ -148,14 +148,14 @@
 
 - name: Generate topology file
   template:
-    src: "{{ openshift.common.examples_content_version }}/topology.json.j2"
+    src: "{{ openshift_examples_content_version }}/topology.json.j2"
     dest: "{{ mktemp.stdout }}/topology.json"
   when:
   - glusterfs_heketi_topology_load
 
 - name: Generate heketi config file
   template:
-    src: "{{ openshift.common.examples_content_version }}/heketi.json.j2"
+    src: "{{ openshift_examples_content_version }}/heketi.json.j2"
     dest: "{{ mktemp.stdout }}/heketi.json"
   when:
   - glusterfs_heketi_is_native
@@ -299,7 +299,7 @@
 
   - name: Generate GlusterFS StorageClass file
     template:
-      src: "{{ openshift.common.examples_content_version }}/glusterfs-storageclass.yml.j2"
+      src: "{{ openshift_examples_content_version }}/glusterfs-storageclass.yml.j2"
       dest: "{{ mktemp.stdout }}/glusterfs-storageclass.yml"
 
   - name: Create GlusterFS StorageClass
@@ -351,7 +351,7 @@
 
   - name: Generate Gluster Block StorageClass file
     template:
-      src: "{{ openshift.common.examples_content_version }}/gluster-block-storageclass.yml.j2"
+      src: "{{ openshift_examples_content_version }}/gluster-block-storageclass.yml.j2"
       dest: "{{ mktemp.stdout }}/gluster-block-storageclass.yml"
 
   - name: Create Gluster Block StorageClass

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
@@ -65,7 +65,7 @@
 
 - name: Copy GlusterFS DaemonSet template
   copy:
-    src: "{{ openshift.common.examples_content_version }}/glusterfs-template.yml"
+    src: "{{ openshift_examples_content_version }}/glusterfs-template.yml"
     dest: "{{ mktemp.stdout }}/glusterfs-template.yml"
 
 - name: Create GlusterFS template

--- a/roles/openshift_storage_glusterfs/tasks/heketi_deploy_part1.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_deploy_part1.yml
@@ -1,7 +1,7 @@
 ---
 - name: Copy initial heketi resource files
   copy:
-    src: "{{ openshift.common.examples_content_version }}/{{ item }}"
+    src: "{{ openshift_examples_content_version }}/{{ item }}"
     dest: "{{ mktemp.stdout }}/{{ item }}"
   with_items:
   - "deploy-heketi-template.yml"

--- a/roles/openshift_storage_glusterfs/tasks/heketi_deploy_part2.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_deploy_part2.yml
@@ -55,12 +55,12 @@
 
 - name: Generate heketi endpoints
   template:
-    src: "{{ openshift.common.examples_content_version }}/heketi-endpoints.yml.j2"
+    src: "{{ openshift_examples_content_version }}/heketi-endpoints.yml.j2"
     dest: "{{ mktemp.stdout }}/heketi-endpoints.yml"
 
 - name: Generate heketi service
   template:
-    src: "{{ openshift.common.examples_content_version }}/heketi-service.yml.j2"
+    src: "{{ openshift_examples_content_version }}/heketi-service.yml.j2"
     dest: "{{ mktemp.stdout }}/heketi-service.yml"
 
 - name: Create heketi endpoints
@@ -83,7 +83,7 @@
 
 - name: Copy heketi template
   copy:
-    src: "{{ openshift.common.examples_content_version }}/heketi-template.yml"
+    src: "{{ openshift_examples_content_version }}/heketi-template.yml"
     dest: "{{ mktemp.stdout }}/heketi-template.yml"
 
 - name: Create heketi template

--- a/roles/openshift_version/tasks/first_master.yml
+++ b/roles/openshift_version/tasks/first_master.yml
@@ -3,11 +3,11 @@
 
 # Protect the installed version by default unless explicitly told not to, or given an
 # openshift_version already.
-- name: Use openshift.common.version fact as version to configure if already installed
+- name: Use openshift_current_version fact as version to configure if already installed
   set_fact:
-    openshift_version: "{{ openshift.common.version }}"
+    openshift_version: "{{ openshift_current_version }}"
   when:
-  - openshift.common.version is defined
+  - openshift_current_version is defined
   - openshift_version is not defined or openshift_version == ""
   - openshift_protect_installed_version | bool
 


### PR DESCRIPTION
openshift.common.version is used for detecting the currently
installed version.

This commit removes the version logic from openshift_facts
into it's own module and action plugins.

This should provide a marginal performance improvement due
to the fact that openshift_facts is run multiple times.