### PR TITLE
[3.9] Install, update and restart openvswitch only when openshift_use_openshift_sdn is set

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/docker/tasks/restart.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/tasks/restart.yml
@@ -6,11 +6,18 @@
   retries: 3
   delay: 30
 
+- name: Restart openvswitch service
+  service:
+    name: openvswitch
+    state: started
+  when:
+    - openshift_is_containerized | bool
+    - openshift_use_openshift_sdn | bool
+
 - name: Restart containerized services
   service: name={{ item }} state=started
   with_items:
     - etcd_container
-    - openvswitch
     - "{{ openshift_service_type }}-master-api"
     - "{{ openshift_service_type }}-master-controllers"
     - "{{ openshift_service_type }}-node"

--- a/playbooks/common/openshift-cluster/upgrades/docker/tasks/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/tasks/upgrade.yml
@@ -1,6 +1,15 @@
 ---
 # We need docker service up to remove all the images, but these services will keep
 # trying to re-start and thus re-pull the images we're trying to delete.
+
+- name: Stop openvswitch service
+  service:
+    name: openvswitch
+    state: stopped
+  when:
+    - openshift_is_containerized | bool
+    - openshift_use_openshift_sdn | bool
+
 - name: Stop containerized services
   service: name={{ item }} state=stopped
   with_items:
@@ -8,7 +17,6 @@
     - "{{ openshift_service_type }}-master-controllers"
     - "{{ openshift_service_type }}-node"
     - etcd_container
-    - openvswitch
   failed_when: false
   when: openshift_is_containerized | bool
 

--- a/playbooks/openshift-node/private/restart.yml
+++ b/playbooks/openshift-node/private/restart.yml
@@ -18,13 +18,20 @@
     delay: 30
     when: openshift_node_restart_docker_required | default(True)
 
+  - name: Restart openvswitch service
+    service:
+      name: openvswitch
+      state: started
+    when:
+      - openshift_is_containerized | bool
+      - openshift_use_openshift_sdn | bool
+
   - name: Restart containerized services
     service:
       name: "{{ item }}"
       state: started
     with_items:
     - etcd_container
-    - openvswitch
     - "{{ openshift_service_type }}-master-api"
     - "{{ openshift_service_type }}-master-controllers"
     - "{{ openshift_service_type }}-node"

--- a/playbooks/openshift-node/private/restart.yml
+++ b/playbooks/openshift-node/private/restart.yml
@@ -23,8 +23,8 @@
       name: openvswitch
       state: started
     when:
-      - openshift_is_containerized | bool
-      - openshift_use_openshift_sdn | bool
+    - openshift_is_containerized | bool
+    - openshift_use_openshift_sdn | bool
 
   - name: Restart containerized services
     service:

--- a/roles/openshift_node/tasks/upgrade/restart.yml
+++ b/roles/openshift_node/tasks/upgrade/restart.yml
@@ -31,11 +31,17 @@
   retries: 3
   delay: 30
 
+- name: Start openvswitch service
+  service:
+    name: openvswitch
+    state: started
+  when:
+    - openshift_node_use_openshift_sdn | bool
+
 - name: Start services
   service: name={{ item }} state=started
   with_items:
     - etcd_container
-    - openvswitch
     - "{{ openshift_service_type }}-master-api"
     - "{{ openshift_service_type }}-master-controllers"
     - "{{ openshift_service_type }}-node"

--- a/roles/openshift_node/tasks/upgrade/rpm_upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade/rpm_upgrade.yml
@@ -22,3 +22,4 @@
   command: "{{ ansible_pkg_mgr }} update -y --downloadonly openvswitch"
   register: result
   until: result is succeeded
+  when: openshift_use_openshift-sdn | bool

--- a/roles/openshift_node/tasks/upgrade/rpm_upgrade_install.yml
+++ b/roles/openshift_node/tasks/upgrade/rpm_upgrade_install.yml
@@ -16,4 +16,9 @@
     openshift_node_upgrade_rpm_list:
       - "{{ openshift_service_type }}-node{{ openshift_pkg_version | default('') }}"
       - "PyYAML"
-      - "openvswitch"
+
+- name: install new openvswitch
+  command: "{{ ansible_pkg_mgr }} install -y openvswitch }}"
+  register: result
+  until: result is succeeded
+  when: openshift_use_openshift-sdn | bool

--- a/roles/openshift_node/tasks/upgrade/stop_services.yml
+++ b/roles/openshift_node/tasks/upgrade/stop_services.yml
@@ -1,11 +1,15 @@
 ---
-- name: Stop node and openvswitch services
+- name: Stop node service
   service:
-    name: "{{ item }}"
+    name: "{{ openshift_service_type }}-node"
     state: stopped
-  with_items:
-  - "{{ openshift_service_type }}-node"
-  - openvswitch
+  failed_when: false
+
+- name: Stop openvswitch service
+  service:
+    name: openvswitch
+    state: stopped
+  when: openshift_node_use_openshift_sdn | bool
   failed_when: false
 
 - name: Ensure containerized services stopped before Docker restart
@@ -14,7 +18,6 @@
     state: stopped
   with_items:
   - etcd_container
-  - openvswitch
   - "{{ openshift_service_type }}-master-api"
   - "{{ openshift_service_type }}-master-controllers"
   - "{{ openshift_service_type }}-node"


### PR DESCRIPTION
Cherry-pick of #8228 to release-3.9

master branch doesn't need these changes, as it uses DaemonSet instead

TODO:
* [x] Fix FAH update test. `openshift_use_openshift_sdn` seems to be undefined in some roles