### PR TITLE
Removing heat template outputs for stack scalability.

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -530,3 +530,13 @@ openshift_hosted_registry_storage_volume_name: registry
 
 The volume will be formatted automaticaly and it will be mounted to one of the
 infra nodes when the registry pod gets started.
+
+
+## Deploying At Scale
+
+By default, heat stack outputs are resolved.  This may cause
+problems in large scale deployments.  Querying heat stack can take
+a long time and eventually time out.  The following setting in
+`inventory/group_vars/all.yml` is recommended to prevent the timeouts:
+
+* `openshift_openstack_resolve_heat_outputs`: False

--- a/playbooks/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/all.yml
@@ -163,6 +163,9 @@ openshift_openstack_pool_end: "192.168.99.254"
 # hardcoded to `openshift`.
 ansible_user: openshift
 
+# Resolve heat stack outputs. Disabling outputs helps stack scalability. (default: True)
+#openshift_openstack_resolve_heat_outputs: True
+
 # # Use a single security group for a cluster (default: false)
 #openshift_openstack_flat_secgrp: false
 

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -6,6 +6,7 @@ parameters:
 
 outputs:
 
+{% if openshift_openstack_resolve_heat_outputs|default(True)|bool %}
   etcd_names:
     description: Name of the etcds
     value: { get_attr: [ etcd, name ] }
@@ -53,6 +54,7 @@ outputs:
   infra_floating_ips:
     description: Floating IPs of the nodes
     value: { get_attr: [ infra_nodes, floating_ip ] }
+{% endif %}
 
   public_api_ip:
     description: IP address for the API/UI endpoint


### PR DESCRIPTION
When scaling up to ~100VMs, "openstack stack show <stack_name>" can take
around 2minutes to complete, causing timeouts on HAProxy side.  This
gets rougly linearly worse as VMs are added.  This is due to resolving
stack outputs.  This PR removes the outputs and helps with stack scalability.