### PR TITLE
Ensure legacy inventories continue to work for infra nodes

### DIFF
--- a/roles/openshift_manage_node/tasks/set_default_node_role.yml
+++ b/roles/openshift_manage_node/tasks/set_default_node_role.yml
@@ -19,3 +19,20 @@
           - key: node-role.kubernetes.io/compute
             value: 'true'
       with_items: "{{ non_master_non_infra_nodes_result.results.results.0['items'] | map(attribute='metadata') | map(attribute='name') | list }}"
+
+    - name: Retrieve nodes that are marked with the infra selector or the legacy infra selector
+      oc_obj:
+        state: list
+        kind: Node
+        selector: '{{ openshift_hosted_infra_selector | default("region=infra") }}'
+      register: infra_nodes_by_selector
+
+    - name: Label infra or legacy infra nodes with the new role label
+      oc_label:
+        name: '{{ item }}'
+        kind: node
+        state: add
+        labels:
+          - key: node-role.kubernetes.io/infra
+            value: 'true'
+      with_items: "{{ infra_nodes_by_selector.results.results.0['items'] | map(attribute='metadata') | map(attribute='name') | list }}"


### PR DESCRIPTION
The infra node default changed from region=infra to
node-role.kubernetes.io/infra=true. This ensures that old inventories
work successfully in labelling nodes.

@sdodson @sjennings as discussed