### PR TITLE
Revert "Use region and zone labels added by cloudprovider for scheduling"

### DIFF
--- a/roles/lib_utils/lookup_plugins/openshift_master_facts_default_predicates.py
+++ b/roles/lib_utils/lookup_plugins/openshift_master_facts_default_predicates.py
@@ -8,7 +8,7 @@ class LookupModule(LookupBase):
     # pylint: disable=too-many-branches,too-many-statements,too-many-arguments
 
     def run(self, terms, variables=None, regions_enabled=True, short_version=None,
-            cloudprovider_enabled=False, **kwargs):
+            **kwargs):
 
         predicates = []
 
@@ -80,15 +80,11 @@ class LookupModule(LookupBase):
             ])
 
         if regions_enabled:
-            if cloudprovider_enabled:
-                region_label = 'failure-domain.beta.kubernetes.io/region'
-            else:
-                region_label = 'region'
             region_predicate = {
                 'name': 'Region',
                 'argument': {
                     'serviceAffinity': {
-                        'labels': [region_label]
+                        'labels': ['region']
                     }
                 }
             }

--- a/roles/lib_utils/lookup_plugins/openshift_master_facts_default_priorities.py
+++ b/roles/lib_utils/lookup_plugins/openshift_master_facts_default_priorities.py
@@ -8,7 +8,7 @@ class LookupModule(LookupBase):
     # pylint: disable=too-many-branches,too-many-statements,too-many-arguments
 
     def run(self, terms, variables=None, zones_enabled=True, short_version=None,
-            cloudprovider_enabled=False, **kwargs):
+            **kwargs):
 
         priorities = []
 
@@ -45,15 +45,11 @@ class LookupModule(LookupBase):
             ])
 
         if zones_enabled:
-            if cloudprovider_enabled:
-                zone_label = 'failure-domain.beta.kubernetes.io/zone'
-            else:
-                zone_label = 'zone'
             zone_priority = {
                 'name': 'Zone',
                 'argument': {
                     'serviceAntiAffinity': {
-                        'label': zone_label
+                        'label': 'zone'
                     }
                 },
                 'weight': 2

--- a/roles/lib_utils/test/conftest.py
+++ b/roles/lib_utils/test/conftest.py
@@ -156,11 +156,6 @@ def zones_enabled(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def cloudprovider_enabled(request):
-    return request.param
-
-
 def v_prefix(release):
     """Prefix a release number with 'v'."""
     return "v" + release

--- a/roles/lib_utils/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/lib_utils/test/openshift_master_facts_default_predicates_tests.py
@@ -57,15 +57,6 @@ REGION_PREDICATE = {
     }
 }
 
-CLOUD_PROVIDER_REGION_PREDICATE = {
-    'name': 'Region',
-    'argument': {
-        'serviceAffinity': {
-            'labels': ['failure-domain.beta.kubernetes.io/region']
-        }
-    }
-}
-
 TEST_VARS = [
     ('3.6', DEFAULT_PREDICATES_3_6),
     ('3.7', DEFAULT_PREDICATES_3_7),
@@ -75,21 +66,17 @@ TEST_VARS = [
 ]
 
 
-def assert_ok(predicates_lookup, default_predicates, regions_enabled, cloudprovider_enabled, **kwargs):
-    results = predicates_lookup.run(None, regions_enabled=regions_enabled,
-                                    cloudprovider_enabled=cloudprovider_enabled, **kwargs)
-    if regions_enabled and cloudprovider_enabled:
-        assert results == default_predicates + [CLOUD_PROVIDER_REGION_PREDICATE]
-    elif regions_enabled and not cloudprovider_enabled:
+def assert_ok(predicates_lookup, default_predicates, regions_enabled, **kwargs):
+    results = predicates_lookup.run(None, regions_enabled=regions_enabled, **kwargs)
+    if regions_enabled:
         assert results == default_predicates + [REGION_PREDICATE]
     else:
         assert results == default_predicates
 
 
-def test_openshift_version(predicates_lookup, openshift_version_fixture, regions_enabled, cloudprovider_enabled):
+def test_openshift_version(predicates_lookup, openshift_version_fixture, regions_enabled):
     facts, default_predicates = openshift_version_fixture
-    assert_ok(predicates_lookup, default_predicates, variables=facts, regions_enabled=regions_enabled,
-              cloudprovider_enabled=cloudprovider_enabled)
+    assert_ok(predicates_lookup, default_predicates, variables=facts, regions_enabled=regions_enabled)
 
 
 @pytest.fixture(params=TEST_VARS)
@@ -100,10 +87,9 @@ def openshift_version_fixture(request, facts):
     return facts, default_predicates
 
 
-def test_openshift_release(predicates_lookup, openshift_release_fixture, regions_enabled, cloudprovider_enabled):
+def test_openshift_release(predicates_lookup, openshift_release_fixture, regions_enabled):
     facts, default_predicates = openshift_release_fixture
-    assert_ok(predicates_lookup, default_predicates, variables=facts, regions_enabled=regions_enabled,
-              cloudprovider_enabled=cloudprovider_enabled)
+    assert_ok(predicates_lookup, default_predicates, variables=facts, regions_enabled=regions_enabled)
 
 
 @pytest.fixture(params=TEST_VARS)
@@ -113,12 +99,11 @@ def openshift_release_fixture(request, facts, release_mod):
     return facts, default_predicates
 
 
-def test_short_version_kwarg(predicates_lookup, short_version_kwarg_fixture, regions_enabled, cloudprovider_enabled):
+def test_short_version_kwarg(predicates_lookup, short_version_kwarg_fixture, regions_enabled):
     facts, short_version, default_predicates = short_version_kwarg_fixture
     assert_ok(
         predicates_lookup, default_predicates, variables=facts,
-        regions_enabled=regions_enabled, short_version=short_version,
-        cloudprovider_enabled=cloudprovider_enabled)
+        regions_enabled=regions_enabled, short_version=short_version)
 
 
 @pytest.fixture(params=TEST_VARS)

--- a/roles/lib_utils/test/openshift_master_facts_default_priorities_tests.py
+++ b/roles/lib_utils/test/openshift_master_facts_default_priorities_tests.py
@@ -23,16 +23,6 @@ ZONE_PRIORITY = {
     'weight': 2
 }
 
-CLOUD_PROVIDER_ZONE_PRIORITY = {
-    'name': 'Zone',
-    'argument': {
-        'serviceAntiAffinity': {
-            'label': 'failure-domain.beta.kubernetes.io/zone'
-        }
-    },
-    'weight': 2
-}
-
 TEST_VARS = [
     ('3.6', DEFAULT_PRIORITIES_3_6),
     ('3.7', DEFAULT_PRIORITIES_3_7),
@@ -42,21 +32,17 @@ TEST_VARS = [
 ]
 
 
-def assert_ok(priorities_lookup, default_priorities, zones_enabled, cloudprovider_enabled, **kwargs):
-    results = priorities_lookup.run(None, zones_enabled=zones_enabled,
-                                    cloudprovider_enabled=cloudprovider_enabled, **kwargs)
-    if zones_enabled and cloudprovider_enabled:
-        assert results == default_priorities + [CLOUD_PROVIDER_ZONE_PRIORITY]
-    elif zones_enabled and not cloudprovider_enabled:
+def assert_ok(priorities_lookup, default_priorities, zones_enabled, **kwargs):
+    results = priorities_lookup.run(None, zones_enabled=zones_enabled, **kwargs)
+    if zones_enabled:
         assert results == default_priorities + [ZONE_PRIORITY]
     else:
         assert results == default_priorities
 
 
-def test_openshift_version(priorities_lookup, openshift_version_fixture, zones_enabled, cloudprovider_enabled):
+def test_openshift_version(priorities_lookup, openshift_version_fixture, zones_enabled):
     facts, default_priorities = openshift_version_fixture
-    assert_ok(priorities_lookup, default_priorities, variables=facts, zones_enabled=zones_enabled,
-              cloudprovider_enabled=cloudprovider_enabled)
+    assert_ok(priorities_lookup, default_priorities, variables=facts, zones_enabled=zones_enabled)
 
 
 @pytest.fixture(params=TEST_VARS)
@@ -67,10 +53,9 @@ def openshift_version_fixture(request, facts):
     return facts, default_priorities
 
 
-def test_openshift_release(priorities_lookup, openshift_release_fixture, zones_enabled, cloudprovider_enabled):
+def test_openshift_release(priorities_lookup, openshift_release_fixture, zones_enabled):
     facts, default_priorities = openshift_release_fixture
-    assert_ok(priorities_lookup, default_priorities, variables=facts, zones_enabled=zones_enabled,
-              cloudprovider_enabled=cloudprovider_enabled)
+    assert_ok(priorities_lookup, default_priorities, variables=facts, zones_enabled=zones_enabled)
 
 
 @pytest.fixture(params=TEST_VARS)
@@ -80,12 +65,11 @@ def openshift_release_fixture(request, facts, release_mod):
     return facts, default_priorities
 
 
-def test_short_version_kwarg(priorities_lookup, short_version_kwarg_fixture, zones_enabled, cloudprovider_enabled):
+def test_short_version_kwarg(priorities_lookup, short_version_kwarg_fixture, zones_enabled):
     facts, short_version, default_priorities = short_version_kwarg_fixture
     assert_ok(
         priorities_lookup, default_priorities, variables=facts,
-        zones_enabled=zones_enabled, short_version=short_version,
-        cloudprovider_enabled=cloudprovider_enabled)
+        zones_enabled=zones_enabled, short_version=short_version)
 
 
 @pytest.fixture(params=TEST_VARS)

--- a/roles/openshift_master/tasks/upgrade/upgrade_predicates.yml
+++ b/roles/openshift_master/tasks/upgrade/upgrade_predicates.yml
@@ -43,10 +43,3 @@
     when:
     - openshift_master_scheduler_current_predicates != osm_default_predicates_no_region
     - openshift_master_scheduler_current_predicates in osm_older_predicates_no_region + [osm_prev_predicates_no_region]
-
-  - name: set_fact openshift_upgrade_scheduler_predicates 3
-    set_fact:
-      openshift_upgrade_scheduler_predicates: "{{ osm_default_predicates_cloud_provider }}"
-    when:
-    - openshift_master_scheduler_current_predicates != osm_default_predicates_cloud_provider
-    - openshift_master_scheduler_current_predicates == osm_prev_predicates_cloud_provider

--- a/roles/openshift_master/tasks/upgrade/upgrade_priorities.yml
+++ b/roles/openshift_master/tasks/upgrade/upgrade_priorities.yml
@@ -43,10 +43,3 @@
     when:
     - openshift_master_scheduler_current_priorities != osm_default_priorities_no_zone
     - openshift_master_scheduler_current_priorities in osm_older_priorities_no_zone + [osm_prev_priorities_no_zone]
-
-  - name: set_fact openshift_upgrade_scheduler_priorities 3
-    set_fact:
-      openshift_upgrade_scheduler_priorities: "{{ osm_default_priorities_cloud_provider }}"
-    when:
-    - openshift_master_scheduler_current_priorities != osm_default_priorities_cloud_provider
-    - openshift_master_scheduler_current_priorities == osm_prev_priorities_cloud_provider

--- a/roles/openshift_master/vars/main.yml
+++ b/roles/openshift_master/vars/main.yml
@@ -3,9 +3,7 @@
 # role lib_utils
 osm_prev_predicates: "{{ lookup('openshift_master_facts_default_predicates', short_version=openshift_upgrade_min }}"
 osm_prev_predicates_no_region: "{{ lookup('openshift_master_facts_default_predicates', short_version=openshift_upgrade_min, regions_enabled=False) }}"
-osm_prev_predicates_cloud_provider: "{{ lookup('openshift_master_facts_default_predicates', short_version=openshift_upgrade_min, cloud_provider_enabled=False) }}"
 osm_default_predicates_no_region: "{{ lookup('openshift_master_facts_default_predicates', regions_enabled=False) }}"
-osm_default_predicates_cloud_provider: "{{ lookup('openshift_master_facts_default_predicates', cloud_provider_enabled=True) }}"
 # osm_older_predicates are the set of predicates that have previously been
 # hard-coded into openshift_facts
 osm_older_predicates:
@@ -62,9 +60,7 @@ osm_older_predicates_no_region:
 
 osm_prev_priorities: "{{ lookup('openshift_master_facts_default_priorities', short_version=openshift_upgrade_min) }}"
 osm_prev_priorities_no_zone: "{{ lookup('openshift_master_facts_default_priorities', short_version=openshift_upgrade_min, zones_enabled=False) }}"
-osm_prev_priorities_cloud_provider: "{{ lookup('openshift_master_facts_default_priorities', short_version=openshift_upgrade_min, cloud_provider_enabled=True) }}"
 osm_default_priorities_no_zone: "{{ lookup('openshift_master_facts_default_priorities', zones_enabled=False) }}"
-osm_default_priorities_cloud_provider: "{{ lookup('openshift_master_facts_default_priorities', cloud_provider_enabled=True) }}"
 # osm_older_priorities are the set of priorities that have previously been
 # hard-coded into openshift_facts
 osm_older_priorities:

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -92,8 +92,8 @@
   set_fact:
     # openshift_master_facts_default_predicates is a custom lookup plugin in
     # role lib_utils
-    openshift_master_scheduler_default_predicates: "{{ lookup('openshift_master_facts_default_predicates', cloudprovider_enabled=has_cloudprovider) }}"
-    openshift_master_scheduler_default_priorities: "{{ lookup('openshift_master_facts_default_priorities', cloudprovider_enabled=has_cloudprovider) }}"
+    openshift_master_scheduler_default_predicates: "{{ lookup('openshift_master_facts_default_predicates') }}"
+    openshift_master_scheduler_default_priorities: "{{ lookup('openshift_master_facts_default_priorities') }}"
 
 - block:
   - name: Retrieve current scheduler config

--- a/roles/openshift_master_facts/vars/main.yml
+++ b/roles/openshift_master_facts/vars/main.yml
@@ -2,4 +2,3 @@
 openshift_master_config_dir: "{{ openshift.common.config_base }}/master"
 openshift_master_config_file: "{{ openshift_master_config_dir }}/master-config.yaml"
 openshift_master_scheduler_conf: "{{ openshift_master_config_dir }}/scheduler.json"
-has_cloudprovider: "{{ openshift_cloudprovider_kind | default(None) != None }}"


### PR DESCRIPTION
Revert #7381

This reverts commit 2113bb68743e714192dd1c3570692cca788d084f.