### PR TITLE
repoquery: Omit exclude lines when ignoring excluders

### DIFF
--- a/roles/lib_utils/library/repoquery.py
+++ b/roles/lib_utils/library/repoquery.py
@@ -536,7 +536,7 @@ class Repoquery(RepoqueryCLI):
             with open("/etc/yum.conf", "r") as file_handler:
                 yum_conf_lines = file_handler.readlines()
 
-            yum_conf_lines = ["exclude=" if l.startswith("exclude=") else l for l in yum_conf_lines]
+            yum_conf_lines = [l for l in yum_conf_lines if not l.startswith("exclude=")]
 
             with open(self.tmp_file.name, "w") as file_handler:
                 file_handler.writelines(yum_conf_lines)

--- a/roles/lib_utils/src/class/repoquery.py
+++ b/roles/lib_utils/src/class/repoquery.py
@@ -117,7 +117,7 @@ class Repoquery(RepoqueryCLI):
             with open("/etc/yum.conf", "r") as file_handler:
                 yum_conf_lines = file_handler.readlines()
 
-            yum_conf_lines = ["exclude=" if l.startswith("exclude=") else l for l in yum_conf_lines]
+            yum_conf_lines = [l for l in yum_conf_lines if not l.startswith("exclude=")]
 
             with open(self.tmp_file.name, "w") as file_handler:
                 file_handler.writelines(yum_conf_lines)


### PR DESCRIPTION
Some yum library that repoquery uses appears to not like empty exclude lines in a yum config file (`exclude=`).  Once encountered, no further options are processed but no exception is thrown either.

Work around this by omitting exclude lines entirely from the temporary config file.