### PR TITLE
Readd crio registry variables

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -84,3 +84,7 @@ openshift_use_crio: False
 l_required_docker_version: '1.13'
 
 l_crio_var_sock: "/var/run/crio/crio.sock"
+
+l_insecure_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l2_docker_insecure_registries)) }}"
+l_crio_registries: "{{ l2_docker_additional_registries + ['docker.io'] }}"
+l_additional_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l_crio_registries)) }}"


### PR DESCRIPTION
Recently, several crio registry variables were removed by mistake.

This commit restores those variables.