### PR TITLE
[3.9] Configure dnsmasq before waiting for node

### DIFF
--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -33,6 +33,9 @@
 
 - import_tasks: upgrade/config_changes.yml
 
+- import_tasks: dnsmasq_install.yml
+- import_tasks: dnsmasq.yml
+
 # Restart all services
 - import_tasks: upgrade/restart.yml
 
@@ -47,9 +50,6 @@
   # Give the node two minutes to come back online.
   retries: 24
   delay: 5
-
-- import_tasks: dnsmasq_install.yml
-- import_tasks: dnsmasq.yml
 
 - import_tasks: journald.yml
 


### PR DESCRIPTION
In some cases, if dnsmasq isn't configured on a node during upgrade, the
upgrade can fail. Changed order of tasks to prevent failure.