### PR TITLE
[3.9] Prometheus nodeselector should default to hosted nodeselector

### DIFF
--- a/roles/openshift_prometheus/defaults/main.yaml
+++ b/roles/openshift_prometheus/defaults/main.yaml
@@ -11,7 +11,7 @@ openshift_prometheus_alerts_hostname: alerts-{{openshift_prometheus_namespace}}.
 openshift_prometheus_alertmanager_hostname: alertmanager-{{openshift_prometheus_namespace}}.{{openshift_master_default_subdomain}}
 
 
-openshift_prometheus_node_selector: {"region":"infra"}
+openshift_prometheus_node_selector: "{{ openshift_hosted_infra_selector | default('region=infra') | map_from_pairs }}"
 
 openshift_prometheus_service_port: 443
 openshift_prometheus_service_targetport: 8443


### PR DESCRIPTION
Cherry-pick of #8377 on release-3.9