### PR TITLE
Set OpenStack VM hostname to the entry in Nova

### DIFF
--- a/roles/openshift_openstack/defaults/main.yml
+++ b/roles/openshift_openstack/defaults/main.yml
@@ -69,6 +69,7 @@ openshift_openstack_cns_hostname: cns
 openshift_openstack_node_hostname: app-node
 openshift_openstack_lb_hostname: lb
 openshift_openstack_etcd_hostname: etcd
+openshift_openstack_set_hostname_to_compute_name: true
 openshift_openstack_keypair_name: openshift
 openshift_openstack_lb_flavor: "{{ openshift_openstack_default_flavor }}"
 openshift_openstack_etcd_flavor: "{{ openshift_openstack_default_flavor }}"

--- a/roles/openshift_openstack/tasks/node-configuration.yml
+++ b/roles/openshift_openstack/tasks/node-configuration.yml
@@ -1,9 +1,10 @@
 ---
 # NOTE(shadower): we need to do this because some of the install tasks seem to
 # ignore openshift_hostname and rely on the actual system's hostname
-- name: Update hostname to openshift_hostname
+- name: Update hostname to match the OpenStack name
   hostname:
-    name: "{{ openshift_hostname }}"
+    name: "{{ inventory_hostname }}"
+  when: openshift_openstack_set_hostname_to_compute_name
 
 - name: "Verify SELinux is enforcing"
   fail:

--- a/roles/openshift_openstack/tasks/node-configuration.yml
+++ b/roles/openshift_openstack/tasks/node-configuration.yml
@@ -1,4 +1,10 @@
 ---
+# NOTE(shadower): we need to do this because some of the install tasks seem to
+# ignore openshift_hostname and rely on the actual system's hostname
+- name: Update hostname to openshift_hostname
+  hostname:
+    name: "{{ openshift_hostname }}"
+
 - name: "Verify SELinux is enforcing"
   fail:
     msg: "SELinux is required for OpenShift and has been detected as '{{ ansible_selinux.config_mode }}'"


### PR DESCRIPTION
OpenStack appends a domain suffix (`.novalocal` by default) to the
hostnames of the VMs it creates. This clashes with the new control plane
install tasks that look at the hostname rather than the
`openshift_hostname` variable.

This makes the OpenStack playbooks function again with the new control
plane/bootstrap installation.