### PR TITLE
Add in crio pause image code back

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -81,6 +81,18 @@ docker_no_proxy: "{{ openshift.common.no_proxy | default('') }}"
 
 openshift_use_crio: False
 
+# Set pause_image variable for crio.conf.j2 required to start the crio service in package_crio.yml
+l_openshift_image_tag_default: "{{ openshift_release | default('latest') }}"
+l_openshift_image_tag: "{{ openshift_image_tag | default(l_openshift_image_tag_default) | string}}"
+
+l_crio_pause_images_dict:
+  origin: 'docker.io/openshift/origin-${component}:${version}'
+  openshift-enterprise: 'registry.access.redhat.com/openshift3/ose-${component}:${version}'
+l_pause_registry_url_default: "{{ l_crio_pause_images_dict[openshift_deployment_type] }}"
+l_os_registry_url: "{{ oreg_url_master | default(oreg_url) | default(l_pause_registry_url_default) | regex_replace('${version}' | regex_escape, l_openshift_image_tag | default('${version}')) }}"
+
+pause_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'pod') }}"
+
 l_required_docker_version: '1.13'
 
 l_crio_var_sock: "/var/run/crio/crio.sock"


### PR DESCRIPTION
Getting the image to use for crio's pause image was removed in
a previous commit by mistake. Adding that back in.

Signed-off-by: umohnani8 <umohnani@redhat.com>