### PR TITLE
Fix containerized 3.9 -> 3.10 upgrade

### DIFF
--- a/playbooks/openshift-etcd/private/upgrade_main.yml
+++ b/playbooks/openshift-etcd/private/upgrade_main.yml
@@ -38,6 +38,13 @@
 # mirrored packages on your own because only the GA and latest versions are
 # available in the repos. So for Fedora we'll simply skip this, sorry.
 
+- name: Detect etcd runtime
+  hosts: oo_etcd_hosts_to_upgrade
+  tasks:
+  - import_role:
+      name: etcd
+      tasks_from: runtime.yml
+
 - name: Backup etcd before upgrading anything
   import_playbook: upgrade_backup.yml
   vars:

--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -2,12 +2,14 @@
 r_etcd_common_backup_tag: ''
 r_etcd_common_backup_sufix_name: ''
 
+l_etcd_bootstrapped: '{{ openshift.node.bootstrapped }}'
+
 l_is_etcd_system_container: "{{ (openshift_use_etcd_system_container | default(openshift_use_system_containers | default(false)) | bool) }}"
 
-l_etcd_static_pod: "{{ not (r_etcd_common_skip_command_shim is defined and r_etcd_common_skip_command_shim) or openshift.node.bootstrapped }}"
+l_etcd_static_pod: "{{ not (r_etcd_common_skip_command_shim is defined and r_etcd_common_skip_command_shim) or l_etcd_bootstrapped }}"
 
-# runc, docker, host
-r_etcd_common_etcd_runtime: "{{ 'static_pod' if l_etcd_static_pod else ('runc' if l_is_etcd_system_container else ('docker' if openshift_is_containerized else 'host')) }}"
+# runc, docker, static pod, host
+r_etcd_common_etcd_runtime: "{{ 'runc' if l_is_etcd_system_container else ('static_pod' if l_etcd_static_pod else ('docker' if openshift_is_containerized else 'host')) }}"
 
 r_etcd_default_version: "3.2.15"
 osm_etcd_image: "registry.access.redhat.com/rhel7/etcd:{{ r_etcd_upgrade_version | default(r_etcd_default_version) }}"

--- a/roles/etcd/tasks/runtime.yml
+++ b/roles/etcd/tasks/runtime.yml
@@ -1,0 +1,24 @@
+---
+- name: Check if etcd service exists
+  systemd:
+    name: "etcd"
+  ignore_errors: true
+  register: etcd_service
+
+- set_fact:
+    r_etcd_common_etcd_runtime: host
+  when: etcd_service.status['ActiveState'] == "active" | bool
+
+- name: Check if etcd service exists
+  systemd:
+    name: "etcd_container"
+  ignore_errors: true
+  register: etcd_container_service
+
+- set_fact:
+    r_etcd_common_etcd_runtime: docker
+  when: etcd_container_service.status['ActiveState'] == "active" | bool and not l_is_etcd_system_container
+
+- set_fact:
+    r_etcd_common_etcd_runtime: runc
+  when: etcd_container_service.status['ActiveState'] == "active" | bool and l_is_etcd_system_container

--- a/roles/etcd/tasks/upgrade_static.yml
+++ b/roles/etcd/tasks/upgrade_static.yml
@@ -2,8 +2,25 @@
 # PREREQ Node service is ready to run static pods
 
 # INPUT r_etcd_upgrade_version
+
+- include_tasks: runtime.yml
+
 - name: Verify cluster is healthy pre-upgrade
   command: "{{ etcdctlv2 }} cluster-health"
+
+# We removed the ability to detect what was previously 'containerized'
+# Need to stop and disable this service, but might not be present.
+- name: Stop, disable and mask old etcd service
+  systemd:
+    name: "{{ item }}"
+    state: stopped
+    enabled: no
+    masked: yes
+    daemon_reload: yes
+  with_items:
+  - etcd
+  - etcd_container
+  failed_when: False
 
 - name: Remove old etcd service files
   file:
@@ -13,33 +30,18 @@
   - "/etc/systemd/system/etcd.service"
   - "/etc/systemd/system/etcd_container.service"
 
-# We removed the ability to detect what was previously 'containerized'
-# Need to stop and disable this service, but might not be present.
-- name: Stop, disable old etcd services
-  systemd:
-    name: "{{ item }}"
-    state: stopped
-    enabled: no
-  failed_when: False
-  with_items:
-  - etcd
-  - etcd_container
-
-- name: Mask old etcd services
-  command: "systemctl mask {{ etcd_service }}"
-  with_items:
-  - etcd
-  - etcd_container
-
-- name: Reload systemd daemon
-  command: "systemctl daemon-reload"
+- name: Remove nonexistent services
+  command: "systemctl reset-failed"
 
 - name: Configure static definition
   import_tasks: static.yml
 
+- set_fact:
+    r_etcd_common_etcd_runtime: static_pod
+
 - name: Verify cluster is healthy
   command: "{{ etcdctlv2 }} cluster-health"
   register: etcdctl
-  until: etcdctl.rc == 0
+  until: etcdctl.rc == 0 and 'stopped' not in etcdctl.stderr
   retries: 30
   delay: 10

--- a/roles/openshift_control_plane/tasks/static.yml
+++ b/roles/openshift_control_plane/tasks/static.yml
@@ -53,6 +53,14 @@
   - apiserver.yaml
   - controller.yaml
 
+- name: Remove old files in /etc/sysconfig
+  file:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+  - /etc/sysconfig/{{ openshift_service_type }}-api
+  - /etc/sysconfig/{{ openshift_service_type }}-controllers
+
 - name: Remove temporary directory
   file:
     name: "{{ mktemp.stdout }}"

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -4,6 +4,7 @@
     src: openshift-node
     dest: /usr/local/bin/openshift-node
     mode: 0500
+
 - name: Install Node service file
   template:
     dest: "/etc/systemd/system/{{ openshift_service_type }}-node.service"
@@ -12,6 +13,16 @@
   notify:
   - reload systemd units
   - restart node
+
+- block:
+  - name: Remove existing systemd service
+    file:
+      path: "/etc/systemd/system/{{ openshift_service_type }}-node.service"
+      state: absent
+    when: not openshift_is_bootstrapped
+  - name: Install node system container
+    import_tasks: node_system_container.yml
+  when: l_is_node_system_container | bool
 
 - import_tasks: config/configure-node-settings.yml
 - import_tasks: config/configure-proxy-settings.yml


### PR DESCRIPTION
* Node is now a system container
* Rework a few etcd parts to properly backup and migrate to a static pod

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1571724

TODO:
* [x] Fix etcd backup and update to static pods for Atomic
* [x] Update ends with
```
TASK [fail] ***************************************************************************************************************************************************
task path: /code/openshift-ansible/playbooks/common/openshift-cluster/upgrades/pre/config.yml:63
Wednesday 02 May 2018  20:48:53 +0000 (0:00:00.040)       0:23:37.982 ********* 
fatal: [vrutkovs_4d58cb0034c4-master-1]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "Master running 3.9.0 must be upgraded to 3.10 before node upgrade can be run."
}
```