### PR TITLE
[3.9] Update dbus before installing dnsmasq

### DIFF
--- a/roles/openshift_node/tasks/dnsmasq_install.yml
+++ b/roles/openshift_node/tasks/dnsmasq_install.yml
@@ -10,11 +10,24 @@
   set_fact:
     network_manager_active: "{{ True if 'ActiveState=active' in nm_show.stdout else False }}"
 
-- name: Install dnsmasq
-  package: name=dnsmasq state=installed
-  when: not openshift_is_atomic | bool
-  register: result
-  until: result is succeeded
+- when: not openshift_is_atomic | bool
+  block:
+  - name: Ensure dbus is updated before installing dnsmasq
+    package:
+      name: dbus
+      state: latest
+    register: dbus_update
+  - name: Restart dbus if it was updated
+    systemd:
+      name: dbus
+      state: restarted
+    when: dbus_update | changed
+  - name: Install dnsmasq
+    package:
+      name: dnsmasq
+      state: installed
+    register: result
+    until: result is succeeded
 
 - name: ensure origin/node directory exists
   file:


### PR DESCRIPTION
Installing dnsmasq updates dbus due to dependencies. However dbus cannot
be updated from the 7.4 version to 7.5 version without a restart.

See https://bugzilla.redhat.com/show_bug.cgi?id=1550582
Backports #7878 