### PR TITLE
Logging external config

### DIFF
--- a/roles/openshift_logging/tasks/main.yaml
+++ b/roles/openshift_logging/tasks/main.yaml
@@ -26,26 +26,64 @@
     selector: "logging-infra,provider=openshift"
   register: _logging_dcs
 
-- assert:
-    that:
-    - _logging_dcs.results.results[0]['items'] | map(attribute='metadata.namespace') | list | unique | count <= 1
-    msg: "Found aggregated logging deploymentconfigs in multiple namespaces which is not supported"
-  when:
-  - _logging_dcs is defined
-  - _logging_dcs.results | count > 0
-
 - set_fact:
-    _logging_namespace: "{{ _logging_dcs.results.results[0]['items'] | map(attribute='metadata.namespace') | list | unique | join('') }}"
+    _current_logging_namespace: "{{ _logging_dcs.results.results[0]['items'] | map(attribute='metadata.namespace') | list | unique | join(' ') }}"
   when:
   - _logging_dcs is defined
   - _logging_dcs.results | count > 0
   - _logging_dcs.results.results | count > 0
 
-- debug:
-    msg: "Using the namespace '{{ _logging_namespace }}' which has an existing deployment"
-  when:
+- when:
+  - logging_disable_namespace_check | default(false) | bool
   - _logging_namespace is defined
-  - _logging_namespace | count > 0
+  - _current_logging_namespace.split(" ") | count > 0
+  - _current_logging_namespace != ''
+  - _logging_namespace != _current_logging_namespace
+  block:
+  - name: Set Logging message about installing in multiple namespaces
+    run_once: true
+    set_stats:
+      data:
+        installer_phase_logging:
+          message: "Aggregated logging installed in multiple namespaces:   \
+                      current namespace(s): {{ _current_logging_namespace }}   \
+                      specified namespace: {{ _logging_namespace | default(_current_logging_namespace) }}"
+
+  - debug:
+      msg: "Aggregated logging installed in multiple namespaces:   \
+              current namespace(s): {{ _current_logging_namespace }}   \
+              specified namespace: {{ _logging_namespace | default(_current_logging_namespace) }}"
+
+- when: not logging_disable_namespace_check | default(false) | bool
+  block:
+  - assert:
+      that:
+      - _current_logging_namespace.split(" ") | count <= 1
+      - not _logging_namespace is defined or not _current_logging_namespace or _logging_namespace == _current_logging_namespace
+      msg: "Configuring aggregated logging in multiple namespaces is not supported:   \
+              current namespace(s): {{ _current_logging_namespace }}   \
+              specified namespace: {{ _logging_namespace | default(_current_logging_namespace) }}"
+
+  - debug:
+      msg: "Using the namespace '{{ _current_logging_namespace }}' which has an existing deployment"
+    when:
+    - _current_logging_namespace is defined
+    - _current_logging_namespace != ''
+
+  - set_fact:
+      _logging_namespace: "{{ _current_logging_namespace if _current_logging_namespace else _logging_namespace | default('openshift-logging') }}"
+
+- when:
+  - logging_disable_namespace_check | default(false) | bool
+  - not _logging_namespace is defined
+  block:
+  - assert:
+      that:
+      - _current_logging_namespace.split(" ") | count == 1
+      msg: "Multiple aggregated logging installations found in [{{ _current_logging_namespace }}], please specify which to use with _logging_namespace"
+
+  - set_fact:
+      _logging_namespace: "{{ _current_logging_namespace }}"
 
 - set_fact:
     openshift_logging_namespace: "{{ _logging_namespace if _logging_namespace else 'openshift-logging' }}"

--- a/roles/openshift_logging_fluentd/defaults/main.yml
+++ b/roles/openshift_logging_fluentd/defaults/main.yml
@@ -34,9 +34,9 @@ openshift_logging_fluentd_journal_read_from_head: "{{ openshift_hosted_logging_j
 openshift_logging_fluentd_app_client_cert: /etc/fluent/keys/cert
 openshift_logging_fluentd_app_client_key: /etc/fluent/keys/key
 openshift_logging_fluentd_app_ca: /etc/fluent/keys/ca
-openshift_logging_fluentd_ops_client_cert: /etc/fluent/keys/cert
-openshift_logging_fluentd_ops_client_key: /etc/fluent/keys/key
-openshift_logging_fluentd_ops_ca: /etc/fluent/keys/ca
+openshift_logging_fluentd_ops_client_cert: /etc/fluent/keys/ops-cert
+openshift_logging_fluentd_ops_client_key: /etc/fluent/keys/ops-key
+openshift_logging_fluentd_ops_ca: /etc/fluent/keys/ops-ca
 
 
 # used by "secure-host" and "secure-aggregator" deployments

--- a/roles/openshift_logging_fluentd/tasks/main.yaml
+++ b/roles/openshift_logging_fluentd/tasks/main.yaml
@@ -140,6 +140,8 @@
       secure-forward.conf: "{{ tempdir }}/secure-forward.conf"
 
 # create Fluentd secret
+# if we don't provide a location for provided certs then we use from generated_certs_dir
+# ops will use the same certs as non-ops by default
 # TODO: add aggregation secrets if necessary
 - name: Set logging-fluentd secret
   oc_secret:
@@ -148,11 +150,17 @@
     namespace: "{{ openshift_logging_fluentd_namespace }}"
     files:
       - name: ca
-        path: "{{ generated_certs_dir }}/ca.crt"
+        path: "{{ openshift_logging_fluentd_ca_path | default(generated_certs_dir ~ '/ca.crt') }}"
       - name: key
-        path: "{{ generated_certs_dir }}/system.logging.fluentd.key"
+        path: "{{ openshift_logging_fluentd_key_path | default(generated_certs_dir ~ '/system.logging.fluentd.key') }}"
       - name: cert
-        path: "{{ generated_certs_dir }}/system.logging.fluentd.crt"
+        path: "{{ openshift_logging_fluentd_cert_path | default(generated_certs_dir ~ '/system.logging.fluentd.crt') }}"
+      - name: ops-ca
+        path: "{{ openshift_logging_fluentd_ops_ca_path | default(generated_certs_dir ~ '/ca.crt') }}"
+      - name: ops-key
+        path: "{{ openshift_logging_fluentd_ops_key_path | default(generated_certs_dir ~ '/system.logging.fluentd.key') }}"
+      - name: ops-cert
+        path: "{{ openshift_logging_fluentd_ops_cert_path | default(generated_certs_dir ~ '/system.logging.fluentd.crt') }}"
 
 # create Fluentd daemonset
 # this should change based on the type of fluentd deployment to be done...


### PR DESCRIPTION
These two commits are to help allow the ops team to have a centralized logging solution where there may be two different aggregated logging stacks installed.

@wshearn @jcantrill 