### PR TITLE
Move crio.conf formatting logic into it's template

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -97,6 +97,8 @@ l_required_docker_version: '1.13'
 
 l_crio_var_sock: "/var/run/crio/crio.sock"
 
-l_insecure_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l2_docker_insecure_registries)) }}"
+# These (l_*_registries) support a legacy CSV format. For new
+# installs, set them to a list of strings instead.
+l_insecure_crio_registries: "{{ l2_docker_insecure_registries | default([]) }}"
 l_crio_registries: "{{ l2_docker_additional_registries + ['docker.io'] }}"
-l_additional_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l_crio_registries)) }}"
+l_additional_crio_registries: "{{ l_crio_registries }}"

--- a/roles/container_runtime/templates/crio.conf.j2
+++ b/roles/container_runtime/templates/crio.conf.j2
@@ -141,15 +141,27 @@ signature_policy = ""
 # The valid values are mkdir and ignore.
 image_volumes = "mkdir"
 
+{% macro normalize_repo_var(repo_list_or_csv) -%}
+    {% if ',' in repo_list_or_csv -%} ## Legacy CSV format
+        {% set _registries = repo_list_or_csv | split(',') %}
+    {%- else -%}          ## Modern list of strings format
+        {% set _registries = repo_list_or_csv %}
+    {%- endif %}
+    {% for _registry in _registries -%}
+        {% set _registry | trim %}   ## Leading/Trailing CSV item whitespace
+        {% if _registry | length -%}  ## Ignore empty CSV items
+            {{ '    ' }}"{{ _registry }}",  ## include leading whitespace
+        {%- end if %}
+    {%- endfor %}
 # insecure_registries is used to skip TLS verification when pulling images.
 insecure_registries = [
-{{ l_insecure_crio_registries|default("") }}
+    {{ normalize_repo_var(l_insecure_crio_registries) }}
 ]
 
 # registries is used to specify a comma separated list of registries to be used
 # when pulling an unqualified image (e.g. fedora:rawhide).
 registries = [
-{{ l_additional_crio_registries|default("") }}
+    {{ normalize_repo_var(l_additional_crio_registries | default([])) }}
 ]
 
 # The "crio.network" table contains settings pertaining to the


### PR DESCRIPTION
Previously, the contents of ``l_insecure_crio_registries`` and
``l_additional_crio_registries`` were pre-formatted from their 'docker'
variable equivalents (#8351).  They were encoded as as a giant string of
quoted, comma-separated-values at definition time.  Forming their
contents relied on embedded python and complex value quoting.
This was done to support a modern list-of-strings format in addition
to a newer string-list format.

ref: https://github.com/openshift/openshift-ansible/blob/release-3.9
/roles/container_runtime/defaults/main.yml#L95

Simplify this situation, while still accepting both formats, by moving
the formatting logic (#8349) from the defaults-definitions, into the
``crio.conf.j2`` template itself.  Utilize a jinja2 macro (a function)
to normalize handling of both legacy and modern formatting.  Call
this macro to help format both the ``insecure_registries`` and
``registries`` lists.  Also add comments regarding legacy and
modern use cases.

Having format-control in the template domain, recuces code duplication,
and locates the logic close to it's use for readability.  These updates
will enhance future maintainer's ability to effeciently handle any
needed changes.

Signed-off-by: Chris Evich <cevich@redhat.com>