### PR TITLE
Add option to enable dnsmasq negative cache

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -90,6 +90,9 @@ openshift_node_dnsmasq_install_network_manager_hook: true
 openshift_node_dnsmasq_except_interfaces:
 - lo
 
+openshift_node_dnsmasq_enable_negative_cache: false
+openshift_node_dnsmasq_enable_negative_cache_ttl: 1
+
 r_openshift_node_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
 r_openshift_node_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 

--- a/roles/openshift_node/templates/origin-dns.conf.j2
+++ b/roles/openshift_node/templates/origin-dns.conf.j2
@@ -1,6 +1,10 @@
 no-resolv
 domain-needed
+{% if openshift_node_dnsmasq_enable_negative_cache %}
+neg-ttl={{ openshift_node_dnsmasq_enable_negative_cache_ttl }}
+{% else %}
 no-negcache
+{% endif %}
 max-cache-ttl=1
 enable-dbus
 dns-forward-max=5000


### PR DESCRIPTION
Add a variable to allow user to enable the negative cache (and its corresponding ttl) in dnsmasq. The default value keeps being the same, no negative cache.

In our cluster, we have noticed problems with the facat that there is no negative cache in a very specific case: DNS aliases (CNAMEs) with a A record but no AAAA record. The empty AAAA record always removes the entry for the host from the cache (as there is no negative cache enabled). This in practice means that queries for hosts like that are never cached.
