### PR TITLE
health checks: use etcd_image as it would work on Origin correctly

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -187,7 +187,7 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
                 add_var_or_default_img("osm_image", image_info["name"])
             if 'oo_etcd_to_config' in host_groups:
                 # special case, note default is the same for origin/enterprise and has no image tag
-                etcd_img = self.get_var("osm_etcd_image", default="registry.access.redhat.com/rhel7/etcd")
+                etcd_img = self.get_var("etcd_image", default="registry.access.redhat.com/rhel7/etcd")
                 required.add(self.template_var(etcd_img))
 
         return required

--- a/roles/openshift_health_checker/test/docker_image_availability_test.py
+++ b/roles/openshift_health_checker/test/docker_image_availability_test.py
@@ -301,7 +301,7 @@ def test_registry_console_image(task_vars, expected):
     ), (
         dict(
             group_names=['oo_etcd_to_config'],
-            osm_etcd_image='spam/etcd',
+            etcd_image='spam/etcd',
         ),
         set(['spam/etcd']),
     ),


### PR DESCRIPTION
This should fix FAH tests