### PR TITLE
Switch from public subnet id to network id at kuryr

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -216,19 +216,20 @@ openshift_node_open_ports:
 - service: dns udp
   port: 53/udp
 
-kuryr_openstack_public_subnet_id: <public/external subnet UUID>
+kuryr_openstack_public_net_id: <public/external net UUID>
 ```
 
-The `kuryr_openstack_public_subnet_id` value must be set to the UUID of the
-public subnet in your OpenStack. In other words, the subnet with the Floating
+The `kuryr_openstack_public_net_id` value must be set to the UUID of the
+public net in your OpenStack. In other words, the net with the Floating
 IP range defined. It corresponds to the public network, which is often called
 `public`, `external` or `ext-net`.
 
-**NOTE**: A lot of OpenStack deployments do not make the public subnet
-accessible to regular users. We will add an option to enter the network here
-instead. This issue is tracked at:
+Additionally, if the public net has different subnet, you can specify the
+specific one with `kuryr_openstack_public_subnet_id`, whose value must be set
+to the UUID of the public subnet in your OpenStack.
 
-https://github.com/openshift/openshift-ansible/issues/7383
+**NOTE**: A lot of OpenStack deployments do not make the public subnet
+accessible to regular users.
 
 ### Port pooling
 

--- a/playbooks/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/all.yml
@@ -47,8 +47,13 @@ openshift_openstack_external_network_name: "public"
 # deployed after kuryr is up and running. This can be done with oadm
 # #Disable management of the OpenShift Registry
 #openshift_hosted_manage_registry: false
-# # Kuryr needs to know the subnet you will be taking Floating IPs for the
-# loadbalancer services from.
+
+# # Kuryr needs to know the network or the subnet you will be taking Floating
+# IPs for the loadbalancer services from.
+# kuryr_openstack_public_net_id: uuid_of_my_fip_net
+# If you have different subnet at the Floating IP network you can also specify
+# it but need to ensure default policy allows your tennat to retrieve that
+# information
 # kuryr_openstack_public_subnet_id: uuid_of_my_fip_subnet
 
 # If you VM images will name the ethernet device different than 'eth0',

--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -293,7 +293,11 @@ data:
     # TODO (apuimedo): Remove the duplicated line just after this one once the
     # RDO packaging contains the upstream patch
     worker_nodes_subnet = {{ kuryr_openstack_worker_nodes_subnet_id }}
+    external_svc_net = {{ kuryr_openstack_public_net_id }}
+{% if kuryr_openstack_public_subnet_id|default(false) %}
     external_svc_subnet = {{ kuryr_openstack_public_subnet_id }}
+{% endif %}
+
 
     [pod_vif_nested]
 


### PR DESCRIPTION
It adds the option to specify the public network id instead of the
subnet id that may be restricted for tenants by the default policy.