### PR TITLE
Fix CORS property for hawkular-alerts

### DIFF
--- a/roles/openshift_metrics/templates/hawkular_metrics_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_metrics_rc.j2
@@ -49,7 +49,7 @@ spec:
         - "-Dhawkular-alerts.cassandra-use-ssl"
         - "-Dhawkular.alerts.openshift.auth-methods=openshift-oauth,htpasswd"
         - "-Dhawkular.alerts.openshift.htpasswd-file=/hawkular-account/hawkular-metrics.htpasswd"
-        - "-Dhawkular.alerts.allowed-cors-access-control-allow-headers=authorization"
+        - "-Dhawkular.allowed-cors-access-control-allow-headers=authorization"
         - "-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"
         - "-Dorg.apache.catalina.connector.CoyoteAdapter.ALLOW_BACKSLASH=true"
         - "-Dcom.datastax.driver.FORCE_NIO=true"


### PR DESCRIPTION
The template uses wrong property for Hawkular-Alerts `allowed-cors-access-control-allow-headers`.

Before:

```
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: origin,accept,content-type,hawkular-tenant
Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD
Access-Control-Allow-Origin: https://127.0.0.1:8443
Access-Control-Max-Age: 259200
```

After:

```
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: origin,accept,content-type,hawkular-tenant,authorization
Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD
Access-Control-Allow-Origin: https://127.0.0.1:8443
Access-Control-Max-Age: 259200
```