### PR TITLE
etcd migrate: Set missing variables

### DIFF
--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -20,6 +20,13 @@
 # TODO: This will be different for release-3.6 branch
 - name: Prepare masters for etcd data migration
   hosts: oo_masters_to_config
+  vars:
+    openshift_master_etcd_hosts: "{{ hostvars
+                                       | oo_select_keys(groups['oo_etcd_to_config'] | union(groups['oo_new_etcd_to_config'] | default([])))
+                                       | oo_collect('openshift.common.hostname')
+                                       | default(none, true) }}"
+    openshift_master_etcd_port: "{{ (etcd_client_port | default('2379')) if (groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config) else none }}"
+    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
   tasks:
   - set_fact:
       master_services:


### PR DESCRIPTION
Commit 2ee4d0ed4 included a file from the "openshift_master" role into
the etcd migration playbook. That role pulls in
"openshift_master_facts", which in turns pulls in
"openshift_master_certificates" where the "openshift_master_etcd_hosts"
and "openshift_master_etcd_port" variables are referenced.

The "etcd_ca_host" variable is required by another role, though
I haven't been able to determine exactly where.