### PR TITLE
Support both direct Octavia and Neutron lbaasv2

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -314,6 +314,14 @@ Put this in your `inventory/group_vars/all.yml`:
 This will create two load balancers: one for the API and UI console and the
 other for the OpenShift router. Each will have its own public IP address.
 
+This playbook defaults to using OpenStack Octavia as its LBaaSv2 provider:
+
+    openshift_openstack_lbaasv2_provider: Octavia
+
+If your cloud uses the deprecated Neutron LBaaSv2 provider set:
+
+    openshift_openstack_lbaasv2_provider: "Neutron::LBaaS"
+
 ### VM-based Load Balancer
 
 If you can't use OpenStack's LBaaS, we can create and configure a virtual

--- a/roles/openshift_openstack/defaults/main.yml
+++ b/roles/openshift_openstack/defaults/main.yml
@@ -13,6 +13,7 @@ openshift_openstack_dns_nameservers: []
 openshift_openstack_nodes_to_remove: []
 
 openshift_openstack_use_lbaas_load_balancer: false
+openshift_openstack_lbaasv2_provider: Octavia
 openshift_openstack_use_vm_load_balancer: false
 
 openshift_openstack_cluster_node_labels:

--- a/roles/openshift_openstack/library/os_service_catalog.py
+++ b/roles/openshift_openstack/library/os_service_catalog.py
@@ -1,0 +1,177 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# pylint: disable=unused-wildcard-import,wildcard-import,unused-import,redefined-builtin
+
+''' os_service_catalog_facts '''
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    import shade
+    HAS_SHADE = True
+except ImportError:
+    HAS_SHADE = False
+
+DOCUMENTATION = '''
+---
+module: os_service_catalog_facts
+short_description: Retrieve OpenStack service catalog facts
+description:
+    - Retrieves all the available OpenStack services
+notes:
+    - This module creates a new top-level C(openstack_service_catalog) fact
+      which contains a dictionary of OpenStack service endpoints like
+      network and load-balancers.
+author:
+    - "Antoni Segura Puimedon <antoni@redhat.com>"
+'''
+
+RETURN = '''
+openstack_service_catalog:
+    description: OpenStack available services.
+    type: dict
+    returned: always
+    sample:
+      alarming:
+      - adminURL: http://172.16.0.9:8042
+        id: 2c40b50da0bb44178db91c8a9a29a46e
+        internalURL: http://172.16.0.9:8042
+        publicURL: https://mycloud.org:13042
+        region: regionOne
+      cloudformation:
+      - adminURL: http://172.16.0.9:8000/v1
+        id: 46648eded04e463281a9cba7ddcc45cb
+        internalURL: http://172.16.0.9:8000/v1
+        publicURL: https://mycloud.org:13005/v1
+        region: regionOne
+      compute:
+      - adminURL: http://172.16.0.9:8774/v2.1
+        id: bff1bc5dd92842c281b2358a6d15c5bc
+        internalURL: http://172.16.0.9:8774/v2.1
+        publicURL: https://mycloud.org:13774/v2.1
+        region: regionOne
+      event:
+      - adminURL: http://172.16.0.9:8779
+        id: 608ac3666ef24f2e8f240785b8612efb
+        internalURL: http://172.16.0.9:8779
+        publicURL: https://mycloud.org:13779
+        region: regionOne
+      identity:
+      - adminURL: https://mycloud.org:35357
+        id: 4d07689ce46b4d51a01cc873bc772c80
+        internalURL: http://172.16.0.9:5000
+        publicURL: https://mycloud.org:13000
+        region: regionOne
+      image:
+      - adminURL: http://172.16.0.9:9292
+        id: 1850105115ea493eb65f3f704d421291
+        internalURL: http://172.16.0.9:9292
+        publicURL: https://mycloud.org:13292
+        region: regionOne
+      metering:
+      - adminURL: http://172.16.0.9:8777
+        id: 4cae4dcabe0a4914a6ec6dabd62490ba
+        internalURL: http://172.16.0.9:8777
+        publicURL: https://mycloud.org:13777
+        region: regionOne
+      metric:
+      - adminURL: http://172.16.0.9:8041
+        id: 29bcecf9a06f40f782f19dd7492af352
+        internalURL: http://172.16.0.9:8041
+        publicURL: https://mycloud.org:13041
+        region: regionOne
+      network:
+      - adminURL: http://172.16.0.9:9696
+        id: 5d5785c9b8174c21bfb19dc3b16c87fa
+        internalURL: http://172.16.0.9:9696
+        publicURL: https://mycloud.org:13696
+        region: regionOne
+      object-store:
+      - adminURL: http://172.17.0.9:8080
+        id: 031f1e342fdf4f25b6099d1f3b0847e3
+        internalURL: http://172.17.0.9:8080/v1/AUTH_6d2847d6a6414308a67644eefc7b98c7
+        publicURL: https://mycloud.org:13808/v1/AUTH_6d2847d6a6414308a67644eefc7b98c7
+        region: regionOne
+      orchestration:
+      - adminURL: http://172.16.0.9:8004/v1/6d2847d6a6414308a67644eefc7b98c7
+        id: 1e6cecbd15b3413d9411052c52b9d433
+        internalURL: http://172.16.0.9:8004/v1/6d2847d6a6414308a67644eefc7b98c7
+        publicURL: https://mycloud.org:13004/v1/6d2847d6a6414308a67644eefc7b98c7
+        region: regionOne
+      placement:
+      - adminURL: http://172.16.0.9:8778/placement
+        id: 1f2551e5450c4bd6a9f716f92e93a154
+        internalURL: http://172.16.0.9:8778/placement
+        publicURL: https://mycloud.org:13778/placement
+        region: regionOne
+      volume:
+      - adminURL: http://172.16.0.9:8776/v1/6d2847d6a6414308a67644eefc7b98c7
+        id: 38e369a0e17346fe8e37a20146e005ef
+        internalURL: http://172.16.0.9:8776/v1/6d2847d6a6414308a67644eefc7b98c7
+        publicURL: https://mycloud.org:13776/v1/6d2847d6a6414308a67644eefc7b98c7
+        region: regionOne
+      volumev2:
+      - adminURL: http://172.16.0.9:8776/v2/6d2847d6a6414308a67644eefc7b98c7
+        id: 113a0bff9f2347b6b8774407a1c8d572
+        internalURL: http://172.16.0.9:8776/v2/6d2847d6a6414308a67644eefc7b98c7
+        publicURL: https://mycloud.org:13776/v2/6d2847d6a6414308a67644eefc7b98c7
+        region: regionOne
+      volumev3:
+      - adminURL: http://172.16.0.9:8776/v3/6d2847d6a6414308a67644eefc7b98c7
+        id: 9982c0afd28941a19feb1ffb13b91daf
+        internalURL: http://172.16.0.9:8776/v3/6d2847d6a6414308a67644eefc7b98c7
+        publicURL: https://mycloud.org:13776/v3/6d2847d6a6414308a67644eefc7b98c7
+        region: regionOne
+'''
+
+
+def main():
+    ''' Main module function '''
+    module = AnsibleModule(argument_spec={}, supports_check_mode=True)
+
+    if not HAS_SHADE:
+        module.fail_json(msg='shade is required for this module')
+
+    try:
+        cloud = shade.openstack_cloud()
+    # pylint: disable=broad-except
+    except Exception:
+        module.fail_json(msg='Failed to connect to the cloud')
+
+    try:
+        sc = cloud.cloud_config.get_service_catalog()
+    # pylint: disable=broad-except
+    except Exception:
+        module.fail_json(msg='Failed to retrieve the service catalog')
+
+    try:
+        endpoints = sc.get_endpoints()
+    # pylint: disable=broad-except
+    except Exception:
+        module.fail_json(msg='Failed to retrieve the service catalog '
+                         'endpoints')
+
+    module.exit_json(
+        changed=False,
+        ansible_facts={'openstack_service_catalog': endpoints})
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/openshift_openstack/library/os_service_catalog.py
+++ b/roles/openshift_openstack/library/os_service_catalog.py
@@ -156,13 +156,13 @@ def main():
         module.fail_json(msg='Failed to connect to the cloud')
 
     try:
-        sc = cloud.cloud_config.get_service_catalog()
+        service_catalog = cloud.cloud_config.get_service_catalog()
     # pylint: disable=broad-except
     except Exception:
         module.fail_json(msg='Failed to retrieve the service catalog')
 
     try:
-        endpoints = sc.get_endpoints()
+        endpoints = service_catalog.get_endpoints()
     # pylint: disable=broad-except
     except Exception:
         module.fail_json(msg='Failed to retrieve the service catalog '

--- a/roles/openshift_openstack/tasks/check-prerequisites.yml
+++ b/roles/openshift_openstack/tasks/check-prerequisites.yml
@@ -21,17 +21,20 @@
 - name: Check for Neutron trunk support
   os_network_extensions:
 
+# Gather OpenStack service catalog endpoint facts
+- name: Check for cloud service catalog endpoints
+  os_service_catalog:
+
 # Check trunk support
 - fail:
     msg: "Trunk ports enabled but support lacking in Neutron"
   when: (use_trunk_ports | default(False)) and
         ('trunk' not in openstack_network_extensions)
 
-# Check lbaasv2 support
+# Check Kuryr has LBaaSv2 available
 - fail:
-    msg: "Kuryr enabled but lacking required lbaasv2 support in Neutron"
-  when: (openshift_use_kuryr | default(False)) and
-        ('lbaasv2' not in openstack_network_extensions)
+    msg: "Kuryr enabled but OpenStack LBaaS is not."
+  when: openshift_use_kuryr | default(False) and not openshift_openstack_use_lbaas_load_balancer
 
 # Check jmespath
 - name: Try to import python module shade
@@ -111,3 +114,11 @@
   when:
   - openshift_openstack_use_lbaas_load_balancer
   - openshift_openstack_use_vm_load_balancer
+
+- name: Check LBaaS Load Balancer providers
+  fail:
+    msg: >
+      Your configured openshift_openstack_lbaasv2_provider is not supported
+      by your cloud.
+  when: (openshift_openstack_use_lbaas_load_balancer and openshift_openstack_lbaasv2_provider == 'Neutron::LBaaS' and 'lbaasv2' not in openstack_network_extensions) or
+        (openshift_openstack_use_lbaas_load_balancer and openshift_openstack_lbaasv2_provider == 'Octavia' and 'load-balancer' not in openstack_service_catalog)

--- a/roles/openshift_openstack/tasks/check-prerequisites.yml
+++ b/roles/openshift_openstack/tasks/check-prerequisites.yml
@@ -31,11 +31,6 @@
   when: (use_trunk_ports | default(False)) and
         ('trunk' not in openstack_network_extensions)
 
-# Check Kuryr has LBaaSv2 available
-- fail:
-    msg: "Kuryr enabled but OpenStack LBaaS is not."
-  when: openshift_use_kuryr | default(False) and not openshift_openstack_use_lbaas_load_balancer
-
 # Check jmespath
 - name: Try to import python module shade
   command: python -c "import jmespath"

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -114,7 +114,7 @@ resources:
 # NOTE: With Kuryr, the load balancer is necessary.
 {% if openshift_openstack_use_lbaas_load_balancer or (openshift_use_kuryr|default(false)|bool and not openshift_openstack_provider_network_name) %}
   api_lb:
-    type: OS::Neutron::LBaaS::LoadBalancer
+    type: OS::{{ openshift_openstack_lbaasv2_provider }}::LoadBalancer
     properties:
       name:
         str_replace:
@@ -129,7 +129,7 @@ resources:
 {% endif %}
 
   api_lb_listener:
-    type: OS::Neutron::LBaaS::Listener
+    type: OS::{{ openshift_openstack_lbaasv2_provider }}::Listener
     properties:
       name:
         str_replace:
@@ -144,7 +144,7 @@ resources:
 {% if openshift_use_kuryr|default(false)|bool and openshift_master_api_port|default(8443) != 443 %}
   # 443 listener for pod access. In non-kuryr envs handled by iptables
   internal_api_lb_listener:
-    type: OS::Neutron::LBaaS::Listener
+    type: OS::{{ openshift_openstack_lbaasv2_provider }}::Listener
     properties:
       name:
         str_replace:
@@ -158,7 +158,7 @@ resources:
 {% endif %}
 
   api_lb_pool:
-    type: OS::Neutron::LBaaS::Pool
+    type: OS::{{ openshift_openstack_lbaasv2_provider }}::Pool
     properties:
       name:
         str_replace:
@@ -943,7 +943,7 @@ resources:
 
 
   router_lb:
-    type: OS::Neutron::LBaaS::LoadBalancer
+    type: OS::{{ openshift_openstack_lbaasv2_provider }}::LoadBalancer
     properties:
       vip_subnet: { get_resource: subnet }
 
@@ -961,14 +961,14 @@ resources:
       port_id: { get_attr: [router_lb, vip_port_id] }
 
   router_lb_listener_http:
-    type: OS::Neutron::LBaaS::Listener
+    type: OS::{{ openshift_openstack_lbaasv2_provider }}::Listener
     properties:
       protocol: HTTP
       protocol_port: 80
       loadbalancer: { get_resource: router_lb }
 
   router_lb_pool_http:
-    type: OS::Neutron::LBaaS::Pool
+    type: OS::{{ openshift_openstack_lbaasv2_provider }}::Pool
     properties:
       # TODO(shadower): Make this configurable?
       lb_algorithm: ROUND_ROBIN
@@ -976,14 +976,14 @@ resources:
       listener: { get_resource: router_lb_listener_http }
 
   router_lb_listener_https:
-    type: OS::Neutron::LBaaS::Listener
+    type: OS::{{ openshift_openstack_lbaasv2_provider }}::Listener
     properties:
       protocol: HTTPS
       protocol_port: 443
       loadbalancer: { get_resource: router_lb }
 
   router_lb_pool_https:
-    type: OS::Neutron::LBaaS::Pool
+    type: OS::{{ openshift_openstack_lbaasv2_provider }}::Pool
     properties:
       # TODO(shadower): Make this configurable?
       lb_algorithm: ROUND_ROBIN

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -139,6 +139,23 @@ resources:
       loadbalancer: { get_resource: api_lb }
       protocol: HTTPS
       protocol_port: {{ openshift_master_api_port }}
+      default_pool: { get_resource: api_lb_pool }
+
+{% if openshift_use_kuryr|default(false)|bool and openshift_master_api_port|default(8443) != 443 %}
+  # 443 listener for pod access. In non-kuryr envs handled by iptables
+  internal_api_lb_listener:
+    type: OS::Neutron::LBaaS::Listener
+    properties:
+      name:
+        str_replace:
+          template: openshift-ansible-cluster_id-api-lb-internal-listener
+          params:
+            cluster_id: {{ openshift_openstack_full_dns_domain }}
+      loadbalancer: { get_resource: api_lb }
+      protocol: HTTPS
+      protocol_port: 443
+      default_pool: { get_resource: api_lb_pool }
+{% endif %}
 
   api_lb_pool:
     type: OS::Neutron::LBaaS::Pool
@@ -151,7 +168,7 @@ resources:
       protocol: HTTPS
       # TODO(shadower): Make this configurable?
       lb_algorithm: ROUND_ROBIN
-      listener: { get_resource: api_lb_listener }
+      loadbalancer: { get_resource: api_lb }
 {% endif %}
 
 {% if not openshift_openstack_provider_network_name %}

--- a/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
@@ -339,7 +339,9 @@ resources:
       pool: { get_param: api_lb_pool }
       protocol_port: {{ openshift_master_api_port }}
       address: { get_attr: [server, first_address]}
+{% if openshift_openstack_lbaasv2_provider != "Octavia"  %}
       subnet: { get_param: subnet }
+{% endif %}
 
   router_lb_pool_member_http:
     condition:

--- a/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
@@ -332,7 +332,7 @@ resources:
 
 
   api_lb_member:
-    type: OS::Neutron::LBaaS::PoolMember
+    type: OS::{{ openshift_openstack_lbaasv2_provider }}::PoolMember
     condition:
       not: {equals: [{get_param: api_lb_pool}, ""]}
     properties:
@@ -344,7 +344,7 @@ resources:
   router_lb_pool_member_http:
     condition:
       not: {equals: [{get_param: router_lb_pool_http}, ""]}
-    type: OS::Neutron::LBaaS::PoolMember
+    type: OS::{{ openshift_openstack_lbaasv2_provider }}::PoolMember
     properties:
       pool: { get_param: router_lb_pool_http }
       protocol_port: 80
@@ -354,7 +354,7 @@ resources:
   router_lb_pool_member_https:
     condition:
       not: {equals: [{get_param: router_lb_pool_https}, ""]}
-    type: OS::Neutron::LBaaS::PoolMember
+    type: OS::{{ openshift_openstack_lbaasv2_provider }}::PoolMember
     properties:
       pool: { get_param: router_lb_pool_https }
       protocol_port: 443


### PR DESCRIPTION
Supports non-proxied Octavia as well as deprecated Neutron LBaaSv2 and make the necessary prerequisite checks.

TODO: library/os_network_endpoints.py that will make a fact of a list of endpoint data.