### PR TITLE
Change openshift_client_binary to openshift.common.client_binary

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/get_es_version.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/get_es_version.yml
@@ -17,7 +17,7 @@
 
 - name: "Getting ES version for logging-es cluster"
   command: >
-    {{ openshift_client_binary }} exec {{ available_pod }} -c elasticsearch -n {{ openshift_logging_elasticsearch_namespace }} -- {{ __es_local_curl }} -XGET 'https://localhost:9200/'
+    {{ openshift.common.client_binary }} exec {{ available_pod }} -c elasticsearch -n {{ openshift_logging_elasticsearch_namespace }} -- {{ __es_local_curl }} -XGET 'https://localhost:9200/'
   register: _curl_output
   when: available_pod is defined
 
@@ -39,7 +39,7 @@
 
 - name: "Getting ES version for logging-es-ops cluster"
   command: >
-    {{ openshift_client_binary }} exec {{ available_ops_pod }} -c elasticsearch -n {{ openshift_logging_elasticsearch_namespace }} -- {{ __es_local_curl }} -XGET 'https://localhost:9200/'
+    {{ openshift.common.client_binary }} exec {{ available_ops_pod }} -c elasticsearch -n {{ openshift_logging_elasticsearch_namespace }} -- {{ __es_local_curl }} -XGET 'https://localhost:9200/'
   register: _ops_curl_output
   when: available_ops_pod is defined
 


### PR DESCRIPTION
This appears to be due to a backport.  openshift_client_binary
is not available in 3.7.  We should use openshift.common.client_binary
instead.