### PR TITLE
Output useful logs in CI on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,19 @@ install:
 script:
   - tox
 
+after_failure:
+  - echo "Here's a list of installed Python packages:"
+  - pip list --format=columns
+  - echo Dumping logs, because tests failed to succeed
+  - |
+      for log in `ls .tox/*/log/*.log`
+      do
+        echo Outputting $log
+        cat $log
+      done
+  - pip_debug_log=/home/travis/.cache/pip/log/debug.log
+  - echo Outputting pip debug log from $pip_debug_log
+  - cat $pip_debug_log
+
 after_success:
   - coveralls


### PR DESCRIPTION
This gets more info about failed env in CI on screen.

Motivation: https://travis-ci.org/openshift/openshift-ansible/jobs/367630711#L539