### PR TITLE
[3.6] Master: upgrade SDN package only when openshift SDN is used

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
@@ -6,17 +6,14 @@
 # of packages into one transaction we need to do that explicitly. The ansible
 # core team tells us not to rely on yum module transaction flattening anyway.
 
-# TODO: If the sdn package isn't already installed this will install it, we
-# should fix that
-
 - name: Upgrade master packages
-  package: name={{ master_pkgs | join(',') }} state=present
+  package: name={{ master_pkgs | reject('equalto', '') | join(',') }} state=present
   vars:
     master_pkgs:
       - "{{ openshift.common.service_type }}{{ openshift_pkg_version }}"
       - "{{ openshift.common.service_type }}-master{{ openshift_pkg_version }}"
       - "{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
-      - "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version}}"
+      - "{{ openshift.common.service_type + '-sdn-ovs' + openshift_pkg_version if openshift_use_openshift_sdn | default(true) | bool else ''}}"
       - "{{ openshift.common.service_type }}-clients{{ openshift_pkg_version }}"
       - "tuned-profiles-{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
       - PyYAML
@@ -30,7 +27,7 @@
     node_pkgs:
       - "{{ openshift.common.service_type }}{{ openshift_pkg_version }}"
       - "{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
-      - "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version }}"
+      - "{{ openshift.common.service_type + '-sdn-ovs' + openshift_pkg_version if openshift_use_openshift_sdn | default(true) | bool else ''}}"
       - "{{ openshift.common.service_type }}-clients{{ openshift_pkg_version }}"
       - "tuned-profiles-{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
       - PyYAML


### PR DESCRIPTION
Cherry-pick of #7653. Nodes are already protected from installing SDN if not 
necessary