### PR TITLE
fix the ELASTICSEARCH_URL for kibana

### DIFF
--- a/roles/openshift_logging_kibana/templates/5.x/kibana.j2
+++ b/roles/openshift_logging_kibana/templates/5.x/kibana.j2
@@ -60,7 +60,7 @@ spec:
 {%   endif %}
 {% endif %}
           env:
-            - name: "ES_URL"
+            - name: "ELASTICSEARCH_URL"
               value: "https://{{ es_host }}:{{ es_port }}"
             -
               name: "KIBANA_MEMORY_LIMIT"


### PR DESCRIPTION
The config can now be over-riden with environment vars and the default for the elasticsearch url is ELASTICSEARCH_URL