### PR TITLE
[3.6] etcd migrate: make sure masters are restarted instead of started

### DIFF
--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -244,7 +244,7 @@
   - name: Start master services
     service:
       name: "{{ item }}"
-      state: started
+      state: restarted
     register: service_status
     # Sometimes the master-api, resp. master-controllers fails to start for the first time
     until: service_status.state is defined and service_status.state == "started"


### PR DESCRIPTION
Replaces PR #7551 
Fixes #7544