### PR TITLE
mark control plane components backed by static pods as critical

### DIFF
--- a/roles/etcd/files/etcd.yaml
+++ b/roles/etcd/files/etcd.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     openshift.io/control-plane: "true"
     openshift.io/component: etcd
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
 spec:
   restartPolicy: Always
   hostNetwork: true

--- a/roles/openshift_control_plane/files/apiserver.yaml
+++ b/roles/openshift_control_plane/files/apiserver.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     openshift.io/control-plane: "true"
     openshift.io/component: api
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
 spec:
   restartPolicy: Always
   hostNetwork: true

--- a/roles/openshift_control_plane/files/controller.yaml
+++ b/roles/openshift_control_plane/files/controller.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     openshift.io/control-plane: "true"
     openshift.io/component: controllers
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
 spec:
   restartPolicy: Always
   hostNetwork: true


### PR DESCRIPTION
pending priority classes graduating in 1.11, we need to mark static pod backed pods as critical.

related:
https://github.com/openshift/origin/pull/19104

we need to decide if we want to enable the feature gate via openshift-ansible, or just globally in the code base.  my preference is the latter as its usage is pretty well-controlled to locked down set of namespaces.

fyi @smarterclayton @sdodson 