### PR TITLE
Split the provision.yml playbook for more flexibility.

### DIFF
--- a/playbooks/openstack/openshift-cluster/provision.yml
+++ b/playbooks/openstack/openshift-cluster/provision.yml
@@ -1,17 +1,4 @@
 ---
-- name: Create the OpenStack resources for cluster installation
-  any_errors_fatal: true
-  hosts: localhost
-  tasks:
-  - name: retrieve cluster name from the environment if present
-    set_fact:
-      openshift_openstack_stack_name: "{{ lookup('env', 'OPENSHIFT_CLUSTER') | ternary (lookup('env', 'OPENSHIFT_CLUSTER'), omit) }}"
-  - name: provision cluster
-    import_role:
-      name: openshift_openstack
-      tasks_from: provision.yml
-
-
 # NOTE(shadower): Bring in the host groups:
 - name: evaluate groups
   import_playbook: ../../init/evaluate_groups.yml

--- a/playbooks/openstack/openshift-cluster/provision_install.yml
+++ b/playbooks/openstack/openshift-cluster/provision_install.yml
@@ -2,6 +2,9 @@
 - name: Check the prerequisites for cluster provisioning in OpenStack
   import_playbook: prerequisites.yml
 
+- name: Create the OpenStack resources for cluster installation
+  import_playbook: provision_resources.yml
+
 - name: Include the provision.yml playbook to create cluster
   import_playbook: provision.yml
 

--- a/playbooks/openstack/openshift-cluster/provision_resources.yml
+++ b/playbooks/openstack/openshift-cluster/provision_resources.yml
@@ -1,0 +1,12 @@
+---
+- name: Create the OpenStack resources for cluster installation or scaleup
+  any_errors_fatal: true
+  hosts: localhost
+  tasks:
+  - name: retrieve cluster name from the environment if present
+    set_fact:
+      openshift_openstack_stack_name: "{{ lookup('env', 'OPENSHIFT_CLUSTER') | ternary (lookup('env', 'OPENSHIFT_CLUSTER'), omit) }}"
+  - name: provision cluster
+    import_role:
+      name: openshift_openstack
+      tasks_from: provision.yml


### PR DESCRIPTION
This will help improving scaleup times at large node counts.