### PR TITLE
Fix registry x509 SAN omit placeholder

### DIFF
--- a/roles/lib_openshift/library/oc_adm_ca_server_cert.py
+++ b/roles/lib_openshift/library/oc_adm_ca_server_cert.py
@@ -1583,8 +1583,7 @@ class CAServerCert(OpenShiftCLI):
     def run_ansible(params, check_mode):
         '''run the idempotent ansible code'''
 
-        # Filter non-strings from hostnames list s.t. the omit filter
-        # may be used to conditionally add a hostname.
+        # Filter non-strings from hostnames list (Such as boolean: False)
         params['hostnames'] = [host for host in params['hostnames'] if isinstance(host, string_types)]
 
         config = CAServerCertConfig(params['kubeconfig'],
@@ -1630,7 +1629,6 @@ class CAServerCert(OpenShiftCLI):
 
         return {'failed': True,
                 'msg': 'Unknown state passed. %s' % state}
-
 
 # -*- -*- -*- End included fragment: class/oc_adm_ca_server_cert.py -*- -*- -*-
 

--- a/roles/lib_openshift/src/class/oc_adm_ca_server_cert.py
+++ b/roles/lib_openshift/src/class/oc_adm_ca_server_cert.py
@@ -95,8 +95,7 @@ class CAServerCert(OpenShiftCLI):
     def run_ansible(params, check_mode):
         '''run the idempotent ansible code'''
 
-        # Filter non-strings from hostnames list s.t. the omit filter
-        # may be used to conditionally add a hostname.
+        # Filter non-strings from hostnames list (Such as boolean: False)
         params['hostnames'] = [host for host in params['hostnames'] if isinstance(host, string_types)]
 
         config = CAServerCertConfig(params['kubeconfig'],
@@ -142,4 +141,3 @@ class CAServerCert(OpenShiftCLI):
 
         return {'failed': True,
                 'msg': 'Unknown state passed. %s' % state}
-

--- a/roles/openshift_hosted/tasks/secure.yml
+++ b/roles/openshift_hosted/tasks/secure.yml
@@ -31,7 +31,7 @@
     - "{{ docker_registry_route.results[0].spec.host }}"
     - "{{ openshift_hosted_registry_name }}.default.svc"
     - "{{ openshift_hosted_registry_name }}.default.svc.{{ openshift_cluster_domain }}"
-    - "{{ openshift_hosted_registry_routehost | default(omit) }}"
+    - "{{ openshift_hosted_registry_routehost | default(False) }}"
     cert: "{{ docker_registry_cert_path }}"
     key: "{{ docker_registry_key_path }}"
     expire_days: "{{ openshift_hosted_registry_cert_expire_days }}"


### PR DESCRIPTION
Currently, custom module oc_adm_ca_server_cert
does not correctly filter out "omit" type from a
list of potential hostnames to add to the x509 SAN
list.

This commit changes the 'omit' placeholder to 'False'
(minus quotes) boolean type to ensure it is filtered
correctly.

Fixes: https://github.com/openshift/openshift-ansible/issues/7923