### PR TITLE
master-restart: wait for container to stop before proceeding

### DIFF
--- a/roles/openshift_control_plane/files/scripts/docker/master-restart
+++ b/roles/openshift_control_plane/files/scripts/docker/master-restart
@@ -18,9 +18,20 @@ done
 # TODO: move to cri-ctl
 # TODO: short term hack for cri-o
 
+# Get a child container name to wait for it to stop
+child_container=$(docker ps -l -q --filter "label=io.kubernetes.container.name=${1}")
+
 container=$(docker ps -l -q --filter "label=openshift.io/component=${1}" --filter "label=io.kubernetes.container.name=POD")
 if [[ -z "${container}" ]]; then
   echo "Component ${1} is already stopped" 1>&2
   exit 0
 fi
-exec docker stop "${container}" --time 30 >/dev/null
+# Stop the pod
+docker stop "${container}" --time 30 >/dev/null
+
+# Wait for child container to change state
+if [[ -z "${child_container}" ]]; then
+  echo "Component ${1} is already stopped" 1>&2
+  exit 0
+fi
+exec timeout 60 docker wait $child_container


### PR DESCRIPTION
`master-restart` script is requesting a pod to stop, but doesn't wait for the container, created by the pod, to change status. As a result the following step to wait for API to come back can still hit the previous API container.

This commit would also wait for child container to finish. The max wait time is 30s (pod grace timeout) + 30s for child container to change state.

This should resolve flakes during install / FAH update

First pass log - https://s3.amazonaws.com/aos-ci/ghprb/openshift/openshift-ansible/0fc516227b8fa5943fb47d7a5988c48221144ed5.1.1524494124917417499/index.html
Second pass - https://s3.amazonaws.com/aos-ci/ghprb/openshift/openshift-ansible/0fc516227b8fa5943fb47d7a5988c48221144ed5.1.1524496529024274488/index.html
Third pass - https://s3.amazonaws.com/aos-ci/ghprb/openshift/openshift-ansible/001dc3982719d0fe394806374bedff0f7d88f794.1.1524499543996845528/index.html