### PR TITLE
Set the pid_max value only when lower than certain threshold.

### DIFF
--- a/roles/tuned/templates/openshift/tuned.conf
+++ b/roles/tuned/templates/openshift/tuned.conf
@@ -13,7 +13,7 @@ avc_cache_threshold=65536
 nf_conntrack_hashsize=131072
 
 [sysctl]
-kernel.pid_max=131072
+kernel.pid_max=>131072
 net.netfilter.nf_conntrack_max=1048576
 fs.inotify.max_user_watches=65536
 net.ipv4.neigh.default.gc_thresh1=8192


### PR DESCRIPTION
Let the kernel set the pid_max value automatically based on the number of CPU cores on high CPU core machines.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1561005