### PR TITLE
Don't install docker-rhel-push-plugin on CentOS

### DIFF
--- a/roles/container_runtime/tasks/package_docker.yml
+++ b/roles/container_runtime/tasks/package_docker.yml
@@ -31,8 +31,21 @@
     state: present
   with_items:
   - "docker{{ '-' + docker_version if docker_version is defined else '' }}"
+  when:
+  - not (openshift_is_atomic | bool)
+  - not (curr_docker_version is skipped)
+  - not (curr_docker_version.stdout != '')
+  register: result
+  until: result is succeeded
+
+- name: Install RHEL-specific Docker Packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
   - docker-rhel-push-plugin
   when:
+  - ansible_distribution == 'RedHat'
   - not (openshift_is_atomic | bool)
   - not (curr_docker_version is skipped)
   - not (curr_docker_version.stdout != '')


### PR DESCRIPTION
The deployment fails on CentOS because the docker-rhel-push-plugin
doesn't exist there. This installs it on RHEL systems only.