### PR TITLE
RPM upgrade: support jinja 2.7

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
@@ -7,7 +7,7 @@
 # core team tells us not to rely on yum module transaction flattening anyway.
 
 - name: Upgrade master packages
-  package: name={{ master_pkgs | reject('equalto', '') | join(',') }} state=present
+  package: name={{ master_pkgs | join(',') | replace(',,', ',') }} state=present
   vars:
     master_pkgs:
       - "{{ openshift.common.service_type }}{{ openshift_pkg_version }}"
@@ -24,7 +24,7 @@
   until: result | success
 
 - name: Upgrade node packages
-  package: name={{ node_pkgs | join(',') }} state=present
+  package: name={{ node_pkgs | join(',') | replace(',,', ',') }} state=present
   vars:
     node_pkgs:
       - "{{ openshift.common.service_type }}{{ openshift_pkg_version }}"


### PR DESCRIPTION
Jinja 2.7 doesn't have `equalto` filter, so the workaround here would
avoid using `reject` and replace double commas instead

Related to #7356
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1558718