### PR TITLE
Drop reconcile security context constraints during upgrade

### DIFF
--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -141,7 +141,7 @@
 # Reconcile Cluster Roles, Cluster Role Bindings and Security Context Constraints
 ###############################################################################
 
-- name: Reconcile Cluster Roles and Cluster Role Bindings and Security Context Constraints
+- name: Reconcile Cluster Roles and Cluster Role Bindings
   hosts: oo_masters_to_config
   roles:
   - { role: openshift_cli }
@@ -149,15 +149,6 @@
   vars:
     __master_shared_resource_viewer_file: "shared_resource_viewer_role.yaml"
   tasks:
-  - name: Reconcile Security Context Constraints
-    command: >
-      {{ openshift_client_binary }} adm policy --config={{ openshift.common.config_base }}/master/admin.kubeconfig reconcile-sccs --confirm --additive-only=true -o name
-    register: reconcile_scc_result
-    changed_when:
-    - reconcile_scc_result.stdout != ''
-    - reconcile_scc_result.rc == 0
-    run_once: true
-
   - name: Migrate storage post policy reconciliation
     command: >
       {{ openshift_client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig


### PR DESCRIPTION
During upgrade, ansible upgrade playbook runs `oc adm reconcile-sccs
--confirm --additive-only=true`, however it could break cluster
depends on users' configuration.

For example, one of OCP users added `nfs` to `restricted` scc as:

~~~
# oc get scc restricted
NAME         ...   VOLUMES
restricted   ...   [configMap downwardAPI emptyDir nfs persistentVolumeClaim projected secret]
                                                    ^
						    +---- added nfs by themselvs.
~~~

However, the additional volumes could be dropped by `oc adm reconcile-sccs --confirm --additive-only=true`.

~~~
# oc adm policy reconcile-sccs --additive-only=true -o name --confirm
securitycontextconstraints/restricted

# oc get scc restricted
NAME        ...   VOLUMES
restricted  ...	  [configMap downwardAPI emptyDir persistentVolumeClaim projected secret]
~~~

Due to this behavior, after upgraded their cluster, some pods
(especially registry pod) failed to start by wrong SCCs. This is just
an example situation, but some users might add some volumes to the
SCCs by their purpose.

So, this patch drops the `oc adm reconcile-sccs --confirm
--additive-only=true` from upgrade playbook.