### PR TITLE
Fix hard-coded version in master config imageConfig.format

### DIFF
--- a/roles/openshift_control_plane/defaults/main.yml
+++ b/roles/openshift_control_plane/defaults/main.yml
@@ -12,6 +12,7 @@ l_openshift_images_dict:
   openshift-enterprise: 'registry.access.redhat.com/openshift3/ose-${component}:${version}'
 l_osm_registry_url_default: "{{ l_openshift_images_dict[openshift_deployment_type] }}"
 l_os_registry_url: "{{ oreg_url_master | default(oreg_url) | default(l_osm_registry_url_default) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
+openshift_imageconfig_format: "{{ oreg_url_master | default(oreg_url) | default(l_osm_registry_url_default) }}"
 
 osm_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'control-plane') }}"
 

--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -65,7 +65,7 @@ etcdStorageConfig:
   openShiftStoragePrefix: openshift.io
   openShiftStorageVersion: v1
 imageConfig:
-  format: {{ l_os_registry_url }}
+  format: {{ openshift_imageconfig_format }}
   latest: {{ openshift_master_image_config_latest }}
 imagePolicyConfig:{{ openshift.master.image_policy_config | default({"internalRegistryHostname":"docker-registry.default.svc:5000"}) | lib_utils_to_padded_yaml(level=1) }}
 kubeletClientInfo:

--- a/roles/openshift_node_group/defaults/main.yml
+++ b/roles/openshift_node_group/defaults/main.yml
@@ -33,7 +33,7 @@ l_openshift_images_dict:
   openshift-enterprise: 'registry.access.redhat.com/openshift3/ose-${component}:${version}'
 l_osm_registry_url_default: "{{ l_openshift_images_dict[openshift_deployment_type] }}"
 l_os_registry_url: "{{ oreg_url | default(l_osm_registry_url_default) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
-openshift_imageconfig_format: "{{ l_os_registry_url }}"
+openshift_imageconfig_format: "{{ oreg_url | default(l_osm_registry_url_default) }}"
 osn_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'node') }}"
 
 openshift_service_type_dict:


### PR DESCRIPTION
Currently, openshift master's config has hard-coded version
for imageConfig.format field by mistake.

This commit corrects the url to allow for normal operations.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1574899