### PR TITLE
Increase timeout waiting for master API availability

### DIFF
--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -157,7 +157,7 @@
     warn: no
   register: control_plane_health
   until: control_plane_health.stdout == 'ok'
-  retries: 60
+  retries: 120
   delay: 5
   changed_when: false
   # Ignore errors so we can log troubleshooting info on failures.


### PR DESCRIPTION
In some setups it may be required to wait 6 or even 7 minutes
before master API becomes available. So, due to this, increase
timeout to 10 minutes to make sure we wait enough time.