### PR TITLE
wait_for_pod: wait for deployment to be Complete

### DIFF
--- a/roles/openshift_hosted/tasks/wait_for_pod.yml
+++ b/roles/openshift_hosted/tasks/wait_for_pod.yml
@@ -27,7 +27,7 @@
              --config {{ openshift_master_config_dir }}/admin.kubeconfig \
              -o jsonpath='{ .metadata.annotations.openshift\.io/deployment\.phase }'
     register: openshift_hosted_wfp_rc_phase
-    until: "'Running' not in openshift_hosted_wfp_rc_phase.stdout"
+    until: "'Complete' in openshift_hosted_wfp_rc_phase.stdout"
     delay: 10
     retries: 60
     failed_when: "'Failed' in openshift_hosted_wfp_rc_phase.stdout"


### PR DESCRIPTION
This ensures the deployment won't stuck in 'Pending' and move further