### PR TITLE
docker_image_availability: bz 1570479

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -181,10 +181,9 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
 
         if self.get_var("openshift_is_containerized", convert=bool):
             if 'oo_nodes_to_config' in host_groups:
-                add_var_or_default_img("osn_image", "node")
-                add_var_or_default_img("osn_ovs_image", "openvswitch")
+                add_var_or_default_img("osn_image", image_info["name"] + "-node")
             if 'oo_masters_to_config' in host_groups:  # name is "origin" or "ose"
-                add_var_or_default_img("osm_image", image_info["name"])
+                add_var_or_default_img("osm_image", image_info["name"] + "-control-plane")
             if 'oo_etcd_to_config' in host_groups:
                 # special case, note default is the same for origin/enterprise and has no image tag
                 etcd_img = self.get_var("osm_etcd_image", default="registry.access.redhat.com/rhel7/etcd")

--- a/roles/openshift_health_checker/test/docker_image_availability_test.py
+++ b/roles/openshift_health_checker/test/docker_image_availability_test.py
@@ -198,9 +198,8 @@ def test_registry_availability(image, registries, connection_test_failed, skopeo
             'openshift/origin-haproxy-router:vtest',
             'cockpit/kubernetes:latest',
             # containerized component images
-            'openshift/origin:vtest',
-            'openshift/node:vtest',
-            'openshift/openvswitch:vtest',
+            'openshift/origin-control-plane:vtest',
+            'openshift/origin-node:vtest',
             'registry.access.redhat.com/rhel7/etcd',
         ])
     ),
@@ -214,8 +213,7 @@ def test_registry_availability(image, registries, connection_test_failed, skopeo
             # registry-console is not constructed/versioned the same as the others.
             'openshift3/registry-console:vtest',
             # containerized images aren't built from oreg_url
-            'openshift3/node:vtest',
-            'openshift3/openvswitch:vtest',
+            'openshift3/ose-node:vtest',
         ])
     ),
     (
@@ -280,11 +278,10 @@ def test_registry_console_image(task_vars, expected):
     (
         dict(
             group_names=['oo_nodes_to_config'],
-            osn_ovs_image='spam/ovs',
             openshift_image_tag="veggs",
         ),
         set([
-            'spam/ovs', 'openshift/node:veggs', 'cockpit/kubernetes:latest',
+            'openshift/origin-node:veggs', 'cockpit/kubernetes:latest',
             'openshift/origin-haproxy-router:veggs', 'openshift/origin-deployer:veggs',
             'openshift/origin-docker-registry:veggs', 'openshift/origin-pod:veggs',
         ]),
@@ -292,7 +289,7 @@ def test_registry_console_image(task_vars, expected):
         dict(
             group_names=['oo_masters_to_config'],
         ),
-        set(['openshift/origin:latest']),
+        set(['openshift/origin-control-plane:latest']),
     ), (
         dict(
             group_names=['oo_etcd_to_config'],


### PR DESCRIPTION
fixes bug 1570479
https://bugzilla.redhat.com/show_bug.cgi?id=1570479

With OCP 3.10, openvswitch is no longer separate from node and node
container name has switched to {origin|ose}-node.