### PR TITLE
Revert delete tsb upgrade

### DIFF
--- a/roles/template_service_broker/tasks/upgrade.yml
+++ b/roles/template_service_broker/tasks/upgrade.yml
@@ -1,6 +1,2 @@
 ---
-# TODO(michaelgugino)
-# We can get rid of this remove section after switching to deployments.
-- include_tasks: remove.yml
-
 - include_tasks: deploy.yml


### PR DESCRIPTION
This commit removes unnecessary and problematic
deletion of tsb during upgrades.

TSB should be upgraded via RollingUpdate
strategy.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1553624