### PR TITLE
Include import task cleanup

### DIFF
--- a/roles/container_runtime/tasks/common/post.yml
+++ b/roles/container_runtime/tasks/common/post.yml
@@ -13,14 +13,14 @@
 # This needs to run after docker is restarted to account for proxy settings.
 # registry_auth is called directly with import_role in some places, so we
 # have to put it in the root of the tasks/ directory.
-- include_tasks: ../registry_auth.yml
+- import_tasks: ../registry_auth.yml
 
 - name: stat the docker data dir
   stat:
     path: "{{ docker_default_storage_path }}"
   register: dockerstat
 
-- include_tasks: setup_docker_symlink.yml
+- import_tasks: setup_docker_symlink.yml
   when:
     - openshift_use_crio | bool
     - dockerstat.stat.islnk is defined and not (dockerstat.stat.islnk | bool)

--- a/roles/container_runtime/tasks/common/pre.yml
+++ b/roles/container_runtime/tasks/common/pre.yml
@@ -1,5 +1,5 @@
 ---
-- include_tasks: udev_workaround.yml
+- import_tasks: udev_workaround.yml
   when: docker_udev_workaround | default(False) | bool
 
 - name: Add enterprise registry, if necessary

--- a/roles/container_runtime/tasks/package_crio.yml
+++ b/roles/container_runtime/tasks/package_crio.yml
@@ -4,7 +4,7 @@
   when:
     - openshift_is_atomic | bool
 
-- include_tasks: common/pre.yml
+- import_tasks: common/pre.yml
 
 - name: Check that overlay is in the kernel
   shell: lsmod | grep overlay
@@ -84,6 +84,6 @@
 
 # If we are using crio only, docker.service might not be available for
 # 'docker login'
-- include_tasks: common/post.yml
+- import_tasks: common/post.yml
   vars:
     openshift_docker_alternative_creds: "{{ (openshift_use_crio_only | bool) or (openshift_docker_use_system_container | bool) }}"

--- a/roles/container_runtime/tasks/package_docker.yml
+++ b/roles/container_runtime/tasks/package_docker.yml
@@ -1,9 +1,9 @@
 ---
-- include_tasks: common/pre.yml
+- import_tasks: common/pre.yml
 
 # In some cases, some services may be run as containers and docker may still
 # be installed via rpm.
-- include_tasks: common/atomic_proxy.yml
+- import_tasks: common/atomic_proxy.yml
   when:
   - >
     (openshift_use_system_containers | default(False)) | bool
@@ -20,7 +20,7 @@
   changed_when: false
 
 # Some basic checks to ensure the role will complete
-- include_tasks: docker_sanity.yml
+- import_tasks: docker_sanity.yml
 
 # Make sure Docker is installed, but does not update a running version.
 # Docker upgrades are handled by a separate playbook.
@@ -157,4 +157,4 @@
 - set_fact:
     docker_service_status_changed: "{{ (r_docker_package_docker_start_result is changed) and (r_docker_already_running_result.stdout != 'ActiveState=active' ) }}"
 
-- include_tasks: common/post.yml
+- import_tasks: common/post.yml

--- a/roles/container_runtime/tasks/systemcontainer_crio.yml
+++ b/roles/container_runtime/tasks/systemcontainer_crio.yml
@@ -6,9 +6,9 @@
     - openshift_is_containerized | bool
     - not l_is_node_system_container | bool
 
-- include_tasks: common/pre.yml
+- import_tasks: common/pre.yml
 
-- include_tasks: common/syscontainer_packages.yml
+- import_tasks: common/syscontainer_packages.yml
 
 - name: Check that overlay is in the kernel
   shell: lsmod | grep overlay
@@ -35,7 +35,7 @@
         state: restarted
 
 - name: Ensure proxies are in the atomic.conf
-  include_tasks: common/atomic_proxy.yml
+  import_tasks: common/atomic_proxy.yml
 
 # Be nice and let the user see the variable result
 - debug:
@@ -110,6 +110,6 @@
 
 # If we are using crio only, docker.service might not be available for
 # 'docker login'
-- include_tasks: common/post.yml
+- import_tasks: common/post.yml
   vars:
     openshift_docker_alternative_creds: "{{ (openshift_use_crio_only | bool) or (openshift_docker_use_system_container | bool) }}"

--- a/roles/container_runtime/tasks/systemcontainer_docker.yml
+++ b/roles/container_runtime/tasks/systemcontainer_docker.yml
@@ -11,9 +11,9 @@
       traditional docker package install. Otherwise, comment out openshift_docker_options
       in your inventory file.
 
-- include_tasks: common/pre.yml
+- import_tasks: common/pre.yml
 
-- include_tasks: common/syscontainer_packages.yml
+- import_tasks: common/syscontainer_packages.yml
 
 # Make sure Docker is installed so we are able to use the client
 - name: Install Docker so we can use the client
@@ -37,7 +37,7 @@
   delay: 30
 
 - name: Ensure proxies are in the atomic.conf
-  include_tasks: common/atomic_proxy.yml
+  import_tasks: common/atomic_proxy.yml
 
 # Be nice and let the user see the variable result
 - debug:
@@ -45,7 +45,7 @@
 
 # Do the authentication before pulling the container engine system container
 # as the pull might be from an authenticated registry.
-- include_tasks: registry_auth.yml
+- import_tasks: registry_auth.yml
   vars:
     openshift_docker_alternative_creds: True
 
@@ -105,6 +105,6 @@
 
 # Since docker is running as a system container, docker login will fail to create
 # credentials.  Use alternate method if requiring authenticated registries.
-- include_tasks: common/post.yml
+- import_tasks: common/post.yml
   vars:
     openshift_docker_alternative_creds: True

--- a/roles/openshift_excluder/tasks/disable.yml
+++ b/roles/openshift_excluder/tasks/disable.yml
@@ -2,11 +2,11 @@
 - when: r_openshift_excluder_verify_upgrade
   block:
   - name: Include verify_upgrade.yml when upgrading
-    include_tasks: verify_upgrade.yml
+    import_tasks: verify_upgrade.yml
 
 # unexclude the current openshift/origin-excluder if it is installed so it can be updated
 - name: Disable excluders before the upgrade to remove older excluding expressions
-  include_tasks: unexclude.yml
+  import_tasks: unexclude.yml
   vars:
     # before the docker excluder can be updated, it needs to be disabled
     # to remove older excluded packages that are no longer excluded
@@ -15,12 +15,12 @@
 
 # Install any excluder that is enabled
 - name: Include install.yml
-  include_tasks: install.yml
+  import_tasks: install.yml
 
 # And finally adjust an excluder in order to update host components correctly. First
 # exclude then unexclude
 - name: Include exclude.yml
-  include_tasks: exclude.yml
+  import_tasks: exclude.yml
   vars:
     # Enable the docker excluder only if it is overridden
     # BZ #1430612: docker excluders should be enabled even during installation and upgrade
@@ -30,7 +30,7 @@
 
 # All excluders that are to be disabled are disabled
 - name: Include unexclude.yml
-  include_tasks: unexclude.yml
+  import_tasks: unexclude.yml
   vars:
     # If the docker override  is not set, default to the generic behaviour
     # BZ #1430612: docker excluders should be enabled even during installation and upgrade

--- a/roles/openshift_excluder/tasks/enable.yml
+++ b/roles/openshift_excluder/tasks/enable.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install excluders
-  include_tasks: install.yml
+  import_tasks: install.yml
 
 - name: Enable excluders
-  include_tasks: exclude.yml
+  import_tasks: exclude.yml

--- a/roles/openshift_excluder/tasks/verify_upgrade.yml
+++ b/roles/openshift_excluder/tasks/verify_upgrade.yml
@@ -1,12 +1,12 @@
 ---
 - name: Verify Docker Excluder version
-  include_tasks: verify_excluder.yml
+  import_tasks: verify_excluder.yml
   vars:
     excluder: "{{ r_openshift_excluder_service_type }}-docker-excluder"
   when: r_openshift_excluder_enable_docker_excluder | bool
 
 - name: Verify OpenShift Excluder version
-  include_tasks: verify_excluder.yml
+  import_tasks: verify_excluder.yml
   vars:
     excluder: "{{ r_openshift_excluder_service_type }}-excluder"
   when: r_openshift_excluder_enable_openshift_excluder | bool

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -1,9 +1,9 @@
 ---
 - name: Install the systemd units
-  include_tasks: systemd_units.yml
+  import_tasks: systemd_units.yml
 
 - name: Pull container images
-  include_tasks: container_images.yml
+  import_tasks: container_images.yml
   when: openshift_is_containerized | bool
 
 - file:

--- a/roles/openshift_node/tasks/container_images.yml
+++ b/roles/openshift_node/tasks/container_images.yml
@@ -1,5 +1,5 @@
 ---
 - name: Install Node system container
-  include_tasks: node_system_container.yml
+  import_tasks: node_system_container.yml
   when:
   - l_is_node_system_container | bool

--- a/roles/openshift_node/tasks/dnsmasq.yml
+++ b/roles/openshift_node/tasks/dnsmasq.yml
@@ -22,5 +22,5 @@
     state: started
 
 # Dynamic NetworkManager based dispatcher
-- include_tasks: dnsmasq/network-manager.yml
+- import_tasks: dnsmasq/network-manager.yml
   when: network_manager_active | bool

--- a/roles/openshift_node/tasks/dnsmasq/no-network-manager.yml
+++ b/roles/openshift_node/tasks/dnsmasq/no-network-manager.yml
@@ -10,4 +10,4 @@
   register: result
   until: result is succeeded
 
-- include_tasks: network-manager.yml
+- import_tasks: network-manager.yml

--- a/roles/openshift_node/tasks/dnsmasq_install.yml
+++ b/roles/openshift_node/tasks/dnsmasq_install.yml
@@ -39,5 +39,5 @@
     dest: /etc/origin/node/node-dnsmasq.conf
 
 # Relies on ansible in order to configure static config
-- include_tasks: dnsmasq/no-network-manager.yml
+- import_tasks: dnsmasq/no-network-manager.yml
   when: not network_manager_active | bool

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -6,14 +6,14 @@
     - openshift_deployment_type == 'openshift-enterprise'
     - not openshift_use_crio | bool
 
-- include_tasks: dnsmasq_install.yml
-- include_tasks: dnsmasq.yml
+- import_tasks: dnsmasq_install.yml
+- import_tasks: dnsmasq.yml
 
 - name: setup firewall
   import_tasks: firewall.yml
 
 - name: Update journald config
-  include_tasks: journald.yml
+  import_tasks: journald.yml
 
 #### Disable SWAP #####
 # https://docs.openshift.com/container-platform/3.4/admin_guide/overcommit.html#disabling-swap-memory
@@ -24,7 +24,7 @@
   when: openshift_disable_swap | default(true) | bool
 
 - name: include node installer
-  include_tasks: install.yml
+  import_tasks: install.yml
 
 - name: Restart cri-o
   systemd:
@@ -53,27 +53,27 @@
     sysctl_file: "/etc/sysctl.d/99-openshift.conf"
     reload: yes
 
-- include_tasks: registry_auth.yml
+- import_tasks: registry_auth.yml
 
 - name: include standard node config
-  include_tasks: config.yml
+  import_tasks: config.yml
 
 #### Storage class plugins here ####
 - name: NFS storage plugin configuration
-  include_tasks: storage_plugins/nfs.yml
+  import_tasks: storage_plugins/nfs.yml
   tags:
     - nfs
 
 - name: GlusterFS storage plugin configuration
-  include_tasks: storage_plugins/glusterfs.yml
+  import_tasks: storage_plugins/glusterfs.yml
   when: "'glusterfs' in osn_storage_plugin_deps"
 
 - name: Ceph storage plugin configuration
-  include_tasks: storage_plugins/ceph.yml
+  import_tasks: storage_plugins/ceph.yml
   when: "'ceph' in osn_storage_plugin_deps"
 
 - name: iSCSI storage plugin configuration
-  include_tasks: storage_plugins/iscsi.yml
+  import_tasks: storage_plugins/iscsi.yml
   when: "'iscsi' in osn_storage_plugin_deps"
 
 ##### END Storage #####

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -16,7 +16,7 @@
 - when: openshift_is_containerized | bool
   block:
   - name: include node deps docker service file
-    include_tasks: config/install-node-deps-docker-service-file.yml
+    import_tasks: config/install-node-deps-docker-service-file.yml
 
-- include_tasks: config/configure-node-settings.yml
-- include_tasks: config/configure-proxy-settings.yml
+- import_tasks: config/configure-node-settings.yml
+- import_tasks: config/configure-proxy-settings.yml

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -10,7 +10,7 @@
 # tasks file for openshift_node_upgrade
 
 - name: stop services for upgrade
-  include_tasks: upgrade/stop_services.yml
+  import_tasks: upgrade/stop_services.yml
 
 # Ensure actually install latest package.
 - name: install docker upgrade rpm
@@ -22,7 +22,7 @@
   - l_docker_upgrade | bool
 
 - name: install pre-pulled rpms.
-  include_tasks: upgrade/rpm_upgrade_install.yml
+  import_tasks: upgrade/rpm_upgrade_install.yml
   vars:
     openshift_version: "{{ openshift_pkg_version | default('') }}"
   when: not openshift_is_containerized | bool
@@ -31,13 +31,13 @@
 - include_tasks: "{{ node_config_hook }}"
   when: node_config_hook is defined
 
-- include_tasks: upgrade/config_changes.yml
+- import_tasks: upgrade/config_changes.yml
 
-- include_tasks: dnsmasq_install.yml
-- include_tasks: dnsmasq.yml
+- import_tasks: dnsmasq_install.yml
+- import_tasks: dnsmasq.yml
 
 # Restart all services
-- include_tasks: upgrade/restart.yml
+- import_tasks: upgrade/restart.yml
 
 - name: Wait for node to be ready
   oc_obj:
@@ -51,6 +51,6 @@
   retries: 24
   delay: 5
 
-- include_tasks: journald.yml
+- import_tasks: journald.yml
 
 - meta: flush_handlers

--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -1,6 +1,6 @@
 ---
 - name: Update systemd units
-  include_tasks: ../systemd_units.yml
+  import_tasks: ../systemd_units.yml
   when: openshift_is_containerized | bool
 
 - name: Update oreg value

--- a/roles/openshift_node/tasks/upgrade_pre.yml
+++ b/roles/openshift_node/tasks/upgrade_pre.yml
@@ -5,7 +5,7 @@
 - set_fact:
     skip_node_svc_handlers: True
 
-- include_tasks: registry_auth.yml
+- import_tasks: registry_auth.yml
 
 - name: update package meta data to speed install later.
   command: "{{ ansible_pkg_mgr }} makecache"
@@ -25,7 +25,7 @@
   - l_docker_upgrade is defined
   - l_docker_upgrade | bool
 
-- include_tasks: upgrade/containerized_upgrade_pull.yml
+- import_tasks: upgrade/containerized_upgrade_pull.yml
   when: openshift_is_containerized | bool
 
 # Prepull the rpms for docker upgrade, but don't install
@@ -37,7 +37,7 @@
   - l_docker_upgrade is defined
   - l_docker_upgrade | bool
 
-- include_tasks: upgrade/rpm_upgrade.yml
+- import_tasks: upgrade/rpm_upgrade.yml
   vars:
     openshift_version: "{{ openshift_pkg_version | default('') }}"
   when: not openshift_is_containerized | bool

--- a/roles/os_firewall/tasks/main.yml
+++ b/roles/os_firewall/tasks/main.yml
@@ -8,12 +8,12 @@
   set_fact:
     r_os_firewall_is_atomic: "{{ r_os_firewall_ostree_booted.stat.exists }}"
 
-- include_tasks: firewalld.yml
+- import_tasks: firewalld.yml
   when:
   - os_firewall_enabled | bool
   - os_firewall_use_firewalld | bool
 
-- include_tasks: iptables.yml
+- import_tasks: iptables.yml
   when:
   - os_firewall_enabled | bool
   - not os_firewall_use_firewalld | bool

--- a/roles/rhel_subscribe/tasks/main.yml
+++ b/roles/rhel_subscribe/tasks/main.yml
@@ -42,7 +42,7 @@
   changed_when: "'Successfully attached a subscription' in openshift_pool_attached.stdout"
   when: rhsub_pool not in openshift_pool_attached.stdout
 
-- include_tasks: satellite.yml
+- import_tasks: satellite.yml
   when:
     - rhsub_server is defined
     - rhsub_server


### PR DESCRIPTION
This commit moves as much as feasible to import_tasks
to create as many static imports as possible.