### PR TITLE
GlusterFS: enable modprobe in pods that manage bricks

### DIFF
--- a/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
+++ b/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
@@ -69,6 +69,9 @@ objects:
           - name: glusterfs-ssl
             mountPath: "/etc/ssl"
             readOnly: true
+          - name: kernel-modules
+            mountPath: "/usr/lib/modules"
+            readOnly: true
           - name: glusterfs-target
             mountPath: "/etc/target"
           securityContext:
@@ -127,6 +130,9 @@ objects:
         - name: glusterfs-ssl
           hostPath:
             path: "/etc/ssl"
+        - name: kernel-modules
+          hostPath:
+            path: "/usr/lib/modules"
         - name: glusterfs-target
           hostPath:
             path: "/etc/target"


### PR DESCRIPTION
Bricks are created with an LVM thin-pool to allow LV-snapshots to be
taken. This requires certain device-mapper modules to be loaded in the
kernel. In case modules are missing, the lvm-tools (like lvcreate) will
try to load them. If the modules are not loaded in advance, and loading
fails in the pod, then it will not be possible to provision bricks for a
Gluster Volume and volume creation will fail.

See-also: gluster/gluster-kubernetes#457
Signed-off-by: Niels de Vos <ndevos@redhat.com>