### PR TITLE
Fixes #8113: Add map_to_pairs filter for openshift_web_console_nodeselector

### DIFF
--- a/roles/openshift_web_console/tasks/install.yml
+++ b/roles/openshift_web_console/tasks/install.yml
@@ -119,7 +119,7 @@
     {{ openshift_client_binary }} process -f "{{ mktemp.stdout }}/{{ __console_template_file }}"
     --param API_SERVER_CONFIG="{{ updated_console_config['content'] | b64decode }}"
     --param IMAGE="{{ openshift_web_console_image_name }}"
-    --param NODE_SELECTOR={{ openshift_web_console_nodeselector | to_json | quote }}
+    --param NODE_SELECTOR={{ openshift_web_console_nodeselector | map_to_pairs | to_json | quote }}
     --param REPLICA_COUNT="{{ openshift_web_console_replica_count }}"
     --config={{ mktemp.stdout }}/admin.kubeconfig
     | {{ openshift_client_binary }} apply --config={{ mktemp.stdout }}/admin.kubeconfig -f -


### PR DESCRIPTION
Allow the "key=value" notation for openshift_web_console_nodeselector.

This is also a workaround for #8113 the prevent the ansible merge for hashes.