### PR TITLE
Fix undefined variable for existing network config

### DIFF
--- a/playbooks/init/basic_facts.yml
+++ b/playbooks/init/basic_facts.yml
@@ -81,18 +81,26 @@
       name: openshift_control_plane
       tasks_from: check_existing_config.yml
 
-  - set_fact:
-      osm_cluster_network_cidr: "{{ l_existing_clusternet_cidr }}"
-      osm_host_subnet_length: "{{ l_existing_clusternet_len }}"
-      openshift_portal_net: "{{ l_existing_config_master_config.networkConfig.serviceNetworkCIDR }}"
-    vars:
-      # networkConfig.clusterNetworks may not be present in upgraded clusters
-      l_clusternet_list: "{{ l_existing_config_master_config.networkConfig.clusterNetworks is defined | bool }}"
-      l_existing_clusternet_cidr: "{{ l_clusternet_list | ternary((l_existing_config_master_config.networkConfig.clusterNetworks[0].cidr | default('')), l_existing_config_master_config.networkConfig.clusterNetworkCIDR) }}"
-      l_existing_clusternet_len: "{{ l_clusternet_list | ternary((l_existing_config_master_config.networkConfig.clusterNetworks[0].hostSubnetLength | default('')), l_existing_config_master_config.networkConfig.hostSubnetLength) }}"
-    when:
+  - when:
     - l_existing_config_master_config is defined
     - l_existing_config_master_config.networkConfig is defined
+    block:
+    - set_fact:
+        openshift_portal_net: "{{ l_existing_config_master_config.networkConfig.serviceNetworkCIDR }}"
+
+    - set_fact:
+        osm_cluster_network_cidr: "{{ l_existing_config_master_config.networkConfig.clusterNetworks[0].cidr }}"
+        osm_host_subnet_length: "{{ l_existing_config_master_config.networkConfig.clusterNetworks[0].hostSubnetLength }}"
+      when:
+      - l_existing_config_master_config.networkConfig.clusterNetworks is defined
+
+    # Use deprecated config variables if newer ones not found above.
+    - set_fact:
+        osm_cluster_network_cidr: "{{ l_existing_config_master_config.networkConfig.clusterNetworkCIDR }}"
+        osm_host_subnet_length: "{{ l_existing_config_master_config.networkConfig.hostSubnetLength }}"
+      when:
+      - l_existing_config_master_config.networkConfig.clusterNetworks is not defined
+      # End block
 
 - name: Initialize special first-master variables
   hosts: oo_first_master


### PR DESCRIPTION
Ansible fails with undefined variable error when newer
setting is not present in master's config, networkConfig.clusterNetworks.

This commit uses an additional set_fact task due to inflexibility
with ansible.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1576592