### PR TITLE
Add prerequisites.yml to papr.sh script

### DIFF
--- a/.papr.sh
+++ b/.papr.sh
@@ -39,6 +39,9 @@ trap upload_journals ERR
 # Store ansible log separately
 export ANSIBLE_LOG_PATH=ansible.log
 
+# run the prerequisites play
+ansible-playbook -v -i $PAPR_INVENTORY playbooks/prerequisites.yml
+
 # run the actual installer
 ansible-playbook -v -i $PAPR_INVENTORY playbooks/deploy_cluster.yml
 


### PR DESCRIPTION
Atomic CI is currently not running prerequisites play.

This commit calls the play prior to deploy_cluster.