### PR TITLE
Change filename to file in htpasswd auth

### DIFF
--- a/roles/lib_utils/filter_plugins/oo_filters.py
+++ b/roles/lib_utils/filter_plugins/oo_filters.py
@@ -694,7 +694,7 @@ def lib_utils_oo_etcd_host_urls(hosts, use_ssl=True, port='2379'):
 def lib_utils_mutate_htpass_provider(idps):
     '''Updates identityProviders list to mutate filename of htpasswd auth
     to hardcode filename = /etc/origin/master/htpasswd'''
-    old_keys = ('file', 'fileName', 'file_name')
+    old_keys = ('filename', 'fileName', 'file_name')
     for idp in idps:
         if 'provider' in idp:
             idp_p = idp['provider']
@@ -702,7 +702,7 @@ def lib_utils_mutate_htpass_provider(idps):
                 for old_key in old_keys:
                     if old_key in idp_p:
                         idp_p.pop(old_key)
-                idp_p['filename'] = '/etc/origin/master/htpasswd'
+                idp_p['file'] = '/etc/origin/master/htpasswd'
     return idps
 
 

--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -275,10 +275,10 @@ class HTPasswdPasswordIdentityProvider(IdentityProviderBase):
     def __init__(self, api_version, idp):
         # Workaround: We used to let users specify arbitrary location of
         # htpasswd file, but now it needs to be in specific spot.
-        idp['filename'] = '/etc/origin/master/htpasswd'
+        idp['file'] = '/etc/origin/master/htpasswd'
         super(HTPasswdPasswordIdentityProvider, self).__init__(api_version, idp)
         self._allow_additional = False
-        self._required += [['filename']]
+        self._required += [['file']]
 
     @staticmethod
     def get_default(key):


### PR DESCRIPTION
This commit changes mistake key 'filename' to
'file' for htpasswd auth provider.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1565447