### PR TITLE
Re-add etcd rpm install path for external etcd

### DIFF
--- a/playbooks/openshift-etcd/private/config.yml
+++ b/playbooks/openshift-etcd/private/config.yml
@@ -19,11 +19,31 @@
   hosts: oo_etcd_to_config
   any_errors_fatal: true
   tasks:
+  - fail:
+      msg: >
+        etcd stand-alone hosts on atomic is no longer supported. Please
+        co-locate your etcd hosts with masters.
+    when:
+    - openshift_is_atomic | bool
+    - not inventory_hostname in groups['oo_masters']
+
+  # Setup etcd as a static pod if collocated with a master
   - import_role:
       name: etcd
+      tasks_from: static.yml
     vars:
       etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"
       etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"
+    when: inventory_hostname in groups['oo_masters']
+
+  - import_role:
+      name: etcd
+      tasks_from: rpm.yml
+    when: not inventory_hostname in groups['oo_masters']
+    vars:
+      etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"
+      etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"
+
   - import_role:
       name: nickhammond.logrotate
 

--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -110,3 +110,6 @@ etcd_quota_backend_bytes: 4294967296
 openshift_docker_service_name: "{{ 'container-engine' if (openshift_docker_use_system_container | default(False) | bool) else 'docker' }}"
 
 etcd_ca_host: "{{ groups['oo_etcd_to_config'].0 }}"
+
+l_etcd_restart_is_pod: "{{ (inventory_hostname in groups['oo_masters']) | bool }}"
+l_etcd_restart_command: "{{ l_etcd_restart_is_pod | ternary('/usr/local/bin/master-restart etcd', 'systemctl restart etcd') }}"

--- a/roles/etcd/handlers/main.yml
+++ b/roles/etcd/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: restart etcd
-  command: /usr/local/bin/master-restart etcd
+  command: "{{ l_etcd_restart_command }}"

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -1,3 +1,2 @@
 ---
-- name: Configure etcd with static pods
-  import_tasks: static.yml
+# This role is meant to be used with import_role and tasks_from.

--- a/roles/etcd/tasks/rpm.yml
+++ b/roles/etcd/tasks/rpm.yml
@@ -51,14 +51,6 @@
     recurse: True
   when: etcd_is_thirdparty | bool
 
-- name: Validate permissions on the config dir
-  file:
-    path: "{{ etcd_conf_dir }}"
-    state: directory
-    owner: "etcd"
-    group: "etcd"
-    mode: 0700
-
 - name: Write etcd global config file
   template:
     src: etcd.conf.j2
@@ -66,6 +58,9 @@
     backup: true
   notify:
   - restart etcd
+
+- name: Ensure etcd owns the files in it's config dir
+  command: "chown etcd:etcd {{ etcd_conf_dir }}/ -R"
 
 - name: Enable etcd
   systemd:


### PR DESCRIPTION
Recent commits removed the ability to have an
external etcd (etcd that is not on a master).

This commit ensures that etcd can be installed via
rpm on hosts that are not masters.

Atomic external etcd hosts are no longer supported.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1569895