### PR TITLE
use new filter name for AWS availability zones

### DIFF
--- a/roles/openshift_aws/tasks/vpc_and_subnet_id.yml
+++ b/roles/openshift_aws/tasks/vpc_and_subnet_id.yml
@@ -15,7 +15,7 @@
   ec2_vpc_subnet_facts:
     region: "{{ openshift_aws_region }}"
     filters:
-      "availability_zone": "{{ openshift_aws_subnet_az }}"
+      "availability-zone": "{{ openshift_aws_subnet_az }}"
       vpc-id: "{{ vpcout.vpcs[0].id }}"
   register: subnetout
 


### PR DESCRIPTION
older ansible releases allows for specifying the availability zone in a filter as 'availability_zone'. newer ansible releases error out with:

TASK [get facts] ***************************************************************
Monday 02 April 2018  18:45:53 +0000 (0:00:00.055)       0:00:00.055 **********
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ClientError: An error occurred (InvalidParameterValue) when calling the DescribeSubnets operation: The filter 'availability_zone' is invalid

change the filter name to 'availability-zone' (availabilityZone would also work according to https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html)