### PR TITLE
Bug 1553576 - Change the self_hostname to ${hostname} in openshift-ansible

### DIFF
--- a/roles/openshift_logging_fluentd/files/2.x/secure-forward.conf
+++ b/roles/openshift_logging_fluentd/files/2.x/secure-forward.conf
@@ -1,7 +1,7 @@
 # <store>
 # @type secure_forward
 
-# self_hostname ${HOSTNAME}
+# self_hostname ${hostname}
 # shared_key <SECRET_STRING>
 
 # secure yes

--- a/roles/openshift_logging_fluentd/files/5.x/secure-forward.conf
+++ b/roles/openshift_logging_fluentd/files/5.x/secure-forward.conf
@@ -1,7 +1,7 @@
 # <store>
 # @type secure_forward
 
-# self_hostname ${HOSTNAME}
+# self_hostname ${hostname}
 # shared_key <SECRET_STRING>
 
 # secure yes

--- a/roles/openshift_logging_fluentd/templates/2.x/fluent.conf.j2
+++ b/roles/openshift_logging_fluentd/templates/2.x/fluent.conf.j2
@@ -18,7 +18,7 @@
   @type secure_forward
   @label @INGRESS
 
-  self_hostname ${HOSTNAME}
+  self_hostname ${hostname}
   bind 0.0.0.0
   port {{openshift_logging_fluentd_aggregating_port}}
 
@@ -62,7 +62,7 @@
   <match **>
     @type secure_forward
 
-    self_hostname ${HOSTNAME}
+    self_hostname ${hostname}
     shared_key {{openshift_logging_fluentd_shared_key}}
 
     secure {{openshift_logging_fluentd_aggregating_secure}}

--- a/roles/openshift_logging_fluentd/templates/5.x/fluent.conf.j2
+++ b/roles/openshift_logging_fluentd/templates/5.x/fluent.conf.j2
@@ -18,7 +18,7 @@
   @type secure_forward
   @label @INGRESS
 
-  self_hostname ${HOSTNAME}
+  self_hostname ${hostname}
   bind 0.0.0.0
   port {{openshift_logging_fluentd_aggregating_port}}
 
@@ -62,7 +62,7 @@
   <match **>
     @type secure_forward
 
-    self_hostname ${HOSTNAME}
+    self_hostname ${hostname}
     shared_key {{openshift_logging_fluentd_shared_key}}
 
     secure {{openshift_logging_fluentd_aggregating_secure}}

--- a/roles/openshift_logging_mux/files/2.x/secure-forward.conf
+++ b/roles/openshift_logging_mux/files/2.x/secure-forward.conf
@@ -1,7 +1,7 @@
 # <store>
 # @type secure_forward
 
-# self_hostname ${HOSTNAME}
+# self_hostname ${hostname}
 # shared_key <SECRET_STRING>
 
 # secure yes

--- a/roles/openshift_logging_mux/files/5.x/secure-forward.conf
+++ b/roles/openshift_logging_mux/files/5.x/secure-forward.conf
@@ -1,7 +1,7 @@
 # <store>
 # @type secure_forward
 
-# self_hostname ${HOSTNAME}
+# self_hostname ${hostname}
 # shared_key <SECRET_STRING>
 
 # secure yes


### PR DESCRIPTION
See also:
Bug 1548720 - fluent-plugin-secure-forward couldn't read the Environment ${HOSTNAME}
https://github.com/openshift/origin-aggregated-logging/pull/988