### PR TITLE
Excluding the eventrouter component when looking for namespaces logging is installed in

### DIFF
--- a/roles/openshift_logging/tasks/main.yaml
+++ b/roles/openshift_logging/tasks/main.yaml
@@ -23,7 +23,7 @@
     state: list
     kind: dc
     all_namespaces: true
-    selector: "logging-infra,provider=openshift"
+    selector: "logging-infra,provider=openshift,component!=eventrouter"
   register: _logging_dcs
 
 - set_fact:


### PR DESCRIPTION
When looking for namespaces that logging components are installed in, we want to exclude the eventrouter since that is always installed in `default` which is likely different than where ES/Kibana/Curator are installed in.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1573696

Confirmed to work locally.
Does not need to be backported.