### PR TITLE
Remove openshift.common.config_base

### DIFF
--- a/DEPLOYMENT_TYPES.md
+++ b/DEPLOYMENT_TYPES.md
@@ -11,7 +11,6 @@ The table below outlines the defaults per `openshift_deployment_type`:
 | openshift_deployment_type                                       | origin                                   | openshift-enterprise                   |
 |-----------------------------------------------------------------|------------------------------------------|----------------------------------------|
 | **openshift_service_type** (also used for package names)        | origin                                   | atomic-openshift                       |
-| **openshift.common.config_base**                                | /etc/origin                              | /etc/origin                            |
 | **openshift_data_dir**                                          | /var/lib/origin                          | /var/lib/origin                        |
 | **openshift.master.registry_url oreg_url_node**                 | openshift/origin-${component}:${version} | openshift3/ose-${component}:${version} |
 | **Image Streams**                                               | centos                                   | rhel                                   |

--- a/inventory/hosts.openstack
+++ b/inventory/hosts.openstack
@@ -19,7 +19,7 @@ openshift_deployment_type=openshift-enterprise
 
 openshift_additional_repos=[{'id': 'ose-3.1', 'name': 'ose-3.1', 'baseurl': 'http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ose/3.1/os', 'enabled': 1, 'gpgcheck': 0}]
 
-openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '{{ openshift.common.config_base }}/htpasswd'}]
+openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/htpasswd'}]
 
 #openshift_pkg_version=-3.0.0.0
 

--- a/playbooks/common/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -72,7 +72,7 @@
   - name: Drain Node for Kubelet upgrade
     command: >
       {{ hostvars[groups.oo_first_master.0]['first_master_client_binary'] }} adm drain {{ openshift.node.nodename | lower }}
-      --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      --config=/etc/origin/master/admin.kubeconfig
       --force --delete-local-data --ignore-daemonsets
       --timeout={{ openshift_upgrade_nodes_drain_timeout | default(0) }}s
     delegate_to: "{{ groups.oo_first_master.0 }}"

--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -148,7 +148,7 @@
   post_tasks:
   # Check if any masters are using pluginOrderOverride and warn if so, only for 1.3/3.3 and beyond:
   - name: grep pluginOrderOverride
-    command: grep pluginOrderOverride {{ openshift.common.config_base }}/master/master-config.yaml
+    command: grep pluginOrderOverride /etc/origin/master/master-config.yaml
     register: grep_plugin_order_override
     changed_when: false
     failed_when: false

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -34,7 +34,7 @@
   - name: Drain Node for Kubelet upgrade
     command: >
       {{ hostvars[groups.oo_first_master.0]['first_master_client_binary'] }} adm drain {{ openshift.node.nodename | lower }}
-      --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      --config=/etc/origin/master/admin.kubeconfig
       --force --delete-local-data --ignore-daemonsets
       --timeout={{ openshift_upgrade_nodes_drain_timeout | default(0) }}s
     delegate_to: "{{ groups.oo_first_master.0 }}"

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_scale_group.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_scale_group.yml
@@ -44,7 +44,7 @@
   - name: Drain Node for Kubelet upgrade
     command: >
       {{ hostvars[groups.oo_first_master.0]['first_master_client_binary'] }} adm drain {{ openshift.node.nodename | lower }}
-      --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      --config=/etc/origin/master/admin.kubeconfig
       --force --delete-local-data --ignore-daemonsets
       --timeout={{ openshift_upgrade_nodes_drain_timeout | default(0) }}s
     delegate_to: "{{ groups.oo_first_master.0 }}"

--- a/playbooks/gcp/openshift-cluster/install.yml
+++ b/playbooks/gcp/openshift-cluster/install.yml
@@ -28,6 +28,6 @@
   tasks:
   - name: Retrieve cluster configuration
     fetch:
-      src: "{{ openshift.common.config_base }}/master/admin.kubeconfig"
+      src: "/etc/origin/master/admin.kubeconfig"
       dest: "/tmp/"
       flat: yes

--- a/playbooks/openshift-etcd/private/master_etcd_certificates.yml
+++ b/playbooks/openshift-etcd/private/master_etcd_certificates.yml
@@ -6,6 +6,6 @@
     - role: openshift_etcd_facts
     - role: openshift_etcd_client_certificates
       etcd_cert_subdir: "openshift-master-{{ openshift.common.hostname }}"
-      etcd_cert_config_dir: "{{ openshift.common.config_base }}/master"
+      etcd_cert_config_dir: "/etc/origin/master"
       etcd_cert_prefix: "master.etcd-"
       when: groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config

--- a/playbooks/openshift-etcd/private/redeploy-ca.yml
+++ b/playbooks/openshift-etcd/private/redeploy-ca.yml
@@ -70,7 +70,7 @@
   - name: Deploy etcd CA
     copy:
       src: "{{ hostvars['localhost'].g_etcd_mktemp.stdout }}/ca.crt"
-      dest: "{{ openshift.common.config_base }}/master/master.etcd-ca.crt"
+      dest: "/etc/origin/master/master.etcd-ca.crt"
     when: groups.oo_etcd_to_config | default([]) | length > 0
 
 - name: Delete temporary directory on localhost
@@ -90,11 +90,11 @@
   - ('expired' not in hostvars
       | lib_utils_oo_select_keys(groups['oo_masters_to_config'])
       | lib_utils_oo_collect('check_results.check_results.ocp_certs')
-      | lib_utils_oo_collect('health', {'path':hostvars[groups.oo_first_master.0].openshift.common.config_base ~ "/master/master.server.crt"}))
+      | lib_utils_oo_collect('health', {'path':"/etc/origin/master/master.server.crt"}))
   - ('expired' not in hostvars
       | lib_utils_oo_select_keys(groups['oo_masters_to_config'])
       | lib_utils_oo_collect('check_results.check_results.ocp_certs')
-      | lib_utils_oo_collect('health', {'path':hostvars[groups.oo_first_master.0].openshift.common.config_base ~ "/master/ca-bundle.crt"}))
+      | lib_utils_oo_collect('health', {'path':"/etc/origin/master/ca-bundle.crt"}))
   # etcd
   - ('expired' not in (hostvars
       | lib_utils_oo_select_keys(groups['etcd'])

--- a/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml
@@ -12,7 +12,7 @@
 
   - name: Copy admin client config(s)
     command: >
-      cp {{ openshift.common.config_base }}/master//admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
+      cp /etc/origin/master//admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
     changed_when: false
 
   - name: Determine if docker-registry exists
@@ -63,13 +63,13 @@
     - name: Generate registry certificate
       command: >
         {{ openshift_client_binary }} adm ca create-server-cert
-        --signer-cert={{ openshift.common.config_base }}/master/ca.crt
-        --signer-key={{ openshift.common.config_base }}/master/ca.key
-        --signer-serial={{ openshift.common.config_base }}/master/ca.serial.txt
+        --signer-cert=/etc/origin/master/ca.crt
+        --signer-key=/etc/origin/master/ca.key
+        --signer-serial=/etc/origin/master/ca.serial.txt
         --config={{ mktemp.stdout }}/admin.kubeconfig
         --hostnames="{{ docker_registry_service_ip.results.clusterip }},docker-registry.default.svc,docker-registry.default.svc.cluster.local,{{ docker_registry_route_hostname }}"
-        --cert={{ openshift.common.config_base }}/master/registry.crt
-        --key={{ openshift.common.config_base }}/master/registry.key
+        --cert=/etc/origin/master/registry.crt
+        --key=/etc/origin/master/registry.key
         --expire-days={{ openshift_hosted_registry_cert_expire_days | default(730) }}
 
     - name: Update registry certificates secret
@@ -80,9 +80,9 @@
         state: present
         files:
         - name: registry.crt
-          path: "{{ openshift.common.config_base }}/master/registry.crt"
+          path: "/etc/origin/master/registry.crt"
         - name: registry.key
-          path: "{{ openshift.common.config_base }}/master/registry.key"
+          path: "/etc/origin/master/registry.key"
       run_once: true
     when: l_docker_registry_dc.rc == 0 and 'registry-certificates' in docker_registry_secrets and 'REGISTRY_HTTP_TLS_CERTIFICATE' in docker_registry_env_vars and 'REGISTRY_HTTP_TLS_KEY' in docker_registry_env_vars
 

--- a/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
@@ -12,7 +12,7 @@
 
   - name: Copy admin client config(s)
     command: >
-      cp {{ openshift.common.config_base }}/master//admin.kubeconfig {{ router_cert_redeploy_tempdir.stdout }}/admin.kubeconfig
+      cp /etc/origin/master//admin.kubeconfig {{ router_cert_redeploy_tempdir.stdout }}/admin.kubeconfig
     changed_when: false
 
   - name: Determine if router exists

--- a/playbooks/openshift-master/private/certificates-backup.yml
+++ b/playbooks/openshift-master/private/certificates-backup.yml
@@ -7,13 +7,13 @@
     openshift_master_count: "{{ openshift.master.master_count | default(groups.oo_masters | length) }}"
   pre_tasks:
   - stat:
-      path: "{{ openshift.common.config_base }}/generated-configs"
+      path: "/etc/origin/generated-configs"
     register: openshift_generated_configs_dir_stat
   - name: Backup generated certificate and config directories
     command: >
       tar -czvf /etc/origin/master-node-cert-config-backup-{{ ansible_date_time.epoch }}.tgz
-      {{ openshift.common.config_base }}/generated-configs
-      {{ openshift.common.config_base }}/master
+      /etc/origin/generated-configs
+      /etc/origin/master
     when: openshift_generated_configs_dir_stat.stat.exists
     delegate_to: "{{ openshift_ca_host }}"
     run_once: true
@@ -22,10 +22,10 @@
       path: "{{ item }}"
       state: absent
     with_items:
-    - "{{ openshift.common.config_base }}/generated-configs"
+    - "/etc/origin/generated-configs"
   - name: Remove generated certificates
     file:
-      path: "{{ openshift.common.config_base }}/master/{{ item }}"
+      path: "/etc/origin/master/{{ item }}"
       state: absent
     with_items:
     # certificates_to_synchronize is a custom filter in lib_utils

--- a/playbooks/openshift-master/private/create_service_signer_cert.yml
+++ b/playbooks/openshift-master/private/create_service_signer_cert.yml
@@ -62,7 +62,7 @@
   - name: Deploy service signer certificate
     copy:
       src: "{{ hostvars.localhost.local_cert_sync_tmpdir.stdout }}/{{ item }}"
-      dest: "{{ openshift.common.config_base }}/master/"
+      dest: "/etc/origin/master/"
     with_items:
     - "service-signer.crt"
     - "service-signer.key"

--- a/playbooks/openshift-master/private/redeploy-openshift-ca.yml
+++ b/playbooks/openshift-master/private/redeploy-openshift-ca.yml
@@ -17,39 +17,39 @@
   hosts: oo_masters_to_config
   tasks:
   - slurp:
-      src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      src: "/etc/origin/master/master-config.yaml"
     register: g_master_config_output
   - modify_yaml:
-      dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      dest: "/etc/origin/master/master-config.yaml"
       yaml_key: kubeletClientInfo.ca
       yaml_value: ca-bundle.crt
     when: (g_master_config_output.content|b64decode|from_yaml).kubeletClientInfo.ca != 'ca-bundle.crt'
   - modify_yaml:
-      dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      dest: "/etc/origin/master/master-config.yaml"
       yaml_key: serviceAccountConfig.masterCA
       yaml_value: ca-bundle.crt
     when: (g_master_config_output.content|b64decode|from_yaml).serviceAccountConfig.masterCA != 'ca-bundle.crt'
   - modify_yaml:
-      dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      dest: "/etc/origin/master/master-config.yaml"
       yaml_key: oauthConfig.masterCA
       yaml_value: ca-bundle.crt
     when: (g_master_config_output.content|b64decode|from_yaml).oauthConfig.masterCA != 'ca-bundle.crt'
   - modify_yaml:
-      dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      dest: "/etc/origin/master/master-config.yaml"
       yaml_key: etcdClientInfo.ca
       yaml_value: ca-bundle.crt
     when:
     - groups.oo_etcd_to_config | default([]) | length == 0
     - (g_master_config_output.content|b64decode|from_yaml).etcdClientInfo.ca != 'ca-bundle.crt'
   - modify_yaml:
-      dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      dest: "/etc/origin/master/master-config.yaml"
       yaml_key: etcdConfig.peerServingInfo.clientCA
       yaml_value: ca-bundle.crt
     when:
     - groups.oo_etcd_to_config | default([]) | length == 0
     - (g_master_config_output.content|b64decode|from_yaml).etcdConfig.peerServingInfo.clientCA != 'ca-bundle.crt'
   - modify_yaml:
-      dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      dest: "/etc/origin/master/master-config.yaml"
       yaml_key: etcdConfig.servingInfo.clientCA
       yaml_value: ca-bundle.crt
     when:
@@ -58,7 +58,7 @@
   # Set servingInfo.clientCA to client-ca-bundle.crt in order to roll the CA certificate.
   # This change will be reverted in playbooks/redeploy-certificates.yml
   - modify_yaml:
-      dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      dest: "/etc/origin/master/master-config.yaml"
       yaml_key: servingInfo.clientCA
       yaml_value: client-ca-bundle.crt
     when: (g_master_config_output.content|b64decode|from_yaml).servingInfo.clientCA != 'client-ca-bundle.crt'
@@ -68,7 +68,7 @@
   pre_tasks:
   - name: Create legacy-ca directory
     file:
-      path: "{{ openshift.common.config_base }}/master/legacy-ca"
+      path: "/etc/origin/master/legacy-ca"
       state: directory
       mode: 0700
       owner: root
@@ -87,8 +87,8 @@
   # - openshift_node_certificates
   - name: Copy current OpenShift CA to legacy directory
     copy:
-      src: "{{ openshift.common.config_base }}/master/{{ item }}"
-      dest: "{{ openshift.common.config_base }}/master/legacy-ca/{{ g_legacy_ca_mktemp.stdout }}-{{ item }}"
+      src: "/etc/origin/master/{{ item }}"
+      dest: "/etc/origin/master/legacy-ca/{{ g_legacy_ca_mktemp.stdout }}-{{ item }}"
       remote_src: true
     # It is possible that redeploying failed and files may be missing.
     # Ignore errors in this case. Files should have been copied to
@@ -166,7 +166,7 @@
   - name: Deploy CA certificate, key, bundle and serial
     copy:
       src: "{{ hostvars['localhost'].g_master_mktemp.stdout }}/{{ item }}"
-      dest: "{{ openshift.common.config_base }}/master/"
+      dest: "/etc/origin/master/"
     with_items:
     - ca.crt
     - ca.key
@@ -175,12 +175,12 @@
     - client-ca-bundle.crt
   - name: Update master client kubeconfig CA data
     kubeclient_ca:
-      client_path: "{{ openshift.common.config_base }}/master/openshift-master.kubeconfig"
-      ca_path: "{{ openshift.common.config_base }}/master/ca-bundle.crt"
+      client_path: "/etc/origin/master/openshift-master.kubeconfig"
+      ca_path: "/etc/origin/master/ca-bundle.crt"
   - name: Update admin client kubeconfig CA data
     kubeclient_ca:
-      client_path: "{{ openshift.common.config_base }}/master/admin.kubeconfig"
-      ca_path: "{{ openshift.common.config_base }}/master/ca-bundle.crt"
+      client_path: "/etc/origin/master/admin.kubeconfig"
+      ca_path: "/etc/origin/master/ca-bundle.crt"
   - name: Lookup default group for ansible_ssh_user
     command: "/usr/bin/id -g {{ ansible_ssh_user | quote }}"
     changed_when: false
@@ -197,7 +197,7 @@
     with_items: "{{ client_users }}"
   - name: Copy the admin client config(s)
     copy:
-      src: "{{ openshift.common.config_base }}/master/admin.kubeconfig"
+      src: "/etc/origin/master/admin.kubeconfig"
       dest: "~{{ item }}/.kube/config"
       remote_src: yes
     with_items: "{{ client_users }}"
@@ -217,11 +217,11 @@
   - ('expired' not in hostvars
       | lib_utils_oo_select_keys(groups['oo_masters_to_config'])
       | lib_utils_oo_collect('check_results.check_results.ocp_certs')
-      | lib_utils_oo_collect('health', {'path':hostvars[groups.oo_first_master.0].openshift.common.config_base ~ "/master/master.server.crt"}))
+      | lib_utils_oo_collect('health', {'path':"/etc/origin/master/master.server.crt"}))
   - ('expired' not in hostvars
       | lib_utils_oo_select_keys(groups['oo_masters_to_config'])
       | lib_utils_oo_collect('check_results.check_results.ocp_certs')
-      | lib_utils_oo_collect('health', {'path':hostvars[groups.oo_first_master.0].openshift.common.config_base ~ "/master/ca-bundle.crt"}))
+      | lib_utils_oo_collect('health', {'path':"/etc/origin/master/ca-bundle.crt"}))
   # etcd
   - ('expired' not in (hostvars
       | lib_utils_oo_select_keys(groups['etcd'])
@@ -235,7 +235,7 @@
   tasks:
   - copy:
       src: "{{ hostvars['localhost'].g_master_mktemp.stdout }}/ca-bundle.crt"
-      dest: "{{ openshift.common.config_base }}/node/ca.crt"
+      dest: "/etc/origin/node/ca.crt"
   - name: Copy OpenShift CA to system CA trust
     copy:
       src: "{{ item.cert }}"
@@ -243,13 +243,13 @@
       remote_src: yes
     with_items:
     - id: openshift
-      cert: "{{ openshift.common.config_base }}/node/ca.crt"
+      cert: "/etc/origin/node/ca.crt"
     notify:
     - update ca trust
   - name: Update node client kubeconfig CA data
     kubeclient_ca:
-      client_path: "{{ openshift.common.config_base }}/node/system:node:{{ openshift.common.hostname }}.kubeconfig"
-      ca_path: "{{ openshift.common.config_base }}/node/ca.crt"
+      client_path: "/etc/origin/node/system:node:{{ openshift.common.hostname }}.kubeconfig"
+      ca_path: "/etc/origin/node/ca.crt"
   handlers:
   # Normally this handler would restart docker after updating ca
   # trust. We'll do that when we restart nodes to avoid restarting
@@ -281,20 +281,20 @@
   - ('expired' not in hostvars
       | lib_utils_oo_select_keys(groups['oo_nodes_to_config'])
       | lib_utils_oo_collect('check_results.check_results.ocp_certs')
-      | lib_utils_oo_collect('health', {'path':hostvars[groups.oo_nodes_to_config.0].openshift.common.config_base ~ "/node/server.crt"}))
+      | lib_utils_oo_collect('health', {'path':"/etc/origin/node/server.crt"}))
   - ('expired' not in hostvars
       | lib_utils_oo_select_keys(groups['oo_nodes_to_config'])
       | lib_utils_oo_collect('check_results.check_results.ocp_certs')
-      | lib_utils_oo_collect('health', {'path':hostvars[groups.oo_nodes_to_config.0].openshift.common.config_base ~ "/node/ca.crt"}))
+      | lib_utils_oo_collect('health', {'path':"/etc/origin/node/ca.crt"}))
   # masters
   - ('expired' not in hostvars
       | lib_utils_oo_select_keys(groups['oo_masters_to_config'])
       | lib_utils_oo_collect('check_results.check_results.ocp_certs')
-      | lib_utils_oo_collect('health', {'path':hostvars[groups.oo_first_master.0].openshift.common.config_base ~ "/master/master.server.crt"}))
+      | lib_utils_oo_collect('health', {'path':"/etc/origin/master/master.server.crt"}))
   - ('expired' not in hostvars
       | lib_utils_oo_select_keys(groups['oo_masters_to_config'])
       | lib_utils_oo_collect('check_results.check_results.ocp_certs')
-      | lib_utils_oo_collect('health', {'path':hostvars[groups.oo_first_master.0].openshift.common.config_base ~ "/master/ca-bundle.crt"}))
+      | lib_utils_oo_collect('health', {'path':"/etc/origin/master/ca-bundle.crt"}))
   # etcd
   - ('expired' not in (hostvars
       | lib_utils_oo_select_keys(groups['etcd'])

--- a/playbooks/openshift-master/private/revert-client-ca.yml
+++ b/playbooks/openshift-master/private/revert-client-ca.yml
@@ -4,14 +4,14 @@
   tasks:
   - name: Read master config
     slurp:
-      src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      src: "/etc/origin/master/master-config.yaml"
     register: g_master_config_output
 
   # servingInfo.clientCA may be set as the client-ca-bundle.crt from
   # CA redeployment and this task reverts that change.
   - name: Set servingInfo.clientCA = ca.crt in master config
     modify_yaml:
-      dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      dest: "/etc/origin/master/master-config.yaml"
       yaml_key: servingInfo.clientCA
       yaml_value: ca.crt
     when: (g_master_config_output.content|b64decode|from_yaml).servingInfo.clientCA != 'ca.crt'

--- a/playbooks/openshift-master/private/scaleup.yml
+++ b/playbooks/openshift-master/private/scaleup.yml
@@ -11,7 +11,7 @@
         master_count: "{{ openshift_master_count | default(groups.oo_masters | length) }}"
   - name: Update master count
     modify_yaml:
-      dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+      dest: "/etc/origin/master/master-config.yaml"
       yaml_key: 'kubernetesMasterConfig.masterCount'
       yaml_value: "{{ openshift.master.master_count }}"
     notify:
@@ -31,7 +31,7 @@
   - name: verify api server
     command: >
       curl --silent --tlsv1.2
-      --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+      --cacert /etc/origin/master/ca-bundle.crt
       {{ openshift.master.api_url }}/healthz/ready
     args:
       # Disables the following warning:

--- a/playbooks/openshift-master/private/set_network_facts.yml
+++ b/playbooks/openshift-master/private/set_network_facts.yml
@@ -4,10 +4,10 @@
   gather_facts: no
   tasks:
   - stat:
-      path: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      path: "/etc/origin/master/master-config.yaml"
     register: g_master_config_stat
   - slurp:
-      src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      src: "/etc/origin/master/master-config.yaml"
     register: g_master_config_slurp
 
 - name: Set network facts for masters

--- a/playbooks/openshift-master/private/tasks/wire_aggregator.yml
+++ b/playbooks/openshift-master/private/tasks/wire_aggregator.yml
@@ -207,7 +207,7 @@
     # wait_for port doesn't provide health information.
     command: >
       curl --silent --tlsv1.2
-      --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+      --cacert /etc/origin/master/ca-bundle.crt
       {{ openshift.master.api_url }}/healthz/ready
     args:
       # Disables the following warning:

--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -10,7 +10,7 @@
   tasks:
   - name: Determine if service signer certificate must be created
     stat:
-      path: "{{ openshift.common.config_base }}/master/service-signer.crt"
+      path: "/etc/origin/master/service-signer.crt"
     register: service_signer_cert_stat
     changed_when: false
 
@@ -25,7 +25,7 @@
   tasks:
   - name: Upgrade all storage
     command: >
-      {{ openshift_client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      {{ openshift_client_binary }} adm --config=/etc/origin/master/admin.kubeconfig
       migrate storage --include=* --confirm
     register: l_pb_upgrade_control_plane_pre_upgrade_storage
     when: openshift_upgrade_pre_storage_migration_enabled | default(true) | bool
@@ -112,7 +112,7 @@
 
   - name: Post master upgrade - Upgrade clusterpolicies storage
     command: >
-      {{ openshift_client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      {{ openshift_client_binary }} adm --config=/etc/origin/master/admin.kubeconfig
       migrate storage --include=clusterpolicies --confirm
     register: l_pb_upgrade_control_plane_post_upgrade_storage
     when:
@@ -158,7 +158,7 @@
   tasks:
   - name: Reconcile Cluster Roles
     command: >
-      {{ openshift_client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      {{ openshift_client_binary }} adm --config=/etc/origin/master/admin.kubeconfig
       policy reconcile-cluster-roles --additive-only=true --confirm -o name
     register: reconcile_cluster_role_result
     when: openshift_version is version_compare('3.7','<')
@@ -169,7 +169,7 @@
 
   - name: Reconcile Cluster Role Bindings
     command: >
-      {{ openshift_client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      {{ openshift_client_binary }} adm --config=/etc/origin/master/admin.kubeconfig
       policy reconcile-cluster-role-bindings
       --exclude-groups=system:authenticated
       --exclude-groups=system:authenticated:oauth
@@ -185,7 +185,7 @@
 
   - name: Reconcile Jenkins Pipeline Role Bindings
     command: >
-      {{ openshift_client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig policy reconcile-cluster-role-bindings system:build-strategy-jenkinspipeline --confirm -o name
+      {{ openshift_client_binary }} adm --config=/etc/origin/master/admin.kubeconfig policy reconcile-cluster-role-bindings system:build-strategy-jenkinspipeline --confirm -o name
     run_once: true
     register: reconcile_jenkins_role_binding_result
     changed_when:
@@ -239,7 +239,7 @@
 
   - name: Reconcile Security Context Constraints
     command: >
-      {{ openshift_client_binary }} adm policy --config={{ openshift.common.config_base }}/master/admin.kubeconfig reconcile-sccs --confirm --additive-only=true -o name
+      {{ openshift_client_binary }} adm policy --config=/etc/origin/master/admin.kubeconfig reconcile-sccs --confirm --additive-only=true -o name
     register: reconcile_scc_result
     changed_when:
     - reconcile_scc_result.stdout != ''
@@ -248,7 +248,7 @@
 
   - name: Migrate storage post policy reconciliation
     command: >
-      {{ openshift_client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      {{ openshift_client_binary }} adm --config=/etc/origin/master/admin.kubeconfig
       migrate storage --include=* --confirm
     run_once: true
     register: l_pb_upgrade_control_plane_post_upgrade_storage
@@ -307,7 +307,7 @@
   - name: Drain Node for Kubelet upgrade
     command: >
       {{ hostvars[groups.oo_first_master.0]['first_master_client_binary'] }} adm drain {{ openshift.node.nodename | lower }}
-      --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      --config=/etc/origin/master/admin.kubeconfig
       --force --delete-local-data --ignore-daemonsets
       --timeout={{ openshift_upgrade_nodes_drain_timeout | default(0) }}s
     delegate_to: "{{ groups.oo_first_master.0 }}"

--- a/playbooks/openshift-node/private/certificates-backup.yml
+++ b/playbooks/openshift-node/private/certificates-backup.yml
@@ -9,7 +9,7 @@
   # that it is missing here.
   - name: Ensure node directories and tarballs are absent from generated configs
     shell: >
-      rm -rf {{ openshift.common.config_base }}/generated-configs/node-*
+      rm -rf /etc/origin/generated-configs/node-*
     args:
       warn: no
 
@@ -21,4 +21,4 @@
       path: "{{ item }}"
       state: absent
     with_items:
-    - "{{ openshift.common.config_base }}/node/ca.crt"
+    - "/etc/origin/node/ca.crt"

--- a/playbooks/openshift-node/private/etcd_client_config.yml
+++ b/playbooks/openshift-node/private/etcd_client_config.yml
@@ -7,4 +7,4 @@
   - role: openshift_etcd_client_certificates
     etcd_cert_prefix: flannel.etcd-
     etcd_cert_subdir: "openshift-node-{{ openshift.common.hostname }}"
-    etcd_cert_config_dir: "{{ openshift.common.config_base }}/node"
+    etcd_cert_config_dir: "/etc/origin/node"

--- a/roles/ansible_service_broker/tasks/generate_certs.yml
+++ b/roles/ansible_service_broker/tasks/generate_certs.yml
@@ -4,30 +4,30 @@
   block:
   - name: Create ansible-service-broker cert directory
     file:
-      path: "{{ openshift.common.config_base }}/ansible-service-broker"
+      path: "/etc/origin/ansible-service-broker"
       state: directory
       mode: 0755
     check_mode: no
 
   - name: Create self signing ca cert
-    command: 'openssl req -nodes -x509 -newkey rsa:4096 -keyout {{ openshift.common.config_base }}/ansible-service-broker/key.pem -out {{ openshift.common.config_base }}/ansible-service-broker/cert.pem -days 365 -subj "/CN=asb-etcd.openshift-ansible-service-broker.svc"'
+    command: 'openssl req -nodes -x509 -newkey rsa:4096 -keyout /etc/origin/ansible-service-broker/key.pem -out /etc/origin/ansible-service-broker/cert.pem -days 365 -subj "/CN=asb-etcd.openshift-ansible-service-broker.svc"'
     args:
-      creates: '{{ openshift.common.config_base }}/ansible-service-broker/cert.pem'
+      creates: '/etc/origin/ansible-service-broker/cert.pem'
 
   - name: Create self signed client cert
     command: '{{ item.cmd }}'
     args:
       creates: '{{ item.creates }}'
     with_items:
-    - cmd: openssl genrsa -out {{ openshift.common.config_base }}/ansible-service-broker/client.key 2048
-      creates: '{{ openshift.common.config_base }}/ansible-service-broker/client.key'
-    - cmd: 'openssl req -new -key {{ openshift.common.config_base }}/ansible-service-broker/client.key -out {{ openshift.common.config_base }}/ansible-service-broker/client.csr -subj "/CN=client"'
-      creates: '{{ openshift.common.config_base }}/ansible-service-broker/client.csr'
-    - cmd: openssl x509 -req -in {{ openshift.common.config_base }}/ansible-service-broker/client.csr -CA {{ openshift.common.config_base }}/ansible-service-broker/cert.pem -CAkey {{ openshift.common.config_base }}/ansible-service-broker/key.pem -CAcreateserial -out {{ openshift.common.config_base }}/ansible-service-broker/client.pem -days 1024
-      creates: '{{ openshift.common.config_base }}/ansible-service-broker/client.pem'
+    - cmd: openssl genrsa -out /etc/origin/ansible-service-broker/client.key 2048
+      creates: '/etc/origin/ansible-service-broker/client.key'
+    - cmd: 'openssl req -new -key /etc/origin/ansible-service-broker/client.key -out /etc/origin/ansible-service-broker/client.csr -subj "/CN=client"'
+      creates: '/etc/origin/ansible-service-broker/client.csr'
+    - cmd: openssl x509 -req -in /etc/origin/ansible-service-broker/client.csr -CA /etc/origin/ansible-service-broker/cert.pem -CAkey /etc/origin/ansible-service-broker/key.pem -CAcreateserial -out /etc/origin/ansible-service-broker/client.pem -days 1024
+      creates: '/etc/origin/ansible-service-broker/client.pem'
 
   - set_fact:
-      ansible_service_broker_certs_dir: "{{ openshift.common.config_base }}/ansible-service-broker"
+      ansible_service_broker_certs_dir: "/etc/origin/ansible-service-broker"
 
 - name: Read in certs for etcd
   slurp:

--- a/roles/calico/defaults/main.yaml
+++ b/roles/calico/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-kubeconfig: "{{  openshift.common.config_base }}/node/{{ 'system:node:' +  openshift.common.hostname }}.kubeconfig"
+kubeconfig: "/etc/origin/node/{{ 'system:node:' +  openshift.common.hostname }}.kubeconfig"
 
 cni_conf_dir: "/etc/cni/net.d/"
 cni_bin_dir: "/opt/cni/bin/"

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -13,7 +13,7 @@
   when: calico_etcd_ca_cert_file is not defined or calico_etcd_cert_file is not defined or calico_etcd_key_file is not defined or calico_etcd_endpoints is not defined or calico_etcd_cert_dir is not defined
   vars:
     etcd_cert_prefix: calico.etcd-
-    etcd_cert_config_dir: "{{ openshift.common.config_base }}/calico"
+    etcd_cert_config_dir: "/etc/origin/calico"
     etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
     etcd_cert_subdir: "openshift-calico-{{ openshift.common.hostname }}"
 

--- a/roles/calico_master/defaults/main.yaml
+++ b/roles/calico_master/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-kubeconfig: "{{ openshift.common.config_base }}/master/openshift-master.kubeconfig"
+kubeconfig: "/etc/origin/master/openshift-master.kubeconfig"
 
 calicoctl_bin_dir: "/usr/local/bin/"
 

--- a/roles/calico_master/tasks/main.yml
+++ b/roles/calico_master/tasks/main.yml
@@ -21,7 +21,7 @@
   command: >
     {{ openshift_client_binary }} create
     -f {{ mktemp.stdout }}/calico-policy-controller.yml
-    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    --config=/etc/origin/master/admin.kubeconfig
   register: calico_create_output
   failed_when: "('already exists' not in calico_create_output.stderr) and ('created' not in calico_create_output.stdout) and calico_create_output.rc != 0"
   changed_when: ('created' in calico_create_output.stdout)

--- a/roles/cockpit-ui/defaults/main.yml
+++ b/roles/cockpit-ui/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-openshift_config_base: "/etc/origin"
-openshift_master_config_dir: "{{ openshift.common.config_base | default(openshift_config_base) }}/master"
+openshift_master_config_dir: "/etc/origin/master"

--- a/roles/contiv/templates/contiv.cfg.j2
+++ b/roles/contiv/templates/contiv.cfg.j2
@@ -1,7 +1,7 @@
 {
   "K8S_API_SERVER": "https://{{ hostvars[groups['masters'][0]]['ansible_' + contiv_netmaster_interface].ipv4.address }}:{{ contiv_kube_master_api_port }}",
-  "K8S_CA": "{{ openshift.common.config_base }}/node/ca.crt",
-  "K8S_KEY": "{{ openshift.common.config_base }}/node/system:node:{{ openshift.common.hostname }}.key",
-  "K8S_CERT": "{{ openshift.common.config_base }}/node/system:node:{{ openshift.common.hostname }}.crt",
+  "K8S_CA": "/etc/origin/node/ca.crt",
+  "K8S_KEY": "/etc/origin/node/system:node:{{ openshift.common.hostname }}.key",
+  "K8S_CERT": "/etc/origin/node/system:node:{{ openshift.common.hostname }}.crt",
   "SVC_SUBNET": "172.30.0.0/16"
 }

--- a/roles/contiv/templates/contiv.cfg.master.j2
+++ b/roles/contiv/templates/contiv.cfg.master.j2
@@ -1,7 +1,7 @@
 {
   "K8S_API_SERVER": "https://{{ hostvars[groups['masters'][0]]['ansible_' + contiv_netmaster_interface].ipv4.address }}:{{ contiv_kube_master_api_port }}",
-  "K8S_CA": "{{ openshift.common.config_base }}/master/ca.crt",
-  "K8S_KEY": "{{ openshift.common.config_base }}/master/system:node:{{ openshift.common.hostname }}.key",
-  "K8S_CERT": "{{ openshift.common.config_base }}/master/system:node:{{ openshift.common.hostname }}.crt",
+  "K8S_CA": "/etc/origin/master/ca.crt",
+  "K8S_KEY": "/etc/origin/master/system:node:{{ openshift.common.hostname }}.key",
+  "K8S_CERT": "/etc/origin/master/system:node:{{ openshift.common.hostname }}.crt",
   "SVC_SUBNET": "172.30.0.0/16"
 }

--- a/roles/etcd/tasks/migration/add_ttls.yml
+++ b/roles/etcd/tasks/migration/add_ttls.yml
@@ -1,7 +1,7 @@
 ---
 # To be executed on first master
 - slurp:
-    src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+    src: "/etc/origin/master/master-config.yaml"
   register: g_master_config_output
 
 - set_fact:

--- a/roles/flannel/README.md
+++ b/roles/flannel/README.md
@@ -19,7 +19,7 @@ Role Variables
 | flannel_interface    | ansible_default_ipv4.interface          | interface to use for inter-host communication |
 | flannel_etcd_key     | /openshift.com/network                  | etcd prefix                                   |
 | etcd_hosts           | etcd_urls                               | a list of etcd endpoints                      |
-| etcd_cert_config_dir | {{ openshift.common.config_base }}/node | SSL certificates directory                    |
+| etcd_cert_config_dir | /etc/origin/node | SSL certificates directory                    |
 | etcd_peer_ca_file    | {{ etcd_conf_dir }}/ca.crt              | SSL CA to use for etcd                        |
 | etcd_peer_cert_file  | Openshift SSL cert                      | SSL cert to use for etcd                      |
 | etcd_peer_key_file   | Openshift SSL key                       | SSL key to use for etcd                       |

--- a/roles/flannel/defaults/main.yaml
+++ b/roles/flannel/defaults/main.yaml
@@ -2,8 +2,8 @@
 flannel_interface: "{{ ansible_default_ipv4.interface }}"
 flannel_etcd_key: /openshift.com/network
 etcd_hosts: "{{ etcd_urls }}"
-etcd_peer_ca_file: "{{ openshift.common.config_base }}/node/flannel.etcd-ca.crt"
-etcd_peer_cert_file: "{{ openshift.common.config_base }}/node/flannel.etcd-client.crt"
-etcd_peer_key_file: "{{ openshift.common.config_base }}/node/flannel.etcd-client.key"
+etcd_peer_ca_file: "/etc/origin/node/flannel.etcd-ca.crt"
+etcd_peer_cert_file: "/etc/origin/node/flannel.etcd-client.crt"
+etcd_peer_key_file: "/etc/origin/node/flannel.etcd-client.key"
 
 openshift_docker_service_name: "{{ 'container-engine' if (openshift_docker_use_system_container | default(False) | bool) else 'docker' }}"

--- a/roles/flannel_register/README.md
+++ b/roles/flannel_register/README.md
@@ -19,7 +19,7 @@ Role Variables
 | flannel_subnet_len  | 24                                                 | size of the subnet allocated to each host       |
 | flannel_etcd_key    | /openshift.com/network                             | etcd prefix                                     |
 | etcd_hosts          | etcd_urls                                          | a list of etcd endpoints                        |
-| etcd_conf_dir       | {{ openshift.common.config_base }}/master          | SSL certificates directory                      |
+| etcd_conf_dir       | /etc/origin/master          | SSL certificates directory                      |
 | etcd_peer_ca_file   | {{ etcd_conf_dir }}/ca.crt                         | SSL CA to use for etcd                          |
 | etcd_peer_cert_file | {{ etcd_conf_dir }}/master.etcd-client.crt         | SSL cert to use for etcd                        |
 | etcd_peer_key_file  | {{ etcd_conf_dir }}/master.etcd-client.key         | SSL key to use for etcd                         |

--- a/roles/flannel_register/defaults/main.yaml
+++ b/roles/flannel_register/defaults/main.yaml
@@ -3,7 +3,7 @@ flannel_network: "{{ openshift.master.sdn_cluster_network_cidr }}"
 flannel_subnet_len: "{{ 32 - (openshift.master.sdn_host_subnet_length | int) }}"
 flannel_etcd_key: /openshift.com/network
 etcd_hosts: "{{ etcd_urls }}"
-etcd_conf_dir: "{{ openshift.common.config_base }}/master"
+etcd_conf_dir: "/etc/origin/master"
 etcd_peer_ca_file: "{{ etcd_conf_dir + '/master.etcd-ca.crt' }}"
 etcd_peer_cert_file: "{{ etcd_conf_dir }}/master.etcd-client.crt"
 etcd_peer_key_file: "{{ etcd_conf_dir }}/master.etcd-client.key"

--- a/roles/nuage_master/vars/main.yaml
+++ b/roles/nuage_master/vars/main.yaml
@@ -1,10 +1,10 @@
 ---
-openshift_master_config_dir: "{{ openshift.common.config_base }}/master"
+openshift_master_config_dir: "/etc/origin/master"
 openshift_master_ca_cert: "{{ openshift_master_config_dir }}/ca.crt"
 openshift_master_ca_key: "{{ openshift_master_config_dir }}/ca.key"
 openshift_master_ca_serial: "{{ openshift_master_config_dir }}/ca.serial.txt"
 ca_cert: "{{ openshift_master_config_dir }}/ca.crt"
-admin_config: "{{ openshift.common.config_base }}/master/admin.kubeconfig"
+admin_config: "/etc/origin/master/admin.kubeconfig"
 cert_output_dir: /usr/share/nuage-openshift-monitor
 kube_config: /usr/share/nuage-openshift-monitor/nuage.kubeconfig
 kubemon_yaml: /usr/share/nuage-openshift-monitor/nuage-openshift-monitor.yaml

--- a/roles/openshift_ca/README.md
+++ b/roles/openshift_ca/README.md
@@ -14,7 +14,7 @@ From this role:
 | Name                    | Default value                                 | Description                                                                 |
 |-------------------------|-----------------------------------------------|-----------------------------------------------------------------------------|
 | openshift_ca_host       | None (Required)                               | The hostname of the system where the OpenShift CA will be created.          |
-| openshift_ca_config_dir | `{{ openshift.common.config_base }}/master`   | CA certificate directory.                                                   |
+| openshift_ca_config_dir | `/etc/origin/master`   | CA certificate directory.                                                   |
 | openshift_ca_cert       | `{{ openshift_ca_config_dir }}/ca.crt`        | CA certificate path including CA certificate filename.                      |
 | openshift_ca_key        | `{{ openshift_ca_config_dir }}/ca.key`        | CA key path including CA key filename.                                      |
 | openshift_ca_serial     | `{{ openshift_ca_config_dir }}/ca.serial.txt` | CA serial path including CA serial filename.                                |

--- a/roles/openshift_ca/defaults/main.yml
+++ b/roles/openshift_ca/defaults/main.yml
@@ -2,7 +2,7 @@
 openshift_ca_cert_expire_days: 1825
 openshift_master_cert_expire_days: 730
 
-openshift_ca_config_dir: "{{ openshift.common.config_base }}/master"
+openshift_ca_config_dir: "/etc/origin/master"
 openshift_ca_cert: "{{ openshift_ca_config_dir }}/ca.crt"
 openshift_ca_key: "{{ openshift_ca_config_dir }}/ca.key"
 openshift_ca_serial: "{{ openshift_ca_config_dir }}/ca.serial.txt"

--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -80,7 +80,7 @@
   run_once: true
 
 - find:
-    paths: "{{ openshift.common.config_base }}/master/legacy-ca/"
+    paths: "/etc/origin/master/legacy-ca/"
     patterns: ".*-ca.crt"
     use_regex: true
   register: g_master_legacy_ca_result

--- a/roles/openshift_cloud_provider/tasks/aws.yml
+++ b/roles/openshift_cloud_provider/tasks/aws.yml
@@ -2,7 +2,7 @@
 # Work around ini_file create option in 2.2 which defaults to no
 - name: Create cloud config file
   file:
-    dest: "{{ openshift.common.config_base }}/cloudprovider/aws.conf"
+    dest: "/etc/origin/cloudprovider/aws.conf"
     state: touch
     mode: 0660
     owner: root
@@ -11,7 +11,7 @@
 
 - name: Configure AWS cloud provider
   ini_file:
-    dest: "{{ openshift.common.config_base }}/cloudprovider/aws.conf"
+    dest: "/etc/origin/cloudprovider/aws.conf"
     section: Global
     option: Zone
     value: "{{ openshift.provider.zone }}"

--- a/roles/openshift_cloud_provider/tasks/gce.yml
+++ b/roles/openshift_cloud_provider/tasks/gce.yml
@@ -12,7 +12,7 @@
 # Work around ini_file create option in 2.2 which defaults to no
 - name: Create cloud config file
   file:
-    dest: "{{ openshift.common.config_base }}/cloudprovider/gce.conf"
+    dest: "/etc/origin/cloudprovider/gce.conf"
     state: touch
     mode: 0660
     owner: root
@@ -21,7 +21,7 @@
 
 - name: Configure GCE cloud provider
   ini_file:
-    dest: "{{ openshift.common.config_base }}/cloudprovider/gce.conf"
+    dest: "/etc/origin/cloudprovider/gce.conf"
     section: Global
     option: "{{ item.key }}"
     value: "{{ item.value }}"

--- a/roles/openshift_cloud_provider/tasks/main.yml
+++ b/roles/openshift_cloud_provider/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Create cloudprovider config dir
   file:
-    path: "{{ openshift.common.config_base }}/cloudprovider"
+    path: "/etc/origin/cloudprovider"
     state: directory
 
 - name: include the defined cloud provider files

--- a/roles/openshift_cloud_provider/tasks/openstack.yml
+++ b/roles/openshift_cloud_provider/tasks/openstack.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create cloud config
   template:
-    dest: "{{ openshift.common.config_base }}/cloudprovider/openstack.conf"
+    dest: "/etc/origin/cloudprovider/openstack.conf"
     src: openstack.conf.j2
   when: openshift_cloudprovider_openstack_auth_url is defined and openshift_cloudprovider_openstack_username is defined and openshift_cloudprovider_openstack_password is defined and (openshift_cloudprovider_openstack_tenant_id is defined or openshift_cloudprovider_openstack_tenant_name is defined)

--- a/roles/openshift_cloud_provider/tasks/vsphere.yml
+++ b/roles/openshift_cloud_provider/tasks/vsphere.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create cloud config
   template:
-    dest: "{{ openshift.common.config_base }}/cloudprovider/vsphere.conf"
+    dest: "/etc/origin/cloudprovider/vsphere.conf"
     src: vsphere.conf.j2
   when: openshift_cloudprovider_vsphere_username is defined and openshift_cloudprovider_vsphere_password is defined and openshift_cloudprovider_vsphere_host is defined and openshift_cloudprovider_vsphere_datacenter is defined and openshift_cloudprovider_vsphere_datastore is defined

--- a/roles/openshift_examples/defaults/main.yml
+++ b/roles/openshift_examples/defaults/main.yml
@@ -8,7 +8,7 @@ openshift_examples_load_quickstarts: true
 
 content_version: "{{ openshift.common.examples_content_version }}"
 
-examples_base: "{{ openshift.common.config_base if openshift_is_containerized | bool else '/usr/share/openshift' }}/examples"
+examples_base: "{{ ''/etc/origin' if openshift_is_containerized | bool else '/usr/share/openshift' }}/examples"
 image_streams_base: "{{ examples_base }}/image-streams"
 centos_image_streams:
   - "{{ image_streams_base }}/image-streams-centos7.json"

--- a/roles/openshift_examples/tasks/main.yml
+++ b/roles/openshift_examples/tasks/main.yml
@@ -57,7 +57,7 @@
 # RHEL and Centos image streams are mutually exclusive
 - name: Import RHEL streams
   command: >
-    {{ openshift_client_binary }} {{ openshift_examples_import_command }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift -f {{ item }}
+    {{ openshift_client_binary }} {{ openshift_examples_import_command }} --config=/etc/origin/master/admin.kubeconfig -n openshift -f {{ item }}
   when: openshift_examples_load_rhel | bool
   with_items:
     - "{{ rhel_image_streams }}"
@@ -67,7 +67,7 @@
 
 - name: Import Centos Image streams
   command: >
-    {{ openshift_client_binary }} {{ openshift_examples_import_command }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift -f {{ item }}
+    {{ openshift_client_binary }} {{ openshift_examples_import_command }} --config=/etc/origin/master/admin.kubeconfig -n openshift -f {{ item }}
   when: openshift_examples_load_centos | bool
   with_items:
     - "{{ centos_image_streams }}"
@@ -77,7 +77,7 @@
 
 - name: Import db templates
   command: >
-    {{ openshift_client_binary }} {{ openshift_examples_import_command }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift -f {{ db_templates_base }}
+    {{ openshift_client_binary }} {{ openshift_examples_import_command }} --config=/etc/origin/master/admin.kubeconfig -n openshift -f {{ db_templates_base }}
   when: openshift_examples_load_db_templates | bool
   register: oex_import_db_templates
   failed_when: "'already exists' not in oex_import_db_templates.stderr and oex_import_db_templates.rc != 0"
@@ -94,7 +94,7 @@
     - "{{ quickstarts_base }}/django.json"
 
 - name: Remove defunct quickstart templates from openshift namespace
-  command: "{{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift delete templates/{{ item }}"
+  command: "{{ openshift_client_binary }} --config=/etc/origin/master/admin.kubeconfig -n openshift delete templates/{{ item }}"
   with_items:
     - nodejs-example
     - cakephp-example
@@ -106,7 +106,7 @@
 
 - name: Import quickstart-templates
   command: >
-    {{ openshift_client_binary }} {{ openshift_examples_import_command }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift -f {{ quickstarts_base }}
+    {{ openshift_client_binary }} {{ openshift_examples_import_command }} --config=/etc/origin/master/admin.kubeconfig -n openshift -f {{ quickstarts_base }}
   when: openshift_examples_load_quickstarts | bool
   register: oex_import_quickstarts
   failed_when: "'already exists' not in oex_import_quickstarts.stderr and oex_import_quickstarts.rc != 0"
@@ -120,7 +120,7 @@
     - "{{ xpaas_templates_base }}/sso70-basic.json"
 
 - name: Remove old xPaas templates from openshift namespace
-  command: "{{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift delete templates/{{ item }}"
+  command: "{{ openshift_client_binary }} --config=/etc/origin/master/admin.kubeconfig -n openshift delete templates/{{ item }}"
   with_items:
     - sso70-basic
   register: oex_delete_old_xpaas_templates
@@ -129,7 +129,7 @@
 
 - name: Import xPaas image streams
   command: >
-    {{ openshift_client_binary }} {{ openshift_examples_import_command }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift -f {{ xpaas_image_streams }}
+    {{ openshift_client_binary }} {{ openshift_examples_import_command }} --config=/etc/origin/master/admin.kubeconfig -n openshift -f {{ xpaas_image_streams }}
   when: openshift_examples_load_xpaas | bool
   register: oex_import_xpaas_streams
   failed_when: "'already exists' not in oex_import_xpaas_streams.stderr and oex_import_xpaas_streams.rc != 0"
@@ -137,7 +137,7 @@
 
 - name: Import xPaas templates
   command: >
-    {{ openshift_client_binary }} {{ openshift_examples_import_command }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift -f {{ xpaas_templates_base }}
+    {{ openshift_client_binary }} {{ openshift_examples_import_command }} --config=/etc/origin/master/admin.kubeconfig -n openshift -f {{ xpaas_templates_base }}
   when: openshift_examples_load_xpaas | bool
   register: oex_import_xpaas_templates
   failed_when: "'already exists' not in oex_import_xpaas_templates.stderr and oex_import_xpaas_templates.rc != 0"

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -613,8 +613,7 @@ def set_sdn_facts_if_unset(facts, system_facts):
         sdn_cluster_network_cidr = '10.128.0.0/14'
         sdn_host_subnet_length = '9'
 
-        master_cfg_path = os.path.join(facts['common']['config_base'],
-                                       'master/master-config.yaml')
+        master_cfg_path = '/etc/origin/master/master-config.yaml'
         if os.path.isfile(master_cfg_path):
             with open(master_cfg_path, 'r') as master_cfg_f:
                 config = yaml.safe_load(master_cfg_f.read())
@@ -751,8 +750,7 @@ def get_current_config(facts):
 
 def build_controller_args(facts):
     """ Build master controller_args """
-    cloud_cfg_path = os.path.join(facts['common']['config_base'],
-                                  'cloudprovider')
+    cloud_cfg_path = '/etc/origin/cloudprovider'
     if 'master' in facts:
         controller_args = {}
         if 'cloudprovider' in facts:
@@ -773,8 +771,7 @@ def build_controller_args(facts):
 
 def build_api_server_args(facts):
     """ Build master api_server_args """
-    cloud_cfg_path = os.path.join(facts['common']['config_base'],
-                                  'cloudprovider')
+    cloud_cfg_path = '/etc/origin/cloudprovider'
     if 'master' in facts:
         api_server_args = {}
         if 'cloudprovider' in facts:
@@ -1416,8 +1413,7 @@ class OpenShiftFacts(object):
                                   hostname=hostname,
                                   public_hostname=hostname,
                                   portal_net='172.30.0.0/16',
-                                  dns_domain='cluster.local',
-                                  config_base='/etc/origin')
+                                  dns_domain='cluster.local')
 
         if 'master' in roles:
             defaults['master'] = dict(api_use_ssl=True, api_port='8443',

--- a/roles/openshift_health_checker/openshift_checks/diagnostics.py
+++ b/roles/openshift_health_checker/openshift_checks/diagnostics.py
@@ -36,7 +36,7 @@ class DiagnosticCheck(OpenShiftCheck):
         Raises OcNotFound or registers OcDiagFailed.
         Returns True on success or False on failure (non-zero rc).
         """
-        config_base = self.get_var("openshift.common.config_base")
+        config_base = '/etc/origin'
         args = {
             "config_file": os.path.join(config_base, "master", "admin.kubeconfig"),
             "cmd": "adm diagnostics",

--- a/roles/openshift_health_checker/openshift_checks/etcd_imagedata_size.py
+++ b/roles/openshift_health_checker/openshift_checks/etcd_imagedata_size.py
@@ -25,7 +25,7 @@ class EtcdImageDataSize(OpenShiftCheck):
         etcd_port = self.get_var("openshift", "master", "etcd_port", default=2379)
         etcd_hosts = self.get_var("openshift", "master", "etcd_hosts")
 
-        config_base = self.get_var("openshift", "common", "config_base")
+        config_base = '/etc/origin'
 
         cert = self.get_var("etcd_client_cert", default=config_base + "/master/master.etcd-client.crt")
         key = self.get_var("etcd_client_key", default=config_base + "/master/master.etcd-client.key")

--- a/roles/openshift_health_checker/openshift_checks/logging/logging.py
+++ b/roles/openshift_health_checker/openshift_checks/logging/logging.py
@@ -76,7 +76,7 @@ class LoggingCheck(OpenShiftCheck):
         Returns: output of command and namespace,
         or raises CouldNotUseOc on error
         """
-        config_base = self.get_var("openshift", "common", "config_base")
+        config_base = '/etc/origin'
         args = {
             "namespace": self.logging_namespace(),
             "config_file": os.path.join(config_base, "master", "admin.kubeconfig"),

--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -18,7 +18,7 @@ openshift_default_projects:
 openshift_additional_projects: {}
 
 openshift_config_base: "/etc/origin"
-openshift_master_config_dir: "{{ openshift.common.config_base | default(openshift_config_base) }}/master"
+openshift_master_config_dir: "{{ openshift_config_base }}/master"
 openshift_cluster_domain: 'cluster.local'
 
 openshift_hosted_images_dict:

--- a/roles/openshift_hosted_templates/defaults/main.yml
+++ b/roles/openshift_hosted_templates/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-hosted_base: "{{ openshift.common.config_base if openshift_is_containerized | bool else '/usr/share/openshift' }}/hosted"
+hosted_base: "{{ '/etc/origin' if openshift_is_containerized | bool else '/usr/share/openshift' }}/hosted"
 hosted_deployment_type: "{{ 'origin' if openshift_deployment_type == 'origin' else 'enterprise' }}"
 
 content_version: "{{ openshift.common.examples_content_version }}"

--- a/roles/openshift_hosted_templates/tasks/main.yml
+++ b/roles/openshift_hosted_templates/tasks/main.yml
@@ -51,7 +51,7 @@
 
 - name: Copy the admin client config(s)
   command: >
-    cp {{ openshift.common.config_base }}/master/admin.kubeconfig {{ openshift_hosted_templates_kubeconfig }}
+    cp /etc/origin/master/admin.kubeconfig {{ openshift_hosted_templates_kubeconfig }}
   changed_when: False
 
 - name: Create or update hosted templates

--- a/roles/openshift_logging/handlers/main.yml
+++ b/roles/openshift_logging/handlers/main.yml
@@ -18,7 +18,7 @@
   # wait_for port doesn't provide health information.
   command: >
     curl --silent --tlsv1.2
-    --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+    --cacert /etc/origin/master/ca-bundle.crt
     {{ openshift.master.api_url }}/healthz/ready
   args:
     # Disables the following warning:

--- a/roles/openshift_logging/tasks/annotate_ops_projects.yaml
+++ b/roles/openshift_logging/tasks/annotate_ops_projects.yaml
@@ -1,7 +1,7 @@
 ---
 - command: >
     {{ openshift_client_binary }}
-    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    --config=/etc/origin/master/admin.kubeconfig
     get namespaces -o jsonpath={.items[*].metadata.name} {{ __default_logging_ops_projects | join(' ') }}
   register: __logging_ops_projects
 

--- a/roles/openshift_logging/tasks/delete_logging.yaml
+++ b/roles/openshift_logging/tasks/delete_logging.yaml
@@ -110,14 +110,14 @@
 # remove annotations added by logging
 - command: >
     {{ openshift_client_binary }}
-    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    --config=/etc/origin/master/admin.kubeconfig
     get namespaces -o name {{ __default_logging_ops_projects | join(' ') }}
   register: __logging_ops_projects
 
 - name: Remove Annotation of Operations Projects
   command: >
     {{ openshift_client_binary }}
-    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    --config=/etc/origin/master/admin.kubeconfig
     annotate {{ project }} openshift.io/logging.ui.hostname-
   with_items: "{{ __logging_ops_projects.stdout_lines }}"
   loop_control:

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -49,7 +49,7 @@
 
 - name: Create logging cert directory
   file:
-    path: "{{ openshift.common.config_base }}/logging"
+    path: "/etc/origin/logging"
     state: directory
     mode: 0755
   changed_when: False
@@ -57,7 +57,7 @@
 
 - include_tasks: generate_certs.yaml
   vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
+    generated_certs_dir: "/etc/origin/logging"
 
 - set_fact:
     __base_file_dir: "{{ '5.x' if openshift_logging_es5_techpreview | bool else '2.x' }}"
@@ -93,7 +93,7 @@
 - include_role:
     name: openshift_logging_elasticsearch
   vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
+    generated_certs_dir: "/etc/origin/logging"
     openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
     openshift_logging_elasticsearch_deployment_name: "{{ outer_item.0.name }}"
     openshift_logging_elasticsearch_pvc_name: "{{ outer_item.0.volumes['elasticsearch-storage'].persistentVolumeClaim.claimName if outer_item.0.volumes['elasticsearch-storage'].persistentVolumeClaim is defined else openshift_logging_es_pvc_prefix ~ '-' ~ outer_item.2 if outer_item.1 is none else outer_item.1 }}"
@@ -122,7 +122,7 @@
 - include_role:
     name: openshift_logging_elasticsearch
   vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
+    generated_certs_dir: "/etc/origin/logging"
     openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
     openshift_logging_elasticsearch_pvc_name: "{{ openshift_logging_es_pvc_prefix }}-{{ outer_item | int + openshift_logging_facts.elasticsearch.deploymentconfigs | count - 1 }}"
     openshift_logging_elasticsearch_pvc_size: "{{ openshift_logging_es_pvc_size }}"
@@ -161,7 +161,7 @@
 - include_role:
     name: openshift_logging_elasticsearch
   vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
+    generated_certs_dir: "/etc/origin/logging"
     openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
     openshift_logging_elasticsearch_deployment_name: "{{ outer_item.0.name }}"
     openshift_logging_elasticsearch_pvc_name: "{{ outer_item.0.volumes['elasticsearch-storage'].persistentVolumeClaim.claimName if outer_item.0.volumes['elasticsearch-storage'].persistentVolumeClaim is defined else openshift_logging_es_ops_pvc_prefix ~ '-' ~ outer_item.2 if outer_item.1 is none else outer_item.1 }}"
@@ -205,7 +205,7 @@
 - include_role:
     name: openshift_logging_elasticsearch
   vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
+    generated_certs_dir: "/etc/origin/logging"
     openshift_logging_elasticsearch_namespace: "{{ openshift_logging_namespace }}"
     openshift_logging_elasticsearch_pvc_name: "{{ openshift_logging_es_ops_pvc_prefix }}-{{ outer_item | int + openshift_logging_facts.elasticsearch_ops.deploymentconfigs | count - 1 }}"
     openshift_logging_elasticsearch_ops_deployment: true
@@ -244,7 +244,7 @@
 - import_role:
     name: openshift_logging_kibana
   vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
+    generated_certs_dir: "/etc/origin/logging"
     openshift_logging_kibana_namespace: "{{ openshift_logging_namespace }}"
     openshift_logging_kibana_master_url: "{{ openshift_logging_master_url }}"
     openshift_logging_kibana_master_public_url: "{{ openshift_logging_master_public_url }}"
@@ -257,7 +257,7 @@
 - import_role:
     name: openshift_logging_kibana
   vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
+    generated_certs_dir: "/etc/origin/logging"
     openshift_logging_kibana_ops_deployment: true
     openshift_logging_kibana_namespace: "{{ openshift_logging_namespace }}"
     openshift_logging_kibana_master_url: "{{ openshift_logging_master_url }}"
@@ -287,7 +287,7 @@
 - import_role:
     name: openshift_logging_curator
   vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
+    generated_certs_dir: "/etc/origin/logging"
     openshift_logging_curator_namespace: "{{ openshift_logging_namespace }}"
     openshift_logging_curator_es_host: "{{ openshift_logging_es_host }}"
     openshift_logging_curator_es_port: "{{ openshift_logging_es_port }}"
@@ -297,7 +297,7 @@
 - import_role:
     name: openshift_logging_curator
   vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
+    generated_certs_dir: "/etc/origin/logging"
     openshift_logging_curator_ops_deployment: true
     openshift_logging_curator_es_host: "{{ openshift_logging_es_ops_host }}"
     openshift_logging_curator_es_port: "{{ openshift_logging_es_ops_port }}"
@@ -315,7 +315,7 @@
 - import_role:
     name: openshift_logging_mux
   vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
+    generated_certs_dir: "/etc/origin/logging"
     openshift_logging_mux_ops_host: "{{ ( openshift_logging_use_ops | bool ) | ternary('logging-es-ops', 'logging-es') }}"
     openshift_logging_mux_namespace: "{{ openshift_logging_namespace }}"
     openshift_logging_mux_master_url: "{{ openshift_logging_master_url }}"
@@ -328,7 +328,7 @@
 - import_role:
     name: openshift_logging_fluentd
   vars:
-    generated_certs_dir: "{{openshift.common.config_base}}/logging"
+    generated_certs_dir: "/etc/origin/logging"
     openshift_logging_fluentd_ops_host: "{{ ( openshift_logging_use_ops | bool ) | ternary('logging-es-ops', 'logging-es') }}"
     openshift_logging_fluentd_image_pull_secret: "{{ openshift_logging_image_pull_secret }}"
     openshift_logging_fluentd_master_url: "{{ openshift_logging_master_url }}"

--- a/roles/openshift_logging/tasks/update_master_config.yaml
+++ b/roles/openshift_logging/tasks/update_master_config.yaml
@@ -2,7 +2,7 @@
 # TODO: Remove when asset config is removed from master-config.yaml
 - name: Adding Kibana route information to loggingPublicURL
   modify_yaml:
-    dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
+    dest: "/etc/origin/master/master-config.yaml"
     yaml_key: assetConfig.loggingPublicURL
     yaml_value: "https://{{ openshift_logging_kibana_hostname }}"
   notify:

--- a/roles/openshift_logging/vars/main.yaml
+++ b/roles/openshift_logging/vars/main.yaml
@@ -1,5 +1,5 @@
 ---
-openshift_master_config_dir: "{{ openshift.common.config_base }}/master"
+openshift_master_config_dir: "/etc/origin/master"
 es_node_quorum: "{{ (openshift_logging_es_cluster_size | int/2 | round(0,'floor') + 1) | int}}"
 es_recover_expected_nodes: "{{openshift_logging_es_cluster_size | int}}"
 es_ops_node_quorum: "{{ (openshift_logging_es_ops_cluster_size | int/2 | round(0,'floor') + 1) | int}}"

--- a/roles/openshift_logging_elasticsearch/vars/main.yml
+++ b/roles/openshift_logging_elasticsearch/vars/main.yml
@@ -6,7 +6,7 @@ __kibana_index_modes: ["unique", "shared_ops"]
 __es_local_curl: "curl -s --cacert /etc/elasticsearch/secret/admin-ca --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key"
 
 # TODO: integrate these
-openshift_master_config_dir: "{{ openshift.common.config_base }}/master"
+openshift_master_config_dir: "/etc/origin/master"
 es_node_quorum: "{{ openshift_logging_elasticsearch_replica_count | int/2 + 1 }}"
 es_min_masters_default: "{{ (openshift_logging_elasticsearch_replica_count | int / 2 | round(0,'floor') + 1) | int }}"
 es_min_masters: "{{ (openshift_logging_elasticsearch_replica_count == 1) | ternary(1, es_min_masters_default) }}"

--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -7,7 +7,7 @@
   # wait_for port doesn't provide health information.
   command: >
     curl --silent --tlsv1.2
-    --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+    --cacert /etc/origin/master/ca-bundle.crt
     {{ openshift_node_master_api_url }}/healthz/ready
   args:
     # Disables the following warning:

--- a/roles/openshift_master/defaults/main.yml
+++ b/roles/openshift_master/defaults/main.yml
@@ -115,7 +115,7 @@ r_openshift_master_sdn_network_plugin_name: "{{ r_openshift_master_sdn_network_p
 openshift_master_image_config_latest_default: "{{ openshift_image_config_latest | default(False) }}"
 openshift_master_image_config_latest: "{{ openshift_master_image_config_latest_default }}"
 
-openshift_master_config_dir_default: "{{ openshift.common.config_base ~ '/master' if openshift is defined and 'common' in openshift else '/etc/origin/master' }}"
+openshift_master_config_dir_default: "/etc/origin"
 openshift_master_config_dir: "{{ openshift_master_config_dir_default }}"
 
 openshift_master_bootstrap_enabled: False

--- a/roles/openshift_master/handlers/main.yml
+++ b/roles/openshift_master/handlers/main.yml
@@ -23,7 +23,7 @@
   # wait_for port doesn't provide health information.
   command: >
     curl --silent --tlsv1.2
-    --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+    --cacert /etc/origin/master/ca-bundle.crt
     {{ openshift.master.api_url }}/healthz/ready
   args:
     # Disables the following warning:

--- a/roles/openshift_master/tasks/check_master_api_is_ready.yml
+++ b/roles/openshift_master/tasks/check_master_api_is_ready.yml
@@ -4,7 +4,7 @@
   # wait_for port doesn't provide health information.
   command: >
     curl --silent --tlsv1.2
-    --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+    --cacert /etc/origin/master/ca-bundle.crt
     {{ openshift.master.api_url }}/healthz/ready
   register: l_api_available_output
   until: l_api_available_output.stdout == 'ok'
@@ -17,7 +17,7 @@
 - name: "Collect verbose curl output when API didn't become available"
   command: >-
     curl --verbose --tlsv1.2
-    --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+    --cacert /etc/origin/master/ca-bundle.crt
     {{ openshift.master.api_url }}/healthz/ready
   register: l_api_available_verbose_output
   failed_when: false

--- a/roles/openshift_master/tasks/update-vsphere.yml
+++ b/roles/openshift_master/tasks/update-vsphere.yml
@@ -5,13 +5,13 @@
     edits:
     - key: kubernetesMasterConfig.controllerArguments.cloud-config
       value:
-      - "{{ openshift.common.config_base }}/cloudprovider/vsphere.conf"
+      - "/etc/origin/cloudprovider/vsphere.conf"
     - key: kubernetesMasterConfig.controllerArguments.cloud-provider
       value:
       - vsphere
     - key: kubernetesMasterConfig.apiServerArguments.cloud-config
       value:
-      - "{{ openshift.common.config_base }}/cloudprovider/vsphere.conf"
+      - "/etc/origin/cloudprovider/vsphere.conf"
     - key: kubernetesMasterConfig.apiServerArguments.cloud-provider
       value:
       - vsphere

--- a/roles/openshift_master/tasks/update_etcd_client_urls.yml
+++ b/roles/openshift_master/tasks/update_etcd_client_urls.yml
@@ -1,6 +1,6 @@
 ---
 - yedit:
-    src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+    src: "/etc/origin/master/master-config.yaml"
     key: 'etcdClientInfo.urls'
     value: "{{ openshift.master.etcd_urls }}"
   notify:

--- a/roles/openshift_master/tasks/upgrade.yml
+++ b/roles/openshift_master/tasks/upgrade.yml
@@ -12,32 +12,32 @@
 
 - name: Check for ca-bundle.crt
   stat:
-    path: "{{ openshift.common.config_base }}/master/ca-bundle.crt"
+    path: "/etc/origin/master/ca-bundle.crt"
   register: ca_bundle_stat
   failed_when: false
 
 - name: Check for ca.crt
   stat:
-    path: "{{ openshift.common.config_base }}/master/ca.crt"
+    path: "/etc/origin/master/ca.crt"
   register: ca_crt_stat
   failed_when: false
 
 - name: Migrate ca.crt to ca-bundle.crt
   command: mv ca.crt ca-bundle.crt
   args:
-    chdir: "{{ openshift.common.config_base }}/master"
+    chdir: "/etc/origin/master"
   when: ca_crt_stat.stat.isreg and not ca_bundle_stat.stat.exists
 
 - name: Link ca.crt to ca-bundle.crt
   file:
-    src: "{{ openshift.common.config_base }}/master/ca-bundle.crt"
-    path: "{{ openshift.common.config_base }}/master/ca.crt"
+    src: "/etc/origin/master/ca-bundle.crt"
+    path: "/etc/origin/master/ca.crt"
     state: link
   when: ca_crt_stat.stat.isreg and not ca_bundle_stat.stat.exists
 
 - name: Update oreg value
   yedit:
-    src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+    src: "/etc/origin/master/master-config.yaml"
     key: 'imageConfig.format'
     value: "{{ oreg_url | default(oreg_url_master) }}"
   when: oreg_url is defined or oreg_url_master is defined

--- a/roles/openshift_master/tasks/upgrade/v3_6/master_config_upgrade.yml
+++ b/roles/openshift_master/tasks/upgrade/v3_6/master_config_upgrade.yml
@@ -1,15 +1,15 @@
 ---
 - modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    dest: "/etc/origin/master/master-config.yaml"
     yaml_key: 'controllerConfig.serviceServingCert.signer.certFile'
     yaml_value: service-signer.crt
 
 - modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    dest: "/etc/origin/master/master-config.yaml"
     yaml_key: 'controllerConfig.serviceServingCert.signer.keyFile'
     yaml_value: service-signer.key
 
 - modify_yaml:
-    dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
+    dest: "/etc/origin/master/master-config.yaml"
     yaml_key: servingInfo.clientCA
     yaml_value: ca.crt

--- a/roles/openshift_master/tasks/upgrade/v3_7/master_config_upgrade.yml
+++ b/roles/openshift_master/tasks/upgrade/v3_7/master_config_upgrade.yml
@@ -1,20 +1,20 @@
 ---
 - modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    dest: "/etc/origin/master/master-config.yaml"
     yaml_key: 'controllerConfig.election.lockName'
     yaml_value: 'openshift-master-controllers'
 
 - modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    dest: "/etc/origin/master/master-config.yaml"
     yaml_key: 'controllerConfig.serviceServingCert.signer.certFile'
     yaml_value: service-signer.crt
 
 - modify_yaml:
-    dest: "{{ openshift.common.config_base}}/master/master-config.yaml"
+    dest: "/etc/origin/master/master-config.yaml"
     yaml_key: 'controllerConfig.serviceServingCert.signer.keyFile'
     yaml_value: service-signer.key
 
 - modify_yaml:
-    dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
+    dest: "/etc/origin/master/master-config.yaml"
     yaml_key: servingInfo.clientCA
     yaml_value: ca.crt

--- a/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-api.service.j2
+++ b/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-api.service.j2
@@ -19,8 +19,8 @@ ExecStart=/usr/bin/docker run --rm --privileged --net=host \
   --env-file=/etc/sysconfig/{{ openshift_service_type }}-master-api \
   -v {{ r_openshift_master_data_dir }}:{{ r_openshift_master_data_dir }} \
   -v /var/log:/var/log -v /var/run/docker.sock:/var/run/docker.sock \
-  -v {{ openshift.common.config_base }}:{{ openshift.common.config_base }} \
-  {% if openshift_cloudprovider_kind | default('') != '' -%} -v {{ openshift.common.config_base }}/cloudprovider:{{ openshift.common.config_base}}/cloudprovider {% endif -%} \
+  -v /etc/origin:/etc/origin \
+  {% if openshift_cloudprovider_kind | default('') != '' -%} -v /etc/origin/cloudprovider:/etc/origin/cloudprovider {% endif -%} \
   -v /etc/pki:/etc/pki:ro \
   {% if l_bind_docker_reg_auth | default(False) %} -v {{ oreg_auth_credentials_path }}:/root/.docker:ro{% endif %}\
   {{ osm_image }}:${IMAGE_VERSION} start master api \

--- a/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-controllers.service.j2
+++ b/roles/openshift_master/templates/docker-cluster/atomic-openshift-master-controllers.service.j2
@@ -16,8 +16,8 @@ ExecStart=/usr/bin/docker run --rm --privileged --net=host \
   --env-file=/etc/sysconfig/{{ openshift_service_type }}-master-controllers \
   -v {{ r_openshift_master_data_dir }}:{{ r_openshift_master_data_dir }} \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v {{ openshift.common.config_base }}:{{ openshift.common.config_base }} \
-  {% if openshift_cloudprovider_kind | default('') != '' -%} -v {{ openshift.common.config_base }}/cloudprovider:{{ openshift.common.config_base}}/cloudprovider {% endif -%} \
+  -v /etc/origin:/etc/origin \
+  {% if openshift_cloudprovider_kind | default('') != '' -%} -v /etc/origin/cloudprovider:/etc/origin/cloudprovider {% endif -%} \
   -v /etc/pki:/etc/pki:ro \
   {% if l_bind_docker_reg_auth | default(False) %} -v {{ oreg_auth_credentials_path }}:/root/.docker:ro{% endif %}\
   {{ osm_image }}:${IMAGE_VERSION} start master controllers \

--- a/roles/openshift_master_certificates/README.md
+++ b/roles/openshift_master_certificates/README.md
@@ -19,10 +19,10 @@ From this role:
 
 | Name                                  | Default value                                                             | Description                                                                                                                   |
 |---------------------------------------|---------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
-| openshift_generated_configs_dir       | `{{ openshift.common.config_base }}/generated-configs`                    | Directory in which per-master generated config directories will be created on the `openshift_ca_host`.                        |
+| openshift_generated_configs_dir       | `/etc/origin/generated-configs`                    | Directory in which per-master generated config directories will be created on the `openshift_ca_host`.                        |
 | openshift_master_cert_subdir          | `master-{{ openshift.common.hostname }}`                                  | Directory within `openshift_generated_configs_dir` where per-master configurations will be placed on the `openshift_ca_host`. |
 | openshift_master_cert_expire_days     | `730` (2 years)                                                           | Validity of the certificates in days. Works only with OpenShift version 1.5 (3.5) and later.                                  |
-| openshift_master_config_dir           | `{{ openshift.common.config_base }}/master`                               | Master configuration directory in which certificates will be deployed on masters.                                             |
+| openshift_master_config_dir           | `/etc/origin/master`                               | Master configuration directory in which certificates will be deployed on masters.                                             |
 | openshift_master_generated_config_dir | `{{ openshift_generated_configs_dir }}/{{ openshift_master_cert_subdir }` | Full path to the per-master generated config directory.                                                                       |
 
 Dependencies

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -193,25 +193,25 @@
 # Ensure ca-bundle exists for 3.2+ configuration
 - name: Check for ca-bundle.crt
   stat:
-    path: "{{ openshift.common.config_base }}/master/ca-bundle.crt"
+    path: "/etc/origin/master/ca-bundle.crt"
   register: ca_bundle_stat
   failed_when: false
 
 - name: Check for ca.crt
   stat:
-    path: "{{ openshift.common.config_base }}/master/ca.crt"
+    path: "/etc/origin/master/ca.crt"
   register: ca_crt_stat
   failed_when: false
 
 - name: Migrate ca.crt to ca-bundle.crt
   command: mv ca.crt ca-bundle.crt
   args:
-    chdir: "{{ openshift.common.config_base }}/master"
+    chdir: "/etc/origin/master"
   when: ca_crt_stat.stat.isreg and not ca_bundle_stat.stat.exists
 
 - name: Link ca.crt to ca-bundle.crt
   file:
-    src: "{{ openshift.common.config_base }}/master/ca-bundle.crt"
-    path: "{{ openshift.common.config_base }}/master/ca.crt"
+    src: "/etc/origin/master/ca-bundle.crt"
+    path: "/etc/origin/master/ca.crt"
     state: link
   when: ca_crt_stat.stat.isreg and not ca_bundle_stat.stat.exists

--- a/roles/openshift_master_certificates/vars/main.yml
+++ b/roles/openshift_master_certificates/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-openshift_generated_configs_dir: "{{ openshift.common.config_base }}/generated-configs"
+openshift_generated_configs_dir: "/etc/origin/generated-configs"
 openshift_master_cert_subdir: "master-{{ openshift.common.hostname }}"
-openshift_master_config_dir: "{{ openshift.common.config_base }}/master"
+openshift_master_config_dir: "/etc/origin/master"
 openshift_master_generated_config_dir: "{{ openshift_generated_configs_dir }}/{{ openshift_master_cert_subdir }}"

--- a/roles/openshift_master_facts/vars/main.yml
+++ b/roles/openshift_master_facts/vars/main.yml
@@ -1,4 +1,4 @@
 ---
-openshift_master_config_dir: "{{ openshift.common.config_base }}/master"
+openshift_master_config_dir: "/etc/origin/master"
 openshift_master_config_file: "{{ openshift_master_config_dir }}/master-config.yaml"
 openshift_master_scheduler_conf: "{{ openshift_master_config_dir }}/scheduler.json"

--- a/roles/openshift_metrics/handlers/main.yml
+++ b/roles/openshift_metrics/handlers/main.yml
@@ -18,7 +18,7 @@
   # wait_for port doesn't provide health information.
   command: >
     curl --silent --tlsv1.2
-    --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+    --cacert /etc/origin/master/ca-bundle.crt
     {{ openshift.master.api_url }}/healthz/ready
   args:
     # Disables the following warning:

--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -38,7 +38,7 @@
 
 - name: Copy the admin client config(s)
   command: >
-     cp {{ openshift.common.config_base}}/master/admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
+     cp /etc/origin/master/admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
   changed_when: False
   check_mode: no
   tags: metrics_init

--- a/roles/openshift_metrics/tasks/update_master_config.yaml
+++ b/roles/openshift_metrics/tasks/update_master_config.yaml
@@ -2,7 +2,7 @@
 # TODO: Remove when asset config is removed from master-config.yaml
 - name: Adding metrics route information to metricsPublicURL
   modify_yaml:
-    dest: "{{ openshift.common.config_base }}/master/master-config.yaml"
+    dest: "/etc/origin/master/master-config.yaml"
     yaml_key: assetConfig.metricsPublicURL
     yaml_value: "https://{{ openshift_metrics_hawkular_hostname}}/hawkular/metrics"
   notify:

--- a/roles/openshift_named_certificates/defaults/main.yml
+++ b/roles/openshift_named_certificates/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-openshift_ca_config_dir: "{{ openshift.common.config_base }}/master"
+openshift_ca_config_dir: "/etc/origin/master"
 openshift_ca_cert: "{{ openshift_ca_config_dir }}/ca.crt"
 openshift_ca_key: "{{ openshift_ca_config_dir }}/ca.key"
 openshift_ca_serial: "{{ openshift_ca_config_dir }}/ca.serial.txt"

--- a/roles/openshift_named_certificates/vars/main.yml
+++ b/roles/openshift_named_certificates/vars/main.yml
@@ -1,5 +1,5 @@
 ---
 overwrite_named_certs: "{{ openshift_master_overwrite_named_certificates | default(false) }}"
-named_certs_dir: "{{ openshift.common.config_base }}/master/named_certificates/"
+named_certs_dir: "/etc/origin/master/named_certificates/"
 internal_hostnames: "{{ openshift.common.internal_hostnames }}"
 named_certificates: "{{ openshift_master_named_certificates | default([]) }}"

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -31,7 +31,7 @@
 # TODO: add the validate parameter when there is a validation command to run
 - name: Create the Node config
   template:
-    dest: "{{ openshift.common.config_base }}/node/node-config.yaml"
+    dest: "/etc/origin/node/node-config.yaml"
     src: node.yaml.v1.j2
     backup: true
     owner: root
@@ -65,7 +65,7 @@
       # Using curl here since the uri module requires python-httplib2 and
       # wait_for port doesn't provide health information.
       command: >
-        curl --silent --tlsv1.2 --cacert {{ openshift.common.config_base }}/node/ca.crt
+        curl --silent --tlsv1.2 --cacert /etc/origin/node/ca.crt
         {{ openshift_node_master_api_url }}/healthz/ready
       args:
         # Disables the following warning:

--- a/roles/openshift_node/tasks/config/configure-node-settings.yml
+++ b/roles/openshift_node/tasks/config/configure-node-settings.yml
@@ -9,7 +9,7 @@
   - regex: '^OPTIONS='
     line: "OPTIONS=--loglevel={{ openshift_node_debug_level }} {{ openshift_node_start_options | default('') }}"
   - regex: '^CONFIG_FILE='
-    line: "CONFIG_FILE={{ openshift.common.config_base }}/node/node-config.yaml"
+    line: "CONFIG_FILE=/etc/origin/node/node-config.yaml"
   - regex: '^IMAGE_VERSION='
     line: "IMAGE_VERSION={{ openshift_image_tag }}"
   notify:

--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -5,7 +5,7 @@
 
 - name: Update oreg value
   yedit:
-    src: "{{ openshift.common.config_base }}/node/node-config.yaml"
+    src: "/etc/origin/node/node-config.yaml"
     key: 'imageConfig.format'
     value: "{{ oreg_url | default(oreg_url_node) }}"
   when: oreg_url is defined or oreg_url_node is defined

--- a/roles/openshift_node/templates/openshift.docker.node.service
+++ b/roles/openshift_node/templates/openshift.docker.node.service
@@ -29,8 +29,8 @@ ExecStart=/usr/bin/docker run --name {{ openshift_service_type }}-node \
   -v /:/rootfs:ro,rslave -e CONFIG_FILE=${CONFIG_FILE} -e OPTIONS=${OPTIONS} \
   -e HOST=/rootfs -e HOST_ETC=/host-etc \
   -v {{ openshift_node_data_dir }}:{{ openshift_node_data_dir }}:rslave \
-  -v {{ openshift.common.config_base }}/node:{{ openshift.common.config_base }}/node \
-  {% if openshift_cloudprovider_kind | default('') != '' -%} -v {{ openshift.common.config_base }}/cloudprovider:{{ openshift.common.config_base}}/cloudprovider {% endif -%} \
+  -v /etc/origin/node:/etc/origin/node \
+  {% if openshift_cloudprovider_kind | default('') != '' -%} -v /etc/origin/cloudprovider:/etc/origin/cloudprovider {% endif -%} \
   -v /etc/localtime:/etc/localtime:ro -v /etc/machine-id:/etc/machine-id:ro \
   -v /run:/run -v /sys:/sys:rw -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
   -v /usr/bin/docker:/usr/bin/docker:ro -v /var/lib/docker:/var/lib/docker \

--- a/roles/openshift_node_certificates/README.md
+++ b/roles/openshift_node_certificates/README.md
@@ -21,10 +21,10 @@ From this role:
 
 | Name                                | Default value                                                           | Description                                                                                                               |
 |-------------------------------------|-------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| openshift_generated_configs_dir     | `{{ openshift.common.config_base }}/generated-configs`                  | Directory in which per-node generated config directories will be created on the `openshift_ca_host`.                      |
+| openshift_generated_configs_dir     | `/etc/origin/generated-configs`                  | Directory in which per-node generated config directories will be created on the `openshift_ca_host`.                      |
 | openshift_node_cert_subdir          | `node-{{ openshift.common.hostname }}`                                  | Directory within `openshift_generated_configs_dir` where per-node certificates will be placed on the `openshift_ca_host`. |
 | openshift_node_cert_expire_days     | `730` (2 years)                                                         | Validity of the certificates in days. Works only with OpenShift version 1.5 (3.5) and later.                              |
-| openshift_node_config_dir           | `{{ openshift.common.config_base }}/node`                               | Node configuration directory in which certificates will be deployed on nodes.                                             |
+| openshift_node_config_dir           | `/etc/origin/node`                               | Node configuration directory in which certificates will be deployed on nodes.                                             |
 | openshift_node_generated_config_dir | `{{ openshift_generated_configs_dir }}/{{ openshift_node_cert_subdir }` | Full path to the per-node generated config directory.                                                                     |
 
 Dependencies

--- a/roles/openshift_node_certificates/tasks/main.yml
+++ b/roles/openshift_node_certificates/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Check status of node certificates
   stat:
-    path: "{{ openshift.common.config_base }}/node/{{ item }}"
+    path: "/etc/origin/node/{{ item }}"
   with_items:
   - "system:node:{{ openshift.common.hostname | lower }}.crt"
   - "system:node:{{ openshift.common.hostname | lower }}.key"
@@ -43,7 +43,7 @@
   delegate_to: "{{ openshift_ca_host }}"
 
 - find:
-    paths: "{{ openshift.common.config_base }}/master/legacy-ca/"
+    paths: "/etc/origin/master/legacy-ca/"
     patterns: ".*-ca.crt"
     use_regex: true
   register: g_master_legacy_ca_result

--- a/roles/openshift_node_certificates/vars/main.yml
+++ b/roles/openshift_node_certificates/vars/main.yml
@@ -1,11 +1,11 @@
 ---
-openshift_generated_configs_dir: "{{ openshift.common.config_base }}/generated-configs"
-openshift_node_cert_dir: "{{ openshift.common.config_base }}/node"
+openshift_generated_configs_dir: "/etc/origin/generated-configs"
+openshift_node_cert_dir: "/etc/origin/node"
 openshift_node_cert_subdir: "node-{{ openshift.common.hostname | lower }}"
-openshift_node_config_dir: "{{ openshift.common.config_base }}/node"
+openshift_node_config_dir: "/etc/origin/node"
 openshift_node_generated_config_dir: "{{ openshift_generated_configs_dir }}/{{ openshift_node_cert_subdir }}"
 
-openshift_ca_config_dir: "{{ openshift.common.config_base }}/master"
+openshift_ca_config_dir: "/etc/origin/master"
 openshift_ca_cert: "{{ openshift_ca_config_dir }}/ca.crt"
 openshift_ca_key: "{{ openshift_ca_config_dir }}/ca.key"
 openshift_ca_serial: "{{ openshift_ca_config_dir }}/ca.serial.txt"

--- a/roles/openshift_persistent_volumes/vars/main.yml
+++ b/roles/openshift_persistent_volumes/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-openshift_master_config_dir: "{{ openshift.common.config_base }}/master"
+openshift_master_config_dir: "/etc/origin/master"

--- a/roles/openshift_project_request_template/tasks/main.yml
+++ b/roles/openshift_project_request_template/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Generate default project template
   command: |
     {{ openshift_client_binary | quote }} \
-      --config {{ openshift.common.config_base | quote }}/master/admin.kubeconfig \
+      --config /etc/origin/master/admin.kubeconfig \
       --output yaml \
       adm create-bootstrap-project-template \
       --name {{ openshift_project_request_template_name | quote }}
@@ -29,7 +29,7 @@
 - name: Create or update project request template
   command: |
     {{ openshift_client_binary }} \
-      --config {{ openshift.common.config_base }}/master/admin.kubeconfig \
+      --config /etc/origin/master/admin.kubeconfig \
       --namespace {{ openshift_project_request_template_namespace | quote }} \
       apply --filename {{ mktemp.stdout }}
 

--- a/roles/openshift_prometheus/tasks/install_node_exporter.yaml
+++ b/roles/openshift_prometheus/tasks/install_node_exporter.yaml
@@ -17,7 +17,7 @@
 
 - name: Copy admin client config
   command: >
-    cp {{ openshift.common.config_base }}/master//admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
+    cp /etc/origin/master//admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
   changed_when: false
 
 # create clusterrolebinding for prometheus-node-exporter serviceaccount

--- a/roles/openshift_provisioners/tasks/main.yaml
+++ b/roles/openshift_provisioners/tasks/main.yaml
@@ -7,7 +7,7 @@
 
 - name: Copy the admin client config(s)
   command: >
-    cp {{ openshift.common.config_base}}/master/admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
+    cp /etc/origin/master/admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
   changed_when: False
   check_mode: no
   tags: provisioners_init

--- a/roles/openshift_service_catalog/tasks/generate_certs.yml
+++ b/roles/openshift_service_catalog/tasks/generate_certs.yml
@@ -1,14 +1,14 @@
 ---
 - name: Create service catalog cert directory
   file:
-    path: "{{ openshift.common.config_base }}/service-catalog"
+    path: "/etc/origin/service-catalog"
     state: directory
     mode: 0755
   changed_when: False
   check_mode: no
 
 - set_fact:
-    generated_certs_dir: "{{ openshift.common.config_base }}/service-catalog"
+    generated_certs_dir: "/etc/origin/service-catalog"
 
 - name: Generate signing cert
   command: >

--- a/roles/openshift_service_catalog/tasks/install.yml
+++ b/roles/openshift_service_catalog/tasks/install.yml
@@ -83,7 +83,7 @@
   register: task_result
   until: task_result.rc == 0
   shell: >
-    {{ openshift_client_binary }} auth reconcile --config={{ openshift.common.config_base }}/master/admin.kubeconfig -f {{ mktemp.stdout}}/openshift_catalog_clusterroles.yml
+    {{ openshift_client_binary }} auth reconcile --config=/etc/origin/master/admin.kubeconfig -f {{ mktemp.stdout}}/openshift_catalog_clusterroles.yml
 
 - oc_adm_policy_user:
     namespace: kube-service-catalog

--- a/roles/openshift_storage_glusterfs/tasks/heketi_deploy_part2.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_deploy_part2.yml
@@ -9,7 +9,7 @@
 # This is used in the subsequent task
 - name: Copy the admin client config
   command: >
-    cp {{ openshift.common.config_base }}/master/admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
+    cp /etc/origin/master/admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
   changed_when: False
   check_mode: no
 

--- a/roles/openshift_web_console/tasks/install.yml
+++ b/roles/openshift_web_console/tasks/install.yml
@@ -14,7 +14,7 @@
 
 - name: Copy admin client config
   command: >
-    cp {{ openshift.common.config_base }}/master//admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
+    cp /etc/origin/master//admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
   changed_when: false
 
 - name: Copy web console templates to temp directory
@@ -50,7 +50,7 @@
   # web console config config map.
   - name: Read existing assetConfig in master-config.yaml
     slurp:
-      src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+      src: "/etc/origin/master/master-config.yaml"
     register: master_config_output
 
   - set_fact:

--- a/roles/openshift_web_console/tasks/remove_old_asset_config.yml
+++ b/roles/openshift_web_console/tasks/remove_old_asset_config.yml
@@ -5,7 +5,7 @@
 - name: Remove assetConfig from master-config.yaml
   yedit:
     state: absent
-    src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+    src: "/etc/origin/master/master-config.yaml"
     key: assetConfig
 
 # This file was written by wire_aggregator.yml. It is no longer needed since
@@ -14,6 +14,4 @@
 - name: Remove obsolete web console / service catalog extension file
   file:
     state: absent
-    # Hard-code the path instead of using `openshift.common.config_base` since
-    # the path is hard-coded in wire_aggregator.yml.
     path: /etc/origin/master/openshift-ansible-catalog-console.js

--- a/roles/template_service_broker/defaults/main.yml
+++ b/roles/template_service_broker/defaults/main.yml
@@ -23,4 +23,4 @@ template_service_broker_prefix: "{{ l_tsb_image_dict[openshift_deployment_type][
 template_service_broker_version: "{{ l_tsb_image_dict[openshift_deployment_type]['version'] }}"
 template_service_broker_image_name: "{{ l_tsb_image_dict[openshift_deployment_type]['image_name'] }}"
 
-openshift_master_config_dir: "{{ openshift.common.config_base }}/master"
+openshift_master_config_dir: "/etc/origin/master"

--- a/roles/template_service_broker/tasks/deploy.yml
+++ b/roles/template_service_broker/tasks/deploy.yml
@@ -11,7 +11,7 @@
 
 - name: Copy admin client config
   command: >
-    cp {{ openshift.common.config_base }}/master//admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
+    cp /etc/origin/master//admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
   changed_when: false
 
 - copy:

--- a/roles/template_service_broker/tasks/remove.yml
+++ b/roles/template_service_broker/tasks/remove.yml
@@ -5,7 +5,7 @@
 
 - name: Copy admin client config
   command: >
-    cp {{ openshift.common.config_base }}/master//admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
+    cp /etc/origin/master//admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
   changed_when: false
 
 - copy:


### PR DESCRIPTION
openshift.common.config_base is not configurable, and is set
by openshift_facts.

This commit removes it and hard-codes the appropriate config path.