### PR TITLE
[3.9] Fix crio pause image syntax

### DIFF
--- a/roles/container_runtime/templates/crio.conf.j2
+++ b/roles/container_runtime/templates/crio.conf.j2
@@ -124,7 +124,7 @@ log_size_max = 52428800
 default_transport = "docker://"
 
 # pause_image is the image which we use to instantiate infra containers.
-pause_image = {{ pause_image }}
+pause_image = "{{ pause_image }}"
 
 # pause_command is the command to run in a pause_image to have a container just
 # sit there.  If the image contains the necessary information, this value need


### PR DESCRIPTION
Need quotes around the pause_image in roles/container_runtime/templates/crio.conf.j2
This is what was breaking the crio service

Signed-off-by: umohnani8 <umohnani@redhat.com>