### PR TITLE
add in password auth for logging proxy

### DIFF
--- a/roles/openshift_logging_elasticsearch/templates/5.x/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/5.x/es.j2
@@ -148,6 +148,7 @@ spec:
            - -client-id=system:serviceaccount:{{ openshift_logging_elasticsearch_namespace }}:aggregated-logging-elasticsearch
            - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
            - -cookie-secret={{ 16 | lib_utils_oo_random_word | b64encode }}
+           - -basic-auth-password={{ basic_auth_passwd }}
            - -upstream=https://localhost:9200
            - '-openshift-sar={"namespace": "{{ openshift_logging_elasticsearch_namespace}}", "verb": "view", "resource": "prometheus", "group": "metrics.openshift.io"}'
            - '-openshift-delegate-urls={"/": {"resource": "prometheus", "verb": "view", "group": "metrics.openshift.io", "namespace": "{{ openshift_logging_elasticsearch_namespace}}"}}'


### PR DESCRIPTION
This adds in the basic bits to the ES template to pass in the basic auth for ES5.x proxy fronting prometheus 

@ewolinetz confirm we shouldnt need to cherrypick back to 3.9 right?