### PR TITLE
[release-3.9] Add max-time option to curl to avoid long running ansible

### DIFF
--- a/playbooks/openshift-master/private/scaleup.yml
+++ b/playbooks/openshift-master/private/scaleup.yml
@@ -30,7 +30,7 @@
     until: result.rc == 0
   - name: verify api server
     command: >
-      curl --silent --tlsv1.2
+      curl --silent --tlsv1.2 --max-time 2
       --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
       {{ openshift.master.api_url }}/healthz/ready
     args:

--- a/playbooks/openshift-master/private/tasks/wire_aggregator.yml
+++ b/playbooks/openshift-master/private/tasks/wire_aggregator.yml
@@ -206,7 +206,7 @@
     # Using curl here since the uri module requires python-httplib2 and
     # wait_for port doesn't provide health information.
     command: >
-      curl --silent --tlsv1.2
+      curl --silent --tlsv1.2 --max-time 2
       --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
       {{ openshift.master.api_url }}/healthz/ready
     args:

--- a/roles/openshift_logging/handlers/main.yml
+++ b/roles/openshift_logging/handlers/main.yml
@@ -17,7 +17,7 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent --tlsv1.2
+    curl --silent --tlsv1.2 --max-time 2
     --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
     {{ openshift.master.api_url }}/healthz/ready
   args:

--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -6,7 +6,7 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent --tlsv1.2
+    curl --silent --tlsv1.2 --max-time 2
     --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
     {{ openshift_node_master_api_url }}/healthz/ready
   args:

--- a/roles/openshift_master/handlers/main.yml
+++ b/roles/openshift_master/handlers/main.yml
@@ -22,7 +22,7 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent --tlsv1.2
+    curl --silent --tlsv1.2 --max-time 2
     --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
     {{ openshift.master.api_url }}/healthz/ready
   args:

--- a/roles/openshift_master/tasks/check_master_api_is_ready.yml
+++ b/roles/openshift_master/tasks/check_master_api_is_ready.yml
@@ -3,7 +3,7 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent --tlsv1.2
+    curl --silent --tlsv1.2 --max-time 2
     --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
     {{ openshift.master.api_url }}/healthz/ready
   register: l_api_available_output

--- a/roles/openshift_metrics/handlers/main.yml
+++ b/roles/openshift_metrics/handlers/main.yml
@@ -17,7 +17,7 @@
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.
   command: >
-    curl --silent --tlsv1.2
+    curl --silent --tlsv1.2 --max-time 2
     --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
     {{ openshift.master.api_url }}/healthz/ready
   args:

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -65,7 +65,8 @@
       # Using curl here since the uri module requires python-httplib2 and
       # wait_for port doesn't provide health information.
       command: >
-        curl --silent --tlsv1.2 --cacert {{ openshift.common.config_base }}/node/ca.crt
+        curl --silent --tlsv1.2 --max-time 2
+        --cacert {{ openshift.common.config_base }}/node/ca.crt
         {{ openshift_node_master_api_url }}/healthz/ready
       args:
         # Disables the following warning:


### PR DESCRIPTION
When curl command is executed to check services health with `retries:
120` and `delay: 1`, it looks like it takes `120 sec` at a
maximum until it gives up. However, in case that peer does not reply
and makes timeout due to some issue, one curl takes around 1 min
(=connection timeout) to fail, so `120(sec) * 1(min) = 2 hours` in
total. It takes too long until users wait for the end of ansible.

To solve this ansible ends after long running issue, this patch adds
`--max-time 2` to curl command to timeout.