### PR TITLE
Adding sslcacert to additional repos

### DIFF
--- a/roles/openshift_repos/tasks/main.yaml
+++ b/roles/openshift_repos/tasks/main.yaml
@@ -27,6 +27,7 @@
       sslverify: "{{ item.sslverify | default(1) }}"
       sslclientkey: "{{ item.sslclientkey | default(omit) }}"
       sslclientcert: "{{ item.sslclientcert | default(omit) }}"
+      sslcacert: "{{ item.sslcacert | default(omit) }}"
       file: "{{ item.name }}"
       enabled: "{{ item.enabled | default('no')}}"
     with_items: "{{ openshift_additional_repos }}"


### PR DESCRIPTION
I need to be able to define the certificate authority for the additional repo I'm adding.