### PR TITLE
add ability to specify storage class for elasticsearch dynamic PVCs

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -437,6 +437,7 @@
       size: "{{ (openshift_logging_elasticsearch_pvc_size | trim | length == 0) | ternary('10Gi', openshift_logging_elasticsearch_pvc_size) }}"
       access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
       pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
+      storage_class_name: "{{ openshift_logging_elasticsearch_pvc_storage_class_name | default('', true) }}"
     when:
     - openshift_logging_elasticsearch_pvc_dynamic | bool
 


### PR DESCRIPTION
ref https://github.com/openshift/openshift-ansible/pull/8013

I suppose this should be added for 3.9 as well?