### PR TITLE
[release-3.7] Change registry for origin deployment

### DIFF
--- a/roles/openshift_health_checker/test/docker_image_availability_test.py
+++ b/roles/openshift_health_checker/test/docker_image_availability_test.py
@@ -206,7 +206,7 @@ def test_registry_availability(image, registries, connection_test_failed, skopeo
             'openshift/origin:vtest',
             'openshift/node:vtest',
             'openshift/openvswitch:vtest',
-            'registry.access.redhat.com/rhel7/etcd',
+            'registry.fedoraproject.org/f27/etcd',
         ])
     ),
     (  # enterprise images


### PR DESCRIPTION
As registry.access.redhat.com/rhel7/etcd need a registered account and most of users using Origin haven't any, I suggest to change this test to registry.fedoraproject.org/f27/etcd.