### PR TITLE
Remove force cache during node upgrade install

### DIFF
--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -14,7 +14,7 @@
 
 # Ensure actually install latest package.
 - name: install docker upgrade rpm
-  command: "{{ ansible_pkg_mgr }} install -C -y docker{{ '-' + docker_version }}"
+  command: "{{ ansible_pkg_mgr }} install -y docker{{ '-' + docker_version }}"
   register: result
   until: result is succeeded
   when:

--- a/roles/openshift_node/tasks/upgrade/rpm_upgrade_install.yml
+++ b/roles/openshift_node/tasks/upgrade/rpm_upgrade_install.yml
@@ -8,8 +8,8 @@
 # Install the pre-pulled RPM
 # Note: dnsmasq is covered in it's own play.  openvswitch is included here
 # because once we have the latest rpm downloaded, it will happily be installed.
-- name: download new node packages
-  command: "{{ ansible_pkg_mgr }} install -C -y {{ openshift_node_upgrade_rpm_list | join(' ')}}"
+- name: install new node packages
+  command: "{{ ansible_pkg_mgr }} install -y {{ openshift_node_upgrade_rpm_list | join(' ')}}"
   register: result
   until: result is succeeded
   vars:


### PR DESCRIPTION
Currently, we attempt to install from only cache
during a node upgrade.

From time to time, the meta data may expire from
rpm cache, causing installs to fail.

By removing the '-C' switch, yum will update
meta data if needed, and still install any
packages from cache that it can.