### PR TITLE
Add logic for new default CRD backend for ASB

### DIFF
--- a/roles/ansible_service_broker/files/bundles.automationbroker.io.yaml
+++ b/roles/ansible_service_broker/files/bundles.automationbroker.io.yaml
@@ -1,0 +1,154 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bundles.automationbroker.io
+spec:
+  group: automationbroker.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: bundles
+    singular: bundle
+    kind: Bundle
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            runtime:
+              type: integer
+              minimum: 1
+              maximum: 2
+            version:
+              type: string
+              pattern: '^[\d]+.[\d*]+$'
+            fqName:
+              type: string
+            image:
+              type: string
+            tags:
+              type: array
+              items:
+                type: string
+            bindable:
+              type: boolean
+            description:
+              type: string
+            metadata:
+              type: string
+            async:
+              type: string
+              pattern: '^(optional|required|unsupported)$'
+            plans:
+              type: array
+              minItems: 1
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  description:
+                    type: string
+                  metadata:
+                    type: string
+                  free:
+                    type: boolean
+                  bindable:
+                    type: boolean
+                  updatesTo:
+                    type: array
+                    items:
+                      type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        title:
+                          type: string
+                        type:
+                          type: string
+                        description:
+                          type: string
+                        default:
+                          type: string
+                        deprecateMaxLength:
+                          type: integer
+                        maxLength:
+                          type: integer
+                        minLength:
+                          type: integer
+                        pattern:
+                          type: string
+                        multipleOf:
+                          type: float
+                        maximum:
+                          type: float
+                        exclusiveMaximum:
+                          type: float
+                        minimum:
+                          type: float
+                        exclusiveMinimum:
+                          type: float
+                        enum:
+                          type: array
+                        items:
+                          type: string
+                        required:
+                          type: boolean
+                        updatable:
+                          type: boolean
+                        displayType:
+                          type: string
+                        displayGroup:
+                          type: string
+                  bindParameters:
+                    type: array
+                    properties:
+                      name:
+                        type: string
+                      title:
+                        type: string
+                      type:
+                        type: string
+                      description:
+                        type: string
+                      default:
+                        type: string
+                      deprecateMaxLength:
+                        type: integer
+                      maxLength:
+                        type: integer
+                      minLength:
+                        type: integer
+                      pattern:
+                        type: string
+                      multipleOf:
+                        type: float
+                      maximum:
+                        type: float
+                      exclusiveMaximum:
+                        type: float
+                      minimum:
+                        type: float
+                      exclusiveMinimum:
+                        type: float
+                      enum:
+                        type: array
+                      items:
+                        type: string
+                      required:
+                        type: boolean
+                      updatable:
+                        type: boolean
+                      displayType:
+                        type: string
+                      displayGroup:
+                        type: string
+

--- a/roles/ansible_service_broker/files/jobstates.automationbroker.io.yaml
+++ b/roles/ansible_service_broker/files/jobstates.automationbroker.io.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: jobstates.automationbroker.io
+spec:
+  group: automationbroker.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: jobstates
+    singular: jobstate
+    kind: JobState
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    # Token is the name of the resource
+    openAPIV3Schema:
+      properties:
+        state:
+          type: string
+        podName:
+          type: string
+        method:
+          type: string
+        error:
+          type: string
+        description:
+          type: string

--- a/roles/ansible_service_broker/files/servicebindings.automationbroker.io.yaml
+++ b/roles/ansible_service_broker/files/servicebindings.automationbroker.io.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicebindings.automationbroker.io
+spec:
+  group: automationbroker.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: servicebindings
+    singular: servicebinding
+    kind: ServiceBinding
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      serviceInstanceId:
+        type: string
+      parameters:
+        type: string
+      JobToken:
+        type: string

--- a/roles/ansible_service_broker/files/serviceinstances.automationbroker.io.yaml
+++ b/roles/ansible_service_broker/files/serviceinstances.automationbroker.io.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceinstances.automationbroker.io
+spec:
+  group: automationbroker.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: serviceinstances
+    singular: serviceinstance
+    kind: ServiceInstance
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            specId:
+              type: string
+            context:
+              type: object
+              properties:
+                plateform:
+                  type: string
+                namespace:
+                  type: string
+            parameters:
+              type: string
+            bindingIds:
+              type: array
+              items:
+                type: string
+

--- a/roles/ansible_service_broker/tasks/facts.yml
+++ b/roles/ansible_service_broker/tasks/facts.yml
@@ -1,0 +1,29 @@
+---
+# Fact setting and validations
+- name: Set default image variables based on deployment type
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ openshift_deployment_type }}.yml"
+    - "default_images.yml"
+
+- name: set ansible_service_broker facts
+  set_fact:
+    ansible_service_broker_image_prefix: "{{ ansible_service_broker_image_prefix | default(__ansible_service_broker_image_prefix) }}"
+    ansible_service_broker_image_tag: "{{ ansible_service_broker_image_tag | default(__ansible_service_broker_image_tag) }}"
+
+    ansible_service_broker_registry_type: "{{ ansible_service_broker_registry_type | default(__ansible_service_broker_registry_type) }}"
+    ansible_service_broker_registry_name: "{{ ansible_service_broker_registry_name | default(__ansible_service_broker_registry_name) }}"
+    ansible_service_broker_registry_url: "{{ ansible_service_broker_registry_url | default(__ansible_service_broker_registry_url) }}"
+    ansible_service_broker_registry_user: "{{ ansible_service_broker_registry_user | default(__ansible_service_broker_registry_user) }}"
+    ansible_service_broker_registry_password: "{{ ansible_service_broker_registry_password | default(__ansible_service_broker_registry_password) }}"
+    ansible_service_broker_registry_organization: "{{ ansible_service_broker_registry_organization | default(__ansible_service_broker_registry_organization) }}"
+    ansible_service_broker_registry_tag: "{{ ansible_service_broker_registry_tag | default(__ansible_service_broker_registry_tag) }}"
+    ansible_service_broker_registry_whitelist: "{{ ansible_service_broker_registry_whitelist | default(__ansible_service_broker_registry_whitelist) }}"
+
+- name: set ansible-service-broker image facts using set prefix and tag
+  set_fact:
+    ansible_service_broker_image: '{{ ansible_service_broker_image | default(__ansible_service_broker_image) }}'
+  vars:
+    __ansible_service_broker_image: "{{ ansible_service_broker_image_prefix }}ansible-service-broker:{{ ansible_service_broker_image_tag }}"
+
+- include_tasks: validate_facts.yml

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -1,36 +1,9 @@
 ---
 
-# Fact setting and validations
-- name: Set default image variables based on deployment type
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ openshift_deployment_type }}.yml"
-    - "default_images.yml"
+- import_tasks: facts.yml
 
-- name: set ansible_service_broker facts
-  set_fact:
-    ansible_service_broker_image_prefix: "{{ ansible_service_broker_image_prefix | default(__ansible_service_broker_image_prefix) }}"
-    ansible_service_broker_image_tag: "{{ ansible_service_broker_image_tag | default(__ansible_service_broker_image_tag) }}"
-
-    ansible_service_broker_etcd_image_prefix: "{{ ansible_service_broker_etcd_image_prefix | default(__ansible_service_broker_etcd_image_prefix) }}"
-    ansible_service_broker_etcd_image_tag: "{{ ansible_service_broker_etcd_image_tag | default(__ansible_service_broker_etcd_image_tag) }}"
-    ansible_service_broker_etcd_image_etcd_path: "{{ ansible_service_broker_etcd_image_etcd_path | default(__ansible_service_broker_etcd_image_etcd_path) }}"
-
-    ansible_service_broker_registry_type: "{{ ansible_service_broker_registry_type | default(__ansible_service_broker_registry_type) }}"
-    ansible_service_broker_registry_name: "{{ ansible_service_broker_registry_name | default(__ansible_service_broker_registry_name) }}"
-    ansible_service_broker_registry_url: "{{ ansible_service_broker_registry_url | default(__ansible_service_broker_registry_url) }}"
-    ansible_service_broker_registry_user: "{{ ansible_service_broker_registry_user | default(__ansible_service_broker_registry_user) }}"
-    ansible_service_broker_registry_password: "{{ ansible_service_broker_registry_password | default(__ansible_service_broker_registry_password) }}"
-    ansible_service_broker_registry_organization: "{{ ansible_service_broker_registry_organization | default(__ansible_service_broker_registry_organization) }}"
-    ansible_service_broker_registry_tag: "{{ ansible_service_broker_registry_tag | default(__ansible_service_broker_registry_tag) }}"
-    ansible_service_broker_registry_whitelist: "{{ ansible_service_broker_registry_whitelist | default(__ansible_service_broker_registry_whitelist) }}"
-
-- name: set ansible-service-broker image facts using set prefix and tag
-  set_fact:
-    ansible_service_broker_image: "{{ ansible_service_broker_image_prefix }}ansible-service-broker:{{ ansible_service_broker_image_tag }}"
-    ansible_service_broker_etcd_image: "{{ ansible_service_broker_etcd_image_prefix }}etcd:{{ ansible_service_broker_etcd_image_tag }}"
-
-- include_tasks: validate_facts.yml
+- import_tasks: upgrade.yml
+  when: openshift_upgrade_target is defined
 
 - include_tasks: generate_certs.yml
 
@@ -81,6 +54,9 @@
       - apiGroups: ["networking.k8s.io"]
         resources: ["networkpolicies"]
         verbs: ["create", "delete"]
+      - apiGroups: ["automationbroker.io"]
+        resources: ["bundles", "jobstates", "servicebindings", "serviceinstances"]
+        verbs: ["*"]
 
 - name: Create asb-access cluster role
   oc_clusterrole:
@@ -129,24 +105,6 @@
             kubernetes.io/service-account.name: asb-client
         type: kubernetes.io/service-account-token
 
-- name: Create etcd-auth secret
-  oc_secret:
-    name: etcd-auth-secret
-    namespace: openshift-ansible-service-broker
-    contents:
-      - path: ca.crt
-        data: '{{ etcd_ca_cert }}'
-
-- name: Create broker-etcd-auth secret
-  oc_secret:
-    name: broker-etcd-auth-secret
-    namespace: openshift-ansible-service-broker
-    contents:
-      - path: client.crt
-        data: '{{ etcd_client_cert }}'
-      - path: client.key
-        data: '{{ etcd_client_key }}'
-
 - oc_secret:
     state: list
     namespace: openshift-ansible-service-broker
@@ -155,6 +113,19 @@
 
 - set_fact:
     service_ca_crt: "{{ asb_client_secret.results.results.0.data['service-ca.crt'] }}"
+
+- name: Create custom resource definitions for asb
+  oc_obj:
+    name: '{{ crd.metadata.name }}'
+    kind: CustomResourceDefinition
+    state: present
+    content:
+      path: /tmp/{{ crd.metadata.name }}
+      data: '{{ crd }}'
+  vars:
+    crd: "{{ lookup('file', item) | from_yaml }}"
+  with_fileglob:
+    - 'files/*.automationbroker.io.yaml'
 
 - name: create ansible-service-broker service
   oc_service:
@@ -174,24 +145,6 @@
       app: openshift-ansible-service-broker
       service: asb
 
-- name: create asb-etcd service
-  oc_service:
-    name: asb-etcd
-    namespace: openshift-ansible-service-broker
-    labels:
-      app: etcd
-      service: asb-etcd
-    annotations:
-      service.alpha.openshift.io/serving-cert-secret-name: etcd-tls
-    ports:
-      - name: port-2379
-        port: 2379
-        targetPort: 2379
-        protocol: TCP
-    selector:
-      app: etcd
-      service: asb-etcd
-
 - name: create route for ansible-service-broker service
   oc_route:
     name: asb-1338
@@ -204,14 +157,6 @@
     port: 1338
     tls_termination: Reencrypt
 
-- name: create persistent volume claim for etcd
-  oc_pvc:
-    name: etcd
-    namespace: openshift-ansible-service-broker
-    access_modes:
-      - ReadWriteOnce
-    volume_capacity: 1G
-
 - name: Set Ansible Service Broker deployment config
   oc_obj:
     force: yes
@@ -221,149 +166,7 @@
     kind: DeploymentConfig
     content:
       path: /tmp/dcout
-      data:
-        apiVersion: v1
-        kind: DeploymentConfig
-        metadata:
-          name: asb
-          labels:
-            app: openshift-ansible-service-broker
-            service: asb
-        spec:
-          replicas: 1
-          selector:
-            app: openshift-ansible-service-broker
-          nodeSelector: '{{ ansible_service_broker_node_selector }}'
-          strategy:
-            type: Rolling
-          template:
-            metadata:
-              labels:
-                app: openshift-ansible-service-broker
-                service: asb
-            spec:
-              serviceAccount: asb
-              containers:
-                - image: "{{ ansible_service_broker_image }}"
-                  name: asb
-                  imagePullPolicy: IfNotPresent
-                  volumeMounts:
-                    - name: config-volume
-                      mountPath: /etc/ansible-service-broker
-                    - name: asb-tls
-                      mountPath: /etc/tls/private
-                    - name: asb-etcd-auth
-                      mountPath: /var/run/asb-etcd-auth
-                  ports:
-                    - containerPort: 1338
-                      protocol: TCP
-                  env:
-                    - name: BROKER_CONFIG
-                      value: /etc/ansible-service-broker/config.yaml
-                    - name: HTTP_PROXY
-                      value: "{{ openshift.common.http_proxy  | default('') }}"
-                    - name: HTTPS_PROXY
-                      value: "{{ openshift.common.https_proxy  | default('') }}"
-                    - name: NO_PROXY
-                      value: "{{ ([openshift.common.no_proxy, '.default'] | join(',')) if openshift.get('common', {}).get('no_proxy') else '' }}"
-                  resources: {}
-                  terminationMessagePath: /tmp/termination-log
-                  readinessProbe:
-                    httpGet:
-                      port: 1338
-                      path: /healthz
-                      scheme: HTTPS
-                    initialDelaySeconds: 15
-                    timeoutSeconds: 1
-                  livenessProbe:
-                    httpGet:
-                      port: 1338
-                      path: /healthz
-                      scheme: HTTPS
-                    initialDelaySeconds: 15
-                    timeoutSeconds: 1
-              volumes:
-                - name: config-volume
-                  configMap:
-                    name: broker-config
-                    items:
-                      - key: broker-config
-                        path: config.yaml
-                - name: asb-tls
-                  secret:
-                    secretName: asb-tls
-                - name: asb-etcd-auth
-                  secret:
-                    secretName: broker-etcd-auth-secret
-
-- name: Create asb-etcd deployment config
-  oc_obj:
-    name: asb-etcd
-    namespace: openshift-ansible-service-broker
-    state: present
-    kind: DeploymentConfig
-    content:
-      path: /tmp/dcout
-      data:
-        apiVersion: v1
-        kind: DeploymentConfig
-        metadata:
-          name: asb-etcd
-          labels:
-            app: etcd
-            service: asb-etcd
-        spec:
-          replicas: 1
-          selector:
-            app: etcd
-          nodeSelector: '{{ ansible_service_broker_node_selector }}'
-          strategy:
-            type: Rolling
-          template:
-            metadata:
-              labels:
-                app: etcd
-                service: asb-etcd
-            spec:
-              serviceAccount: asb
-              containers:
-                - image: "{{ ansible_service_broker_etcd_image }}"
-                  name: etcd
-                  imagePullPolicy: IfNotPresent
-                  terminationMessagePath: /tmp/termination-log
-                  workingDir: /etcd
-                  args:
-                    - "{{ ansible_service_broker_etcd_image_etcd_path }}"
-                    - "--data-dir=/data"
-                    - "--listen-client-urls=https://0.0.0.0:2379"
-                    - "--advertise-client-urls=https://asb-etcd.openshift-ansible-service-broker.svc:2379"
-                    - "--client-cert-auth"
-                    - "--trusted-ca-file=/var/run/etcd-auth-secret/ca.crt"
-                    - "--cert-file=/etc/tls/private/tls.crt"
-                    - "--key-file=/etc/tls/private/tls.key"
-                  ports:
-                    - containerPort: 2379
-                      protocol: TCP
-                  env:
-                    - name: ETCDCTL_API
-                      value: "3"
-                  volumeMounts:
-                    - name: etcd
-                      mountPath: /data
-                    - name: etcd-tls
-                      mountPath: /etc/tls/private
-                    - name: etcd-auth
-                      mountPath: /var/run/etcd-auth-secret
-              volumes:
-                - name: etcd
-                  persistentVolumeClaim:
-                    claimName: etcd
-                - name: etcd-tls
-                  secret:
-                    secretName: etcd-tls
-                - name: etcd-auth
-                  secret:
-                    secretName: etcd-auth-secret
+      data: "{{ lookup('template', 'asb_dc.yaml.j2') | from_yaml }}"
 
 - name: set auth name and type facts if needed
   set_fact:
@@ -380,60 +183,7 @@
     kind: ConfigMap
     content:
       path: /tmp/cmout
-      data:
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: broker-config
-          namespace: openshift-ansible-service-broker
-          labels:
-            app: openshift-ansible-service-broker
-        data:
-          broker-config: |
-            registry:
-              - type: {{ ansible_service_broker_registry_type }}
-                name: {{ ansible_service_broker_registry_name }}
-                url:  {{ ansible_service_broker_registry_url }}
-                org:  {{ ansible_service_broker_registry_organization }}
-                tag:  {{ ansible_service_broker_registry_tag }}
-                white_list: {{  ansible_service_broker_registry_whitelist | to_yaml }}
-                auth_type: "{{ ansible_service_broker_registry_auth_type | default("") }}"
-                auth_name: "{{ ansible_service_broker_registry_auth_name | default("") }}"
-              - type: local_openshift
-                name: localregistry
-                namespaces: ['openshift']
-                white_list: {{ ansible_service_broker_local_registry_whitelist | to_yaml }}
-            dao:
-              etcd_host: asb-etcd.openshift-ansible-service-broker.svc
-              etcd_port: 2379
-              etcd_ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
-              etcd_client_cert: /var/run/asb-etcd-auth/client.crt
-              etcd_client_key: /var/run/asb-etcd-auth/client.key
-            log:
-              stdout: true
-              level: {{ ansible_service_broker_log_level }}
-              color: true
-            openshift:
-              host: ""
-              ca_file: ""
-              bearer_token_file: ""
-              sandbox_role: {{ ansible_service_broker_sandbox_role }}
-              image_pull_policy: {{ ansible_service_broker_image_pull_policy }}
-              keep_namespace: {{ ansible_service_broker_keep_namespace | bool | lower }}
-              keep_namespace_on_error: {{ ansible_service_broker_keep_namespace_on_error | bool | lower }}
-            broker:
-              dev_broker: {{ ansible_service_broker_dev_broker | bool | lower }}
-              bootstrap_on_startup: {{ ansible_service_broker_bootstrap_on_startup | bool | lower }}
-              refresh_interval: {{ ansible_service_broker_refresh_interval }}
-              launch_apb_on_bind: {{ ansible_service_broker_launch_apb_on_bind | bool | lower }}
-              output_request: {{ ansible_service_broker_output_request | bool | lower }}
-              recovery: {{ ansible_service_broker_recovery | bool | lower }}
-              ssl_cert_key: /etc/tls/private/tls.key
-              ssl_cert: /etc/tls/private/tls.crt
-              auto_escalate: {{ ansible_service_broker_auto_escalate }}
-              auth:
-                - type: basic
-                  enabled: false
+      data: "{{ lookup('template', 'configmap.yaml.j2') | from_yaml }}"
 
 - oc_secret:
     name: asb-registry-auth

--- a/roles/ansible_service_broker/tasks/migrate.yml
+++ b/roles/ansible_service_broker/tasks/migrate.yml
@@ -1,0 +1,200 @@
+---
+
+- block:
+    - name: scale down asb deploymentconfig
+      oc_scale:
+        name: asb
+        namespace: openshift-ansible-service-broker
+        kind: dc
+        replicas: 0
+
+    - name: Add required permissions to asb-auth clusterrole
+      oc_clusterrole:
+        state: present
+        name: asb-auth
+        rules:
+          - apiGroups: [""]
+            resources: ["namespaces"]
+            verbs: ["create", "delete"]
+          - apiGroups: ["authorization.openshift.io"]
+            resources: ["subjectrulesreview"]
+            verbs: ["create"]
+          - apiGroups: ["authorization.k8s.io"]
+            resources: ["subjectaccessreviews"]
+            verbs: ["create"]
+          - apiGroups: ["authentication.k8s.io"]
+            resources: ["tokenreviews"]
+            verbs: ["create"]
+          - apiGroups: ["image.openshift.io", ""]
+            resources: ["images"]
+            verbs: ["get", "list"]
+          - apiGroups: ["network.openshift.io"]
+            resources: ["clusternetworks", "netnamespaces"]
+            verbs: ["get"]
+          - apiGroups: ["network.openshift.io"]
+            resources: ["netnamespaces"]
+            verbs: ["update"]
+          - apiGroups: ["networking.k8s.io"]
+            resources: ["networkpolicies"]
+            verbs: ["create", "delete"]
+          - apiGroups: ["automationbroker.io"]
+            resources: ["bundles", "jobstates", "servicebindings", "serviceinstances"]
+            verbs: ["*"]
+
+    - name: Create custom resource definitions for asb
+      oc_obj:
+        name: '{{ crd.metadata.name }}'
+        kind: CustomResourceDefinition
+        state: present
+        content:
+          path: /tmp/{{ crd.metadata.name }}
+          data: '{{ crd }}'
+      vars:
+        crd: "{{ lookup('file', item) | from_yaml }}"
+      with_fileglob:
+        - 'files/*.automationbroker.io.yaml'
+
+
+    - name: Migrate from etcd to CustomResources
+      oc_obj:
+        force: yes
+        name: asb-etcd-migration
+        namespace: openshift-ansible-service-broker
+        kind: Job
+        state: present
+        content:
+          path: /tmp/asb_migrate_out
+          data:
+            apiVersion: batch/v1
+            kind: Job
+            metadata:
+              name: asb-etcd-migration
+            spec:
+              parallelism: 1
+              completions: 1
+              backoffLimit: 3
+              template:
+                metadata:
+                  name: asb-etcd-migration
+                spec:
+                  containers:
+                    - name: asb
+                      image: '{{ ansible_service_broker_image }}'
+                      imagePullPolicy: IfNotPresent
+                      command:
+                        - '/usr/bin/migration'
+                      args:
+                        - '-host=asb-etcd.openshift-ansible-service-broker.svc'
+                        - '-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt'
+                        - '-client-cert=/var/run/asb-etcd-auth/client.crt'
+                        - '-client-key=/var/run/asb-etcd-auth/client.key'
+                        - '-namespace=openshift-ansible-service-broker'
+                      volumeMounts:
+                        - name: config-volume
+                          mountPath: /etc/ansible-service-broker
+                        - name: asb-tls
+                          mountPath: /etc/tls/private
+                        - name: asb-etcd-auth
+                          mountPath: /var/run/asb-etcd-auth
+                      env:
+                        - name: BROKER_CONFIG
+                          value: /etc/ansible-service-broker/config.yaml
+                        - name: HTTP_PROXY
+                          value: "{{ openshift.common.http_proxy  | default('') }}"
+                        - name: HTTPS_PROXY
+                          value: "{{ openshift.common.https_proxy  | default('') }}"
+                        - name: NO_PROXY
+                          value: "{{ ([openshift.common.no_proxy, '.default'] | join(',')) if openshift.get('common', {}).get('no_proxy') else '' }}"
+                  volumes:
+                    - name: config-volume
+                      configMap:
+                        name: broker-config
+                        items:
+                          - key: broker-config
+                            path: config.yaml
+                    - name: asb-tls
+                      secret:
+                        secretName: asb-tls
+                    - name: asb-etcd-auth
+                      secret:
+                        secretName: broker-etcd-auth-secret
+                  restartPolicy: Never
+                  serviceAccount: asb
+                  serviceAccountName: asb
+
+    - name: wait for migration to complete
+      oc_obj:
+        namespace: openshift-ansible-service-broker
+        kind: Job
+        state: list
+        name: asb-etcd-migration
+      register: migration_status
+      ignore_errors: true
+      until:
+        - "'results' in migration_status.results and migration_status.results.results | count > 0"
+        # Pod's 'Complete' status must be True
+        - "migration_status.results.results | lib_utils_oo_collect(attribute='status.conditions') | lib_utils_oo_collect(attribute='status', filters={'type': 'Complete'}) | map('bool') | select | list | count == 1"
+      delay: 10
+      retries: "{{ (asb_migration_timeout|default(600) | int / 10) | int }}"
+      failed_when:
+        - "'results' in migration_status.results"
+        - "migration_status.results.results | count > 0"
+        # Fail when pod's 'Failed' status is True
+        - "migration_status.results.results | lib_utils_oo_collect(attribute='status.conditions') | lib_utils_oo_collect(attribute='status', filters={'type': 'Failed'}) | map('bool') | select | list | count == 1"
+
+    - when: not (migration_status is failed)
+      block:
+        - name: Update broker configmap to use CRD backend
+          oc_obj:
+            name: broker-config
+            namespace: openshift-ansible-service-broker
+            state: present
+            kind: ConfigMap
+            content:
+              path: /tmp/cmout
+              data: "{{ lookup('template', 'configmap.yaml.j2') | from_yaml }}"
+          register: updated_configmap
+
+        - name: Update broker deploymentconfig
+          oc_obj:
+            force: yes
+            name: asb
+            namespace: openshift-ansible-service-broker
+            state: present
+            kind: DeploymentConfig
+            content:
+              path: /tmp/dcout
+              data: "{{ lookup('template', 'asb_dc.yaml.j2') | from_yaml }}"
+
+        - name: delete etcd service
+          oc_service:
+            name: asb-etcd
+            namespace: openshift-ansible-service-broker
+            state: absent
+
+        - name: delete etcd deploymentconfig
+          oc_obj:
+            name: asb-etcd
+            namespace: openshift-ansible-service-broker
+            kind: DeploymentConfig
+            state: absent
+
+        - name: delete broker etcd secret
+          oc_secret:
+            name: broker-etcd-auth-secret
+            namespace: openshift_ansible_service_broker
+            state: absent
+  always:
+    - name: scale up asb deploymentconfig
+      oc_scale:
+        name: asb
+        namespace: openshift-ansible-service-broker
+        kind: dc
+        replicas: 1
+
+- name: Fail out because the ASB etcd to CRD migration was unsuccessful
+  fail:
+    msg: >
+      The migration from etcd to CustomResourceDefinitions was not
+      successful, aborting upgrade of the ansible service broker.
+  when: migration_status is not defined or migration_status is failed or updated_configmap is not defined or updated_configmap is failed

--- a/roles/ansible_service_broker/tasks/remove.yml
+++ b/roles/ansible_service_broker/tasks/remove.yml
@@ -1,27 +1,5 @@
 ---
 
-- name: remove ansible-service-broker serviceaccount
-  oc_serviceaccount:
-    name: asb
-    namespace: openshift-ansible-service-broker
-    state: absent
-
-- name: remove ansible-service-broker client serviceaccount
-  oc_serviceaccount:
-    name: asb-client
-    namespace: openshift-ansible-service-broker
-    state: absent
-
-- name: remove asb-auth cluster role
-  oc_clusterrole:
-    state: absent
-    name: asb-auth
-
-- name: remove asb-access cluster role
-  oc_clusterrole:
-    state: absent
-    name: asb-access
-
 - name: Unbind admin cluster-role to asb serviceaccount
   oc_adm_policy_user:
     state: absent
@@ -46,6 +24,28 @@
     resource_name: asb-access
     user: "system:serviceaccount:openshift-ansible-service-broker:asb-client"
 
+- name: remove ansible-service-broker serviceaccount
+  oc_serviceaccount:
+    name: asb
+    namespace: openshift-ansible-service-broker
+    state: absent
+
+- name: remove ansible-service-broker client serviceaccount
+  oc_serviceaccount:
+    name: asb-client
+    namespace: openshift-ansible-service-broker
+    state: absent
+
+- name: remove asb-auth cluster role
+  oc_clusterrole:
+    state: absent
+    name: asb-auth
+
+- name: remove asb-access cluster role
+  oc_clusterrole:
+    state: absent
+    name: asb-access
+
 - name: remove asb-registry auth secret
   oc_secret:
     state: absent
@@ -58,45 +58,15 @@
     name: asb-client
     namespace: openshift-ansible-service-broker
 
-- name: Remove etcd-auth secret
-  oc_secret:
-    state: absent
-    name: etcd-auth-secret
-    namespace: openshift-ansible-service-broker
-
-- name: Remove broker-etcd-auth secret
-  oc_secret:
-    state: absent
-    name: broker-etcd-auth-secret
-    namespace: openshift-ansible-service-broker
-
 - name: remove ansible-service-broker service
   oc_service:
     name: asb
     namespace: openshift-ansible-service-broker
     state: absent
 
-- name: remove asb-etcd service
-  oc_service:
-    state: absent
-    name: asb-etcd
-    namespace: openshift-ansible-service-broker
-
-- name: remove etcd service
-  oc_service:
-    name: etcd
-    namespace: openshift-ansible-service-broker
-    state: absent
-
 - name: remove route for ansible-service-broker service
   oc_route:
     name: asb-1338
-    namespace: openshift-ansible-service-broker
-    state: absent
-
-- name: remove persistent volume claim for etcd
-  oc_pvc:
-    name: etcd
     namespace: openshift-ansible-service-broker
     state: absent
 
@@ -107,14 +77,6 @@
     kind: DeploymentConfig
     state: absent
 
-- name: remove Ansible Service Broker etcd deployment config
-  oc_obj:
-    name: asb-etcd
-    namespace: openshift-ansible-service-broker
-    kind: DeploymentConfig
-    state: absent
-
-
 - name: remove secret for broker auth
   oc_obj:
     name: asb-client
@@ -122,13 +84,21 @@
     kind: Secret
     state: absent
 
-# TODO: saw a oc_configmap in the library, but didn't understand how to get it to do the following:
 - name: remove config map for ansible-service-broker
-  oc_obj:
+  oc_configmap:
     name: broker-config
     namespace: openshift-ansible-service-broker
     state: absent
-    kind: ConfigMap
+
+- name: remove custom resource definitions for asb
+  oc_obj:
+    name: '{{ crd.metadata.name }}'
+    kind: CustomResourceDefinition
+    state: absent
+  vars:
+    crd: "{{ lookup('file', item) | from_yaml }}"
+  with_fileglob:
+    - 'files/*.automationbroker.io.yaml'
 
 # TODO: Is this going to work?
 - shell: >

--- a/roles/ansible_service_broker/tasks/upgrade.yml
+++ b/roles/ansible_service_broker/tasks/upgrade.yml
@@ -1,0 +1,16 @@
+---
+
+- when: openshift_upgrade_target is version_compare('3.10', '>=')
+  block:
+    - name: retrieve broker configmap
+      oc_configmap:
+        state: list
+        name: broker-config
+        namespace: openshift-ansible-service-broker
+      register: broker_configmap_raw
+
+    - name: Migrate from etcd to CRDs
+      import_tasks: migrate.yml
+      when: broker_configmap.dao.get('type') != 'crd'
+      vars:
+        broker_configmap: '{{ (broker_configmap_raw.results.results.0.data | from_yaml)["broker-config"] | from_yaml }}'

--- a/roles/ansible_service_broker/templates/asb_dc.yaml.j2
+++ b/roles/ansible_service_broker/templates/asb_dc.yaml.j2
@@ -1,0 +1,70 @@
+---
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: asb
+  labels:
+    app: openshift-ansible-service-broker
+    service: asb
+spec:
+  replicas: 1
+  selector:
+    app: openshift-ansible-service-broker
+  nodeSelector: {{ ansible_service_broker_node_selector }}
+  strategy:
+    type: Rolling
+  template:
+    metadata:
+      labels:
+        app: openshift-ansible-service-broker
+        service: asb
+    spec:
+      serviceAccount: asb
+      containers:
+        - image: {{ ansible_service_broker_image }}
+          name: asb
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/ansible-service-broker
+            - name: asb-tls
+              mountPath: /etc/tls/private
+          ports:
+            - containerPort: 1338
+              protocol: TCP
+          env:
+            - name: BROKER_CONFIG
+              value: /etc/ansible-service-broker/config.yaml
+            - name: HTTP_PROXY
+              value: {{ openshift.common.http_proxy  | default('') }}
+            - name: HTTPS_PROXY
+              value: {{ openshift.common.https_proxy  | default('') }}
+            - name: NO_PROXY
+              value: {{ ([openshift.common.no_proxy, '.default'] | join(',')) if openshift.get('common', {}).get('no_proxy') else '' }}
+          resources: {}
+          terminationMessagePath: /tmp/termination-log
+          readinessProbe:
+            httpGet:
+              port: 1338
+              path: /healthz
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          livenessProbe:
+            httpGet:
+              port: 1338
+              path: /healthz
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+      volumes:
+        - name: config-volume
+          configMap:
+            name: broker-config
+            items:
+              - key: broker-config
+                path: config.yaml
+        - name: asb-tls
+          secret:
+            secretName: asb-tls
+

--- a/roles/ansible_service_broker/templates/configmap.yaml.j2
+++ b/roles/ansible_service_broker/templates/configmap.yaml.j2
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: broker-config
+  namespace: openshift-ansible-service-broker
+  labels:
+    app: openshift-ansible-service-broker
+data:
+  broker-config: |
+    registry:
+      - type: {{ ansible_service_broker_registry_type }}
+        name: {{ ansible_service_broker_registry_name }}
+        url:  {{ ansible_service_broker_registry_url }}
+        org:  {{ ansible_service_broker_registry_organization }}
+        tag:  {{ ansible_service_broker_registry_tag }}
+        white_list: {{  ansible_service_broker_registry_whitelist | to_yaml }}
+        auth_type: "{{ ansible_service_broker_registry_auth_type | default("") }}"
+        auth_name: "{{ ansible_service_broker_registry_auth_name | default("") }}"
+      - type: local_openshift
+        name: localregistry
+        namespaces: ['openshift']
+        white_list: {{ ansible_service_broker_local_registry_whitelist | to_yaml }}
+    dao:
+      type: crd
+    log:
+      stdout: true
+      level: {{ ansible_service_broker_log_level }}
+      color: true
+    openshift:
+      host: ""
+      ca_file: ""
+      bearer_token_file: ""
+      sandbox_role: {{ ansible_service_broker_sandbox_role }}
+      image_pull_policy: {{ ansible_service_broker_image_pull_policy }}
+      keep_namespace: {{ ansible_service_broker_keep_namespace | bool | lower }}
+      keep_namespace_on_error: {{ ansible_service_broker_keep_namespace_on_error | bool | lower }}
+    broker:
+      dev_broker: {{ ansible_service_broker_dev_broker | bool | lower }}
+      bootstrap_on_startup: {{ ansible_service_broker_bootstrap_on_startup | bool | lower }}
+      refresh_interval: {{ ansible_service_broker_refresh_interval }}
+      launch_apb_on_bind: {{ ansible_service_broker_launch_apb_on_bind | bool | lower }}
+      output_request: {{ ansible_service_broker_output_request | bool | lower }}
+      recovery: {{ ansible_service_broker_recovery | bool | lower }}
+      ssl_cert_key: /etc/tls/private/tls.key
+      ssl_cert: /etc/tls/private/tls.crt
+      auto_escalate: {{ ansible_service_broker_auto_escalate }}
+      auth:
+        - type: basic
+          enabled: false
+


### PR DESCRIPTION
Not quite ready yet, but wanted to get the PR in early because there's some complexity here and I wanted to make sure I had time to address concerns about the general approach.

TODO:
- [x] Ensure the image of ASB contains the migration binary
- [x] Ensure upgrade.yml is called on upgrade
- [x] Make sure migration failure is properly handled in the context of a full upgrade
- [x] Update remove.yml, including logic for cleaning up CRDs
- [x] Update entrypoint for migration job to point to actual migration binary (does not yet exist)

depends on https://github.com/openshift/ansible-service-broker/pull/870