### PR TITLE
Bug 1564499 - ASB usability improvements

### DIFF
--- a/roles/ansible_service_broker/defaults/main.yml
+++ b/roles/ansible_service_broker/defaults/main.yml
@@ -15,7 +15,7 @@ ansible_service_broker_launch_apb_on_bind: false
 ansible_service_broker_keep_namespace_on_error: true
 ansible_service_broker_keep_namespace: false
 
-ansible_service_broker_image_pull_policy: IfNotPresent
+ansible_service_broker_image_pull_policy: Always
 ansible_service_broker_sandbox_role: edit
 ansible_service_broker_auto_escalate: false
 ansible_service_broker_local_registry_whitelist: []

--- a/roles/ansible_service_broker/templates/configmap.yaml.j2
+++ b/roles/ansible_service_broker/templates/configmap.yaml.j2
@@ -31,6 +31,7 @@ data:
       host: ""
       ca_file: ""
       bearer_token_file: ""
+      namespace: openshift-ansible-service-broker
       sandbox_role: {{ ansible_service_broker_sandbox_role }}
       image_pull_policy: {{ ansible_service_broker_image_pull_policy }}
       keep_namespace: {{ ansible_service_broker_keep_namespace | bool | lower }}


### PR DESCRIPTION
This addresses 2 problems in the ASB config map:
* `openshift.namespace` needs to be set to `openshift-ansible-service-broker`
* default imagePullPolicy should be `always`