### PR TITLE
Allow no sdn's to be specified in sanity checks

### DIFF
--- a/roles/lib_utils/action_plugins/sanity_checks.py
+++ b/roles/lib_utils/action_plugins/sanity_checks.py
@@ -133,7 +133,7 @@ class ActionModule(ActionBase):
                 res_temp = default_val
             res.append(to_bool(res_temp))
 
-        if sum(res) != 1:
+        if sum(res) not in (0, 1):
             plugin_str = list(zip([x[0] for x in NET_PLUGIN_LIST], res))
 
             msg = "Host Checked: {} Only one of must be true. Found: {}".format(host, plugin_str)


### PR DESCRIPTION
This commit allows specifying no sdn's during install.

Fixes: https://github.com/openshift/openshift-ansible/issues/7583