### PR TITLE
[BZ 1567251] make cassandra snapshots configurable

### DIFF
--- a/roles/openshift_metrics/defaults/main.yaml
+++ b/roles/openshift_metrics/defaults/main.yaml
@@ -24,6 +24,7 @@ openshift_metrics_cassandra_requests_memory: 1G
 openshift_metrics_cassandra_requests_cpu: null
 openshift_metrics_cassandra_nodeselector: ""
 openshift_metrics_cassandra_storage_group: 65534
+openshift_metrics_cassandra_take_snapshot: False
 
 openshift_metrics_heapster_standalone: False
 openshift_metrics_heapster_limits_memory: 3.75G

--- a/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
@@ -62,6 +62,8 @@ spec:
           value: "/hawkular-cassandra-certs/tls.peer.truststore.crt"
         - name: TRUSTSTORE_CLIENT_AUTHORITIES
           value: "/hawkular-cassandra-certs/tls.client.truststore.crt"
+        - name: TAKE_SNAPSHOT
+          value: "{{ openshift_metrics_cassandra_take_snapshot }}"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Auto snapshots are now disabled. The Cassandra image exposes a
TAKE_SNAPSHOT environment variable. It can turned on/off using the
openshift_metrics_cassandra_take_snapshot variable which defaults to
False. When true, the snapshot will be taken during the post startup
lifecycle hook, and the snapshot name will be a timestamp.