### PR TITLE
Label all-in-one cluster as compute=true

### DIFF
--- a/roles/openshift_manage_node/tasks/set_default_node_role.yml
+++ b/roles/openshift_manage_node/tasks/set_default_node_role.yml
@@ -36,3 +36,13 @@
           - key: node-role.kubernetes.io/compute
             value: 'true'
       with_items: "{{ non_master_non_infra_nodes_result.results.results.0['items'] | map(attribute='metadata') | map(attribute='name') | list }}"
+
+    - name: Label all-in-one master as a compute node
+      oc_label:
+        name: '{{ openshift.node.nodename }}'
+        kind: node
+        state: add
+        labels:
+          - key: node-role.kubernetes.io/compute
+            value: 'true'
+      when: groups['oo_nodes_to_config'] | default([]) | union(groups['oo_nodes_to_bootstrap'] | default([])) | union(groups['oo_masters_to_config']) | length == 1


### PR DESCRIPTION
If there is just one node and one master (all-in-one cluster) the node should be labelled as compute

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1567025

TODO:
* [x] Fix GCP test