### PR TITLE
GlusterFS: Fix setting heketi route

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
@@ -341,14 +341,12 @@
     register: heketi_route
     when:
     - glusterfs_heketi_is_native
-    - glusterfs_heketi_route is not defined
 
   - name: Determine StorageClass heketi URL
     set_fact:
       glusterfs_heketi_route: "{{ heketi_route.results.results[0]['spec']['host'] }}"
     when:
     - glusterfs_heketi_is_native
-    - glusterfs_heketi_route is not defined
 
   - name: Generate Gluster Block StorageClass file
     template:


### PR DESCRIPTION
We don't care if the heketi route has been previously defined, it could be from a previous run of the role.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>