### PR TITLE
Skip oc_adm_csr when no bootstrapping is required on GCP

### DIFF
--- a/roles/openshift_gcp/tasks/configure_master_bootstrap.yml
+++ b/roles/openshift_gcp/tasks/configure_master_bootstrap.yml
@@ -34,3 +34,4 @@
   oc_adm_csr:
     nodes: "{{ groups['all'] | map('extract', hostvars) | selectattr('gce_metadata.bootstrap', 'match', 'true') | map(attribute='gce_name') | list }}"
     timeout: 60
+  when: groups['all'] | map('extract', hostvars) | selectattr('gce_metadata.bootstrap', 'match', 'true') | map(attribute='gce_name') | list | length > 0


### PR DESCRIPTION
Caused the job to exit with 'No hosts specified.'