### PR TITLE
[WIP] origin-ansible-container: OpenStack support

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -7,15 +7,23 @@ USER root
 # Add origin repo for including the oc client
 COPY images/installer/origin-extra-root /
 
+ARG EXTRA_REPOS
+ARG EXTRA_REPO_PKGS
+
 # install ansible and deps
-RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl java-1.8.0-openjdk-headless python2-passlib httpd-tools openssh-clients origin-clients" \
- && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
+# Doing pyOpenSSL separately due to the fact that some centos SIGs package it
+# under the different name python2-pyOpenSSL
+RUN INSTALL_PKGS="python-lxml python-dns python2-cryptography openssl java-1.8.0-openjdk-headless python2-passlib httpd-tools openssh-clients origin-clients" \
+ && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS pyOpenSSL \
  && EPEL_PKGS="python2-boto python2-boto3 python2-crypto google-cloud-sdk-183.0.0 which python2-pip.noarch" \
+ && EXTRA_REPOS="epel-release ${EXTRA_REPOS}" \
+ && EXTRA_REPO_PKGS="${EPEL_PKGS} ${EXTRA_REPO_PKGS}" \
  && EPEL_TESTING_PKGS="ansible" \
- && yum install -y epel-release \
- && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
+ && yum install -y $EXTRA_REPOS \
+ && yum install -y --setopt=tsflags=nodocs $EXTRA_REPO_PKGS \
  && yum install -y --setopt=tsflags=nodocs --enablerepo=epel-testing $EPEL_TESTING_PKGS \
- && rpm -V $INSTALL_PKGS $EPEL_PKGS $EPEL_TESTING_PKGS \
+ && rpm -V pyOpenSSL || rpm -V python2-pyOpenSSL \
+ && rpm -V $INSTALL_PKGS $EXTRA_REPO_PKGS $EPEL_TESTING_PKGS \
  && pip install apache-libcloud~=2.2.1 \
  && yum clean all
 

--- a/playbooks/openstack/README.md
+++ b/playbooks/openstack/README.md
@@ -15,6 +15,32 @@ OpenStack-native services (storage, lbaas, baremetal as a service, dns, etc.).
 In order to run these Ansible playbooks, you'll need an Ansible host and an
 OpenStack environment.
 
+### OpenShift-Ansible container
+
+OpenShift Ansible provides a container image that can be used for deployment.
+You can build it from the root of the openshift ansible repository with support
+for running this playbook with:
+
+   docker build -t openshift/origin-ansible:openstack . \
+       --build-arg EXTRA_REPOS="centos-release-openstack-pike" \
+       --build-arg EXTRA_REPO_PKGS="python2-shade python-netaddr python2-openstackclient python2-heatclient" \
+       -f images/installer/Dockerfile
+
+Once it is built (or pulled from docker hub), you can run it like so:
+
+    docker run -u `id -u` \
+           -v $HOME/.ssh/id_rsa:/opt/app-root/src/.ssh/id_rsa:Z \
+           -v /path/to/my/inventory:/tmp/inventory \
+           -e INVENTORY_FILE=/tmp/inventory \
+           -e PLAYBOOK_FILE=playbooks/openstack/openshift-cluster/provision_install.yml \
+           -e OPTS="-v -i playbooks/openstack/inventory.py --user openshfit" \
+           --env-file /path/to/my/keystonerc \
+           -t openshift/origin-ansible
+
+Refer to the [Configuration](#configuration) section for information about
+generating the *inventory* that appears above as */path/to/my/inventory*. Note
+that the keystonerc should only have key=value entries, no bash.
+
 ### Ansible Host
 
 Start by choosing a host from which you'll run [Ansible][ansible]. This can


### PR DESCRIPTION
the OpenShift Ansible container documentation in the repo states that it
should support the playbooks in this repo. Unfortunately, due to some
extra dependencies in the openstack case, it failed. This patch aims to
make it easy for playbooks that have extra requirements to be able to
build their own tagged origin-ansible containers.

It would be nice if it could be pushed to docker hub as
openshift/origin-ansible:v3.10.0-openstack

TODO: Now that it successfully builds, we should try the deployment
to see that no dep was missed.

Change-Id: Ibb162ec01a432f6b9d061ede76e9e0e35c64f9f5
Signed-off-by: Antoni Segura Puimedon <antonisp@celebdor.com>