### PR TITLE
[release-3.9] Copy files from openshift_master_generated_config_dir instead using hardlinks

### DIFF
--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -86,11 +86,10 @@
   delegate_to: "{{ openshift_ca_host }}"
   run_once: true
 
-- file:
+- copy:
     src: "{{ openshift_master_config_dir }}/{{ item }}"
     dest: "{{ openshift_master_generated_config_dir }}/{{ item }}"
-    state: hard
-    force: true
+    remote_src: yes
   with_items:
   # certificates_to_synchronize is a custom filter in lib_utils
   - "{{ hostvars[inventory_hostname] | certificates_to_synchronize }}"


### PR DESCRIPTION
Fixes #7075

Follow up from https://github.com/openshift/openshift-ansible/pull/7076#issuecomment-389337305

