### PR TITLE
Only install docker-rhel-push-plugin on enterprise

### DIFF
--- a/roles/container_runtime/tasks/package_docker.yml
+++ b/roles/container_runtime/tasks/package_docker.yml
@@ -27,15 +27,18 @@
 # Note: The curr_docker_version.stdout check can be removed when https://github.com/ansible/ansible/issues/33187 gets fixed.
 - name: Install Docker Packages
   package:
-    name: "{{ item }}"
+    name: "{{ item.name }}"
     state: present
   with_items:
-  - "docker{{ '-' + docker_version if docker_version is defined else '' }}"
-  - docker-rhel-push-plugin
+  - name: "docker{{ '-' + docker_version if docker_version is defined else '' }}"
+    install: True
+  - name: docker-rhel-push-plugin
+    install: "{{ openshift_deployment_type == 'openshift-enterprise' }}"
   when:
   - not (openshift_is_atomic | bool)
   - not (curr_docker_version is skipped)
   - not (curr_docker_version.stdout != '')
+  - item['install'] | bool
   register: result
   until: result is succeeded
 


### PR DESCRIPTION
This commit changes docker to only install the rpm
docker-rhel-push-plugin if the openshift_deployment_type
is 'openshift-enterprise'.

This allows us to maintain same install across all
origin distros.