### PR TITLE
dockergc: use oc rather than openshift for ex subcommand

### DIFF
--- a/roles/openshift_docker_gc/templates/dockergc-ds.yaml.j2
+++ b/roles/openshift_docker_gc/templates/dockergc-ds.yaml.j2
@@ -29,6 +29,8 @@ items:
         serviceAccountName: dockergc
         containers:
         - image: {{ openshift_docker_gc_image }}:{{ openshift_docker_gc_version }}
+          command:
+          - "/usr/bin/oc"
           args:
           - "ex"
           - "dockergc"


### PR DESCRIPTION
related https://github.com/openshift/origin/pull/18904

@vikaslaad @derekwaynecarr 