### PR TITLE
Add missing 'is' in when condiditon for slurp

### DIFF
--- a/roles/openshift_control_plane/tasks/generate_session_secrets.yml
+++ b/roles/openshift_control_plane/tasks/generate_session_secrets.yml
@@ -23,7 +23,7 @@
     l_existing_osm_session: "{{ (l_osm_session_secrets_slurp.content | b64decode | from_yaml) }}"
   when:
   - l_osm_session_secrets_stat.stat.exists
-  - l_osm_session_secrets_slurp defined
+  - l_osm_session_secrets_slurp is defined
   - l_existing_osm_session.secrets is defined
   - l_existing_osm_session.secrets != ''
   - l_existing_osm_session.secrets != []


### PR DESCRIPTION
This commit adds missing syntax word 'is' for when
condition on slurp task.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1565305
Fixes #7868