### PR TITLE
Enable extended validation of routes by default

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -391,6 +391,11 @@ debug_level=2
 # based on the number of nodes matching the openshift router selector.
 #openshift_hosted_router_replicas=2
 #
+# Router extended route validation (optional)
+# If enabled, openshift-ansible will configure the router to perform extended
+# validation on routes before admitting them.
+#openshift_hosted_router_extended_validation=true
+#
 # Router force subdomain (optional)
 # A router path format to force on all routes used by this router
 # (will ignore the route host value)

--- a/roles/lib_openshift/library/oc_adm_router.py
+++ b/roles/lib_openshift/library/oc_adm_router.py
@@ -147,6 +147,12 @@ options:
     required: false
     default: haproxy-router
     aliases: []
+  extended_validation:
+    description:
+    - If true, configure the router to perform extended validation on routes before admitting them.
+    required: false
+    default: True
+    aliases: []
   external_host:
     description:
     - If the underlying router implementation connects with an external host, this is the external host's hostname.
@@ -247,8 +253,8 @@ EXAMPLES = '''
       action: put
     - key: spec.template.spec.containers[0].env
       value:
-        name: EXTENDED_VALIDATION
-        value: 'false'
+        name: ROUTER_MAX_CONNECTIONS
+        value: "10000"
       action: update
   register: router_out
   run_once: True
@@ -2844,6 +2850,16 @@ class Router(OpenShiftCLI):
         '''modify the deployment config'''
         # We want modifications in the form of edits coming in from the module.
         # Let's apply these here
+
+        # If extended validation is enabled, set the corresponding environment
+        # variable.
+        if self.config.config_options['extended_validation']['value']:
+            if not deploymentconfig.exists_env_key('EXTENDED_VALIDATION'):
+                deploymentconfig.add_env_value('EXTENDED_VALIDATION', "true")
+            else:
+                deploymentconfig.update_env_var('EXTENDED_VALIDATION', "true")
+
+        # Apply any edits.
         edit_results = []
         for edit in self.config.config_options['edits'].get('value', []):
             if edit['action'] == 'put':
@@ -3077,6 +3093,7 @@ class Router(OpenShiftCLI):
                                 'service_account': {'value': params['service_account'], 'include': True},
                                 'router_type': {'value': params['router_type'], 'include': False},
                                 'host_network': {'value': params['host_network'], 'include': True},
+                                'extended_validation': {'value': params['extended_validation'], 'include': False},
                                 'external_host': {'value': params['external_host'], 'include': True},
                                 'external_host_vserver': {'value': params['external_host_vserver'],
                                                           'include': True},
@@ -3192,6 +3209,7 @@ def main():
             service_account=dict(default='router', type='str'),
             router_type=dict(default='haproxy-router', type='str'),
             host_network=dict(default=True, type='bool'),
+            extended_validation=dict(default=True, type='bool'),
             # external host options
             external_host=dict(default=None, type='str'),
             external_host_vserver=dict(default=None, type='str'),

--- a/roles/lib_openshift/src/ansible/oc_adm_router.py
+++ b/roles/lib_openshift/src/ansible/oc_adm_router.py
@@ -28,6 +28,7 @@ def main():
             service_account=dict(default='router', type='str'),
             router_type=dict(default='haproxy-router', type='str'),
             host_network=dict(default=True, type='bool'),
+            extended_validation=dict(default=True, type='bool'),
             # external host options
             external_host=dict(default=None, type='str'),
             external_host_vserver=dict(default=None, type='str'),

--- a/roles/lib_openshift/src/class/oc_adm_router.py
+++ b/roles/lib_openshift/src/class/oc_adm_router.py
@@ -179,6 +179,16 @@ class Router(OpenShiftCLI):
         '''modify the deployment config'''
         # We want modifications in the form of edits coming in from the module.
         # Let's apply these here
+
+        # If extended validation is enabled, set the corresponding environment
+        # variable.
+        if self.config.config_options['extended_validation']['value']:
+            if not deploymentconfig.exists_env_key('EXTENDED_VALIDATION'):
+                deploymentconfig.add_env_value('EXTENDED_VALIDATION', "true")
+            else:
+                deploymentconfig.update_env_var('EXTENDED_VALIDATION', "true")
+
+        # Apply any edits.
         edit_results = []
         for edit in self.config.config_options['edits'].get('value', []):
             if edit['action'] == 'put':
@@ -412,6 +422,7 @@ class Router(OpenShiftCLI):
                                 'service_account': {'value': params['service_account'], 'include': True},
                                 'router_type': {'value': params['router_type'], 'include': False},
                                 'host_network': {'value': params['host_network'], 'include': True},
+                                'extended_validation': {'value': params['extended_validation'], 'include': False},
                                 'external_host': {'value': params['external_host'], 'include': True},
                                 'external_host_vserver': {'value': params['external_host_vserver'],
                                                           'include': True},

--- a/roles/lib_openshift/src/doc/router
+++ b/roles/lib_openshift/src/doc/router
@@ -94,6 +94,12 @@ options:
     required: false
     default: haproxy-router
     aliases: []
+  extended_validation:
+    description:
+    - If true, configure the router to perform extended validation on routes before admitting them.
+    required: false
+    default: True
+    aliases: []
   external_host:
     description:
     - If the underlying router implementation connects with an external host, this is the external host's hostname.
@@ -194,8 +200,8 @@ EXAMPLES = '''
       action: put
     - key: spec.template.spec.containers[0].env
       value:
-        name: EXTENDED_VALIDATION
-        value: 'false'
+        name: ROUTER_MAX_CONNECTIONS
+        value: "10000"
       action: update
   register: router_out
   run_once: True

--- a/roles/lib_openshift/src/test/unit/test_oc_adm_router.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_adm_router.py
@@ -314,6 +314,7 @@ class RouterTest(unittest.TestCase):
                   'service_account': 'router',
                   'router_type': None,
                   'host_network': None,
+                  'extended_validation': True,
                   'external_host': None,
                   'external_host_vserver': None,
                   'external_host_insecure': False,

--- a/roles/openshift_hosted/README.md
+++ b/roles/openshift_hosted/README.md
@@ -23,6 +23,7 @@ From this role:
 | openshift_hosted_router_replicas      | Number of nodes matching selector        | The number of replicas to configure.                                                                                     |
 | openshift_hosted_router_selector      | node-role.kubernetes.io/infra=true       | Node selector used when creating router. The OpenShift router will only be deployed to nodes matching this selector.     |
 | openshift_hosted_router_name          | router                                   | The name of the router to be created.                                                                                    |
+| openshift_hosted_router_extended_validation | True                               | Whether to configure the router to perform extended validation on routes before admitting them. |
 | openshift_hosted_registry_registryurl | 'registry.access.redhat.com/openshift3/ose-${component}:${version}' | The image to base the OpenShift registry on.                                                                             |
 | openshift_hosted_registry_replicas    | Number of nodes matching selector        | The number of replicas to configure.                                                                                     |
 | openshift_hosted_registry_selector    | node-role.kubernetes.io/infra=true                   | Node selector used when creating registry. The OpenShift registry will only be deployed to nodes matching this selector. |

--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -55,6 +55,7 @@ openshift_hosted_routers:
   selector: "{{ openshift_hosted_router_selector | default(None) }}"
   images: "{{ openshift_hosted_router_registryurl }}"
   edits: "{{ openshift_hosted_router_edits }}"
+  extended_validation: "{{ openshift_hosted_router_extended_validation | default(True) | bool }}"
   stats_port: 1936
   ports:
   - 80:80

--- a/roles/openshift_hosted/tasks/router.yml
+++ b/roles/openshift_hosted/tasks/router.yml
@@ -96,6 +96,7 @@
     key_file: "{{ ('/etc/origin/master/' ~ (item.certificate.keyfile | basename)) if 'keyfile' in item.certificate else omit }}"
     cacert_file: "{{ ('/etc/origin/master/' ~ (item.certificate.cafile | basename)) if 'cafile' in item.certificate else omit }}"
     edits: "{{ openshift_hosted_router_edits | union(item.edits)  }}"
+    extended_validation: "{{ item.extended_validation | default(True) | bool }}"
     ports: "{{ item.ports }}"
     stats_port: "{{ item.stats_port }}"
   with_items: "{{ openshift_hosted_routers }}"


### PR DESCRIPTION
Add a new Boolean variable, `openshift_hosted_router_extended_validation`, default true, that determines whether to configure the router to perform extended validation on routes before admitting them.

This commit fixes bug 1542711.

https://bugzilla.redhat.com/show_bug.cgi?id=1542711