### PR TITLE
Fix upgrade containerized to bootstrap

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -155,8 +155,6 @@ l_docker_image_tag: "{{ l_crt_docker_image_tag_dict[openshift_deployment_type] }
 l_docker_image_default: "{{ l_docker_image_prepend }}:{{ l_docker_image_tag }}"
 l_docker_image: "{{ openshift_docker_systemcontainer_image_override | default(l_docker_image_default) }}"
 
-l_is_node_system_container: "{{ (openshift_use_node_system_container | default(openshift_use_system_containers | default(false)) | bool) }}"
-
 l_crio_var_sock: "/var/run/crio/crio.sock"
 
 container_runtime_oci_umounts:

--- a/roles/container_runtime/tasks/systemcontainer_crio.yml
+++ b/roles/container_runtime/tasks/systemcontainer_crio.yml
@@ -1,11 +1,4 @@
 ---
-# TODO: Much of this file is shared with container engine tasks
-- name: Check we are not using node as a Docker container with CRI-O
-  fail: msg='Cannot use CRI-O with node configured as a Docker container'
-  when:
-    - openshift_is_containerized | bool
-    - not l_is_node_system_container | bool
-
 - import_tasks: common/pre.yml
 
 - import_tasks: common/syscontainer_packages.yml

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -98,8 +98,6 @@ openshift_node_dnsmasq_neg_ttl: '1'
 r_openshift_node_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
 r_openshift_node_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
-l_is_node_system_container: "{{ openshift_use_node_system_container | default(openshift_use_system_containers | default(openshift_is_containerized | default(false))) | bool }}"
-
 openshift_node_syscon_auth_mounts_l:
 - type: bind
   source: "{{ oreg_auth_credentials_path }}"

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -2,10 +2,6 @@
 - name: Install the systemd units
   import_tasks: systemd_units.yml
 
-- name: Install Node system container
-  import_tasks: node_system_container.yml
-  when: l_is_node_system_container | bool
-
 - file:
     dest: "{{ l2_openshift_node_kubelet_args['config'] }}"
     state: directory

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -9,19 +9,14 @@
   template:
     dest: "/etc/systemd/system/{{ openshift_service_type }}-node.service"
     src: "node.service.j2"
-  when: not l_is_node_system_container | bool
+  when: not openshift_is_atomic | bool
   notify:
   - reload systemd units
 
-- block:
-  - name: Remove existing systemd service
-    file:
-      path: "/etc/systemd/system/{{ openshift_service_type }}-node.service"
-      state: absent
-    when: not openshift_is_bootstrapped
-  - name: Install node system container
-    import_tasks: node_system_container.yml
-  when: l_is_node_system_container | bool
+- name: Install node system container
+  import_tasks: node_system_container.yml
+  when: openshift_is_atomic | bool
+
 
 - import_tasks: config/configure-node-settings.yml
 - import_tasks: config/configure-proxy-settings.yml

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -23,7 +23,7 @@
 
 - name: install pre-pulled rpms.
   import_tasks: upgrade/rpm_upgrade_install.yml
-  when: not openshift_is_containerized | bool
+  when: not openshift_is_atomic | bool
 
 - include_tasks: "{{ node_config_hook }}"
   when: node_config_hook is defined

--- a/roles/openshift_node/tasks/upgrade_pre.yml
+++ b/roles/openshift_node/tasks/upgrade_pre.yml
@@ -35,4 +35,4 @@
   - l_docker_upgrade | bool
 
 - import_tasks: upgrade/rpm_upgrade.yml
-  when: not openshift_is_containerized | bool
+  when: not openshift_is_atomic | bool


### PR DESCRIPTION
Currently, upgrades from containerized hosts
(Such as RHEL or CentOS or Fedora non-atomic)
are not operational.

This commit fixes upgrades from containerized hosts
on 3.9 to 3.10 rpm-based, bootstrap, static pod hosts.

This commit also cleans up various pieces of logic
to remove option to force node as system container
outside of atomic host.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1575897