### PR TITLE
Change default set for networkConfig.externalIPNetworkCIDRs to reject all CIDRs

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -804,7 +804,7 @@ debug_level=2
 # will be applied first, then the IP checked against one of the
 # allowed CIDRs. You should ensure this range does not overlap with
 # your nodes, pods, or service CIDRs for security reasons.
-#openshift_master_external_ip_network_cidrs=['0.0.0.0/0']
+#openshift_master_external_ip_network_cidrs=['!0.0.0.0/0']
 
 # IngressIPNetworkCIDR controls the range to assign ingress IPs from for
 # services of type LoadBalancer on bare metal. If empty, ingress IPs will not

--- a/roles/openshift_master/templates/master.yaml.v1.j2
+++ b/roles/openshift_master/templates/master.yaml.v1.j2
@@ -147,7 +147,7 @@ networkConfig:
 {% endif %}
 # serviceNetworkCIDR must match kubernetesMasterConfig.servicesSubnet
   serviceNetworkCIDR: {{ openshift.common.portal_net }}
-  externalIPNetworkCIDRs: {{ openshift_master_external_ip_network_cidrs | default(["0.0.0.0/0"]) | lib_utils_to_padded_yaml(1,2) }}
+  externalIPNetworkCIDRs: {{ openshift_master_external_ip_network_cidrs | default(["!0.0.0.0/0"]) | lib_utils_to_padded_yaml(1,2) }}
 {% if openshift_master_ingress_ip_network_cidr is defined %}
   ingressIPNetworkCIDR: {{ openshift_master_ingress_ip_network_cidr }}
 {% endif %}


### PR DESCRIPTION
Changing master-config.yaml networkConfig.externalIPNetworkCIDRs to reject all IPs by default. Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1560712