### PR TITLE
vsphere workaround to bypass cloud-provider ingressIPNetworkCIDR check

### DIFF
--- a/roles/openshift_master/tasks/update-vsphere.yml
+++ b/roles/openshift_master/tasks/update-vsphere.yml
@@ -8,12 +8,14 @@
       - "{{ openshift.common.config_base }}/cloudprovider/vsphere.conf"
     - key: kubernetesMasterConfig.controllerArguments.cloud-provider
       value:
+      - ""
       - vsphere
     - key: kubernetesMasterConfig.apiServerArguments.cloud-config
       value:
       - "{{ openshift.common.config_base }}/cloudprovider/vsphere.conf"
     - key: kubernetesMasterConfig.apiServerArguments.cloud-provider
       value:
+      - ""
       - vsphere
   notify:
   - restart master controllers

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -56,6 +56,7 @@ openshift_node_kubelet_args_dict:
     node-labels: "{{ l_node_kubelet_node_labels }}"
   vsphere:
     cloud-provider:
+    - ""
     - vsphere
     cloud-config:
     - "{{ openshift_config_base ~ '/cloudprovider/vsphere.conf' }}"


### PR DESCRIPTION
This allows the user to configure the ingressIPNetworkCIDR parameter and bypass the check that openshift does to disable it's usage when using a cloud provider. The vsphere cloud provider does not offer IP allocation, thus this check serves no purpose there.

Addresses https://github.com/openshift/origin/issues/19252

This is a PR against the release-3.9 branch as hopefully OpenShift 3.10 will address the issue properly.