### PR TITLE
cluster_monitoring_operator: Don't use cluster-admin role

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/files/cluster-monitoring-operator.yaml
+++ b/roles/openshift_cluster_monitoring_operator/files/cluster-monitoring-operator.yaml
@@ -43,6 +43,126 @@ objects:
         baseImage: ${PROMETHEUS_IMAGE}
       alertmanagerMain:
         baseImage: ${ALERTMANAGER_IMAGE}
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRole
+  metadata: {name: cluster-monitoring-operator}
+  rules:
+  - apiGroups: [rbac.authorization.k8s.io]
+    resources: [roles, rolebindings, clusterroles, clusterrolebindings]
+    verbs: [create, get, list, watch, update, delete]
+  - apiGroups: ['']
+    resources: [serviceaccounts]
+    verbs: [create, get, list, watch, update, delete]
+  - apiGroups: [apps]
+    resources: [deployments, daemonsets]
+    verbs: [create, get, list, watch, update, delete]
+  - apiGroups: [route.openshift.io]
+    resources: [routes]
+    verbs: [create, get, list, watch, update, delete]
+  - apiGroups: [security.openshift.io]
+    resources: [securitycontextconstraints]
+    verbs: [create, get, list, watch, update, delete]
+  - apiGroups: [authentication.k8s.io]
+    resources: [tokenreviews]
+    verbs: [create]
+  - apiGroups: [authorization.k8s.io]
+    resources: [subjectaccessreviews]
+    verbs: [create]
+  - apiGroups: ['']
+    resources: [nodes, pods, services, resourcequotas, replicationcontrollers, limitranges, persistentvolumeclaims, persistentvolumes, namespaces, endpoints]
+    verbs: [list, watch]
+  - apiGroups: [extensions]
+    resources: [daemonsets, deployments, replicasets]
+    verbs: [list, watch]
+  - apiGroups: [apps]
+    resources: [statefulsets]
+    verbs: [list, watch]
+  - apiGroups: [batch]
+    resources: [cronjobs, jobs]
+    verbs: [list, watch]
+  - apiGroups: [autoscaling]
+    resources: [horizontalpodautoscalers]
+    verbs: [list, watch]
+  - apiGroups: [authentication.k8s.io]
+    resources: [tokenreviews]
+    verbs: [create]
+  - apiGroups: [authorization.k8s.io]
+    resources: [subjectaccessreviews]
+    verbs: [create]
+  - apiGroups: ['']
+    resources: [pods]
+    verbs: [get]
+  - apiGroups: [extensions]
+    resourceNames: [kube-state-metrics]
+    resources: [deployments]
+    verbs: [get, update]
+  - apiGroups: [authentication.k8s.io]
+    resources: [tokenreviews]
+    verbs: [create]
+  - apiGroups: [authorization.k8s.io]
+    resources: [subjectaccessreviews]
+    verbs: [create]
+  - nonResourceURLs: [/metrics]
+    verbs: [get]
+  - apiGroups: [authentication.k8s.io]
+    resources: [tokenreviews]
+    verbs: [create]
+  - apiGroups: [authorization.k8s.io]
+    resources: [subjectaccessreviews]
+    verbs: [create]
+  - apiGroups: ['']
+    resources: [namespaces, nodes/metrics]
+    verbs: [get]
+  - apiGroups: ['']
+    resources: [nodes, services, endpoints, pods]
+    verbs: [get, list, watch]
+  - apiGroups: ['']
+    resources: [configmaps]
+    verbs: [get]
+  - apiGroups: [extensions]
+    resources: [thirdpartyresources]
+    verbs: ['*']
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: ['*']
+  - apiGroups: [monitoring.coreos.com]
+    resources: [alertmanagers, prometheuses, prometheuses/finalizers, alertmanagers/finalizers, servicemonitors]
+    verbs: ['*']
+  - apiGroups: [apps]
+    resources: [statefulsets]
+    verbs: ['*']
+  - apiGroups: ['']
+    resources: [configmaps, secrets]
+    verbs: ['*']
+  - apiGroups: ['']
+    resources: [pods]
+    verbs: [list, delete]
+  - apiGroups: ['']
+    resources: [services, endpoints]
+    verbs: [get, create, update]
+  - apiGroups: ['']
+    resources: [nodes]
+    verbs: [list, watch]
+  - apiGroups: ['']
+    resources: [namespaces]
+    verbs: [list]
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: cluster-monitoring-operator
+    namespace: ${NAMESPACE}
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRoleBinding
+  metadata:
+    name: cluster-monitoring-operator
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: cluster-monitoring-operator
+  subjects:
+  - kind: ServiceAccount
+    name: cluster-monitoring-operator
+    namespace: ${NAMESPACE}
 - apiVersion: extensions/v1beta1
   kind: Deployment
   metadata:
@@ -62,6 +182,7 @@ objects:
           k8s-app: cluster-monitoring-operator
           tectonic-app-version-name: tectonic-monitoring
       spec:
+        serviceAccountName: cluster-monitoring-operator
         containers:
         - image: ${OPERATOR_IMAGE}
           name: cluster-monitoring-operator

--- a/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
+++ b/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
@@ -23,13 +23,6 @@
     description: Openshift Monitoring
     node_selector: ""
 
-#TODO Remove need for cluster-admin permission
-- name: Add cluster admin permission
-  command: >
-    {{ openshift_client_binary }} adm policy add-cluster-role-to-user cluster-admin -z default
-    --config={{ mktemp.stdout }}/admin.kubeconfig
-    -n openshift-monitoring
-
 - name: Apply the cluster monitoring operator template
   shell: >
     {{ openshift_client_binary }} process -f "{{ mktemp.stdout 	}}/{{ item }}"


### PR DESCRIPTION
Note: if the role looks like it could be simplified, it is
because it's autogenerated from all the roles that the operator
creates for its subcomponents.

cc: @ironcladlou @brancz @mxinden 