### PR TITLE
Prefix the node-problem-detector with the system:

### DIFF
--- a/roles/openshift_node_problem_detector/tasks/install.yaml
+++ b/roles/openshift_node_problem_detector/tasks/install.yaml
@@ -11,7 +11,7 @@
     user: "system:serviceaccount:{{ openshift_node_problem_detector_namespace }}:{{ openshift_node_problem_detector_service_account }}"
     namespace: "{{ openshift_node_problem_detector_namespace }}"
     resource_kind: cluster-role
-    resource_name: "{{ openshift_node_problem_detector_cluster_role_name }}"
+    resource_name: "system:{{ openshift_node_problem_detector_cluster_role_name }}"
 
 - name: Grant privileged SCC from node problem detector service account
   oc_adm_policy_user:

--- a/roles/openshift_node_problem_detector/tasks/uninstall.yaml
+++ b/roles/openshift_node_problem_detector/tasks/uninstall.yaml
@@ -20,7 +20,7 @@
     user: "system:serviceaccount:{{ openshift_node_problem_detector_namespace }}:{{ openshift_node_problem_detector_service_account }}"
     namespace: "{{ openshift_node_problem_detector_namespace }}"
     resource_kind: cluster-role
-    resource_name: "{{ openshift_node_problem_detector_cluster_role_name }}"
+    resource_name: "system:{{ openshift_node_problem_detector_cluster_role_name }}"
 
 - name: remove node problem detector service account
   oc_serviceaccount:


### PR DESCRIPTION
The `node-problem-detector` cluster role is actually `system:` prefixed.

Otherwise the NPD complains about:
```
E0406 09:24:55.434670       1 manager.go:160] failed to update node conditions: nodes "172.16.186.37" is forbidden: User "system:serviceaccount:openshift-infra:node-problem-detector" cannot patch nodes/status at the cluster scope: User "system:serviceaccount:openshift-infra:node-problem-detector" cannot "patch" "nodes/status" with name "172.16.186.37" in project "": clusterrole.rbac.authorization.k8s.io "node-problem-detector" not found
```

Bug: 1564852