### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
 ansible==2.4.3.0
-boto==2.34.0
+boto==2.44.0
 click==6.7
 pyOpenSSL==17.5.0
 # We need to disable ruamel.yaml for now because of test failures


### PR DESCRIPTION
Issue with: 
ec2_ami_find fails 'Image' object has no attribute 'creationDate'

was fixed in boto 2.44