### PR TITLE
Use long form of "scc" resource type in logging facts

### DIFF
--- a/roles/openshift_logging/library/openshift_logging_facts.py
+++ b/roles/openshift_logging/library/openshift_logging_facts.py
@@ -261,7 +261,7 @@ class OpenshiftLoggingFacts(OCBaseCommand):
     def facts_for_sccs(self):
         ''' Gathers facts for SCCs used with logging '''
         self.default_keys_for("sccs")
-        scc = self.oc_command("get", "scc", name="privileged")
+        scc = self.oc_command("get", "securitycontextconstraints.v1.security.openshift.io", name="privileged")
         if len(scc["users"]) == 0:
             return
         for item in scc["users"]:


### PR DESCRIPTION
"oc get scc" fails in OpenShift Origin 3.7.1:

  $ oc get scc
  the server doesn't have a resource type "scc"

According to [1] this was lost in a rebase and we were able to identify
it in OpenShift Origin commit 75bcc760f2, file
"vendor/k8s.io/kubernetes/pkg/kubectl/kubectl.go". A workaround is to
use "oc get securitycontextconstraints".

[1]
https://bugzilla.redhat.com/show_bug.cgi?id=1525014#c1