### PR TITLE
Run the node config for the Kuryr CNI

### DIFF
--- a/playbooks/openshift-node/private/additional_config.yml
+++ b/playbooks/openshift-node/private/additional_config.yml
@@ -1,6 +1,6 @@
 ---
 - name: create additional node network plugin groups
-  hosts: "{{ openshift_node_scale_up_group | default('oo_nodes_to_config') }}:!oo_nodes_to_bootstrap"
+  hosts: "{{ openshift_node_scale_up_group | default('oo_nodes_to_config') }}"
   tasks:
   # Creating these node groups will prevent a ton of skipped tasks.
   # Create group for flannel nodes


### PR DESCRIPTION
Kuryr expects the `roles/kuryr/tasks/node.yml` to be executed on each
node. During the initial deployment `oo_nodes_to_bootstrap` contains all
the Kuryr nodes and therefore the tasks end up never being run.

This removes that group exclusion to fix Kuryr-based deployments.