### PR TITLE
Remove obsolete openshift_docker_disable_push_dockerhub

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -128,8 +128,6 @@ debug_level=2
 #openshift_docker_additional_registries=registry.example.com
 #openshift_docker_insecure_registries=registry.example.com
 #openshift_docker_blocked_registries=registry.hacker.com
-# Disable pushing to dockerhub
-#openshift_docker_disable_push_dockerhub=True
 # Use Docker inside a System Container. Note that this is a tech preview and should
 # not be used to upgrade!
 # The following options for docker are ignored:

--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -9,7 +9,6 @@ oreg_host: "{{ oreg_url.split('/')[0] if (oreg_url is defined and '.' in oreg_ur
 oreg_auth_credentials_replace: False
 
 openshift_docker_use_system_container: False
-openshift_docker_disable_push_dockerhub: False  # bool
 openshift_docker_selinux_enabled: True
 openshift_docker_service_name: "{{ 'container-engine' if (openshift_docker_use_system_container | default(False) | bool) else 'docker' }}"
 

--- a/roles/container_runtime/tasks/package_docker.yml
+++ b/roles/container_runtime/tasks/package_docker.yml
@@ -115,7 +115,6 @@
       {% if (openshift_docker_hosted_registry_insecure | bool) and openshift_docker_hosted_registry_network %} --insecure-registry={{ openshift_docker_hosted_registry_network }} {% endif %} \
       {% if docker_options is defined %} {{ docker_options }}{% endif %} \
       {% if openshift_docker_options %} {{ openshift_docker_options }}{% endif %} \
-      {% if openshift_docker_disable_push_dockerhub | bool %} --confirm-def-push={{ openshift_docker_disable_push_dockerhub | bool }}{% endif %} \
       --signature-verification={{ openshift_docker_signature_verification | bool }}'"
   when: docker_check.stat.isreg is defined and docker_check.stat.isreg
   notify:


### PR DESCRIPTION
This option no longer has any effect other than to crash
docker.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1564076