### PR TITLE
Remove the old registry symlink before updating it

### DIFF
--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -17,6 +17,12 @@
     state: directory
     path: "/etc/docker/certs.d/docker-registry.default.svc:5000"
 
+# removing a broken link in ansible fails, so we must first remove it
+- name: Forcibly remove the old registry CA symlink
+  file:
+    path: "/etc/docker/certs.d/docker-registry.default.svc:5000/node-client-ca.crt"
+    state: absent
+
 - name: Update the docker-registry CA symlink
   file:
     src: "{{ openshift_node_config_dir }}/client-ca.crt"


### PR DESCRIPTION
It looks like ansible fails to force a symlink update if the previous
symlink is broken (which it is during the upgrade).

```
TASK [openshift_node : Update the docker-registry CA symlink] ******************
Tuesday 01 May 2018  15:42:27 +0000 (0:00:00.263)       0:04:44.210 ***********
fatal: [prtest-c4a8d93-486-ig-m-98dq]: FAILED! => {"changed": false, "msg": "path /etc/origin/node/node-client-ca.crt does not exist", "path": "/etc/origin/node/node-client-ca.crt", "state": "absent"}
```

Seen from https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_openshift-ansible/8187/test_pull_request_openshift_ansible_install_upgrade_gce/486/