### PR TITLE
Forward infra elb port 80 to instance port 80.

### DIFF
--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -108,7 +108,7 @@ openshift_aws_elb_dict:
       - protocol: tcp
         load_balancer_port: 80
         instance_protocol: tcp
-        instance_port: 443
+        instance_port: 80
         proxy_protocol: True
       - protocol: tcp
         load_balancer_port: 443


### PR DESCRIPTION
https://trello.com/c/kWsKllUY/122-cibug-infra-elb-forwards-port-80-to-port-443-but-the-router-listens-on-port-80-for-http-traffic