### PR TITLE
Trigger main init

### DIFF
--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -1,4 +1,7 @@
 ---
+- set_fact:
+  full_install: true
+
 - import_playbook: init/main.yml
 
 - import_playbook: common/private/control_plane.yml

--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -1,7 +1,4 @@
 ---
-- set_fact:
-  full_install: true
-
 - import_playbook: init/main.yml
 
 - import_playbook: common/private/control_plane.yml

--- a/playbooks/init/main.yml
+++ b/playbooks/init/main.yml
@@ -15,6 +15,9 @@
         installer_phase_initialize:
           status: "In Progress"
           start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+  - name: Set init_called fact
+    set_fact:
+      init_called: true
 
 - import_playbook: evaluate_groups.yml
 

--- a/playbooks/openshift-grafana/private/config.yml
+++ b/playbooks/openshift-grafana/private/config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Trigger init.main.yml
-  import_playbook: init/main.yml
+  import_playbook: ../../init/main.yml
   when: full_deploy is undefined
 
 - name: Grafana Install Checkpoint Start

--- a/playbooks/openshift-grafana/private/config.yml
+++ b/playbooks/openshift-grafana/private/config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Trigger init.main.yml
   import_playbook: ../../init/main.yml
-  when: full_deploy is undefined
+  when: init_called is undefined
 
 - name: Grafana Install Checkpoint Start
   hosts: all

--- a/playbooks/openshift-grafana/private/config.yml
+++ b/playbooks/openshift-grafana/private/config.yml
@@ -1,4 +1,8 @@
 ---
+- name: Trigger init.main.yml
+  import_playbook: init/main.yml
+  when: full_deploy is undefined
+
 - name: Grafana Install Checkpoint Start
   hosts: all
   gather_facts: false

--- a/playbooks/openshift-logging/private/config.yml
+++ b/playbooks/openshift-logging/private/config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Trigger init.main.yml
-  import_playbook: init/main.yml
+  import_playbook: ../../init/main.yml
   when: full_deploy is undefined
 
 - name: Logging Install Checkpoint Start

--- a/playbooks/openshift-logging/private/config.yml
+++ b/playbooks/openshift-logging/private/config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Trigger init.main.yml
   import_playbook: ../../init/main.yml
-  when: full_deploy is undefined
+  when: init_called is undefined
 
 - name: Logging Install Checkpoint Start
   hosts: all

--- a/playbooks/openshift-logging/private/config.yml
+++ b/playbooks/openshift-logging/private/config.yml
@@ -1,4 +1,8 @@
 ---
+- name: Trigger init.main.yml
+  import_playbook: init/main.yml
+  when: full_deploy is undefined
+
 - name: Logging Install Checkpoint Start
   hosts: all
   gather_facts: false

--- a/playbooks/openshift-management/private/config.yml
+++ b/playbooks/openshift-management/private/config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Trigger init.main.yml
-  import_playbook: init/main.yml
+  import_playbook: ../../init/main.yml
   when: full_deploy is undefined
 
 - name: Management Install Checkpoint Start

--- a/playbooks/openshift-management/private/config.yml
+++ b/playbooks/openshift-management/private/config.yml
@@ -1,4 +1,8 @@
 ---
+- name: Trigger init.main.yml
+  import_playbook: init/main.yml
+  when: full_deploy is undefined
+
 - name: Management Install Checkpoint Start
   hosts: all
   gather_facts: false

--- a/playbooks/openshift-management/private/config.yml
+++ b/playbooks/openshift-management/private/config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Trigger init.main.yml
   import_playbook: ../../init/main.yml
-  when: full_deploy is undefined
+  when: init_called is undefined
 
 - name: Management Install Checkpoint Start
   hosts: all

--- a/playbooks/openshift-metrics/private/config.yml
+++ b/playbooks/openshift-metrics/private/config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Trigger init.main.yml
   import_playbook: ../../init/main.yml
-  when: full_deploy is undefined
+  when: init_called is undefined
 
 - name: Metrics Install Checkpoint Start
   hosts: all

--- a/playbooks/openshift-metrics/private/config.yml
+++ b/playbooks/openshift-metrics/private/config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Trigger init.main.yml
-  import_playbook: init/main.yml
+  import_playbook: ../../init/main.yml
   when: full_deploy is undefined
 
 - name: Metrics Install Checkpoint Start

--- a/playbooks/openshift-metrics/private/config.yml
+++ b/playbooks/openshift-metrics/private/config.yml
@@ -1,4 +1,8 @@
 ---
+- name: Trigger init.main.yml
+  import_playbook: init/main.yml
+  when: full_deploy is undefined
+
 - name: Metrics Install Checkpoint Start
   hosts: all
   gather_facts: false

--- a/playbooks/openshift-prometheus/private/config.yml
+++ b/playbooks/openshift-prometheus/private/config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Trigger init.main.yml
-  import_playbook: init/main.yml
+  import_playbook: ../../init/main.yml
   when: full_deploy is undefined
 
 - name: Prometheus Install Checkpoint Start

--- a/playbooks/openshift-prometheus/private/config.yml
+++ b/playbooks/openshift-prometheus/private/config.yml
@@ -1,4 +1,8 @@
 ---
+- name: Trigger init.main.yml
+  import_playbook: init/main.yml
+  when: full_deploy is undefined
+
 - name: Prometheus Install Checkpoint Start
   hosts: all
   gather_facts: false

--- a/playbooks/openshift-prometheus/private/config.yml
+++ b/playbooks/openshift-prometheus/private/config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Trigger init.main.yml
   import_playbook: ../../init/main.yml
-  when: full_deploy is undefined
+  when: init_called is undefined
 
 - name: Prometheus Install Checkpoint Start
   hosts: all

--- a/playbooks/openshift-service-catalog/private/config.yml
+++ b/playbooks/openshift-service-catalog/private/config.yml
@@ -1,4 +1,8 @@
 ---
+- name: Trigger init.main.yml
+  import_playbook: init/main.yml
+  when: full_deploy is undefined
+
 - name: Service Catalog Install Checkpoint Start
   hosts: all
   gather_facts: false

--- a/playbooks/openshift-service-catalog/private/config.yml
+++ b/playbooks/openshift-service-catalog/private/config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Trigger init.main.yml
   import_playbook: ../../init/main.yml
-  when: full_deploy is undefined
+  when: init_called is undefined
 
 - name: Service Catalog Install Checkpoint Start
   hosts: all

--- a/playbooks/openshift-service-catalog/private/config.yml
+++ b/playbooks/openshift-service-catalog/private/config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Trigger init.main.yml
-  import_playbook: init/main.yml
+  import_playbook: ../../init/main.yml
   when: full_deploy is undefined
 
 - name: Service Catalog Install Checkpoint Start

--- a/playbooks/openshift-web-console/private/config.yml
+++ b/playbooks/openshift-web-console/private/config.yml
@@ -1,4 +1,8 @@
 ---
+- name: Trigger init.main.yml
+  import_playbook: init/main.yml
+  when: full_deploy is undefined
+
 - name: Web Console Install Checkpoint Start
   hosts: all
   gather_facts: false

--- a/playbooks/openshift-web-console/private/config.yml
+++ b/playbooks/openshift-web-console/private/config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Trigger init.main.yml
-  import_playbook: init/main.yml
+  import_playbook: ../../init/main.yml
   when: full_deploy is undefined
 
 - name: Web Console Install Checkpoint Start

--- a/playbooks/openshift-web-console/private/config.yml
+++ b/playbooks/openshift-web-console/private/config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Trigger init.main.yml
   import_playbook: ../../init/main.yml
-  when: full_deploy is undefined
+  when: init_called is undefined
 
 - name: Web Console Install Checkpoint Start
   hosts: all


### PR DESCRIPTION
There are times when we want to re-deploy a single component without re-deploying the entire cluster.

This adds a fact, init_called, to the init/main.yml playbook.

Individual component playbooks, i.e., openshift-logging, check for
the init_called fact and if it's defined, skip calling the
init/main.yml playbook.

If init_called is not defined, the component playbook will call the
init/main.yml playbook and configure the facts necessary to run the individual
component playbook.