### PR TITLE
Removing the extra closing parentheses.

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 openshift_logging_use_ops: False
 openshift_logging_master_url: "https://kubernetes.default.svc.{{ openshift.common.dns_domain }}"
-openshift_logging_master_public_url: "{{ 'https://' + openshift_master_cluster_public_hostname | default(openshift.common.public_hostname) + ':' ~ openshift_master_api_port) }}"
+openshift_logging_master_public_url: "{{ 'https://' + openshift_master_cluster_public_hostname | default(openshift.common.public_hostname, true) + ':' ~ openshift_master_api_port }}"
 openshift_logging_nodeselector: null
 openshift_logging_labels: {}
 openshift_logging_label_key: ""


### PR DESCRIPTION
While installing 3.10 OpenShift I encountered the error: 
```
TASK [openshift_logging_kibana : Generate Kibana DC template] *************************************************************************************************************************************
task path: /home/cloud-user/openshift-ansible/roles/openshift_logging_kibana/tasks/main.yaml:240
Monday 23 April 2018  17:19:15 -0400 (0:00:00.528)       0:46:50.705 **********
fatal: [master-2.scale-ci.example.com]: FAILED! => {
    "changed": false,
    "msg": "AnsibleError: {{ openshift_logging_master_public_url }}: {{ 'https://' + openshift_master_cluster_public_hostname | default(openshift.common.public_hostname) + ':' ~ openshift_master_api_port) }}: template error while templating string: unexpected ')'. String: {{ 'https://' + openshift_master_cluster_public_hostname | default(openshift.common.public_hostname) + ':' ~ openshift_master_api_port) }}"
}
```
I believe `roles/openshift_logging/defaults/main.yml` has too many closing parentheses.

I found other examples of similar string manipulation:
[0] - https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_logging_elasticsearch/defaults/main.yml#L58
[1] - https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_logging_mux/defaults/main.yml#L5

Thanks!