### PR TITLE
Avoid hardcoded namespace default in lib_openshift/oc_adm_router

### DIFF
--- a/roles/lib_openshift/library/oc_adm_router.py
+++ b/roles/lib_openshift/library/oc_adm_router.py
@@ -2692,7 +2692,7 @@ class Router(OpenShiftCLI):
            - secret/router-certs
            - clusterrolebinding/router-router-role
         '''
-        super(Router, self).__init__('default', router_config.kubeconfig, verbose)
+        super(Router, self).__init__(router_config.namespace, router_config.kubeconfig, verbose)
         self.config = router_config
         self.verbose = verbose
         self.router_parts = [{'kind': 'dc', 'name': self.config.name},

--- a/roles/lib_openshift/src/class/oc_adm_router.py
+++ b/roles/lib_openshift/src/class/oc_adm_router.py
@@ -27,7 +27,7 @@ class Router(OpenShiftCLI):
            - secret/router-certs
            - clusterrolebinding/router-router-role
         '''
-        super(Router, self).__init__('default', router_config.kubeconfig, verbose)
+        super(Router, self).__init__(router_config.namespace, router_config.kubeconfig, verbose)
         self.config = router_config
         self.verbose = verbose
         self.router_parts = [{'kind': 'dc', 'name': self.config.name},


### PR DESCRIPTION
Fixes #7009