### PR TITLE
TSB upgrade remove and reinstall

### DIFF
--- a/roles/template_service_broker/tasks/upgrade.yml
+++ b/roles/template_service_broker/tasks/upgrade.yml
@@ -1,3 +1,6 @@
 ---
+# TODO(michaelgugino)
+# We can get rid of this remove section after switching to deployments.
+- include_tasks: remove.yml
 
 - include_tasks: deploy.yml


### PR DESCRIPTION
Daemonsets can't be updated in the same way as
deployment configs.

This commit instructs upgrade to first remove
then reintsall tsb.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1540521