### PR TITLE
add ability to specify storage class for elasticsearch dynamic PVCs

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -379,6 +379,7 @@
         size: "{{ (openshift_logging_elasticsearch_pvc_size | trim | length == 0) | ternary('10Gi', openshift_logging_elasticsearch_pvc_size) }}"
         access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
         pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
+        storage_class_name: "{{ openshift_logging_elasticsearch_pvc_storage_class_name | default('', true) }}"
       when:
         - openshift_logging_elasticsearch_pvc_dynamic | bool
 


### PR DESCRIPTION
with AWS you can have multiple storage classes. for example you might have both efs
and gp2 but there's no way to tell what storage class you want elasticsearch to
use if the PVC is created dynamically - it just uses whatever the default it.