### PR TITLE
system containers: ensure Atomic won't reset permissions for etcd_data_dir

### DIFF
--- a/roles/etcd/tasks/system_container.yml
+++ b/roles/etcd/tasks/system_container.yml
@@ -86,3 +86,9 @@
     owner: root
     group: root
     recurse: True
+
+- name: Ensure correct permissions are set for etcd_data_dir
+  template:
+    src: etcd-dir.conf.j2
+    dest: "/etc/tmpfiles.d/etcd-dir.conf"
+    backup: true

--- a/roles/etcd/templates/etcd-dir.conf.j2
+++ b/roles/etcd/templates/etcd-dir.conf.j2
@@ -1,0 +1,1 @@
+d {{ etcd_data_dir }} 0700 root root - -


### PR DESCRIPTION
Default Atomic tmpfile has:
```
d /var/lib/etcd 0755 etcd etcd - -
```
in /usr/lib/tmpfiles.d/rpm-ostree-1-autovar.conf

Etcd system container requires this dir to be owned by root, so system
container installation should override tmpfiles.

Note, that etcd system container installs its own
/etc/tmpfiles.d/etcd.conf, so this override should probably happen
there.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1553084