### PR TITLE
Don't install etcd on bootstrapped hosts

### DIFF
--- a/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
+++ b/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
@@ -3,9 +3,9 @@
   package:
     name: "etcd{{ '-' + etcd_version if etcd_version is defined else '' }}"
     state: present
-  when: not etcd_is_atomic | bool
-  delegate_to: "{{ etcd_ca_host }}"
-  run_once: true
+  when:
+  - not etcd_is_atomic | bool
+  - not openshift_is_bootstrapped | bool
   register: result
   until: result is succeeded
 
@@ -180,8 +180,8 @@
   file:
     path: "{{ item }}"
     mode: 0600
-    owner: "etcd"
-    group: "etcd"
+    owner: "{{ 'etcd' if not openshift_is_bootstrapped else omit }}"
+    group: "{{ 'etcd' if not openshift_is_bootstrapped else omit }}"
   when: etcd_url_scheme == 'https'
   with_items:
   - "{{ etcd_ca_file }}"
@@ -192,8 +192,8 @@
   file:
     path: "{{ item }}"
     mode: 0600
-    owner: "etcd"
-    group: "etcd"
+    owner: "{{ 'etcd' if not openshift_is_bootstrapped else omit }}"
+    group: "{{ 'etcd' if not openshift_is_bootstrapped else omit }}"
   when: etcd_peer_url_scheme == 'https'
   with_items:
   - "{{ etcd_peer_ca_file }}"
@@ -204,6 +204,6 @@
   file:
     path: "{{ etcd_conf_dir }}"
     state: directory
-    owner: "etcd"
-    group: "etcd"
+    owner: "{{ 'etcd' if not openshift_is_bootstrapped else omit }}"
+    group: "{{ 'etcd' if not openshift_is_bootstrapped else omit }}"
     mode: 0700

--- a/roles/etcd/tasks/static.yml
+++ b/roles/etcd/tasks/static.yml
@@ -20,8 +20,6 @@
   file:
     path: "{{ etcd_conf_dir }}"
     state: directory
-    owner: "etcd"
-    group: "etcd"
     mode: 0700
 
 - name: Validate permissions on the static pods dir


### PR DESCRIPTION
This also ensures correct permissions are set for etcd certs - use `owner/group: etcd` for dedicated etcd node and don't install `etcd` package and don't set owner on bootstrapped nodes
Replaces #7752
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1562322