### PR TITLE
set become=no on local_action to support AWX/Tower deployment as non-…

### DIFF
--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -7,7 +7,7 @@
 
 - import_playbook: common/private/components.yml
 
-# need to have a play expilicitly defined here otherwise can't add as job template in AWX/Tower.
+# need to have a play explicitly defined here otherwise can't add as job template in AWX/Tower.
 - name: noop
   hosts: localhost
   tasks:

--- a/playbooks/init/evaluate_groups.yml
+++ b/playbooks/init/evaluate_groups.yml
@@ -2,6 +2,7 @@
 - name: Populate config host groups
   hosts: localhost
   connection: local
+  become: no
   gather_facts: no
   tasks:
   - name: Load group name mapping variables

--- a/playbooks/openshift-node/private/setup.yml
+++ b/playbooks/openshift-node/private/setup.yml
@@ -9,6 +9,7 @@
 - name: Evaluate node groups
   hosts: localhost
   connection: local
+  become: no
   tasks:
   - name: Evaluate oo_containerized_master_nodes
     add_host:

--- a/roles/etcd/tasks/certificates/fetch_client_certificates_from_ca.yml
+++ b/roles/etcd/tasks/certificates/fetch_client_certificates_from_ca.yml
@@ -115,6 +115,7 @@
 
 - name: Delete temporary directory
   local_action: file path="/tmp/{{ inventory_hostname }}" state=absent
+  become: no
   changed_when: False
   when: etcd_client_certs_missing | bool
 

--- a/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
+++ b/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
@@ -171,6 +171,7 @@
 
 - name: Delete temporary directory
   local_action: file path="/tmp/{{ inventory_hostname }}" state=absent
+  become: no
   changed_when: False
   when: etcd_server_certs_missing | bool
 

--- a/roles/openshift_examples/tasks/main.yml
+++ b/roles/openshift_examples/tasks/main.yml
@@ -13,11 +13,13 @@
 # use it either due to changes introduced in Ansible 2.x.
 - name: Create local temp dir for OpenShift examples copy
   local_action: command mktemp -d /tmp/openshift-ansible-XXXXXXX
+  become: no
   register: copy_examples_mktemp
   run_once: True
 
 - name: Chmod local temp dir for OpenShift examples copy
   local_action: command chmod 777 "{{ copy_examples_mktemp.stdout }}"
+  become: no
   run_once: True
 
 - name: Create tar of OpenShift examples
@@ -26,9 +28,11 @@
     # Disables the following warning:
     # Consider using unarchive module rather than running tar
     warn: no
+  become: no
 
 - name: Chmod local temp dir for OpenShift examples copy
   local_action: command chmod 744 "{{ copy_examples_mktemp.stdout }}/openshift-examples.tar"
+  become: no
   run_once: True
 
 - name: Create the remote OpenShift examples directory
@@ -44,6 +48,7 @@
 
 - name: Cleanup the OpenShift Examples temp dir
   local_action: file dest="{{ copy_examples_mktemp.stdout }}" state=absent
+  become: no
 
 # Done copying examples
 ######################################################################

--- a/roles/openshift_hosted_templates/tasks/main.yml
+++ b/roles/openshift_hosted_templates/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Create local temp dir for OpenShift hosted templates copy
   local_action: command mktemp -d /tmp/openshift-ansible-XXXXXXX
+  become: no
   register: copy_hosted_templates_mktemp
   run_once: True
   # AUDIT:changed_when: not set here because this task actually
@@ -8,6 +9,7 @@
 
 - name: Chmod local temp dir for OpenShift examples copy
   local_action: command chmod 777 "{{ copy_hosted_templates_mktemp.stdout }}"
+  become: no
   run_once: True
 
 - name: Create tar of OpenShift examples
@@ -16,9 +18,11 @@
     # Disables the following warning:
     # Consider using unarchive module rather than running tar
     warn: no
+  become: no
 
 - name: Chmod local tar of OpenShift examples
   local_action: command chmod 744 "{{ copy_hosted_templates_mktemp.stdout }}/openshift-hosted-templates.tar"
+  become: no
   run_once: True
 
 - name: Create remote OpenShift hosted templates directory
@@ -34,6 +38,7 @@
 
 - name: Cleanup the OpenShift hosted templates temp dir
   local_action: file dest="{{ copy_hosted_templates_mktemp.stdout }}" state=absent
+  become: no
 
 - name: Modify registry paths if registry_url is not registry.access.redhat.com
   shell: >

--- a/roles/openshift_node_certificates/tasks/main.yml
+++ b/roles/openshift_node_certificates/tasks/main.yml
@@ -130,6 +130,7 @@
 
 - name: Delete local temp directory
   local_action: file path="/tmp/{{ inventory_hostname }}" state=absent
+  become: no
   changed_when: False
   when: node_certs_missing | bool
 


### PR DESCRIPTION
on local_action tasks, become should be set to no explicitly. Otherwise it breaks deployment from AWX/Tower with 'privilege escalation' enabled on the job template with non-root credentials. See the same playbook files on 3.7 release as this was correctly implemented there and working.