### PR TITLE
Make Kuryr healthchecks probes optional

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -265,7 +265,7 @@ In order to enable the kuryr `multi-pool` driver support, we need to tag
 the nodes with their corresponding `pod_vif` labels so that the right kuryr
 pool driver is used for each VM/node. To do that, uncomment:
 
-```
+```yaml
 openshift_openstack_cluster_node_labels:
   app:
     region: primary
@@ -289,6 +289,17 @@ For more information (e.g. how to use a specific storage backend), please
 follow the OpenShift documentation on the registry:
 
 https://docs.openshift.org/latest/install_config/registry/index.html
+
+
+### Kuryr Controller and CNI healthchecks probes
+
+By default kuryr controller and cni pods are deployed with readiness and
+liveness probes enabled. To disable them you can just uncomment:
+
+```yaml
+enable_kuryr_controller_probes: True
+enable_kuryr_cni_probes: True
+```
 
 
 ## API and Router Load Balancing

--- a/playbooks/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/all.yml
@@ -71,6 +71,11 @@ openshift_openstack_external_network_name: "public"
 #
 ## You can also change the default device owner for the precreated subports
 #openshift_kuryr_device_owner: compute:kuryr
+#
+# You can also disable the kuryr controller and cni healthcheck probes by
+# uncommenting the next
+# enable_kuryr_controller_probes: False
+# enable_kuryr_cni_probes: False
 
 
 ## If you want to use a provider network, set its name here.

--- a/roles/kuryr/defaults/main.yaml
+++ b/roles/kuryr/defaults/main.yaml
@@ -36,6 +36,10 @@ openshift_openstack_kuryr_cni_image: kuryr/cni:latest
 # Enable kuryr ports pool by default
 kuryr_openstack_enable_pools: True
 
+# Enable kuryr healthchecks probes by default
+enable_kuryr_controller_probes: True
+enable_kuryr_cni_probes: True
+
 # Path to the cni binaries
 cni_bin_dir: /opt/cni/bin
 

--- a/roles/kuryr/templates/cni-daemonset.yaml.j2
+++ b/roles/kuryr/templates/cni-daemonset.yaml.j2
@@ -51,6 +51,7 @@ spec:
           mountPath: /host_proc
         - name: openvswitch
           mountPath: /var/run/openvswitch
+{% if enable_kuryr_cni_probes|default(true)|bool %}
         readinessProbe:
           httpGet:
             path: /ready
@@ -63,6 +64,7 @@ spec:
             path: /alive
             port: {{ kuryr_healthcheck_port }}
           initialDelaySeconds: 15
+{% endif %}
       volumes:
         - name: bin
           hostPath:

--- a/roles/kuryr/templates/controller-deployment.yaml.j2
+++ b/roles/kuryr/templates/controller-deployment.yaml.j2
@@ -22,6 +22,7 @@ spec:
       - image: {{ openshift_openstack_kuryr_controller_image }}
         imagePullPolicy: IfNotPresent
         name: controller
+{% if enable_kuryr_controller_probes|default(true)|bool %}
         readinessProbe:
           httpGet:
             path: /ready
@@ -33,6 +34,7 @@ spec:
             path: /alive
             port: {{ kuryr_healthcheck_port }}
           initialDelaySeconds: 15
+{% endif %}
         terminationMessagePath: "/dev/termination-log"
         # FIXME(dulek): This shouldn't be required, but without it selinux is
         #               complaining about access to kuryr.conf.


### PR DESCRIPTION
This patch adds the option to disable the kuryr controller and cni
healthchecks probes.