### PR TITLE
Changing python regex method from match to search

### DIFF
--- a/roles/openshift_logging/library/logging_patch.py
+++ b/roles/openshift_logging/library/logging_patch.py
@@ -77,7 +77,7 @@ def account_for_whitelist(current_file_contents, new_file_contents, white_list=N
 
     for line in white_list:
         regex_line = r".*" + re.escape(line) + r":.*\n"
-        new_file_line = re.match(regex_line, new_file_contents)
+        new_file_line = re.search(regex_line, new_file_contents)
         if new_file_line:
             current_file_contents = re.sub(regex_line, new_file_line.group(0), current_file_contents)
         else:


### PR DESCRIPTION
Changing due to variable content structure
`new_file_contents` is structured in such a way that we need to search anywhere in the string.

```
>>> for curr_line in current_contents.split("\n"):
...     print curr_line
... 
index: 
  number_of_shards: 2
  number_of_replicas: 1
bogusness: true

>>> for line in white_list:
...     regex_line = r".+" + re.escape(line) + r":.*\n"
...     new_line_file = re.match(regex_line, current_contents)
...     if new_line_file:
...         print new_line_file.group(0)
...     else:
...         print ""
... 




>>> for line in white_list:
...     regex_line = r".*" + re.escape(line) + r":.*\n"
...     new_line_file = re.search(regex_line, current_contents)
...     if new_line_file:
...         print new_line_file.group(0)
...     else:
...         print ""
... 
  number_of_shards: 2

  number_of_replicas: 1

```