### PR TITLE
[3.9] Fix openshift_hosted_templates registry_host

### DIFF
--- a/roles/openshift_examples/defaults/main.yml
+++ b/roles/openshift_examples/defaults/main.yml
@@ -26,9 +26,6 @@ cockpit_ui_base: "{{ examples_base }}/infrastructure-templates/enterprise"
 
 
 openshift_examples_import_command: "create"
-registry_host: "{{ openshift_examples_registryurl.split('/')[0] if '.' in openshift_examples_registryurl.split('/')[0] else '' }}"
 
-openshift_hosted_images_dict:
-  origin: 'openshift/origin-${component}:${version}'
-  openshift-enterprise: 'openshift3/ose-${component}:${version}'
-openshift_examples_registryurl: "{{ oreg_url_master | default(oreg_url) | default(openshift_hosted_images_dict[openshift_deployment_type]) }}"
+openshift_examples_registryurl: "{{ oreg_url_master | default(oreg_url) | default('') }}"
+registry_host: "{{ openshift_examples_registryurl.split('/')[0] if '.' in openshift_examples_registryurl.split('/')[0] else '' }}"

--- a/roles/openshift_hosted_templates/defaults/main.yml
+++ b/roles/openshift_hosted_templates/defaults/main.yml
@@ -4,7 +4,7 @@ hosted_deployment_type: "{{ 'origin' if openshift_deployment_type == 'origin' el
 
 content_version: "{{ openshift.common.examples_content_version }}"
 
-registry_url: ""
-registry_host: "{{ registry_url.split('/')[0] if '.' in registry_url.split('/')[0] else '' }}"
+openshift_hosted_templates_registryurl: "{{ oreg_url_master | default(oreg_url) | default('') }}"
+registry_host: "{{ openshift_hosted_templates_registryurl.split('/')[0] if '.' in openshift_hosted_templates_registryurl.split('/')[0] else '' }}"
 
 openshift_hosted_templates_import_command: 'create'


### PR DESCRIPTION
This commit corrects missing logic for registry_host in
the role openshift_hosted_templates.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1555220