### PR TITLE
Adjust Kuryr CNI definitions for new Docker image

### DIFF
--- a/roles/kuryr/templates/cni-daemonset.yaml.j2
+++ b/roles/kuryr/templates/cni-daemonset.yaml.j2
@@ -33,6 +33,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KURYR_CNI_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         securityContext:
           privileged: true
         volumeMounts:
@@ -41,10 +45,8 @@ spec:
         - name: net-conf
           mountPath: /etc/cni/net.d
         - name: config-volume
-          mountPath: /tmp/kuryr/kuryr.conf
+          mountPath: /etc/kuryr/kuryr.conf
           subPath: kuryr-cni.conf
-        - name: etc
-          mountPath: /etc
         - name: proc
           mountPath: /host_proc
         - name: openvswitch
@@ -71,9 +73,6 @@ spec:
         - name: config-volume
           configMap:
             name: kuryr-config
-        - name: etc
-          hostPath:
-            path: /etc
         - name: proc
           hostPath:
             path: /proc

--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -653,13 +653,6 @@ data:
     # Minimun interval (in seconds) between pool updates (integer value)
     ports_pool_update_frequency = {{ kuryr_openstack_pool_update_frequency | default(20) }}
 
-    [oslo_concurrency]
-
-    #
-    # From kuryr_kubernetes
-    #
-    lock_path = {{ kuryr_openstack_lock_path | default('/var/kuryr-lock') }}
-
     [cni_health_server]
     port = {{ kuryr_healthcheck_port }}
 


### PR DESCRIPTION
New Kuryr CNI Docker images are using `docker exec` instead of `docker
run` to execute CNI binary. This required a few changes to CNI resources
definitions. In particular:

* host's /etc directory is no longer mounted into CNI container.
* `KURYR_CNI_POD_NAME` environment variable is added and it's supposed
  to hold CNI pod name for cni_ds_init to be able to identify the pod.
* `lock_path` option of oslo_concurrency is no longer needed to be set,
  default value is defined by OSLO_LOCK_PATH environment variable.