### PR TITLE
Set the master cluster hostname under OpenStack

### DIFF
--- a/playbooks/openstack/inventory.py
+++ b/playbooks/openstack/inventory.py
@@ -51,7 +51,7 @@ def base_openshift_inventory(cluster_hosts):
     osev3 = list(set(nodes + etcd + load_balancers))
 
     inventory['cluster_hosts'] = {'hosts': [s.name for s in cluster_hosts]}
-    inventory['OSEv3'] = {'hosts': osev3}
+    inventory['OSEv3'] = {'hosts': osev3, 'vars': {}}
     inventory['masters'] = {'hosts': masters}
     inventory['etcd'] = {'hosts': etcd}
     inventory['nodes'] = {'hosts': nodes}
@@ -167,6 +167,12 @@ def build_inventory():
                 stout['api_lb_sg_id']})
         except KeyError:
             pass  # Not an API load balanced deployment
+
+        try:
+            inventory['OSEv3']['vars'][
+                'openshift_master_cluster_hostname'] = stout['private_api_ip']
+        except KeyError:
+            pass  # Internal LB not specified
 
         inventory['localhost']['openshift_openstack_public_api_ip'] = \
             stout.get('public_api_ip')

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -76,6 +76,18 @@ outputs:
     value: { get_attr: [infra_nodes, resource.0, floating_ip] }
 {% endif %}
 
+  private_api_ip:
+    description: >
+      The address of the private OpenShift API. This is used during OpenShift
+      deployment and for API access by the internal pods and services.
+{% if openshift_openstack_use_lbaas_load_balancer %}
+    value: { get_attr: [api_lb, vip_address] }
+{% elif openshift_openstack_use_vm_load_balancer %}
+    value: { get_attr: [loadbalancer, resource.0, private_ip] }
+{% else %}
+    value: { get_attr: [masters, resource.0, private_ip] }
+{% endif %}
+
 {% if openshift_use_kuryr|default(false)|bool %}
   vm_subnet:
     description: ID of the subnet the Pods will be on


### PR DESCRIPTION
Depending on the deployment (with or without a loadbalancer, with or
without external DNS) the `openshift_master_cluster_hostname` may be
different. And given the OpenStack's hostname suffix behaviour, it is
almost never set to the right value on its own.

This updates the Heat templates and the dynamic inventory to set the
variable to a value that should always work and it can always be
overridden in the group_vars .