### PR TITLE
etcd migrate: ensure all master vars are set

### DIFF
--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -27,6 +27,7 @@
                                        | default(none, true) }}"
     openshift_master_etcd_port: "{{ (etcd_client_port | default('2379')) if (groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config) else none }}"
     etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
+    openshift_ca_host: "{{ groups.oo_masters_to_config.0 }}"
   tasks:
   - set_fact:
       master_services:

--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -20,6 +20,13 @@
 # TODO: This will be different for release-3.6 branch
 - name: Prepare masters for etcd data migration
   hosts: oo_masters_to_config
+  vars:
+    openshift_master_etcd_hosts: "{{ hostvars
+                                       | oo_select_keys(groups['oo_etcd_to_config'] | union(groups['oo_new_etcd_to_config'] | default([])))
+                                       | oo_collect('openshift.common.hostname')
+                                       | default(none, true) }}"
+    openshift_master_etcd_port: "{{ (etcd_client_port | default('2379')) if (groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config) else none }}"
+    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
   tasks:
   - set_fact:
       master_services:


### PR DESCRIPTION
This is based on PR #7491, but adds `openshift_ca_host` var

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1544399