### PR TITLE
always add es and es-ops hostname to the es server cert

### DIFF
--- a/roles/openshift_logging/files/generate-jks.sh
+++ b/roles/openshift_logging/files/generate-jks.sh
@@ -159,6 +159,11 @@ fi
 dir=$1
 SCRATCH_DIR=$dir
 PROJECT=${2:-logging}
+# these must already be comma delimited
+MORE_ES_NAMES=${3:-}
+escomma=${MORE_ES_NAMES:+,}
+MORE_ES_OPS_NAMES=${4:-}
+esopscomma=${MORE_ES_OPS_NAMES:+,}
 
 if [[ ! -f $dir/system.admin.jks || -z "$(keytool -list -keystore $dir/system.admin.jks -storepass kspass | grep sig-ca)" ]]; then
   generate_JKS_client_cert "system.admin"
@@ -169,7 +174,7 @@ if [[ ! -f $dir/elasticsearch.jks || -z "$(keytool -list -keystore $dir/elastics
 fi
 
 if [[ ! -f $dir/logging-es.jks || -z "$(keytool -list -keystore $dir/logging-es.jks -storepass kspass | grep sig-ca)" ]]; then
-  generate_JKS_chain false logging-es "$(join , logging-es{,-ops}{,-cluster}{,.${PROJECT}.svc.cluster.local})"
+  generate_JKS_chain false logging-es "$(join , logging-es{,-ops}{,-cluster}{,.${PROJECT}.svc.cluster.local})"${escomma}${MORE_ES_NAMES}${esopscomma}${MORE_ES_OPS_NAMES}
 fi
 
 [ ! -f $dir/truststore.jks ] && createTruststore

--- a/roles/openshift_logging/tasks/generate_jks.yaml
+++ b/roles/openshift_logging/tasks/generate_jks.yaml
@@ -64,7 +64,7 @@
   when: not elasticsearch_jks.stat.exists or not logging_es_jks.stat.exists or not system_admin_jks.stat.exists or not truststore_jks.stat.exists
 
 - name: Run JKS generation script
-  local_action: script generate-jks.sh {{local_tmp.stdout}} {{openshift_logging_namespace}}
+  local_action: script generate-jks.sh {{local_tmp.stdout}} {{openshift_logging_namespace}} {{openshift_logging_es_hostname | default()}} {{openshift_logging_es_ops_hostname | default()}}
   check_mode: no
   become: false
   when: not elasticsearch_jks.stat.exists or not logging_es_jks.stat.exists or not system_admin_jks.stat.exists or not truststore_jks.stat.exists


### PR DESCRIPTION
This will add X509v3 Subject Alternative Name items to the Elasticsearch
server cert like this:

    DNS:es.openshift.public.host, DNS:es-ops.openshift.public.host

This allows external Elasticsearch clients using client cert auth
and the Elasticsearch service using externalIPs to be able to turn
on cert verification.