### PR TITLE
Bug 1567767 - openshift_logging : Run JKS generation script failed

### DIFF
--- a/roles/openshift_logging/files/generate-jks.sh
+++ b/roles/openshift_logging/files/generate-jks.sh
@@ -159,11 +159,29 @@ fi
 dir=$1
 SCRATCH_DIR=$dir
 PROJECT=${2:-logging}
+
+MORE_ES_NAMES=
+escomma=
 # these must already be comma delimited
-MORE_ES_NAMES=${3:-}
-escomma=${MORE_ES_NAMES:+,}
-MORE_ES_OPS_NAMES=${4:-}
-esopscomma=${MORE_ES_OPS_NAMES:+,}
+if [ -n "${3:-}" ] ; then
+    if echo "${3:-}" | egrep -q '^[0-9]|[.][0-9]' ; then
+        echo invalid ES hostname $3 - skipping adding to subject alt name
+    else
+        MORE_ES_NAMES=${3:-}
+        escomma=${MORE_ES_NAMES:+,}
+    fi
+fi
+
+MORE_ES_OPS_NAMES=
+esopscomma=
+if [ -n "${4:-}" ] ; then
+    if echo "${4:-}" | egrep -q '^[0-9]|[.][0-9]' ; then
+        echo invalid ES ops hostname $4 - skipping adding to subject alt name
+    else
+        MORE_ES_OPS_NAMES=${4:-}
+        esopscomma=${MORE_ES_OPS_NAMES:+,}
+    fi
+fi
 
 if [[ ! -f $dir/system.admin.jks || -z "$(keytool -list -keystore $dir/system.admin.jks -storepass kspass | grep sig-ca)" ]]; then
   generate_JKS_client_cert "system.admin"

--- a/roles/openshift_logging/tasks/generate_jks.yaml
+++ b/roles/openshift_logging/tasks/generate_jks.yaml
@@ -1,5 +1,35 @@
 ---
 # check if pod generated files exist -- if they all do don't run the pod
+- when:
+    - openshift_logging_es_allow_external | default(False)
+    - openshift_logging_es_hostname | default('') | regex_search('^[0-9]|[.][0-9]')
+  block:
+    - name: Report invalid external Elasticsearch hostnames for conclusion
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_logging:
+            message: "Elasticsearch external hostname {{ openshift_logging_es_hostname }} contains invalid characters for certificate subject Alt Name.  Not adding to Elasticsearch certificate."
+
+    - name: Report invalid external Elasticsearch hostnames
+      debug:
+        msg: "Elasticsearch external hostname {{ openshift_logging_es_hostname }} contains invalid characters for certificate subject Alt Name.  Not adding to Elasticsearch certificate."
+
+- when:
+    - openshift_logging_es_ops_allow_external | default(False)
+    - openshift_logging_es_ops_hostname | default('') | regex_search('^[0-9]|[.][0-9]')
+  block:
+    - name: Report invalid external Elasticsearch ops hostnames for conclusion
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_logging:
+            message: "Elasticsearch external ops hostname {{ openshift_logging_es_ops_hostname }} contains invalid characters for certificate subject Alt Name.  Not adding to Elasticsearch certificate."
+
+    - name: Report invalid external Elasticsearch ops hostnames
+      debug:
+        msg: "Elasticsearch external hostname {{ openshift_logging_es_ops_hostname }} contains invalid characters for certificate subject Alt Name.  Not adding to Elasticsearch certificate."
+
 - name: Checking for elasticsearch.jks
   stat: path="{{generated_certs_dir}}/elasticsearch.jks"
   register: elasticsearch_jks


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1567767
Hostnames or hostname components beginning with a digit are not
allowed to be a DNS item in a certificate subjectAltName.  If
such hostnames are presented as Elasticsearch hostnames, ops and
non-ops, then issue a warning, and exclude them from the Elasticsearch
server certificate subjectAltName.