### PR TITLE
Add oo_etcd_to_config to service_catalog init

### DIFF
--- a/playbooks/openshift-service-catalog/config.yml
+++ b/playbooks/openshift-service-catalog/config.yml
@@ -1,10 +1,9 @@
 ---
 - import_playbook: ../init/main.yml
   vars:
-    l_init_fact_hosts: "oo_masters_to_config"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
     l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
-
 
 - import_playbook: private/config.yml


### PR DESCRIPTION
Currently, service_catalog entrypoint play
playbooks/openshift-service-catalog/config.yml does not
place group oo_etcd_to_config into l_init_fact hosts.
The result is that we don't collect the interface IPs
for each of our etcd hosts, and we are unable to build
urls.

This commit ensures that service-catalog init's etcd facts
to build appropriate urls.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1557036