### PR TITLE
Update ensure_nodes_matching_selector.yml

### DIFF
--- a/roles/openshift_master/tasks/ensure_nodes_matching_selector.yml
+++ b/roles/openshift_master/tasks/ensure_nodes_matching_selector.yml
@@ -4,7 +4,7 @@
     state: list
     kind: node
     selector: "{{ openshift_master_ensure_nodes_selector }}"
-    field_selector: "spec.unschedulable!=true"
+    selector: "spec.unschedulable!=true"
   register: __schedulable_nodes_matching_selector
 
 - name: "Ensure that {{ openshift_master_ensure_nodes_service }} has nodes to run on"


### PR DESCRIPTION
FIX proposed 

[root@poc-ansible-1 openshift-ansible]# diff roles/openshift_master/tasks/ensure_nodes_matching_selector.yml roles/openshift_master/tasks/ensure_nodes_matching_selector.yml.`date +%Y%m%d`
7c7
<     selector: "spec.unschedulable!=true"
---
>     field_selector: "spec.unschedulable!=true"

REASON  

"/bin/oc get node --selector=region=infra --field-selector=spec.unschedulable!=true -o json -n default" cmd is not correct. It should be "/bin/oc get node --selector=region=infra --selector=spec.unschedulable!=true -o json -n default"

TO AVOID 

TASK [openshift_master : Retrieve list of schedulable nodes matching selector] ***********************************************************************************************************************************************************************
Wednesday 07 March 2018  19:42:27 +0000 (0:00:00.080)       0:01:02.091 ******* 
fatal: [localhost]: FAILED! => {"changed": false, "msg": {"cmd": "/bin/oc get node --selector=region=infra --field-selector=spec.unschedulable!=true -o json -n default", "results": [{}], "returncode": 1, "stderr": "Error: unknown flag: --field-se
lector\n\n\nUsage:\n  oc get [(-o|--output=)json|yaml|wide|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=...] (TYPE [NAME | -l label] | TYPE/NAME ...) [flags] [options]\n\nExamples:\n  
# List all pods in ps output format.\n  oc get pods\n  \n  # List a single replication controller with specified ID in ps output format.\n  oc get rc redis\n  \n  # List all pods and show more details about them.\n  oc get -o wide pods\n  \n  # L
ist a single pod in JSON output format.\n  oc get -o json pod redis-pod\n  \n  # Return only the status value of the specified pod.\n  oc get -o template pod redis-pod --template={{.currentState.status}}\n\nOptions:\n      --all-namespaces=false:
 If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.\n      --allow-missing-template-keys=true: If true, ignore any errors in templates when a field or map ke
y is missing in the template. Only applies to golang and jsonpath output formats.\n      --experimental-use-openapi-print-columns=false: If true, use x-kubernetes-print-column metadata (if present) from openapi schema for displaying a resource.\n
      --export=false: If true, use 'export' for the resources.  Exported resources are stripped of cluster-specific information.\n  -f, --filename=[]: Filename, directory, or URL to files identifying the resource to get from a server.\n      --ig
nore-not-found=false: Treat \"resource not found\" as a successful retrieval.\n      --include-extended-apis=true: If true, include definitions of new APIs via calls to the API server. [default true]\n  -L, --label-columns=[]: Accepts a comma sep
arated list of labels that are going to be presented as columns. Names are case-sensitive. You can also use multiple flag options like -L label1 -L label2...\n      --no-headers=false: When using the default or custom-column output format, don't 
print headers (default print headers).\n  -o, --output='': Output format. One of: json|yaml|wide|name|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See custom columns [http://kubern
etes.io/docs/user-guide/kubectl-overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].\n      --raw='': Raw URI to request from the ser
ver.  Uses the transport specified by the kubeconfig file.\n  -R, --recursive=false: Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.\n      --schema-c
ache-dir='~/.kube/schema': If non-empty, load/store cached API schemas in this directory, default is '$HOME/.kube/schema'\n  -l, --selector='': Selector (label query) to filter on, supports '=', '==', and '!='.\n  -a, --show-all=true: When printi
ng, show all resources (false means hide terminated pods.)\n      --show-kind=false: If present, list the resource type for the requested object(s).\n      --show-labels=false: When printing, show all labels as the last column (default hide label
s column)\n      --sort-by='': If non-empty, sort list types using this field specification.  The field specification is expressed as a JSONPath expression (e.g. '{.metadata.name}'). The field in the API resource specified by this JSONPath expres
sion must be an integer or a string.\n      --template='': Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].\n  -
w, --watch=false: After listing/getting the requested object, watch for changes.\n      --watch-only=false: Watch for changes to the requested object(s), without listing/getting first.\n\nUse \"oc options\" for a list of global command-line optio
ns (applies to all commands).\n\n", "stdout": ""}}
PLAY RECAP *******************************************************************************************************************************************************************************************************************************************
localhost                  : ok=117  changed=24   unreachable=0    failed=1   


