### PR TITLE
bug 1565625. Mount /var/lib/docker instead of /var/lib/docker/container

### DIFF
--- a/roles/openshift_logging_fluentd/templates/2.x/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/2.x/fluentd.j2
@@ -58,8 +58,8 @@ spec:
           mountPath: /run/log/journal
         - name: varlog
           mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
+        - name: varlibdocker
+          mountPath: /var/lib/docker
           readOnly: true
         - name: config
           mountPath: /etc/fluent/configs.d/user
@@ -219,9 +219,9 @@ spec:
       - name: varlog
         hostPath:
           path: /var/log
-      - name: varlibdockercontainers
+      - name: varlibdocker
         hostPath:
-          path: /var/lib/docker/containers
+          path: /var/lib/docker
       - name: config
         configMap:
           name: logging-fluentd

--- a/roles/openshift_logging_fluentd/templates/5.x/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/5.x/fluentd.j2
@@ -58,8 +58,8 @@ spec:
           mountPath: /run/log/journal
         - name: varlog
           mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
+        - name: varlibdocker
+          mountPath: /var/lib/docker
           readOnly: true
         - name: config
           mountPath: /etc/fluent/configs.d/user
@@ -216,9 +216,9 @@ spec:
       - name: varlog
         hostPath:
           path: /var/log
-      - name: varlibdockercontainers
+      - name: varlibdocker
         hostPath:
-          path: /var/lib/docker/containers
+          path: /var/lib/docker
       - name: config
         configMap:
           name: logging-fluentd


### PR DESCRIPTION
This PR fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1565625

As recommended to mount the parent dir instead of the vol