### PR TITLE
Move openshift-checks before node bootstrapping

### DIFF
--- a/playbooks/aws/openshift-cluster/install.yml
+++ b/playbooks/aws/openshift-cluster/install.yml
@@ -18,6 +18,8 @@
 - name: run the init
   import_playbook: ../../init/main.yml
 
+- import_playbook: ../../openshift-checks/private/install.yml
+
 - name: configure the control plane
   import_playbook: ../../common/private/control_plane.yml
 

--- a/playbooks/common/private/control_plane.yml
+++ b/playbooks/common/private/control_plane.yml
@@ -19,8 +19,6 @@
 # 2. The master has an /etc/origin/master/admin.kubeconfig file that gives cluster-admin
 #    access.
 
-- import_playbook: ../../openshift-checks/private/install.yml
-
 - import_playbook: ../../openshift-etcd/private/config.yml
 
 - import_playbook: ../../openshift-nfs/private/config.yml

--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -1,6 +1,8 @@
 ---
 - import_playbook: init/main.yml
 
+- import_playbook: openshift-checks/private/install.yml
+
 - import_playbook: openshift-node/private/bootstrap.yml
 
 - import_playbook: common/private/control_plane.yml

--- a/playbooks/gcp/openshift-cluster/install.yml
+++ b/playbooks/gcp/openshift-cluster/install.yml
@@ -11,6 +11,8 @@
 - name: run the init
   import_playbook: ../../init/main.yml
 
+- import_playbook: ../../openshift-checks/private/install.yml
+
 - name: ensure master nodes are ready for bootstrapping
   import_playbook: ../../openshift-node/private/bootstrap.yml
 


### PR DESCRIPTION
Refactoring has moved openshift-checks after node installation which
makes many of the checks worthless since installation has already begun.