### PR TITLE
Specify full path to /sbin/ and /usr/sbin binaries

### DIFF
--- a/playbooks/adhoc/docker_loopback_to_lvm/ops-docker-loopback-to-direct-lvm.yml
+++ b/playbooks/adhoc/docker_loopback_to_lvm/ops-docker-loopback-to-direct-lvm.yml
@@ -98,7 +98,7 @@
   - debug: var=setup_output
 
   - name: extend the vg
-    command: lvextend -l 90%VG /dev/docker_vg/docker-pool
+    command: /usr/sbin/lvextend -l 90%VG /dev/docker_vg/docker-pool
     register: extend_output
 
   - debug: var=extend_output

--- a/playbooks/adhoc/grow_docker_vg/grow_docker_vg.yml
+++ b/playbooks/adhoc/grow_docker_vg/grow_docker_vg.yml
@@ -176,7 +176,7 @@
     poll: 10
 
   - name: Remove the old docker drive from the volume group
-    command: "vgreduce {{ docker_vg_name.stdout }} {{ docker_pv_name.stdout }}"
+    command: "/usr/sbin/vgreduce {{ docker_vg_name.stdout }} {{ docker_pv_name.stdout }}"
 
   - name: Remove the pv from the old drive
     command: "pvremove {{ docker_pv_name.stdout }}"

--- a/playbooks/adhoc/grow_docker_vg/grow_docker_vg.yml
+++ b/playbooks/adhoc/grow_docker_vg/grow_docker_vg.yml
@@ -171,7 +171,7 @@
     command: /usr/sbin/vgextend "{{ docker_vg_name.stdout }}" /dev/xvdc1
 
   - name: pvmove onto new volume
-    command: "pvmove {{ docker_pv_name.stdout }} /dev/xvdc1"
+    command: "/usr/sbin/pvmove {{ docker_pv_name.stdout }} /dev/xvdc1"
     async: 43200
     poll: 10
 

--- a/playbooks/adhoc/grow_docker_vg/grow_docker_vg.yml
+++ b/playbooks/adhoc/grow_docker_vg/grow_docker_vg.yml
@@ -182,7 +182,7 @@
     command: "pvremove {{ docker_pv_name.stdout }}"
 
   - name: Extend the docker lvm
-    command: "lvextend -l '90%VG' /dev/{{ docker_vg_name.stdout }}/docker-pool"
+    command: "/usr/sbin/lvextend -l '90%VG' /dev/{{ docker_vg_name.stdout }}/docker-pool"
 
   - name: detach  old docker volume
     delegate_to: localhost

--- a/playbooks/adhoc/grow_docker_vg/grow_docker_vg.yml
+++ b/playbooks/adhoc/grow_docker_vg/grow_docker_vg.yml
@@ -179,7 +179,7 @@
     command: "/usr/sbin/vgreduce {{ docker_vg_name.stdout }} {{ docker_pv_name.stdout }}"
 
   - name: Remove the pv from the old drive
-    command: "pvremove {{ docker_pv_name.stdout }}"
+    command: "/usr/sbin/pvremove {{ docker_pv_name.stdout }}"
 
   - name: Extend the docker lvm
     command: "/usr/sbin/lvextend -l '90%VG' /dev/{{ docker_vg_name.stdout }}/docker-pool"

--- a/playbooks/adhoc/grow_docker_vg/grow_docker_vg.yml
+++ b/playbooks/adhoc/grow_docker_vg/grow_docker_vg.yml
@@ -162,7 +162,7 @@
     delay: 2
 
   - name: partition the new drive and make it lvm
-    command: parted /dev/xvdc --script -- mklabel msdos mkpart primary 0% 100% set 1 lvm
+    command: /usr/sbin/parted /dev/xvdc --script -- mklabel msdos mkpart primary 0% 100% set 1 lvm
 
   - name: pvcreate /dev/xvdc
     command: pvcreate /dev/xvdc1

--- a/playbooks/adhoc/grow_docker_vg/grow_docker_vg.yml
+++ b/playbooks/adhoc/grow_docker_vg/grow_docker_vg.yml
@@ -165,7 +165,7 @@
     command: /usr/sbin/parted /dev/xvdc --script -- mklabel msdos mkpart primary 0% 100% set 1 lvm
 
   - name: pvcreate /dev/xvdc
-    command: pvcreate /dev/xvdc1
+    command: /usr/sbin/pvcreate /dev/xvdc1
 
   - name: Extend the docker volume group
     command: vgextend "{{ docker_vg_name.stdout }}" /dev/xvdc1

--- a/playbooks/adhoc/grow_docker_vg/grow_docker_vg.yml
+++ b/playbooks/adhoc/grow_docker_vg/grow_docker_vg.yml
@@ -168,7 +168,7 @@
     command: /usr/sbin/pvcreate /dev/xvdc1
 
   - name: Extend the docker volume group
-    command: vgextend "{{ docker_vg_name.stdout }}" /dev/xvdc1
+    command: /usr/sbin/vgextend "{{ docker_vg_name.stdout }}" /dev/xvdc1
 
   - name: pvmove onto new volume
     command: "pvmove {{ docker_pv_name.stdout }} /dev/xvdc1"

--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -336,7 +336,7 @@
     changed_when: false
 
   - name: Wipe out Docker storage contents
-    command: vgremove -f {{ item }}
+    command: /usr/sbin/vgremove -f {{ item }}
     with_items: "{{ docker_vg_name.stdout_lines }}"
     when: docker_vg_name.rc == 0
 

--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -146,7 +146,7 @@
       failed_when: False
 
     - name: Remove linux interfaces
-      shell: ip link del "{{ item }}"
+      shell: /usr/sbin/ip link del "{{ item }}"
       changed_when: False
       failed_when: False
       with_items:

--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -330,7 +330,7 @@
       regexp='(ADD_REGISTRY|BLOCK_REGISTRY|INSECURE_REGISTRY)=.*'
 
   - name: Detect Docker storage configuration
-    shell: vgs -o name | grep docker
+    shell: /usr/sbin/vgs -o name | grep docker
     register: docker_vg_name
     failed_when: false
     changed_when: false

--- a/playbooks/gcp/openshift-cluster/build_base_image.yml
+++ b/playbooks/gcp/openshift-cluster/build_base_image.yml
@@ -128,10 +128,10 @@
   - role: os_update_latest
   post_tasks:
   - name: Disable all repos on RHEL
-    command: subscription-manager repos --disable="*"
+    command: /usr/sbin/subscription-manager repos --disable="*"
     when: using_rhel_subscriptions
   - name: Enable repos for packages on RHEL
-    command: subscription-manager repos --enable="rhel-7-server-rpms" --enable="rhel-7-server-extras-rpms"
+    command: /usr/sbin/subscription-manager repos --enable="rhel-7-server-rpms" --enable="rhel-7-server-extras-rpms"
     when: using_rhel_subscriptions
   - name: Install common image prerequisites
     package: name={{ item }} state=latest

--- a/playbooks/openshift-master/private/tasks/restart_hosts.yml
+++ b/playbooks/openshift-master/private/tasks/restart_hosts.yml
@@ -1,7 +1,7 @@
 ---
 - name: Restart master system
   # https://github.com/ansible/ansible/issues/10616
-  shell: sleep 2 && shutdown -r now "OpenShift Ansible master rolling restart"
+  shell: sleep 2 && /usr/sbin/shutdown -r now "OpenShift Ansible master rolling restart"
   async: 1
   poll: 0
   ignore_errors: true

--- a/roles/container_runtime/tasks/common/post.yml
+++ b/roles/container_runtime/tasks/common/post.yml
@@ -5,7 +5,7 @@
     state: directory
 
 - name: Fix SELinux Permissions on /var/lib/containers
-  command: "restorecon -R /var/lib/containers/"
+  command: "/sbin/restorecon -R /var/lib/containers/"
   changed_when: false
 
 - meta: flush_handlers

--- a/roles/container_runtime/tasks/common/setup_docker_symlink.yml
+++ b/roles/container_runtime/tasks/common/setup_docker_symlink.yml
@@ -19,7 +19,7 @@
         - "'already exists' not in results.stderr"
 
     - name: "restorecon the {{ docker_alt_storage_path }}"
-      command: "restorecon -r {{ docker_alt_storage_path }}"
+      command: "/sbin/restorecon -r {{ docker_alt_storage_path }}"
 
     - name: Remove the old docker location
       file:

--- a/roles/container_runtime/tasks/common/setup_docker_symlink.yml
+++ b/roles/container_runtime/tasks/common/setup_docker_symlink.yml
@@ -12,7 +12,7 @@
         - results.rc != 0
 
     - name: "Set the selinux context on {{ docker_alt_storage_path }}"
-      command: "semanage fcontext -a -e {{ docker_default_storage_path }} {{ docker_alt_storage_path }}"
+      command: "/usr/sbin/semanage fcontext -a -e {{ docker_default_storage_path }} {{ docker_alt_storage_path }}"
       register: results
       failed_when:
         - results.rc == 1

--- a/roles/container_runtime/tasks/systemcontainer_crio.yml
+++ b/roles/container_runtime/tasks/systemcontainer_crio.yml
@@ -26,7 +26,7 @@
         backup: yes
 
     - name: Manually modprobe overlay into the kernel
-      command: modprobe overlay
+      command: /usr/sbin/modprobe overlay
 
     - name: Enable and start systemd-modules-load
       service:

--- a/roles/contiv/tasks/ovs.yml
+++ b/roles/contiv/tasks/ovs.yml
@@ -5,7 +5,7 @@
     - binary-update
 
 - name: OVS | Configure selinux for ovs
-  command: "semanage permissive -a openvswitch_t"
+  command: "/usr/sbin/semanage permissive -a openvswitch_t"
 
 - name: OVS | Enable ovs
   service:

--- a/roles/flannel/handlers/main.yml
+++ b/roles/flannel/handlers/main.yml
@@ -24,4 +24,4 @@
 
 - name: save iptable rules
   become: yes
-  command: 'iptables-save'
+  command: '/usr/sbin/iptables-save'

--- a/roles/flannel/tasks/main.yml
+++ b/roles/flannel/tasks/main.yml
@@ -37,7 +37,7 @@
 
 - name: Remove docker bridge ip
   become: yes
-  shell: ip a del `ip a show docker0 | grep "inet[[:space:]]" | awk '{print $2}'` dev docker0
+  shell: /usr/sbin/ip a del `ip a show docker0 | grep "inet[[:space:]]" | awk '{print $2}'` dev docker0
   notify:
     - restart docker
     - restart node

--- a/roles/lib_utils/library/swapoff.py
+++ b/roles/lib_utils/library/swapoff.py
@@ -72,7 +72,7 @@ def check_swap_in_fstab(module):
 def check_swapon_status(module):
     '''Check if swap is actually in use.'''
     try:
-        res = subprocess.check_output(['swapon', '--show'])
+        res = subprocess.check_output(['/sbin/swapon', '--show'])
     except subprocess.CalledProcessError:
         # Some other grep error code, we shouldn't get here.
         result = {'failed': True,

--- a/roles/lib_utils/library/swapoff.py
+++ b/roles/lib_utils/library/swapoff.py
@@ -96,7 +96,7 @@ def comment_swap_fstab(module):
 
 def run_swapoff(module, changed):
     '''Run swapoff command'''
-    res = subprocess.call(['swapoff', '--all'])
+    res = subprocess.call(['/usr/sbin/swapoff', '--all'])
     if res:
         result = {'failed': True,
                   'changed': changed,

--- a/roles/nuage_node/handlers/main.yaml
+++ b/roles/nuage_node/handlers/main.yaml
@@ -5,4 +5,4 @@
 
 - name: save iptable rules
   become: yes
-  command: iptables-save
+  command: /usr/sbin/iptables-save

--- a/roles/nuage_node/tasks/iptables.yml
+++ b/roles/nuage_node/tasks/iptables.yml
@@ -1,6 +1,6 @@
 ---
 - name: IPtables | Get iptables rules
-  command: iptables -L --wait
+  command: /sbin/iptables -L --wait
   register: iptablesrules
   check_mode: no
 

--- a/roles/openshift_expand_partition/tasks/main.yml
+++ b/roles/openshift_expand_partition/tasks/main.yml
@@ -20,5 +20,5 @@
   when: oep_file_system == "xfs"
 
 - name: Expand the filesystem - ext(2,3,4)
-  command: "resize2fs {{oep_drive}}{{oep_partition}}"
+  command: "/usr/sbin/resize2fs {{oep_drive}}{{oep_partition}}"
   when: oep_file_system == "ext"

--- a/roles/openshift_expand_partition/tasks/main.yml
+++ b/roles/openshift_expand_partition/tasks/main.yml
@@ -16,7 +16,7 @@
   command: "growpart {{oep_drive}} {{oep_partition}}"
 
 - name: Expand the filesystem - xfs
-  command: "xfs_growfs {{oep_drive}}{{oep_partition}}"
+  command: "/usr/sbin/xfs_growfs {{oep_drive}}{{oep_partition}}"
   when: oep_file_system == "xfs"
 
 - name: Expand the filesystem - ext(2,3,4)

--- a/roles/openshift_nfs/tasks/create_export.yml
+++ b/roles/openshift_nfs/tasks/create_export.yml
@@ -29,6 +29,6 @@
   register: created_export
 
 - name: Re-export NFS filesystems
-  command: exportfs -ar
+  command: /usr/sbin/exportfs -ar
   when:
     - created_export is changed

--- a/roles/openshift_node/tasks/storage_plugins/glusterfs.yml
+++ b/roles/openshift_node/tasks/storage_plugins/glusterfs.yml
@@ -41,7 +41,7 @@
 # ansible release.
 - name: Set seboolean to allow gluster storage plugin access from containers (python 3)
   command: >
-    setsebool -P {{ item.item }} on
+    /usr/sbin/setsebool -P {{ item.item }} on
   when:
   - ansible_selinux
   - ansible_selinux.status == "enabled"

--- a/roles/openshift_node/tasks/storage_plugins/glusterfs.yml
+++ b/roles/openshift_node/tasks/storage_plugins/glusterfs.yml
@@ -6,7 +6,7 @@
   until: result is succeeded
 
 - name: Check for existence of fusefs sebooleans
-  command: getsebool {{ item }}
+  command: /usr/sbin/getsebool {{ item }}
   register: fusefs_getsebool_status
   when:
   - ansible_selinux

--- a/roles/openshift_node/tasks/storage_plugins/iscsi.yml
+++ b/roles/openshift_node/tasks/storage_plugins/iscsi.yml
@@ -30,5 +30,5 @@
 
 #enable multipath
 - name: Enable multipath
-  command: "mpathconf --enable"
+  command: "/usr/sbin/mpathconf --enable"
   when: not openshift_is_atomic | bool

--- a/roles/openshift_node/tasks/storage_plugins/nfs.yml
+++ b/roles/openshift_node/tasks/storage_plugins/nfs.yml
@@ -41,7 +41,7 @@
 # ansible release.
 - name: Set seboolean to allow nfs storage plugin access from containers (python 3)
   command: >
-    setsebool -P {{ item.item }} on
+    /usr/sbin/setsebool -P {{ item.item }} on
   when:
   - ansible_selinux
   - ansible_selinux.status == "enabled"

--- a/roles/openshift_node/tasks/storage_plugins/nfs.yml
+++ b/roles/openshift_node/tasks/storage_plugins/nfs.yml
@@ -6,7 +6,7 @@
   until: result is succeeded
 
 - name: Check for existence of nfs sebooleans
-  command: getsebool {{ item }}
+  command: /usr/sbin/getsebool {{ item }}
   register: nfs_getsebool_status
   when:
   - ansible_selinux

--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -53,7 +53,7 @@
   when: not openshift_is_containerized | bool
 
 - name: Reset selinux context
-  command: restorecon -RF {{ openshift_node_data_dir }}/openshift.local.volumes
+  command: /sbin/restorecon -RF {{ openshift_node_data_dir }}/openshift.local.volumes
   when:
   - ansible_selinux is defined
   - ansible_selinux.status == 'enabled'

--- a/roles/openshift_repos/tasks/rhel_repos.yml
+++ b/roles/openshift_repos/tasks/rhel_repos.yml
@@ -19,11 +19,11 @@
   failed_when: repo_rhel.rc == 11
 
 - name: Disable all repositories
-  command: bash -c "subscription-manager repos --disable='*'"
+  command: bash -c "/usr/sbin/subscription-manager repos --disable='*'"
   when: repo_rhel.changed
 
 - name: Enable RHEL repositories
-  command: subscription-manager repos \
+  command: /usr/sbin/subscription-manager repos \
                --enable="rhel-7-server-rpms" \
                --enable="rhel-7-server-extras-rpms" \
                --enable="rhel-7-server-ose-{{ (openshift_release | default('')).split('.')[0:2] | join('.') }}-rpms" \

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
@@ -34,7 +34,7 @@
   when: glusterfs_wipe
 
 - name: Get GlusterFS storage devices state
-  command: "pvdisplay -C --noheadings -o pv_name,vg_name {% for device in hostvars[item].glusterfs_devices %}{{ device }} {% endfor %}"
+  command: "/usr/sbin/pvdisplay -C --noheadings -o pv_name,vg_name {% for device in hostvars[item].glusterfs_devices %}{{ device }} {% endfor %}"
   register: devices_info
   delegate_to: "{{ item }}"
   with_items: "{{ glusterfs_nodes | default([]) }}"

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
@@ -43,7 +43,7 @@
 
   # Runs "lvremove -ff <vg>; vgremove -fy <vg>; pvremove -fy <pv>" for every device found to be a physical volume.
 - name: Clear GlusterFS storage device contents
-  shell: "{% for line in item.stdout_lines %}{% set fields = line.split() %}{% if fields | count > 1 %}lvremove -ff {{ fields[1] }}; vgremove -fy {{ fields[1] }}; {% endif %}pvremove -fy {{ fields[0] }}; {% endfor %}"
+  shell: "{% for line in item.stdout_lines %}{% set fields = line.split() %}{% if fields | count > 1 %}lvremove -ff {{ fields[1] }}; /usr/sbin/vgremove -fy {{ fields[1] }}; {% endif %}/usr/sbin/pvremove -fy {{ fields[0] }}; {% endfor %}"
   delegate_to: "{{ item.item }}"
   with_items: "{{ devices_info.results }}"
   register: clear_devices

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
@@ -128,7 +128,7 @@
 
   # Runs "lvremove -ff <vg>; vgremove -fy <vg>; pvremove -fy <pv>" for every device found to be a physical volume.
 - name: Clear GlusterFS storage device contents
-  shell: "{% for line in item.stdout_lines %}{% set fields = line.split() %}{% if fields | count > 1 %}lvremove -ff {{ fields[1] }}; vgremove -fy {{ fields[1] }}; {% endif %}pvremove -fy {{ fields[0] }}; {% endfor %}"
+  shell: "{% for line in item.stdout_lines %}{% set fields = line.split() %}{% if fields | count > 1 %}lvremove -ff {{ fields[1] }}; /usr/sbin/vgremove -fy {{ fields[1] }}; {% endif %}/usr/sbin/pvremove -fy {{ fields[0] }}; {% endfor %}"
   delegate_to: "{{ item.item }}"
   with_items: "{{ devices_info.results }}"
   register: clear_devices

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
@@ -119,7 +119,7 @@
   failed_when: False
 
 - name: Get GlusterFS storage devices state
-  command: "pvdisplay -C --noheadings -o pv_name,vg_name {% for device in hostvars[item].glusterfs_devices %}{{ device }} {% endfor %}"
+  command: "/usr/sbin/pvdisplay -C --noheadings -o pv_name,vg_name {% for device in hostvars[item].glusterfs_devices %}{{ device }} {% endfor %}"
   register: devices_info
   delegate_to: "{{ item }}"
   with_items: "{{ glusterfs_nodes | default([]) }}"

--- a/roles/rhel_subscribe/tasks/main.yml
+++ b/roles/rhel_subscribe/tasks/main.yml
@@ -11,7 +11,7 @@
   until: result is succeeded
 
 - name: Is host already registered?
-  command: "subscription-manager version"
+  command: "/usr/sbin/subscription-manager version"
   register: rh_subscribed
   changed_when: False
 
@@ -31,13 +31,13 @@
     - rh_subscription.failed
 
 - name: Determine if OpenShift Pool Already Attached
-  command: "subscription-manager list --consumed --pool-only --matches '*OpenShift*'"
+  command: "/usr/sbin/subscription-manager list --consumed --pool-only --matches '*OpenShift*'"
   register: openshift_pool_attached
   changed_when: False
   ignore_errors: yes
 
 - name: Attach to OpenShift Pool
-  command: "subscription-manager attach --pool {{ rhsub_pool }}"
+  command: "/usr/sbin/subscription-manager attach --pool {{ rhsub_pool }}"
   register: openshift_pool_attached
   changed_when: "'Successfully attached a subscription' in openshift_pool_attached.stdout"
   when: rhsub_pool not in openshift_pool_attached.stdout


### PR DESCRIPTION
Some admins might want to restrict sudo access to /usr/sbin and /sbin binaries,
so openshift-ansible should use full paths when an unprivileged user and 
sudo are used

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1552454

Created a commit per binary name, I'll squash those after the review is done