### PR TITLE
Move crio.conf format-control to it's template

### DIFF
--- a/roles/container_runtime/templates/crio.conf.j2
+++ b/roles/container_runtime/templates/crio.conf.j2
@@ -143,13 +143,23 @@ image_volumes = "mkdir"
 
 # insecure_registries is used to skip TLS verification when pulling images.
 insecure_registries = [
-{{ l_insecure_crio_registries|default("") }}
+{% set _ins_crio_regs = l2_docker_insecure_registries | default([]) %}
+{% if _ins_crio_regs | length %}
+    {% for _ins_crio_reg in _ins_crio_regs %}
+    "{{ _ins_crio_reg }}",
+    {% endfor %}
+{% endif %}
 ]
 
 # registries is used to specify a comma separated list of registries to be used
 # when pulling an unqualified image (e.g. fedora:rawhide).
 registries = [
-{{ l_additional_crio_registries|default("") }}
+{% set _add_crio_regs = l2_docker_additional_registries | default([]) %}
+{% if _add_crio_regs | length %}
+    {% for _add_crio_reg in _add_crio_regs %}
+    "{{ _add_crio_reg }}",
+    {% endfor %}
+{% endif %}
 ]
 
 # The "crio.network" table contains settings pertaining to the


### PR DESCRIPTION
Previously, the contents of ``l_insecure_crio_registries`` and
``l_additional_crio_registries`` were pre-formatted from their 'docker'
variable equivalents.  They were encoded as as a giant string of
quoted, comma-separated-values at definition time.  Forming the
contents of those variables for use in ``crio.conf``, in a role's
defaults file required lots of quote-escaping and black-magic-voodoo.

ref: https://github.com/openshift/openshift-ansible/blob/release-3.9/roles/container_runtime/defaults/main.yml#L95

Simplify this greatly by simply accepting ``l_docker_insecure_registries`` and
``l_docker_additional_registries`` directly, as-is (list of registry strings).
Handle the ``crio.conf``-specific formatting, directly in the template using
an in-line for-loop.

This puts format-control in the template's hands, which is a much better
strategy from a maintenance perspective.  If a developer needs to account
for some future ``crio.conf`` change, the necessary formatting logic is in
an obvious, easy-to-find place and in simple terms.

Signed-off-by: Chris Evich <cevich@redhat.com>