### PR TITLE
Enable kuryr pool driver selection

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -242,12 +242,6 @@ documentation:
 
 https://docs.openstack.org/kuryr-kubernetes/latest/installation/ports-pool.html
 
-To disable this feature, you must set:
-
-```yaml
-kuryr_openstack_enable_pools: false
-```
-
 You can control the port pooling characteristics with these options:
 
 ```yaml
@@ -261,11 +255,30 @@ kuryr_openstack_pool_update_frequency: 20
 Note in the last variable you specify the number of subports that will
 be created per trunk port, i.e., per pool.
 
-In order to enable the kuryr `multi-pool` driver support, we need to tag
-the nodes with their corresponding `pod_vif` labels so that the right kuryr
-pool driver is used for each VM/node. To do that, uncomment:
+You need to set the pool driver you want to use, depending on the target
+environment, i.e., neutron for baremetal deployments or nested for deployments
+on top of VMs:
 
 ```yaml
+kuryr_openstack_pool_driver: neutron
+kuryr_openstack_pool_driver: nested
+```
+
+And to disable this feature, you must set:
+
+```yaml
+kuryr_openstack_pool_driver: noop
+```
+
+On the other hand, there is a multi driver support to enable hybrid
+deployments with different pools drivers. In order to enable the kuryr
+`multi-pool` driver support, we need to also tag the nodes with their
+corresponding `pod_vif` labels so that the right kuryr pool driver is used
+for each VM/node. To do that, uncomment:
+
+```yaml
+kuryr_openstack_pool_driver: multi
+
 openshift_openstack_cluster_node_labels:
   app:
     region: primary

--- a/playbooks/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/all.yml
@@ -55,8 +55,9 @@ openshift_openstack_external_network_name: "public"
 # override this
 #kuryr_cni_link_interface: eth0
 
-## Ports pooling is enabled by default, to disable, uncomment the next:
-#kuryr_openstack_enable_pools: False
+## Ports pooling is enabled by default (with nested driver).
+## To disable, uncomment the next:
+#kuryr_openstack_pool_driver: noop
 #
 ## You can also alter the port pooling defaults here
 #kuryr_openstack_pool_max: 0

--- a/roles/kuryr/README.md
+++ b/roles/kuryr/README.md
@@ -31,7 +31,7 @@ pods. This allows to have interconnectivity between pods and OpenStack VMs.
 * ``kuryr_openstack_pod_service_id=service_subnet_uuid``
 * ``kuryr_openstack_pod_project_id=pod_project_uuid``
 * ``kuryr_openstack_worker_nodes_subnet_id=worker_nodes_subnet_uuid``
-* ``kuryr_openstack_enable_pools=True``
+* ``kuryr_openstack_pool_driver=nested``
 * ``kuryr_openstack_pool_max=0``
 * ``kuryr_openstack_pool_min=1``
 * ``kuryr_openstack_pool_batch=5``

--- a/roles/kuryr/defaults/main.yaml
+++ b/roles/kuryr/defaults/main.yaml
@@ -34,7 +34,7 @@ openshift_openstack_kuryr_controller_image: kuryr/controller:latest
 openshift_openstack_kuryr_cni_image: kuryr/cni:latest
 
 # Enable kuryr ports pool by default
-kuryr_openstack_enable_pools: True
+kuryr_openstack_pool_driver: nested
 
 # Enable kuryr healthchecks probes by default
 enable_kuryr_controller_probes: True

--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -231,7 +231,7 @@ data:
     pod_vif_driver = nested-vlan
 
     # The driver that manages VIFs pools for Kubernetes Pods (string value)
-    vif_pool_driver = {{ kuryr_openstack_enable_pools | ternary('multi', 'noop') }}
+    vif_pool_driver = {{ kuryr_openstack_pool_driver }}
 
     [neutron]
     # Configuration options for OpenStack Neutron
@@ -556,7 +556,7 @@ data:
     pod_vif_driver = nested-vlan
 
     # The driver that manages VIFs pools for Kubernetes Pods (string value)
-    vif_pool_driver = {{ kuryr_openstack_enable_pools | ternary('multi', 'noop') }}
+    vif_pool_driver = {{ kuryr_openstack_pool_driver }}
 
     [neutron]
     # Configuration options for OpenStack Neutron


### PR DESCRIPTION
This PR enables the option to select the desired driver for the
kuryr ports pool. The nested driver is set to be the default one.