### PR TITLE
Wipe filesystem metadata from CNS block devices.

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
@@ -139,3 +139,10 @@
   when:
   - glusterfs_wipe
   - item.stdout_lines | count > 0
+
+- name: Wipe filesystem signatures from storage devices
+  command: "wipefs -a {% for device in hostvars[item].glusterfs_devices %}{{ device }} {% endfor %}"
+  delegate_to: "{{ item }}"
+  with_items: "{{ glusterfs_nodes | default([]) }}"
+  failed_when: False
+  when: glusterfs_wipe


### PR DESCRIPTION
CNS deployment fails if gluster block devices are XFS formatted.  Wipe filesystem metadata from the devices in addition to LVM metadata.

A workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1564070

/cc @ekuric 