### PR TITLE
SDN should read bootstrapped config

### DIFF
--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -70,11 +70,6 @@
     force: yes
     follow: no
 
-- name: Remove default node-config.yaml to allow bootstrapping config
-  file:
-    path: "/etc/origin/node/node-config.yaml"
-    state: absent
-
 - when: rpmgenerated_config.stat.exists
   block:
   - name: Remove RPM generated config files if present

--- a/roles/openshift_node_group/tasks/bootstrap.yml
+++ b/roles/openshift_node_group/tasks/bootstrap.yml
@@ -5,6 +5,7 @@
     dest: "/etc/origin/node/bootstrap-node-config.yaml"
     mode: 0600
 
+# Make sure a single master has node-config so that SDN and sync daemonsets requires it
 - name: remove existing node config
   file:
     dest: "/etc/origin/node/node-config.yaml"

--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -37,7 +37,7 @@ spec:
       # It relies on an up to date node-config.yaml being present.
       - name: sdn
         image: " "
-        command: 
+        command:
         - /bin/bash
         - -c
         - |
@@ -63,7 +63,23 @@ spec:
           # if the node config doesn't exist yet, wait until it does
           retries=0
           while true; do
-            if [[ ! -f /etc/origin/node/node-config.yaml ]]; then
+            file=/etc/sysconfig/origin-node
+            if [[ -f /etc/sysconfig/atomic-openshift-node ]]; then
+              file=/etc/sysconfig/atomic-openshift-node
+            elif [[ -f /etc/sysconfig/origin-node ]]; then
+              file=/etc/sysconfig/origin-node
+            else
+              echo "info: Waiting for the node sysconfig file to be created" 2>&1
+              sleep 15 & wait
+              continue
+            fi
+            config_file="$(sed -nE 's|^CONFIG_FILE=([^#].+)|\1|p' "${file}" | head -1)"
+            if [[ -z "${config_file}" ]]; then
+              echo "info: Waiting for CONFIG_FILE to be set" 2>&1
+              sleep 15 & wait
+              continue
+            fi
+            if [[ ! -f ${config_file} ]]; then
               echo "warning: Cannot find existing node-config.yaml, waiting 15s ..." 2>&1
               sleep 15 & wait
               (( retries += 1 ))
@@ -102,7 +118,7 @@ spec:
           oc config --config=/tmp/kubeconfig set-credentials sa "--token=$( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"
           oc config --config=/tmp/kubeconfig set-context "$( oc config --config=/tmp/kubeconfig current-context )" --user=sa
           # Launch the network process
-          exec openshift start network --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
+          exec openshift start network --config=${config_file} --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
 
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
Node-config.yaml is being removed on masters during control-plane install. Due to a race condition it might not be saved in the configmap and restored later on, as sync service requires SDN to start, which might not be up yet.

Instead of waiting for components to sync it's safe to leave node-config.yaml, as it won't be used by bootstrapped masters. If any changes would be required sync service would rewrite it and restart the node.

SDN script was updated to read atomic-openshift/origin config and extract CONFIG_FILE instead of hardcoded node-config.yaml

This should fix FAH single master install flakes

Fixes #8264 

First run: https://s3.amazonaws.com/aos-ci/ghprb/openshift/openshift-ansible/5c6f01c7018c3068c985bdd8e6b6530dc932d080.0.1525977983960669013/index.html

2nd run: https://s3.amazonaws.com/aos-ci/ghprb/openshift/openshift-ansible/5c6f01c7018c3068c985bdd8e6b6530dc932d080.0.1525982173679960029/index.html