### PR TITLE
pass cluster-cidr to proxy

### DIFF
--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -57,6 +57,10 @@ volumeDirectory: {{ openshift_node_data_dir }}/openshift.local.volumes
 proxyArguments:
   proxy-mode:
      - {{ openshift_node_proxy_mode }}
+{% if openshift_use_calico | default(False) | bool %}
+  cluster-cidr:
+    - {{ osm_cluster_network_cidr }}
+{% endif %}
 {% endif %}
 volumeConfig:
   localQuota:


### PR DESCRIPTION
When using Calico networking, connections to nodeports only succeed if the pod backing the nodeport service is running on the host being hit. So requests are not forwarded to other nodes if the pod is running there.

This PR resolves the issue by passing Cluster CIDR to kube-proxy, which implements the nececssary iptables rules.

I'm guessing this is not an issue in openshift_sdn because it implements the necessary iptables rules itself, but this is not standard in kubernetes networking plugins.

I'm open to feedback, specifically on if this can be moved out of "extraArgs" and acceptped as a first class param in origin-node.