### PR TITLE
Supports the latest image tag in a major version

### DIFF
--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -49,9 +49,9 @@
     when: openshift.common.deployment_type == 'origin'
     assert:
       that:
-      - "{{ openshift_image_tag|match('(^v?\\d+\\.\\d+\\.\\d+(-[\\w\\-\\.]*)?$)') }}"
+      - "{{ openshift_image_tag|match('(^v?\\d+\\.\\d+(\\.\\d+(-[\\w\\-\\.]*)?)?$)') }}"
       msg: |-
-        openshift_image_tag must be in the format v#.#.#[-optional.#]. Examples: v1.2.3, v3.5.1-alpha.1
+        openshift_image_tag must be in the format v#.#[.#[-optional.#]]. Examples: v3.7, v1.2.3, v3.5.1-alpha.1
         You specified openshift_image_tag={{ openshift_image_tag }}
 
   # Verifies that when the deployment type is openshift-enterprise the version:


### PR DESCRIPTION
I would like to use the latest image tag in a major version like OCP.
Now we must specify minor version of a image tag like v3.7 **.1**.

https://hub.docker.com/r/openshift/origin/tags/

```yaml
  vars:
    openshift_deployment_type: origin
    openshift_image_tag: v3.7
```
