### PR TITLE
Filter OpenStack Inventory on OPENSHIFT_CLUSTER; Private DNS fix

### DIFF
--- a/playbooks/openstack/inventory.py
+++ b/playbooks/openstack/inventory.py
@@ -124,11 +124,10 @@ def build_inventory():
     '''Build the dynamic inventory.'''
     cloud = shade.openstack_cloud()
 
-    # TODO(shadower): filter the servers based on the `OPENSHIFT_CLUSTER`
-    # environment variable.
+    cluster_name = os.getenv('OPENSHIFT_CLUSTER', 'openshift-cluster')
     cluster_hosts = [
         server for server in cloud.list_servers()
-        if 'metadata' in server and 'clusterid' in server.metadata]
+        if 'metadata' in server and 'clusterid' in server.metadata and server.metadata['clusterid'] == cluster_name ]
 
     inventory = base_openshift_inventory(cluster_hosts)
 

--- a/playbooks/openstack/inventory.py
+++ b/playbooks/openstack/inventory.py
@@ -127,7 +127,7 @@ def build_inventory():
     cluster_name = os.getenv('OPENSHIFT_CLUSTER', 'openshift-cluster')
     cluster_hosts = [
         server for server in cloud.list_servers()
-        if 'metadata' in server and 'clusterid' in server.metadata and server.metadata['clusterid'] == cluster_name ]
+        if 'metadata' in server and 'clusterid' in server.metadata and server.metadata['clusterid'] == cluster_name]
 
     inventory = base_openshift_inventory(cluster_hosts)
 

--- a/roles/openshift_openstack/tasks/generate-dns.yml
+++ b/roles/openshift_openstack/tasks/generate-dns.yml
@@ -3,11 +3,15 @@
   set_fact:
     private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': hostvars[item]['ansible_hostname'] + openshift_openstack_private_hostname_suffix, 'ip': hostvars[item]['private_v4'] } ] }}"
   with_items: "{{ groups['cluster_hosts'] }}"
+  when:
+    - openshift_openstack_external_nsupdate_keys['private'] is defined
 
 - name: "Add wildcard records to the private A records for infrahosts"
   set_fact:
     private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': '*.' + openshift_openstack_app_subdomain, 'ip': hostvars[item]['private_v4'] } ] }}"
   with_items: "{{ groups['infra_hosts'] }}"
+  when:
+    - openshift_openstack_external_nsupdate_keys['private'] is defined
 
 - name: "Add public master cluster hostname records to the private A records (single master)"
   set_fact:
@@ -15,6 +19,7 @@
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openshift_openstack_num_masters == 1
+    - openshift_openstack_external_nsupdate_keys['private'] is defined
 
 - name: "Add public master cluster hostname records to the private A records (multi-master)"
   set_fact:
@@ -22,6 +27,7 @@
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openshift_openstack_num_masters > 1
+    - openshift_openstack_external_nsupdate_keys['private'] is defined
 
 - name: "Set the private DNS server to use the external value (if provided)"
   set_fact:

--- a/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
@@ -228,7 +228,7 @@ resources:
       metadata:
         group: { get_param: group }
         environment: { get_param: cluster_env }
-        clusterid: { get_param: cluster_id }
+        clusterid: {{ openshift_openstack_clusterid }}
         host-type: { get_param: type }
         sub-host-type:    { get_param: subtype }
         node_labels: { get_param: node_labels }


### PR DESCRIPTION
This PR addresses a couple of issues I hit while testing:

1/ We have multiple OpenShift clusters. This PR will honour the cluster ID when using the dynamic inventory.

2/ Our environment uses provider networks so there are no private IP addresses. Updated the generate-dns playbook to skip when not creating private DNS entries. Otherwise, playbook fails.