### PR TITLE
Papr 3.7 to 3.9 upgrade

### DIFF
--- a/.papr.sh
+++ b/.papr.sh
@@ -26,10 +26,20 @@ git config --global user.name "OpenShift Atomic CI"
 # Rebase existing branch on the latest code locally, as PAPR running doesn't do merges
 git fetch origin ${target_branch_in} && git rebase origin/${target_branch_in}
 
-pip install -r requirements.txt
-
 PAPR_INVENTORY=${PAPR_INVENTORY:-.papr.inventory}
 PAPR_RUN_UPDATE=${PAPR_RUN_UPDATE:-0}
+PAPR_UPGRADE_FROM=${PAPR_UPGRADE_FROM:-0}
+PAPR_EXTRAVARS=""
+
+# Replace current branch with PAPR_UPGRADE_FROM
+if [[ "${PAPR_UPGRADE_FROM}" != "0" ]]; then
+  git branch new-code
+  git checkout release-${PAPR_UPGRADE_FROM}
+  git clean -fdx
+  PAPR_EXTRAVARS="-e openshift_release=${PAPR_UPGRADE_FROM}"
+fi
+
+pip install -r requirements.txt
 
 # ping the nodes to check they're responding and register their ostree versions
 ansible -vvv -i $PAPR_INVENTORY nodes -a 'rpm-ostree status'
@@ -44,14 +54,22 @@ upload_journals() {
 
 trap upload_journals ERR
 
-# Store ansible log separately
-export ANSIBLE_LOG_PATH=ansible.log
+# run the prerequisites play
+ansible-playbook -vvv -i $PAPR_INVENTORY $PAPR_EXTRAVARS playbooks/prerequisites.yml
+DEPLOY_PLAYBOOK="playbooks/deploy_cluster.yml"
+if [ ! -f $DEPLOY_PLAYBOOK ]; then
+  DEPLOY_PLAYBOOK="playbooks/byo/config.yml"
+fi
+ansible-playbook -vvv -i $PAPR_INVENTORY $PAPR_EXTRAVARS $DEPLOY_PLAYBOOK
 
-# run the actual installer
-ansible-playbook -v -i $PAPR_INVENTORY playbooks/deploy_cluster.yml
+# Restore the branch if needed
+if [[ "${PAPR_UPGRADE_FROM}" != "0" ]]; then
+  git checkout new-code
+  git clean -fdx
+fi
 
-# Run upgrade playbook (to a minor version)
-if [[ "${PAPR_RUN_UPDATE:-0}" != "0" ]]; then
+# Run upgrade playbook
+if [[ "${PAPR_RUN_UPDATE}" != "0" ]]; then
   update_version="$(echo $target_branch | sed 's/\./_/')"
   ansible-playbook -v -i $PAPR_INVENTORY playbooks/byo/openshift-cluster/upgrades/v${update_version}/upgrade.yml
 fi

--- a/.papr.sh
+++ b/.papr.sh
@@ -33,10 +33,12 @@ PAPR_EXTRAVARS=""
 
 # Replace current branch with PAPR_UPGRADE_FROM
 if [[ "${PAPR_UPGRADE_FROM}" != "0" ]]; then
+  cp $PAPR_INVENTORY /tmp
   git branch new-code
   git checkout release-${PAPR_UPGRADE_FROM}
   git clean -fdx
   PAPR_EXTRAVARS="-e openshift_release=${PAPR_UPGRADE_FROM}"
+  cp /tmp/$PAPR_INVENTORY .
 fi
 
 pip install -r requirements.txt

--- a/.papr.sh
+++ b/.papr.sh
@@ -37,7 +37,7 @@ if [[ "${PAPR_UPGRADE_FROM}" != "0" ]]; then
   git branch new-code
   git checkout release-${PAPR_UPGRADE_FROM}
   git clean -fdx
-  PAPR_EXTRAVARS="-e openshift_release=${PAPR_UPGRADE_FROM}"
+  PAPR_EXTRAVARS="-e openshift_release=${PAPR_UPGRADE_FROM} -e openshift_image_tag=v${PAPR_UPGRADE_FROM}"
   cp /tmp/$PAPR_INVENTORY .
 fi
 

--- a/.papr.yml
+++ b/.papr.yml
@@ -40,11 +40,10 @@ tests:
 
 artifacts:
   - journals/
-  - ansible.log
 
 ---
 inherit: true
-context: 'fedora/27/atomic/update'
+context: 'fedora/27/atomic/upgrade_minor'
 
 cluster:
   hosts:
@@ -58,6 +57,22 @@ env:
   PAPR_INVENTORY: .papr.all-in-one.inventory
   PAPR_RUN_UPDATE: "yes"
 
+---
+inherit: true
+context: 'fedora/27/atomic/upgrade_major'
+
+cluster:
+  hosts:
+    - name: ocp-master
+      distro: fedora/27/atomic
+      specs:
+        ram: 4096
+  container:
+    image: registry.fedoraproject.org/fedora:27
+env:
+  PAPR_INVENTORY: .papr.all-in-one.inventory
+  PAPR_UPGRADE_FROM: "3.7"
+  PAPR_RUN_UPDATE: "yes"
 ---
 inherit: true
 context: 'fedora/27/atomic/master-ha'


### PR DESCRIPTION
TODO:
* [ ] Fix incorrect openshift_version:
```
openshift_image_tag must be in the format v#.#.#[-optional.#]. Examples: v1.2.3, v3.5.1-alpha.1
               You specified openshift_image_tag=v3.7
```