### PR TITLE
Fix missing slash in oreg_host

### DIFF
--- a/roles/openshift_sdn/defaults/main.yml
+++ b/roles/openshift_sdn/defaults/main.yml
@@ -2,5 +2,5 @@
 openshift_node_image_dict:
   origin: 'openshift/node'
   openshift-enterprise: 'openshift3/node'
-oreg_host: "{{ oreg_url.split('/')[0] if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"
+oreg_host: "{{ oreg_url.split('/')[0] ~ '/' if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"
 osn_image: "{{ oreg_host }}{{ openshift_node_image_dict[openshift_deployment_type | default('origin')] }}:{{ openshift_image_tag | default('latest') }}"


### PR DESCRIPTION
When using oreg_url, this would result:

```
tag:
  from:
    kind: DockerImage
    name: registry.reg-aws.openshift.com:443openshift3/node:v3.9.7
```