### PR TITLE
CRIO openshift-sdn toggle

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -47,6 +47,7 @@ r_crio_os_firewall_allow:
 - service: crio
   port: 10010/tcp
 
+r_crio_use_openshift_sdn: "{{ openshift_use_openshift_sdn | default(True) }}"
 
 openshift_docker_is_node_or_master: "{{ True if inventory_hostname in (groups['oo_masters_to_config']|default([])) or inventory_hostname in (groups['oo_nodes_to_config']|default([])) else False | bool }}"
 

--- a/roles/container_runtime/tasks/package_crio.yml
+++ b/roles/container_runtime/tasks/package_crio.yml
@@ -63,6 +63,7 @@
   template:
     dest: /etc/cni/net.d/openshift-sdn.conf
     src: 80-openshift-sdn.conf.j2
+  when: r_crio_use_openshift_sdn | bool
 
 - name: Create /etc/sysconfig/crio-network
   template:

--- a/roles/container_runtime/tasks/systemcontainer_crio.yml
+++ b/roles/container_runtime/tasks/systemcontainer_crio.yml
@@ -82,6 +82,7 @@
   template:
     dest: /etc/cni/net.d/openshift-sdn.conf
     src: 80-openshift-sdn.conf.j2
+  when: r_crio_use_openshift_sdn | bool
 
 - name: Create /etc/sysconfig/crio-storage
   copy:


### PR DESCRIPTION
This ensures we don't configure CRIO to use the openshift-sdn plugin when it's disabled.

Fixes #7716 