### PR TITLE
Convert SDN master facts to openshift_facts defaults

### DIFF
--- a/.papr-master-ha.inventory
+++ b/.papr-master-ha.inventory
@@ -11,9 +11,7 @@ openshift_release="{{ lookup('env', 'target_branch') }}"
 openshift_master_default_subdomain="{{ lookup('env', 'RHCI_ocp_master1_IP') }}.xip.io"
 openshift_check_min_host_disk_gb=1.5
 openshift_check_min_host_memory_gb=1.9
-osm_cluster_network_cidr=10.128.0.0/14
 openshift_portal_net=172.30.0.0/16
-osm_host_subnet_length=9
 openshift_enable_service_catalog=false
 
 [all:vars]

--- a/.papr.all-in-one.inventory
+++ b/.papr.all-in-one.inventory
@@ -11,9 +11,7 @@ openshift_release="{{ lookup('env', 'target_branch') }}"
 openshift_master_default_subdomain="{{ lookup('env', 'RHCI_ocp_master_IP') }}.xip.io"
 openshift_check_min_host_disk_gb=1.5
 openshift_check_min_host_memory_gb=1.9
-osm_cluster_network_cidr=10.128.0.0/14
 openshift_portal_net=172.30.0.0/16
-osm_host_subnet_length=9
 openshift_enable_service_catalog=false
 
 [all:vars]

--- a/.papr.inventory
+++ b/.papr.inventory
@@ -11,9 +11,7 @@ openshift_release="{{ lookup('env', 'target_branch') }}"
 openshift_master_default_subdomain="{{ lookup('env', 'RHCI_ocp_node1_IP') }}.xip.io"
 openshift_check_min_host_disk_gb=1.5
 openshift_check_min_host_memory_gb=1.9
-osm_cluster_network_cidr=10.128.0.0/14
 openshift_portal_net=172.30.0.0/16
-osm_host_subnet_length=9
 
 [all:vars]
 # bootstrap configs

--- a/inventory/hosts.localhost
+++ b/inventory/hosts.localhost
@@ -9,9 +9,7 @@ etcd
 # if your target hosts are Fedora uncomment this
 #ansible_python_interpreter=/usr/bin/python3
 openshift_deployment_type=origin
-osm_cluster_network_cidr=10.128.0.0/14
 openshift_portal_net=172.30.0.0/16
-osm_host_subnet_length=9
 # localhost likely doesn't meet the minimum requirements
 openshift_disable_check=disk_availability,memory_availability
 

--- a/playbooks/openshift-master/private/set_network_facts.yml
+++ b/playbooks/openshift-master/private/set_network_facts.yml
@@ -18,12 +18,6 @@
   post_tasks:
   - block:
     - set_fact:
-        osm_cluster_network_cidr: "{{ (hostvars[groups.oo_first_master.0].g_master_config_slurp.content|b64decode|from_yaml).networkConfig.clusterNetworkCIDR }}"
-      when: osm_cluster_network_cidr is not defined
-    - set_fact:
-        osm_host_subnet_length: "{{ (hostvars[groups.oo_first_master.0].g_master_config_slurp.content|b64decode|from_yaml).networkConfig.hostSubnetLength }}"
-      when: osm_host_subnet_length is not defined
-    - set_fact:
         openshift_portal_net: "{{ (hostvars[groups.oo_first_master.0].g_master_config_slurp.content|b64decode|from_yaml).networkConfig.serviceNetworkCIDR }}"
       when: openshift_portal_net is not defined
     - openshift_facts:

--- a/roles/calico_master/templates/calico.yml.j2
+++ b/roles/calico_master/templates/calico.yml.j2
@@ -177,7 +177,7 @@ spec:
               value: "ACCEPT"
             # Configure the IP Pool from which Pod IPs will be chosen.
             - name: CALICO_IPV4POOL_CIDR
-              value: "{{ openshift.master.sdn_cluster_network_cidr }}"
+              value: "{{ openshift_cluster_network_cidr }}"
             - name: CALICO_IPV4POOL_IPIP
               value: "{{ calico_ipv4pool_ipip }}"
             # Disable IPv6 on Kubernetes.

--- a/roles/flannel/tasks/main.yml
+++ b/roles/flannel/tasks/main.yml
@@ -43,7 +43,7 @@
     - restart node
 
 - name: Enable Pod to Pod communication
-  command: /sbin/iptables --wait -I FORWARD -d {{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }} -i {{ flannel_interface }} -j ACCEPT -m comment --comment "Pod to Pod communication"
+  command: /sbin/iptables --wait -I FORWARD -d {{ openshift_cluster_network_cidr }} -i {{ flannel_interface }} -j ACCEPT -m comment --comment "Pod to Pod communication"
   notify:
     - save iptable rules
 

--- a/roles/flannel_register/defaults/main.yaml
+++ b/roles/flannel_register/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
-flannel_network: "{{ openshift.master.sdn_cluster_network_cidr }}"
-flannel_subnet_len: "{{ 32 - (openshift.master.sdn_host_subnet_length | int) }}"
+flannel_network: "{{ openshift_cluster_network_cidr }}"
+flannel_subnet_len: "{{ 32 - (openshift_host_subnet_length | int) }}"
 flannel_etcd_key: /openshift.com/network
 etcd_hosts: "{{ etcd_urls }}"
 etcd_conf_dir: "{{ openshift.common.config_base }}/master"

--- a/roles/nuage_master/templates/nuage-node-config-daemonset.j2
+++ b/roles/nuage_master/templates/nuage-node-config-daemonset.j2
@@ -93,7 +93,7 @@ spec:
                   key: cni_yaml_config
             # Nuage cluster network CIDR for iptables configuration
             - name: NUAGE_CLUSTER_NW_CIDR
-              value: "{{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }}"
+              value: "{{ openshift_cluster_network_cidr }}"
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir

--- a/roles/nuage_node/tasks/iptables.yml
+++ b/roles/nuage_node/tasks/iptables.yml
@@ -5,19 +5,19 @@
   check_mode: no
 
 - name: Allow traffic from overlay to underlay
-  command: /sbin/iptables --wait -I FORWARD 1 -s {{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }} -j ACCEPT -m comment --comment "nuage-overlay-underlay"
+  command: /sbin/iptables --wait -I FORWARD 1 -s {{ openshift_cluster_network_cidr }} -j ACCEPT -m comment --comment "nuage-overlay-underlay"
   when: "'nuage-overlay-underlay' not in iptablesrules.stdout"
   notify:
     - save iptable rules
 
 - name: Allow traffic from underlay to overlay
-  command: /sbin/iptables --wait -I FORWARD 1 -d {{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }} -j ACCEPT -m comment --comment "nuage-underlay-overlay"
+  command: /sbin/iptables --wait -I FORWARD 1 -d {{ openshift_cluster_network_cidr }} -j ACCEPT -m comment --comment "nuage-underlay-overlay"
   when: "'nuage-underlay-overlay' not in iptablesrules.stdout"
   notify:
     - save iptable rules
 
 - name: Allow docker daemon traffic from underlay to overlay
-  command: /sbin/iptables -t nat -A POSTROUTING ! -s {{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }} -o svc-pat-tap -j MASQUERADE -m comment --comment "nuage-docker-underlay-overlay"
+  command: /sbin/iptables -t nat -A POSTROUTING ! -s {{ openshift_cluster_network_cidr }} -o svc-pat-tap -j MASQUERADE -m comment --comment "nuage-docker-underlay-overlay"
   when: "'nuage-docker-underlay-overlay' not in iptablesrules.stdout"
   notify:
     - save iptable rules

--- a/roles/openshift_control_plane/templates/master.env.j2
+++ b/roles/openshift_control_plane/templates/master.env.j2
@@ -12,7 +12,7 @@ HTTP_PROXY={{ openshift.common.http_proxy | default('') }}
 HTTPS_PROXY={{ openshift.common.https_proxy | default('')}}
 {% endif %}
 {% if 'no_proxy' in openshift.common %}
-NO_PROXY={{ openshift.common.no_proxy | default('') }},{{ openshift.common.portal_net }},{{ openshift.master.sdn_cluster_network_cidr }}
+NO_PROXY={{ openshift.common.no_proxy | default('') }},{{ openshift.common.portal_net }},{{ openshift_cluster_network_cidr }}
 {% endif %}
 
 {% if openshift_master_debug_level is defined %}

--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -112,8 +112,8 @@ masterClients:
 masterPublicURL: {{ openshift.master.public_api_url }}
 networkConfig:
   clusterNetworks:
-  - cidr: {{ openshift.master.sdn_cluster_network_cidr }}
-    hostSubnetLength: {{ openshift.master.sdn_host_subnet_length }}
+  - cidr: {{ openshift_cluster_network_cidr }}
+    hostSubnetLength: {{ openshift_host_subnet_length }}
 {% if r_openshift_master_use_openshift_sdn or r_openshift_master_use_nuage or r_openshift_master_use_contiv or r_openshift_master_use_kuryr or r_openshift_master_sdn_network_plugin_name == 'cni' %}
   networkPluginName: {{ r_openshift_master_sdn_network_plugin_name_default }}
 {% endif %}

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -14,6 +14,9 @@ openshift_cli_image: "{{ osm_image | default(openshift_cli_image_dict[openshift_
 osm_default_subdomain: "router.default.svc.cluster.local"
 openshift_master_default_subdomain: "{{ osm_default_subdomain }}"
 
+openshift_cluster_network_cidr: "{{ osm_cluster_network_cidr | default('10.128.0.0/14') }}"
+openshift_host_subnet_length: " {{ osm_host_subnet_length | default('9') }}"
+
 openshift_hosted_etcd_storage_nfs_directory: '/exports'
 openshift_hosted_etcd_storage_nfs_options: '*(rw,root_squash)'
 openshift_hosted_etcd_storage_volume_name: 'etcd'

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -478,31 +478,6 @@ def set_sdn_facts_if_unset(facts, system_facts):
                   were not already present
     """
 
-    if 'master' in facts:
-        # set defaults for sdn_cluster_network_cidr and sdn_host_subnet_length
-        # these might be overridden if they exist in the master config file
-        sdn_cluster_network_cidr = '10.128.0.0/14'
-        sdn_host_subnet_length = '9'
-
-        master_cfg_path = os.path.join(facts['common']['config_base'],
-                                       'master/master-config.yaml')
-        if os.path.isfile(master_cfg_path):
-            with open(master_cfg_path, 'r') as master_cfg_f:
-                config = yaml.safe_load(master_cfg_f.read())
-
-            if 'networkConfig' in config:
-                if 'clusterNetworkCIDR' in config['networkConfig']:
-                    sdn_cluster_network_cidr = \
-                        config['networkConfig']['clusterNetworkCIDR']
-                if 'hostSubnetLength' in config['networkConfig']:
-                    sdn_host_subnet_length = \
-                        config['networkConfig']['hostSubnetLength']
-
-        if 'sdn_cluster_network_cidr' not in facts['master']:
-            facts['master']['sdn_cluster_network_cidr'] = sdn_cluster_network_cidr
-        if 'sdn_host_subnet_length' not in facts['master']:
-            facts['master']['sdn_host_subnet_length'] = sdn_host_subnet_length
-
     if 'node' in facts and 'sdn_mtu' not in facts['node']:
         node_ip = facts['common']['ip']
 

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -44,8 +44,6 @@
       ldap_ca: "{{ openshift_master_ldap_ca | default(lookup('file', openshift_master_ldap_ca_file) if openshift_master_ldap_ca_file is defined else None) }}"
       openid_ca: "{{ openshift_master_openid_ca | default(lookup('file', openshift_master_openid_ca_file) if openshift_master_openid_ca_file is defined else None) }}"
       registry_url: "{{ oreg_url_master | default(oreg_url) | default(None) }}"
-      sdn_cluster_network_cidr: "{{ osm_cluster_network_cidr | default(None) }}"
-      sdn_host_subnet_length: "{{ osm_host_subnet_length | default(None) }}"
       registry_selector: "{{ openshift_registry_selector | default(None) }}"
       api_server_args: "{{ osm_api_server_args | default(None) }}"
       controller_args: "{{ osm_controller_args | default(None) }}"

--- a/roles/openshift_node/tasks/config/configure-proxy-settings.yml
+++ b/roles/openshift_node/tasks/config/configure-proxy-settings.yml
@@ -11,7 +11,7 @@
   - regex: '^HTTPS_PROXY='
     line: "HTTPS_PROXY={{ openshift.common.https_proxy | default('') }}"
   - regex: '^NO_PROXY='
-    line: "NO_PROXY={{ openshift.common.no_proxy | default([]) }},{{ openshift.common.portal_net }},{{ hostvars[groups.oo_first_master.0].openshift.master.sdn_cluster_network_cidr }}"
+    line: "NO_PROXY={{ openshift.common.no_proxy | default([]) }},{{ openshift.common.portal_net }},{{ openshift_cluster_network_cidr }}"
   when: ('http_proxy' in openshift.common and openshift.common.http_proxy != '')
   notify:
   - restart node

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -276,7 +276,7 @@ resources:
     properties:
       name: openshift-ansible-{{ openshift_openstack_full_dns_domain }}-data-subnet
       network: { get_resource: data_net }
-      cidr: {{ osm_cluster_network_cidr|default('10.128.0.0/14') }}
+      cidr: {{ openshift_cluster_network_cidr }}
       gateway_ip: null
 {% endif %}
 

--- a/test/ci/inventory/group_vars/all.yml
+++ b/test/ci/inventory/group_vars/all.yml
@@ -31,6 +31,4 @@ openshift_template_service_broker_namespaces:
   - "openshift"
 ansible_ssh_user: "ec2-user"
 enable_excluders: "false"
-osm_cluster_network_cidr: "10.128.0.0/14"
 openshift_portal_net: "172.30.0.0/16"
-osm_host_subnet_length: 9


### PR DESCRIPTION
sdn_cluster_network_cidr
sdn_host_subnet_length

Due to bootstrapping, nodes are installed before masters so master facts are not available.

Setting inventory values for the variables below are no longer necessary because they have defaults.
* osm_cluster_network_cidr
* osm_host_subnet_length

Bug 1574300 | https://bugzilla.redhat.com/show_bug.cgi?id=1574300