### PR TITLE
[3.7] etcd migrate: skip openshift version check during migration

### DIFF
--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -15,6 +15,8 @@
 - name: Run pre-checks
   hosts: oo_etcd_to_migrate
   tasks:
+  - set_fact:
+      etcd_migration_in_progress: true
   - include_role:
       name: etcd
       tasks_from: migrate.pre_check
@@ -255,5 +257,9 @@
     with_items: "{{ master_services[::-1] }}"
   - fail:
       msg: "Migration failed. The following hosts were not properly migrated: {{ etcd_migration_failed | join(',') }}"
+    when:
+    - etcd_migration_failed | length > 0
+  - set_fact:
+      etcd_migration_in_progress: false
     when:
     - etcd_migration_failed | length > 0

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -191,6 +191,7 @@
     when:
     - not is_containerized | bool
     - openshift_release is defined
+    - etcd_migration_completed is not defined and etcd_migration_in_progress is not defined
     assert:
       that:
       - openshift_version.startswith(openshift_release) | bool


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1565496