### PR TITLE
WIP Wait for bootstrap autoapprover pods to appear

### DIFF
--- a/playbooks/openshift-master/private/additional_config.yml
+++ b/playbooks/openshift-master/private/additional_config.yml
@@ -22,6 +22,8 @@
   #   should be moved into components once nodes are using dynamic config
   - role: openshift_sdn
     when: openshift_use_openshift_sdn | default(True) | bool
+  - role: openshift_bootstrap_autoapprover
+    when: openshift_master_bootstrap_auto_approve | default(False) | bool
   - role: openshift_project_request_template
     when: openshift_project_request_template_manage
   - role: openshift_examples

--- a/playbooks/openshift-master/private/tasks/enable_bootstrap_config.yml
+++ b/playbooks/openshift-master/private/tasks/enable_bootstrap_config.yml
@@ -2,9 +2,3 @@
 - name: Setup the node group config maps
   import_role:
     name: openshift_node_group
-
-- name: Setup the node bootstrap auto approver
-  import_role:
-    name: openshift_bootstrap_autoapprover
-  when:
-  - openshift_master_bootstrap_auto_approve | default(False) | bool

--- a/roles/openshift_sdn/tasks/main.yml
+++ b/roles/openshift_sdn/tasks/main.yml
@@ -48,3 +48,18 @@
     state: absent
     name: "{{ mktemp.stdout }}"
   changed_when: False
+
+- name: Wait for bootstrap autoapprover pod to start
+  oc_obj:
+    namespace: openshift-infra
+    kind: pod
+    state: list
+    selector: "app=bootstrap-autoapprover"
+  register: bootstrap_autoapprover
+  until:
+  - "bootstrap_autoapprover.results.results[0]['items'] | count > 0"
+  # Pod's 'Ready' status must be True
+  - "bootstrap_autoapprover.results.results[0]['items'] | lib_utils_oo_collect(attribute='status.conditions') | lib_utils_oo_collect(attribute='status', filters={'type': 'Ready'}) | map('bool') | select | list | count == 1"
+  delay: 10
+  retries: 60
+  when: openshift_master_bootstrap_auto_approve | default(False) | bool


### PR DESCRIPTION
Sometimes autoapprover pod stucks in Pending, so CSRs from master don't 
get approved and web console won't start.

This PR will ensure autoapprover starts after SDN is configured
Fixes #8264