### PR TITLE
Change set imagepullpolicy to allow for offline install

### DIFF
--- a/roles/openshift_storage_glusterfs/files/deploy-heketi-template.yml
+++ b/roles/openshift_storage_glusterfs/files/deploy-heketi-template.yml
@@ -65,6 +65,7 @@ objects:
         containers:
         - name: heketi
           image: ${IMAGE_NAME}:${IMAGE_VERSION}
+          imagePullPolicy: IfNotPresent
           env:
           - name: HEKETI_USER_KEY
             value: ${HEKETI_USER_KEY}


### PR DESCRIPTION
minor change to heketi deploy template. this will allow for offline install scenario where the administrator has manually seeded the nodes with the Gluster images.

This should also be backported to release-3.7 and release-3.9

@sdodson