### PR TITLE
Updating default image tags to be only vX.Y for origin installs

### DIFF
--- a/roles/openshift_logging_curator/vars/default_images.yml
+++ b/roles/openshift_logging_curator/vars/default_images.yml
@@ -1,3 +1,6 @@
 ---
+# unable to escape characters in here for some reason -- ideally would be '^[v]?\d\.\d+'
+__openshift_logging_image_tag: "{{ openshift_image_tag | regex_search('^[v]?[0-9].[0-9]+') }}"
+
 __openshift_logging_curator_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_logging_curator_image_version: "{{ openshift_logging_image_version | default(openshift_image_tag) }}"
+__openshift_logging_curator_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_tag) }}"

--- a/roles/openshift_logging_elasticsearch/vars/default_images.yml
+++ b/roles/openshift_logging_elasticsearch/vars/default_images.yml
@@ -1,5 +1,8 @@
 ---
+# unable to escape characters in here for some reason -- ideally would be '^[v]?\d\.\d+'
+__openshift_logging_image_tag: "{{ openshift_image_tag | regex_search('^[v]?[0-9].[0-9]+') }}"
+
 __openshift_logging_elasticsearch_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_logging_elasticsearch_image_version: "{{ openshift_logging_image_version | default(openshift_image_tag) }}"
+__openshift_logging_elasticsearch_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_tag) }}"
 __openshift_logging_elasticsearch_proxy_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/') }}"
 __openshift_logging_elasticsearch_proxy_image_version: "{{ openshift_logging_image_version | default('v1.0.0') }}"

--- a/roles/openshift_logging_eventrouter/vars/default_images.yml
+++ b/roles/openshift_logging_eventrouter/vars/default_images.yml
@@ -1,3 +1,6 @@
 ---
+# unable to escape characters in here for some reason -- ideally would be '^[v]?\d\.\d+'
+__openshift_logging_image_tag: "{{ openshift_image_tag | regex_search('^[v]?[0-9].[0-9]+') }}"
+
 __openshift_logging_eventrouter_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_logging_eventrouter_image_version: "{{ openshift_logging_image_version | default(openshift_image_tag) }}"
+__openshift_logging_eventrouter_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_tag) }}"

--- a/roles/openshift_logging_fluentd/vars/default_images.yml
+++ b/roles/openshift_logging_fluentd/vars/default_images.yml
@@ -1,3 +1,6 @@
 ---
+# unable to escape characters in here for some reason -- ideally would be '^[v]?\d\.\d+'
+__openshift_logging_image_tag: "{{ openshift_image_tag | regex_search('^[v]?[0-9].[0-9]+') }}"
+
 __openshift_logging_fluentd_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_logging_fluentd_image_version: "{{ openshift_logging_image_version | default(openshift_image_tag) }}"
+__openshift_logging_fluentd_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_tag) }}"

--- a/roles/openshift_logging_kibana/vars/default_images.yml
+++ b/roles/openshift_logging_kibana/vars/default_images.yml
@@ -1,5 +1,8 @@
 ---
+# unable to escape characters in here for some reason -- ideally would be '^[v]?\d\.\d+'
+__openshift_logging_image_tag: "{{ openshift_image_tag | regex_search('^[v]?[0-9].[0-9]+') }}"
+
 __openshift_logging_kibana_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_logging_kibana_image_version: "{{ openshift_logging_image_version | default(openshift_image_tag) }}"
+__openshift_logging_kibana_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_tag) }}"
 __openshift_logging_kibana_proxy_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_logging_kibana_proxy_image_version: "{{ openshift_logging_image_version | default(openshift_image_tag) }}"
+__openshift_logging_kibana_proxy_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_tag) }}"

--- a/roles/openshift_logging_mux/vars/default_images.yml
+++ b/roles/openshift_logging_mux/vars/default_images.yml
@@ -1,3 +1,6 @@
 ---
+# unable to escape characters in here for some reason -- ideally would be '^[v]?\d\.\d+'
+__openshift_logging_image_tag: "{{ openshift_image_tag | regex_search('^[v]?[0-9].[0-9]+') }}"
+
 __openshift_logging_mux_image_prefix: "{{ openshift_logging_image_prefix | default('docker.io/openshift/origin-') }}"
-__openshift_logging_mux_image_version: "{{ openshift_logging_image_version | default(openshift_image_tag) }}"
+__openshift_logging_mux_image_version: "{{ openshift_logging_image_version | default(__openshift_logging_image_tag) }}"


### PR DESCRIPTION
Follow up to https://github.com/openshift/openshift-ansible/pull/7414

For logging origin images, we only have `vX.Y` tags

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1561882