### PR TITLE
Stop upgrade when existing sccs will be changed

### DIFF
--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -3,6 +3,22 @@
 # Upgrade Masters
 ###############################################################################
 
+# Some change makes critical outage on current cluster.
+- name: Confirm upgrade will not make critical changes
+  hosts: oo_first_master
+  tasks:
+  - name: Confirm Reconcile Security Context Constraints will not change current SCCs
+    command: >
+      {{ openshift_client_binary }} adm policy --config={{ openshift.common.config_base }}/master/admin.kubeconfig reconcile-sccs --additive-only=true -o name
+    register: check_reconcile_scc_result
+    when: openshift_reconcile_sccs_reject_change | default(true) | bool
+
+  - fail:
+      msg: "Trying to change SCCs. Run \"{{ openshift_client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig\" and confirm SCCs which will be changed."
+    when:
+    - openshift_reconcile_sccs_reject_change
+    - check_reconcile_scc_result.stdout != '' or check_reconcile_scc_result.rc != 0
+
 # Create service signer cert when missing. Service signer certificate
 # is added to master config in the master_config_upgrade hook.
 - name: Determine if service signer cert must be created

--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -16,7 +16,7 @@
   - fail:
       msg: "Trying to change SCCs. Run \"{{ openshift_client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig\" and confirm SCCs which will be changed."
     when:
-    - openshift_reconcile_sccs_reject_change
+    - openshift_reconcile_sccs_reject_change | default(true) | bool
     - check_reconcile_scc_result.stdout != '' or check_reconcile_scc_result.rc != 0
 
 # Create service signer cert when missing. Service signer certificate


### PR DESCRIPTION
When running upgrade playbook, ansible upgrade playbook runs `oc adm
reconcile-sccs --confirm --additive-only=true` by design. It could
break cluster depends on users' configuration.

Although we are saying that changing default SCCs is bad practice,
some users notice it after the worst thing happened. To make matters
worse, once customized SCCs are reconciled, it is difficult to recover
the cluster from it as nobody took the backup of SCCs.

To prevent such worst case, this PR changes upgrade playbook to stop
when existing SCCs will be changed.

Fixes https://github.com/openshift/openshift-ansible/issues/8400