### PR TITLE
Adding anti affinity configurations for ES and kibana pods

### DIFF
--- a/roles/openshift_logging_elasticsearch/templates/2.x/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/2.x/es.j2
@@ -27,6 +27,32 @@ spec:
         component: "{{component}}"
         deployment: "{{deploy_name}}"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: logging-infra
+                operator: In
+                values:
+                - elasticsearch
+            topologyKey: kubernetes.io/hostname
+{% if openshift_infra_anti_affinity_labels is defined and openshift_infra_anti_affinity_labels is iterable and openshift_infra_anti_affinity_labels | length > 0 %}
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+{% for aa_key, aa_values in openshift_infra_anti_affinity_labels.items() %}
+                - key: "{{ aa_key }}"
+                  operator: In
+                  values:
+{% for aa_value in aa_values %}
+                  - "{{ aa_value }}"
+{% endfor %}
+{% endfor %}
+              topologyKey: kubernetes.io/hostname
+{% endif %}
       terminationGracePeriod: 600
       serviceAccountName: aggregated-logging-elasticsearch
       securityContext:

--- a/roles/openshift_logging_elasticsearch/templates/2.x/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/2.x/es.j2
@@ -29,30 +29,16 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: logging-infra
-                operator: In
-                values:
-                - elasticsearch
-            topologyKey: kubernetes.io/hostname
-{% if openshift_infra_anti_affinity_labels is defined and openshift_infra_anti_affinity_labels is iterable and openshift_infra_anti_affinity_labels | length > 0 %}
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:
               labelSelector:
                 matchExpressions:
-{% for aa_key, aa_values in openshift_infra_anti_affinity_labels.items() %}
-                - key: "{{ aa_key }}"
+                - key: logging-infra
                   operator: In
                   values:
-{% for aa_value in aa_values %}
-                  - "{{ aa_value }}"
-{% endfor %}
-{% endfor %}
-              topologyKey: kubernetes.io/hostname
-{% endif %}
+                  - elasticsearch
+            topologyKey: kubernetes.io/hostname
       terminationGracePeriod: 600
       serviceAccountName: aggregated-logging-elasticsearch
       securityContext:

--- a/roles/openshift_logging_elasticsearch/templates/5.x/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/5.x/es.j2
@@ -27,6 +27,32 @@ spec:
         component: "{{component}}"
         deployment: "{{deploy_name}}"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: logging-infra
+                operator: In
+                values:
+                - elasticsearch
+            topologyKey: kubernetes.io/hostname
+{% if openshift_infra_anti_affinity_labels is defined and openshift_infra_anti_affinity_labels is iterable and openshift_infra_anti_affinity_labels | length > 0 %}
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+{% for aa_key, aa_values in openshift_infra_anti_affinity_labels.items() %}
+                - key: "{{ aa_key }}"
+                  operator: In
+                  values:
+{% for aa_value in aa_values %}
+                  - "{{ aa_value }}"
+{% endfor %}
+{% endfor %}
+              topologyKey: kubernetes.io/hostname
+{% endif %}
       terminationGracePeriod: 600
       serviceAccountName: aggregated-logging-elasticsearch
       securityContext:

--- a/roles/openshift_logging_elasticsearch/templates/5.x/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/5.x/es.j2
@@ -29,30 +29,16 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: logging-infra
-                operator: In
-                values:
-                - elasticsearch
-            topologyKey: kubernetes.io/hostname
-{% if openshift_infra_anti_affinity_labels is defined and openshift_infra_anti_affinity_labels is iterable and openshift_infra_anti_affinity_labels | length > 0 %}
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:
               labelSelector:
                 matchExpressions:
-{% for aa_key, aa_values in openshift_infra_anti_affinity_labels.items() %}
-                - key: "{{ aa_key }}"
+                - key: logging-infra
                   operator: In
                   values:
-{% for aa_value in aa_values %}
-                  - "{{ aa_value }}"
-{% endfor %}
-{% endfor %}
-              topologyKey: kubernetes.io/hostname
-{% endif %}
+                  - elasticsearch
+            topologyKey: kubernetes.io/hostname
       terminationGracePeriod: 600
       serviceAccountName: aggregated-logging-elasticsearch
       securityContext:

--- a/roles/openshift_logging_kibana/templates/2.x/kibana.j2
+++ b/roles/openshift_logging_kibana/templates/2.x/kibana.j2
@@ -26,6 +26,32 @@ spec:
         provider: openshift
         component: "{{ component }}"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: logging-infra
+                operator: In
+                values:
+                - kibana
+            topologyKey: kubernetes.io/hostname
+{% if openshift_infra_anti_affinity_labels is defined and openshift_infra_anti_affinity_labels is iterable and openshift_infra_anti_affinity_labels | length > 0 %}
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+{% for aa_key, aa_values in openshift_infra_anti_affinity_labels.items() %}
+                  - key: "{{ aa_key }}"
+                    operator: In
+                    values:
+{% for aa_value in aa_values %}
+                    - "{{ aa_value }}"
+{% endfor %}
+{% endfor %}
+                topologyKey: kubernetes.io/hostname
+{% endif %}
       serviceAccountName: aggregated-logging-kibana
 {% if kibana_node_selector is iterable and kibana_node_selector | length > 0 %}
       nodeSelector:

--- a/roles/openshift_logging_kibana/templates/2.x/kibana.j2
+++ b/roles/openshift_logging_kibana/templates/2.x/kibana.j2
@@ -28,30 +28,16 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: logging-infra
-                operator: In
-                values:
-                - kibana
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: logging-infra
+                  operator: In
+                  values:
+                  - kibana
             topologyKey: kubernetes.io/hostname
-{% if openshift_infra_anti_affinity_labels is defined and openshift_infra_anti_affinity_labels is iterable and openshift_infra_anti_affinity_labels | length > 0 %}
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-{% for aa_key, aa_values in openshift_infra_anti_affinity_labels.items() %}
-                  - key: "{{ aa_key }}"
-                    operator: In
-                    values:
-{% for aa_value in aa_values %}
-                    - "{{ aa_value }}"
-{% endfor %}
-{% endfor %}
-                topologyKey: kubernetes.io/hostname
-{% endif %}
       serviceAccountName: aggregated-logging-kibana
 {% if kibana_node_selector is iterable and kibana_node_selector | length > 0 %}
       nodeSelector:

--- a/roles/openshift_logging_kibana/templates/5.x/kibana.j2
+++ b/roles/openshift_logging_kibana/templates/5.x/kibana.j2
@@ -26,6 +26,32 @@ spec:
         provider: openshift
         component: "{{ component }}"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: logging-infra
+                operator: In
+                values:
+                - kibana
+            topologyKey: kubernetes.io/hostname
+{% if openshift_infra_anti_affinity_labels is defined and openshift_infra_anti_affinity_labels is iterable and openshift_infra_anti_affinity_labels | length > 0 %}
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+{% for aa_key, aa_values in openshift_infra_anti_affinity_labels.items() %}
+                  - key: "{{ aa_key }}"
+                    operator: In
+                    values:
+{% for aa_value in aa_values %}
+                    - "{{ aa_value }}"
+{% endfor %}
+{% endfor %}
+                topologyKey: kubernetes.io/hostname
+{% endif %}
       serviceAccountName: aggregated-logging-kibana
 {% if kibana_node_selector is iterable and kibana_node_selector | length > 0 %}
       nodeSelector:

--- a/roles/openshift_logging_kibana/templates/5.x/kibana.j2
+++ b/roles/openshift_logging_kibana/templates/5.x/kibana.j2
@@ -28,30 +28,16 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
               matchExpressions:
               - key: logging-infra
                 operator: In
                 values:
                 - kibana
-            topologyKey: kubernetes.io/hostname
-{% if openshift_infra_anti_affinity_labels is defined and openshift_infra_anti_affinity_labels is iterable and openshift_infra_anti_affinity_labels | length > 0 %}
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-{% for aa_key, aa_values in openshift_infra_anti_affinity_labels.items() %}
-                  - key: "{{ aa_key }}"
-                    operator: In
-                    values:
-{% for aa_value in aa_values %}
-                    - "{{ aa_value }}"
-{% endfor %}
-{% endfor %}
-                topologyKey: kubernetes.io/hostname
-{% endif %}
+          topologyKey: kubernetes.io/hostname
       serviceAccountName: aggregated-logging-kibana
 {% if kibana_node_selector is iterable and kibana_node_selector | length > 0 %}
       nodeSelector:


### PR DESCRIPTION
Would address https://bugzilla.redhat.com/show_bug.cgi?id=1564944

The variable `openshift_infra_anti_affinity_labels` can be specified in the host file like:
```
openshift_infra_anti_affinity_labels={'openshift-infra':['master']}
```

So we would try to not schedule our pods on the same nodes that contain other pods with the label `openshift-infra: master`.

But we require that we do not schedule ES pods on the same node as other ES pods (not distinguishing ops and non-ops deployments)

@portante