### PR TITLE
[3.9] PAPR: verify minor update on all-in-one cluster

### DIFF
--- a/.papr.all-in-one.inventory
+++ b/.papr.all-in-one.inventory
@@ -1,0 +1,27 @@
+[OSEv3:children]
+masters
+nodes
+etcd
+
+[OSEv3:vars]
+ansible_ssh_user=root
+ansible_python_interpreter=/usr/bin/python3
+openshift_deployment_type=origin
+openshift_release="{{ lookup('env', 'target_branch') }}"
+openshift_master_default_subdomain="{{ lookup('env', 'RHCI_ocp_master_IP') }}.xip.io"
+openshift_check_min_host_disk_gb=1.5
+openshift_check_min_host_memory_gb=1.9
+osm_cluster_network_cidr=10.128.0.0/14
+openshift_portal_net=172.30.0.0/16
+osm_host_subnet_length=9
+template_service_broker_install=false
+openshift_hosted_infra_selector="node-role.kubernetes.io/infra=true"
+
+[masters]
+ocp-master
+
+[etcd]
+ocp-master
+
+[nodes]
+ocp-master openshift_schedulable=true openshift_node_labels="{'node-role.kubernetes.io/infra':'true'}"

--- a/.papr.yml
+++ b/.papr.yml
@@ -40,3 +40,20 @@ tests:
 
 artifacts:
   - journals/
+
+---
+inherit: true
+context: 'fedora/27/atomic/update'
+
+cluster:
+  hosts:
+    - name: ocp-master
+      distro: fedora/27/atomic
+      specs:
+        ram: 4096
+  container:
+    image: registry.fedoraproject.org/fedora:27
+
+env:
+  PAPR_INVENTORY: .papr.all-in-one.inventory
+  PAPR_RUN_UPDATE: "yes"

--- a/setup.py
+++ b/setup.py
@@ -324,7 +324,7 @@ class OpenShiftAnsibleSyntaxCheck(Command):
         for yaml_file in find_files(
                 os.getcwd(), exclude_dirs, None, r'\.ya?ml$'):
             with open(yaml_file, 'r') as contents:
-                yaml_contents = yaml.safe_load(contents)
+                yaml_contents = yaml.safe_load_all(contents)
                 if not isinstance(yaml_contents, list):
                     continue
 


### PR DESCRIPTION
Run update playbooks to update to a minor version. Currently it won't do much, but gives a simple smoketest of our playbooks for containerized install

Updates are failing on 3.9:
```
TASK [Redeploy docker registry] ************************************************
Friday 06 April 2018  15:37:19 +0000 (0:00:01.969)       0:07:51.668 ********** 
fatal: [ocp-master]: FAILED! => {"changed": true, "cmd": ["/usr/local/bin/oc", "rollout", "latest", "dc/docker-registry", "--config=/tmp/openshift-ansible-LOjFLz/admin.kubeconfig", "-n", "default"], "delta": "0:00:00.283338", "end": "2018-04-06 15:37:08.649934", "msg": "non-zero return code", "rc": 1, "start": "2018-04-06 15:37:08.366596", "stderr": "error: #1 is already in progress (Pending).", "stderr_lines": ["error: #1 is already in progress (Pending)."], "stdout": "", "stdout_lines": []}
```

UPD Fixed by setting correct node label. Long-term fix to detect this is in #7855 