### PR TITLE
Grafana: fix references to service account, and use it for authentication

### DIFF
--- a/roles/openshift_grafana/tasks/install_grafana.yaml
+++ b/roles/openshift_grafana/tasks/install_grafana.yaml
@@ -138,9 +138,13 @@
   delay: 10
   retries: "{{ (grafana_timeout | int / 10) | int }}"
 
-- name: Get the prometheus SA
+- name: Get the prometheus SA token
   shell: oc sa get-token {{ grafana_prometheus_serviceaccount }} -n {{ grafana_prometheus_namespace }}
   register: prometheus_sa_token
+
+- name: Get the grafana SA token
+  shell: oc sa get-token {{ grafana_serviceaccount_name }} -n {{ grafana_namespace }}
+  register: grafana_sa_token
 
 - name: Get prometheus route
   oc_route:
@@ -149,7 +153,7 @@
     namespace: "{{ grafana_prometheus_namespace }}"
   register: prometheus_route
 
-- name: Get prometheus route
+- name: Get grafana route
   oc_route:
     state: list
     name: grafana
@@ -164,8 +168,8 @@
 - name: Add new datasource to grafana
   uri:
     url: "{{ grafana_route }}/api/datasources"
-    user: admin
-    password: admin
+    user: "{{ grafana_sa_token.stdout }}"
+    force_basic_auth: true
     method: POST
     body: '{{ payload_data }}'
     body_format: json
@@ -210,8 +214,8 @@
 - name: Add openshift dashboard
   uri:
     url: "{{ grafana_route }}/api/dashboards/db"
-    user: admin
-    password: admin
+    user: "{{ grafana_sa_token.stdout }}"
+    force_basic_auth: true
     method: POST
     body: '{{ slurpfile["content"] | b64decode }}'
     body_format: json
@@ -227,8 +231,8 @@
 - name: Add node exporter dashboard
   uri:
     url: "{{ grafana_route }}/api/dashboards/db"
-    user: admin
-    password: admin
+    user: "{{ grafana_sa_token.stdout }}"
+    force_basic_auth: true
     method: POST
     body: '{{ slurpfile["content"] | b64decode }}'
     body_format: json

--- a/roles/openshift_grafana/templates/grafana.yml.j2
+++ b/roles/openshift_grafana/templates/grafana.yml.j2
@@ -17,7 +17,7 @@ spec:
         app: grafana
       name: grafana
     spec:
-      serviceAccountName: {{ grafana_namespace }}
+      serviceAccountName: {{ grafana_serviceaccount_name }}
 {% if grafana_node_selector is iterable and grafana_node_selector | length > 0 %}
       nodeSelector:
 {% for key, value in grafana_node_selector.items() %}
@@ -50,7 +50,7 @@ spec:
         - -https-address=:{{ grafana_service_targetport }}
         - -http-address=
         - -email-domain=*
-        - -client-id=system:serviceaccount:{{ grafana_namespace }}:{{ grafana_service_name }}
+        - -client-id=system:serviceaccount:{{ grafana_namespace }}:{{ grafana_serviceaccount_name }}
         - -upstream=http://localhost:{{ grafana_container_port }}
         - -provider=openshift
 #       - '-openshift-delegate-urls={"/api/datasources": {"resource": "namespace", "verb": "get", "resourceName": "{{ grafana_namespace }}", "namespace": "{{ grafana_namespace }}"}}'


### PR DESCRIPTION
There were a couple of places in the grafana role where the service account name was taken from the wrong variable.

Also, the post of configuration (datasource, dashboards) was using a hardcoded username - this changes it to use the existing service account instead.
