### PR TITLE
Pop etcd_port from local_facts file

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1271,6 +1271,17 @@ def set_container_facts_if_unset(facts):
     return facts
 
 
+def pop_obsolete_local_facts(local_facts):
+    """Remove unused keys from local_facts"""
+    keys_to_remove = {
+        'master': ('etcd_port',)
+    }
+    for role in keys_to_remove:
+        if role in local_facts:
+            for key in keys_to_remove[role]:
+                local_facts[role].pop(key, None)
+
+
 class OpenShiftFactsInternalError(Exception):
     """Origin Facts Error"""
     pass
@@ -1550,6 +1561,7 @@ class OpenShiftFacts(object):
                                       additive_facts_to_overwrite)
 
         new_local_facts = self.remove_empty_facts(new_local_facts)
+        pop_obsolete_local_facts(new_local_facts)
 
         if new_local_facts != local_facts:
             self.validate_local_facts(new_local_facts)


### PR DESCRIPTION
Some variables are hanging around in openshift.facts
fact file on hosts that shouldn't be.

This causes old versions of defaults to take precedence
over new default values in openshift_facts.

This commit pops master.etcd_port from the facts being
saved to disk.  This allows the correct default port
for etcd to take effect.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1546365