### PR TITLE
Updating for es5.x image naming and removing origin restriction

### DIFF
--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -63,10 +63,6 @@
     __base_file_dir: "{{ '5.x' if openshift_logging_es5_techpreview | bool else '2.x' }}"
     __es_version: "{{ '5.x' if openshift_logging_es5_techpreview | bool else '2.x' }}"
 
-- set_fact:
-    openshift_logging_image_version: "techpreview"
-  when: openshift_logging_es5_techpreview | bool
-
 ## Elasticsearch
 
 - set_fact: es_indices={{ es_indices | default([]) + [item | int - 1] }}

--- a/roles/openshift_logging/tasks/main.yaml
+++ b/roles/openshift_logging/tasks/main.yaml
@@ -3,11 +3,6 @@
     msg: Only one Fluentd nodeselector key pair should be provided
   when: openshift_logging_fluentd_nodeselector.keys() | count > 1
 
-- assert:
-    that: openshift_deployment_type in ['origin']
-    msg: "Only 'origin' deployments are allowed with openshift_logging_es5_techpreview set to true"
-  when: openshift_logging_es5_techpreview | bool
-
 - name: Create temp directory for doing work in
   command: mktemp -d /tmp/openshift-logging-ansible-XXXXXX
   register: mktemp

--- a/roles/openshift_logging_curator/tasks/main.yaml
+++ b/roles/openshift_logging_curator/tasks/main.yaml
@@ -89,7 +89,6 @@
         component: "{{ curator_component }}"
         logging_component: curator
         deploy_name: "{{ curator_name }}"
-        image: "{{openshift_logging_curator_image_prefix}}logging-curator:{{openshift_logging_curator_image_version}}"
         es_host: "{{ openshift_logging_curator_es_host }}"
         es_port: "{{ openshift_logging_curator_es_port }}"
         curator_cpu_limit: "{{ openshift_logging_curator_cpu_limit }}"
@@ -153,7 +152,6 @@
         component: "{{ curator_component }}"
         logging_component: curator
         deploy_name: "{{ curator_name }}"
-        image: "{{openshift_logging_curator_image_prefix}}logging-curator:{{openshift_logging_curator_image_version}}"
         es_host: "{{ openshift_logging_curator_es_host }}"
         es_port: "{{ openshift_logging_curator_es_port }}"
         curator_cpu_limit: "{{ openshift_logging_curator_cpu_limit }}"

--- a/roles/openshift_logging_curator/templates/2.x/curator.j2
+++ b/roles/openshift_logging_curator/templates/2.x/curator.j2
@@ -37,7 +37,7 @@ spec:
       containers:
         -
           name: "curator"
-          image: {{image}}
+          image: "{{openshift_logging_curator_image_prefix}}logging-curator:{{openshift_logging_curator_image_version}}"
           imagePullPolicy: IfNotPresent
 {% if (curator_memory_limit is defined and curator_memory_limit is not none and curator_memory_limit != "") or (curator_cpu_limit is defined and curator_cpu_limit is not none and curator_cpu_limit != "") or (curator_cpu_request is defined and curator_cpu_request is not none and curator_cpu_request != "") %}
           resources:

--- a/roles/openshift_logging_curator/templates/5.x/curator-cj.j2
+++ b/roles/openshift_logging_curator/templates/5.x/curator-cj.j2
@@ -37,7 +37,7 @@ spec:
           containers:
             -
               name: "curator"
-              image: {{image}}
+              image: "{{openshift_logging_curator_image_prefix}}logging-curator5:{{openshift_logging_curator_image_version}}"
               imagePullPolicy: IfNotPresent
 {% if (curator_memory_limit is defined and curator_memory_limit) or (curator_cpu_limit is defined and curator_cpu_limit) or (curator_cpu_request is defined and curator_cpu_request) %}
               resources:

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -468,8 +468,6 @@
     component: "{{ es_component }}"
     logging_component: elasticsearch
     deploy_name: "{{ es_deploy_name }}"
-    image: "{{ openshift_logging_elasticsearch_image_prefix }}logging-elasticsearch:{{ openshift_logging_elasticsearch_image_version }}"
-    proxy_image: "{{ openshift_logging_elasticsearch_proxy_image_prefix }}oauth-proxy:{{ openshift_logging_elasticsearch_proxy_image_version }}"
     es_cpu_limit: "{{ openshift_logging_elasticsearch_cpu_limit | default('') }}"
     es_cpu_request: "{{ openshift_logging_elasticsearch_cpu_request | min_cpu(openshift_logging_elasticsearch_cpu_limit | default(none)) }}"
     es_memory_limit: "{{ openshift_logging_elasticsearch_memory_limit }}"

--- a/roles/openshift_logging_elasticsearch/templates/2.x/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/2.x/es.j2
@@ -42,7 +42,7 @@ spec:
 {% endif %}
       containers:
         - name: "elasticsearch"
-          image: {{image}}
+          image: "{{ openshift_logging_elasticsearch_image_prefix }}logging-elasticsearch:{{ openshift_logging_elasticsearch_image_version }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -131,7 +131,7 @@ spec:
             periodSeconds: 5
         -
           name: proxy
-          image: {{ proxy_image }}
+          image: "{{ openshift_logging_elasticsearch_proxy_image_prefix }}oauth-proxy:{{ openshift_logging_elasticsearch_proxy_image_version }}"
           imagePullPolicy: IfNotPresent
           args:
            - --upstream-ca=/etc/elasticsearch/secret/admin-ca

--- a/roles/openshift_logging_elasticsearch/templates/5.x/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/5.x/es.j2
@@ -42,7 +42,7 @@ spec:
 {% endif %}
       containers:
         - name: "elasticsearch"
-          image: {{image}}
+          image: "{{ openshift_logging_elasticsearch_image_prefix }}logging-elasticsearch5:{{ openshift_logging_elasticsearch_image_version }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -137,9 +137,9 @@ spec:
             initialDelaySeconds: 10
             timeoutSeconds: 30
             periodSeconds: 5
-        - 
+        -
           name: proxy
-          image: {{ proxy_image }}
+          image: "{{ openshift_logging_elasticsearch_proxy_image_prefix }}oauth-proxy:{{ openshift_logging_elasticsearch_proxy_image_version }}"
           imagePullPolicy: IfNotPresent
           args:
            - --upstream-ca=/etc/elasticsearch/secret/admin-ca

--- a/roles/openshift_logging_fluentd/templates/2.x/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/2.x/fluentd.j2
@@ -28,7 +28,7 @@ spec:
         {{ fluentd_nodeselector_key }}: "{{ fluentd_nodeselector_value }}"
       containers:
       - name: "{{ daemonset_container_name }}"
-        image: "{{ openshift_logging_fluentd_image_prefix }}{{ daemonset_name }}:{{ openshift_logging_fluentd_image_version }}"
+        image: "{{ openshift_logging_fluentd_image_prefix }}logging-fluentd:{{ openshift_logging_fluentd_image_version }}"
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -79,7 +79,7 @@ spec:
         - name: dockerdaemoncfg
           mountPath: /etc/docker
           readOnly: true
-        - name: originnodecfg 
+        - name: originnodecfg
           mountPath: /etc/origin/node
           readOnly: true
         - name: filebufferstorage
@@ -237,7 +237,7 @@ spec:
       - name: dockercfg
         hostPath:
           path: /etc/sysconfig/docker
-      - name: originnodecfg 
+      - name: originnodecfg
         hostPath:
           path: /etc/origin/node
       - name: dockerdaemoncfg

--- a/roles/openshift_logging_fluentd/templates/5.x/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/5.x/fluentd.j2
@@ -28,7 +28,7 @@ spec:
         {{ fluentd_nodeselector_key }}: "{{ fluentd_nodeselector_value }}"
       containers:
       - name: "{{ daemonset_container_name }}"
-        image: "{{ openshift_logging_fluentd_image_prefix }}{{ daemonset_name }}:{{ openshift_logging_fluentd_image_version }}"
+        image: "{{ openshift_logging_fluentd_image_prefix }}logging-fluentd:{{ openshift_logging_fluentd_image_version }}"
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true

--- a/roles/openshift_logging_kibana/tasks/main.yaml
+++ b/roles/openshift_logging_kibana/tasks/main.yaml
@@ -245,8 +245,6 @@
     component: "{{ kibana_component }}"
     logging_component: kibana
     deploy_name: "{{ kibana_name }}"
-    image: "{{ openshift_logging_kibana_image_prefix }}logging-kibana:{{ openshift_logging_kibana_image_version }}"
-    proxy_image: "{{ openshift_logging_kibana_proxy_image_prefix }}logging-auth-proxy:{{ openshift_logging_kibana_proxy_image_version }}"
     es_host: "{{ openshift_logging_kibana_es_host }}"
     es_port: "{{ openshift_logging_kibana_es_port }}"
     kibana_cpu_limit: "{{ openshift_logging_kibana_cpu_limit }}"

--- a/roles/openshift_logging_kibana/templates/2.x/kibana.j2
+++ b/roles/openshift_logging_kibana/templates/2.x/kibana.j2
@@ -36,7 +36,7 @@ spec:
       containers:
         -
           name: "kibana"
-          image: {{ image }}
+          image: "{{ openshift_logging_kibana_image_prefix }}logging-kibana:{{ openshift_logging_kibana_image_version }}"
           imagePullPolicy: IfNotPresent
 {% if (kibana_memory_limit is defined and kibana_memory_limit is not none and kibana_memory_limit != "") or (kibana_cpu_limit is defined and kibana_cpu_limit is not none and kibana_cpu_limit != "") or (kibana_cpu_request is defined and kibana_cpu_request is not none and kibana_cpu_request != "") %}
           resources:
@@ -87,7 +87,7 @@ spec:
             periodSeconds: 5
         -
           name: "kibana-proxy"
-          image: {{ proxy_image }}
+          image: "{{ openshift_logging_kibana_proxy_image_prefix }}logging-auth-proxy:{{ openshift_logging_kibana_proxy_image_version }}"
           imagePullPolicy: IfNotPresent
 {% if (kibana_proxy_memory_limit is defined and kibana_proxy_memory_limit is not none and kibana_proxy_memory_limit != "") or (kibana_proxy_cpu_limit is defined and kibana_proxy_cpu_limit is not none and kibana_proxy_cpu_limit != "") or (kibana_proxy_cpu_request is defined and kibana_proxy_cpu_request is not none and kibana_proxy_cpu_request != "") %}
           resources:

--- a/roles/openshift_logging_kibana/templates/5.x/kibana.j2
+++ b/roles/openshift_logging_kibana/templates/5.x/kibana.j2
@@ -36,7 +36,7 @@ spec:
       containers:
         -
           name: "kibana"
-          image: {{ image }}
+          image: "{{ openshift_logging_kibana_image_prefix }}logging-kibana5:{{ openshift_logging_kibana_image_version }}"
           imagePullPolicy: IfNotPresent
 {% if (kibana_memory_limit is defined and kibana_memory_limit is not none and kibana_memory_limit != "") or (kibana_cpu_limit is defined and kibana_cpu_limit is not none and kibana_cpu_limit != "") or (kibana_cpu_request is defined and kibana_cpu_request is not none and kibana_cpu_request != "") %}
           resources:
@@ -81,7 +81,7 @@ spec:
             periodSeconds: 5
         -
           name: "kibana-proxy"
-          image: {{ proxy_image }}
+          image: "{{ openshift_logging_kibana_proxy_image_prefix }}logging-auth-proxy:{{ openshift_logging_kibana_proxy_image_version }}"
           imagePullPolicy: IfNotPresent
 {% if (kibana_proxy_memory_limit is defined and kibana_proxy_memory_limit is not none and kibana_proxy_memory_limit != "") or (kibana_proxy_cpu_limit is defined and kibana_proxy_cpu_limit is not none and kibana_proxy_cpu_limit != "") or (kibana_proxy_cpu_request is defined and kibana_proxy_cpu_request is not none and kibana_proxy_cpu_request != "") %}
           resources:


### PR DESCRIPTION
Updating the image naming convention to match the proposed naming structure and removing the requirement that tech preview will only be allowed for origin installs.