### PR TITLE
Master: change openshift_node include_tasks to import_tasks

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -1,9 +1,9 @@
 ---
 - name: Install the systemd units
-  include_tasks: systemd_units.yml
+  import_tasks: systemd_units.yml
 
 - name: Pull container images
-  include_tasks: container_images.yml
+  import_tasks: container_images.yml
   when: openshift_is_containerized | bool
 
 - file:

--- a/roles/openshift_node/tasks/container_images.yml
+++ b/roles/openshift_node/tasks/container_images.yml
@@ -1,5 +1,5 @@
 ---
 - name: Install Node system container
-  include_tasks: node_system_container.yml
+  import_tasks: node_system_container.yml
   when:
   - l_is_node_system_container | bool

--- a/roles/openshift_node/tasks/dnsmasq.yml
+++ b/roles/openshift_node/tasks/dnsmasq.yml
@@ -22,5 +22,5 @@
     state: started
 
 # Dynamic NetworkManager based dispatcher
-- include_tasks: dnsmasq/network-manager.yml
+- import_tasks: dnsmasq/network-manager.yml
   when: network_manager_active | bool

--- a/roles/openshift_node/tasks/dnsmasq/no-network-manager.yml
+++ b/roles/openshift_node/tasks/dnsmasq/no-network-manager.yml
@@ -10,4 +10,4 @@
   register: result
   until: result is succeeded
 
-- include_tasks: network-manager.yml
+- import_tasks: network-manager.yml

--- a/roles/openshift_node/tasks/dnsmasq_install.yml
+++ b/roles/openshift_node/tasks/dnsmasq_install.yml
@@ -39,5 +39,5 @@
     dest: /etc/origin/node/node-dnsmasq.conf
 
 # Relies on ansible in order to configure static config
-- include_tasks: dnsmasq/no-network-manager.yml
+- import_tasks: dnsmasq/no-network-manager.yml
   when: not network_manager_active | bool

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -6,14 +6,14 @@
     - openshift_deployment_type == 'openshift-enterprise'
     - not openshift_use_crio | bool
 
-- include_tasks: dnsmasq_install.yml
-- include_tasks: dnsmasq.yml
+- import_tasks: dnsmasq_install.yml
+- import_tasks: dnsmasq.yml
 
 - name: setup firewall
   import_tasks: firewall.yml
 
 - name: Update journald config
-  include_tasks: journald.yml
+  import_tasks: journald.yml
 
 #### Disable SWAP #####
 # https://docs.openshift.com/container-platform/3.4/admin_guide/overcommit.html#disabling-swap-memory
@@ -24,7 +24,7 @@
   when: openshift_disable_swap | default(true) | bool
 
 - name: include node installer
-  include_tasks: install.yml
+  import_tasks: install.yml
 
 - name: Restart cri-o
   systemd:
@@ -53,27 +53,27 @@
     sysctl_file: "/etc/sysctl.d/99-openshift.conf"
     reload: yes
 
-- include_tasks: registry_auth.yml
+- import_tasks: registry_auth.yml
 
 - name: include standard node config
-  include_tasks: config.yml
+  import_tasks: config.yml
 
 #### Storage class plugins here ####
 - name: NFS storage plugin configuration
-  include_tasks: storage_plugins/nfs.yml
+  import_tasks: storage_plugins/nfs.yml
   tags:
     - nfs
 
 - name: GlusterFS storage plugin configuration
-  include_tasks: storage_plugins/glusterfs.yml
+  import_tasks: storage_plugins/glusterfs.yml
   when: "'glusterfs' in osn_storage_plugin_deps"
 
 - name: Ceph storage plugin configuration
-  include_tasks: storage_plugins/ceph.yml
+  import_tasks: storage_plugins/ceph.yml
   when: "'ceph' in osn_storage_plugin_deps"
 
 - name: iSCSI storage plugin configuration
-  include_tasks: storage_plugins/iscsi.yml
+  import_tasks: storage_plugins/iscsi.yml
   when: "'iscsi' in osn_storage_plugin_deps"
 
 ##### END Storage #####

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -16,7 +16,7 @@
 - when: openshift_is_containerized | bool
   block:
   - name: include node deps docker service file
-    include_tasks: config/install-node-deps-docker-service-file.yml
+    import_tasks: config/install-node-deps-docker-service-file.yml
 
-- include_tasks: config/configure-node-settings.yml
-- include_tasks: config/configure-proxy-settings.yml
+- import_tasks: config/configure-node-settings.yml
+- import_tasks: config/configure-proxy-settings.yml

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -10,7 +10,7 @@
 # tasks file for openshift_node_upgrade
 
 - name: stop services for upgrade
-  include_tasks: upgrade/stop_services.yml
+  import_tasks: upgrade/stop_services.yml
 
 # Ensure actually install latest package.
 - name: install docker upgrade rpm
@@ -22,7 +22,7 @@
   - l_docker_upgrade | bool
 
 - name: install pre-pulled rpms.
-  include_tasks: upgrade/rpm_upgrade_install.yml
+  import_tasks: upgrade/rpm_upgrade_install.yml
   vars:
     openshift_version: "{{ openshift_pkg_version | default('') }}"
   when: not openshift_is_containerized | bool
@@ -31,13 +31,13 @@
 - include_tasks: "{{ node_config_hook }}"
   when: node_config_hook is defined
 
-- include_tasks: upgrade/config_changes.yml
+- import_tasks: upgrade/config_changes.yml
 
-- include_tasks: dnsmasq_install.yml
-- include_tasks: dnsmasq.yml
+- import_tasks: dnsmasq_install.yml
+- import_tasks: dnsmasq.yml
 
 # Restart all services
-- include_tasks: upgrade/restart.yml
+- import_tasks: upgrade/restart.yml
 
 - name: Wait for node to be ready
   oc_obj:
@@ -51,6 +51,6 @@
   retries: 24
   delay: 5
 
-- include_tasks: journald.yml
+- import_tasks: journald.yml
 
 - meta: flush_handlers

--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -1,6 +1,6 @@
 ---
 - name: Update systemd units
-  include_tasks: ../systemd_units.yml
+  import_tasks: ../systemd_units.yml
   when: openshift_is_containerized | bool
 
 - name: Update oreg value

--- a/roles/openshift_node/tasks/upgrade_pre.yml
+++ b/roles/openshift_node/tasks/upgrade_pre.yml
@@ -5,7 +5,7 @@
 - set_fact:
     skip_node_svc_handlers: True
 
-- include_tasks: registry_auth.yml
+- import_tasks: registry_auth.yml
 
 - name: update package meta data to speed install later.
   command: "{{ ansible_pkg_mgr }} makecache"
@@ -25,7 +25,7 @@
   - l_docker_upgrade is defined
   - l_docker_upgrade | bool
 
-- include_tasks: upgrade/containerized_upgrade_pull.yml
+- import_tasks: upgrade/containerized_upgrade_pull.yml
   when: openshift_is_containerized | bool
 
 # Prepull the rpms for docker upgrade, but don't install
@@ -37,7 +37,7 @@
   - l_docker_upgrade is defined
   - l_docker_upgrade | bool
 
-- include_tasks: upgrade/rpm_upgrade.yml
+- import_tasks: upgrade/rpm_upgrade.yml
   vars:
     openshift_version: "{{ openshift_pkg_version | default('') }}"
   when: not openshift_is_containerized | bool


### PR DESCRIPTION
This commit changes include_tasks to import_tasks in the
openshift_node role, where possible.

(cherry picked from commit c62bc3471a1aec6d407b3870fcb27fb8dc7bbb3b)