### PR TITLE
line 8: restorecon needs absolute path

### DIFF
--- a/roles/container_runtime/tasks/common/post.yml
+++ b/roles/container_runtime/tasks/common/post.yml
@@ -5,7 +5,7 @@
     state: directory
 
 - name: Fix SELinux Permissions on /var/lib/containers
-  command: "restorecon -R /var/lib/containers/"
+  command: "/sbin/restorecon -R /var/lib/containers/"
   changed_when: false
 
 - meta: flush_handlers


### PR DESCRIPTION
otherwise it fails on the scaleup.yml in some scenarios.