### PR TITLE
EFS Provisioner: switch OCP tag to latest

### DIFF
--- a/roles/openshift_provisioners/defaults/main.yaml
+++ b/roles/openshift_provisioners/defaults/main.yaml
@@ -15,4 +15,4 @@ openshift_provisioners_image_prefix_dict:
 
 openshift_provisioners_image_version_dict:
   origin: "latest"
-  openshift-enterprise: "{{ openshift_image_tag }}"
+  openshift-enterprise: "latest"


### PR DESCRIPTION
EFS provisioner hasn't changed since 3.6, so its safe to use 'latest' for OCP.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1558407