### PR TITLE
add support for exposing containerized haproxy logs to rsyslog

### DIFF
--- a/roles/openshift_loadbalancer/defaults/main.yml
+++ b/roles/openshift_loadbalancer/defaults/main.yml
@@ -39,3 +39,6 @@ openshift_docker_service_name: "{{ 'container-engine' if (openshift_docker_use_s
 # openshift_use_nuage, if defined, may affect other roles or play behavior.
 r_openshift_lb_use_nuage_default: "{{ openshift_use_nuage | default(False) }}"
 r_openshift_lb_use_nuage: "{{ r_openshift_lb_use_nuage_default }}"
+
+r_openshift_lb_rsyslog_logging_enabled: "{{ openshift_lb_rsyslog_logging_enabled | default(False) }}"
+r_openshift_lb_rsyslog_logging_socket: "{{ openshift_lb_rsyslog_logging_socket | default('/dev/log') }}"

--- a/roles/openshift_loadbalancer/templates/haproxy.docker.service.j2
+++ b/roles/openshift_loadbalancer/templates/haproxy.docker.service.j2
@@ -7,7 +7,7 @@ PartOf={{ openshift_docker_service_name }}.service
 
 [Service]
 ExecStartPre=-/usr/bin/docker rm -f openshift_loadbalancer
-ExecStart=/usr/bin/docker run --rm --name openshift_loadbalancer {% for frontend in openshift_loadbalancer_frontends %} {% for bind in frontend.binds %} -p {{ bind |regex_replace('^[^:]*:(\d+).*$', '\\1') }}:{{ bind |regex_replace('^[^:]*:(\d+).*$', '\\1') }} {% endfor %} {% endfor %} -v /etc/haproxy/haproxy.cfg:/etc/haproxy/haproxy.cfg:ro --entrypoint=haproxy {{ openshift_router_image }}:{{ openshift_image_tag }} -f /etc/haproxy/haproxy.cfg
+ExecStart=/usr/bin/docker run --rm --name openshift_loadbalancer {% for frontend in openshift_loadbalancer_frontends %} {% for bind in frontend.binds %} -p {{ bind |regex_replace('^[^:]*:(\d+).*$', '\\1') }}:{{ bind |regex_replace('^[^:]*:(\d+).*$', '\\1') }} {% endfor %} {% endfor %} {% if r_openshift_lb_rsyslog_logging_enabled %} -v {{ r_openshift_lb_rsyslog_logging_socket }}:/dev/log {% endif %} -v /etc/haproxy/haproxy.cfg:/etc/haproxy/haproxy.cfg:ro --entrypoint=haproxy {{ openshift_router_image }}:{{ openshift_image_tag }} -f /etc/haproxy/haproxy.cfg
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop openshift_loadbalancer
 LimitNOFILE={{ openshift_loadbalancer_limit_nofile | default(100000) }}


### PR DESCRIPTION
What:
* provides support for collecting logs via local rsyslog process by mounting the rsyslog log socket in to haproxy

Why:  
* currently containerized (master lb) haproxy complains about the log path not existing (`/dev/log local0 ...`) 
* there is already support hardcoded in the container image to try and send logs to /dev/log endpoint but that does not exist within the container and there are no way to get haproxy (access) logs out of the system. this change provides a mechanism to do so (disabled by default)