### PR TITLE
Cleanup master related plays and variables

### DIFF
--- a/playbooks/openshift-etcd/private/redeploy-ca.yml
+++ b/playbooks/openshift-etcd/private/redeploy-ca.yml
@@ -64,8 +64,8 @@
 
 - name: Distribute etcd CA to masters
   hosts: oo_masters_to_config
-  vars:
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+  roles:
+  - openshift_facts
   tasks:
   - name: Deploy etcd CA
     copy:

--- a/playbooks/openshift-master/private/certificates-backup.yml
+++ b/playbooks/openshift-master/private/certificates-backup.yml
@@ -2,8 +2,8 @@
 - name: Backup and remove master cerftificates
   hosts: oo_masters_to_config
   any_errors_fatal: true
-  vars:
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+  roles:
+  - openshift_facts
   pre_tasks:
   - stat:
       path: "{{ openshift.common.config_base }}/generated-configs"

--- a/playbooks/openshift-master/private/certificates.yml
+++ b/playbooks/openshift-master/private/certificates.yml
@@ -1,8 +1,6 @@
 ---
 - name: Create OpenShift certificates for master hosts
   hosts: oo_masters_to_config
-  vars:
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
   roles:
   - role: openshift_master_facts
   - role: openshift_named_certificates

--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -13,28 +13,16 @@
 
 - import_playbook: certificates.yml
 
-- name: Disable excluders
+- name: Disable excluders and gather facts
   hosts: oo_masters_to_config
-  gather_facts: no
   roles:
-  - role: openshift_excluder
-    r_openshift_excluder_action: disable
-
-- name: Gather and set facts for master hosts
-  hosts: oo_masters_to_config
-  pre_tasks:
-  # Per https://bugzilla.redhat.com/show_bug.cgi?id=1469336
-  #
-  # When scaling up a cluster upgraded from OCP <= 3.5, ensure that
-  # OPENSHIFT_DEFAULT_REGISTRY is present as defined on the existing
-  # masters, or absent if such is the case.
-  - name: Detect if this host is a new master in a scale up
-    set_fact:
-      g_openshift_master_is_scaleup: "{{ inventory_hostname in ( groups['new_masters'] | default([]) ) }}"
-
-  - name: Scaleup Detection
-    debug:
-      var: g_openshift_master_is_scaleup
+  - openshift_facts
+  tasks:
+  - name: Disable excluders
+    import_role:
+      name: openshift_excluder
+    vars:
+      r_openshift_excluder_action: disable
 
   - name: Check for RPM generated config marker file .config_managed
     stat:
@@ -53,9 +41,6 @@
     - node
     - .config_managed
 
-  roles:
-  - openshift_facts
-  post_tasks:
   - openshift_facts:
       role: master
       local_facts:
@@ -88,8 +73,6 @@
 - name: Configure masters
   hosts: oo_masters_to_config
   any_errors_fatal: true
-  vars:
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
   pre_tasks:
   - name: Prepare the bootstrap node config on masters for self-hosting
     import_role:
@@ -139,6 +122,11 @@
   - name: Create group for deployment type
     group_by: key=oo_masters_deployment_type_{{ openshift_deployment_type }}
     changed_when: False
+  - name: Re-enable excluders
+    import_role:
+      name: openshift_excluder
+    vars:
+      r_openshift_excluder_action: enable
 
 - name: Deploy the central bootstrap configuration
   hosts: oo_first_master
@@ -155,13 +143,6 @@
     openshift_master_host: "{{ groups.oo_first_master.0 }}"
     openshift_manage_node_is_master: "{{ ('oo_masters_to_config' in group_names) | bool }}"
     openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
-
-- name: Re-enable excluder if it was previously enabled
-  hosts: oo_masters_to_config
-  gather_facts: no
-  roles:
-  - role: openshift_excluder
-    r_openshift_excluder_action: enable
 
 - name: Master Install Checkpoint End
   hosts: all

--- a/playbooks/openshift-master/private/redeploy-openshift-ca.yml
+++ b/playbooks/openshift-master/private/redeploy-openshift-ca.yml
@@ -120,7 +120,6 @@
   - role: openshift_master_facts
   - role: openshift_named_certificates
   - role: openshift_ca
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
 
 - name: Create temp directory for syncing certs
   hosts: localhost
@@ -138,8 +137,8 @@
 
 - name: Retrieve OpenShift CA
   hosts: oo_first_master
-  vars:
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+  roles:
+  - openshift_facts
   tasks:
   - name: Retrieve CA certificate, key, bundle and serial
     fetch:
@@ -160,8 +159,8 @@
 
 - name: Distribute OpenShift CA to masters
   hosts: oo_masters_to_config
-  vars:
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+  roles:
+  - openshift_facts
   tasks:
   - name: Deploy CA certificate, key, bundle and serial
     copy:
@@ -230,8 +229,8 @@
 
 - name: Distribute OpenShift CA certificate to nodes
   hosts: oo_nodes_to_config
-  vars:
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+  roles:
+  - openshift_facts
   tasks:
   - copy:
       src: "{{ hostvars['localhost'].g_master_mktemp.stdout }}/ca-bundle.crt"

--- a/playbooks/openshift-node/private/certificates.yml
+++ b/playbooks/openshift-node/private/certificates.yml
@@ -4,4 +4,3 @@
   gather_facts: no
   roles:
   - role: openshift_node_certificates
-    openshift_ca_host: "{{ groups.oo_first_master.0 }}"

--- a/roles/openshift_ca/README.md
+++ b/roles/openshift_ca/README.md
@@ -35,7 +35,6 @@ Example Playbook
   hosts: localhost
   roles:
   - role: openshift_ca
-    openshift_ca_host: master1.example.com
 ```
 
 License

--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -1,9 +1,5 @@
 ---
 - fail:
-    msg: "openshift_ca_host variable must be defined for this role"
-  when: openshift_ca_host is not defined
-
-- fail:
     msg: "Both 'certfile' and 'keyfile' keys must be supplied when configuring openshift_master_ca_certificate"
   when: openshift_master_ca_certificate is defined and ('certfile' not in openshift_master_ca_certificate or 'keyfile' not in openshift_master_ca_certificate)
 

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -205,5 +205,3 @@
   fail:
     msg: Control plane install failed.
   when: control_plane_health.stdout != 'ok'
-
-- import_tasks: bootstrap.yml

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -94,5 +94,5 @@ openshift_service_type_dict:
   openshift-enterprise: atomic-openshift
 
 openshift_service_type: "{{ openshift_service_type_dict[openshift_deployment_type] }}"
-
 openshift_master_api_port: "8443"
+openshift_ca_host: "{{ groups.oo_first_master.0 }}"

--- a/roles/openshift_node_certificates/README.md
+++ b/roles/openshift_node_certificates/README.md
@@ -15,7 +15,6 @@ From `openshift_ca`:
 
 | Name                                | Default value                                                           | Description                                                                                                               |
 |-------------------------------------|-------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| openshift_ca_host                   | None (Required)                                                         | The hostname of the system where the OpenShift CA will be (or has been) created.                                          |
 
 From this role:
 
@@ -40,7 +39,6 @@ Example Playbook
   hosts: nodes
   roles:
   - role: openshift_node_certificates
-    openshift_ca_host: master1.example.com
 ```
 
 License

--- a/roles/openshift_node_certificates/defaults/main.yml
+++ b/roles/openshift_node_certificates/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
 openshift_node_cert_expire_days: 730
-openshift_ca_host: ''
 
 openshift_docker_service_name: "{{ 'container-engine' if (openshift_docker_use_system_container | default(False) | bool) else 'docker' }}"

--- a/roles/openshift_node_certificates/meta/main.yml
+++ b/roles/openshift_node_certificates/meta/main.yml
@@ -14,3 +14,4 @@ galaxy_info:
   - system
 dependencies:
 - role: lib_utils
+- role: openshift_facts


### PR DESCRIPTION
This commit defines openshift_ca_host in one place.

This commit combines plays to have fewer plays,
resulting in faster task processing due to not
needing to re-establish tasks across plays.

This commit also removes redundant call of
bootstrap.yml task in openshift_control_plane role.