### PR TITLE
Add static cluster id label to alerts

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/defaults/main.yml
+++ b/roles/openshift_cluster_monitoring_operator/defaults/main.yml
@@ -6,6 +6,8 @@ openshift_cluster_monitoring_operator_alertmanager_repo: quay.io/prometheus/aler
 openshift_cluster_monitoring_operator_prometheus_reloader_repo: quay.io/coreos/prometheus-config-reloader
 openshift_cluster_monitoring_oeprator_configmap_reloader_repo: quay.io/coreos/configmap-reload
 
+openshift_cluster_monitoring_operator_cluster_id: "{{ openshift_clusterid | default(openshift_master_cluster_public_hostname, true) | default(openshift_master_cluster_hostname, true) | default('openshift', true) }}"
+
 openshift_cluster_monitoring_operator_alertmanager_config: |+
   global:
     resolve_timeout: 5m

--- a/roles/openshift_cluster_monitoring_operator/files/cluster-monitoring-operator.yaml
+++ b/roles/openshift_cluster_monitoring_operator/files/cluster-monitoring-operator.yaml
@@ -27,10 +27,15 @@ parameters:
 - name: ALERTMANAGER_CONFIG
   required: true
   description: A complete (base64-encoded) Alertmanager configuration YAML file.
+- name: CLUSTER_ID
+  description: Identifies the cluster being monitored; the value is added to a `cluster` label in every alert.
+  required: true
 - name: NAMESPACE
   # This namespace cannot be changed. Only `openshift-monitoring` is supported.
   value: openshift-monitoring
+
 objects:
+# Configures the Cluster Monitoring Operator.
 - apiVersion: v1
   kind: ConfigMap
   metadata:
@@ -44,9 +49,12 @@ objects:
         configReloaderBaseImage: ${CONFIG_RELOADER_IMAGE}
       prometheusK8s:
         baseImage: ${PROMETHEUS_IMAGE}
+        externalLabels:
+          cluster: ${CLUSTER_ID}
       alertmanagerMain:
         baseImage: ${ALERTMANAGER_IMAGE}
 
+# Configures Alertmanager.
 - apiVersion: v1
   kind: Secret
   metadata:

--- a/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
+++ b/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
@@ -33,6 +33,7 @@
     --param PROMETHEUS_CONFIG_RELOADER_IMAGE="{{ openshift_cluster_monitoring_operator_prometheus_reloader_repo }}"
     --param CONFIG_RELOADER_IMAGE="{{ openshift_cluster_monitoring_oeprator_configmap_reloader_repo }}"
     --param ALERTMANAGER_CONFIG="{{ openshift_cluster_monitoring_operator_alertmanager_config | b64encode }}"
+    --param CLUSTER_ID="{{ openshift_cluster_monitoring_operator_cluster_id }}"
     --config={{ mktemp.stdout }}/admin.kubeconfig
     | {{ openshift_client_binary }} apply --config={{ mktemp.stdout }}/admin.kubeconfig -f -
   with_items:


### PR DESCRIPTION
Add a static `cluster` label to every alert which uniquely identifies the
cluster which produced the alert. This allows more flexible downstream alert
processing.