### PR TITLE
Remove the openshift-master filter check for hostvars subclass.

### DIFF
--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -483,8 +483,6 @@ class FilterModule(object):
     @staticmethod
     def certificates_to_synchronize(hostvars, include_keys=True, include_ca=True):
         ''' Return certificates to synchronize based on facts. '''
-        if not issubclass(type(hostvars), dict):
-            raise errors.AnsibleFilterError("|failed expects hostvars is a dict")
         certs = ['admin.crt',
                  'admin.key',
                  'admin.kubeconfig',

--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -481,7 +481,7 @@ class FilterModule(object):
                            Dumper=AnsibleDumper))
 
     @staticmethod
-    def certificates_to_synchronize(include_keys=True, include_ca=True):
+    def certificates_to_synchronize(hostvars, include_keys=True, include_ca=True):
         ''' Return certificates to synchronize. '''
         certs = ['admin.crt',
                  'admin.key',

--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -481,8 +481,8 @@ class FilterModule(object):
                            Dumper=AnsibleDumper))
 
     @staticmethod
-    def certificates_to_synchronize(hostvars, include_keys=True, include_ca=True):
-        ''' Return certificates to synchronize based on facts. '''
+    def certificates_to_synchronize(include_keys=True, include_ca=True):
+        ''' Return certificates to synchronize. '''
         certs = ['admin.crt',
                  'admin.key',
                  'admin.kubeconfig',


### PR DESCRIPTION
Ansible 2.6+ hostvars objects do not have a subclass of dict. This
change fixes compatibility going forward.