### PR TITLE
Ensure /opt/cni/bin exists when running a node in a system container

### DIFF
--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -14,6 +14,7 @@
   with_items:
   - "/etc/origin/openvswitch"
   - "/var/lib/kubelet"
+  - "/opt/cni/bin"
 
 - name: Pre-pull node system container image
   command: >


### PR DESCRIPTION
After https://github.com/openshift/origin/pull/19445 is fixed Atomic hosts should have this dir created