### PR TITLE
Configure NetworkManager to ignore calico interfaces

### DIFF
--- a/roles/calico/files/calico.conf
+++ b/roles/calico/files/calico.conf
@@ -1,0 +1,2 @@
+[keyfile]
+unmanaged-devices=interface-name:cali*;interface-name:tunl0

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -7,6 +7,19 @@
     msg: You are running a systemd based installation of Calico. Please run the calico upgrade playbook to upgrade to a self-hosted installation.
   when: sym.stat.exists
 
+- name: Configure NetworkManager to ignore Calico interfaces
+  copy:
+    src: files/calico.conf
+    dest: /etc/NetworkManager/conf.d/
+  when: using_network_manager | default(true) | bool
+  register: nm
+
+- name: restart NetworkManager
+  systemd:
+    name: NetworkManager
+    state: restarted
+  when: nm.changed
+
 # TODO: Move into shared vars file
 - name: Load default node image
   set_fact:


### PR DESCRIPTION
NetworkManager interferes with Calico unless this configuration is put in place.