### PR TITLE
When bootstrapping automatically sync node config

### DIFF
--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -167,16 +167,12 @@
     import_role:
       name: openshift_node_group
       tasks_from: bootstrap
-  # TODO: move me into a more appropriate location
-  - name: Update the sysconfig for the masters to give them bootstrap config
-    lineinfile:
-      dest: "/etc/sysconfig/{{ openshift_service_type }}-node"
-      line: "{{ item.line | default(omit) }}"
-      regexp: "{{ item.regexp }}"
-      state: "{{ item.state | default('present') }}"
-    with_items:
-    - line: "BOOTSTRAP_CONFIG_NAME={{ openshift_node_group_master | default('node-config-master') }}"
-      regexp: "^BOOTSTRAP_CONFIG_NAME=.*"
+  - name: Have the masters automatically pull their configuration
+    import_role:
+      name: openshift_node_group
+      tasks_from: bootstrap_config
+    vars:
+      r_node_bootstrap_config_name: "{{ openshift_node_group_master | default('node-config-master') }}"
 
   roles:
   - role: openshift_master_facts

--- a/playbooks/openshift-node/private/bootstrap.yml
+++ b/playbooks/openshift-node/private/bootstrap.yml
@@ -20,10 +20,16 @@
   tasks:
   - import_role:
       name: openshift_node
-      tasks_from: bootstrap.yml
+      tasks_from: bootstrap
   - import_role:
       name: openshift_node_group
-      tasks_from: bootstrap.yml
+      tasks_from: bootstrap
+  - name: Have the nodes automatically pull their configuration
+    import_role:
+      name: openshift_node_group
+      tasks_from: bootstrap_config
+    vars:
+      r_node_bootstrap_config_name: "{{ openshift_node_group_name | default('node-config-compute') }}"
   - set_fact:
       openshift_is_bootstrapped: True
 

--- a/roles/openshift_node_group/defaults/main.yml
+++ b/roles/openshift_node_group/defaults/main.yml
@@ -41,3 +41,8 @@ l_openshift_prefix_dict:
 l_os_prefix: "{{ l_openshift_prefix_dict[openshift_deployment_type] }}"
 # TODO: we should publish oreg_url component=node
 osn_image: "{{ l_os_registry_url | regex_replace(l_os_prefix | regex_escape, 'node') }}"
+
+openshift_service_type_dict:
+  origin: origin
+  openshift-enterprise: atomic-openshift
+openshift_service_type: "{{ openshift_service_type_dict[openshift_deployment_type] }}"

--- a/roles/openshift_node_group/tasks/bootstrap_config.yml
+++ b/roles/openshift_node_group/tasks/bootstrap_config.yml
@@ -1,0 +1,20 @@
+---
+- name: Ensure required directories are present
+  file:
+    path: "{{ item }}"
+    owner: root
+    group: root
+    mode: 0755
+    state: directory
+  with_items:
+  - /etc/origin/node/pods
+  - /etc/origin/node/certificates
+- name: Update the sysconfig to group "{{ r_node_bootstrap_config_name }}"
+  lineinfile:
+    dest: "/etc/sysconfig/{{ openshift_service_type }}-node"
+    line: "{{ item.line | default(omit) }}"
+    regexp: "{{ item.regexp }}"
+    state: "{{ item.state | default('present') }}"
+  with_items:
+  - line: "BOOTSTRAP_CONFIG_NAME={{ r_node_bootstrap_config_name }}"
+    regexp: "^BOOTSTRAP_CONFIG_NAME=.*"


### PR DESCRIPTION
The masters are configured for dynamic sync but nodes are not.

Fixes an issue found by @sjennings when using non-bootstrapped nodes that are not pre-baked.