### PR TITLE
Update the docker-registry CA symlink on nodes during upgrade

### DIFF
--- a/roles/openshift_gcp/tasks/setup_scale_group_facts.yml
+++ b/roles/openshift_gcp/tasks/setup_scale_group_facts.yml
@@ -31,7 +31,7 @@
   add_host:
     name: "{{ hostvars[item].gce_name }}"
     groups: nodes, new_nodes
-    openshift_node_bootstrap: False
+    openshift_node_bootstrap: "{{ openshift_node_bootstrap | default(True) }}"
   with_items: "{{ groups['tag_ocp-node'] | default([]) | difference(groups['tag_ocp-bootstrap'] | default([])) }}"
 
 - name: Add bootstrap node instances

--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -60,14 +60,12 @@
     src: bootstrap.yml.j2
     dest: /root/openshift_bootstrap/bootstrap.yml
 
-- name: symlink master ca for docker-registry
+- name: Create a symlink to the node client CA for the docker registry
   file:
-    src: "{{ item }}"
-    dest: "/etc/docker/certs.d/docker-registry.default.svc:5000/{{ item | basename }}"
+    src: "{{ openshift_node_config_dir }}/client-ca.crt"
+    dest: "/etc/docker/certs.d/docker-registry.default.svc:5000/node-client-ca.crt"
     state: link
     force: yes
-  with_items:
-  - "{{ openshift_node_config_dir }}/client-ca.crt"
 
 - name: Remove default node-config.yaml to allow bootstrapping config
   file:

--- a/roles/openshift_node/tasks/upgrade/bootstrap_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/bootstrap_changes.yml
@@ -1,25 +1,4 @@
 ---
-- name: Update node-config to prepare for bootstrapping
-  yedit:
-    src: "{{ openshift.common.config_base }}/node/node-config.yaml"
-    edits:
-    - key: servingInfo.certFile
-      value: ""
-    - key: servingInfo.keyFile
-      value: ""
-    - key: kubeletArguments.bootstrap-kubeconfig
-      value:
-      - "{{ openshift.common.config_base }}/node/bootstrap.kubeconfig"
-    - key: kubeletArguments.rotate-certificates
-      value:
-      - "true"
-    - key: kubeletArguments.cert-dir
-      value:
-      - "{{ openshift.common.config_base }}/node/certificates"
-    - key: kubeletArguments.feature-gates
-      value:
-      - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-
 - name: Check for existing node-config.yaml
   stat:
     path: "{{ openshift.common.config_base }}/node/node-config.yaml"
@@ -42,6 +21,7 @@
     - "{{ openshift.common.config_base }}/node"
     patterns:
     - system*.kubeconfig
+    - node.kubeconfig
   register: system_kubeconfigs
 
 - name: Copy existing credentials to bootstrap credentials
@@ -53,7 +33,7 @@
     owner: root
     group: root
     mode: 0600
-  with_items: "{{ system_kubeconfigs.files | default([]) | map(attribute='path') | list + [openshift.common.config_base+'/node/node.kubeconfig'] }}"
+  with_items: "{{ system_kubeconfigs.files | default([]) | map(attribute='path') | list }}"
 
 - name: Remove non-bootstrap configuration
   file:
@@ -62,6 +42,31 @@
   with_items:
   - "{{ openshift.common.config_base }}/node/node.kubeconfig"
   - "{{ openshift.common.config_base }}/node/node-config.yaml"
+
+- name: Update node-config to prepare for bootstrapping
+  yedit:
+    src: "{{ openshift.common.config_base }}/node/bootstrap-node-config.yaml"
+    edits:
+    - key: servingInfo.certFile
+      value: ""
+    - key: servingInfo.clientCA
+      value: client-ca.crt
+    - key: servingInfo.keyFile
+      value: ""
+    - key: kubeletArguments.bootstrap-kubeconfig
+      value:
+      - "{{ openshift.common.config_base }}/node/bootstrap.kubeconfig"
+    - key: kubeletArguments.rotate-certificates
+      value:
+      - "true"
+    - key: kubeletArguments.cert-dir
+      value:
+      - "{{ openshift.common.config_base }}/node/certificates"
+    - key: kubeletArguments.feature-gates
+      value:
+      - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
+    - key: masterKubeConfig
+      value: node.kubeconfig
 
 - name: Use the admin.kubeconfig for the kubelet bootstrap identity
   copy:

--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -12,6 +12,13 @@
     state: directory
     mode: 0755
 
+- name: Update the docker-registry CA symlink
+  file:
+    src: "{{ openshift_node_config_dir }}/client-ca.crt"
+    dest: "/etc/docker/certs.d/docker-registry.default.svc:5000/node-client-ca.crt"
+    state: link
+    force: yes
+
 - name: Update node-config for static pods
   yedit:
     src: "{{ openshift.common.config_base }}/node/node-config.yaml"

--- a/roles/openshift_node_group/tasks/upgrade.yml
+++ b/roles/openshift_node_group/tasks/upgrade.yml
@@ -8,6 +8,8 @@
       value: ""
     - key: servingInfo.keyFile
       value: ""
+    - key: servingInfo.clientCA
+      value: "client-ca.crt"
     - key: kubeletArguments.pod-manifest-path
       value:
       - /etc/origin/node/pods
@@ -23,6 +25,8 @@
     - key: kubeletArguments.cert-dir
       value:
       - /etc/origin/node/certificates
+    - key: masterKubeConfig
+      value: node.kubeconfig
     openshift_node_group_labels: "{{ node_group.labels | default([]) }}"
   with_items: "{{ openshift_node_groups }}"
   loop_control:


### PR DESCRIPTION
Change the target name to be consistent with 3.9 while updating the
source name to be consistent with upstream.