### PR TITLE
Fix references to oc client

### DIFF
--- a/roles/openshift_bootstrap_autoapprover/tasks/main.yml
+++ b/roles/openshift_bootstrap_autoapprover/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Create auto-approver on cluster
   run_once: true
-  command: oc apply -f /tmp/openshift-approver/
+  command: "{{ openshift_client_binary }} apply -f /tmp/openshift-approver/"
 
 - name: Remove auto-approver config
   run_once: true

--- a/roles/openshift_cloud_provider/tasks/vsphere-svc.yml
+++ b/roles/openshift_cloud_provider/tasks/vsphere-svc.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check to see if the vsphere cluster role already exists
-  command: oc get clusterrole
+  command: "{{ openshift_client_binary}}  get clusterrole"
   register: cluster_role
 
 - block:
@@ -13,7 +13,7 @@
 
   - name: Create vsphere-svc on cluster
     run_once: true
-    command: oc create -f /tmp/vsphere-svc.yml
+    command: "{{ openshift_client_binary}} create -f /tmp/vsphere-svc.yml"
 
   - name: Remove vsphere-svc file
     run_once: true

--- a/roles/openshift_control_plane/tasks/bootstrap.yml
+++ b/roles/openshift_control_plane/tasks/bootstrap.yml
@@ -3,7 +3,7 @@
 # oc_serviceaccounts_kubeconfig
 - name: create service account kubeconfig with csr rights
   command: >
-    oc serviceaccounts create-kubeconfig {{ openshift_master_csr_sa }} -n {{ openshift_master_csr_namespace }}
+    {{ openshift_client_binary }} serviceaccounts create-kubeconfig {{ openshift_master_csr_sa }} -n {{ openshift_master_csr_namespace }}
   register: kubeconfig_out
   until: kubeconfig_out.rc == 0
   retries: 24


### PR DESCRIPTION
Atomic host doesn't have oc in path by default.

This commit updates tasks to use openshift_client_binary
instead.