### PR TITLE
[3.6] Backport etcd certificate updates from 3.7

### DIFF
--- a/playbooks/common/openshift-cluster/redeploy-certificates/etcd-ca.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/etcd-ca.yml
@@ -60,14 +60,9 @@
   roles:
   - role: etcd_common
     r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
-  tasks:
-  - include_role:
-      name: etcd
-      tasks_from: distribute_ca
-    vars:
-      r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
-      etcd_sync_cert_dir: "{{ hostvars['localhost'].g_etcd_mktemp.stdout }}"
-    static: true
+  - role: etcd_server_certificates
+    r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
+    etcd_sync_cert_dir: "{{ hostvars['localhost'].g_etcd_mktemp.stdout }}"
 
 - include: ../../openshift-etcd/restart.yml
   # Do not restart etcd when etcd certificates were previously expired.

--- a/playbooks/common/openshift-cluster/redeploy-certificates/etcd-ca.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/etcd-ca.yml
@@ -61,46 +61,13 @@
   - role: etcd_common
     r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
   tasks:
-  - name: Create a tarball of the etcd ca certs
-    command: >
-      tar -czvf {{ etcd_conf_dir }}/{{ etcd_ca_name }}.tgz
-        -C {{ etcd_ca_dir }} .
-    args:
-      creates: "{{ etcd_conf_dir }}/{{ etcd_ca_name }}.tgz"
-      warn: no
-    delegate_to: "{{ etcd_ca_host }}"
-    run_once: true
-  - name: Retrieve etcd ca cert tarball
-    fetch:
-      src: "{{ etcd_conf_dir }}/{{ etcd_ca_name }}.tgz"
-      dest: "{{ hostvars['localhost'].g_etcd_mktemp.stdout }}/"
-      flat: yes
-      fail_on_missing: yes
-      validate_checksum: yes
-    delegate_to: "{{ etcd_ca_host }}"
-    run_once: true
-  - name: Ensure ca directory exists
-    file:
-      path: "{{ etcd_ca_dir }}"
-      state: directory
-  - name: Unarchive etcd ca cert tarballs
-    unarchive:
-      src: "{{ hostvars['localhost'].g_etcd_mktemp.stdout }}/{{ etcd_ca_name }}.tgz"
-      dest: "{{ etcd_ca_dir }}"
-  - name: Read current etcd CA
-    slurp:
-      src: "{{ etcd_conf_dir }}/ca.crt"
-    register: g_current_etcd_ca_output
-  - name: Read new etcd CA
-    slurp:
-      src: "{{ etcd_ca_dir }}/ca.crt"
-    register: g_new_etcd_ca_output
-  - copy:
-      content: "{{ (g_new_etcd_ca_output.content|b64decode) + (g_current_etcd_ca_output.content|b64decode) }}"
-      dest: "{{ item }}/ca.crt"
-    with_items:
-    - "{{ etcd_conf_dir }}"
-    - "{{ etcd_ca_dir }}"
+  - include_role:
+      name: etcd
+      tasks_from: distribute_ca
+    vars:
+      r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
+      etcd_sync_cert_dir: "{{ hostvars['localhost'].g_etcd_mktemp.stdout }}"
+    static: true
 
 - include: ../../openshift-etcd/restart.yml
   # Do not restart etcd when etcd certificates were previously expired.

--- a/playbooks/common/openshift-cluster/redeploy-certificates/etcd.yml
+++ b/playbooks/common/openshift-cluster/redeploy-certificates/etcd.yml
@@ -1,6 +1,6 @@
 ---
 - name: Backup and remove generated etcd certificates
-  hosts: oo_first_etcd
+  hosts: oo_etcd_to_config
   any_errors_fatal: true
   roles:
     - role: etcd_common

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -55,6 +55,8 @@
 - import_playbook: ../../openshift-etcd/certificates.yml
   when:
   - true in hostvars | oo_select_keys(groups['oo_etcd_to_config']) | oo_collect('__etcd_cert_lacks_hostname') | default([false])
+  vars:
+    etcd_certificates_redeploy: True
 
 - name: Upgrade and backup etcd
   include: ./etcd/main.yml

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -33,6 +33,29 @@
         embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
         debug_level: "{{ openshift_master_debug_level | default(openshift.common.debug_level | default(2)) }}"
 
+# Prior to 3.6, openshift-ansible created etcd serving certificates
+# without a SubjectAlternativeName entry for the system hostname. The
+# SAN list in Go 1.8 is now (correctly) authoritative and since
+# openshift-ansible configures masters to talk to etcd hostnames
+# rather than IP addresses, we must correct etcd certificates.
+#
+# This play examines the etcd serving certificate SANs on each etcd
+# host and records whether or not the system hostname is missing.
+- name: Examine etcd serving certificate SAN
+  hosts: oo_etcd_to_config
+  tasks:
+  - slurp:
+      src: /etc/etcd/server.crt
+    register: etcd_serving_cert
+  - set_fact:
+      __etcd_cert_lacks_hostname: "{{ (openshift.common.hostname not in (etcd_serving_cert.content | b64decode | oo_parse_certificate_san)) | bool }}"
+
+# Redeploy etcd certificates when hostnames were missing from etcd
+# serving certificate SANs.
+- import_playbook: ../../openshift-etcd/certificates.yml
+  when:
+  - true in hostvars | oo_select_keys(groups['oo_etcd_to_config']) | oo_collect('__etcd_cert_lacks_hostname') | default([false])
+
 - name: Upgrade and backup etcd
   include: ./etcd/main.yml
 

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -52,7 +52,7 @@
 
 # Redeploy etcd certificates when hostnames were missing from etcd
 # serving certificate SANs.
-- import_playbook: ../../openshift-etcd/certificates.yml
+- include: ../../openshift-etcd/certificates.yml
   when:
   - true in hostvars | oo_select_keys(groups['oo_etcd_to_config']) | oo_collect('__etcd_cert_lacks_hostname') | default([false])
   vars:

--- a/playbooks/common/openshift-etcd/ca.yml
+++ b/playbooks/common/openshift-etcd/ca.yml
@@ -1,0 +1,15 @@
+---
+- name: Generate new etcd CA
+  hosts: oo_first_etcd
+  roles:
+  - role: openshift_etcd_facts
+  tasks:
+  - include_role:
+      name: etcd
+      tasks_from: ca
+    vars:
+      etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"
+      etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"
+    when:
+    - etcd_ca_setup | default(True) | bool
+    static: true

--- a/playbooks/common/openshift-etcd/certificates.yml
+++ b/playbooks/common/openshift-etcd/certificates.yml
@@ -1,0 +1,4 @@
+---
+- include: server_certificates.yml
+
+- include: master_etcd_certificates.yml

--- a/playbooks/common/openshift-etcd/config.yml
+++ b/playbooks/common/openshift-etcd/config.yml
@@ -5,7 +5,6 @@
   roles:
   - role: openshift_etcd
     etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"
-    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
     etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"
     r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
   - role: nickhammond.logrotate

--- a/playbooks/common/openshift-etcd/master_etcd_certificates.yml
+++ b/playbooks/common/openshift-etcd/master_etcd_certificates.yml
@@ -1,0 +1,12 @@
+---
+- name: Create etcd client certificates for master hosts
+  hosts: oo_masters_to_config
+  any_errors_fatal: true
+  roles:
+    - role: openshift_etcd_facts
+    - role: openshift_etcd_client_certificates
+      etcd_cert_subdir: "openshift-master-{{ openshift.common.hostname }}"
+      etcd_cert_config_dir: "{{ openshift.common.config_base }}/master"
+      etcd_cert_prefix: "master.etcd-"
+      r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
+      when: groups.oo_etcd_to_config is defined and groups.oo_etcd_to_config

--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -9,8 +9,8 @@
   - set_fact:
       etcd_migration_in_progress: true
   - include_role:
-      name: etcd
-      tasks_from: migrate.pre_check
+      name: etcd_migrate
+      tasks_from: check
     vars:
       r_etcd_common_embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
       etcd_peer: "{{ ansible_default_ipv4.address }}"

--- a/playbooks/common/openshift-etcd/migrate.yml
+++ b/playbooks/common/openshift-etcd/migrate.yml
@@ -5,13 +5,16 @@
 
 - name: Run pre-checks
   hosts: oo_etcd_to_migrate
-  tags:
-  - always
-  roles:
-  - role: etcd_migrate
-    r_etcd_migrate_action: check
-    r_etcd_common_embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
-    etcd_peer: "{{ ansible_default_ipv4.address }}"
+  tasks:
+  - set_fact:
+      etcd_migration_in_progress: true
+  - include_role:
+      name: etcd
+      tasks_from: migrate.pre_check
+    vars:
+      r_etcd_common_embedded_etcd: "{{ groups.oo_etcd_to_config | default([]) | length == 0 }}"
+      etcd_peer: "{{ ansible_default_ipv4.address }}"
+    static: true
 
 - include: ../openshift-cluster/initialize_facts.yml
   tags:
@@ -253,5 +256,9 @@
     with_items: "{{ master_services[::-1] }}"
   - fail:
       msg: "Migration failed. The following hosts were not properly migrated: {{ etcd_migration_failed | join(',') }}"
+    when:
+    - etcd_migration_failed | length > 0
+  - set_fact:
+      etcd_migration_in_progress: false
     when:
     - etcd_migration_failed | length > 0

--- a/playbooks/common/openshift-etcd/scaleup.yml
+++ b/playbooks/common/openshift-etcd/scaleup.yml
@@ -12,8 +12,6 @@
   hosts: oo_new_etcd_to_config
   serial: 1
   any_errors_fatal: true
-  vars:
-    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
   pre_tasks:
   - name: Add new etcd members to cluster
     command: >
@@ -34,7 +32,6 @@
   - role: openshift_etcd
     when: etcd_add_check.rc == 0
     etcd_peers: "{{ groups.oo_etcd_to_config | union(groups.oo_new_etcd_to_config)| default([], true) }}"
-    etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
     etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"
     etcd_initial_cluster_state: "existing"
     initial_etcd_cluster: "{{ etcd_add_check.stdout_lines[3] | regex_replace('ETCD_INITIAL_CLUSTER=','') | regex_replace('\"','') }}"

--- a/playbooks/common/openshift-etcd/server_certificates.yml
+++ b/playbooks/common/openshift-etcd/server_certificates.yml
@@ -6,8 +6,7 @@
     - role: openshift_etcd_facts
   post_tasks:
     - include_role:
-        name: etcd
-        tasks_from: server_certificates
+        name: etcd_server_certificates
       vars:
         etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"
         etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"

--- a/playbooks/common/openshift-etcd/server_certificates.yml
+++ b/playbooks/common/openshift-etcd/server_certificates.yml
@@ -1,0 +1,15 @@
+---
+- name: Create etcd server certificates for etcd hosts
+  hosts: oo_etcd_to_config
+  any_errors_fatal: true
+  roles:
+    - role: openshift_etcd_facts
+  post_tasks:
+    - include_role:
+        name: etcd
+        tasks_from: server_certificates
+      vars:
+        etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"
+        etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"
+        r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"
+      static: true

--- a/playbooks/common/openshift-node/etcd_client_config.yml
+++ b/playbooks/common/openshift-node/etcd_client_config.yml
@@ -1,0 +1,10 @@
+---
+- name: etcd_client node config
+  hosts: "{{ openshift_node_scale_up_group | default('this_group_does_not_exist') }}"
+  roles:
+  - role: openshift_facts
+  - role: openshift_etcd_facts
+  - role: openshift_etcd_client_certificates
+    etcd_cert_prefix: flannel.etcd-
+    etcd_cert_subdir: "openshift-node-{{ openshift.common.hostname }}"
+    etcd_cert_config_dir: "{{ openshift.common.config_base }}/node"

--- a/roles/etcd_client_certificates/tasks/main.yml
+++ b/roles/etcd_client_certificates/tasks/main.yml
@@ -86,6 +86,13 @@
   when: etcd_client_certs_missing | bool
   become: no
 
+- name: Delete existing certificate tarball if certs need to be regenerated
+  file:
+    path: "{{ etcd_generated_certs_dir }}/{{ etcd_cert_subdir }}.tgz"
+    state: absent
+  when: etcd_client_certs_missing | bool
+  delegate_to: "{{ etcd_ca_host }}"
+
 - name: Create a tarball of the etcd certs
   command: >
     tar -czvf {{ etcd_generated_certs_dir }}/{{ etcd_cert_subdir }}.tgz

--- a/roles/etcd_server_certificates/tasks/main.yml
+++ b/roles/etcd_server_certificates/tasks/main.yml
@@ -111,6 +111,13 @@
   changed_when: False
   when: etcd_server_certs_missing | bool
 
+- name: Delete existing certificate tarball if certs need to be regenerated
+  file:
+    path: "{{ etcd_generated_certs_dir }}/{{ etcd_cert_subdir }}.tgz"
+    state: absent
+  when: etcd_server_certs_missing | bool
+  delegate_to: "{{ etcd_ca_host }}"
+
 - name: Create a tarball of the etcd certs
   command: >
     tar -czvf {{ etcd_generated_certs_dir }}/{{ etcd_cert_subdir }}.tgz

--- a/roles/openshift_etcd_facts/defaults/main.yml
+++ b/roles/openshift_etcd_facts/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+etcd_ca_host_group: "oo_etcd_to_config"

--- a/roles/openshift_etcd_facts/tasks/main.yml
+++ b/roles/openshift_etcd_facts/tasks/main.yml
@@ -3,3 +3,5 @@
     role: etcd
     local_facts:
       etcd_image: "{{ osm_etcd_image | default(None) }}"
+- include: set_etcd_ca_host.yml
+  static: true

--- a/roles/openshift_etcd_facts/tasks/set_etcd_ca_host.yml
+++ b/roles/openshift_etcd_facts/tasks/set_etcd_ca_host.yml
@@ -1,0 +1,44 @@
+---
+- name: Check for CA indicator files
+  stat:
+    path: "{{ item.0 }}"
+  delegate_to: "{{ item.1 }}"
+  with_nested:
+  - - /etc/etcd/ca
+    - /etc/etcd/generated_certs
+  - "{{ groups[etcd_ca_host_group] }}"
+  register: __etcd_ca_host_stat
+  run_once: true
+
+# Collect ansible_host (inventory hostname) of hosts with /etc/etcd/ca
+# and /etc/etcd/generated_certs directories.
+- set_fact:
+    __etcd_ca_dir_hosts: "{{ __etcd_ca_host_stat.results
+                             | oo_collect('_ansible_delegated_vars.ansible_host',
+                                                    filters={'stat.path':'/etc/etcd/ca','stat.exists':True}) }}"
+    __etcd_generated_certs_dir_hosts: "{{ __etcd_ca_host_stat.results
+                                          | oo_collect('_ansible_delegated_vars.ansible_host',
+                                                                 filters={'stat.path':'/etc/etcd/generated_certs','stat.exists':True}) }}"
+  run_once: true
+
+# __etcd_ca_hosts is the intersection of hosts which have /etc/etcd/ca
+# and /etc/etcd/generated_certs directories.
+- set_fact:
+    __etcd_ca_hosts: "{{ __etcd_ca_dir_hosts | intersect(__etcd_generated_certs_dir_hosts) }}"
+  run_once: true
+
+# __etcd_ca_hosts should only contain one host. If more than one host
+# is able to be an etcd CA host then we will use the first.
+- set_fact:
+    etcd_ca_host: "{{ __etcd_ca_hosts[0] }}"
+  when:
+  - __etcd_ca_hosts | length > 0
+  - etcd_ca_host is not defined
+
+# No etcd_ca_host was found in __etcd_ca_hosts. This is probably a
+# fresh installation so we will default to the first member of the
+# etcd host group.
+- set_fact:
+    etcd_ca_host: "{{ groups[etcd_ca_host_group].0 }}"
+  when:
+  - etcd_ca_host is not defined

--- a/roles/openshift_version/tasks/main.yml
+++ b/roles/openshift_version/tasks/main.yml
@@ -183,6 +183,7 @@
     when:
     - not is_containerized | bool
     - openshift_release is defined
+    - etcd_migration_completed is not defined and etcd_migration_in_progress is not defined
     assert:
       that:
       - openshift_version.startswith(openshift_release) | bool


### PR DESCRIPTION
Cherrypick of
* #7914
* #7918
* #8158
* #8174

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1572377

Verified that upgrade from OCP 3.5 with etcd 3.1.9 -> OCP 3.6 etcd 3.2.15 
works fine and updated the certs

TODO:
* [x] Fix containerized install
* [x] Verify 3.5 with old etcd -> 3.6 with new etcd upgrade
* [x] Verify migrate playbook: