### PR TITLE
Add bootstrap and join to node scaleup

### DIFF
--- a/playbooks/openshift-node/scaleup.yml
+++ b/playbooks/openshift-node/scaleup.yml
@@ -36,4 +36,6 @@
     l_openshift_version_set_hosts: "oo_nodes_to_config:!oo_first_master"
     l_openshift_version_check_hosts: "oo_nodes_to_config"
 
+- import_playbook: private/bootstrap.yml
+- import_playbook: private/join.yml
 - import_playbook: private/config.yml


### PR DESCRIPTION
Without the bootstrap and join tasks, the new nodes won't be configured
properly and added to the cluster on scaleup.

Fixes #7946