### PR TITLE
upgrade_control_plan needs to invoke wire_aggregator

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -127,6 +127,13 @@
   vars:
     master_config_hook: "v3_7/master_config_upgrade.yml"
 
+# this must occur after the control plane is upgraded because systemd service
+# names are changed
+- name: Configure API aggregation on masters
+  hosts: oo_masters_to_config
+  tasks:
+  - include: ../../../openshift-master/tasks/wire_aggregator.yml
+
 # All controllers must be stopped at the same time then restarted
 - name: Cycle all controller services to force new leader election mode
   hosts: oo_masters_to_config


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1573827

When upgrading the control plane and nodes in separate phases, upgrade_control_plane.yml needs to invoke wire_aggregator exactly as is done in the single step upgrade.yml.