### PR TITLE
Fix unwanted removal of openshift.fact file

### DIFF
--- a/playbooks/openshift-node/private/bootstrap.yml
+++ b/playbooks/openshift-node/private/bootstrap.yml
@@ -39,10 +39,6 @@
   vars:
     l_node_group: oo_nodes_to_bootstrap:!oo_exclude_bootstrapped_nodes
 
-- import_playbook: clean_image.yml
-  vars:
-    l_node_group: oo_nodes_to_bootstrap:!oo_exclude_bootstrapped_nodes
-
 - name: Node Preparation Checkpoint End
   hosts: all
   gather_facts: false


### PR DESCRIPTION
Currently, existing openshift_facts fact-file (openshift.fact)
is removed during provisioning a new cluster.

This commit removes call to clean_image.yml from
bootstrap.yml as it should not be called from that
playbook.