### PR TITLE
[3.9] etcd: rework r_etcd_common_etcdctl_command

### DIFF
--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -16,7 +16,11 @@ etcd_image: "{{ etcd_image_dict[openshift_deployment_type | default('origin')] }
 # etcd run on a host => use etcdctl command directly
 # etcd run as a docker container => use docker exec
 # etcd run as a runc container => use runc exec
-r_etcd_common_etcdctl_command: "{{ 'etcdctl' if r_etcd_common_etcd_runtime == 'host' | bool else 'docker exec etcd_container etcdctl' if r_etcd_common_etcd_runtime == 'docker' else 'runc exec etcd etcdctl' }}"
+etcdctl_dict:
+  host: 'etcdctl'
+  docker: 'docker exec etcd_container etcdctl'
+  runc: 'runc exec etcd etcdctl'
+r_etcd_common_etcdctl_command: "{{ etcdctl_dict[r_etcd_common_etcd_runtime | default('host')] }}"
 
 # etcd server vars
 etcd_conf_dir: '/etc/etcd'


### PR DESCRIPTION
Use a dictionary-based approach to determine `etcdctl` command instead of complicated `if`s

A fix for master branch is in #7802 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1566238