### PR TITLE
broker-config can't have null values in template

### DIFF
--- a/roles/ansible_service_broker/templates/configmap.yaml.j2
+++ b/roles/ansible_service_broker/templates/configmap.yaml.j2
@@ -9,18 +9,18 @@ metadata:
 data:
   broker-config: |
     registry:
-      - type: {{ ansible_service_broker_registry_type }}
-        name: {{ ansible_service_broker_registry_name }}
-        url:  {{ ansible_service_broker_registry_url }}
-        org:  {{ ansible_service_broker_registry_organization }}
-        tag:  {{ ansible_service_broker_registry_tag }}
-        white_list: {{  ansible_service_broker_registry_whitelist | to_yaml }}
-        auth_type: "{{ ansible_service_broker_registry_auth_type | default("") }}"
-        auth_name: "{{ ansible_service_broker_registry_auth_name | default("") }}"
+      - type:{{ ansible_service_broker_registry_type }}
+        name:{{ ansible_service_broker_registry_name }}
+        url:{{ ansible_service_broker_registry_url }}
+        org:{{ ansible_service_broker_registry_organization }}
+        tag:{{ ansible_service_broker_registry_tag }}
+        white_list:{{  ansible_service_broker_registry_whitelist | to_yaml }}
+        auth_type:{{ ansible_service_broker_registry_auth_type | default("") }}
+        auth_name:{{ ansible_service_broker_registry_auth_name | default("") }}
       - type: local_openshift
         name: localregistry
         namespaces: ['openshift']
-        white_list: {{ ansible_service_broker_local_registry_whitelist | to_yaml }}
+        white_list:{{ ansible_service_broker_local_registry_whitelist | to_yaml }}
     dao:
       type: crd
     log:


### PR DESCRIPTION
If you use a null value in the broker-config template, then issues crop up
when you edit the broker-config with 'oc edit configmap broker-config'.
To allow pretty yaml to be shown rather than ugly escaped data, we should
use double quotes to signify a blank value.

Closes #8066

Signed-off-by: Leif <lmadsen@redhat.com>