### PR TITLE
Remove deprecated networkPluginName from node config template

### DIFF
--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -28,11 +28,6 @@ masterClientConnectionOverrides:
   burst: 200
   qps: 100
 masterKubeConfig: system:node:{{ openshift.common.hostname | lower }}.kubeconfig
-{% if openshift_node_use_openshift_sdn | bool %}
-networkPluginName: {{ openshift_node_sdn_network_plugin_name }}
-{% endif %}
-# networkConfig struct introduced in origin 1.0.6 and OSE 3.0.2 which
-# deprecates networkPluginName above. The two should match.
 networkConfig:
    mtu: {{ openshift.node.sdn_mtu }}
 {% if openshift_node_use_openshift_sdn | bool or openshift_node_use_nuage | bool or openshift_node_use_contiv | bool or openshift_node_use_kuryr | bool or openshift_node_sdn_network_plugin_name == 'cni' %}


### PR DESCRIPTION
multiple `networkPluginName`s are set for compatibility since long time ago - https://github.com/openshift/openshift-ansible/pull/544. Current version should only support `networkPluginName` under `networkConfig`.  In fact [roles/openshift_node_group/templates/node-config.yaml.j2](https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_node_group/templates/node-config.yaml.j2) adds only one `networkPluginName`.

Since this creates confusion and redundant configuration, this patch
remove the duplicated `networkPluginName` from node.yaml template.