### PR TITLE
Use oreg_url for node and master images

### DIFF
--- a/.papr.sh
+++ b/.papr.sh
@@ -11,10 +11,10 @@ else
   target_branch=$PAPR_PULL_TARGET_BRANCH
 fi
 if [[ "${target_branch}" =~ ^release- ]]; then
-  target_branch="${target_branch/release-/v}"
+  target_branch="${target_branch/release-/}"
 else
   dnf install -y sed
-  target_branch="$( git describe | sed 's/^openshift-ansible-\([0-9]*\.[0-9]*\)\.[0-9]*-.*/v\1/' )"
+  target_branch="$( git describe | sed 's/^openshift-ansible-\([0-9]*\.[0-9]*\)\.[0-9]*-.*/\1/' )"
 fi
 
 pip install -r requirements.txt
@@ -35,7 +35,7 @@ trap upload_journals ERR
 ansible-playbook -vvv -i .papr.inventory playbooks/openshift-node/private/image_prep.yml
 
 # run the actual installer
-ansible-playbook -vvv -i .papr.inventory playbooks/deploy_cluster.yml -e "openshift_release=${target_release}"
+ansible-playbook -vvv -i .papr.inventory playbooks/deploy_cluster.yml -e "openshift_release=${target_branch}"
 
 ### DISABLING TESTS FOR NOW, SEE:
 ### https://github.com/openshift/openshift-ansible/pull/6132

--- a/roles/openshift_control_plane/defaults/main.yml
+++ b/roles/openshift_control_plane/defaults/main.yml
@@ -7,17 +7,19 @@ openshift_master_debug_level: "{{ debug_level | default(2) }}"
 r_openshift_master_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
 r_openshift_master_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
-osm_image_default_dict:
-  origin: 'openshift/origin'
-  openshift-enterprise: 'openshift3/ose'
-osm_image_default: "{{ osm_image_default_dict[openshift_deployment_type] }}"
-osm_image: "{{ osm_image_default }}"
-
-l_openshift_master_images_dict:
+l_openshift_images_dict:
   origin: 'openshift/origin-${component}:${version}'
   openshift-enterprise: 'openshift3/ose-${component}:${version}'
-l_osm_registry_url_default: "{{ l_openshift_master_images_dict[openshift_deployment_type] }}"
-l_osm_registry_url: "{{ oreg_url_master | default(oreg_url) | default(l_osm_registry_url_default) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
+l_osm_registry_url_default: "{{ l_openshift_images_dict[openshift_deployment_type] }}"
+l_os_registry_url: "{{ oreg_url_master | default(oreg_url) | default(l_osm_registry_url_default) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
+
+l_openshift_prefix_dict:
+  origin: 'origin-${component}'
+  openshift-enterprise: 'ose-${component}'
+l_os_prefix: "{{ l_openshift_prefix_dict[openshift_deployment_type] }}"
+l_os_prefix_base: "{{ l_openshift_prefix_dict[openshift_deployment_type] | regex_replace('-${component}' | regex_escape, '') }}"
+# TODO: we should publish oreg_url component=master
+osm_image: "{{ l_os_registry_url | regex_replace(l_os_prefix | regex_escape, l_os_prefix_base) }}"
 
 system_images_registry_dict:
   openshift-enterprise: "registry.access.redhat.com"

--- a/roles/openshift_control_plane/tasks/static.yml
+++ b/roles/openshift_control_plane/tasks/static.yml
@@ -29,7 +29,7 @@
     src: "{{ mktemp.stdout }}/{{ item }}"
     edits:
     - key: spec.containers[0].image
-      value: "{{ osm_image }}:{{ openshift_image_tag }}"
+      value: "{{ osm_image }}"
   with_items:
   - apiserver.yaml
   - controller.yaml

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -92,10 +92,18 @@ openshift_node_syscon_add_mounts_l: []
 
 openshift_deployment_type: "{{ openshift_deployment_type | default('origin') }}"
 
-openshift_node_image_dict:
-  origin: 'openshift/node'
-  openshift-enterprise: 'openshift3/node'
-osn_image: "{{ openshift_node_image_dict[openshift_deployment_type] }}"
+l_openshift_images_dict:
+  origin: 'openshift/origin-${component}:${version}'
+  openshift-enterprise: 'openshift3/ose-${component}:${version}'
+l_osm_registry_url_default: "{{ l_openshift_images_dict[openshift_deployment_type] }}"
+l_os_registry_url: "{{ oreg_url | default(l_osm_registry_url_default) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
+
+l_openshift_prefix_dict:
+  origin: 'origin-${component}'
+  openshift-enterprise: 'ose-${component}'
+l_os_prefix: "{{ l_openshift_prefix_dict[openshift_deployment_type] }}"
+# TODO: we should publish oreg_url component=node
+osn_image: "{{ l_os_registry_url | regex_replace(l_os_prefix | regex_escape, 'node') }}"
 
 openshift_service_type_dict:
   origin: origin

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -19,6 +19,6 @@
   block:
   - name: Pre-pull node image when containerized
     command: >
-      docker pull {{ osn_image }}:{{ openshift_image_tag }}
+      docker pull {{ osn_image }}
     register: pull_result
     changed_when: "'Downloaded newer image' in pull_result.stdout"

--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -7,7 +7,7 @@
 
 - name: Pre-pull node system container image
   command: >
-    atomic pull --storage=ostree {{ 'docker:' if system_images_registry == 'docker' else system_images_registry + '/' }}{{ osn_image }}:{{ openshift_image_tag }}
+    atomic pull --storage=ostree {{ osn_image }}
   register: pull_result
   changed_when: "'Pulling layer' in pull_result.stdout"
 
@@ -21,7 +21,7 @@
 - name: Install or Update node system container
   oc_atomic_container:
     name: "{{ openshift_service_type }}-node"
-    image: "{{ 'docker:' if system_images_registry == 'docker' else system_images_registry + '/' }}{{ osn_image }}:{{ openshift_image_tag }}"
+    image: "{{ osn_image }}"
     values:
     - "DNS_DOMAIN={{ openshift.common.dns_domain }}"
     - "DOCKER_SERVICE={{ openshift_docker_service_name }}.service"

--- a/roles/openshift_sdn/defaults/main.yml
+++ b/roles/openshift_sdn/defaults/main.yml
@@ -1,6 +1,13 @@
 ---
-openshift_node_image_dict:
-  origin: 'openshift/node'
-  openshift-enterprise: 'openshift3/node'
-oreg_host: "{{ oreg_url.split('/')[0] ~ '/' if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"
-osn_image: "{{ oreg_host }}{{ openshift_node_image_dict[openshift_deployment_type | default('origin')] }}:{{ openshift_image_tag | default('latest') }}"
+l_openshift_images_dict:
+  origin: 'openshift/origin-${component}:${version}'
+  openshift-enterprise: 'openshift3/ose-${component}:${version}'
+l_osm_registry_url_default: "{{ l_openshift_images_dict[openshift_deployment_type] }}"
+l_os_registry_url: "{{ oreg_url | default(l_osm_registry_url_default) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
+
+l_openshift_prefix_dict:
+  origin: 'origin-${component}'
+  openshift-enterprise: 'ose-${component}'
+l_os_prefix: "{{ l_openshift_prefix_dict[openshift_deployment_type] }}"
+# TODO: we should publish oreg_url component=node
+osn_image: "{{ l_os_registry_url | regex_replace(l_os_prefix | regex_escape, 'node') }}"

--- a/roles/openshift_sdn/files/sdn-images.yaml
+++ b/roles/openshift_sdn/files/sdn-images.yaml
@@ -4,6 +4,7 @@ metadata:
   name: node:v3.9
   namespace: openshift-sdn
 tag:
+  reference: true
   from:
     kind: DockerImage
     name: openshift/node:v3.9

--- a/roles/openshift_sdn/tasks/main.yml
+++ b/roles/openshift_sdn/tasks/main.yml
@@ -29,7 +29,6 @@
   yedit:
     src: "{{ mktemp.stdout }}/sdn-images.yaml"
     key: 'tag.from.name'
-    # TODO: this should be easier to replace
     value: "{{ osn_image }}"
 
 - name: Ensure the SDN can run privileged


### PR DESCRIPTION
Fixes broken GCP builds when pulling from a non-default registry.

For 3.10 we need to start publishing an origin-kube, origin-master, and origin-node (names TBD) image.