### PR TITLE
Getting intersection of __default_ops_projects and all projects…

### DIFF
--- a/roles/openshift_logging/tasks/annotate_ops_projects.yaml
+++ b/roles/openshift_logging/tasks/annotate_ops_projects.yaml
@@ -2,8 +2,11 @@
 - command: >
     {{ openshift_client_binary }}
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-    get namespaces -o jsonpath={.items[*].metadata.name} {{ __default_logging_ops_projects | join(' ') }}
-  register: __logging_ops_projects
+    get namespaces -o jsonpath={.items[*].metadata.name}
+  register: __all_namespace_names
+
+- set_fact:
+    __logging_ops_projects: "{{ __all_namespace_names.stdout.split(' ') | intersect(__default_logging_ops_projects) }}"
 
 - name: Annotate Operations Projects for hostname
   oc_edit:
@@ -12,11 +15,10 @@
     separator: '#'
     content:
       metadata#annotations#openshift.io/logging.ui.hostname: "{{ openshift_logging_kibana_ops_hostname }}"
-  with_items: "{{ __logging_ops_projects.stdout.split(' ') }}"
+  with_items: "{{ __logging_ops_projects }}"
   loop_control:
     loop_var: project
   when:
-  - __logging_ops_projects.stderr | length == 0
   - openshift_logging_use_ops | default(false) | bool
 
 - name: Annotate Operations Projects for data prefix
@@ -26,8 +28,6 @@
     separator: '#'
     content:
       metadata#annotations#openshift.io/logging.data.prefix: ".operations"
-  with_items: "{{ __logging_ops_projects.stdout.split(' ') }}"
+  with_items: "{{ __logging_ops_projects }}"
   loop_control:
     loop_var: project
-  when:
-  - __logging_ops_projects.stderr | length == 0

--- a/roles/openshift_logging/tasks/delete_logging.yaml
+++ b/roles/openshift_logging/tasks/delete_logging.yaml
@@ -113,19 +113,20 @@
 - command: >
     {{ openshift_client_binary }}
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-    get namespaces -o name {{ __default_logging_ops_projects | join(' ') }}
-  register: __logging_ops_projects
+    get namespaces -o jsonpath={.items[*].metadata.name}
+  register: __all_namespace_names
+
+- set_fact:
+    __logging_ops_projects: "{{ __all_namespace_names.stdout.split(' ') | intersect(__default_logging_ops_projects) }}"
 
 - name: Remove Annotation of Operations Projects
   command: >
     {{ openshift_client_binary }}
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-    annotate {{ project }} openshift.io/logging.ui.hostname-
-  with_items: "{{ __logging_ops_projects.stdout_lines }}"
+    annotate project/{{ project }} openshift.io/logging.ui.hostname-
+  with_items: "{{ __logging_ops_projects }}"
   loop_control:
     loop_var: project
-  when:
-    - __logging_ops_projects.stderr | length == 0
 
 ## EventRouter
 - import_role:


### PR DESCRIPTION
that are currently installed for case where we reuse installation into logging namespace and openshift-logging isnt available

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1571819