### PR TITLE
Don't attempt to set context on non existant paths

### DIFF
--- a/roles/container_runtime/tasks/package_crio.yml
+++ b/roles/container_runtime/tasks/package_crio.yml
@@ -70,11 +70,6 @@
     dest: /etc/sysconfig/crio-network
     src: crio-network.j2
 
-- name: Fixup SELinux permissions for docker
-  shell: |
-          semanage fcontext -a -e /var/lib/docker/overlay2 /var/lib/containers/overlay2
-          restorecon -R -v /var/lib/containers/overlay2
-
 - name: Start the CRI-O service
   systemd:
     name: "cri-o"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1564840

Corrects problem introduced in https://github.com/openshift/openshift-ansible/pull/7466