### PR TITLE
Fixing crlnumber file missing during 'openshift_logging' install

### DIFF
--- a/roles/openshift_logging/tasks/generate_certs.yaml
+++ b/roles/openshift_logging/tasks/generate_certs.yaml
@@ -98,15 +98,15 @@
   when:
     - not ca_db_file.stat.exists
 
-- name: Checking for ca.crt.srl
-  stat: path="{{generated_certs_dir}}/ca.crt.srl"
-  register: ca_cert_srl_file
+- name: Checking for ca.crl.srl
+  stat: path="{{generated_certs_dir}}/ca.crl.srl"
+  register: ca_crl_srl_file
   check_mode: no
 
-- copy: content="" dest={{generated_certs_dir}}/ca.crt.srl
+- copy: content="" dest={{generated_certs_dir}}/ca.crl.srl
   check_mode: no
   when:
-    - not ca_cert_srl_file.stat.exists
+    - not ca_crl_srl_file.stat.exists
 
 - name: Generate PEM certs
   include_tasks: generate_pems.yaml component={{node_name}}


### PR DESCRIPTION
This is a proposed fix for issue #7725.

I have tested this change on a real system and it fixes the issue outlined in #7725. I.e.: tested with OCP `3.7.23` on RHEL7.4 with `openshift-ansible` `release-3.7` branch.

I am *not* 100% certain that this is the correct solution, however, so would like to have someone more familiar with this area review to double check. Maybe @ewolinetz can chime in as I see he was the original author of this area?
