### PR TITLE
Allow overriding master/node iam role and policy.

### DIFF
--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -18,9 +18,9 @@ openshift_aws_iam_cert_name: "{{ openshift_aws_clusterid }}-master-external"
 openshift_aws_iam_cert_path: ''
 openshift_aws_iam_cert_key_path: ''
 
-openshift_aws_iam_role_name: openshift_node_describe_instances
+openshift_aws_iam_role_name: "openshift_node_describe_instances_{{ openshift_aws_clusterid }}"
 openshift_aws_iam_role_policy_json: "{{ lookup('file', 'describeinstances.json') }}"
-openshift_aws_iam_role_policy_name: "describe_instances"
+openshift_aws_iam_role_policy_name: "describe_instances_{{ openshift_aws_clusterid }}"
 
 openshift_aws_iam_kms_alias: "alias/{{ openshift_aws_clusterid }}_kms"
 openshift_aws_ami: ''

--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -192,9 +192,9 @@ openshift_aws_master_group_config:
     wait_for_instances: True
     termination_policy: "{{ openshift_aws_node_group_termination_policy }}"
     replace_all_instances: "{{ openshift_aws_node_group_replace_all_instances }}"
-    iam_role: "{{ openshift_aws_iam_role_name }}"
-    policy_name: "{{ openshift_aws_iam_role_policy_name }}"
-    policy_json: "{{ openshift_aws_iam_role_policy_json }}"
+    iam_role: "{{ openshift_aws_iam_master_role_name | default(openshift_aws_iam_role_name) }}"
+    policy_name: "{{ openshift_aws_iam_master_role_policy_name | default(openshift_aws_iam_role_policy_name) }}"
+    policy_json: "{{ openshift_aws_iam_master_role_policy_json | default(openshift_aws_iam_role_policy_json) }}"
     elbs: "{{ openshift_aws_elb_dict | json_query('master.[*][0][*].name') }}"
 
 openshift_aws_node_group_config:
@@ -208,9 +208,9 @@ openshift_aws_node_group_config:
     desired_size: "{{ openshift_aws_compute_group_desired_size | default(3) }}"
     termination_policy: "{{ openshift_aws_node_group_termination_policy }}"
     replace_all_instances: "{{ openshift_aws_node_group_replace_all_instances }}"
-    iam_role: "{{ openshift_aws_iam_role_name }}"
-    policy_name: "{{ openshift_aws_iam_role_policy_name }}"
-    policy_json: "{{ openshift_aws_iam_role_policy_json }}"
+    iam_role: "{{ openshift_aws_iam_node_role_name | default(openshift_aws_iam_role_name) }}"
+    policy_name: "{{ openshift_aws_iam_node_role_policy_name | default(openshift_aws_iam_role_policy_name) }}"
+    policy_json: "{{ openshift_aws_iam_node_role_policy_json | default(openshift_aws_iam_role_policy_json) }}"
   # The 'infra' key is always required here.
   infra:
     instance_type: "{{ openshift_aws_infra_group_instance_type | default('m4.xlarge') }}"
@@ -221,9 +221,9 @@ openshift_aws_node_group_config:
     desired_size: "{{ openshift_aws_infra_group_desired_size | default(2) }}"
     termination_policy: "{{ openshift_aws_node_group_termination_policy }}"
     replace_all_instances: "{{ openshift_aws_node_group_replace_all_instances }}"
-    iam_role: "{{ openshift_aws_iam_role_name }}"
-    policy_name: "{{ openshift_aws_iam_role_policy_name }}"
-    policy_json: "{{ openshift_aws_iam_role_policy_json }}"
+    iam_role: "{{ openshift_aws_iam_node_role_name | default(openshift_aws_iam_role_name) }}"
+    policy_name: "{{ openshift_aws_iam_node_role_policy_name | default(openshift_aws_iam_role_policy_name) }}"
+    policy_json: "{{ openshift_aws_iam_node_role_policy_json | default(openshift_aws_iam_role_policy_json) }}"
     elbs: "{{ openshift_aws_elb_dict | json_query('infra.[*][0][*].name') }}"
 
 # build_instance_tags is a custom filter in role lib_utils

--- a/roles/openshift_aws/templates/launchinstances.json.j2
+++ b/roles/openshift_aws/templates/launchinstances.json.j2
@@ -1,0 +1,136 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+	{
+	    "Sid": "AllowDescribeResources",
+	    "Effect": "Allow",
+	    "Action": [
+		"ec2:DescribeAvailabilityZones",
+		"ec2:DescribeImages",
+		"ec2:DescribeInstances",
+		"ec2:DescribeKeyPairs",
+		"ec2:DescribeSecurityGroups",
+		"ec2:DescribeVpcs",
+		"ec2:DescribeSubnets"
+	    ],
+	    "Resource": [
+		"*"
+	    ]
+	},
+        {
+	    "Sid": "AllowRunInstances",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:RunInstances"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:image/*",
+                "arn:aws:ec2:*:*:subnet/*",
+                "arn:aws:ec2:*:*:network-interface/*",
+                "arn:aws:ec2:*:*:security-group/*",
+                "arn:aws:ec2:*:*:key-pair/*"
+            ]
+        },
+        {
+	    "Sid": "AllowRunTaggedInstances",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:RunInstances"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:volume/*",
+                "arn:aws:ec2:*:*:instance/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:RequestTag/clusterid": "{{ openshift_aws_clusterid }}"
+                },
+                "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                        "clusterid"
+                    ]
+                }
+            }
+        },
+        {
+	    "Sid": "AllowCreateTagsRunInstances",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:*/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "RunInstances"
+                }
+            }
+        },
+	{
+	    "Sid": "AllowCreateTaggedVolumes",
+	    "Effect": "Allow",
+	    "Action": [
+		"ec2:CreateVolume"
+	    ],
+            "Resource": [
+                "arn:aws:ec2:*:*:volume/*"
+            ],
+	    "Condition": {
+		"StringEquals": {
+		    "aws:RequestTag/clusterid": "{{ openshift_aws_clusterid }}"
+		},
+		"ForAllValues:StringEquals": {
+		    "aws:TagKeys": [
+			"clusterid"
+		    ]
+		}
+	    }
+	},
+        {
+	    "Sid": "AllowCreateTagsCreateVolume",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:*/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateVolume"
+                }
+            }
+        },
+	{
+	    "Sid": "AllowManageTaggedInstances",
+	    "Effect": "Allow",
+	    "Action": [
+		"ec2:StartInstances",
+		"ec2:StopInstances",
+		"ec2:TerminateInstances"
+	    ],
+	    "Resource": [
+		"*"
+	    ],
+	    "Condition": {
+		"StringEquals": {
+		    "ec2:ResourceTag/clusterid": "{{ openshift_aws_clusterid }}"
+		}
+	    }
+	},
+	{
+	    "Sid": "AllowManageTaggedVolumes",
+	    "Effect": "Allow",
+	    "Action": [
+		"ec2:DetachVolume",
+		"ec2:DeleteVolume",
+		"ec2:AttachVolume"
+	    ],
+	    "Resource": [
+		"*"
+	    ],
+	    "Condition": {
+		"StringEquals": {
+		    "ec2:ResourceTag/clusterid": "{{ openshift_aws_clusterid }}"
+		}
+	    }
+	}
+    ]
+}

--- a/roles/openshift_aws/templates/launchinstances.json.j2
+++ b/roles/openshift_aws/templates/launchinstances.json.j2
@@ -2,6 +2,16 @@
     "Version": "2012-10-17",
     "Statement": [
 	{
+	    "Sid": "AllowPassDescribeInstancesRole",
+	    "Effect": "Allow",
+	    "Action": [
+		"iam:PassRole"
+	    ],
+	    "Resource": [
+		"arn:aws:iam::*:role/openshift_node_describe_instances_{{ openshift_aws_clusterid }}"
+	    ]
+	},
+	{
 	    "Sid": "AllowDescribeResources",
 	    "Effect": "Allow",
 	    "Action": [
@@ -45,7 +55,7 @@
                 "StringEquals": {
                     "aws:RequestTag/clusterid": "{{ openshift_aws_clusterid }}"
                 },
-                "ForAllValues:StringEquals": {
+                "ForAnyValue:StringEquals": {
                     "aws:TagKeys": [
                         "clusterid"
                     ]
@@ -78,7 +88,7 @@
 		"StringEquals": {
 		    "aws:RequestTag/clusterid": "{{ openshift_aws_clusterid }}"
 		},
-		"ForAllValues:StringEquals": {
+		"ForAnyValue:StringEquals": {
 		    "aws:TagKeys": [
 			"clusterid"
 		    ]


### PR DESCRIPTION
Allow specifying alternate iam role and policy definitions for master and node groups. By default `openshift_node_describe_instances` will be applied to both masters and nodes which only allows describe.

Overriding the master's policy looks like this. Policy json could be completely specified in inventory/vars rather than from a processed template.

```
openshift_aws_iam_master_role_name: "openshift_master_launch_instances_{{ openshift_aws_clusterid }}"
openshift_aws_iam_master_role_policy_name: "launch_instances_{{ openshift_aws_clusterid }}"
openshift_aws_iam_master_role_policy_json: "{{ lookup('template', 'launchinstances.json.j2') }}"
```

I've added an example `launchinstances.json` policy to `openshift_aws` role templates that cluster operator might use in the short term to facilitate provisioning from the control plane while we test out AWS actuators. This policy allows launching instances but launched instances and instance volumes must be tagged with the `clusterid` of the cluster. The policy can only manage instances and volumes with the specific `clusterid`.