### PR TITLE
[WIP] Fix etcd runtime detection to fix upgrade 3.9 -> 3.10

### DIFF
--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -2,12 +2,14 @@
 r_etcd_common_backup_tag: ''
 r_etcd_common_backup_sufix_name: ''
 
+l_etcd_bootstrapped: '{{ openshift.node.bootstrapped }}'
+
 l_is_etcd_system_container: "{{ (openshift_use_etcd_system_container | default(openshift_use_system_containers | default(false)) | bool) }}"
 
-l_etcd_static_pod: "{{ not (r_etcd_common_skip_command_shim is defined and r_etcd_common_skip_command_shim) or openshift.node.bootstrapped }}"
+l_etcd_static_pod: "{{ not (r_etcd_common_skip_command_shim is defined and r_etcd_common_skip_command_shim) and l_etcd_bootstrapped }}"
 
-# runc, docker, host
-r_etcd_common_etcd_runtime: "{{ 'static_pod' if l_etcd_static_pod else ('runc' if l_is_etcd_system_container else ('docker' if openshift_is_containerized else 'host')) }}"
+# runc, docker, static pod, host
+r_etcd_common_etcd_runtime: "{{ 'runc' if l_is_etcd_system_container else ('docker' if openshift_is_containerized else ('static_pod' if l_etcd_bootstrapped else 'host')) }}"
 
 r_etcd_default_version: "3.2.15"
 osm_etcd_image: "registry.access.redhat.com/rhel7/etcd:{{ r_etcd_upgrade_version | default(r_etcd_default_version) }}"


### PR DESCRIPTION
During upgrade the nodes are being updated first, so bootstrapped is set
to true, which make etcd_runtime try static pod first

Upgrade script should look for etcd in runc/docker container
first and fall back to static pods or host install

UPD: this breaks minor upgrades, as there is no etcd in system container anymore