### PR TITLE
Updating to use existing logging facts over role defaults if available

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -14,8 +14,8 @@ openshift_logging_image_pull_secret: ""
 openshift_logging_es5_techpreview: False
 
 openshift_logging_curator_default_days: 30
-openshift_logging_curator_run_hour: 0
-openshift_logging_curator_run_minute: 0
+openshift_logging_curator_run_hour: 3
+openshift_logging_curator_run_minute: 30
 openshift_logging_curator_run_timezone: UTC
 openshift_logging_curator_timeout: 300
 openshift_logging_curator_script_log_level: INFO

--- a/roles/openshift_logging/filter_plugins/openshift_logging.py
+++ b/roles/openshift_logging/filter_plugins/openshift_logging.py
@@ -79,6 +79,16 @@ def entry_from_named_pair(register_pairs, key):
     raise RuntimeError("There was no entry found in the dict that had an item with a name that matched {}".format(key))
 
 
+def entry_from_name_value_pair(key_value_dict, key, key_label='name', value_label='value'):
+    ''' Returns the entry in key given results provided by register_pairs '''
+    for key_value in key_value_dict:
+        name = key_value.get(key_label)
+        if name == key:
+            return key_value[value_label]
+    # pylint: disable=line-too-long, too-few-format-args
+    raise RuntimeError("There was no entry found in the dict that had an item with a name that matched {}:{}".format(key_label).format(key))
+
+
 def serviceaccount_name(qualified_sa):
     ''' Returns the simple name from a fully qualified name '''
     return qualified_sa.split(":")[-1]
@@ -126,6 +136,7 @@ class FilterModule(object):
         return {
             'random_word': random_word,
             'entry_from_named_pair': entry_from_named_pair,
+            'entry_from_name_value_pair': entry_from_name_value_pair,
             'min_cpu': min_cpu,
             'es_storage': es_storage,
             'serviceaccount_name': serviceaccount_name,

--- a/roles/openshift_logging/library/openshift_logging_facts.py
+++ b/roles/openshift_logging/library/openshift_logging_facts.py
@@ -38,7 +38,8 @@ LOGGING_INFRA_KEY = "logging-infra"
 DS_FLUENTD_SELECTOR = LOGGING_INFRA_KEY + "=" + "fluentd"
 LOGGING_SELECTOR = LOGGING_INFRA_KEY + "=" + "support"
 ROUTE_SELECTOR = "component=support,logging-infra=support,provider=openshift"
-COMPONENTS = ["kibana", "curator", "elasticsearch", "fluentd", "kibana_ops", "curator_ops", "elasticsearch_ops"]
+# pylint: disable=line-too-long
+COMPONENTS = ["kibana", "curator", "elasticsearch", "fluentd", "kibana_ops", "curator_ops", "elasticsearch_ops", "mux", "eventrouter"]
 
 
 class OCBaseCommand(object):
@@ -136,15 +137,15 @@ class OpenshiftLoggingFacts(OCBaseCommand):
             name = ds_item["metadata"]["name"]
             comp = self.comp(name)
             spec = ds_item["spec"]["template"]["spec"]
-            container = spec["containers"][0]
             result = dict(
                 selector=ds_item["spec"]["selector"],
-                image=container["image"],
-                resources=container["resources"],
+                containers=dict(),
                 nodeSelector=spec["nodeSelector"],
                 serviceAccount=spec["serviceAccount"],
                 terminationGracePeriodSeconds=spec["terminationGracePeriodSeconds"]
             )
+            for container in spec["containers"]:
+                result["containers"][container["name"]] = container
             self.add_facts_for(comp, "daemonsets", name, result)
 
     def facts_for_pvcs(self, namespace):
@@ -309,6 +310,10 @@ class OpenshiftLoggingFacts(OCBaseCommand):
             return "elasticsearch"
         elif name.startswith("logging-fluentd") or name.endswith("aggregated-logging-fluentd"):
             return "fluentd"
+        elif name.startswith("logging-mux"):
+            return "mux"
+        elif name.startswith("logging-eventrouter"):
+            return "eventrouter"
         else:
             return None
 

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -304,6 +304,10 @@
     openshift_logging_curator_cpu_request: "{{ openshift_logging_curator_ops_cpu_request }}"
     openshift_logging_curator_memory_limit: "{{ openshift_logging_curator_ops_memory_limit }}"
     openshift_logging_curator_nodeselector: "{{ openshift_logging_curator_ops_nodeselector }}"
+    openshift_logging_curator_default_days: "{{ openshift_logging_curator_ops_default_days | default() }}"
+    openshift_logging_curator_run_hour: "{{ openshift_logging_curator_ops_run_hour | default() }}"
+    openshift_logging_curator_run_minute: "{{ openshift_logging_curator_ops_run_minute | default() }}"
+    openshift_logging_curator_run_timezone: "{{ openshift_logging_curator_ops_run_timezone | default() }}"
   when:
   - openshift_logging_use_ops | bool
 

--- a/roles/openshift_logging/tasks/set_defaults_from_current.yml
+++ b/roles/openshift_logging/tasks/set_defaults_from_current.yml
@@ -11,24 +11,236 @@
 ##  but fall back to using the value from a configmap as a default. If neither is set
 ##  then the variable remains undefined and the role default will be used.
 
-- conditional_set_fact:
+
+# Elasticsearch
+- when: openshift_logging_facts['elasticsearch']['configmaps']['logging-elasticsearch'] is defined
+  conditional_set_fact:
     facts: "{{ openshift_logging_facts['elasticsearch']['configmaps']['logging-elasticsearch']['elasticsearch.yml'] | flatten_dict }}"
     vars:
       __openshift_logging_es_number_of_shards: index.number_of_shards
       __openshift_logging_es_number_of_replicas: index.number_of_replicas
-  when: openshift_logging_facts['elasticsearch']['configmaps']['logging-elasticsearch'] is defined
 
-- conditional_set_fact:
+- when: openshift_logging_facts['elasticsearch']['deploymentconfigs'].keys() | count > 0
+  block:
+    - set_fact:
+        __es_dc_name: "{{ openshift_logging_facts['elasticsearch']['deploymentconfigs'].keys()[0] }}"
+
+    - set_fact:
+        __openshift_logging_es_recover_after_time: "{{ openshift_logging_facts['elasticsearch']['deploymentconfigs'][__es_dc_name]['containers']['elasticsearch']['env'] | entry_from_name_value_pair('RECOVER_AFTER_TIME') }}"
+
+    - conditional_set_fact:
+        facts: "{{ openshift_logging_facts['elasticsearch']['deploymentconfigs'][__es_dc_name]['containers'] | flatten_dict }}"
+        vars:
+          __openshift_logging_elasticsearch_cpu_limit: elasticsearch.resources.limits.cpu
+          __openshift_logging_elasticsearch_memory_limit: elasticsearch.resources.limits.memory
+          __openshift_logging_elasticsearch_cpu_request: elasticsearch.resources.requests.cpu
+          __openshift_logging_elasticsearch_proxy_cpu_request: proxy.resources.requests.cpu
+          __openshift_logging_elasticsearch_proxy_memory_limit: proxy.resources.limits.memory
+
+
+# Elasticsearch Ops
+- when: openshift_logging_facts['elasticsearch_ops']['configmaps']['logging-elasticsearch-ops'] is defined
+  conditional_set_fact:
     facts: "{{ openshift_logging_facts['elasticsearch_ops']['configmaps']['logging-elasticsearch-ops']['elasticsearch.yml'] | flatten_dict }}"
     vars:
       __openshift_logging_es_ops_number_of_shards: index.number_of_shards
       __openshift_logging_es_ops_number_of_replicas: index.number_of_replicas
-  when: openshift_logging_facts['elasticsearch_ops']['configmaps']['logging-elasticsearch-ops'] is defined
 
+- when: openshift_logging_facts['elasticsearch_ops']['deploymentconfigs'].keys() | count > 0
+  block:
+    - set_fact:
+        __es_dc_name: "{{ openshift_logging_facts['elasticsearch_ops']['deploymentconfigs'].keys()[0] }}"
+
+    - set_fact:
+        __openshift_logging_es_ops_recover_after_time: "{{ openshift_logging_facts['elasticsearch_ops']['deploymentconfigs'][__es_dc_name]['containers']['elasticsearch']['env'] | entry_from_name_value_pair('RECOVER_AFTER_TIME') }}"
+
+    - conditional_set_fact:
+        facts: "{{ openshift_logging_facts['elasticsearch_ops']['deploymentconfigs'][__es_dc_name]['containers'] | flatten_dict }}"
+        vars:
+          __openshift_logging_es_ops_cpu_limit: elasticsearch.resources.limits.cpu
+          __openshift_logging_es_ops_memory_limit: elasticsearch.resources.limits.memory
+          __openshift_logging_es_ops_cpu_request: elasticsearch.resources.requests.cpu
+          __openshift_logging_es_ops_proxy_cpu_request: proxy.resources.requests.cpu
+          __openshift_logging_es_ops_proxy_memory_limit: proxy.resources.limits.memory
+
+
+# Kibana
+- when: openshift_logging_facts['kibana']['deploymentconfigs']['logging-kibana'] is defined
+  conditional_set_fact:
+    facts: "{{ openshift_logging_facts['kibana']['deploymentconfigs']['logging-kibana']['containers'] | flatten_dict }}"
+    vars:
+      __openshift_logging_kibana_cpu_limit: kibana.resources.limits.cpu
+      __openshift_logging_kibana_cpu_request: kibana.resources.requests.cpu
+      __openshift_logging_kibana_memory_limit: kibana.resources.limits.memory
+      __openshift_logging_kibana_proxy_cpu_limit: kibana.resources.limits.cpu
+      __openshift_logging_kibana_proxy_cpu_request: kibana-proxy.resources.requests.cpu
+      __openshift_logging_kibana_proxy_memory_limit: kibana-proxy.resources.limits.memory
+
+
+# Kibana Ops
+- when: openshift_logging_facts['kibana_ops']['deploymentconfigs']['logging-kibana-ops'] is defined
+  conditional_set_fact:
+    facts: "{{ openshift_logging_facts['kibana_ops']['deploymentconfigs']['logging-kibana-ops']['containers'] | flatten_dict }}"
+    vars:
+      __openshift_logging_kibana_ops_cpu_limit: kibana.resources.limits.cpu
+      __openshift_logging_kibana_ops_cpu_request: kibana.resources.requests.cpu
+      __openshift_logging_kibana_ops_memory_limit: kibana.resources.limits.memory
+      __openshift_logging_kibana_ops_proxy_cpu_limit: kibana.resources.limits.cpu
+      __openshift_logging_kibana_ops_proxy_cpu_request: kibana-proxy.resources.requests.cpu
+      __openshift_logging_kibana_ops_proxy_memory_limit: kibana-proxy.resources.limits.memory
+
+
+# Curator
+- when: openshift_logging_facts['curator']['deploymentconfigs']['logging-curator'] is defined
+  block:
+    - set_fact:
+        __openshift_logging_curator_default_days: "{{ openshift_logging_facts['curator']['deploymentconfigs']['logging-curator']['containers']['curator']['env'] | entry_from_name_value_pair('CURATOR_DEFAULT_DAYS') }}"
+        __openshift_logging_curator_run_hour: "{{ openshift_logging_facts['curator']['deploymentconfigs']['logging-curator']['containers']['curator']['env'] | entry_from_name_value_pair('CURATOR_RUN_HOUR') }}"
+        __openshift_logging_curator_run_minute: "{{ openshift_logging_facts['curator']['deploymentconfigs']['logging-curator']['containers']['curator']['env'] | entry_from_name_value_pair('CURATOR_RUN_MINUTE') }}"
+        __openshift_logging_curator_run_timezone: "{{ openshift_logging_facts['curator']['deploymentconfigs']['logging-curator']['containers']['curator']['env'] | entry_from_name_value_pair('CURATOR_RUN_TIMEZONE') }}"
+
+    - conditional_set_fact:
+        facts: "{{ openshift_logging_facts['curator']['deploymentconfigs']['logging-curator']['containers'] | flatten_dict }}"
+        vars:
+          __openshift_logging_curator_cpu_limit: curator.resources.limits.cpu
+          __openshift_logging_curator_memory_limit: curator.resources.limits.memory
+          __openshift_logging_curator_cpu_request: curator.resources.requests.cpu
+
+
+# Curator Ops
+- when: openshift_logging_facts['curator_ops']['deploymentconfigs']['logging-curator-ops'] is defined
+  block:
+    - set_fact:
+        __openshift_logging_curator_ops_default_days: "{{ openshift_logging_facts['curator_ops']['deploymentconfigs']['logging-curator-ops']['containers']['curator']['env'] | entry_from_name_value_pair('CURATOR_DEFAULT_DAYS') }}"
+        __openshift_logging_curator_ops_run_hour: "{{ openshift_logging_facts['curator_ops']['deploymentconfigs']['logging-curator-ops']['containers']['curator']['env'] | entry_from_name_value_pair('CURATOR_RUN_HOUR') }}"
+        __openshift_logging_curator_ops_run_minute: "{{ openshift_logging_facts['curator_ops']['deploymentconfigs']['logging-curator-ops']['containers']['curator']['env'] | entry_from_name_value_pair('CURATOR_RUN_MINUTE') }}"
+        __openshift_logging_curator_ops_run_timezone: "{{ openshift_logging_facts['curator_ops']['deploymentconfigs']['logging-curator-ops']['containers']['curator']['env'] | entry_from_name_value_pair('CURATOR_RUN_TIMEZONE') }}"
+
+    - conditional_set_fact:
+        facts: "{{ openshift_logging_facts['curator_ops']['deploymentconfigs']['logging-curator-ops']['containers'] | flatten_dict }}"
+        vars:
+          __openshift_logging_curator_ops_cpu_limit: curator.resources.limits.cpu
+          __openshift_logging_curator_ops_memory_limit: curator.resources.limits.memory
+          __openshift_logging_curator_ops_cpu_request: curator.resources.requests.cpu
+
+
+# Fluentd
+- when: openshift_logging_facts['fluentd']['daemonsets']['logging-fluentd'] is defined
+  block:
+    - set_fact:
+        __openshift_logging_fluentd_file_buffer_limit: "{{ openshift_logging_facts['fluentd']['daemonsets']['logging-fluentd']['containers']['fluentd-elasticsearch']['env'] | entry_from_name_value_pair('FILE_BUFFER_LIMIT') }}"
+        __openshift_logging_fluentd_buffer_queue_limit: "{{ openshift_logging_facts['fluentd']['daemonsets']['logging-fluentd']['containers']['fluentd-elasticsearch']['env'] | entry_from_name_value_pair('BUFFER_QUEUE_LIMIT') }}"
+        __openshift_logging_fluentd_buffer_size_limit: "{{ openshift_logging_facts['fluentd']['daemonsets']['logging-fluentd']['containers']['fluentd-elasticsearch']['env'] | entry_from_name_value_pair('BUFFER_SIZE_LIMIT') }}"
+
+    - conditional_set_fact:
+        facts: "{{ openshift_logging_facts['fluentd']['daemonsets']['logging-fluentd']['containers'] | flatten_dict }}"
+        vars:
+          __openshift_logging_fluentd_cpu_limit: fluentd-elasticsearch.resources.limits.cpu
+          __openshift_logging_fluentd_memory_limit: fluentd-elasticsearch.resources.limits.memory
+          __openshift_logging_fluentd_cpu_request: fluentd-elasticsearch.resources.requests.cpu
+
+
+# Mux
+- when: openshift_logging_facts['mux']['deploymentconfigs']['logging-mux'] is defined
+  block:
+    - set_fact:
+        __openshift_logging_mux_file_buffer_limit: "{{ openshift_logging_facts['mux']['deploymentconfigs']['logging-mux']['containers']['mux']['env'] | entry_from_name_value_pair('FILE_BUFFER_LIMIT') }}"
+        __openshift_logging_mux_buffer_queue_limit: "{{ openshift_logging_facts['mux']['deploymentconfigs']['logging-mux']['containers']['mux']['env'] | entry_from_name_value_pair('BUFFER_QUEUE_LIMIT') }}"
+        __openshift_logging_mux_buffer_size_limit: "{{ openshift_logging_facts['mux']['deploymentconfigs']['logging-mux']['containers']['mux']['env'] | entry_from_name_value_pair('BUFFER_SIZE_LIMIT') }}"
+
+    - conditional_set_fact:
+        facts: "{{ openshift_logging_facts['mux']['deploymentconfigs']['logging-mux']['containers'] | flatten_dict }}"
+        vars:
+          __openshift_logging_mux_cpu_limit: mux.resources.limits.cpu
+          __openshift_logging_mux_memory_limit: mux.resources.limits.memory
+          __openshift_logging_mux_cpu_request: mux.resources.requests.cpu
+
+
+# EventRouter
+- when: openshift_logging_facts['eventrouter']['deploymentconfigs']['logging-eventrouter'] is defined
+  conditional_set_fact:
+    facts: "{{ openshift_logging_facts['eventrouter']['deploymentconfigs']['logging-eventrouter']['containers'] | flatten_dict }}"
+    vars:
+      __openshift_logging_eventrouter_cpu_limit: kube-eventrouter.resources.limits.cpu
+      __openshift_logging_eventrouter_cpu_request: kube-eventrouter.resources.requests.cpu
+      __openshift_logging_eventrouter_memory_limit: kube-eventrouter.resources.limits.memory
+
+
+# Set the defaults based on collected facts
 - conditional_set_fact:
     facts: "{{ hostvars[inventory_hostname] }}"
     vars:
+      # Elasticsearch
       openshift_logging_es_number_of_shards: openshift_logging_es_number_of_shards | __openshift_logging_es_number_of_shards
       openshift_logging_es_number_of_replicas: openshift_logging_es_number_of_replicas | __openshift_logging_es_number_of_replicas
+      openshift_logging_elasticsearch_recover_after_time: openshift_logging_es_recover_after_time | __openshift_logging_es_recover_after_time
+      openshift_logging_elasticsearch_cpu_limit: openshift_logging_elasticsearch_cpu_limit | __openshift_logging_elasticsearch_cpu_limit
+      openshift_logging_elasticsearch_cpu_request: openshift_logging_elasticsearch_cpu_request | __openshift_logging_elasticsearch_cpu_request
+      openshift_logging_elasticsearch_memory_limit: openshift_logging_elasticsearch_memory_limit | __openshift_logging_elasticsearch_memory_limit
+      openshift_logging_elasticsearch_proxy_cpu_request: openshift_logging_elasticsearch_proxy_cpu_request | __openshift_logging_elasticsearch_proxy_cpu_request
+      openshift_logging_elasticsearch_proxy_memory_limit: openshift_logging_elasticsearch_proxy_memory_limit | __openshift_logging_elasticsearch_proxy_memory_limit
+
+      # Elasticsearch Ops
       openshift_logging_es_ops_number_of_shards: openshift_logging_es_ops_number_of_shards | __openshift_logging_es_ops_number_of_shards
       openshift_logging_es_ops_number_of_replicas: openshift_logging_es_ops_number_of_replicas | __openshift_logging_es_ops_number_of_replicas
+      openshift_logging_es_ops_recover_after_time: openshift_logging_es_ops_recover_after_time | __openshift_logging_es_ops_recover_after_time
+      openshift_logging_es_ops_cpu_limit: openshift_logging_es_ops_cpu_limit | __openshift_logging_es_ops_cpu_limit
+      openshift_logging_es_ops_cpu_request: openshift_logging_es_ops_cpu_request | __openshift_logging_es_ops_cpu_request
+      openshift_logging_es_ops_memory_limit: openshift_logging_es_ops_memory_limit | __openshift_logging_es_ops_memory_limit
+      openshift_logging_es_ops_proxy_cpu_request: openshift_logging_es_ops_proxy_cpu_request | __openshift_logging_es_ops_proxy_cpu_request
+      openshift_logging_es_ops_proxy_memory_limit: openshift_logging_es_ops_proxy_memory_limit | __openshift_logging_es_ops_proxy_memory_limit
+
+      # Kibana
+      openshift_logging_kibana_cpu_limit: openshift_logging_kibana_cpu_limit | __openshift_logging_kibana_cpu_limit
+      openshift_logging_kibana_cpu_request: openshift_logging_kibana_cpu_request | __openshift_logging_kibana_cpu_request
+      openshift_logging_kibana_memory_limit: openshift_logging_kibana_memory_limit | __openshift_logging_kibana_memory_limit
+      openshift_logging_kibana_proxy_cpu_limit: openshift_logging_kibana_proxy_cpu_limit | __openshift_logging_kibana_proxy_cpu_limit
+      openshift_logging_kibana_proxy_cpu_request: openshift_logging_kibana_proxy_cpu_request | __openshift_logging_kibana_proxy_cpu_request
+      openshift_logging_kibana_proxy_memory_limit: openshift_logging_kibana_proxy_memory_limit | __openshift_logging_kibana_proxy_memory_limit
+
+      # Kibana Ops
+      openshift_logging_kibana_ops_cpu_limit: openshift_logging_kibana_ops_cpu_limit | __openshift_logging_kibana_ops_cpu_limit
+      openshift_logging_kibana_ops_cpu_request: openshift_logging_kibana_ops_cpu_request | __openshift_logging_kibana_ops_cpu_request
+      openshift_logging_kibana_ops_memory_limit: openshift_logging_kibana_ops_memory_limit | __openshift_logging_kibana_ops_memory_limit
+      openshift_logging_kibana_ops_proxy_cpu_limit: openshift_logging_kibana_ops_proxy_cpu_limit | __openshift_logging_kibana_ops_proxy_cpu_limit
+      openshift_logging_kibana_ops_proxy_cpu_request: openshift_logging_kibana_ops_proxy_cpu_request | __openshift_logging_kibana_ops_proxy_cpu_request
+      openshift_logging_kibana_ops_proxy_memory_limit: openshift_logging_kibana_ops_proxy_memory_limit | __openshift_logging_kibana_ops_proxy_memory_limit
+
+      # Curator
+      openshift_logging_curator_default_days: openshift_logging_curator_default_days | __openshift_logging_curator_default_days
+      openshift_logging_curator_run_hour: openshift_logging_curator_run_hour | __openshift_logging_curator_run_hour
+      openshift_logging_curator_run_minute: openshift_logging_curator_run_minute | __openshift_logging_curator_run_minute
+      openshift_logging_curator_run_timezone: openshift_logging_curator_run_timezone | __openshift_logging_curator_run_timezone
+      openshift_logging_curator_cpu_limit: openshift_logging_curator_cpu_limit | __openshift_logging_curator_cpu_limit
+      openshift_logging_curator_cpu_request: openshift_logging_curator_cpu_request | __openshift_logging_curator_cpu_request
+      openshift_logging_curator_memory_limit: openshift_logging_curator_memory_limit | __openshift_logging_curator_memory_limit
+
+      # Curator Ops
+      openshift_logging_curator_ops_default_days: openshift_logging_curator_ops_default_days | __openshift_logging_curator_ops_default_days
+      openshift_logging_curator_ops_run_hour: openshift_logging_curator_ops_run_hour | __openshift_logging_curator_ops_run_hour
+      openshift_logging_curator_ops_run_minute: openshift_logging_curator_ops_run_minute | __openshift_logging_curator_ops_run_minute
+      openshift_logging_curator_ops_run_timezone: openshift_logging_curator_ops_run_timezone | __openshift_logging_curator_ops_run_timezone
+      openshift_logging_curator_ops_cpu_limit: openshift_logging_curator_ops_cpu_limit | __openshift_logging_curator_ops_cpu_limit
+      openshift_logging_curator_ops_cpu_request: openshift_logging_curator_ops_cpu_request | __openshift_logging_curator_ops_cpu_request
+      openshift_logging_curator_ops_memory_limit: openshift_logging_curator_ops_memory_limit | __openshift_logging_curator_ops_memory_limit
+
+      # Fluentd
+      openshift_logging_fluentd_cpu_limit: openshift_logging_fluentd_cpu_limit | __openshift_logging_fluentd_cpu_limit
+      openshift_logging_fluentd_cpu_request: openshift_logging_fluentd_cpu_request | __openshift_logging_fluentd_cpu_request
+      openshift_logging_fluentd_memory_limit: openshift_logging_fluentd_memory_limit | __openshift_logging_fluentd_memory_limit
+      openshift_logging_fluentd_file_buffer_limit: openshift_logging_fluentd_file_buffer_limit | __openshift_logging_fluentd_file_buffer_limit
+      openshift_logging_fluentd_buffer_queue_limit: openshift_logging_fluentd_buffer_queue_limit | __openshift_logging_fluentd_buffer_queue_limit
+      openshift_logging_fluentd_buffer_size_limit: openshift_logging_fluentd_buffer_size_limit | __openshift_logging_fluentd_buffer_size_limit
+
+      # Mux
+      openshift_logging_mux_cpu_limit: openshift_logging_mux_cpu_limit | __openshift_logging_mux_cpu_limit
+      openshift_logging_mux_cpu_request: openshift_logging_mux_cpu_request | __openshift_logging_mux_cpu_request
+      openshift_logging_mux_memory_limit: openshift_logging_mux_memory_limit | __openshift_logging_mux_memory_limit
+      openshift_logging_mux_buffer_queue_limit: openshift_logging_mux_buffer_queue_limit | __openshift_logging_mux_buffer_queue_limit
+      openshift_logging_mux_buffer_size_limit: openshift_logging_mux_buffer_size_limit | __openshift_logging_mux_buffer_size_limit
+      openshift_logging_mux_file_buffer_limit: openshift_logging_mux_file_buffer_limit | __openshift_logging_mux_file_buffer_limit
+
+      # EventRouter
+      openshift_logging_eventrouter_cpu_limit: openshift_logging_eventrouter_cpu_limit | __openshift_logging_eventrouter_cpu_limit
+      openshift_logging_eventrouter_cpu_request: openshift_logging_eventrouter_cpu_request | __openshift_logging_eventrouter_cpu_request
+      openshift_logging_eventrouter_memory_limit: openshift_logging_eventrouter_memory_limit | __openshift_logging_eventrouter_memory_limit


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1561196

If we have an existing deployment for logging, we will collects facts from it and use those gathered facts instead of role defaults to provide more 'sane' values and to help prevent from a changed default putting a tuned logging stack into a failed/bad state.

@richm @jcantrill @portante PTAL
Please also double check my variable names... there is a lot of redundancy so I may have missed something because I've been looking at it too long.