### PR TITLE
Make ports pool the default when deploying with kuryr

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -243,10 +243,10 @@ documentation:
 
 https://docs.openstack.org/kuryr-kubernetes/latest/installation/ports-pool.html
 
-To enable this feature, you must set:
+To disable this feature, you must set:
 
 ```yaml
-kuryr_openstack_enable_pools: true
+kuryr_openstack_enable_pools: false
 ```
 
 You can control the port pooling characteristics with these options:
@@ -256,31 +256,8 @@ kuryr_openstack_pool_max: 0
 kuryr_openstack_pool_min: 1
 kuryr_openstack_pool_batch: 5
 kuryr_openstack_pool_update_frequency: 20
+`openshift_kuryr_precreate_subports: 5`
 ```
-
-### Deploying OpenShift Registry
-
-Since we've disabled the OpenShift registry creation, you will have to create
-it manually afterwards. SSH to a master node and run this as root:
-
-```yaml
-oadm registry --config=/etc/origin/master/admin.kubeconfig --service-account=registry
-```
-
-For more information (e.g. how to use a specific storage backend), please
-follow the OpenShift documentation on the registry:
-
-https://docs.openshift.org/latest/install_config/registry/index.html
-
-And if you also want to enable the ports pooling options, as well as
-preloading them, you should uncomment and set the next:
-
-* `kuryr_openstack_enable_pools: True`
-* `kuryr_openstack_pool_max: 0`
-* `kuryr_openstack_pool_min: 1`
-* `kuryr_openstack_pool_batch: 5`
-* `kuryr_openstack_pool_update_frequency: 60`
-* `openshift_kuryr_precreate_subports: 5`
 
 Note in the last variable you specify the number of subports that will
 be created per trunk port, i.e., per pool.
@@ -298,6 +275,21 @@ openshift_openstack_cluster_node_labels:
     region: infra
     pod_vif: nested-vlan
 ```
+
+
+### Deploying OpenShift Registry
+
+Since we've disabled the OpenShift registry creation, you will have to create
+it manually afterwards. SSH to a master node and run this as root:
+
+```yaml
+oadm registry --config=/etc/origin/master/admin.kubeconfig --service-account=registry
+```
+
+For more information (e.g. how to use a specific storage backend), please
+follow the OpenShift documentation on the registry:
+
+https://docs.openshift.org/latest/install_config/registry/index.html
 
 
 ## Multi-Master Configuration

--- a/playbooks/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/all.yml
@@ -55,10 +55,10 @@ openshift_openstack_external_network_name: "public"
 # override this
 #kuryr_cni_link_interface: eth0
 
-## To enable the ports pooling you need to enable the next
-#kuryr_openstack_enable_pools: True
+## Ports pooling is enabled by default, to disable, uncomment the next:
+#kuryr_openstack_enable_pools: False
 #
-## You can alter the port pooling defaults here
+## You can also alter the port pooling defaults here
 #kuryr_openstack_pool_max: 0
 #kuryr_openstack_pool_min: 1
 #kuryr_openstack_pool_batch: 5

--- a/roles/kuryr/defaults/main.yaml
+++ b/roles/kuryr/defaults/main.yaml
@@ -30,6 +30,9 @@ bin_dir: /usr/bin
 openshift_openstack_kuryr_controller_image: kuryr/controller:latest
 openshift_openstack_kuryr_cni_image: kuryr/cni:latest
 
+# Enable kuryr ports pool by default
+kuryr_openstack_enable_pools: True
+
 # Path to the cni binaries
 cni_bin_dir: /opt/cni/bin
 

--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -231,7 +231,7 @@ data:
     pod_vif_driver = nested-vlan
 
     # The driver that manages VIFs pools for Kubernetes Pods (string value)
-    vif_pool_driver = {{ kuryr_openstack_enable_pools | default(False) | ternary('multi', 'noop') }}
+    vif_pool_driver = {{ kuryr_openstack_enable_pools | ternary('multi', 'noop') }}
 
     [neutron]
     # Configuration options for OpenStack Neutron
@@ -553,7 +553,7 @@ data:
     pod_vif_driver = nested-vlan
 
     # The driver that manages VIFs pools for Kubernetes Pods (string value)
-    vif_pool_driver = {{ kuryr_openstack_enable_pools | default(False) | ternary('nested', 'noop') }}
+    vif_pool_driver = {{ kuryr_openstack_enable_pools | ternary('multi', 'noop') }}
 
     [neutron]
     # Configuration options for OpenStack Neutron


### PR DESCRIPTION
It ensures kuryr gets deployed with ports pooling enabled unless
otherwise stated. It also update the related documentation