### PR TITLE
cri-o install honoring both rpm and system container

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -150,10 +150,12 @@ debug_level=2
 # The following options must not be used
 # - openshift_docker_options
 #openshift_docker_use_system_container=False
-# Install and run cri-o along side docker
+# Install and run cri-o. By default this will install cri-o as a system container.
+#openshift_use_crio=False
+# You can install cri-o as an rpm by setting the following variable:
+#openshift_crio_use_rpm=False
 # NOTE: This uses openshift_docker_systemcontainer_image_registry_override as it's override
 # just as container-engine does.
-#openshift_use_crio=False
 # Force the registry to use for the container-engine/crio system container. By default the registry
 # will be built off of the deployment type and ansible_distribution. Only
 # use this option if you are sure you know what you are doing!

--- a/playbooks/container-runtime/private/config.yml
+++ b/playbooks/container-runtime/private/config.yml
@@ -34,4 +34,12 @@
         tasks_from: systemcontainer_crio.yml
       when:
         - openshift_use_crio | bool
+        - not openshift_crio_use_rpm | bool
+        - openshift_docker_is_node_or_master | bool
+    - import_role:
+        name: container_runtime
+        tasks_from: package_crio.yml
+      when:
+        - openshift_use_crio | bool
+        - openshift_crio_use_rpm | bool
         - openshift_docker_is_node_or_master | bool

--- a/playbooks/init/basic_facts.yml
+++ b/playbooks/init/basic_facts.yml
@@ -35,6 +35,12 @@
       openshift_is_atomic: "{{ ostree_booted.stat.exists }}"
       openshift_is_containerized: "{{ ostree_booted.stat.exists or (containerized | default(false) | bool) }}"
 
+  - name: Set use_crio to True if cri-o rpm is requested
+    set_fact:
+      openshift_use_crio: True
+    when:
+    - openshift_crio_use_rpm | default(False) | bool
+
   # TODO: Should this be moved into health checks??
   # Seems as though any check that happens with a corresponding fail should move into health_checks
   # Fail as early as possible if Atomic and old version of Docker

--- a/roles/container_runtime/README.md
+++ b/roles/container_runtime/README.md
@@ -12,6 +12,7 @@ Entry points
 * package_docker.yml - install and setup docker container runtime.
 * systemcontainer_docker.yml - utilize docker + systemcontainer
 * systemcontainer_crio.yml - utilize crio + systemcontainer
+* package_crio.yml - install and setup crio container runtime.
 * registry_auth.yml - place docker login credentials.
 
 Requirements

--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -81,6 +81,7 @@ docker_https_proxy: "{{ openshift.common.https_proxy | default('') }}"
 docker_no_proxy: "{{ openshift.common.no_proxy | default('') }}"
 
 openshift_use_crio: False
+openshift_crio_use_rpm: False
 openshift_use_crio_only: False
 
 l_openshift_image_tag_default: "{{ openshift_release | default('latest') }}"

--- a/roles/container_runtime/tasks/package_crio.yml
+++ b/roles/container_runtime/tasks/package_crio.yml
@@ -1,14 +1,10 @@
 ---
-# TODO: Much of this file is shared with container engine tasks
-- name: Check we are not using node as a Docker container with CRI-O
-  fail: msg='Cannot use CRI-O with node configured as a Docker container'
+- name: Fail if Atomic Host since this is an rpm request
+  fail: msg='Cannot use CRI-O as a package on Atomic Host'
   when:
-    - openshift_is_containerized | bool
-    - not l_is_node_system_container | bool
+    - openshift_is_atomic | bool
 
 - include_tasks: common/pre.yml
-
-- include_tasks: common/syscontainer_packages.yml
 
 - name: Check that overlay is in the kernel
   shell: lsmod | grep overlay
@@ -34,27 +30,12 @@
         enabled: yes
         state: restarted
 
-- name: Ensure proxies are in the atomic.conf
-  include_tasks: common/atomic_proxy.yml
-
-# Be nice and let the user see the variable result
-- debug:
-    var: l_crio_image
-
-# NOTE: no_proxy added as a workaround until https://github.com/projectatomic/atomic/pull/999 is released
-- name: Pre-pull CRI-O System Container image
-  command: "atomic pull --storage ostree {{ l_crio_image }}"
-  changed_when: false
-  environment:
-    NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
-
-- name: Install CRI-O System Container
-  oc_atomic_container:
+- name: Install cri-o
+  package:
     name: "cri-o"
-    image: "{{ l_crio_image }}"
-    state: latest
-    values:
-      - "ADDTL_MOUNTS={{ l_crio_additional_mounts }}"
+    state: present
+  register: result
+  until: result is succeeded
 
 - name: Remove CRI-O default configuration files
   file:
@@ -83,12 +64,6 @@
     dest: /etc/cni/net.d/openshift-sdn.conf
     src: 80-openshift-sdn.conf.j2
 
-- name: Create /etc/sysconfig/crio-storage
-  copy:
-    content: ""
-    dest: /etc/sysconfig/crio-storage
-    force: no
-
 - name: Create /etc/sysconfig/crio-network
   template:
     dest: /etc/sysconfig/crio-network
@@ -98,7 +73,7 @@
   systemd:
     name: "cri-o"
     enabled: yes
-    state: started
+    state: restarted
     daemon_reload: yes
   register: start_result
 

--- a/roles/openshift_cli/defaults/main.yml
+++ b/roles/openshift_cli/defaults/main.yml
@@ -6,6 +6,7 @@ system_images_registry_dict:
 system_images_registry: "{{ system_images_registry_dict[openshift_deployment_type | default('origin')] }}"
 
 openshift_use_crio_only: False
+openshift_crio_use_rpm: False
 
 l_is_system_container_image: "{{ openshift_use_master_system_container | default(openshift_use_system_containers | default(False)) | bool }}"
-l_use_cli_atomic_image: "{{ (openshift_use_crio_only | bool) or (l_is_system_container_image | bool) }}"
+l_use_cli_atomic_image: "{{ (openshift_use_crio_only | bool and not openshift_crio_use_rpm | bool) or (l_is_system_container_image | bool) }}"


### PR DESCRIPTION
I fully expect this to fail cri-o CI being that the variables have been modified :smile:.

- ```openshift_use_crio```: When ```True``` will default to system container install.
- ```openshift_crio_use_rpm```: When ```True``` overrides and uses a rpm install instead. It's expected that ```openshift_use_crio``` is also ```True```.
- New task file: container_runtime: package_crio
- Bug fix: ```map_to_pairs``` for docker_gc check


/cc @cevich @mrunalp @sdodson