### PR TITLE
Remove system_container image from openshift_cli

### DIFF
--- a/roles/openshift_cli/defaults/main.yml
+++ b/roles/openshift_cli/defaults/main.yml
@@ -22,5 +22,4 @@ system_openshift_cli_image: "{{ (system_images_registry == 'docker') | ternary('
 openshift_use_crio_only: False
 openshift_crio_use_rpm: False
 
-l_is_system_container_image: "{{ openshift_use_master_system_container | default(openshift_use_system_containers | default(False)) | bool }}"
-l_use_cli_atomic_image: "{{ (openshift_use_crio_only | bool and not openshift_crio_use_rpm | bool) or (l_is_system_container_image | bool) }}"
+l_use_cli_atomic_image: "{{ (openshift_use_crio_only | bool and not openshift_crio_use_rpm | bool) }}"


### PR DESCRIPTION
We don't need to account for system_container masters
anymore.