### PR TITLE
[WIP] Create namespace for running smoke tests against origin-web-console

### DIFF
--- a/roles/openshift_web_console/defaults/main.yml
+++ b/roles/openshift_web_console/defaults/main.yml
@@ -13,3 +13,16 @@ openshift_web_console_image_name: "{{ l_osm_registry_url | regex_replace('${comp
 
 # Default the replica count to the number of masters.
 openshift_web_console_replica_count: "{{ groups.oo_masters_to_config | length }}"
+
+# openshift_web_console_smoke_test common setup
+openshift_web_console_smoke_test_namespace: openshift-web-console-smoke-test
+openshift_web_console_smoke_test_tmp_location: /tmp
+
+openshift_web_console_smoke_test_pod_template_file: templates/console-smoke-test-pod.yaml.j2
+
+openshift_web_console_smoke_test_service_account: web-console-smoke-test
+openshift_web_console_smoke_test_cluster_role_name: web-console-smoke-test
+
+openshift_web_console_smoke_test_name: openshift-web-console-smoke-test-pod
+openshift_web_console_delete_tempfiles: True
+

--- a/roles/openshift_web_console/tasks/install.yml
+++ b/roles/openshift_web_console/tasks/install.yml
@@ -141,3 +141,5 @@
   when: not create_console_project.changed
 
 - include_tasks: start.yml
+
+- include_tasks: smoke_tests.yml

--- a/roles/openshift_web_console/tasks/smoke_tests.yml
+++ b/roles/openshift_web_console/tasks/smoke_tests.yml
@@ -1,0 +1,20 @@
+---
+- name: Create openshift-web-console-smoke-test project
+  oc_project:
+    name: "{{ openshift_web_console_smoke_test_namespace }}"
+    state: present
+
+- name: Render web console smoke test pod
+  template:
+    src: "{{ openshift_web_console_smoke_test_pod_template_file }}"
+    dest: "{{ openshift_web_console_smoke_test_tmp_location }}/smoke-test-pod.yaml"
+
+- name: Create web console smoke test pod
+  oc_obj:
+    kind: pod
+    name: "{{ openshift_web_console_smoke_test_name }}"
+    namespace: "{{ openshift_web_console_smoke_test_namespace }}"
+    state: present
+    files:
+    - "{{ openshift_web_console_smoke_test_tmp_location }}/smoke-test-pod.yaml"
+    delete_after: "{{ openshift_web_console_delete_tempfiles }}"

--- a/roles/openshift_web_console/templates/console-smoke-test-pod.yaml.j2
+++ b/roles/openshift_web_console/templates/console-smoke-test-pod.yaml.j2
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: openshift-web-console-smoke-test-pod
+  labels:
+    app: openshift-web-console-smoke-test
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/scheme: http
+spec:
+  restartPolicy: Never
+  containers:
+  - name: openshift-web-console-smoke-test
+    image: jhadvig/origin-web-console-smoke-test:latest
+    ports:
+    - containerPort: 3000
+      protocol: TCP
+    imagePullPolicy: IfNotPresent
+    env:
+    - name: CONSOLE_URL
+      value: {{ openshift.master.public_console_url }}
+    - name: TEST_INTERVAL
+      value: '5'


### PR DESCRIPTION
Updating `openshift_web_console` playbook so at the end the of the installation a additional reserved namespace `openshift-web-console-smoke-test` will be created, in which a pod running a container that serves as a sanity check for the origin-web-console, will be launched.

Originally I wanted to create a separate playbook but adding it as at the end of the `openshift_web_console` playbook make sense as well.

@ingvagabund PTAL

cc'ing @spadgett 