### PR TITLE
Add missing attribute on htpasswd object

### DIFF
--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -278,6 +278,7 @@ class HTPasswdPasswordIdentityProvider(IdentityProviderBase):
         idp['filename'] = '/etc/origin/master/htpasswd'
         super(HTPasswdPasswordIdentityProvider, self).__init__(api_version, idp)
         self._allow_additional = False
+        self._required += [['filename']]
 
     @staticmethod
     def get_default(key):


### PR DESCRIPTION
This commit re-adds the self._required code to allow
the 'filename' field to be present in the appropriate
class.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1565447