### PR TITLE
[3.9] Update cri-o pause image and pause command

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -137,6 +137,14 @@ l_crio_image_tag: "{{ l_crt_crio_image_tag_dict[openshift_deployment_type] }}"
 l_crio_image_default: "{{ l_crio_image_name }}:{{ l_crio_image_tag }}"
 l_crio_image: "{{ openshift_crio_systemcontainer_image_override | default(l_crio_image_default) }}"
 
+l_crio_pause_images_dict:
+  origin: 'docker.io/openshift/origin-${component}:${version}'
+  openshift-enterprise: 'registry.access.redhat.com/openshift3/ose-${component}:${version}'
+l_pause_registry_url_default: "{{ l_crio_pause_images_dict[openshift_deployment_type] }}"
+l_os_registry_url: "{{ oreg_url_master | default(oreg_url) | default(l_pause_registry_url_default) | regex_replace('${version}' | regex_escape, l_openshift_image_tag | default('${version}')) }}"
+
+pause_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'pod') }}"
+
 # ----------------------- #
 # systemcontainers_docker #
 # ----------------------- #

--- a/roles/container_runtime/tasks/systemcontainer_crio.yml
+++ b/roles/container_runtime/tasks/systemcontainer_crio.yml
@@ -95,6 +95,9 @@
     dest: /etc/sysconfig/crio-network
     src: crio-network.j2
 
+- debug:
+    msg: "pause - {{ pause_image }}"
+
 - name: Start the CRI-O service
   systemd:
     name: "cri-o"

--- a/roles/container_runtime/templates/crio.conf.j2
+++ b/roles/container_runtime/templates/crio.conf.j2
@@ -124,12 +124,12 @@ log_size_max = 52428800
 default_transport = "docker://"
 
 # pause_image is the image which we use to instantiate infra containers.
-pause_image = "kubernetes/pause"
+pause_image = {{ pause_image }}
 
 # pause_command is the command to run in a pause_image to have a container just
 # sit there.  If the image contains the necessary information, this value need
 # not be specified.
-pause_command = "/pause"
+pause_command = "/usr/bin/pod"
 
 # signature_policy is the name of the file which decides what sort of policy we
 # use when deciding whether or not to trust an image that we've pulled.


### PR DESCRIPTION
Change the pause image from "kubernetes/pause" to the openshift pod image
(supports origin and enterprise) and "/usr/bin/pod".
Change the pause command from "/pause" to "/usr/bin/pod".

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1572869

Signed-off-by: umohnani8 <umohnani@redhat.com>