### PR TITLE
cluster-operator: Break up components installs into separate playbooks

### DIFF
--- a/playbooks/cluster-operator/aws/components/openshift-glusterfs.yml
+++ b/playbooks/cluster-operator/aws/components/openshift-glusterfs.yml
@@ -1,0 +1,25 @@
+---
+- name: Alert user to variables needed
+  hosts: localhost
+  tasks:
+  - name: Alert user to variables needed - clusterid
+    debug:
+      msg: "openshift_aws_clusterid={{ openshift_aws_clusterid | default('default') }}"
+
+  - name: Alert user to variables needed - region
+    debug:
+      msg: "openshift_aws_region={{ openshift_aws_region | default('us-east-1') }}"
+
+- name: Setup the master node group
+  hosts: localhost
+  tasks:
+  - import_role:
+      name: openshift_aws
+      tasks_from: setup_master_group.yml
+
+- name: run the init
+  import_playbook: ../../../init/main.yml
+
+- name: Run openshift-glusterfs playbook
+  import_playbook: ../../../openshift-glusterfs/private/config.yml
+  when: groups.oo_glusterfs_to_config | default([]) | count > 0

--- a/playbooks/cluster-operator/aws/components/openshift-hosted.yml
+++ b/playbooks/cluster-operator/aws/components/openshift-hosted.yml
@@ -1,0 +1,24 @@
+---
+- name: Alert user to variables needed
+  hosts: localhost
+  tasks:
+  - name: Alert user to variables needed - clusterid
+    debug:
+      msg: "openshift_aws_clusterid={{ openshift_aws_clusterid | default('default') }}"
+
+  - name: Alert user to variables needed - region
+    debug:
+      msg: "openshift_aws_region={{ openshift_aws_region | default('us-east-1') }}"
+
+- name: Setup the master node group
+  hosts: localhost
+  tasks:
+  - import_role:
+      name: openshift_aws
+      tasks_from: setup_master_group.yml
+
+- name: run the init
+  import_playbook: ../../../init/main.yml
+
+- name: Run openshift-hosted playbook
+  import_playbook: ../../../openshift-hosted/private/config.yml

--- a/playbooks/cluster-operator/aws/components/openshift-logging.yml
+++ b/playbooks/cluster-operator/aws/components/openshift-logging.yml
@@ -1,0 +1,25 @@
+---
+- name: Alert user to variables needed
+  hosts: localhost
+  tasks:
+  - name: Alert user to variables needed - clusterid
+    debug:
+      msg: "openshift_aws_clusterid={{ openshift_aws_clusterid | default('default') }}"
+
+  - name: Alert user to variables needed - region
+    debug:
+      msg: "openshift_aws_region={{ openshift_aws_region | default('us-east-1') }}"
+
+- name: Setup the master node group
+  hosts: localhost
+  tasks:
+  - import_role:
+      name: openshift_aws
+      tasks_from: setup_master_group.yml
+
+- name: run the init
+  import_playbook: ../../../init/main.yml
+
+- name: Run openshift-logging playbook
+  import_playbook: ../../../openshift-logging/private/config.yml
+  when: openshift_logging_install_logging | default(false) | bool

--- a/playbooks/cluster-operator/aws/components/openshift-management.yml
+++ b/playbooks/cluster-operator/aws/components/openshift-management.yml
@@ -1,0 +1,25 @@
+---
+- name: Alert user to variables needed
+  hosts: localhost
+  tasks:
+  - name: Alert user to variables needed - clusterid
+    debug:
+      msg: "openshift_aws_clusterid={{ openshift_aws_clusterid | default('default') }}"
+
+  - name: Alert user to variables needed - region
+    debug:
+      msg: "openshift_aws_region={{ openshift_aws_region | default('us-east-1') }}"
+
+- name: Setup the master node group
+  hosts: localhost
+  tasks:
+  - import_role:
+      name: openshift_aws
+      tasks_from: setup_master_group.yml
+
+- name: run the init
+  import_playbook: ../../../init/main.yml
+
+- name: Run openshift-management playbook
+  import_playbook: ../../../openshift-management/private/config.yml
+  when: openshift_management_install_management | default(false) | bool

--- a/playbooks/cluster-operator/aws/components/openshift-metrics.yml
+++ b/playbooks/cluster-operator/aws/components/openshift-metrics.yml
@@ -1,0 +1,25 @@
+---
+- name: Alert user to variables needed
+  hosts: localhost
+  tasks:
+  - name: Alert user to variables needed - clusterid
+    debug:
+      msg: "openshift_aws_clusterid={{ openshift_aws_clusterid | default('default') }}"
+
+  - name: Alert user to variables needed - region
+    debug:
+      msg: "openshift_aws_region={{ openshift_aws_region | default('us-east-1') }}"
+
+- name: Setup the master node group
+  hosts: localhost
+  tasks:
+  - import_role:
+      name: openshift_aws
+      tasks_from: setup_master_group.yml
+
+- name: run the init
+  import_playbook: ../../../init/main.yml
+
+- name: Run openshift-metrics playbook
+  import_playbook: ../../../openshift-metrics/private/config.yml
+  when: openshift_metrics_install_metrics | default(false) | bool

--- a/playbooks/cluster-operator/aws/components/openshift-prometheus.yml
+++ b/playbooks/cluster-operator/aws/components/openshift-prometheus.yml
@@ -1,0 +1,25 @@
+---
+- name: Alert user to variables needed
+  hosts: localhost
+  tasks:
+  - name: Alert user to variables needed - clusterid
+    debug:
+      msg: "openshift_aws_clusterid={{ openshift_aws_clusterid | default('default') }}"
+
+  - name: Alert user to variables needed - region
+    debug:
+      msg: "openshift_aws_region={{ openshift_aws_region | default('us-east-1') }}"
+
+- name: Setup the master node group
+  hosts: localhost
+  tasks:
+  - import_role:
+      name: openshift_aws
+      tasks_from: setup_master_group.yml
+
+- name: run the init
+  import_playbook: ../../../init/main.yml
+
+- name: Run prometheus playbook
+  import_playbook: ../../../openshift-prometheus/private/config.yml
+  when: openshift_hosted_prometheus_deploy | default(false) | bool

--- a/playbooks/cluster-operator/aws/components/openshift-service-catalog.yml
+++ b/playbooks/cluster-operator/aws/components/openshift-service-catalog.yml
@@ -1,0 +1,25 @@
+---
+- name: Alert user to variables needed
+  hosts: localhost
+  tasks:
+  - name: Alert user to variables needed - clusterid
+    debug:
+      msg: "openshift_aws_clusterid={{ openshift_aws_clusterid | default('default') }}"
+
+  - name: Alert user to variables needed - region
+    debug:
+      msg: "openshift_aws_region={{ openshift_aws_region | default('us-east-1') }}"
+
+- name: Setup the master node group
+  hosts: localhost
+  tasks:
+  - import_role:
+      name: openshift_aws
+      tasks_from: setup_master_group.yml
+
+- name: run the init
+  import_playbook: ../../../init/main.yml
+
+- name: Run openshift-service-catalog playbook
+  import_playbook: ../../../openshift-service-catalog/private/config.yml
+  when: openshift_enable_service_catalog | default(true) | bool

--- a/playbooks/cluster-operator/aws/components/openshift-web-console.yml
+++ b/playbooks/cluster-operator/aws/components/openshift-web-console.yml
@@ -1,0 +1,25 @@
+---
+- name: Alert user to variables needed
+  hosts: localhost
+  tasks:
+  - name: Alert user to variables needed - clusterid
+    debug:
+      msg: "openshift_aws_clusterid={{ openshift_aws_clusterid | default('default') }}"
+
+  - name: Alert user to variables needed - region
+    debug:
+      msg: "openshift_aws_region={{ openshift_aws_region | default('us-east-1') }}"
+
+- name: Setup the master node group
+  hosts: localhost
+  tasks:
+  - import_role:
+      name: openshift_aws
+      tasks_from: setup_master_group.yml
+
+- name: run the init
+  import_playbook: ../../../init/main.yml
+
+- name: Run openshift-web-console playbook
+  import_playbook: ../../../openshift-web-console/private/config.yml
+  when: openshift_web_console_install | default(true) | bool


### PR DESCRIPTION
Separate the cluster-operator components install playbook into separate playbook so that cluster-operator can run them in parallel.

As follow-on work once the corresponding changes are made to cluster-operator to use the granulated playbooks, the existing components install playbook will be removed.