### PR TITLE
Openshift facts: ensure 'disable-attach-detach-reconcile-sync' contains a list value

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -634,7 +634,7 @@ def build_controller_args(facts):
                 if facts['cloudprovider']['kind'] == 'aws':
                     controller_args['cloud-provider'] = ['aws']
                     controller_args['cloud-config'] = [cloud_cfg_path + '/aws.conf']
-                    controller_args['disable-attach-detach-reconcile-sync'] = 'true'
+                    controller_args['disable-attach-detach-reconcile-sync'] = ['true']
                 if facts['cloudprovider']['kind'] == 'openstack':
                     controller_args['cloud-provider'] = ['openstack']
                     controller_args['cloud-config'] = [cloud_cfg_path + '/openstack.conf']


### PR DESCRIPTION
3.10 now requires all params in `kubernetesMasterConfig.controllerArguments` to be lists, otherwise controller server won't start, throwing:

`could not load config file "/etc/origin/master/master-config.yaml" due to an error: error reading config: [pos 3135]: only encoded map or array can be decoded into a slice (6)`