### PR TITLE
Add new key and remove deprecated key for master network conf

### DIFF
--- a/playbooks/init/basic_facts.yml
+++ b/playbooks/init/basic_facts.yml
@@ -94,6 +94,7 @@
       when:
       - l_existing_config_master_config.networkConfig.clusterNetworks is defined
 
+    # TODO(michaelgugino): Remove in 3.11
     # Use deprecated config variables if newer ones not found above.
     - set_fact:
         osm_cluster_network_cidr: "{{ l_existing_config_master_config.networkConfig.clusterNetworkCIDR }}"

--- a/roles/openshift_control_plane/defaults/main.yml
+++ b/roles/openshift_control_plane/defaults/main.yml
@@ -156,3 +156,8 @@ openshift_master_max_requests_inflight: 500
 openshift_master_embedded_dns: True
 openshift_master_embedded_kube: True
 openshift_master_pod_eviction_timeout: ""
+
+# TODO(michaelgugino): Remove in 3.11
+l_new_config_clusterNetworks:
+- cidr: "{{ openshift_cluster_network_cidr }}"
+  hostSubnetLength: "{{ openshift_host_subnet_length }}"

--- a/roles/openshift_control_plane/tasks/upgrade.yml
+++ b/roles/openshift_control_plane/tasks/upgrade.yml
@@ -71,6 +71,26 @@
       value: "{{ item | regex_replace('^OPENSHIFT_DEFAULT_REGISTRY=\\s*([^#\\s]+).*','\\1') }}"
     with_items: "{{ (sysconfig.content | b64decode).split('\n') | select('match','^OPENSHIFT_DEFAULT_REGISTRY=\\s*.+') | list }}"
 
+# TODO(michaelgugino): Remove in 3.11
+- name: Add new network config section to master conf
+  yedit:
+    src: /etc/origin/master/master-config.yml
+    key: networkConfig.clusterNetworks
+    value: "{{ l_new_config_clusterNetworks }}"
+  # l_existing_config_master_config is set via playbooks/init/basic_facts.yml
+  when: l_existing_config_master_config.networkConfig.clusterNetworks is not defined
+
+# TODO(michaelgugino): Remove in 3.11
+- name: Remove old network config section in master conf
+  yedit:
+    src: /etc/origin/master/master-config.yaml
+    key: "{{ item }}"
+    state: absent
+  with_items:
+  - networkConfig.clusterNetworkCIDR
+  - networkConfig.hostSubnetLength
+
+
 - name: Create the master service env file if it does not exist
   template:
     src: "master.env.j2"


### PR DESCRIPTION
This commit adds new keys that may not be present in upgraded
clusters and removes deprecated key.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1576458