### PR TITLE
Allow disabling Network Manager managed dns

### DIFF
--- a/roles/openshift_node/tasks/dnsmasq/network-manager.yml
+++ b/roles/openshift_node/tasks/dnsmasq/network-manager.yml
@@ -7,4 +7,20 @@
   notify: restart NetworkManager
   when: openshift_node_dnsmasq_install_network_manager_hook | default(true) | bool
 
+- name: Add network manager configuration
+  ini_file:
+    path: /etc/NetworkManager/conf.d/99-origin.conf
+    section: main
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+    state: "{{ 'present' if item.present is not defined or item.present else 'absent' }}"
+    no_extra_spaces: yes
+    create: yes
+    mode: 0600
+  notify: restart NetworkManager
+  with_items:
+    - key: dns
+      value: none
+      present: "{{ openshift_node_dnsmasq_disable_network_manager_dns | default(false) | bool }}"
+
 - meta: flush_handlers


### PR DESCRIPTION
When using Network Manager with default configuration, in certain
scenarios (eg: azure), restarting the Network Manager causes the
resolv.conf to be overwritten without the discovered search domains.

This change allows for the addition of a Network Manager configuration
slice during installation. If
`openshift_node_dnsmasq_disable_network_manager_dns` is set to `true`,
Network Manager is configured with `dns=none` preventing the issue
detailed above.

Relates-to: BZ#1535340
Reference: https://access.redhat.com/solutions/2817911