### PR TITLE
Update installation/uninstallation/upgrade of descheduler component.

### DIFF
--- a/playbooks/common/private/components.yml
+++ b/playbooks/common/private/components.yml
@@ -39,3 +39,6 @@
 
 - import_playbook: ../../openshift-management/private/config.yml
   when: openshift_management_install_management | default(false) | bool
+
+- import_playbook: ../../openshift-descheduler/private/config.yml
+  when: openshift_descheduler_install | default(false) | bool

--- a/playbooks/openshift-descheduler/private/uninstall.yml
+++ b/playbooks/openshift-descheduler/private/uninstall.yml
@@ -1,8 +1,6 @@
 ---
 - name: Uninstall Descheduler
   hosts: oo_first_master
-  vars:
-    openshift_descheduler_state: absent
   tasks:
   - name: Run the Descheduler Uninstall Role Tasks
     include_role:

--- a/roles/openshift_descheduler/README.md
+++ b/roles/openshift_descheduler/README.md
@@ -11,9 +11,23 @@ Installing Descheduler
 --------------------
 
 ```
+openshift_descheduler_install=true
+```
+
+```
 ansible-playbook -i <inventory-file> playbooks/openshift-descheduler/config.yml
 ```
 
+Uninstalling Descheduler
+--------------------
+
+```
+openshift_descheduler_install=false
+```
+
+```
+ansible-playbook -i <inventory-file> playbooks/openshift-descheduler/config.yml
+```
 
 Notes
 -----

--- a/roles/openshift_descheduler/defaults/main.yaml
+++ b/roles/openshift_descheduler/defaults/main.yaml
@@ -1,8 +1,8 @@
 ---
 # descheduler common setup
-openshift_descheduler_state: present
+openshift_descheduler_install: false
 openshift_descheduler_tmp_location: /tmp
-openshift_descheduler_delete_config: True
+openshift_descheduler_delete_config: true
 
 # descheduler image setup
 openshift_descheduler_image_dict:

--- a/roles/openshift_descheduler/tasks/install_descheduler.yaml
+++ b/roles/openshift_descheduler/tasks/install_descheduler.yaml
@@ -61,7 +61,7 @@
   template:
     src: policy.yaml.j2
     dest: "{{ openshift_descheduler_tmp_location }}/policy.yaml"
-  when: openshift_descheduler_state == 'present'
+  when: openshift_descheduler_install | bool
 
 - name: create descheduler policy configmap
   oc_configmap:
@@ -75,9 +75,9 @@
   template:
     src: descheduler-cronjob.yaml.j2
     dest: "{{ openshift_descheduler_tmp_location }}/descheduler-cronjob.yaml"
-  when: openshift_descheduler_state == 'present'
+  when: openshift_descheduler_install | bool
 
-- name: "Ensure the descheduler is {{ openshift_descheduler_state }}"
+- name: Ensure the descheduler is present
   oc_obj:
     namespace: openshift-descheduler
     state: present

--- a/roles/openshift_descheduler/tasks/main.yaml
+++ b/roles/openshift_descheduler/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - include_tasks: install_descheduler.yaml
-  when: openshift_descheduler_state == 'present'
+  when: openshift_descheduler_install | bool
 
 - include_tasks: uninstall_descheduler.yaml
-  when: openshift_descheduler_state == 'absent'
+  when: not openshift_descheduler_install | bool


### PR DESCRIPTION
Now descheduler can be installed/uninstalled using `openshift_descheduler_install` .

@wjiangjay @mdshuai @sjenning 