### PR TITLE
filter_plugins: handle lazy loaded hostvars

### DIFF
--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -3,6 +3,7 @@
 '''
 Custom filters for use in openshift-master
 '''
+import collections
 import copy
 import sys
 
@@ -483,7 +484,8 @@ class FilterModule(object):
     @staticmethod
     def certificates_to_synchronize(hostvars, include_keys=True, include_ca=True):
         ''' Return certificates to synchronize based on facts. '''
-        if not issubclass(type(hostvars), dict):
+        if not issubclass(type(hostvars), dict) \
+                and not issubclass(type(hostvars), collections.Mapping):
             raise errors.AnsibleFilterError("|failed expects hostvars is a dict")
         certs = ['admin.crt',
                  'admin.key',


### PR DESCRIPTION
Ensure that the openshift_master.py filter plugin handles ansible 2.4
and 2.5 hostvars gracefully.

This is required due to the changes introduced in ansible via changes in
ansible/ansible#35913.

Resolves: #7596