### PR TITLE
Adding missing deprecated var openshift_hosted_metrics_public_url

### DIFF
--- a/roles/openshift_sanitize_inventory/tasks/__deprecations_metrics.yml
+++ b/roles/openshift_sanitize_inventory/tasks/__deprecations_metrics.yml
@@ -15,3 +15,4 @@
       openshift_metrics_image_version: openshift_hosted_metrics_deployer_version
       openshift_metrics_install_metrics: openshift_hosted_metrics_deploy
       openshift_metrics_storage_kind: openshift_hosted_metrics_storage_kind
+      openshift_metrics_hawkular_hostname: openshift_hosted_metrics_public_url

--- a/roles/openshift_sanitize_inventory/vars/main.yml
+++ b/roles/openshift_sanitize_inventory/vars/main.yml
@@ -74,3 +74,4 @@ __warn_deprecated_vars:
   - 'openshift_hosted_metrics_storage_labels'
   - 'openshift_hosted_metrics_deployer_prefix'
   - 'openshift_hosted_metrics_deployer_version'
+  - 'openshift_hosted_metrics_public_url'


### PR DESCRIPTION
And its mapped var

Per an email thread with @mwoodson adding this missing var to the list and mapping it.
@jsanda can you please verify that this is indeed the correct var to map it to (based on looking at the code I believe it is correct but would like a second opinion)?