### PR TITLE
Aligning version defaults for logging components

### DIFF
--- a/roles/openshift_logging_elasticsearch/vars/default_images.yml
+++ b/roles/openshift_logging_elasticsearch/vars/default_images.yml
@@ -1,5 +1,5 @@
 ---
 __openshift_logging_elasticsearch_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_logging_elasticsearch_image_version: "{{ openshift_logging_image_version | default('latest') }}"
+__openshift_logging_elasticsearch_image_version: "{{ openshift_logging_image_version | default(openshift_image_tag) }}"
 __openshift_logging_elasticsearch_proxy_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/') }}"
 __openshift_logging_elasticsearch_proxy_image_version: "{{ openshift_logging_image_version | default('v1.0.0') }}"

--- a/roles/openshift_logging_eventrouter/vars/default_images.yml
+++ b/roles/openshift_logging_eventrouter/vars/default_images.yml
@@ -1,3 +1,3 @@
 ---
 __openshift_logging_eventrouter_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_logging_eventrouter_image_version: "{{ openshift_logging_image_version | default('latest') }}"
+__openshift_logging_eventrouter_image_version: "{{ openshift_logging_image_version | default(openshift_image_tag) }}"

--- a/roles/openshift_logging_fluentd/vars/default_images.yml
+++ b/roles/openshift_logging_fluentd/vars/default_images.yml
@@ -1,3 +1,3 @@
 ---
 __openshift_logging_fluentd_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_logging_fluentd_image_version: "{{ openshift_logging_image_version | default('latest') }}"
+__openshift_logging_fluentd_image_version: "{{ openshift_logging_image_version | default(openshift_image_tag) }}"

--- a/roles/openshift_logging_kibana/vars/default_images.yml
+++ b/roles/openshift_logging_kibana/vars/default_images.yml
@@ -1,5 +1,5 @@
 ---
 __openshift_logging_kibana_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_logging_kibana_image_version: "{{ openshift_logging_image_version | default('latest') }}"
+__openshift_logging_kibana_image_version: "{{ openshift_logging_image_version | default(openshift_image_tag) }}"
 __openshift_logging_kibana_proxy_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_logging_kibana_proxy_image_version: "{{ openshift_logging_image_version | default('latest') }}"
+__openshift_logging_kibana_proxy_image_version: "{{ openshift_logging_image_version | default(openshift_image_tag) }}"

--- a/roles/openshift_logging_mux/vars/default_images.yml
+++ b/roles/openshift_logging_mux/vars/default_images.yml
@@ -1,3 +1,3 @@
 ---
 __openshift_logging_mux_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_logging_mux_image_version: "{{ openshift_logging_image_version | default('latest') }}"
+__openshift_logging_mux_image_version: "{{ openshift_logging_image_version | default(openshift_image_tag) }}"


### PR DESCRIPTION
I'm not sure about other `var/default_images.yml` files, but this shouldn't have been changed for logging|metrics.

Original change found here: https://github.com/openshift/openshift-ansible/commit/e6e8c13d7d65c81c287a5b53403866db8280a5bf

@jsanda can you confirm this for metrics?