### PR TITLE
Bug 1538560 - [RFE]rename the project name mux-undefined

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -184,10 +184,9 @@ Elasticsearch OPS too, if using an OPS cluster:
  interface as reported by the `ansible_default_ipv4` fact.
 - `openshift_logging_mux_cpu_request`: 100m
 - `openshift_logging_mux_memory_limit`: 512Mi
-- `openshift_logging_mux_default_namespaces`: Default `["mux-undefined"]` - the
- first value in the list is the namespace to use for undefined projects,
- followed by any additional namespaces to create by default - users will
- typically not need to set this
+- `openshift_logging_mux_default_namespaces`:
+  openshift_logging_mux_default_namespaces is not supported.
+  use openshift_logging_mux_namespaces instead.
 - `openshift_logging_mux_namespaces`: Default `[]` - additional namespaces to
   create for _external_ mux clients to associate with their logs - users will
   need to set this

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -172,9 +172,7 @@ openshift_logging_mux_port: 24284
 openshift_logging_mux_cpu_limit: null
 openshift_logging_mux_memory_limit: 512Mi
 openshift_logging_mux_cpu_request: 100m
-# the namespace to use for undefined projects should come first, followed by any
-# additional namespaces to create by default - users will typically not need to set this
-openshift_logging_mux_default_namespaces: ["mux-undefined"]
+# the namespace to use for undefined projects - users will typically not need to set this
 # extra namespaces to create for mux clients - users will need to set this
 openshift_logging_mux_namespaces: []
 

--- a/roles/openshift_logging_mux/defaults/main.yml
+++ b/roles/openshift_logging_mux/defaults/main.yml
@@ -32,10 +32,8 @@ openshift_logging_use_mux: "{{ openshift_logging_mux_allow_external | default(Fa
 openshift_logging_mux_hostname: "{{ 'mux.' ~ openshift_master_default_subdomain }}"
 openshift_logging_mux_port: 24284
 openshift_logging_mux_external_address: "{{ ansible_default_ipv4.address }}"
-# the namespace to use for undefined projects should come first, followed by any
-# additional namespaces to create by default - users will typically not need to set this
-openshift_logging_mux_default_namespaces: ["mux-undefined"]
-# extra namespaces to create for mux clients - users will need to set this
+# the namespace to use for undefined projects
+# namespaces to create for mux clients - users will need to set this
 openshift_logging_mux_namespaces: []
 
 openshift_logging_mux_app_client_cert: /etc/fluent/keys/cert

--- a/roles/openshift_logging_mux/tasks/main.yaml
+++ b/roles/openshift_logging_mux/tasks/main.yaml
@@ -7,6 +7,10 @@
     msg: Operations logs destination is required
   when: not openshift_logging_mux_ops_host or openshift_logging_mux_ops_host == ''
 
+- fail:
+    msg: openshift_logging_mux_default_namespaces is not supported; use openshift_logging_mux_namespaces instead.
+  when: openshift_logging_mux_default_namespaces is defined
+
 - name: Ensure that Logging Mux has nodes to run on
   import_role:
     name: openshift_control_plane
@@ -222,7 +226,7 @@
     state: present
     name: "{{ item }}"
     node_selector: ""
-  with_items: "{{ openshift_logging_mux_namespaces | union(openshift_logging_mux_default_namespaces) }}"
+  with_items: "{{ openshift_logging_mux_namespaces }}"
 
 - name: Delete temp directory
   file:


### PR DESCRIPTION
mux-undefined ==> .orphaned
Removing openshift_logging_mux_default_namespaces.