### PR TITLE
Update the openshift_management manageiq templates to the latest release

### DIFF
--- a/roles/openshift_management/files/templates/manageiq/miq-scc-sysadmin.yaml
+++ b/roles/openshift_management/files/templates/manageiq/miq-scc-sysadmin.yaml
@@ -1,0 +1,38 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+apiVersion: v1
+defaultAddCapabilities:
+- SYS_ADMIN
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: miq-sysadmin provides all features of the anyuid SCC but allows users to have SYS_ADMIN capabilities. This is the required scc for Pods requiring to run with systemd and the message bus.
+  creationTimestamp:
+  name: miq-sysadmin
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+- SYS_CHROOT
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- secret

--- a/roles/openshift_management/files/templates/manageiq/miq-template-ext-db.yaml
+++ b/roles/openshift_management/files/templates/manageiq/miq-template-ext-db.yaml
@@ -31,6 +31,7 @@ objects:
     name: "${NAME}-secrets"
   stringData:
     pg-password: "${DATABASE_PASSWORD}"
+    admin-password: "${APPLICATION_ADMIN_PASSWORD}"
     database-url: postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_SERVICE_NAME}/${DATABASE_NAME}?encoding=utf8&pool=5&wait_timeout=5
     v2-key: "${V2_KEY}"
 - apiVersion: v1
@@ -90,15 +91,15 @@ objects:
         - name: manageiq
           image: "${APPLICATION_IMG_NAME}:${FRONTEND_APPLICATION_IMG_TAG}"
           livenessProbe:
-            tcpSocket:
-              port: 80
+            exec:
+              command:
+              - pidof
+              - MIQ Server
             initialDelaySeconds: 480
             timeoutSeconds: 3
           readinessProbe:
-            httpGet:
-              path: "/"
+            tcpSocket:
               port: 80
-              scheme: HTTP
             initialDelaySeconds: 200
             timeoutSeconds: 3
           ports:
@@ -114,8 +115,6 @@ objects:
                 fieldPath: metadata.namespace
           - name: APPLICATION_INIT_DELAY
             value: "${APPLICATION_INIT_DELAY}"
-          - name: DATABASE_SERVICE_NAME
-            value: "${DATABASE_SERVICE_NAME}"
           - name: DATABASE_REGION
             value: "${DATABASE_REGION}"
           - name: DATABASE_URL
@@ -123,17 +122,16 @@ objects:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: database-url
-          - name: MEMCACHED_SERVER
-            value: "${MEMCACHED_SERVICE_NAME}:11211"
-          - name: MEMCACHED_SERVICE_NAME
-            value: "${MEMCACHED_SERVICE_NAME}"
           - name: V2_KEY
             valueFrom:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: v2-key
-          - name: ANSIBLE_SERVICE_NAME
-            value: "${ANSIBLE_SERVICE_NAME}"
+          - name: APPLICATION_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "${NAME}-secrets"
+                key: admin-password
           - name: ANSIBLE_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -213,15 +211,11 @@ objects:
             value: database_operations,event,reporting,scheduler,smartstate,ems_operations,ems_inventory,automate
           - name: FRONTEND_SERVICE_NAME
             value: "${NAME}"
-          - name: MEMCACHED_SERVER
-            value: "${MEMCACHED_SERVICE_NAME}:11211"
           - name: V2_KEY
             valueFrom:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: v2-key
-          - name: ANSIBLE_SERVICE_NAME
-            value: "${ANSIBLE_SERVICE_NAME}"
           - name: ANSIBLE_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -445,18 +439,173 @@ objects:
 
       <VirtualHost *:80>
         KeepAlive on
+        # Without ServerName mod_auth_mellon compares against http:// and not https:// from the IdP
+        ServerName https://%{REQUEST_HOST}
+
         ProxyPreserveHost on
-        ProxyPass        /ws/ ws://${NAME}/ws/
-        ProxyPassReverse /ws/ ws://${NAME}/ws/
-        ProxyPass        / http://${NAME}/
+
+        RewriteCond %{REQUEST_URI}     ^/ws        [NC]
+        RewriteCond %{HTTP:UPGRADE}    ^websocket$ [NC]
+        RewriteCond %{HTTP:CONNECTION} ^Upgrade$   [NC]
+        RewriteRule .* ws://${NAME}%{REQUEST_URI}  [P,QSA,L]
+
+        # For httpd, some ErrorDocuments must by served by the httpd pod
+        RewriteCond %{REQUEST_URI} !^/proxy_pages
+
+        # For SAML /saml2 is only served by mod_auth_mellon in the httpd pod
+        RewriteCond %{REQUEST_URI} !^/saml2
+        RewriteRule ^/ http://${NAME}%{REQUEST_URI} [P,QSA,L]
         ProxyPassReverse / http://${NAME}/
+
+        # Ensures httpd stdout/stderr are seen by docker logs.
+        ErrorLog  "| /usr/bin/tee /proc/1/fd/2 /var/log/httpd/error_log"
+        CustomLog "| /usr/bin/tee /proc/1/fd/1 /var/log/httpd/access_log" common
       </VirtualHost>
+    authentication.conf: |
+      # Load appropriate authentication configuration files
+      #
+      Include "conf.d/configuration-${HTTPD_AUTH_TYPE}-auth"
+    configuration-internal-auth: |
+      # Internal authentication
+      #
+    configuration-external-auth: |
+      Include "conf.d/external-auth-load-modules-conf"
+
+      <Location /dashboard/kerberos_authenticate>
+        AuthType                   Kerberos
+        AuthName                   "Kerberos Login"
+        KrbMethodNegotiate         On
+        KrbMethodK5Passwd          Off
+        KrbAuthRealms              ${HTTPD_AUTH_KERBEROS_REALMS}
+        Krb5KeyTab                 /etc/http.keytab
+        KrbServiceName             Any
+        Require                    pam-account httpd-auth
+
+        ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
+      </Location>
+
+      Include "conf.d/external-auth-login-form-conf"
+      Include "conf.d/external-auth-application-api-conf"
+      Include "conf.d/external-auth-lookup-user-details-conf"
+      Include "conf.d/external-auth-remote-user-conf"
+    configuration-active-directory-auth: |
+      Include "conf.d/external-auth-load-modules-conf"
+
+      <Location /dashboard/kerberos_authenticate>
+        AuthType                   Kerberos
+        AuthName                   "Kerberos Login"
+        KrbMethodNegotiate         On
+        KrbMethodK5Passwd          Off
+        KrbAuthRealms              ${HTTPD_AUTH_KERBEROS_REALMS}
+        Krb5KeyTab                 /etc/krb5.keytab
+        KrbServiceName             Any
+        Require                    pam-account httpd-auth
+
+        ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
+      </Location>
+
+      Include "conf.d/external-auth-login-form-conf"
+      Include "conf.d/external-auth-application-api-conf"
+      Include "conf.d/external-auth-lookup-user-details-conf"
+      Include "conf.d/external-auth-remote-user-conf"
+    configuration-saml-auth: |
+      LoadModule auth_mellon_module modules/mod_auth_mellon.so
+
+      <Location />
+        MellonEnable               "info"
+
+        MellonIdPMetadataFile      "/etc/httpd/saml2/idp-metadata.xml"
+
+        MellonSPPrivateKeyFile     "/etc/httpd/saml2/sp-key.key"
+        MellonSPCertFile           "/etc/httpd/saml2/sp-cert.cert"
+        MellonSPMetadataFile       "/etc/httpd/saml2/sp-metadata.xml"
+
+        MellonVariable             "sp-cookie"
+        MellonSecureCookie         On
+        MellonCookiePath           "/"
+
+        MellonIdP                  "IDP"
+
+        MellonEndpointPath         "/saml2"
+
+        MellonUser                 username
+        MellonMergeEnvVars         On
+
+        MellonSetEnvNoPrefix       "REMOTE_USER"            username
+        MellonSetEnvNoPrefix       "REMOTE_USER_EMAIL"      email
+        MellonSetEnvNoPrefix       "REMOTE_USER_FIRSTNAME"  firstname
+        MellonSetEnvNoPrefix       "REMOTE_USER_LASTNAME"   lastname
+        MellonSetEnvNoPrefix       "REMOTE_USER_FULLNAME"   fullname
+        MellonSetEnvNoPrefix       "REMOTE_USER_GROUPS"     groups
+      </Location>
+
+      <Location /saml_login>
+        AuthType                   "Mellon"
+        MellonEnable               "auth"
+        Require                    valid-user
+      </Location>
+
+      Include "conf.d/external-auth-remote-user-conf"
+    external-auth-load-modules-conf: |
+      LoadModule authnz_pam_module            modules/mod_authnz_pam.so
+      LoadModule intercept_form_submit_module modules/mod_intercept_form_submit.so
+      LoadModule lookup_identity_module       modules/mod_lookup_identity.so
+      LoadModule auth_kerb_module             modules/mod_auth_kerb.so
+    external-auth-login-form-conf: |
+      <Location /dashboard/external_authenticate>
+        InterceptFormPAMService    httpd-auth
+        InterceptFormLogin         user_name
+        InterceptFormPassword      user_password
+        InterceptFormLoginSkip     admin
+        InterceptFormClearRemoteUserForSkipped on
+      </Location>
+    external-auth-application-api-conf: |
+      <LocationMatch ^/api>
+        SetEnvIf Authorization     '^Basic +YWRtaW46' let_admin_in
+        SetEnvIf X-Auth-Token      '^.+$'             let_api_token_in
+        SetEnvIf X-MIQ-Token       '^.+$'             let_sys_token_in
+
+        AuthType                   Basic
+        AuthName                   "External Authentication (httpd) for API"
+        AuthBasicProvider          PAM
+
+        AuthPAMService             httpd-auth
+        Require                    valid-user
+        Order                      Allow,Deny
+        Allow from                 env=let_admin_in
+        Allow from                 env=let_api_token_in
+        Allow from                 env=let_sys_token_in
+        Satisfy                    Any
+      </LocationMatch>
+    external-auth-lookup-user-details-conf: |
+      <LocationMatch ^/dashboard/external_authenticate$|^/dashboard/kerberos_authenticate$|^/api>
+        LookupUserAttr mail        REMOTE_USER_EMAIL
+        LookupUserAttr givenname   REMOTE_USER_FIRSTNAME
+        LookupUserAttr sn          REMOTE_USER_LASTNAME
+        LookupUserAttr displayname REMOTE_USER_FULLNAME
+        LookupUserAttr domainname  REMOTE_USER_DOMAIN
+
+        LookupUserGroups           REMOTE_USER_GROUPS ":"
+        LookupDbusTimeout          5000
+      </LocationMatch>
+    external-auth-remote-user-conf: |
+      RequestHeader unset X_REMOTE_USER
+
+      RequestHeader set X_REMOTE_USER           %{REMOTE_USER}e           env=REMOTE_USER
+      RequestHeader set X_EXTERNAL_AUTH_ERROR   %{EXTERNAL_AUTH_ERROR}e   env=EXTERNAL_AUTH_ERROR
+      RequestHeader set X_REMOTE_USER_EMAIL     %{REMOTE_USER_EMAIL}e     env=REMOTE_USER_EMAIL
+      RequestHeader set X_REMOTE_USER_FIRSTNAME %{REMOTE_USER_FIRSTNAME}e env=REMOTE_USER_FIRSTNAME
+      RequestHeader set X_REMOTE_USER_LASTNAME  %{REMOTE_USER_LASTNAME}e  env=REMOTE_USER_LASTNAME
+      RequestHeader set X_REMOTE_USER_FULLNAME  %{REMOTE_USER_FULLNAME}e  env=REMOTE_USER_FULLNAME
+      RequestHeader set X_REMOTE_USER_GROUPS    %{REMOTE_USER_GROUPS}e    env=REMOTE_USER_GROUPS
+      RequestHeader set X_REMOTE_USER_DOMAIN    %{REMOTE_USER_DOMAIN}e    env=REMOTE_USER_DOMAIN
 - apiVersion: v1
   kind: ConfigMap
   metadata:
     name: "${HTTPD_SERVICE_NAME}-auth-configs"
   data:
     auth-type: internal
+    auth-kerberos-realms: undefined
     auth-configuration.conf: |
       # External Authentication Configuration File
       #
@@ -473,6 +622,20 @@ objects:
     - name: http
       port: 80
       targetPort: 80
+    selector:
+      name: httpd
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: "${HTTPD_DBUS_API_SERVICE_NAME}"
+    annotations:
+      description: Exposes the httpd server dbus api
+      service.alpha.openshift.io/dependencies: '[{"name":"${NAME}","namespace":"","kind":"Service"}]'
+  spec:
+    ports:
+    - name: http-dbus-api
+      port: 8080
+      targetPort: 8080
     selector:
       name: httpd
 - apiVersion: v1
@@ -509,6 +672,9 @@ objects:
           image: "${HTTPD_IMG_NAME}:${HTTPD_IMG_TAG}"
           ports:
           - containerPort: 80
+            protocol: TCP
+          - containerPort: 8080
+            protocol: TCP
           livenessProbe:
             exec:
               command:
@@ -538,13 +704,18 @@ objects:
               configMapKeyRef:
                 name: "${HTTPD_SERVICE_NAME}-auth-configs"
                 key: auth-type
+          - name: HTTPD_AUTH_KERBEROS_REALMS
+            valueFrom:
+              configMapKeyRef:
+                name: "${HTTPD_SERVICE_NAME}-auth-configs"
+                key: auth-kerberos-realms
           lifecycle:
             postStart:
               exec:
                 command:
                 - "/usr/bin/save-container-environment"
-        serviceAccount: miq-anyuid
-        serviceAccountName: miq-anyuid
+        serviceAccount: miq-httpd
+        serviceAccountName: miq-httpd
 parameters:
 - name: NAME
   displayName: Name
@@ -593,6 +764,11 @@ parameters:
   displayName: Application Database Region
   description: Database region that will be used for application.
   value: '0'
+- name: APPLICATION_ADMIN_PASSWORD
+  displayName: Application Admin Password
+  required: true
+  description: Admin password that will be set on the application.
+  value: smartvm
 - name: ANSIBLE_DATABASE_NAME
   displayName: Ansible PostgreSQL database name
   required: true
@@ -702,11 +878,11 @@ parameters:
 - name: FRONTEND_APPLICATION_IMG_TAG
   displayName: Front end Application Image Tag
   description: This is the ManageIQ Frontend Application image tag/version requested to deploy.
-  value: frontend-latest
+  value: frontend-latest-gaprindashvili
 - name: BACKEND_APPLICATION_IMG_TAG
   displayName: Back end Application Image Tag
   description: This is the ManageIQ Backend Application image tag/version requested to deploy.
-  value: backend-latest
+  value: backend-latest-gaprindashvili
 - name: ANSIBLE_IMG_NAME
   displayName: Ansible Image Name
   description: This is the Ansible image name requested to deploy.
@@ -738,6 +914,11 @@ parameters:
   displayName: Apache httpd Service Name
   description: The name of the OpenShift Service exposed for the httpd container.
   value: httpd
+- name: HTTPD_DBUS_API_SERVICE_NAME
+  required: true
+  displayName: Apache httpd DBus API Service Name
+  description: The name of httpd dbus api service.
+  value: httpd-dbus-api
 - name: HTTPD_IMG_NAME
   displayName: Apache httpd Image Name
   description: This is the httpd image name requested to deploy.

--- a/roles/openshift_management/files/templates/manageiq/miq-template.yaml
+++ b/roles/openshift_management/files/templates/manageiq/miq-template.yaml
@@ -31,6 +31,7 @@ objects:
     name: "${NAME}-secrets"
   stringData:
     pg-password: "${DATABASE_PASSWORD}"
+    admin-password: "${APPLICATION_ADMIN_PASSWORD}"
     database-url: postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_SERVICE_NAME}/${DATABASE_NAME}?encoding=utf8&pool=5&wait_timeout=5
     v2-key: "${V2_KEY}"
 - apiVersion: v1
@@ -128,18 +129,173 @@ objects:
 
       <VirtualHost *:80>
         KeepAlive on
+        # Without ServerName mod_auth_mellon compares against http:// and not https:// from the IdP
+        ServerName https://%{REQUEST_HOST}
+
         ProxyPreserveHost on
-        ProxyPass        /ws/ ws://${NAME}/ws/
-        ProxyPassReverse /ws/ ws://${NAME}/ws/
-        ProxyPass        / http://${NAME}/
+
+        RewriteCond %{REQUEST_URI}     ^/ws        [NC]
+        RewriteCond %{HTTP:UPGRADE}    ^websocket$ [NC]
+        RewriteCond %{HTTP:CONNECTION} ^Upgrade$   [NC]
+        RewriteRule .* ws://${NAME}%{REQUEST_URI}  [P,QSA,L]
+
+        # For httpd, some ErrorDocuments must by served by the httpd pod
+        RewriteCond %{REQUEST_URI} !^/proxy_pages
+
+        # For SAML /saml2 is only served by mod_auth_mellon in the httpd pod
+        RewriteCond %{REQUEST_URI} !^/saml2
+        RewriteRule ^/ http://${NAME}%{REQUEST_URI} [P,QSA,L]
         ProxyPassReverse / http://${NAME}/
+
+        # Ensures httpd stdout/stderr are seen by docker logs.
+        ErrorLog  "| /usr/bin/tee /proc/1/fd/2 /var/log/httpd/error_log"
+        CustomLog "| /usr/bin/tee /proc/1/fd/1 /var/log/httpd/access_log" common
       </VirtualHost>
+    authentication.conf: |
+      # Load appropriate authentication configuration files
+      #
+      Include "conf.d/configuration-${HTTPD_AUTH_TYPE}-auth"
+    configuration-internal-auth: |
+      # Internal authentication
+      #
+    configuration-external-auth: |
+      Include "conf.d/external-auth-load-modules-conf"
+
+      <Location /dashboard/kerberos_authenticate>
+        AuthType                   Kerberos
+        AuthName                   "Kerberos Login"
+        KrbMethodNegotiate         On
+        KrbMethodK5Passwd          Off
+        KrbAuthRealms              ${HTTPD_AUTH_KERBEROS_REALMS}
+        Krb5KeyTab                 /etc/http.keytab
+        KrbServiceName             Any
+        Require                    pam-account httpd-auth
+
+        ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
+      </Location>
+
+      Include "conf.d/external-auth-login-form-conf"
+      Include "conf.d/external-auth-application-api-conf"
+      Include "conf.d/external-auth-lookup-user-details-conf"
+      Include "conf.d/external-auth-remote-user-conf"
+    configuration-active-directory-auth: |
+      Include "conf.d/external-auth-load-modules-conf"
+
+      <Location /dashboard/kerberos_authenticate>
+        AuthType                   Kerberos
+        AuthName                   "Kerberos Login"
+        KrbMethodNegotiate         On
+        KrbMethodK5Passwd          Off
+        KrbAuthRealms              ${HTTPD_AUTH_KERBEROS_REALMS}
+        Krb5KeyTab                 /etc/krb5.keytab
+        KrbServiceName             Any
+        Require                    pam-account httpd-auth
+
+        ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
+      </Location>
+
+      Include "conf.d/external-auth-login-form-conf"
+      Include "conf.d/external-auth-application-api-conf"
+      Include "conf.d/external-auth-lookup-user-details-conf"
+      Include "conf.d/external-auth-remote-user-conf"
+    configuration-saml-auth: |
+      LoadModule auth_mellon_module modules/mod_auth_mellon.so
+
+      <Location />
+        MellonEnable               "info"
+
+        MellonIdPMetadataFile      "/etc/httpd/saml2/idp-metadata.xml"
+
+        MellonSPPrivateKeyFile     "/etc/httpd/saml2/sp-key.key"
+        MellonSPCertFile           "/etc/httpd/saml2/sp-cert.cert"
+        MellonSPMetadataFile       "/etc/httpd/saml2/sp-metadata.xml"
+
+        MellonVariable             "sp-cookie"
+        MellonSecureCookie         On
+        MellonCookiePath           "/"
+
+        MellonIdP                  "IDP"
+
+        MellonEndpointPath         "/saml2"
+
+        MellonUser                 username
+        MellonMergeEnvVars         On
+
+        MellonSetEnvNoPrefix       "REMOTE_USER"            username
+        MellonSetEnvNoPrefix       "REMOTE_USER_EMAIL"      email
+        MellonSetEnvNoPrefix       "REMOTE_USER_FIRSTNAME"  firstname
+        MellonSetEnvNoPrefix       "REMOTE_USER_LASTNAME"   lastname
+        MellonSetEnvNoPrefix       "REMOTE_USER_FULLNAME"   fullname
+        MellonSetEnvNoPrefix       "REMOTE_USER_GROUPS"     groups
+      </Location>
+
+      <Location /saml_login>
+        AuthType                   "Mellon"
+        MellonEnable               "auth"
+        Require                    valid-user
+      </Location>
+
+      Include "conf.d/external-auth-remote-user-conf"
+    external-auth-load-modules-conf: |
+      LoadModule authnz_pam_module            modules/mod_authnz_pam.so
+      LoadModule intercept_form_submit_module modules/mod_intercept_form_submit.so
+      LoadModule lookup_identity_module       modules/mod_lookup_identity.so
+      LoadModule auth_kerb_module             modules/mod_auth_kerb.so
+    external-auth-login-form-conf: |
+      <Location /dashboard/external_authenticate>
+        InterceptFormPAMService    httpd-auth
+        InterceptFormLogin         user_name
+        InterceptFormPassword      user_password
+        InterceptFormLoginSkip     admin
+        InterceptFormClearRemoteUserForSkipped on
+      </Location>
+    external-auth-application-api-conf: |
+      <LocationMatch ^/api>
+        SetEnvIf Authorization     '^Basic +YWRtaW46' let_admin_in
+        SetEnvIf X-Auth-Token      '^.+$'             let_api_token_in
+        SetEnvIf X-MIQ-Token       '^.+$'             let_sys_token_in
+
+        AuthType                   Basic
+        AuthName                   "External Authentication (httpd) for API"
+        AuthBasicProvider          PAM
+
+        AuthPAMService             httpd-auth
+        Require                    valid-user
+        Order                      Allow,Deny
+        Allow from                 env=let_admin_in
+        Allow from                 env=let_api_token_in
+        Allow from                 env=let_sys_token_in
+        Satisfy                    Any
+      </LocationMatch>
+    external-auth-lookup-user-details-conf: |
+      <LocationMatch ^/dashboard/external_authenticate$|^/dashboard/kerberos_authenticate$|^/api>
+        LookupUserAttr mail        REMOTE_USER_EMAIL
+        LookupUserAttr givenname   REMOTE_USER_FIRSTNAME
+        LookupUserAttr sn          REMOTE_USER_LASTNAME
+        LookupUserAttr displayname REMOTE_USER_FULLNAME
+        LookupUserAttr domainname  REMOTE_USER_DOMAIN
+
+        LookupUserGroups           REMOTE_USER_GROUPS ":"
+        LookupDbusTimeout          5000
+      </LocationMatch>
+    external-auth-remote-user-conf: |
+      RequestHeader unset X_REMOTE_USER
+
+      RequestHeader set X_REMOTE_USER           %{REMOTE_USER}e           env=REMOTE_USER
+      RequestHeader set X_EXTERNAL_AUTH_ERROR   %{EXTERNAL_AUTH_ERROR}e   env=EXTERNAL_AUTH_ERROR
+      RequestHeader set X_REMOTE_USER_EMAIL     %{REMOTE_USER_EMAIL}e     env=REMOTE_USER_EMAIL
+      RequestHeader set X_REMOTE_USER_FIRSTNAME %{REMOTE_USER_FIRSTNAME}e env=REMOTE_USER_FIRSTNAME
+      RequestHeader set X_REMOTE_USER_LASTNAME  %{REMOTE_USER_LASTNAME}e  env=REMOTE_USER_LASTNAME
+      RequestHeader set X_REMOTE_USER_FULLNAME  %{REMOTE_USER_FULLNAME}e  env=REMOTE_USER_FULLNAME
+      RequestHeader set X_REMOTE_USER_GROUPS    %{REMOTE_USER_GROUPS}e    env=REMOTE_USER_GROUPS
+      RequestHeader set X_REMOTE_USER_DOMAIN    %{REMOTE_USER_DOMAIN}e    env=REMOTE_USER_DOMAIN
 - apiVersion: v1
   kind: ConfigMap
   metadata:
     name: "${HTTPD_SERVICE_NAME}-auth-configs"
   data:
     auth-type: internal
+    auth-kerberos-realms: undefined
     auth-configuration.conf: |
       # External Authentication Configuration File
       #
@@ -203,15 +359,15 @@ objects:
         - name: manageiq
           image: "${APPLICATION_IMG_NAME}:${FRONTEND_APPLICATION_IMG_TAG}"
           livenessProbe:
-            tcpSocket:
-              port: 80
+            exec:
+              command:
+              - pidof
+              - MIQ Server
             initialDelaySeconds: 480
             timeoutSeconds: 3
           readinessProbe:
-            httpGet:
-              path: "/"
+            tcpSocket:
               port: 80
-              scheme: HTTP
             initialDelaySeconds: 200
             timeoutSeconds: 3
           ports:
@@ -227,8 +383,6 @@ objects:
                 fieldPath: metadata.namespace
           - name: APPLICATION_INIT_DELAY
             value: "${APPLICATION_INIT_DELAY}"
-          - name: DATABASE_SERVICE_NAME
-            value: "${DATABASE_SERVICE_NAME}"
           - name: DATABASE_REGION
             value: "${DATABASE_REGION}"
           - name: DATABASE_URL
@@ -236,17 +390,16 @@ objects:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: database-url
-          - name: MEMCACHED_SERVER
-            value: "${MEMCACHED_SERVICE_NAME}:11211"
-          - name: MEMCACHED_SERVICE_NAME
-            value: "${MEMCACHED_SERVICE_NAME}"
           - name: V2_KEY
             valueFrom:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: v2-key
-          - name: ANSIBLE_SERVICE_NAME
-            value: "${ANSIBLE_SERVICE_NAME}"
+          - name: APPLICATION_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "${NAME}-secrets"
+                key: admin-password
           - name: ANSIBLE_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -326,15 +479,11 @@ objects:
             value: database_operations,event,reporting,scheduler,smartstate,ems_operations,ems_inventory,automate
           - name: FRONTEND_SERVICE_NAME
             value: "${NAME}"
-          - name: MEMCACHED_SERVER
-            value: "${MEMCACHED_SERVICE_NAME}:11211"
           - name: V2_KEY
             valueFrom:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: v2-key
-          - name: ANSIBLE_SERVICE_NAME
-            value: "${ANSIBLE_SERVICE_NAME}"
           - name: ANSIBLE_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -490,7 +639,7 @@ objects:
           - name: miq-pgdb-volume
             mountPath: "/var/lib/pgsql/data"
           - name: miq-pg-configs
-            mountPath: "${POSTGRESQL_CONFIG_DIR}"
+            mountPath: "/opt/app-root/src/postgresql-cfg/"
           env:
           - name: POSTGRESQL_USER
             value: "${DATABASE_USER}"
@@ -505,8 +654,6 @@ objects:
             value: "${POSTGRESQL_MAX_CONNECTIONS}"
           - name: POSTGRESQL_SHARED_BUFFERS
             value: "${POSTGRESQL_SHARED_BUFFERS}"
-          - name: POSTGRESQL_CONFIG_DIR
-            value: "${POSTGRESQL_CONFIG_DIR}"
           resources:
             requests:
               memory: "${POSTGRESQL_MEM_REQ}"
@@ -623,6 +770,20 @@ objects:
     selector:
       name: httpd
 - apiVersion: v1
+  kind: Service
+  metadata:
+    name: "${HTTPD_DBUS_API_SERVICE_NAME}"
+    annotations:
+      description: Exposes the httpd server dbus api
+      service.alpha.openshift.io/dependencies: '[{"name":"${NAME}","namespace":"","kind":"Service"}]'
+  spec:
+    ports:
+    - name: http-dbus-api
+      port: 8080
+      targetPort: 8080
+    selector:
+      name: httpd
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: "${HTTPD_SERVICE_NAME}"
@@ -656,6 +817,9 @@ objects:
           image: "${HTTPD_IMG_NAME}:${HTTPD_IMG_TAG}"
           ports:
           - containerPort: 80
+            protocol: TCP
+          - containerPort: 8080
+            protocol: TCP
           livenessProbe:
             exec:
               command:
@@ -685,13 +849,18 @@ objects:
               configMapKeyRef:
                 name: "${HTTPD_SERVICE_NAME}-auth-configs"
                 key: auth-type
+          - name: HTTPD_AUTH_KERBEROS_REALMS
+            valueFrom:
+              configMapKeyRef:
+                name: "${HTTPD_SERVICE_NAME}-auth-configs"
+                key: auth-kerberos-realms
           lifecycle:
             postStart:
               exec:
                 command:
                 - "/usr/bin/save-container-environment"
-        serviceAccount: miq-anyuid
-        serviceAccountName: miq-anyuid
+        serviceAccount: miq-httpd
+        serviceAccountName: miq-httpd
 parameters:
 - name: NAME
   displayName: Name
@@ -730,6 +899,11 @@ parameters:
   displayName: Application Database Region
   description: Database region that will be used for application.
   value: '0'
+- name: APPLICATION_ADMIN_PASSWORD
+  displayName: Application Admin Password
+  required: true
+  description: Admin password that will be set on the application.
+  value: smartvm
 - name: ANSIBLE_DATABASE_NAME
   displayName: Ansible PostgreSQL database name
   required: true
@@ -752,10 +926,6 @@ parameters:
   displayName: Memcached Slab Page Size
   description: Memcached size of each slab page.
   value: 1m
-- name: POSTGRESQL_CONFIG_DIR
-  displayName: PostgreSQL Configuration Overrides
-  description: Directory used to store PostgreSQL configuration overrides.
-  value: "/var/lib/pgsql/conf.d"
 - name: POSTGRESQL_MAX_CONNECTIONS
   displayName: PostgreSQL Max Connections
   description: PostgreSQL maximum number of database connections allowed.
@@ -874,11 +1044,11 @@ parameters:
 - name: FRONTEND_APPLICATION_IMG_TAG
   displayName: Front end Application Image Tag
   description: This is the ManageIQ Frontend Application image tag/version requested to deploy.
-  value: frontend-latest
+  value: frontend-latest-gaprindashvili
 - name: BACKEND_APPLICATION_IMG_TAG
   displayName: Back end Application Image Tag
   description: This is the ManageIQ Backend Application image tag/version requested to deploy.
-  value: backend-latest
+  value: backend-latest-gaprindashvili
 - name: ANSIBLE_IMG_NAME
   displayName: Ansible Image Name
   description: This is the Ansible image name requested to deploy.
@@ -915,6 +1085,11 @@ parameters:
   displayName: Apache httpd Service Name
   description: The name of the OpenShift Service exposed for the httpd container.
   value: httpd
+- name: HTTPD_DBUS_API_SERVICE_NAME
+  required: true
+  displayName: Apache httpd DBus API Service Name
+  description: The name of httpd dbus api service.
+  value: httpd-dbus-api
 - name: HTTPD_IMG_NAME
   displayName: Apache httpd Image Name
   description: This is the httpd image name requested to deploy.


### PR DESCRIPTION
This adds external authentication functionality and the ability to set the application admin password.

Additionally, the image tags are updated to pull from the upstream release tag and some PG pod bugs are addressed.

/cc @tbielawa @elad661 

This should replace #6782