### PR TITLE
Removing hardcoding of configmap_namespace for patching

### DIFF
--- a/roles/openshift_logging_curator/tasks/main.yaml
+++ b/roles/openshift_logging_curator/tasks/main.yaml
@@ -110,7 +110,7 @@
         tasks_from: patch_configmap_files.yaml
       vars:
         configmap_name: "logging-curator"
-        configmap_namespace: "logging"
+        configmap_namespace: "{{ openshift_logging_namespace }}"
         configmap_file_names:
           - current_file: "config.yaml"
             new_file: "{{ tempdir }}/curator.yml"
@@ -179,7 +179,7 @@
         tasks_from: patch_configmap_files.yaml
       vars:
         configmap_name: "logging-curator"
-        configmap_namespace: "logging"
+        configmap_namespace: "{{ openshift_logging_namespace }}"
         configmap_file_names:
           - current_file: "actions.yaml"
             new_file: "{{ tempdir }}/actions.yaml"

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -231,7 +231,7 @@
       tasks_from: patch_configmap_files.yaml
     vars:
       configmap_name: "{{ elasticsearch_name }}"
-      configmap_namespace: "logging"
+      configmap_namespace: "{{ openshift_logging_namespace }}"
       configmap_file_names:
       - current_file: "elasticsearch.yml"
         new_file: "{{ tempdir }}/elasticsearch.yml"
@@ -275,7 +275,7 @@
       tasks_from: patch_configmap_files.yaml
     vars:
       configmap_name: "{{ elasticsearch_name }}"
-      configmap_namespace: "logging"
+      configmap_namespace: "{{ openshift_logging_namespace }}"
       configmap_file_names:
       - current_file: "elasticsearch.yml"
         new_file: "{{ tempdir }}/elasticsearch.yml"

--- a/roles/openshift_logging_fluentd/tasks/main.yaml
+++ b/roles/openshift_logging_fluentd/tasks/main.yaml
@@ -120,7 +120,7 @@
     tasks_from: patch_configmap_files.yaml
   vars:
     configmap_name: "logging-fluentd"
-    configmap_namespace: "logging"
+    configmap_namespace: "{{ openshift_logging_namespace }}"
     configmap_file_names:
       - current_file: "fluent.conf"
         new_file: "{{ tempdir }}/fluent.conf"


### PR DESCRIPTION
Addresses issue found in https://bugzilla.redhat.com/show_bug.cgi?id=1507712

This cannot be cherrypicked to release-3.7 -- opened https://github.com/openshift/openshift-ansible/pull/7703