### PR TITLE
[3.6] fix bz 1550271: restore mpath defaults config

### DIFF
--- a/roles/openshift_node/templates/multipath.conf.j2
+++ b/roles/openshift_node/templates/multipath.conf.j2
@@ -13,3 +13,8 @@ devices {
                 rr_weight "uniform"
         }
 }
+defaults {
+	user_friendly_names yes
+	find_multipaths yes
+}
+


### PR DESCRIPTION
cherrypick from mastered. 
restore mpath defaults config, fix https://bugzilla.redhat.com/show_bug.cgi?id=1550271

