### PR TITLE
Disable mount propagation feature

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -629,6 +629,7 @@ def build_controller_args(facts):
                                   'cloudprovider')
     if 'master' in facts:
         controller_args = {}
+        controller_args['feature-gates'] = ['MountPropagation=false']
         if 'cloudprovider' in facts:
             if 'kind' in facts['cloudprovider']:
                 if facts['cloudprovider']['kind'] == 'aws':
@@ -652,6 +653,7 @@ def build_api_server_args(facts):
                                   'cloudprovider')
     if 'master' in facts:
         api_server_args = {}
+        api_server_args['feature-gates'] = ['MountPropagation=false']
         if 'cloudprovider' in facts:
             if 'kind' in facts['cloudprovider']:
                 if facts['cloudprovider']['kind'] == 'aws':

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -47,6 +47,10 @@ openshift_node_env_vars: {}
 l_node_kubelet_node_labels: "{{ openshift_node_labels | default({}) | lib_utils_oo_dict_to_keqv_list }}"
 
 openshift_node_kubelet_args_dict:
+  feature-gates:
+  - "MountPropagation=false"
+
+openshift_node_kubelet_cloudprovider_arg_dict:
   aws:
     cloud-provider:
     - aws
@@ -80,7 +84,7 @@ openshift_node_kubelet_args_dict:
   undefined:
     node-labels: "{{ l_node_kubelet_node_labels }}"
 
-l_node_kubelet_args_default: "{{ openshift_node_kubelet_args_dict[openshift_cloudprovider_kind | default('undefined')] }}"
+l_node_kubelet_args_default: "{{ openshift_node_kubelet_args_dict | combine(openshift_node_kubelet_cloudprovider_arg_dict[openshift_cloudprovider_kind | default('undefined')], recursive=True) }}"
 
 l_openshift_node_kubelet_args: "{{ openshift_node_kubelet_args | default({}) }}"
 # Combine the default kubelet_args dictionary (based on cloud provider, if provided)
@@ -89,6 +93,7 @@ l_openshift_node_kubelet_args: "{{ openshift_node_kubelet_args | default({}) }}"
 # are present in both.
 l2_openshift_node_kubelet_args: "{{ l_node_kubelet_args_default | combine(l_openshift_node_kubelet_args, recursive=True) }}"
 openshift_node_dnsmasq_install_network_manager_hook: true
+
 
 # lo must always be present in this list or dnsmasq will conflict with
 # the node's dns service.


### PR DESCRIPTION
We need to disable mount propagation feature in openshift-ansible for
now becaue it breaks private mounts. We are changing
the defaults in upstream to revert the feature to old behaviour

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1565625

