### PR TITLE
Update openshift_release to 3.9 in hosts.localhost

### DIFF
--- a/inventory/hosts.localhost
+++ b/inventory/hosts.localhost
@@ -9,7 +9,7 @@ etcd
 # if your target hosts are Fedora uncomment this
 #ansible_python_interpreter=/usr/bin/python3
 openshift_deployment_type=origin
-openshift_release=3.7
+openshift_release=3.9
 osm_cluster_network_cidr=10.128.0.0/14
 openshift_portal_net=172.30.0.0/16
 osm_host_subnet_length=9


### PR DESCRIPTION
The `inventory/hosts.localhost` file tries to install version 3.7 and that does not work in branch release-3.9. I have updated openshift_release to 3.9 to fix this.