### PR TITLE
catalog: use service serving cert  for ctrl mgr & use default prometheus scrape

### DIFF
--- a/roles/openshift_prometheus/templates/prometheus.yml.j2
+++ b/roles/openshift_prometheus/templates/prometheus.yml.j2
@@ -241,25 +241,6 @@ scrape_configs:
     action: keep
     regex: apiserver;https
 
-# Scrape config for Service Catalog controllers
-- job_name: 'catalog-controllers'
-  scheme: https
-  tls_config:
-    server_name: 'controller-manager.kube-service-catalog'
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
-  kubernetes_sd_configs:
-  - role: endpoints
-    namespaces:
-      names:
-      - kube-service-catalog
-
-  relabel_configs:
-  - source_labels: [__meta_kubernetes_service_name]
-    action: keep
-    regex: controller-manager
-
 alerting:
   alertmanagers:
   - scheme: http

--- a/roles/openshift_service_catalog/tasks/generate_certs.yml
+++ b/roles/openshift_service_catalog/tasks/generate_certs.yml
@@ -26,30 +26,11 @@
     path: "{{ generated_certs_dir }}/apiserver.key"
     state: absent
 
-- name: Delete old controllermanager.crt
-  file:
-    path: "{{ generated_certs_dir }}/controllermanager.crt"
-    state: absent
-
-- name: Delete old controllermanager.key
-  file:
-    path: "{{ generated_certs_dir }}/controllermanager.key"
-    state: absent
-
 - name: Generating API Server keys
   oc_adm_ca_server_cert:
     cert: "{{ generated_certs_dir }}/apiserver.crt"
     key: "{{ generated_certs_dir }}/apiserver.key"
     hostnames: "apiserver.kube-service-catalog.svc,apiserver.kube-service-catalog.svc.cluster.local,apiserver.kube-service-catalog"
-    signer_cert: "{{ generated_certs_dir }}/ca.crt"
-    signer_key: "{{ generated_certs_dir }}/ca.key"
-    signer_serial: "{{ generated_certs_dir }}/apiserver.serial.txt"
-
-- name: Generating Controller Manager keys
-  oc_adm_ca_server_cert:
-    cert: "{{ generated_certs_dir }}/controllermanager.crt"
-    key: "{{ generated_certs_dir }}/controllermanager.key"
-    hostnames: "controller-manager.kube-service-catalog.svc,controller-manager.kube-service-catalog.svc.cluster.local,controller-manager.kube-service-catalog"
     signer_cert: "{{ generated_certs_dir }}/ca.crt"
     signer_key: "{{ generated_certs_dir }}/ca.key"
     signer_serial: "{{ generated_certs_dir }}/apiserver.serial.txt"
@@ -64,17 +45,6 @@
       path: "{{ generated_certs_dir }}/apiserver.crt"
     - name: tls.key
       path: "{{ generated_certs_dir }}/apiserver.key"
-
-- name: Create controllermanager-ssl secret
-  oc_secret:
-    state: present
-    name: controllermanager-ssl
-    namespace: kube-service-catalog
-    files:
-    - name: tls.crt
-      path: "{{ generated_certs_dir }}/controllermanager.crt"
-    - name: tls.key
-      path: "{{ generated_certs_dir }}/controllermanager.key"
 
 - slurp:
     src: "{{ generated_certs_dir }}/ca.crt"

--- a/roles/openshift_service_catalog/tasks/install.yml
+++ b/roles/openshift_service_catalog/tasks/install.yml
@@ -187,6 +187,10 @@
     name: controller-manager
     namespace: kube-service-catalog
     state: present
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: controllermanager-ssl
+      prometheus.io/scrape: "true"
+      prometheus.io/scheme: https
     ports:
     - name: secure
       port: 443


### PR DESCRIPTION
background in https://github.com/openshift/openshift-ansible/pull/7681#pullrequestreview-110966957

two issues:
1) Use the annotation serving-cert-secret-name to create ssl cert and key. 
2) We don't need a custom prometheus scrape config, instead just add annotations to our service and use the default service endpoint scrape config.

This PR backs off changes from https://github.com/openshift/openshift-ansible/pull/7681.  It matches changes for cluster up in https://github.com/openshift/origin/pull/19286

I have not changed the Catalog API Server cert creation over to this method but I did create https://github.com/openshift/openshift-ansible/issues/7924 for tracking.