### PR TITLE
Create web console smoke test app in openshift-monitor-availability project

### DIFF
--- a/roles/openshift_monitor_availability/defaults/main.yml
+++ b/roles/openshift_monitor_availability/defaults/main.yml
@@ -14,3 +14,17 @@ openshift_monitor_app_create_image: "{{ openshift_monitor_app_create_image_prefi
 openshift_monitor_app_create_run_interval: 5m
 openshift_monitor_app_create_timeout: 5m
 openshift_monitor_app_create_log_level: 0
+
+openshift_monitor_web_console_create_images:
+  origin:
+    prefix: "quay.io/redhat/web-console-smoke-test"
+    version: "0.0.1"
+  openshift-enterprise:
+    prefix: "quay.io/redhat/web-console-smoke-test"
+    version: "0.0.1"
+
+openshift_monitor_web_console_create_image_prefix: "{{ openshift_monitor_web_console_create_images[openshift_deployment_type]['prefix'] }}"
+openshift_monitor_web_console_create_image_version: "{{ openshift_monitor_web_console_create_images[openshift_deployment_type]['version'] }}"
+openshift_monitor_web_console_create_image: "{{ openshift_monitor_web_console_create_image_prefix }}:{{ openshift_monitor_web_console_create_image_version }}"
+
+openshift_monitor_web_console_create_interval_minutes: 5

--- a/roles/openshift_monitor_availability/files/monitor-web-console-app-create.yaml
+++ b/roles/openshift_monitor_availability/files/monitor-web-console-app-create.yaml
@@ -1,0 +1,114 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: web-console-smoke-test-template
+  annotations:
+    openshift.io/display-name: Web Console Smoke Test
+    iconClass: icon-openshift
+    tags: openshift,infra
+    openshift.io/documentation-url: https://github.com/openshift/origin-web-console-smoke-test
+    openshift.io/support-url: https://access.redhat.com
+    openshift.io/provider-display-name: Red Hat, Inc.
+    description: >
+      Runs smoke tests in a headless browser against the web console at a provided URL.
+
+      For more information about using this template, see
+      https://github.com/openshift/origin-web-console-smoke-test/blob/master/README.md
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: web-console-smoke-test
+    namespace: ${NAMESPACE}
+    labels:
+      app: web-console-smoke-test
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: web-console-smoke-test
+    template:
+      metadata:
+        labels:
+          app: web-console-smoke-test
+      spec:
+        containers:
+        - name: web-console-smoke-test
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          env:
+          - name: CONSOLE_URL
+            value: ${CONSOLE_URL}
+          - name: TEST_INTERVAL_MINUTES
+            value: ${TEST_INTERVAL_MINUTES}
+          - name: SELF_SIGN_CERT
+            value: ${SELF_SIGN_CERT}
+          ports:
+          - name: smoke-test-port
+            containerPort: 3000
+          restartPolicy: Always
+          volumeMounts:
+            - mountPath: /etc/tls-certs
+              name: web-console-smoke-test-serving-cert
+              readOnly: true
+        - name: kube-rbac-proxy
+          image: quay.io/coreos/kube-rbac-proxy:v0.3.0
+          args:
+          - "--secure-listen-address=:3001"
+          - "--upstream=http://127.0.0.1:3000/"
+          - "--tls-cert-file=/etc/tls/private/tls.crt"
+          - "--tls-private-key-file=/etc/tls/private/tls.key"
+          ports:
+          - name: https
+            containerPort: 3001
+            protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+            limits:
+              memory: 40Mi
+              cpu: 20m
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: tls
+        volumes:
+        - name: web-console-smoke-test-serving-cert
+          secret:
+            defaultMode: 400
+            secretName: web-console-smoke-test-serving-cert
+        - name: tls
+          secret:
+            secretName: monitor-app-create-tls
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: web-console-smoke-test
+    namespace: ${NAMESPACE}
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: web-console-smoke-test-serving-cert
+  spec:
+    ports:
+    - name: web
+      protocol: TCP
+      port: 443
+      targetPort: https
+    selector:
+      app: web-console-smoke-test
+    type: ClusterIP
+    sessionAffinity: None
+parameters:
+- name: IMAGE
+  required: true
+- name: NAMESPACE
+  value: openshift-monitor-availability
+- name: CONSOLE_URL
+  description: The location of the web console, in the format of https://<console-public-url>:8443
+  required: true
+- name: TEST_INTERVAL_MINUTES
+  description: An optional time interval to run tests, defaults to 2
+- name: SELF_SIGN_CERT
+  description: Indicator to obtain self-signed certificate from web-console upon testing. Defaults to true so the self-signed cert is obrained.
+  value: "true"

--- a/roles/openshift_monitor_availability/tasks/install.yaml
+++ b/roles/openshift_monitor_availability/tasks/install.yaml
@@ -31,6 +31,8 @@
 
 - import_tasks: install_monitor_app_create.yaml
 
+- import_tasks: install_monitor_web_console_app_create.yaml
+
 - name: Delete temp directory
   file:
     name: "{{ mktemp.stdout }}"

--- a/roles/openshift_monitor_availability/tasks/install_monitor_web_console_app_create.yaml
+++ b/roles/openshift_monitor_availability/tasks/install_monitor_web_console_app_create.yaml
@@ -1,0 +1,14 @@
+---
+- name: Apply the smoke test template
+  shell: >
+    {{ openshift_client_binary }} process -f "{{ mktemp.stdout }}/monitor-web-console-app-create.yaml"
+    --param CONSOLE_URL="{{ openshift.master.public_api_url  }}"
+    --param IMAGE="{{ openshift_monitor_web_console_create_image }}"
+    --param TEST_INTERVAL_MINUTES="{{ openshift_monitor_web_console_create_interval_minutes }}"
+    --config={{ mktemp.stdout }}/admin.kubeconfig
+    | {{ openshift_client_binary }} apply --config={{ mktemp.stdout }}/admin.kubeconfig -f -
+
+- name: Verify that web-console monitor pod is running
+  command: "{{ openshift_client_binary }} get pods --config={{ mktemp.stdout }}/admin.kubeconfig -l app=web-console-smoke-test -n openshift-monitor-availability"
+  register: get_monitor_web_console_pod_output
+  failed_when: "'No resources found.' in get_monitor_web_console_pod_output.stderr"


### PR DESCRIPTION
Adding creation of web-console-smoke-test application in the openshift-monitor-availability project.
The app is running `docker.io/benjaminapetersen/origin-web-console-smoke-test:latest` image, but one the the `github.com/benjaminapetersen/origin-web-console-smoke-test` repo is migrated under **openshift** organization will publish the image under the official **openshift** organization on **dockerhub** and also on **quay.io**

@ironcladlou @spadgett PTAL