### PR TITLE
Don't always update dbus but do restart dbus if dnsmasq changed

### DIFF
--- a/roles/openshift_node/tasks/dnsmasq_install.yml
+++ b/roles/openshift_node/tasks/dnsmasq_install.yml
@@ -12,22 +12,23 @@
 
 - when: not openshift_is_atomic | bool
   block:
-  - name: Ensure dbus is updated before installing dnsmasq
-    package:
-      name: dbus
-      state: latest
-    register: dbus_update
-  - name: Restart dbus if it was updated
-    systemd:
-      name: dbus
-      state: restarted
-    when: dbus_update | changed
   - name: Install dnsmasq
     package:
       name: dnsmasq
       state: installed
     register: result
     until: result is succeeded
+  # This works around https://bugzilla.redhat.com/show_bug.cgi?id=1550582
+  - name: Restart dbus and systemd-logind if dnsmasq was installed
+    systemd:
+      name: "{{ item }}"
+      state: restarted
+    when: result is changed
+    with_items:
+    - dbus
+    - systemd-logind
+    register: dbussvcs_restart
+  - wait_for_connection:
 
 - name: ensure origin/node directory exists
   file:


### PR DESCRIPTION
It's been observed that restarting dbus causes systemd-logind to hang.
So to ensure that upgrades are protected from that problem only restart
dbus and systemd-logind if the dnsmasq package changed