### PR TITLE
[3.9] Add no_proxy to verify to check .svc

### DIFF
--- a/roles/openshift_web_console/tasks/install.yml
+++ b/roles/openshift_web_console/tasks/install.yml
@@ -135,14 +135,14 @@
   when: not create_console_project.changed
 
 - name: Verify that the web console is running
-  command: >
-    curl -k https://webconsole.openshift-web-console.svc/healthz
-  args:
-    # Disables the following warning:
-    # Consider using get_url or uri module rather than running curl
-    warn: no
+  uri:
+    url: https://webconsole.openshift-web-console.svc/healthz
+    validate_certs: no
+    return_content: yes
+  environment:
+    no_proxy: '*'
   register: console_health
-  until: console_health.stdout == 'ok'
+  until: "'ok' in console_health.content"
   retries: 60
   delay: 10
   changed_when: false
@@ -150,7 +150,7 @@
   ignore_errors: yes
 
 # Log the result of `oc status`, `oc get pods`, `oc get events`, and `oc logs deployment/webconsole` for troubleshooting failures.
-- when: console_health.stdout != 'ok'
+- when: "'ok' not in console_health.content"
   block:
   - name: Check status in the openshift-web-console namespace
     command: >
@@ -190,4 +190,4 @@
 - name: Report console errors
   fail:
     msg: Console install failed.
-  when: console_health.stdout != 'ok'
+  when: "'ok' not in console_health.content"

--- a/roles/template_service_broker/tasks/deploy.yml
+++ b/roles/template_service_broker/tasks/deploy.yml
@@ -50,14 +50,14 @@
 
 # Check that the TSB is running
 - name: Verify that TSB is running
-  command: >
-    curl -k https://apiserver.openshift-template-service-broker.svc/healthz
-  args:
-    # Disables the following warning:
-    # Consider using get_url or uri module rather than running curl
-    warn: no
+  uri:
+    url: https://apiserver.openshift-template-service-broker.svc/healthz
+    validate_certs: no
+    return_content: yes
+  environment:
+    no_proxy: '*'
   register: api_health
-  until: api_health.stdout == 'ok'
+  until: "'ok' in api_health.content"
   retries: 60
   delay: 10
   changed_when: false


### PR DESCRIPTION
This patch changees:

- to add no_proxy option to verify the url `*.svc`.
- to use uri module to consistent with start_api_server.yml.

Cherry-pick of #7338 to release-3.9

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1570566