### PR TITLE
sdn: don't blow away all existing CNI plugins

### DIFF
--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -77,8 +77,7 @@ spec:
           done
 
           # Take over network functions on the node
-          rm -Rf /etc/cni/net.d/*
-          rm -Rf /host/opt/cni/bin/*
+          rm -Rf /etc/cni/net.d/80-openshift-network.conf
           cp -Rf /opt/cni/bin/* /host/opt/cni/bin/
 
           if [[ -f /etc/sysconfig/origin-node ]]; then


### PR DESCRIPTION
The SDN only cares about plugins it runs, which is handled by
explicitly copying known binaries to /host/opt/cni/bin on
daemonset startup; we don't need to remove them all first.

Removing them all would potentially blow away 3rd party CNI
plugins that we shouldn't touch.  Even if they exist, they
won't be activated/used when the SDN daemonset is run due to
the /etc/cni/net.d/ handling.

@knobunc @smarterclayton 

Let's play well with others instead of deleting them unconditionally.