### PR TITLE
[3.6] GlusterFS: enable modprobe in pods that manage bricks

### DIFF
--- a/roles/openshift_storage_glusterfs/files/v3.6/glusterfs-template.yml
+++ b/roles/openshift_storage_glusterfs/files/v3.6/glusterfs-template.yml
@@ -71,6 +71,9 @@ objects:
             readOnly: true
           - name: glusterfs-target
             mountPath: "/etc/target"
+          - name: kernel-modules
+            mountPath: "/usr/lib/modules"
+            readOnly: true
           securityContext:
             capabilities: {}
             privileged: true
@@ -130,6 +133,9 @@ objects:
         - name: glusterfs-target
           hostPath:
             path: "/etc/target"
+        - name: kernel-modules
+          hostPath:
+            path: "/usr/lib/modules"
         restartPolicy: Always
         terminationGracePeriodSeconds: 30
         dnsPolicy: ClusterFirst


### PR DESCRIPTION
Backports #7831
@jarrpa pls help review