### PR TITLE
Enabling multi vif pool drivers

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -196,6 +196,20 @@ preloading them, you should uncomment and set the next:
 Note in the last variable you specify the number of subports that will
 be created per trunk port, i.e., per pool.
 
+In order to enable the kuryr `multi-pool` driver support, we need to tag
+the nodes with their corresponding `pod_vif` labels so that the right kuryr
+pool driver is used for each VM/node. To do that, uncomment:
+
+```
+openshift_openstack_cluster_node_labels:
+  app:
+    region: primary
+    pod_vif: nested-vlan
+  infra:
+    region: infra
+    pod_vif: nested-vlan
+```
+
 
 ## Multi-Master Configuration
 

--- a/playbooks/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/all.yml
@@ -177,11 +177,15 @@ ansible_user: openshift
 # # OpenShift node labels
 # # - in order to customise node labels for app and/or infra group, set the
 # #   openshift_openstack_cluster_node_labels variable
+# # - to enable the multi-pool driver support at Kuryr the driver for the pod
+#  #  pod vif need to be added as a node label
 #openshift_openstack_cluster_node_labels:
 #  app:
 #    region: primary
+#    pod_vif: nested-vlan
 #  infra:
 #    region: infra
+#    pod_vif: nested-vlan
 
 ## cloud config
 openshift_openstack_disable_root: true

--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -231,8 +231,7 @@ data:
     pod_vif_driver = nested-vlan
 
     # The driver that manages VIFs pools for Kubernetes Pods (string value)
-    vif_pool_driver = {{ kuryr_openstack_enable_pools | default(False) | ternary('nested', 'noop') }}
-
+    vif_pool_driver = {{ kuryr_openstack_enable_pools | default(False) | ternary('multi', 'noop') }}
 
     [neutron]
     # Configuration options for OpenStack Neutron
@@ -286,6 +285,7 @@ data:
 
     [neutron_defaults]
 
+    ovs_bridge = br-int
     pod_security_groups = {{ kuryr_openstack_pod_sg_id }}
     pod_subnet = {{ kuryr_openstack_pod_subnet_id }}
     service_subnet = {{ kuryr_openstack_service_subnet_id }}
@@ -328,6 +328,9 @@ data:
 
     # Minimun interval (in seconds) between pool updates (integer value)
     ports_pool_update_frequency = {{ kuryr_openstack_pool_update_frequency | default(20) }}
+
+    # Pod VIF drivers vs Pool Drivers mapping allowed
+    pools_vif_drivers = nested:nested-vlan,neutron:neutron-vif
 
   kuryr-cni.conf: |+
     [DEFAULT]
@@ -604,6 +607,7 @@ data:
 
     [neutron_defaults]
 
+    ovs_bridge = br-int
     pod_security_groups = {{ kuryr_openstack_pod_sg_id }}
     pod_subnet = {{ kuryr_openstack_pod_subnet_id }}
     service_subnet = {{ kuryr_openstack_service_subnet_id }}


### PR DESCRIPTION
This PR add support for the new Kuryr multi pool driver that is used to
support hybrid environments where some nodes are Bare Metal while others
are running inside VMs, therefore having different VIF drivers
(e.g., neutron and nested-vlan)