### PR TITLE
Wait for node to become Ready before setting up router/registry

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_10/label_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_10/label_nodes.yml
@@ -23,3 +23,9 @@
         tasks_from: set_default_node_role.yml
       vars:
         openshift_master_host: '{{ groups.oo_first_master.0 }}'
+    # Wait for nodes to become ready before updating hosted components
+    - import_role:
+        name: openshift_manage_node
+        tasks_from: node_ready.yml
+      vars:
+        openshift_master_host: '{{ groups.oo_first_master.0 }}'

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/label_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/label_nodes.yml
@@ -23,3 +23,9 @@
         tasks_from: set_default_node_role.yml
       vars:
         openshift_master_host: '{{ groups.oo_first_master.0 }}'
+    # Wait for nodes to become ready before updating hosted components
+    - import_role:
+        name: openshift_manage_node
+        tasks_from: node_ready.yml
+      vars:
+        openshift_master_host: '{{ groups.oo_first_master.0 }}'

--- a/playbooks/openshift-node/private/join.yml
+++ b/playbooks/openshift-node/private/join.yml
@@ -50,3 +50,10 @@
   - role: openshift_manage_node
     openshift_master_host: "{{ groups.oo_first_master.0 }}"
     openshift_manage_node_is_master: "{{ ('oo_masters_to_config' in group_names) | bool }}"
+  tasks:
+  # Wait for nodes to become ready before installing hosted components
+  - import_role:
+      name: openshift_manage_node
+      tasks_from: node_ready.yml
+    vars:
+      openshift_master_host: '{{ groups.oo_first_master.0 }}'

--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Wait for Node Registration
   oc_obj:
-    name: "{{ openshift.node.nodename }}"
+    name: "{{ openshift.node.nodename | lower }}"
     kind: node
     state: list
   register: get_node

--- a/roles/openshift_manage_node/tasks/node_ready.yml
+++ b/roles/openshift_manage_node/tasks/node_ready.yml
@@ -1,0 +1,12 @@
+---
+- name: Wait for node to be ready
+  oc_obj:
+    state: list
+    kind: node
+    name: "{{ openshift.node.nodename | lower }}"
+  register: node_output
+  until: node_output.results.returncode == 0 and node_output.results.results[0].status.conditions | selectattr('type', 'match', '^Ready$') | map(attribute='status') | join | bool == True
+  # Give the node two minutes to come back online.
+  retries: 24
+  delay: 5
+  delegate_to: "{{ openshift_master_host }}"


### PR DESCRIPTION
Hosted components scale accordingly to a number of nodes, skipping nodes in NotReady status. As a result, if SDN didn't come up by the time `openshift_hosted` has started the registry and routers would scale to 0 replicas.

This PR ensures nodes are Ready in `openshift_manage_node`, before `openshift_hosted` starts

Fixes #7897 