### PR TITLE
openshift_node: Remove hardcoded cri-o node labels

### DIFF
--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -19,9 +19,6 @@ kubeletArguments: {{  l2_openshift_node_kubelet_args  | default(None) | lib_util
   - {{ l_crio_var_sock }}
   image-service-endpoint:
   - {{ l_crio_var_sock }}
-  node-labels:
-  - router=true
-  - registry=true
   runtime-request-timeout:
   - 10m
 {% endif %}


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1553012