### PR TITLE
[FIX] Use router_config.namespace and stop enforcing default

### DIFF
--- a/roles/lib_openshift/library/oc_adm_router.py
+++ b/roles/lib_openshift/library/oc_adm_router.py
@@ -2703,7 +2703,7 @@ class Router(OpenShiftCLI):
            - secret/router-certs
            - clusterrolebinding/router-router-role
         '''
-        super(Router, self).__init__('default', router_config.kubeconfig, verbose)
+        super(Router, self).__init__(router_config.namespace, router_config.kubeconfig, verbose)
         self.config = router_config
         self.verbose = verbose
         self.router_parts = [{'kind': 'dc', 'name': self.config.name},


### PR DESCRIPTION
Option namespace is ignored in module oc_adm_router. Module enforce 'default' namespace

Following tasks is executed in 'default' namespace instead of 'my-namespace'

- name: create routers
  oc_adm_router:
    name: router
    service_account: router
    replicas: 2
    namespace: my-namespace

