### PR TITLE
fixing Master Scaleup process

### DIFF
--- a/playbooks/common/openshift-master/tasks/wire_aggregator.yml
+++ b/playbooks/common/openshift-master/tasks/wire_aggregator.yml
@@ -186,6 +186,7 @@
     name: extension-apiserver-authentication
     namespace: kube-system
   when:
+  - openshift_version is defined
   - openshift_version | version_compare('3.7','<')
   - openshift_upgrade_target is defined
   - openshift_upgrade_target | version_compare('3.7','>=')


### PR DESCRIPTION
While doing a Scaleup on `Openshift Cluster 3.7.42` I found this ansible playbook execution error and was able to fix it with a new condition.
The error looks like this 
```
                    }, 
                    "task": {
                        "id": "024b6e90-4ef6-ce5a-76ee-000000000877", 
                        "name": "Update master config"
                    }
                }, 
                {
                    "hosts": {
                        "10.76.11.44": {
                            "msg": "The conditional check 'openshift_version | version_compare('3.7','<')' failed. The error was: Version comparison: 'openshift_version' is undefined\n\nThe error appears to have been in '/usr/share/ansible/openshift-ansible/playbooks/common/openshift-master/tasks/wire_aggregator.yml': line 183, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n# this is needed for repopulating during upgrade, so delete before restart\n- name: Delete apiserver extensionconfigmap\n  ^ here\n"
                        }
                    }, 
                    "task": {
                        "id": "024b6e90-4ef6-ce5a-76ee-000000000878", 
                        "name": "Delete apiserver extensionconfigmap"
                    }
                }
            ]
        }
    ], 
```