### PR TITLE
openshift-node: sync script with origin

### DIFF
--- a/roles/openshift_node/files/openshift-node
+++ b/roles/openshift_node/files/openshift-node
@@ -14,5 +14,5 @@ config=/etc/origin/node/bootstrap-node-config.yaml
 if [[ -f /etc/origin/node/node-config.yaml ]]; then
   config=/etc/origin/node/node-config.yaml
 fi
-flags=$( /usr/bin/openshift start node --write-flags "--config=${config}" --loglevel=${DEBUG_LOGLEVEL:-2} )
+flags=$( /usr/bin/openshift-node-config "--config=${config}" )
 exec /usr/bin/hyperkube kubelet --v=${DEBUG_LOGLEVEL:-2} ${flags}


### PR DESCRIPTION
Sync the script with the version used by the containerized Kubelet.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>