### PR TITLE
Add critical pod annotation so that descheduler does not evict itself or does not get evicted by others.

### DIFF
--- a/roles/openshift_descheduler/templates/descheduler-cronjob.yaml.j2
+++ b/roles/openshift_descheduler/templates/descheduler-cronjob.yaml.j2
@@ -3,6 +3,8 @@ kind: CronJob
 metadata:
   name: "{{ openshift_descheduler_cronjob_name }}"
   namespace: openshift-descheduler
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
 spec:
   schedule: "{{ openshift_descheduler_cronjob_schedule }}"
   jobTemplate:


### PR DESCRIPTION
Testing looks good.

@ravisantoshgudimetla @ingvagabund @sjenning 