### PR TITLE
Remove clusterNetworkCIDR/hostSubnetLength from default config

### DIFF
--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -111,8 +111,6 @@ masterClients:
   openshiftLoopbackKubeConfig: openshift-master.kubeconfig
 masterPublicURL: {{ openshift.master.public_api_url }}
 networkConfig:
-  clusterNetworkCIDR: {{ openshift.master.sdn_cluster_network_cidr }}
-  hostSubnetLength: {{ openshift.master.sdn_host_subnet_length }}
   clusterNetworks:
   - cidr: {{ openshift.master.sdn_cluster_network_cidr }}
     hostSubnetLength: {{ openshift.master.sdn_host_subnet_length }}


### PR DESCRIPTION
clusterNetworkCIDR and hostSubnetLength have been deprecated in favor
of a clusterNetwork object that allows a cluster administrator to
specify multiple cidr ranges of different sizes.

bug 1534779
https://bugzilla.redhat.com/show_bug.cgi?id=1534779