### PR TITLE
Fix wrong reference to user policy.

### DIFF
--- a/roles/openshift_grafana/tasks/install_grafana.yaml
+++ b/roles/openshift_grafana/tasks/install_grafana.yaml
@@ -37,7 +37,7 @@
     namespace: "{{ grafana_namespace }}"
     resource_kind: cluster-role
     resource_name: cluster-reader
-    user: "system:serviceaccount:{{ grafana_namespace }}:{{ grafana_serviceaccount_name }}"
+    user: "{{ openshift_grafana_serviceaccount_name }}"
 
 - name: create grafana routes
   oc_route:


### PR DESCRIPTION
this patch fix wrong reference for user cluster role policy.
otherwise we can't login the grafana UI