### PR TITLE
Allowing means to provide custom es config entries with openshift_logging_es_config

### DIFF
--- a/roles/openshift_logging_elasticsearch/defaults/main.yml
+++ b/roles/openshift_logging_elasticsearch/defaults/main.yml
@@ -50,9 +50,8 @@ openshift_logging_elasticsearch_ops_deployment: false
 
 openshift_logging_elasticsearch_ops_allow_cluster_reader: false
 
-# following can be uncommented to provide values for configmaps -- take care when providing file contents as it may cause your cluster to not operate correctly
-#es_logging_contents:
-#es_config_contents:
+# openshift_logging_es_config is a hash to be merged into the defaults for the elasticsearch.yaml
+openshift_logging_es_config: {}
 
 
 openshift_logging_master_url: "https://kubernetes.default.svc.{{ openshift.common.dns_domain }}"

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -239,6 +239,17 @@
       - current_file: "logging.yml"
         new_file: "{{ tempdir }}/elasticsearch-logging.yml"
 
+  - slurp:
+      src: "{{ tempdir }}/elasticsearch.yml"
+    register: _patched_elasticsearch_config
+
+  - copy:
+      content: "{{ config_source | combine(override_config, recursive=True) | to_nice_yaml(indent=2) }}"
+      dest: "{{ tempdir }}/elasticsearch.yml"
+    vars:
+      config_source: "{{ _patched_elasticsearch_config['content'] | b64decode | from_yaml }}"
+      override_config: "{{ openshift_logging_es_config | default({}) | from_yaml }}"
+
   - name: Set ES configmap
     oc_configmap:
       state: present
@@ -270,6 +281,17 @@
         new_file: "{{ tempdir }}/elasticsearch.yml"
       - current_file: "log4j2.properties"
         new_file: "{{ tempdir }}/log4j2.properties"
+
+  - slurp:
+      src: "{{ tempdir }}/elasticsearch.yml"
+    register: _patched_elasticsearch_config
+
+  - copy:
+      content: "{{ config_source | combine(override_config, recursive=True) | to_nice_yaml(indent=2) }}"
+      dest: "{{ tempdir }}/elasticsearch.yml"
+    vars:
+      config_source: "{{ _patched_elasticsearch_config['content'] | b64decode | from_yaml }}"
+      override_config: "{{ openshift_logging_es_config | default({}) | from_yaml }}"
 
   - name: Set ES configmap
     oc_configmap:


### PR DESCRIPTION
This allows customers to provide entries that should end up in the elasticsearch config file.
Re-adds features from: https://github.com/openshift/openshift-ansible/pull/3647/files

The ordering of this being applied is such:
1) If nothing is provided in the inventory and a new install is done, push out a configmap based on files in the role (current-day)
2) If nothing is provided in the inventory and this is an upgrade and changes exist in the current configmap, we patch so that we preserve custom changes
3) We specify variables that are whitelist items (e.g. number of shards), same outcome as 2 except that we use the inventory variable values as the final say for those lines
4) We specify variables with openshift_logging_es_config (and whitelist variables), same as 3 except that any values in openshift_logging_es_config are final say (these will overwrite values provided in whitelist variables).