### PR TITLE
Remove etcd_version

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -172,8 +172,6 @@ debug_level=2
 # Skip upgrading Docker during an OpenShift upgrade, leaves the current Docker version alone.
 # docker_upgrade=False
 
-# Specify exact version of etcd to configure or upgrade to.
-# etcd_version="3.1.0"
 # Enable etcd debug logging, defaults to false
 # etcd_debug=true
 # Set etcd log levels by package

--- a/roles/etcd/tasks/auxiliary/drop_etcdctl.yml
+++ b/roles/etcd/tasks/auxiliary/drop_etcdctl.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install etcd for etcdctl
-  package: name=etcd{{ '-' + etcd_version if etcd_version is defined else '' }} state=present
+  package: name=etcd state=present
   when: not openshift_is_containerized | bool
   register: result
   until: result is succeeded

--- a/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
+++ b/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install etcd
   package:
-    name: "etcd{{ '-' + etcd_version if etcd_version is defined else '' }}"
+    name: "etcd"
     state: present
   when:
   - not etcd_is_atomic | bool

--- a/roles/etcd/tasks/rpm.yml
+++ b/roles/etcd/tasks/rpm.yml
@@ -6,7 +6,7 @@
   import_tasks: firewall.yml
 
 - name: Install etcd
-  package: name=etcd{{ '-' + etcd_version if etcd_version is defined else '' }} state=present
+  package: name=etcd state=present
   register: result
   until: result is succeeded
 


### PR DESCRIPTION
etcd version can no longer be specified in `etcd_version`.

This parameter never worked properly, as for various platforms a minimum version was required. Instead of some outdated version the latest etcd should always be used

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1538989