### PR TITLE
ignore non-existent directory fixing docker selinux permissions

### DIFF
--- a/roles/container_runtime/tasks/package_crio.yml
+++ b/roles/container_runtime/tasks/package_crio.yml
@@ -74,6 +74,8 @@
   shell: |
           semanage fcontext -a -e /var/lib/docker/overlay2 /var/lib/containers/overlay2
           restorecon -R -v /var/lib/containers/overlay2
+  register: result
+  failed_when: result.rc != 0 and 'No such file or directory' not in result.stderr
 
 - name: Start the CRI-O service
   systemd:


### PR DESCRIPTION
Fixes #7715

I'm not sure under what conditions this directory is supposed to exist, but on my system it does not.
This is not an elegant solution, but the issue doesn't seem to be getting much attention, so I figure this is better than nothing.