### PR TITLE
Prometheus: add firewall rules for node exporter

### DIFF
--- a/playbooks/openshift-prometheus/private/config.yml
+++ b/playbooks/openshift-prometheus/private/config.yml
@@ -16,6 +16,13 @@
   roles:
   - role: openshift_prometheus
 
+- name: Prometheus firewall rules
+  hosts: oo_nodes_to_config
+  tasks:
+  - import_role:
+      name: openshift_prometheus
+      tasks_from: firewall.yml
+
 - name: Prometheus Install Checkpoint End
   hosts: all
   gather_facts: false

--- a/roles/openshift_prometheus/defaults/main.yaml
+++ b/roles/openshift_prometheus/defaults/main.yaml
@@ -79,3 +79,12 @@ openshift_prometheus_node_exporter_cpu_limit: 200m
 openshift_prometheus_node_exporter_memory_limit: 50Mi
 openshift_prometheus_node_exporter_cpu_requests: 100m
 openshift_prometheus_node_exporter_memory_requests: 30Mi
+
+# Firewall settings
+r_openshift_prometheus_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
+r_openshift_prometheus_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
+r_openshift_prometheus_os_firewall_deny: []
+r_openshift_prometheus_os_firewall_allow:
+  - service: node-exporter
+    port: "9100/tcp"
+    cond: "{{ openshift_prometheus_node_exporter_install | bool }}"

--- a/roles/openshift_prometheus/tasks/firewall.yml
+++ b/roles/openshift_prometheus/tasks/firewall.yml
@@ -1,0 +1,40 @@
+---
+- when: r_openshift_prometheus_firewall_enabled | bool and not r_openshift_prometheus_use_firewalld | bool
+  block:
+  - name: Add iptables allow rules
+    os_firewall_manage_iptables:
+      name: "{{ item.service }}"
+      action: add
+      protocol: "{{ item.port.split('/')[1] }}"
+      port: "{{ item.port.split('/')[0] }}"
+    when: item.cond | default(True)
+    with_items: "{{ r_openshift_prometheus_os_firewall_allow }}"
+
+  - name: Remove iptables rules
+    os_firewall_manage_iptables:
+      name: "{{ item.service }}"
+      action: remove
+      protocol: "{{ item.port.split('/')[1] }}"
+      port: "{{ item.port.split('/')[0] }}"
+    when: item.cond | default(True)
+    with_items: "{{ r_openshift_prometheus_os_firewall_deny }}"
+
+- when: r_openshift_prometheus_firewall_enabled | bool and r_openshift_prometheus_use_firewalld | bool
+  block:
+  - name: Add firewalld allow rules
+    firewalld:
+      port: "{{ item.port }}"
+      permanent: true
+      immediate: true
+      state: enabled
+    when: item.cond | default(True)
+    with_items: "{{ r_openshift_prometheus_os_firewall_allow }}"
+
+  - name: Remove firewalld allow rules
+    firewalld:
+      port: "{{ item.port }}"
+      permanent: true
+      immediate: true
+      state: disabled
+    when: item.cond | default(True)
+    with_items: "{{ r_openshift_prometheus_os_firewall_deny }}"


### PR DESCRIPTION
Adds the framework for firewall rules to the prometheus role and the settings for the node exporter port to use it. 

The firewall setup is called from the playbook as it affects a different set of hosts than the rest of the role (first master vs nodes).
