### PR TITLE
Bug fix: Haproxy stats page not reachable when using containerized load balancer

### DIFF
--- a/roles/openshift_loadbalancer/templates/haproxy.docker.service.j2
+++ b/roles/openshift_loadbalancer/templates/haproxy.docker.service.j2
@@ -7,7 +7,7 @@ PartOf={{ openshift_docker_service_name }}.service
 
 [Service]
 ExecStartPre=-/usr/bin/docker rm -f openshift_loadbalancer
-ExecStart=/usr/bin/docker run --rm --name openshift_loadbalancer {% for frontend in openshift_loadbalancer_frontends %} {% for bind in frontend.binds %} -p {{ bind |regex_replace('^[^:]*:(\d+).*$', '\\1') }}:{{ bind |regex_replace('^[^:]*:(\d+).*$', '\\1') }} {% endfor %} {% endfor %} -v /etc/haproxy/haproxy.cfg:/etc/haproxy/haproxy.cfg:ro --entrypoint=haproxy {{ openshift_router_image }}:{{ openshift_image_tag }} -f /etc/haproxy/haproxy.cfg
+ExecStart=/usr/bin/docker run --rm --name openshift_loadbalancer -p 9000:9000 {% for frontend in openshift_loadbalancer_frontends %} {% for bind in frontend.binds %} -p {{ bind |regex_replace('^[^:]*:(\d+).*$', '\\1') }}:{{ bind |regex_replace('^[^:]*:(\d+).*$', '\\1') }} {% endfor %} {% endfor %} -v /etc/haproxy/haproxy.cfg:/etc/haproxy/haproxy.cfg:ro --entrypoint=haproxy {{ openshift_router_image }}:{{ openshift_image_tag }} -f /etc/haproxy/haproxy.cfg
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop openshift_loadbalancer
 LimitNOFILE={{ openshift_loadbalancer_limit_nofile | default(100000) }}


### PR DESCRIPTION
It seems the intention based on other places in this role is for the stats to be enabled and reachable :
* firewall.yml exposes 9000
* haproxy.cfg.j2 has 9000 listener for stats and stats are enabled

however, the container itself is not set to expose this port which makes the stats page unreachable. this PR fixes that. this fix applies to master -- a similar change (assuming this is approved) would be proposed on release-3.7 as the syntax on the line modified in that branch is slightly different so a direct cherry pick will not work

nb: there are a number of places in this role where port 9000 is hardcoded, it felt out of scope of this PR to try and address that but if there is strong feeling that it should be cleaned up as part of this change, I can try and work on that