### PR TITLE
Ensure runtime-config is correct for generated masters

### DIFF
--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -115,7 +115,10 @@ kubeletClientInfo:
   port: 10250
 {% if openshift.master.embedded_kube | bool %}
 kubernetesMasterConfig:
-  apiServerArguments: {{ openshift.master.api_server_args | default(None) | lib_utils_to_padded_yaml( level=2 ) }}
+  apiServerArguments:
+    runtime-config:
+    - apis/settings.k8s.io/v1alpha1=true
+    {{ openshift.master.api_server_args | default(None) | lib_utils_to_padded_yaml( level=2 ) }}
     storage-backend:
     - etcd3
     storage-media-type:


### PR DESCRIPTION
Change from wire_aggregator was lost, causing the PodPreset plugin to fail.