### PR TITLE
WIP fixes for 3.9 to 3.10 upgrade

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -98,32 +98,33 @@
   - block:
     - block:
       - name: Remove packages
-        package: name={{ item }} state=absent
-        with_items:
-        - atomic-openshift
-        - atomic-openshift-clients
-        - atomic-openshift-excluder
-        - atomic-openshift-docker-excluder
-        - atomic-openshift-node
-        - atomic-openshift-sdn-ovs
-        - cockpit-bridge
-        - cockpit-docker
-        - cockpit-system
-        - cockpit-ws
-        - kubernetes-client
-        - openshift
-        - openshift-node
-        - openshift-sdn
-        - openshift-sdn-ovs
-        - openvswitch
-        - origin
-        - origin-excluder
-        - origin-docker-excluder
-        - origin-clients
-        - origin-node
-        - origin-sdn-ovs
-        - tuned-profiles-atomic-openshift-node
-        - tuned-profiles-origin-node
+        package: name={{ node_pkgs | join(',') }} state=absent
+        vars:
+          node_pkgs:
+          - atomic-openshift
+          - atomic-openshift-clients
+          - atomic-openshift-excluder
+          - atomic-openshift-docker-excluder
+          - atomic-openshift-node
+          - atomic-openshift-sdn-ovs
+          - cockpit-bridge
+          - cockpit-docker
+          - cockpit-system
+          - cockpit-ws
+          - kubernetes-client
+          - openshift
+          - openshift-node
+          - openshift-sdn
+          - openshift-sdn-ovs
+          - openvswitch
+          - origin
+          - origin-excluder
+          - origin-docker-excluder
+          - origin-clients
+          - origin-node
+          - origin-sdn-ovs
+          - tuned-profiles-atomic-openshift-node
+          - tuned-profiles-origin-node
         register: result
         until: result is succeeded
 
@@ -361,27 +362,28 @@
     - atomic-openshift-master
 
   - name: Remove packages
-    package: name={{ item }} state=absent
+    package: name={{ master_pkgs | join (',') }} state=absent
     when: not openshift_is_atomic | bool and openshift_remove_all | default(True) | bool
-    with_items:
-    - atomic-openshift
-    - atomic-openshift-clients
-    - atomic-openshift-excluder
-    - atomic-openshift-docker-excluder
-    - atomic-openshift-master
-    - cockpit-bridge
-    - cockpit-docker
-    - cockpit-system
-    - cockpit-ws
-    - corosync
-    - kubernetes-client
-    - openshift
-    - openshift-master
-    - origin
-    - origin-clients
-    - origin-excluder
-    - origin-docker-excluder
-    - origin-master
+    vars:
+      master_pkgs:
+      - atomic-openshift
+      - atomic-openshift-clients
+      - atomic-openshift-excluder
+      - atomic-openshift-docker-excluder
+      - atomic-openshift-master
+      - cockpit-bridge
+      - cockpit-docker
+      - cockpit-system
+      - cockpit-ws
+      - corosync
+      - kubernetes-client
+      - openshift
+      - openshift-master
+      - origin
+      - origin-clients
+      - origin-excluder
+      - origin-docker-excluder
+      - origin-master
     register: result
     until: result is succeeded
 
@@ -496,7 +498,6 @@
     when: not openshift_is_atomic | bool and openshift_remove_all | default(True) | bool
     with_items:
     - etcd
-    - etcd3
     register: result
     until: result is succeeded
 

--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -494,10 +494,10 @@
     failed_when: false
 
   - name: Remove packages
-    package: name={{ item }} state=absent
+    package:
+      name: etcd
+      state: absent
     when: not openshift_is_atomic | bool and openshift_remove_all | default(True) | bool
-    with_items:
-    - etcd
     register: result
     until: result is succeeded
 
@@ -553,10 +553,10 @@
     - firewalld
 
   - name: Remove packages
-    package: name={{ item }} state=absent
+    package:
+      name: haproxy
+      state: absent
     when: not openshift_is_atomic | bool and openshift_remove_all | default(True) | bool
-    with_items:
-    - haproxy
     register: result
     until: result is succeeded
 

--- a/playbooks/gcp/openshift-cluster/build_base_image.yml
+++ b/playbooks/gcp/openshift-cluster/build_base_image.yml
@@ -134,20 +134,23 @@
     command: subscription-manager repos --enable="rhel-7-server-rpms" --enable="rhel-7-server-extras-rpms"
     when: using_rhel_subscriptions
   - name: Install common image prerequisites
-    package: name={{ item }} state=latest
-    with_items:
-    # required by Ansible
-    - PyYAML
-    - google-compute-engine
-    - google-compute-engine-init
-    - google-config
-    - wget
-    - git
-    - net-tools
-    - bind-utils
-    - iptables-services
-    - bridge-utils
-    - bash-completion
+    package:
+      name: "{{ img_prereqs | join(',) }}"
+      state: latest
+    vars:
+      - img_prereqs:
+        # required by Ansible
+        - PyYAML
+        - google-compute-engine
+        - google-compute-engine-init
+        - google-config
+        - wget
+        - git
+        - net-tools
+        - bind-utils
+        - iptables-services
+        - bridge-utils
+        - bash-completion
   - name: Clean yum metadata
     command: yum clean all
     args:

--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -56,6 +56,9 @@
     failed_when:
     - l_pb_upgrade_control_plane_pre_upgrade_storage.rc != 0
     - openshift_upgrade_pre_storage_migration_fatal | default(true) | bool
+    until: l_pb_upgrade_control_plane_pre_upgrade_storage is succeeded
+    retries: 2
+    delay: 30
 
 # Set openshift_master_facts separately. In order to reconcile
 # admission_config's, we currently must run openshift_master_facts and

--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -37,6 +37,16 @@
   roles:
   - openshift_facts
   tasks:
+  - name: Wait for first master go Ready
+    oc_obj:
+      state: list
+      kind: node
+      name: "{{ openshift.node.nodename | lower }}"
+    register: node_output
+    until: node_output.results.returncode == 0 and node_output.results.results[0].status.conditions | selectattr('type', 'match', '^Ready$') | map(attribute='status') | join | bool == True
+    # Give the node two minutes to come back online.
+    retries: 24
+    delay: 5
   - name: Upgrade all storage
     command: >
       {{ openshift_client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig

--- a/roles/cockpit/tasks/main.yml
+++ b/roles/cockpit/tasks/main.yml
@@ -3,13 +3,16 @@
   import_tasks: firewall.yml
 
 - name: Install cockpit-ws
-  package: name={{ item }} state=present
-  with_items:
-    - cockpit-ws
-    - cockpit-system
-    - cockpit-bridge
-    - cockpit-docker
-    - "{{ cockpit_plugins }}"
+  package:
+    name: "{{ cockpit_pkgs | join(',') }}"
+    state: present
+  vars:
+    - cockpit_pkgs:
+      - cockpit-ws
+      - cockpit-system
+      - cockpit-bridge
+      - cockpit-docker
+      - "{{ cockpit_plugins }}"
   when: not openshift_is_containerized | bool
   register: result
   until: result is succeeded

--- a/roles/nuage_master/tasks/main.yaml
+++ b/roles/nuage_master/tasks/main.yaml
@@ -132,6 +132,5 @@
 - name: Restart daemons
   command: /bin/true
   notify:
-    - restart master api
-    - restart master controllers
+    - restart master
   ignore_errors: true

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -118,7 +118,6 @@ default_r_openshift_node_image_prep_packages:
 - ansible
 - bash-completion
 - docker
-- haproxy
 - dnsmasq
 - ntp
 - logrotate

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -128,7 +128,6 @@ default_r_openshift_node_image_prep_packages:
 - libselinux-python
 - conntrack-tools
 - openssl
-- cloud-init
 - iproute
 - python-dbus
 - PyYAML

--- a/roles/openshift_node/tasks/install_rpms.yml
+++ b/roles/openshift_node/tasks/install_rpms.yml
@@ -1,9 +1,8 @@
 ---
 - name: install needed rpm(s)
   package:
-    name: "{{ item }}"
+    name: "{{ r_openshift_node_image_prep_packages | join(',') }}"
     state: present
-  with_items: "{{ r_openshift_node_image_prep_packages }}"
   register: result
   until: result is succeeded
   when: not (openshift_is_atomic | default(False) | bool)


### PR DESCRIPTION
Outstanding problems for simple 3.9 RPM -> 3.10 static pod config on RHEL7, 2 masters, 3 etcd, 3 nodes.
 - [ ] Second master's node fails to go online, copying /etc/cni/net.d from first master makes it go ready
 - [ ] /opt/cni/bin is empty on both first and second master
 - [ ] Storage migration fails after control plane `https://ose3-master.example.com:8443/apis/servicecatalog.k8s.io/v1beta1 404`
