### PR TITLE
Implicitly create node's IST in Kuryr's namespace

### DIFF
--- a/roles/kuryr/defaults/main.yaml
+++ b/roles/kuryr/defaults/main.yaml
@@ -87,3 +87,11 @@ kuryr_clusterrole:
         - services
         - services/status
         - routes
+
+# OpenShift-Node image definitions
+l_openshift_master_images_dict:
+  origin: 'docker.io/openshift/origin-${component}:${version}'
+  openshift-enterprise: 'registry.access.redhat.com/openshift3/ose-${component}:${version}'
+l_osm_registry_url_default: "{{ l_openshift_master_images_dict[openshift_deployment_type] }}"
+l_os_registry_url: "{{ oreg_url | default(l_osm_registry_url_default) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
+osn_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'node') }}"

--- a/roles/kuryr/tasks/master.yaml
+++ b/roles/kuryr/tasks/master.yaml
@@ -7,6 +7,12 @@
   command: mktemp -d
   register: manifests_tmpdir
 
+- name: Create OpenShift node's ImageStreamTag manifest
+  become: yes
+  template:
+    src: node-images.yaml.j2
+    dest: "{{ manifests_tmpdir.stdout }}/node-images.yaml"
+
 - name: Create kuryr ConfigMap manifest
   become: yes
   template:
@@ -24,6 +30,17 @@
   template:
     src: cni-daemonset.yaml.j2
     dest: "{{ manifests_tmpdir.stdout }}/cni-daemonset.yaml"
+
+- name: Apply OpenShift node's ImageStreamTag manifest
+  oc_obj:
+    state: present
+    kind: ImageStreamTag
+    name: "node:v3.10"
+    namespace: "{{ kuryr_namespace }}"
+    files:
+    - "{{ manifests_tmpdir.stdout }}/node-images.yaml"
+  run_once: true
+  ignore_errors: yes
 
 - name: Apply ConfigMap manifest
   oc_obj:

--- a/roles/kuryr/templates/node-images.yaml.j2
+++ b/roles/kuryr/templates/node-images.yaml.j2
@@ -1,0 +1,10 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStreamTag
+metadata:
+  name: node:v3.10
+  namespace: {{ kuryr_namespace }}
+tag:
+  reference: true
+  from:
+    kind: DockerImage
+    name: {{ osn_image }}


### PR DESCRIPTION
This commit adds implicit creation of openshift-node ImageStreamTag to
Kuryr's role in its namespace. This seems to be required for Origin
deployments.