### PR TITLE
[3.7] Allow PVCs to specify StorageClass (or none)

### DIFF
--- a/filter_plugins/oo_filters.py
+++ b/filter_plugins/oo_filters.py
@@ -932,10 +932,14 @@ def oo_component_pv_claims(hostvars, component, subcomponent=None):
                         volume = params['volume']['name']
                         size = params['volume']['size']
                         access_modes = params['access']['modes']
+                        storageclass = params['volume'].get('storageclass')
+                        if storageclass is None and kind != 'dynamic':
+                            storageclass = ''
                         persistent_volume_claim = dict(
                             name="{0}-claim".format(volume),
                             capacity=size,
-                            access_modes=access_modes)
+                            access_modes=access_modes,
+                            storageclass=storageclass)
                         return persistent_volume_claim
     return None
 

--- a/playbooks/common/openshift-glusterfs/registry.yml
+++ b/playbooks/common/openshift-glusterfs/registry.yml
@@ -23,6 +23,7 @@
       - name: "{{ openshift.hosted.registry.storage.volume.name }}-glusterfs-claim"
         capacity: "{{ openshift.hosted.registry.storage.volume.size }}"
         access_modes: "{{ openshift.hosted.registry.storage.access.modes }}"
+        storageclass: ""
     when: openshift.hosted.registry.storage.glusterfs.swap
 
 - name: Create persistent volumes

--- a/roles/openshift_persistent_volumes/templates/persistent-volume-claim.yml.j2
+++ b/roles/openshift_persistent_volumes/templates/persistent-volume-claim.yml.j2
@@ -12,4 +12,7 @@ items:
     resources:
       requests:
         storage: "{{ claim.capacity }}"
+{% if claim.storageclass is not none %}
+    storageClassName: "{{ claim.storageclass }}"
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
If no StorageClass is specified, PVCs will try to provision from the default StorageClass. Allow a PVC to specify a StorageClass, and if one isn't set and the storage_kind is NOT "dynamic", set it to `""` to not use any StorageClass.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1568260