### PR TITLE
Calico fixes

### DIFF
--- a/roles/calico_master/tasks/certs.yml
+++ b/roles/calico_master/tasks/certs.yml
@@ -39,6 +39,7 @@
 - name: Create secret
   oc_secret:
     name: calico-etcd-secrets
+    state: present
     namespace: kube-system
     files:
     - name: etcd-key

--- a/roles/calico_master/tasks/main.yml
+++ b/roles/calico_master/tasks/main.yml
@@ -15,6 +15,12 @@
     resource_name: privileged
     state: present
 
+- name: Set default selector for kube-system
+  command: >
+    {{ openshift_client_binary }}
+    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    annotate  ns kube-system openshift.io/node-selector="" --overwrite
+
 - name: Calico Master | Create temp directory
   command: mktemp -d /tmp/openshift-ansible-XXXXXXX
   register: mktemp


### PR DESCRIPTION
1. Fix an issue where oc_secret sometimes complained that the secret already exists
2. Fix an issue where Calico pods were getting assigned the project's defaultNodeSelector since the kube-system project doesn't have a default nodeselector.

I'm not sure if 2. is the proper fix for this, so open to any other suggestions.