### PR TITLE
[3.9] docker rootdir is different when installing crio

### DIFF
--- a/roles/openshift_docker_gc/templates/dockergc-ds.yaml.j2
+++ b/roles/openshift_docker_gc/templates/dockergc-ds.yaml.j2
@@ -47,14 +47,14 @@ items:
           volumeMounts:
           - name: docker-root
             readOnly:  true
-            mountPath: /var/lib/docker
+            mountPath: /var/lib/containers/docker
           - name: docker-socket
             readOnly:  false
             mountPath: /var/run/docker.sock
         volumes:
         - name: docker-root
           hostPath:
-            path: /var/lib/docker
+            path: /var/lib/containers/docker
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock


### PR DESCRIPTION
master PR: https://github.com/openshift/openshift-ansible/pull/8027

xref https://bugzilla.redhat.com/show_bug.cgi?id=1552827#c25

/cc @ashcrow @vikaslaad
/assign @sdodson