### PR TITLE
Ensure calico starts on docker daemon start

### DIFF
--- a/roles/calico/templates/calico.service.j2
+++ b/roles/calico/templates/calico.service.j2
@@ -29,4 +29,4 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
 ExecStop=-/usr/bin/docker stop calico-node
 
 [Install]
-WantedBy=multi-user.target
+WantedBy={{ openshift.docker.service_name }}.service


### PR DESCRIPTION
When upgrading Docker, the Docker daemon is stopped and started again.
The calico.service is stopped but not started.

The change ensures that calico is always started when Docker daemon is started.
More details regarding systemd [WantedBy](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#WantedBy=).