### PR TITLE
migrate: update ETCD_NAME for migrated hosts

### DIFF
--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -173,6 +173,11 @@
     retries: 12
     delay: 10
     until: etcd_add_check.rc == 0
+  - name: Make sure ETCD_NAME is updated
+    lineinfile:
+      regexp: ^ETCD_NAME=
+      line: "ETCD_NAME={{ etcd_hostname }}"
+      dest: /etc/etcd/etcd.conf
   - name: Set ETCD_INITIAL_CLUSTER_STATE=existing on migrated etcd host
     lineinfile:
       regexp: ^ETCD_INITIAL_CLUSTER_STATE=


### PR DESCRIPTION
Some hosts may have changed IP / hostname before migration. Migrate playbook 
should ensure ETCD_NAME is updated, otherwise the member cannot be added

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1559173