### PR TITLE
Ensure grafana has nodes to run.

### DIFF
--- a/roles/openshift_grafana/tasks/install_grafana.yaml
+++ b/roles/openshift_grafana/tasks/install_grafana.yaml
@@ -1,11 +1,12 @@
 ---
 
 - name: Ensure that Grafana has nodes to run on
-  fail:
-    msg: |-
-      No schedulable nodes found matching node selector for Grafana - '{{ grafana_node_selector }}'
-  when:
-  - openshift_schedulable_node_labels  | lib_utils_oo_has_no_matching_selector(grafana_node_selector)
+  import_role:
+    name: openshift_master
+    tasks_from: ensure_nodes_matching_selector.yml
+  vars:
+    openshift_master_ensure_nodes_selector: "{{ openshift_grafana_node_selector | map_to_pairs }}"
+    openshift_master_ensure_nodes_service: Grafana
 
 - name: Create grafana namespace
   oc_project:


### PR DESCRIPTION
The current ensurance didn't work.
this PR aligns with the logic of prometheus installation.