### PR TITLE
Enable the bootstrap update service

### DIFF
--- a/roles/openshift_gcp/tasks/configure_master_bootstrap.yml
+++ b/roles/openshift_gcp/tasks/configure_master_bootstrap.yml
@@ -28,6 +28,7 @@
   systemd:
     name: "openshift-bootstrap-update.timer"
     state: started
+    enabled: true
 
 - name: Bootstrap all nodes that were identified with bootstrap metadata
   run_once: true


### PR DESCRIPTION
On reboot it's no longer enabled