### PR TITLE
Add EAP CD imagestream to 3.10

### DIFF
--- a/roles/openshift_examples/files/examples/v3.10/xpaas-streams/eap-cd-image-stream.json
+++ b/roles/openshift_examples/files/examples/v3.10/xpaas-streams/eap-cd-image-stream.json
@@ -1,0 +1,87 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "jboss-cd-image-streams",
+        "annotations": {
+            "description": "ImageStream definition for JBoss Enterprise Application Platform continuous delivery.",
+            "openshift.io/provider-display-name": "Red Hat, Inc."
+        }
+    },
+    "items": [
+    {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "eap-cd-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "JBoss EAP continuous delivery",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "12.0"
+                }
+            },
+            "labels": {
+                "xpaas": "1.4.10"
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "12",
+                        "annotations": {
+                            "description": "The latest available build of JBoss EAP continuous delivery Tech Preview.",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.2,javaee:7,java:8",
+                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "openshift",
+                            "version": "12",
+                            "openshift.io/display-name": "JBoss EAP continuous delivery (Tech Preview)"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "12.0"
+
+                        }
+                    },
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "JBoss EAP continuous delivery Tech Preview S2I Image",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.2,javaee:7,java:8",
+                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts/openshift",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "openshift",
+                            "version": "12.0",
+                            "openshift.io/display-name": "JBoss EAP continuous delivery (Tech Preview)"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/jboss-eap-7-tech-preview/eap-cd-openshift:latest"
+                        }
+                    },
+                    {
+                        "name": "12.0",
+                        "annotations": {
+                            "description": "JBoss EAP continuous delivery Tech Preview S2I Image",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.2,javaee:7,java:8",
+                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts/openshift",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "openshift",
+                            "version": "12.0",
+                            "openshift.io/display-name": "JBoss EAP continuous delivery (Tech Preview)"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/jboss-eap-7-tech-preview/eap-cd-openshift:12.0"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This is the same IS definition as: https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/templates/eap-cd-image-stream.json