### PR TITLE
Revert "crio: Fixup docker SELinux permissions"

### DIFF
--- a/roles/container_runtime/tasks/package_crio.yml
+++ b/roles/container_runtime/tasks/package_crio.yml
@@ -70,11 +70,6 @@
     dest: /etc/sysconfig/crio-network
     src: crio-network.j2
 
-- name: Fixup SELinux permissions for docker
-  shell: |
-          semanage fcontext -a -e /var/lib/docker/overlay2 /var/lib/containers/overlay2
-          restorecon -R -v /var/lib/containers/overlay2
-
 - name: Start the CRI-O service
   systemd:
     name: "cri-o"


### PR DESCRIPTION
This reverts commit c5762a2b90674ae1df04b07cea73d3986d407ace.