### PR TITLE
Fix etcd runtime detection

### DIFF
--- a/roles/etcd/tasks/runtime.yml
+++ b/roles/etcd/tasks/runtime.yml
@@ -5,9 +5,10 @@
   ignore_errors: true
   register: etcd_service
 
-- set_fact:
+- name: Set runtime to host
+  set_fact:
     r_etcd_common_etcd_runtime: host
-  when: etcd_service.status['ActiveState'] == "active" | bool
+  when: etcd_service.status.ActiveState == 'active'
 
 - name: Check if etcd service exists
   systemd:
@@ -15,10 +16,14 @@
   ignore_errors: true
   register: etcd_container_service
 
-- set_fact:
+- name: Set runtime to docker
+  set_fact:
     r_etcd_common_etcd_runtime: docker
-  when: etcd_container_service.status['ActiveState'] == "active" | bool and not l_is_etcd_system_container
+  when: etcd_container_service.status.ActiveState == 'active' and not l_is_etcd_system_container
 
-- set_fact:
+- name: Set runtime to runc
+  set_fact:
     r_etcd_common_etcd_runtime: runc
-  when: etcd_container_service.status['ActiveState'] == "active" | bool and l_is_etcd_system_container
+  when: etcd_container_service.status.ActiveState == 'active' and l_is_etcd_system_container
+
+- pause: prompt=test


### PR DESCRIPTION
Not sure why this worked the first time we tested it. The free-int upgrade had the same problem as before where it was defaulting to the incorrect runtime. I was able to replicate the problem locally and tested this fix.

/cc @vrutkovs 
/assign @vrutkovs 