### PR TITLE
Add helfup comment for error-prone task

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -23,7 +23,10 @@
 - set_fact:
     ovs_service_status_changed: "{{ ovs_start_result is changed }}"
 
-- file:
+# If this tasks fails, you may have a malformed openshift_node_kubelet_args
+# or openshift_node_labels.  Those variables must be dictionaries.
+- name: Create kublet args config dir
+  file:
     dest: "{{ l2_openshift_node_kubelet_args['config'] }}"
     state: directory
   when: ('config' in l2_openshift_node_kubelet_args) | bool


### PR DESCRIPTION
Certain task in node role can fail of user is
not careful with their variables and the
error message is very cryptic.

This commit adds some comments to assist users
in potentially isolating which variable is the
problem.