### PR TITLE
Update all catalog RBAC to use upstream API

### DIFF
--- a/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
+++ b/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
@@ -4,7 +4,7 @@ metadata:
   name: service-catalog-role-bindings
 objects:
 
-- apiVersion: authorization.openshift.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: servicecatalog-serviceclass-viewer
@@ -19,11 +19,12 @@ objects:
     - watch
     - get
 
-- apiVersion: authorization.openshift.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: servicecatalog-serviceclass-viewer-binding
   roleRef:
+    kind: ClusterRole
     name: servicecatalog-serviceclass-viewer
   groupNames:
   - system:authenticated
@@ -38,7 +39,7 @@ objects:
   metadata:
     name: service-catalog-apiserver
 
-- apiVersion: authorization.openshift.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: sar-creator
@@ -50,18 +51,19 @@ objects:
     verbs:
     - create
 
-- apiVersion: authorization.openshift.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: service-catalog-sar-creator-binding
   roleRef:
+    kind: ClusterRole
     name: sar-creator
   subjects:
   - kind: ServiceAccount
     name: service-catalog-apiserver
     namespace: kube-service-catalog
 
-- apiVersion: authorization.openshift.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: namespace-viewer
@@ -75,29 +77,31 @@ objects:
     - watch
     - get
 
-- apiVersion: authorization.openshift.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: service-catalog-namespace-viewer-binding
   roleRef:
+    kind: ClusterRole
     name: namespace-viewer
   subjects:
   - kind: ServiceAccount
     name: service-catalog-apiserver
     namespace: kube-service-catalog
 
-- apiVersion: authorization.openshift.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: service-catalog-controller-namespace-viewer-binding
   roleRef:
+    kind: ClusterRole
     name: namespace-viewer
   subjects:
   - kind: ServiceAccount
     name: service-catalog-controller
     namespace: kube-service-catalog
 
-- apiVersion: authorization.openshift.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: service-catalog-controller
@@ -168,18 +172,19 @@ objects:
     - list
     - watch
 
-- apiVersion: authorization.openshift.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: service-catalog-controller-binding
   roleRef:
+    kind: ClusterRole
     name: service-catalog-controller
   subjects:
   - kind: ServiceAccount
     name: service-catalog-controller
     namespace: kube-service-catalog
-  
-- apiVersion: authorization.openshift.io/v1
+
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:
     name: configmap-accessor
@@ -195,23 +200,25 @@ objects:
     - create
     - update
 
-- apiVersion: authorization.openshift.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
     name: configmap-accessor-binding
-  roleRef:
-    name: configmap-accessor
     namespace: kube-service-catalog
+  roleRef:
+    kind: Role
+    name: configmap-accessor
   subjects:
   - kind: ServiceAccount
     namespace: kube-service-catalog
     name: service-catalog-controller
 
-- apiVersion: authorization.openshift.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: system:auth-delegator-binding
   roleRef:
+    kind: ClusterRole
     name: system:auth-delegator
   subjects:
   - kind: ServiceAccount

--- a/roles/openshift_service_catalog/files/kubesystem_roles_bindings.yml
+++ b/roles/openshift_service_catalog/files/kubesystem_roles_bindings.yml
@@ -4,7 +4,7 @@ metadata:
   name: kube-system-service-catalog-role-bindings
 objects:
 
-- apiVersion: authorization.openshift.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:
     name: extension-apiserver-authentication-reader
@@ -19,14 +19,14 @@ objects:
     verbs:
     - get
 
-- apiVersion: authorization.openshift.io/v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
     name: extension-apiserver-authentication-reader-binding
     namespace: ${KUBE_SYSTEM_NAMESPACE}
   roleRef:
+    kind: Role
     name: extension-apiserver-authentication-reader
-    namespace: ${KUBE_SYSTEM_NAMESPACE}
   subjects:
   - kind: ServiceAccount
     name: service-catalog-apiserver


### PR DESCRIPTION
This work is largely based off origin's
examples/service-catalog/service-catalog-rbac.yaml file. Essentially
this translates authorization.openshift.io/v1 to rbac.authorization.k8s.io/v1.

Closes #5039