### PR TITLE
Remove installer fact caching

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -18,9 +18,6 @@ nocows = True
 remote_user = root
 roles_path = roles/
 gathering = smart
-fact_caching = jsonfile
-fact_caching_connection = $HOME/ansible/facts
-fact_caching_timeout = 600
 callback_whitelist = profile_tasks
 inventory_ignore_extensions = secrets.py, .pyc, .cfg, .crt, .ini
 # work around privilege escalation timeouts in ansible:


### PR DESCRIPTION
While this can make running multiple playbooks faster, there's a very ugly side-effect:  It also caches incorrect values.  This can cause some very non-[POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment) behavior, esp. for anyone who doesn't know/understand this feature of Ansible.  For example:

1. Setup an otherwise correct inventory file, but specify incorrect value of openshift_hostname (e.g. a typo)
2. Apply ./playbooks/prerequisites.yml (it fails)
3. Correct the inventory file (fix typo)
4. Apply ./playbooks/prerequisites.yml (it fails for same reason: incorrect value was cached -> Astonishment)
5. Wait 600 seconds (make no other changes)
4. Apply ./playbooks/prerequisites.yml (it works -> Astonishment)