### PR TITLE
node upgrade: wait for API to come back after master nodes are drained and updated

### DIFF
--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -310,3 +310,17 @@
     vars:
       openshift_master_host: "{{ groups.oo_first_master.0 }}"
       openshift_manage_node_is_master: true
+  - name: verify api server
+    command: >
+      curl --silent --tlsv1.2
+      --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+      {{ openshift.master.api_url }}/healthz/ready
+    args:
+      # Disables the following warning:
+      # Consider using get_url or uri module rather than running curl
+      warn: no
+    register: api_available_output
+    until: api_available_output.stdout == 'ok'
+    retries: 120
+    delay: 1
+    changed_when: false


### PR DESCRIPTION
This should fix flakes in update tests