### PR TITLE
[3.7] Adding check in case only one ES container is in the pod for upgrades to 3.7

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/get_es_version.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/get_es_version.yml
@@ -6,6 +6,8 @@
     selector: component=es
   register: pod_list
 
+# 3.6 logging installations only have one container for the ES pod
+# if we are upgrading from 3.6 we only want to check the status of one container
 - set_fact:
     available_pod: "{{ item.metadata.name }}"
   with_items: "{{ pod_list.results.results[0]['items'] }}"
@@ -13,6 +15,18 @@
   - pod_list.results.results is defined
   - item.status.phase == "Running"
   - item.status.containerStatuses[0].ready == true
+  - not item.status.containerStatuses[1] is defined
+
+# As of 3.7 logging installations we have two containers for the ES pod
+# we want to check the status of both containers to make sure they're ready
+- set_fact:
+    available_pod: "{{ item.metadata.name }}"
+  with_items: "{{ pod_list.results.results[0]['items'] }}"
+  when:
+  - pod_list.results.results is defined
+  - item.status.phase == "Running"
+  - item.status.containerStatuses[0].ready == true
+  - item.status.containerStatuses[1] is defined
   - item.status.containerStatuses[1].ready == true
 
 - name: "Getting ES version for logging-es cluster"


### PR DESCRIPTION
Addresses upgrades from 3.6 where we only had one container in the ES pod to 3.7 where we have two.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1557044