### PR TITLE
Update playbooks/adhoc/uninstall.yml

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -312,7 +312,7 @@
     - /etc/systemd/system/origin-node-dep.service
     - /etc/systemd/system/origin-node.service
     - /etc/systemd/system/origin-node.service.wants
-    - /var/lib/docker
+    - /var/lib/docker/*
 
   - name: Rebuild ca-trust
     command: update-ca-trust


### PR DESCRIPTION
/assign @michaelgugino
 
It is impossible to delete directory /var/lib/docker when it is a mount point to the docker file system.
In this case the uninstall process fails with error.
I propose just clean it up from all docker's stuff
 
 - name: Remove remaining files
    file: path={{ item }} state=absent
    with_items:
    - /var/lib/docker/*