### PR TITLE
Add libsemanage-python to base packages prerequisites

### DIFF
--- a/playbooks/init/base_packages.yml
+++ b/playbooks/init/base_packages.yml
@@ -18,6 +18,7 @@
       - "{{ 'python3-dbus' if ansible_distribution == 'Fedora' else 'dbus-python' }}"
       - "{{ 'python3-PyYAML' if ansible_distribution == 'Fedora' else 'PyYAML' }}"
       - "{{ 'python-ipaddress' if ansible_distribution != 'Fedora' else '' }}"
+      - libsemanage-python
       - yum-utils
       when: item != ''
       register: result


### PR DESCRIPTION
Without libsemanage-python, the task
"Set seboolean to allow nfs storage plugin access from containers"
fails with this message:
"This module requires libsemanage-python support""

Signed-off-by: Tristan Cacqueray <tdecacqu@redhat.com>