### PR TITLE
[release-3.7] Set efs provisioner image version to latest

### DIFF
--- a/roles/openshift_provisioners/defaults/main.yaml
+++ b/roles/openshift_provisioners/defaults/main.yaml
@@ -15,4 +15,4 @@ openshift_provisioners_image_prefix_dict:
 
 openshift_provisioners_image_version_dict:
   origin: "latest"
-  openshift-enterprise: "{{ openshift_image_tag }}"
+  openshift-enterprise: "latest"


### PR DESCRIPTION
As you can refer to https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/openshift3/efs-provisioner , there are no tag like `v3.7.23` ,`v3.7`, since `v3.6`.