### PR TITLE
[release-3.7] [1529575] Ensure etcd.conf variables are updated during upgrade

### DIFF
--- a/roles/etcd/tasks/upgrade/upgrade_image.yml
+++ b/roles/etcd/tasks/upgrade/upgrade_image.yml
@@ -20,10 +20,8 @@
     regexp: "{{ current_image.stdout }}$"
     replace: "{{ new_etcd_image }}"
 
-- lineinfile:
-    destfile: "{{ etcd_conf_file }}"
-    regexp: '^ETCD_QUOTA_BACKEND_BYTES='
-    line: "ETCD_QUOTA_BACKEND_BYTES={{ etcd_quota_backend_bytes }}"
+- include: validate_etcd_conf.yml
+  static: true
 
 - name: Restart etcd_container
   systemd:

--- a/roles/etcd/tasks/upgrade/upgrade_rpm.yml
+++ b/roles/etcd/tasks/upgrade/upgrade_rpm.yml
@@ -21,10 +21,8 @@
   register: result
   until: result | success
 
-- lineinfile:
-    destfile: "{{ etcd_conf_file }}"
-    regexp: '^ETCD_QUOTA_BACKEND_BYTES='
-    line: "ETCD_QUOTA_BACKEND_BYTES={{ etcd_quota_backend_bytes }}"
+- include: validate_etcd_conf.yml
+  static: true
 
 - name: Restart etcd
   service:

--- a/roles/etcd/tasks/upgrade/validate_etcd_conf.yml
+++ b/roles/etcd/tasks/upgrade/validate_etcd_conf.yml
@@ -1,0 +1,45 @@
+---
+# This task file ensures expected variables exist in the case where systems have
+# been upgraded from states where these values were not initially configured.
+
+- name: Ensure ETCD_CA_FILE is absent
+  lineinfile:
+    destfile: "{{ etcd_conf_file }}"
+    regexp: 'ETCD_CA_FILE'
+    state: absent
+
+- name: Ensure ETCD_PEER_CA_FILE is absent
+  lineinfile:
+    destfile: "{{ etcd_conf_file }}"
+    regexp: 'ETCD_PEER_CA_FILE'
+    state: absent
+
+- name: Ensure ETCD_QUOTA_BACKEND_BYTES exists
+  lineinfile:
+    destfile: "{{ etcd_conf_file }}"
+    regexp: '^ETCD_QUOTA_BACKEND_BYTES='
+    line: 'ETCD_QUOTA_BACKEND_BYTES={{ etcd_quota_backend_bytes }}'
+
+- name: Ensure ETCD_CLIENT_CERT_AUTH exists
+  lineinfile:
+    destfile: "{{ etcd_conf_file }}"
+    regexp: '^ETCD_CLIENT_CERT_AUTH='
+    line: 'ETCD_CLIENT_CERT_AUTH="true"'
+
+- name: Ensure ETCD_PEER_CLIENT_CERT_AUTH exists
+  lineinfile:
+    destfile: "{{ etcd_conf_file }}"
+    regexp: '^ETCD_PEER_CLIENT_CERT_AUTH='
+    line: 'ETCD_PEER_CLIENT_CERT_AUTH="true"'
+
+- name: Ensure ETCD_TRUSTED_CA_FILE exists
+  lineinfile:
+    destfile: "{{ etcd_conf_file }}"
+    regexp: '^ETCD_TRUSTED_CA_FILE='
+    line: 'ETCD_TRUSTED_CA_FILE={{ etcd_ca_file }}'
+
+- name: Ensure ETCD_PEER_TRUSTED_CA_FILE exists
+  lineinfile:
+    destfile: "{{ etcd_conf_file }}"
+    regexp: '^ETCD_PEER_TRUSTED_CA_FILE='
+    line: 'ETCD_PEER_TRUSTED_CA_FILE={{ etcd_peer_ca_file }}'

--- a/roles/openshift_certificate_expiry/library/openshift_cert_expiry.py
+++ b/roles/openshift_certificate_expiry/library/openshift_cert_expiry.py
@@ -456,9 +456,9 @@ an OpenShift Container Platform cluster
 
     # etcd, where do you hide your certs? Used when parsing etcd.conf
     etcd_cert_params = [
-        "ETCD_CA_FILE",
+        "ETCD_TRUSTED_CA_FILE",
         "ETCD_CERT_FILE",
-        "ETCD_PEER_CA_FILE",
+        "ETCD_PEER_TRUSTED_CA_FILE",
         "ETCD_PEER_CERT_FILE",
     ]
 


### PR DESCRIPTION
Modified cherry-pick of #7711 to account for `include:` instead of `import_task:`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1563376