### PR TITLE
Ensure that the aggregator is configured during all control plane

### DIFF
--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -260,6 +260,14 @@
   - set_fact:
       reconcile_complete: True
 
+- name: Configure API aggregation on masters
+  hosts: oo_masters_to_config
+  serial: 1
+  roles:
+  - role: openshift_facts
+  tasks:
+  - include_tasks: tasks/wire_aggregator.yml
+
 ##############################################################################
 # Gate on reconcile
 ##############################################################################


### PR DESCRIPTION
upgrades

This should've happened during 3.7 upgrade but it may have been missed in certain circumstances.
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1546365