### PR TITLE
Remove obsolete openshift_docker_disable_push_dockerhub

### DIFF
--- a/inventory/byo/hosts.example
+++ b/inventory/byo/hosts.example
@@ -104,8 +104,6 @@ openshift_release=v3.7
 #openshift_docker_additional_registries=registry.example.com
 #openshift_docker_insecure_registries=registry.example.com
 #openshift_docker_blocked_registries=registry.hacker.com
-# Disable pushing to dockerhub
-#openshift_docker_disable_push_dockerhub=True
 # Use Docker inside a System Container. Note that this is a tech preview and should
 # not be used to upgrade!
 # The following options for docker are ignored:

--- a/roles/docker/tasks/package_docker.yml
+++ b/roles/docker/tasks/package_docker.yml
@@ -114,7 +114,6 @@
       {% if docker_log_driver is defined  %} --log-driver {{ docker_log_driver }}{% endif %} \
       {% if docker_log_options is defined %} {{ docker_log_options |  oo_split() | oo_prepend_strings_in_list('--log-opt ') | join(' ')}}{% endif %} \
       {% if docker_options is defined %} {{ docker_options }}{% endif %} \
-      {% if docker_disable_push_dockerhub is defined %} --confirm-def-push={{ docker_disable_push_dockerhub | bool }}{% endif %} \
       --signature-verification={{ openshift_docker_signature_verification | bool }}'"
   when: docker_check.stat.isreg is defined and docker_check.stat.isreg
   notify:


### PR DESCRIPTION
This option no longer has any effect other than to crash
docker.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1564076
(cherry picked from commit 9695722c94a9d17c41d391d0f7bfbb424a84c67f)