### PR TITLE
remove stray LCs on deprovision

### DIFF
--- a/roles/openshift_aws/tasks/uninstall_node_group.yml
+++ b/roles/openshift_aws/tasks/uninstall_node_group.yml
@@ -33,3 +33,16 @@
 
   - when: openshift_aws_create_launch_config
     include_tasks: uninstall_launch_config.yml
+
+- name: get list of LCs
+  ec2_lc_facts:
+    region: "{{ openshift_aws_region }}"
+  register: l_launch_config_list
+
+- name: remove stray LCs for this node group
+  ec2_lc:
+    name: "{{ item.launch_configuration_name }}"
+    state: absent
+    region: "{{ openshift_aws_region }}"
+  when: item.launch_configuration_name is match("^{{ openshift_aws_node_group.name }}.*")
+  with_items: "{{ l_launch_config_list.launch_configurations }}"


### PR DESCRIPTION
when a scale group creation is attempted, a launch config is always created. the scale group creation may be a failure (eg. the ami can't be launched as an m5 instance because no ENA support). this leaves behind unreferenced launch configs.

during deprovisioning, try to clean up any orphaned launch configs for each node group.