### PR TITLE
Sync etcd ca certs from etcd_ca_host to other etcd hosts

### DIFF
--- a/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
+++ b/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
@@ -171,6 +171,12 @@
   - "{{ etcd_ca_dir }}"
   when: etcd_server_certs_missing | bool
 
+- name: Unarchive etcd ca cert tarballs
+  unarchive:
+    src: "{{ g_etcd_server_mktemp.stdout }}/{{ etcd_ca_name }}.tgz"
+    dest: "{{ etcd_ca_dir }}"
+  when: etcd_server_certs_missing | bool
+
 - name: Delete temporary directory
   local_action: file path="/tmp/{{ inventory_hostname }}" state=absent
   changed_when: False


### PR DESCRIPTION
If master 0 is down or lost, and if we try to scale again the cluster to add new master, it fails  with this error 
fatal: [master-3.]: FAILED! =>
{"changed": false, "failed": true, "msg": "CA certificate /etc/etcd/ca/ca.crt doesn't exist on CA host master-2. Apply 'etcd_ca' role to master-2"}

this fixes the issue
