### PR TITLE
docker rootdir is different when installing crio

### DIFF
--- a/roles/openshift_docker_gc/templates/dockergc-ds.yaml.j2
+++ b/roles/openshift_docker_gc/templates/dockergc-ds.yaml.j2
@@ -47,14 +47,14 @@ items:
           volumeMounts:
           - name: docker-root
             readOnly:  true
-            mountPath: /var/lib/docker
+            mountPath: /var/lib/containers/docker
           - name: docker-socket
             readOnly:  false
             mountPath: /var/run/docker.sock
         volumes:
         - name: docker-root
           hostPath:
-            path: /var/lib/docker
+            path: /var/lib/containers/docker
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock


### PR DESCRIPTION
The docker root directory is overridden to `/var/lib/containers/docker` with `use_crio=true`.  Since this DS is designed to be used in that situation, we need to update the volume mount path.

@vikaslaad 