### PR TITLE
Fix BZ 1570922.

### DIFF
--- a/roles/openshift_grafana/tasks/install_grafana.yaml
+++ b/roles/openshift_grafana/tasks/install_grafana.yaml
@@ -169,7 +169,7 @@
   uri:
     url: "{{ grafana_route }}/api/datasources"
     user: "{{ grafana_sa_token.stdout }}"
-    force_basic_auth: true
+    validate_certs: false
     method: POST
     body: '{{ payload_data }}'
     body_format: json
@@ -215,7 +215,7 @@
   uri:
     url: "{{ grafana_route }}/api/dashboards/db"
     user: "{{ grafana_sa_token.stdout }}"
-    force_basic_auth: true
+    validate_certs: false
     method: POST
     body: '{{ slurpfile["content"] | b64decode }}'
     body_format: json
@@ -232,7 +232,7 @@
   uri:
     url: "{{ grafana_route }}/api/dashboards/db"
     user: "{{ grafana_sa_token.stdout }}"
-    force_basic_auth: true
+    validate_certs: false
     method: POST
     body: '{{ slurpfile["content"] | b64decode }}'
     body_format: json

--- a/roles/openshift_grafana/tasks/uninstall_grafana.yaml
+++ b/roles/openshift_grafana/tasks/uninstall_grafana.yaml
@@ -4,4 +4,4 @@
 - name: Remove grafana project
   oc_project:
     state: absent
-    name: "{{ grafana_namespace }}"
+    name: "{{ openshift_grafana_namespace }}"


### PR DESCRIPTION
we should not use certs in insecure http posts.
this PR remove basic auth force (since the proxy auth) and make sure we don't validate certs (since we don't use any, otherwise the playbook will fail).

Fixes https://bugzilla.redhat.com/1570922