### PR TITLE
Fix wrong handler name masters

### DIFF
--- a/roles/openshift_control_plane/tasks/bootstrap_settings.yml
+++ b/roles/openshift_control_plane/tasks/bootstrap_settings.yml
@@ -9,6 +9,4 @@
     - key: kubernetesMasterConfig.controllerArguments.cluster-signing-key-file
       value:
       - /etc/origin/master/ca.key
-  notify:
-  - restart master controllers
-  - restart master api
+  notify: restart master

--- a/roles/openshift_control_plane/tasks/update-vsphere.yml
+++ b/roles/openshift_control_plane/tasks/update-vsphere.yml
@@ -15,6 +15,4 @@
     - key: kubernetesMasterConfig.apiServerArguments.cloud-provider
       value:
       - vsphere
-  notify:
-  - restart master controllers
-  - restart master api
+  notify: restart master


### PR DESCRIPTION
This commit updates handler to account for new handler
in openshift_control_plane.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1567579