### PR TITLE
Replace and refactor openshift_is_containerized in places

### DIFF
--- a/playbooks/openshift-etcd/private/upgrade_rpm_members.yml
+++ b/playbooks/openshift-etcd/private/upgrade_rpm_members.yml
@@ -1,7 +1,6 @@
 ---
 # INPUT etcd_upgrade_version
 # INPUT etcd_rpm_version
-# INPUT openshift_is_containerized
 - name: Upgrade to {{ etcd_upgrade_version }}
   hosts: oo_etcd_hosts_to_upgrade
   serial: 1
@@ -15,4 +14,3 @@
     when:
     - etcd_rpm_version.stdout | default('99') is version_compare(etcd_upgrade_version, '<')
     - ansible_distribution == 'RedHat'
-    - not openshift_is_containerized | bool

--- a/playbooks/openshift-node/private/restart.yml
+++ b/playbooks/openshift-node/private/restart.yml
@@ -18,19 +18,6 @@
     delay: 30
     when: openshift_node_restart_docker_required | default(True)
 
-  - name: Restart containerized services
-    service:
-      name: "{{ item }}"
-      state: started
-    with_items:
-    - etcd_container
-    - openvswitch
-    - "{{ openshift_service_type }}-master-api"
-    - "{{ openshift_service_type }}-master-controllers"
-    - "{{ openshift_service_type }}-node"
-    failed_when: false
-    when: openshift_is_containerized | bool
-
   - name: Wait for master API to come back online
     wait_for:
       host: "{{ openshift.common.hostname }}"

--- a/roles/cockpit/tasks/main.yml
+++ b/roles/cockpit/tasks/main.yml
@@ -10,7 +10,7 @@
     - cockpit-bridge
     - cockpit-docker
     - "{{ cockpit_plugins }}"
-  when: not openshift_is_containerized | bool
+  when: not openshift_is_atomic | bool
   register: result
   until: result is succeeded
 
@@ -19,4 +19,4 @@
     name: cockpit.socket
     enabled: true
     state: started
-  when: not openshift_is_containerized | bool
+  when: not openshift_is_atomic | bool

--- a/roles/container_runtime/tasks/docker_restart.yml
+++ b/roles/container_runtime/tasks/docker_restart.yml
@@ -13,18 +13,12 @@
   - controllers
   - etcd
   failed_when: false
-  when: openshift_is_containerized | bool
 
-- name: Restart containerized services
+- name: Restart node service
   service: name={{ item }} state=started
   with_items:
-  - etcd_container
-  - openvswitch
-  - "{{ openshift_service_type }}-master-api"
-  - "{{ openshift_service_type }}-master-controllers"
   - "{{ openshift_service_type }}-node"
   failed_when: false
-  when: openshift_is_containerized | bool
 
 - name: Wait for master API to come back online
   wait_for:

--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -7,7 +7,7 @@
   package:
     name: "{{ openshift_service_type }}{{ openshift_pkg_version | default('') | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
     state: present
-  when: not openshift_is_containerized | bool
+  when: not openshift_is_atomic | bool
   register: install_result
   until: install_result is succeeded
   delegate_to: "{{ openshift_ca_host }}"

--- a/roles/openshift_cli/tasks/main.yml
+++ b/roles/openshift_cli/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install clients
   package: name={{ openshift_service_type }}-clients{{ openshift_pkg_version | default('') }} state=present
-  when: not openshift_is_containerized | bool
+  when: not openshift_is_atomic | bool
   register: result
   until: result is succeeded
 
@@ -23,10 +23,10 @@
     openshift_container_binary_sync:
       image: "{{ openshift_cli_image }}"
       backend: "{{ l_openshift_cli_image_backend }}"
-  when: openshift_is_containerized | bool
+  when: openshift_is_atomic | bool
 
 - name: Install bash completion for oc tools
   package: name=bash-completion state=present
-  when: not openshift_is_containerized | bool
+  when: not openshift_is_atomic | bool
   register: result
   until: result is succeeded

--- a/roles/openshift_control_plane/defaults/main.yml
+++ b/roles/openshift_control_plane/defaults/main.yml
@@ -69,7 +69,6 @@ r_openshift_master_os_firewall_allow: "{{ default_r_openshift_master_os_firewall
 oreg_host: "{{ oreg_url.split('/')[0] if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"
 oreg_auth_credentials_path: "{{ r_openshift_master_data_dir }}/.docker"
 oreg_auth_credentials_replace: False
-l_bind_docker_reg_auth: False
 openshift_docker_alternative_creds: "{{ openshift_use_crio_only | bool }}"
 
 containerized_svc_dir: "/usr/lib/systemd/system"

--- a/roles/openshift_control_plane/tasks/registry_auth.yml
+++ b/roles/openshift_control_plane/tasks/registry_auth.yml
@@ -35,16 +35,3 @@
   register: master_oreg_auth_credentials_create_alt
   notify:
   - restart master
-
-# Container images may need the registry credentials
-- name: Setup ro mount of /root/.docker for containerized hosts
-  set_fact:
-    l_bind_docker_reg_auth: True
-  when:
-  - openshift_is_containerized | bool
-  - oreg_auth_user is defined
-  - >
-      (master_oreg_auth_credentials_stat.stat.exists
-      or oreg_auth_credentials_replace
-      or master_oreg_auth_credentials_create.changed
-      or master_oreg_auth_credentials_create_alt.changed) | bool

--- a/roles/openshift_expand_partition/tasks/main.yml
+++ b/roles/openshift_expand_partition/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensure growpart is installed
   package: name=cloud-utils-growpart state=present
-  when: not openshift_is_containerized | bool
+  when: not openshift_is_atomic | bool
   register: result
   until: result is succeeded
 
@@ -10,7 +10,7 @@
   register: has_growpart
   failed_when: has_growpart.rc != 0 and 'package cloud-utils-growpart is not installed' not in has_growpart.stdout
   changed_when: false
-  when: openshift_is_containerized | bool
+  when: openshift_is_atomic | bool
 
 - name: Grow the partitions
   command: "growpart {{oep_drive}} {{oep_partition}}"

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-openshift_client_binary: "{{ (openshift_is_containerized | bool) | ternary('/usr/local/bin/oc', 'oc') }}"
+openshift_client_binary: "{{ (openshift_is_atomic | bool) | ternary('/usr/local/bin/oc', 'oc') }}"
 
 openshift_cli_image_dict:
   origin: 'openshift/origin'

--- a/roles/openshift_manage_node/tasks/main.yml
+++ b/roles/openshift_manage_node/tasks/main.yml
@@ -18,7 +18,7 @@
   retries: 120
   delay: 1
   changed_when: false
-  when: openshift_is_containerized | bool
+  when: openshift_is_atomic | bool
   delegate_to: "{{ openshift_master_host }}"
   run_once: true
 

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -10,5 +10,5 @@
   - name: "{{ openshift_service_type }}-clients{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
   - name: "conntrack-tools"
   when:
-  - not openshift_is_containerized | bool
+  - not openshift_is_atomic | bool
   - item['install'] | default(True) | bool

--- a/roles/openshift_node/tasks/registry_auth.yml
+++ b/roles/openshift_node/tasks/registry_auth.yml
@@ -37,7 +37,7 @@
   set_fact:
     l_bind_docker_reg_auth: True
   when:
-    - openshift_is_containerized | bool
+    - openshift_is_atomic | bool
     - oreg_auth_user is defined
     - >
         (node_oreg_auth_credentials_stat.stat.exists

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -4,7 +4,6 @@
 # - openshift_is_atomic
 # - node_config_hook
 # - openshift_pkg_version
-# - openshift_is_containerized
 # - openshift_release
 
 # tasks file for openshift_node_upgrade

--- a/roles/openshift_node/tasks/upgrade/restart.yml
+++ b/roles/openshift_node/tasks/upgrade/restart.yml
@@ -1,7 +1,6 @@
 ---
 # input variables:
 # - openshift_service_type
-# - openshift_is_containerized
 # - openshift.common.hostname
 # - openshift_master_api_port
 

--- a/roles/openshift_node/tasks/upgrade/stop_services.yml
+++ b/roles/openshift_node/tasks/upgrade/stop_services.yml
@@ -26,13 +26,3 @@
   when:
   - l_docker_upgrade is defined
   - l_docker_upgrade | bool
-
-- name: Stop rpm based services
-  service:
-    name: "{{ item }}"
-    state: stopped
-  with_items:
-  - "{{ openshift_service_type }}-node"
-  - openvswitch
-  failed_when: false
-  when: not openshift_is_containerized | bool

--- a/roles/openshift_node/tasks/upgrade_pre.yml
+++ b/roles/openshift_node/tasks/upgrade_pre.yml
@@ -11,7 +11,7 @@
   command: "{{ ansible_pkg_mgr }} makecache"
   register: result
   until: result is succeeded
-  when: not openshift_is_containerized | bool
+  when: not openshift_is_atomic | bool
 
 - name: Check Docker image count
   shell: "docker images -aq | wc -l"

--- a/roles/openshift_storage_nfs_lvm/tasks/nfs.yml
+++ b/roles/openshift_storage_nfs_lvm/tasks/nfs.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install NFS server
   package: name=nfs-utils state=present
-  when: not openshift_is_containerized | bool
+  when: not openshift_is_atomic | bool
   register: result
   until: result is succeeded
 


### PR DESCRIPTION
This commit refactors some code and replaces openshift_is_containerized
with openshift_is_atomic where appropriate.

Some logic has been adjusted to account migrations to rpm or
static pod based components.