### PR TITLE
Remove unused l_openshift_version_check_hosts

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/docker/docker_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/docker_upgrade.yml
@@ -20,7 +20,6 @@
 - import_playbook: ../../../../init/version.yml
   vars:
     l_openshift_version_set_hosts: "oo_etcd_to_config:oo_nodes_to_upgrade:oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
 
 # Ensure inventory sanity_checks are run.
 - import_playbook: ../../../../init/sanity_checks.yml

--- a/playbooks/common/openshift-cluster/upgrades/pre/config.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/config.yml
@@ -49,7 +49,6 @@
     openshift_release: "{{ openshift_upgrade_target }}"
     # openshift_protect_installed_version is passed n via upgrade_control_plane.yml
     # l_openshift_version_set_hosts is passed via upgrade_control_plane.yml
-    # l_openshift_version_check_hosts is passed via upgrade_control_plane.yml
 
 # version_override will set various version-related variables during a double upgrade.
 - import_playbook: version_override.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
@@ -30,7 +30,6 @@
   # them by default.
   vars:
     l_openshift_version_set_hosts: "oo_etcd_to_config:oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "oo_masters_to_config:!oo_first_master"
     l_upgrade_repo_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
     l_upgrade_no_proxy_hosts: "oo_masters_to_config"
     l_upgrade_health_check_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"

--- a/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_9/upgrade_control_plane.yml
@@ -44,7 +44,6 @@
   vars:
     l_version_override_hosts: "oo_masters_to_config:oo_etcd_to_config"
     l_openshift_version_set_hosts: "oo_etcd_to_config:oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "oo_masters_to_config:!oo_first_master"
     l_upgrade_repo_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
     l_upgrade_no_proxy_hosts: "oo_masters_to_config"
     l_upgrade_health_check_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
@@ -100,7 +99,6 @@
   # them by default.
   vars:
     l_openshift_version_set_hosts: "oo_etcd_to_config:oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "oo_masters_to_config:!oo_first_master"
     l_upgrade_repo_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
     l_upgrade_no_proxy_hosts: "oo_masters_to_config"
     l_upgrade_health_check_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"

--- a/playbooks/openshift-descheduler/config.yml
+++ b/playbooks/openshift-descheduler/config.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-descheduler/upgrade.yml
+++ b/playbooks/openshift-descheduler/upgrade.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/upgrade.yml

--- a/playbooks/openshift-etcd/certificates.yml
+++ b/playbooks/openshift-etcd/certificates.yml
@@ -2,7 +2,6 @@
 - import_playbook: ../init/main.yml
   vars:
     l_openshift_version_set_hosts: "all:!all"
-    l_openshift_version_check_hosts: "all:!all"
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
     l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 

--- a/playbooks/openshift-etcd/config.yml
+++ b/playbooks/openshift-etcd/config.yml
@@ -2,7 +2,6 @@
 - import_playbook: ../init/main.yml
   vars:
     l_openshift_version_set_hosts: "all:!all"
-    l_openshift_version_check_hosts: "all:!all"
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
     l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 

--- a/playbooks/openshift-etcd/redeploy-ca.yml
+++ b/playbooks/openshift-etcd/redeploy-ca.yml
@@ -2,7 +2,6 @@
 - import_playbook: ../init/main.yml
   vars:
     l_openshift_version_set_hosts: "all:!all"
-    l_openshift_version_check_hosts: "all:!all"
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
     l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 

--- a/playbooks/openshift-etcd/redeploy-certificates.yml
+++ b/playbooks/openshift-etcd/redeploy-certificates.yml
@@ -2,7 +2,6 @@
 - import_playbook: ../init/main.yml
   vars:
     l_openshift_version_set_hosts: "all:!all"
-    l_openshift_version_check_hosts: "all:!all"
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
     l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 

--- a/playbooks/openshift-etcd/restart.yml
+++ b/playbooks/openshift-etcd/restart.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
     l_openshift_version_set_hosts: "all:!all"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 
 - import_playbook: private/restart.yml

--- a/playbooks/openshift-etcd/scaleup.yml
+++ b/playbooks/openshift-etcd/scaleup.yml
@@ -46,7 +46,6 @@
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_new_etcd_to_config"
     l_sanity_check_hosts: "{{ groups['oo_new_etcd_to_config'] | union(groups['oo_masters_to_config']) | union(groups['oo_etcd_to_config']) }}"
     l_openshift_version_set_hosts: "all:!all"
-    l_openshift_version_check_hosts: "all:!all"
   when:
   - inventory_hostname in groups['oo_masters']
   - inventory_hostname in groups['oo_nodes_to_config']

--- a/playbooks/openshift-etcd/upgrade.yml
+++ b/playbooks/openshift-etcd/upgrade.yml
@@ -2,7 +2,6 @@
 - import_playbook: ../init/main.yml
   vars:
     l_openshift_version_set_hosts: "all:!all"
-    l_openshift_version_check_hosts: "all:!all"
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
     l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
 

--- a/playbooks/openshift-glusterfs/config.yml
+++ b/playbooks/openshift-glusterfs/config.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config:oo_glusterfs_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] | union(groups['oo_glusterfs_to_config']) }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-glusterfs/registry.yml
+++ b/playbooks/openshift-glusterfs/registry.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config:oo_glusterfs_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] | union(groups['oo_glusterfs_to_config']) }}"
 
 - import_playbook: private/registry.yml

--- a/playbooks/openshift-grafana/config.yml
+++ b/playbooks/openshift-grafana/config.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-hosted/config.yml
+++ b/playbooks/openshift-hosted/config.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-hosted/deploy_registry.yml
+++ b/playbooks/openshift-hosted/deploy_registry.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/openshift_hosted_registry.yml

--- a/playbooks/openshift-hosted/deploy_router.yml
+++ b/playbooks/openshift-hosted/deploy_router.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/openshift_hosted_router.yml

--- a/playbooks/openshift-hosted/redeploy-registry-certificates.yml
+++ b/playbooks/openshift-hosted/redeploy-registry-certificates.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/redeploy-registry-certificates.yml

--- a/playbooks/openshift-hosted/redeploy-router-certificates.yml
+++ b/playbooks/openshift-hosted/redeploy-router-certificates.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/redeploy-router-certificates.yml

--- a/playbooks/openshift-loadbalancer/config.yml
+++ b/playbooks/openshift-loadbalancer/config.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config:oo_lb_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] | union(groups['oo_lb_to_config']) }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-logging/config.yml
+++ b/playbooks/openshift-logging/config.yml
@@ -8,7 +8,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-management/config.yml
+++ b/playbooks/openshift-management/config.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-master/scaleup.yml
+++ b/playbooks/openshift-master/scaleup.yml
@@ -39,6 +39,5 @@
 - import_playbook: ../init/version.yml
   vars:
     l_openshift_version_set_hosts: "oo_masters_to_config:oo_nodes_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "oo_masters_to_config:oo_nodes_to_config"
 
 - import_playbook: private/scaleup.yml

--- a/playbooks/openshift-metrics/config.yml
+++ b/playbooks/openshift-metrics/config.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 

--- a/playbooks/openshift-monitoring/config.yml
+++ b/playbooks/openshift-monitoring/config.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-monitoring/install-gcp.yml
+++ b/playbooks/openshift-monitoring/install-gcp.yml
@@ -11,7 +11,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-nfs/config.yml
+++ b/playbooks/openshift-nfs/config.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config:oo_nfs_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] | union(groups['oo_nfs_to_config']) }}"
 
 

--- a/playbooks/openshift-node-problem-detector/config.yml
+++ b/playbooks/openshift-node-problem-detector/config.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-node-problem-detector/uninstall.yml
+++ b/playbooks/openshift-node-problem-detector/uninstall.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/uninstall.yml

--- a/playbooks/openshift-node-problem-detector/upgrade.yml
+++ b/playbooks/openshift-node-problem-detector/upgrade.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/upgrade.yml

--- a/playbooks/openshift-node/private/image_prep.yml
+++ b/playbooks/openshift-node/private/image_prep.yml
@@ -6,7 +6,6 @@
     skip_validate_hostnames: True
     l_openshift_version_determine_hosts: "oo_nodes_to_config"
     l_openshift_version_set_hosts: "all:!all"
-    l_openshift_version_check_hosts: "all:!all"
 
 - name: run node config setup
   import_playbook: disable_excluders.yml

--- a/playbooks/openshift-node/scaleup.yml
+++ b/playbooks/openshift-node/scaleup.yml
@@ -34,7 +34,6 @@
 - import_playbook: ../init/version.yml
   vars:
     l_openshift_version_set_hosts: "oo_nodes_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "oo_nodes_to_config"
 
 - import_playbook: private/bootstrap.yml
 - import_playbook: private/join.yml

--- a/playbooks/openshift-prometheus/config.yml
+++ b/playbooks/openshift-prometheus/config.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 

--- a/playbooks/openshift-provisioners/config.yml
+++ b/playbooks/openshift-provisioners/config.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 

--- a/playbooks/openshift-service-catalog/config.yml
+++ b/playbooks/openshift-service-catalog/config.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml

--- a/playbooks/openshift-web-console/config.yml
+++ b/playbooks/openshift-web-console/config.yml
@@ -3,7 +3,6 @@
   vars:
     l_init_fact_hosts: "oo_masters_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_openshift_version_check_hosts: "all:!all"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
 - import_playbook: private/config.yml


### PR DESCRIPTION
We no longer check to see if the requested version actually
exists, thus we don't need this variable any more.