### PR TITLE
Don't remove pvs when uninstalling openshift_management

### DIFF
--- a/roles/openshift_management/tasks/uninstall.yml
+++ b/roles/openshift_management/tasks/uninstall.yml
@@ -6,7 +6,6 @@
     - dc
     - po
     - svc
-    - pv
     - pvc
     - statefulsets
     - routes


### PR DESCRIPTION
This task removed every PV from my system.

When I ran it the openshift_management_project did not exist so I would think no PVs would be removed.

Unless there is some way to ensure that this isn't detrimental to the system as a whole, I suggest we not clean up pvs.

/cc @tbielawa 