### PR TITLE
Bug 1561485- get now returns empty instead of error when the namespace is missing

### DIFF
--- a/roles/lib_openshift/library/oc_pvc.py
+++ b/roles/lib_openshift/library/oc_pvc.py
@@ -1748,6 +1748,9 @@ class OCPVC(OpenShiftCLI):
         elif '\"%s\" not found' % self.config.name in result['stderr']:
             result['returncode'] = 0
             result['results'] = [{}]
+        elif 'namespaces \"%s\" not found' % self.config.namespace in result['stderr']:
+            result['returncode'] = 0
+            result['results'] = [{}]
 
         return result
 

--- a/roles/lib_openshift/library/oc_route.py
+++ b/roles/lib_openshift/library/oc_route.py
@@ -1706,6 +1706,9 @@ class OCRoute(OpenShiftCLI):
         elif 'routes \"%s\" not found' % self.config.name in result['stderr']:
             result['returncode'] = 0
             result['results'] = [{}]
+        elif 'namespaces \"%s\" not found' % self.config.namespace in result['stderr']:
+            result['returncode'] = 0
+            result['results'] = [{}]
 
         return result
 

--- a/roles/lib_openshift/library/oc_service.py
+++ b/roles/lib_openshift/library/oc_service.py
@@ -1777,6 +1777,9 @@ class OCService(OpenShiftCLI):
         elif 'services \"%s\" not found' % self.config.name  in result['stderr']:
             result['clusterip'] = ''
             result['returncode'] = 0
+        elif 'namespaces \"%s\" not found' % self.config.namespace  in result['stderr']:
+            result['clusterip'] = ''
+            result['returncode'] = 0
 
         return result
 

--- a/roles/lib_openshift/library/oc_serviceaccount.py
+++ b/roles/lib_openshift/library/oc_serviceaccount.py
@@ -1619,6 +1619,9 @@ class OCServiceAccount(OpenShiftCLI):
         elif '\"%s\" not found' % self.config.name in result['stderr']:
             result['returncode'] = 0
             result['results'] = [{}]
+        elif 'namespaces \"%s\" not found' % self.config.namespace in result['stderr']:
+            result['returncode'] = 0
+            result['results'] = [{}]
 
         return result
 

--- a/roles/lib_openshift/src/class/oc_pvc.py
+++ b/roles/lib_openshift/src/class/oc_pvc.py
@@ -52,6 +52,9 @@ class OCPVC(OpenShiftCLI):
         elif '\"%s\" not found' % self.config.name in result['stderr']:
             result['returncode'] = 0
             result['results'] = [{}]
+        elif 'namespaces \"%s\" not found' % self.config.namespace in result['stderr']:
+            result['returncode'] = 0
+            result['results'] = [{}]
 
         return result
 

--- a/roles/lib_openshift/src/class/oc_route.py
+++ b/roles/lib_openshift/src/class/oc_route.py
@@ -42,6 +42,9 @@ class OCRoute(OpenShiftCLI):
         elif 'routes \"%s\" not found' % self.config.name in result['stderr']:
             result['returncode'] = 0
             result['results'] = [{}]
+        elif 'namespaces \"%s\" not found' % self.config.namespace in result['stderr']:
+            result['returncode'] = 0
+            result['results'] = [{}]
 
         return result
 

--- a/roles/lib_openshift/src/class/oc_service.py
+++ b/roles/lib_openshift/src/class/oc_service.py
@@ -60,6 +60,9 @@ class OCService(OpenShiftCLI):
         elif 'services \"%s\" not found' % self.config.name  in result['stderr']:
             result['clusterip'] = ''
             result['returncode'] = 0
+        elif 'namespaces \"%s\" not found' % self.config.namespace  in result['stderr']:
+            result['clusterip'] = ''
+            result['returncode'] = 0
 
         return result
 

--- a/roles/lib_openshift/src/class/oc_serviceaccount.py
+++ b/roles/lib_openshift/src/class/oc_serviceaccount.py
@@ -31,6 +31,9 @@ class OCServiceAccount(OpenShiftCLI):
         elif '\"%s\" not found' % self.config.name in result['stderr']:
             result['returncode'] = 0
             result['results'] = [{}]
+        elif 'namespaces \"%s\" not found' % self.config.namespace in result['stderr']:
+            result['returncode'] = 0
+            result['results'] = [{}]
 
         return result
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1561485

Still  working on testing, not sure if there may be more changes needed. Needs backport to 3.9.z