### PR TITLE
PARP: Store ansible log file separately

### DIFF
--- a/.papr.sh
+++ b/.papr.sh
@@ -32,6 +32,9 @@ upload_journals() {
 
 trap upload_journals ERR
 
+# Store ansible log separately
+export ANSIBLE_LOG_PATH=ansible.log
+
 # run the actual installer
 ansible-playbook -v -i .papr.inventory playbooks/deploy_cluster.yml
 

--- a/.papr.yml
+++ b/.papr.yml
@@ -40,3 +40,4 @@ tests:
 
 artifacts:
   - journals/
+  - ansible.log


### PR DESCRIPTION
This would make PARP upload a separate ansible log file, as it might be
cutoff if test output reaches few MBs