### PR TITLE
Remove certificates_to_synchronize filter module

### DIFF
--- a/playbooks/openshift-master/private/certificates-backup.yml
+++ b/playbooks/openshift-master/private/certificates-backup.yml
@@ -27,12 +27,24 @@
       path: "{{ openshift.common.config_base }}/master/{{ item }}"
       state: absent
     with_items:
-    # certificates_to_synchronize is a custom filter in lib_utils
-    - "{{ hostvars[inventory_hostname] | certificates_to_synchronize(include_keys=false, include_ca=false) }}"
-    - "etcd.server.crt"
-    - "etcd.server.key"
-    - "master.server.crt"
-    - "master.server.key"
-    - "openshift-master.crt"
-    - "openshift-master.key"
-    - "openshift-master.kubeconfig"
+    - admin.crt
+    - admin.key
+    - admin.kubeconfig
+    - aggregator-front-proxy.crt
+    - aggregator-front-proxy.key
+    - aggregator-front-proxy.kubeconfig
+    - front-proxy-ca.crt
+    - front-proxy-ca.key
+    - master.kubelet-client.crt
+    - master.kubelet-client.key
+    - master.proxy-client.crt
+    - master.proxy-client.key
+    - service-signer.crt
+    - service-signer.key
+    - etcd.server.crt
+    - etcd.server.key
+    - master.server.crt
+    - master.server.key
+    - openshift-master.crt
+    - openshift-master.key
+    - openshift-master.kubeconfig

--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -484,32 +484,6 @@ class FilterModule(object):
                            Dumper=AnsibleDumper))
 
     @staticmethod
-    def certificates_to_synchronize(hostvars, include_keys=True, include_ca=True):
-        ''' Return certificates to synchronize based on facts. '''
-        if not issubclass(type(hostvars), dict):
-            raise errors.AnsibleFilterError("|failed expects hostvars is a dict")
-        certs = ['admin.crt',
-                 'admin.key',
-                 'admin.kubeconfig',
-                 'aggregator-front-proxy.crt',
-                 'aggregator-front-proxy.key',
-                 'aggregator-front-proxy.kubeconfig',
-                 'front-proxy-ca.crt',
-                 'front-proxy-ca.key',
-                 'master.kubelet-client.crt',
-                 'master.kubelet-client.key',
-                 'master.proxy-client.crt',
-                 'master.proxy-client.key',
-                 'service-signer.crt',
-                 'service-signer.key']
-        if bool(include_ca):
-            certs += ['ca.crt', 'ca.key', 'ca-bundle.crt', 'client-ca-bundle.crt']
-        if bool(include_keys):
-            certs += ['serviceaccounts.private.key',
-                      'serviceaccounts.public.key']
-        return certs
-
-    @staticmethod
     def oo_htpasswd_users_from_file(file_contents):
         ''' return a dictionary of htpasswd users from htpasswd file contents '''
         htpasswd_entries = {}
@@ -532,5 +506,4 @@ class FilterModule(object):
     def filters(self):
         ''' returns a mapping of filters to methods '''
         return {"translate_idps": self.translate_idps,
-                "certificates_to_synchronize": self.certificates_to_synchronize,
                 "oo_htpasswd_users_from_file": self.oo_htpasswd_users_from_file}

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -94,8 +94,26 @@
     state: hard
     force: true
   with_items:
-  # certificates_to_synchronize is a custom filter in lib_utils
-  - "{{ hostvars[inventory_hostname] | certificates_to_synchronize }}"
+  - admin.crt
+  - admin.key
+  - admin.kubeconfig
+  - aggregator-front-proxy.crt
+  - aggregator-front-proxy.key
+  - aggregator-front-proxy.kubeconfig
+  - front-proxy-ca.crt
+  - front-proxy-ca.key
+  - master.kubelet-client.crt
+  - master.kubelet-client.key
+  - master.proxy-client.crt
+  - master.proxy-client.key
+  - service-signer.crt
+  - service-signer.key
+  - ca-bundle.crt
+  - ca.crt
+  - ca.key
+  - client-ca-bundle.crt
+  - serviceaccounts.private.key
+  - serviceaccounts.public.key
   when: master_certs_missing | bool and inventory_hostname != openshift_ca_host
   delegate_to: "{{ openshift_ca_host }}"
 


### PR DESCRIPTION
This filter is no longer necessary with recent refactors.  Removing the module and placing static lists in place.

I was going to put the lists in vars but found that in one place the filter was used in a role and in another it was used in a playbook.  I opted to put the lists directly in the places where they are used to surface the usage throughout the codebase.  A follow-up PR could address putting ALL the various lists scattered around into one set of lists, possibly in openshift_facts defaults.

Supersedes https://github.com/openshift/openshift-ansible/pull/8002