### PR TITLE
[wip] (TSB) Bug 1565896- Prevent TSB daemonset from scheduling on non-master nodes

### DIFF
--- a/roles/template_service_broker/tasks/deploy.yml
+++ b/roles/template_service_broker/tasks/deploy.yml
@@ -3,7 +3,7 @@
     name: openshift-template-service-broker
     state: present
     node_selector:
-    - ""
+    - 'node-role.kubernetes.io/master=true'
 
 - command: mktemp -d /tmp/tsb-ansible-XXXXXX
   register: mktemp


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1565896

The issue seems to be related to the addition of the default node selector in 3.9.
I'm not yet sure if this change fixes it, as I'm not sure what's involved in the scheduling of a pod created by a daemonset.

Will update after more testing.