### PR TITLE
Fix issue with dnsmasq not caching NXDOMAIN

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -90,6 +90,10 @@ openshift_node_dnsmasq_install_network_manager_hook: true
 openshift_node_dnsmasq_except_interfaces:
 - lo
 
+# dnsmasq defaults to neg caching enabled with a ttl of 1 second
+openshift_node_dnsmasq_no_negcache: false
+openshift_node_dnsmasq_neg_ttl: '1'
+
 r_openshift_node_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
 r_openshift_node_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 

--- a/roles/openshift_node/templates/origin-dns.conf.j2
+++ b/roles/openshift_node/templates/origin-dns.conf.j2
@@ -1,6 +1,10 @@
 no-resolv
 domain-needed
+{% if openshift_node_dnsmasq_no_negcache %}
 no-negcache
+{% else %}
+neg-ttl={{ openshift_node_dnsmasq_neg_ttl }}
+{% endif %}
 max-cache-ttl=1
 enable-dbus
 dns-forward-max=5000


### PR DESCRIPTION
dnsmasq should cache negative replies to avoid an unnessary amount of NXDOMAIN
upstream DNS requests.  This will also allow an Openshift administrator to set
their own neg-ttl value or re-enable the old behavior of no-negcache if they so
wish.

Fixes https://github.com/openshift/openshift-ansible/issues/8167