### PR TITLE
quick installer: make all nodes schedulable

### DIFF
--- a/utils/src/ooinstall/oo_config.py
+++ b/utils/src/ooinstall/oo_config.py
@@ -134,14 +134,7 @@ class Host(object):
         """ Will this host be a node marked as schedulable. """
         if not self.is_node():
             return False
-        if not self.is_master():
-            return True
-
-        masters = [host for host in all_hosts if host.is_master()]
-        nodes = [host for host in all_hosts if host.is_node()]
-        if len(masters) == len(nodes):
-            return True
-        return False
+        return True
 
 
 class Role(object):

--- a/utils/test/cli_installer_tests.py
+++ b/utils/test/cli_installer_tests.py
@@ -788,7 +788,7 @@ class AttendedCliTests(OOCliFixture):
         inventory = configparser.ConfigParser(allow_no_value=True)
         inventory.read(os.path.join(self.work_dir, 'hosts'))
         self.assert_inventory_host_var(
-            inventory, 'nodes', '10.0.0.1', 'openshift_schedulable=False')
+            inventory, 'nodes', '10.0.0.1', 'openshift_schedulable=True')
         self.assert_inventory_host_var_unset(
             inventory, 'nodes', '10.0.0.2', 'openshift_schedulable=True')
         self.assert_inventory_host_var_unset(
@@ -915,11 +915,11 @@ class AttendedCliTests(OOCliFixture):
         inventory = configparser.ConfigParser(allow_no_value=True)
         inventory.read(os.path.join(self.work_dir, 'hosts'))
         self.assert_inventory_host_var(inventory, 'nodes', '10.0.0.1',
-                                       'openshift_schedulable=False')
+                                       'openshift_schedulable=True')
         self.assert_inventory_host_var(inventory, 'nodes', '10.0.0.2',
-                                       'openshift_schedulable=False')
+                                       'openshift_schedulable=True')
         self.assert_inventory_host_var(inventory, 'nodes', '10.0.0.3',
-                                       'openshift_schedulable=False')
+                                       'openshift_schedulable=True')
         self.assert_inventory_host_var_unset(inventory, 'nodes', '10.0.0.4',
                                              'openshift_schedulable=True')
 
@@ -1088,7 +1088,7 @@ class AttendedCliTests(OOCliFixture):
         inventory = configparser.ConfigParser(allow_no_value=True)
         inventory.read(os.path.join(self.work_dir, 'hosts'))
         self.assert_inventory_host_var(
-            inventory, 'nodes', '10.0.0.1', 'openshift_schedulable=False')
+            inventory, 'nodes', '10.0.0.1', 'openshift_schedulable=True')
         self.assert_inventory_host_var_unset(
             inventory, 'nodes', '10.0.0.2', 'openshift_schedulable=True')
         self.assert_inventory_host_var_unset(


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1570918

Cherrypicks to master and release-3.7 are not required