### PR TITLE
Fix openshift_hosted_templates/examples registry_host

### DIFF
--- a/roles/openshift_examples/defaults/main.yml
+++ b/roles/openshift_examples/defaults/main.yml
@@ -25,9 +25,6 @@ infrastructure_enterprise_base: "{{ examples_base }}/infrastructure-templates/en
 cockpit_ui_base: "{{ examples_base }}/infrastructure-templates/enterprise"
 
 openshift_examples_import_command: "create"
-registry_host: "{{ openshift_examples_registryurl.split('/')[0] if '.' in openshift_examples_registryurl.split('/')[0] else '' }}"
 
-openshift_hosted_images_dict:
-  origin: 'openshift/origin-${component}:${version}'
-  openshift-enterprise: 'openshift3/ose-${component}:${version}'
-openshift_examples_registryurl: "{{ oreg_url_master | default(oreg_url) | default(openshift_hosted_images_dict[openshift_deployment_type]) }}"
+openshift_examples_registryurl: "{{ oreg_url_master | default(oreg_url) | default('') }}"
+registry_host: "{{ openshift_examples_registryurl.split('/')[0] if '.' in openshift_examples_registryurl.split('/')[0] else '' }}"

--- a/roles/openshift_hosted_templates/defaults/main.yml
+++ b/roles/openshift_hosted_templates/defaults/main.yml
@@ -4,11 +4,7 @@ hosted_deployment_type: "{{ 'origin' if openshift_deployment_type == 'origin' el
 
 content_version: "{{ openshift_examples_content_version }}"
 
-openshift_hosted_images_dict:
-  origin: 'openshift/origin-${component}:${version}'
-  openshift-enterprise: 'openshift3/ose-${component}:${version}'
-
-openshift_hosted_templates_registryurl: "{{ oreg_url_master | default(oreg_url) | default(openshift_hosted_images_dict[openshift_deployment_type]) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
+openshift_hosted_templates_registryurl: "{{ oreg_url_master | default(oreg_url) | default('') }}"
 registry_host: "{{ openshift_hosted_templates_registryurl.split('/')[0] if '.' in openshift_hosted_templates_registryurl.split('/')[0] else '' }}"
 
 openshift_hosted_templates_import_command: 'create'


### PR DESCRIPTION
This commit corrects missing logic for registry_host in
the role openshift_hosted_templates and openshift_examples.

This commit removes unnecessary default values and simplifies
logic.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1555220
(cherry picked from commit 5693072390f7143966d5f78337a3770509713125)