### PR TITLE
Disable image_tag check because it is broken

### DIFF
--- a/roles/lib_utils/action_plugins/sanity_checks.py
+++ b/roles/lib_utils/action_plugins/sanity_checks.py
@@ -165,7 +165,8 @@ class ActionModule(ActionBase):
         distro = self.template_var(hostvars, host, 'ansible_distribution')
         odt = self.check_openshift_deployment_type(hostvars, host)
         self.check_python_version(hostvars, host, distro)
-        self.check_image_tag_format(hostvars, host, odt)
+        # TODO: disabled because this breaks legitimate uses
+        # self.check_image_tag_format(hostvars, host, odt)
         self.no_origin_image_version(hostvars, host, odt)
         self.network_plugin_check(hostvars, host)
         self.check_hostname_vars(hostvars, host)


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/18916

lifted commit from https://github.com/openshift/openshift-ansible/pull/6916 to fix the origin queue


@smarterclayton @sdodson 