### PR TITLE
Upgrade: verify that at least one master is not marked as unschedulable

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -45,7 +45,7 @@
     when:
     - (openshift_pkg_version | default('-0.0', True)).split('-')[1] is version_compare(openshift_upgrade_target, '<')
 
-- name: Fail when openshift version does not meet minium requirement for Origin upgrade
+- name: Fail when openshift version does not meet minimum requirement for Origin upgrade
   fail:
     msg: "This upgrade playbook must be run against OpenShift {{ openshift_upgrade_min }} or later"
   when:

--- a/roles/openshift_sanitize_inventory/tasks/main.yml
+++ b/roles/openshift_sanitize_inventory/tasks/main.yml
@@ -115,3 +115,15 @@
   when:
     - openshift_master_console_port is defined
     - openshift_master_console_port != openshift_master_api_port
+
+- name: At least one master is schedulable
+  fail:
+    msg: >
+      No schedulable masters found, please remove 'openshift_schedulable=False' from all of your masters.
+  when:
+    - l_master_schedulable | length > 0
+    - false in l_master_schedulable
+  vars:
+    l_masters_group: "{{ ('oo_masters_to_config' in groups) | ternary('oo_masters_to_config', 'oo_nodes_to_bootstrap') }}"
+    l_openshift_schedulable: "{{ groups[l_masters_group] | map('extract', hostvars, 'openshift_schedulable') | select('defined') | list }}"
+    l_master_schedulable: "{{ l_openshift_schedulable | map('bool') | list }}"


### PR DESCRIPTION
Pre-upgrade playbook should ensure there are schedulable masters