### PR TITLE
Make sure the master service are restarted always

### DIFF
--- a/playbooks/openshift-etcd/private/migrate.yml
+++ b/playbooks/openshift-etcd/private/migrate.yml
@@ -149,7 +149,7 @@
   - name: Start master services
     service:
       name: "{{ item }}"
-      state: started
+      state: restarted
     register: service_status
     # Sometimes the master-api, resp. master-controllers fails to start for the first time
     until: service_status.state is defined and service_status.state == "started"


### PR DESCRIPTION
Due to https://github.com/openshift/openshift-ansible/pull/5367, the master service are restarted and running right after the etcd cluster is scaled up. The original assumption was both master services are stopped. So this refactoring change causes the master services not to be restarted. So the master-config.yaml is configured to use the etcd3 backend but the change is not reflected in the masters until they are restarted.

So here is what is going on:
1. the first etcd member is migrated
2. all remaining members are cleansed (their `/var/lib/etcd/member` is removed, ...)
3. etcd cluster is scale-up (so all etcd members are on v3) [1]
4. master-config.yaml is updated and `restart master api` and `restart master controllers` handlers are run [1] (not right away but eventually) which restarts both master services so they are running now
5. master-config.yaml is updated to use the etcd3 storage back-end [3]
6. The master services is to be restarted but they are not cause they are already running. So `state: started` is not enough to restart them. The state needs to be set to `restarted` so the services are restarted and the updated configuration takes affect.

[1] https://github.com/openshift/openshift-ansible/blob/master/playbooks/openshift-etcd/private/migrate.yml#L111
[2] https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_master/tasks/update_etcd_client_urls.yml#L6
[3] https://github.com/openshift/openshift-ansible/blob/master/playbooks/openshift-etcd/private/migrate.yml#L141
[4] https://github.com/openshift/openshift-ansible/blob/master/playbooks/openshift-etcd/private/migrate.yml#L150