### PR TITLE
NTP service is a pre-requisite for glusterfs

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/host_services.yml
+++ b/roles/openshift_storage_glusterfs/tasks/host_services.yml
@@ -2,3 +2,12 @@
 # as per https://access.redhat.com/documentation/en-us/red_hat_gluster_storage/3.3/html/container-native_storage_for_openshift_container_platform/ch06s03
 - name: Ensure systemd has right dependencies
   command: "systemctl add-wants multi-user rpcbind.service"
+
+- name: Enable the NTP service chronyd
+  command: "systemctl add-wants multi-user chronyd.service"
+
+- name: Start chronyd
+  systemd:
+    name: chronyd
+    state: started
+    enabled: yes


### PR DESCRIPTION
NTP service is a pre-requisite for glusterfs.
Ensure it is enabled and started in host.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>