### PR TITLE
Remove openshift-ansible-catalog-console.js

### DIFF
--- a/playbooks/openshift-master/private/templates/openshift-ansible-catalog-console.js
+++ b/playbooks/openshift-master/private/templates/openshift-ansible-catalog-console.js
@@ -1,1 +1,0 @@
-window.OPENSHIFT_CONSTANTS.TEMPLATE_SERVICE_BROKER_ENABLED = {{ 'true' if (template_service_broker_install | default(True)) else 'false' }};


### PR DESCRIPTION
This file is no longer used in 3.9+ and I can find no code that references it.