### PR TITLE
Bug 1562783 - Fix egress router setup

### DIFF
--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -31,6 +31,7 @@ spec:
       # as all pods.
       serviceAccountName: sdn
       hostNetwork: true
+      hostPID: true
       containers:
       # The network container launches the openshift-sdn process, the kube-proxy, and the local DNS service.
       # It relies on an up to date node-config.yaml being present.


### PR DESCRIPTION
- For egress router, we add macvlan interface to a container
and that calls ns.GetNS(pod-netns-path) which expects pid namespace to
be shared with the host. Until we find some mechanism to push this
logic to cni plugin, we need to set hostPID=true for the sdn static pod.