### PR TITLE
Revert docker-rhel-push-plugin

### DIFF
--- a/roles/container_runtime/tasks/package_docker.yml
+++ b/roles/container_runtime/tasks/package_docker.yml
@@ -25,20 +25,14 @@
 # Make sure Docker is installed, but does not update a running version.
 # Docker upgrades are handled by a separate playbook.
 # Note: The curr_docker_version.stdout check can be removed when https://github.com/ansible/ansible/issues/33187 gets fixed.
-- name: Install Docker Packages
+- name: Install Docker
   package:
-    name: "{{ item.name }}"
+    name: "docker{{ '-' + docker_version if docker_version is defined else '' }}"
     state: present
-  with_items:
-  - name: "docker{{ '-' + docker_version if docker_version is defined else '' }}"
-    install: True
-  - name: docker-rhel-push-plugin
-    install: "{{ openshift_deployment_type == 'openshift-enterprise' }}"
   when:
   - not (openshift_is_atomic | bool)
   - not (curr_docker_version is skipped)
   - not (curr_docker_version.stdout != '')
-  - item['install'] | bool
   register: result
   until: result is succeeded
 


### PR DESCRIPTION
This package is already a dependency of the docker
package in rhel, we don't need to install it explicitly.