### PR TITLE
PAPR: run upgrade from 3.9 branch

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -60,6 +60,22 @@ env:
 
 ---
 inherit: true
+context: 'fedora/27/atomic/upgrade_3.9'
+
+cluster:
+  hosts:
+    - name: ocp-master
+      distro: fedora/27/atomic
+      specs:
+        ram: 4096
+  container:
+    image: registry.fedoraproject.org/fedora:27
+env:
+  PAPR_INVENTORY: .papr.all-in-one.inventory
+  PAPR_UPGRADE_FROM: "3.9"
+  PAPR_RUN_UPDATE: "yes"
+---
+inherit: true
 context: 'fedora/27/atomic/master-ha'
 
 cluster:


### PR DESCRIPTION
Add a new PAPR instance to verify FAH 3.9 can be upgraded to master

Needs to be updated when a branching happens