### PR TITLE
Making the app nodes an optional return.

### DIFF
--- a/playbooks/openstack/inventory.py
+++ b/playbooks/openstack/inventory.py
@@ -121,11 +121,15 @@ def build_inventory():
     '''Build the dynamic inventory.'''
     cloud = shade.openstack_cloud()
 
+    # Use an environment variable to optionally skip returning the app nodes.
+    show_compute_nodes = os.environ.get('OPENSTACK_SHOW_COMPUTE_NODES', 'true').lower() == "true"
+
     # TODO(shadower): filter the servers based on the `OPENSHIFT_CLUSTER`
     # environment variable.
     cluster_hosts = [
         server for server in cloud.list_servers()
-        if 'metadata' in server and 'clusterid' in server.metadata]
+        if 'metadata' in server and 'clusterid' in server.metadata and
+        (show_compute_nodes or server.metadata.get('sub-host-type') != 'app')]
 
     inventory = base_openshift_inventory(cluster_hosts)
 


### PR DESCRIPTION
I was asked to make a PR with the improvements that @jmencak created for the inventory.py file. Would like to start a discussion on performance for large scale OpenShift cluster on OpenStack.

Our team is attempting to scale up to past 1000 nodes and we are finding the performance of the inventory.py was very slow and got worse as the cluster size increased. 

The `inventory.py` script returns all the app nodes on each query. This is slowing down our scaleup operations significantly, so we came up with this patch to not include the app nodes when an environment variable is present. We only set the environment variable `INV_NO_APP_NODES` when performing scaleup operations.

We would like to have a discussion about this approach and see if there are other time saving things we can do to the inventory.py file when scaling to 1000+ app nodes.
