### PR TITLE
Registry remove legacy vars

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
@@ -56,3 +56,14 @@
   - import_role:
       name: openshift_web_console
       tasks_from: remove_old_asset_config
+
+# This is a one time migration. No need to save it in the 3.11.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1565736
+- hosts: oo_first_master
+  tasks:
+  - import_role:
+      name: openshift_hosted
+      tasks_from: registry_service_account.yml
+  - import_role:
+      name: openshift_hosted
+      tasks_from: remove_legacy_env_variables.yml

--- a/roles/openshift_hosted/tasks/registry_service_account.yml
+++ b/roles/openshift_hosted/tasks/registry_service_account.yml
@@ -1,0 +1,15 @@
+---
+- name: create registry serviceaccount
+  oc_serviceaccount:
+    state: present
+    name: "{{ openshift_hosted_registry_serviceaccount }}"
+    namespace: "{{ openshift_hosted_registry_namespace }}"
+  changed_when: no
+
+- name: grant the system:registry role to registry serviceaccount
+  oc_adm_policy_user:
+    state: present
+    namespace: "{{ openshift_hosted_registry_namespace }}"
+    resource_kind: cluster-role
+    resource_name: system:registry
+    user: "system:serviceaccount:{{ openshift_hosted_registry_namespace }}:{{ openshift_hosted_registry_serviceaccount }}"

--- a/roles/openshift_hosted/tasks/remove_legacy_env_variables.yml
+++ b/roles/openshift_hosted/tasks/remove_legacy_env_variables.yml
@@ -1,0 +1,16 @@
+---
+- name: remove legacy environment variables from registry dc
+  oc_env:
+    kind: dc
+    name: "{{ openshift_hosted_registry_name }}"
+    namespace: "{{ openshift_hosted_registry_namespace }}"
+    state: absent
+    env_vars:
+      BEARER_TOKEN:
+      BEARER_TOKEN_FILE:
+      KUBERNETES_MASTER:
+      OPENSHIFT_CA_FILE:
+      OPENSHIFT_CERT_FILE:
+      OPENSHIFT_INSECURE:
+      OPENSHIFT_KEY_FILE:
+      OPENSHIFT_MASTER:


### PR DESCRIPTION
- remove legacy env variables from the registry deploymentconfig if present;
- ensure the registry service account exists;
- grant the system:registry role to system:serviceaccount:default:registry;

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1565736
