### PR TITLE
Flush ansible handlers before running restart service tasks in contiv

### DIFF
--- a/roles/contiv/handlers/main.yml
+++ b/roles/contiv/handlers/main.yml
@@ -6,13 +6,11 @@
   service:
     name: netmaster
     state: restarted
-  when: netmaster_started.changed == false
 
 - name: restart netplugin
   service:
     name: netplugin
     state: restarted
-  when: netplugin_started.changed == false
 
 - name: Save iptables rules
   command: service iptables save

--- a/roles/contiv/tasks/netmaster.yml
+++ b/roles/contiv/tasks/netmaster.yml
@@ -41,6 +41,9 @@
     dest: /etc/systemd/system/netmaster.service
   notify: reload systemd
 
+- name: Netmaster | Flush handlers
+  meta: flush_handlers
+
 - name: Netmaster | Enable Netmaster
   service:
     name: netmaster
@@ -50,7 +53,6 @@
   service:
     name: netmaster
     state: started
-  register: netmaster_started
 
 - include_tasks: aci.yml
   when: contiv_fabric_mode == "aci"

--- a/roles/contiv/tasks/netplugin.yml
+++ b/roles/contiv/tasks/netplugin.yml
@@ -102,6 +102,9 @@
   command: systemctl daemon-reload
   when: docker_updated is changed
 
+- name: Netplugin | Flush handlers
+  meta: flush_handlers
+
 - name: Netplugin | Restart docker
   service:
     name: "{{ contiv_openshift_docker_service_name }}"
@@ -121,5 +124,4 @@
   service:
     name: netplugin
     state: started
-  register: netplugin_started
 # notify: restart kubelet


### PR DESCRIPTION
Need flush the handler to reload systemd before running restart service
tasks.