### PR TITLE
Hardcode htpasswd auth provider filename

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -221,7 +221,7 @@ debug_level=2
 #osm_etcd_image=rhel7/etcd
 
 # htpasswd auth
-#openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
+#openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider'}]
 # Defining htpasswd users
 #openshift_master_htpasswd_users={'user1': '<pre-hashed password>', 'user2': '<pre-hashed password>'}
 # or

--- a/inventory/hosts.openstack
+++ b/inventory/hosts.openstack
@@ -19,7 +19,7 @@ openshift_deployment_type=openshift-enterprise
 
 openshift_additional_repos=[{'id': 'ose-3.1', 'name': 'ose-3.1', 'baseurl': 'http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ose/3.1/os', 'enabled': 1, 'gpgcheck': 0}]
 
-openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '{{ openshift.common.config_base }}/htpasswd'}]
+openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider'}]
 
 #openshift_pkg_version=-3.0.0.0
 

--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -273,9 +273,11 @@ class HTPasswdPasswordIdentityProvider(IdentityProviderBase):
             AnsibleFilterError:
     """
     def __init__(self, api_version, idp):
+        # Workaround: We used to let users specify arbitrary location of
+        # htpasswd file, but now it needs to be in specific spot.
+        idp['filename'] = '/etc/origin/master/htpasswd'
         super(HTPasswdPasswordIdentityProvider, self).__init__(api_version, idp)
         self._allow_additional = False
-        self._required += [['file', 'filename', 'fileName', 'file_name']]
 
     @staticmethod
     def get_default(key):

--- a/roles/openshift_control_plane/tasks/htpass_provider.yml
+++ b/roles/openshift_control_plane/tasks/htpass_provider.yml
@@ -1,0 +1,30 @@
+---
+- name: Install httpd-tools if needed
+  package: name=httpd-tools state=present
+  when:
+  - item.kind == 'HTPasswdPasswordIdentityProvider'
+  - not openshift_is_atomic | bool
+  with_items: "{{ openshift_master_identity_providers }}"
+  register: result
+  until: result is succeeded
+
+- name: Create the htpasswd file if needed
+  template:
+    dest: "/etc/origin/master/htpasswd"
+    src: htpasswd.j2
+    backup: yes
+    mode: 0600
+  when:
+  - item.kind == 'HTPasswdPasswordIdentityProvider'
+  - openshift_master_manage_htpasswd | bool
+  with_items: "{{ openshift_master_identity_providers }}"
+
+- name: Ensure htpasswd file exists
+  copy:
+    dest: "/etc/origin/master/htpasswd"
+    force: no
+    content: ""
+    mode: 0600
+  when:
+  - item.kind == 'HTPasswdPasswordIdentityProvider'
+  with_items: "{{ openshift_master_identity_providers }}"

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -42,43 +42,7 @@
     dest: "{{ openshift_master_scheduler_conf }}"
     backup: true
 
-- name: Install httpd-tools if needed
-  package: name=httpd-tools state=present
-  when:
-  - item.kind == 'HTPasswdPasswordIdentityProvider'
-  - not openshift_is_atomic | bool
-  with_items: "{{ openshift_master_identity_providers }}"
-  register: result
-  until: result is succeeded
-
-- name: Ensure htpasswd directory exists
-  file:
-    path: "{{ item.filename | dirname }}"
-    state: directory
-  when:
-  - item.kind == 'HTPasswdPasswordIdentityProvider'
-  with_items: "{{ openshift_master_identity_providers }}"
-
-- name: Create the htpasswd file if needed
-  template:
-    dest: "{{ item.filename }}"
-    src: htpasswd.j2
-    backup: yes
-    mode: 0600
-  when:
-  - item.kind == 'HTPasswdPasswordIdentityProvider'
-  - openshift_master_manage_htpasswd | bool
-  with_items: "{{ openshift_master_identity_providers }}"
-
-- name: Ensure htpasswd file exists
-  copy:
-    dest: "{{ item.filename }}"
-    force: no
-    content: ""
-    mode: 0600
-  when:
-  - item.kind == 'HTPasswdPasswordIdentityProvider'
-  with_items: "{{ openshift_master_identity_providers }}"
+- import_tasks: htpass_provider.yml
 
 - name: Create the ldap ca file if needed
   copy:


### PR DESCRIPTION
Previously, we allowed users to specify an arbitrary path
for the htpasswd file.  Due to switching master process
to a pod, we need everything for the master to be present
in /etc/origin/master.

This commit removes the ability to specify the path
of the htpasswd file and hardcodes it to
/etc/origin/master/htpasswd

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1565447