### PR TITLE
docker_gc: map the r_docker_gc_node_selectors to pairs

### DIFF
--- a/roles/openshift_docker_gc/tasks/main.yml
+++ b/roles/openshift_docker_gc/tasks/main.yml
@@ -4,7 +4,7 @@
     name: openshift_master
     tasks_from: ensure_nodes_matching_selector.yml
   vars:
-    openshift_master_ensure_nodes_selector: "{{ r_docker_gc_node_selectors }}"
+    openshift_master_ensure_nodes_selector: "{{ r_docker_gc_node_selectors | map_to_pairs }}"
     openshift_master_ensure_nodes_service: docker-gc daemonset
 
 - name: Create docker-gc tempdir


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1552438