### PR TITLE
fix certificate auth on containerized etcd

### DIFF
--- a/roles/etcd/tasks/upgrade/validate_etcd_conf.yml
+++ b/roles/etcd/tasks/upgrade/validate_etcd_conf.yml
@@ -24,13 +24,13 @@
   lineinfile:
     destfile: "{{ etcd_conf_file }}"
     regexp: '^ETCD_CLIENT_CERT_AUTH='
-    line: 'ETCD_CLIENT_CERT_AUTH="true"'
+    line: 'ETCD_CLIENT_CERT_AUTH=true'
 
 - name: Ensure ETCD_PEER_CLIENT_CERT_AUTH exists
   lineinfile:
     destfile: "{{ etcd_conf_file }}"
     regexp: '^ETCD_PEER_CLIENT_CERT_AUTH='
-    line: 'ETCD_PEER_CLIENT_CERT_AUTH="true"'
+    line: 'ETCD_PEER_CLIENT_CERT_AUTH=true'
 
 - name: Ensure ETCD_TRUSTED_CA_FILE exists
   lineinfile:

--- a/roles/etcd/templates/etcd.conf.j2
+++ b/roles/etcd/templates/etcd.conf.j2
@@ -44,7 +44,7 @@ ETCD_INITIAL_CLUSTER_TOKEN={{ etcd_initial_cluster_token }}
 ETCD_ADVERTISE_CLIENT_URLS={{ etcd_advertise_client_urls }}
 #ETCD_STRICT_RECONFIG_CHECK="false"
 #ETCD_AUTO_COMPACTION_RETENTION="0"
-#ETCD_ENABLE_V2="true"
+#ETCD_ENABLE_V2=true
 ETCD_QUOTA_BACKEND_BYTES={{ etcd_quota_backend_bytes }}
 
 #[proxy]
@@ -58,14 +58,14 @@ ETCD_QUOTA_BACKEND_BYTES={{ etcd_quota_backend_bytes }}
 #[security]
 {% if etcd_url_scheme == 'https' -%}
 ETCD_TRUSTED_CA_FILE={{ etcd_ca_file }}
-ETCD_CLIENT_CERT_AUTH="true"
+ETCD_CLIENT_CERT_AUTH=true
 ETCD_CERT_FILE={{ etcd_cert_file }}
 ETCD_KEY_FILE={{ etcd_key_file }}
 {% endif -%}
 #ETCD_AUTO_TLS="false"
 {% if etcd_peer_url_scheme == 'https' -%}
 ETCD_PEER_TRUSTED_CA_FILE={{ etcd_peer_ca_file }}
-ETCD_PEER_CLIENT_CERT_AUTH="true"
+ETCD_PEER_CLIENT_CERT_AUTH=true
 ETCD_PEER_CERT_FILE={{ etcd_peer_cert_file }}
 ETCD_PEER_KEY_FILE={{ etcd_peer_key_file }}
 {% endif -%}

--- a/roles/etcd/templates/etcd.conf.j2
+++ b/roles/etcd/templates/etcd.conf.j2
@@ -11,7 +11,7 @@
 ETCD_NAME={{ etcd_hostname }}
 ETCD_LISTEN_PEER_URLS={{ etcd_listen_peer_urls }}
 ETCD_DATA_DIR={{ etcd_data_dir }}
-#ETCD_WAL_DIR=""
+#ETCD_WAL_DIR=
 #ETCD_SNAPSHOT_COUNT=10000
 ETCD_HEARTBEAT_INTERVAL=500
 ETCD_ELECTION_TIMEOUT=2500
@@ -42,18 +42,18 @@ ETCD_INITIAL_CLUSTER_TOKEN={{ etcd_initial_cluster_token }}
 #ETCD_DISCOVERY_PROXY=
 {% endif %}
 ETCD_ADVERTISE_CLIENT_URLS={{ etcd_advertise_client_urls }}
-#ETCD_STRICT_RECONFIG_CHECK="false"
-#ETCD_AUTO_COMPACTION_RETENTION="0"
+#ETCD_STRICT_RECONFIG_CHECK=false
+#ETCD_AUTO_COMPACTION_RETENTION=0
 #ETCD_ENABLE_V2=true
 ETCD_QUOTA_BACKEND_BYTES={{ etcd_quota_backend_bytes }}
 
 #[proxy]
 #ETCD_PROXY=off
-#ETCD_PROXY_FAILURE_WAIT="5000"
-#ETCD_PROXY_REFRESH_INTERVAL="30000"
-#ETCD_PROXY_DIAL_TIMEOUT="1000"
-#ETCD_PROXY_WRITE_TIMEOUT="5000"
-#ETCD_PROXY_READ_TIMEOUT="0"
+#ETCD_PROXY_FAILURE_WAIT=5000
+#ETCD_PROXY_REFRESH_INTERVAL=30000
+#ETCD_PROXY_DIAL_TIMEOUT=1000
+#ETCD_PROXY_WRITE_TIMEOUT=5000
+#ETCD_PROXY_READ_TIMEOUT=0
 
 #[security]
 {% if etcd_url_scheme == 'https' -%}
@@ -62,24 +62,24 @@ ETCD_CLIENT_CERT_AUTH=true
 ETCD_CERT_FILE={{ etcd_cert_file }}
 ETCD_KEY_FILE={{ etcd_key_file }}
 {% endif -%}
-#ETCD_AUTO_TLS="false"
+#ETCD_AUTO_TLS=false
 {% if etcd_peer_url_scheme == 'https' -%}
 ETCD_PEER_TRUSTED_CA_FILE={{ etcd_peer_ca_file }}
 ETCD_PEER_CLIENT_CERT_AUTH=true
 ETCD_PEER_CERT_FILE={{ etcd_peer_cert_file }}
 ETCD_PEER_KEY_FILE={{ etcd_peer_key_file }}
 {% endif -%}
-#ETCD_PEER_AUTO_TLS="false"
+#ETCD_PEER_AUTO_TLS=false
 
 #[logging]
-ETCD_DEBUG="{{ etcd_debug | default(false) | bool | string }}"
+ETCD_DEBUG={{ etcd_debug | default(false) | bool | string }}
 {% if etcd_log_package_levels is defined %}
-ETCD_LOG_PACKAGE_LEVELS="{{ etcd_log_package_levels }}"
+ETCD_LOG_PACKAGE_LEVELS={{ etcd_log_package_levels }}
 {% endif %}
 
 #[profiling]
-#ETCD_ENABLE_PPROF="false"
-#ETCD_METRICS="basic"
+#ETCD_ENABLE_PPROF=false
+#ETCD_METRICS=basic
 #
 #[auth]
-#ETCD_AUTH_TOKEN="simple"
+#ETCD_AUTH_TOKEN=simple


### PR DESCRIPTION
addresses an issue where quotation marks in files passed to docker's --env-file are escaped in a way that makes them unreadable by etcd

this change should have no impact on non-containerized etcd nodes as the quoted `true` environment variables are interpreted the same way:

```
$ export FOO=true
$ env | grep FOO
FOO=true

$ export FOO="true"
$ env | grep FOO
FOO=true
```

Reference: CVE-2018-1085 | https://bugzilla.redhat.com/show_bug.cgi?id=1557822