### PR TITLE
Update console liveness probe

### DIFF
--- a/roles/openshift_web_console/files/console-template.yaml
+++ b/roles/openshift_web_console/files/console-template.yaml
@@ -42,6 +42,7 @@ objects:
       metadata:
         name: webconsole
         labels:
+          app: openshift-web-console
           webconsole: "true"
       spec:
         serviceAccountName: webconsole
@@ -70,12 +71,12 @@ objects:
             exec:
               command:
                 - /bin/sh
-                - -i
                 - -c
                 - |-
                   if [[ ! -f /tmp/webconsole-config.hash ]]; then \
                     md5sum /var/webconsole-config/webconsole-config.yaml > /tmp/webconsole-config.hash; \
                   elif [[ $(md5sum /var/webconsole-config/webconsole-config.yaml) != $(cat /tmp/webconsole-config.hash) ]]; then \
+                    echo 'webconsole-config.yaml has changed.'; \
                     exit 1; \
                   fi && curl -k -f https://0.0.0.0:8443/console/
           resources:


### PR DESCRIPTION
Avoid error in liveness probe:
cannot set terminal process group (-1):
Inappropriate ioctl for device bash: no job control in this shell exit

Add message:
webconsole-config.yaml has changed.

![screen shot 2018-04-05 at 1 44 23 pm](https://user-images.githubusercontent.com/1167259/38384171-6cbf88c4-38dc-11e8-89f4-9eefd44ef793.png)

See https://github.com/openshift/origin/pull/19232
Also includes https://github.com/openshift/origin/pull/18214 for the app label, which was never merged to openshift-ansible (openshift-ansible PR #7100)

/assign @sdodson 
cc @jwforres 