### PR TITLE
Force creating hard- and softlinks

### DIFF
--- a/roles/contiv/tasks/netmaster.yml
+++ b/roles/contiv/tasks/netmaster.yml
@@ -12,6 +12,7 @@
     src: "{{ contiv_current_release_directory }}/{{ item }}"
     dest: "{{ contiv_bin_dir }}/{{ item }}"
     state: link
+    force: yes
   with_items:
     - netmaster
     - netctl

--- a/roles/contiv/tasks/netplugin.yml
+++ b/roles/contiv/tasks/netplugin.yml
@@ -27,6 +27,7 @@
     src: "{{ contiv_current_release_directory }}/netplugin"
     dest: "{{ contiv_bin_dir }}/netplugin"
     state: link
+    force: yes
 
 - name: Netplugin | Ensure contiv_cni_bin_dir exists
   file:
@@ -39,6 +40,7 @@
     src: "{{ contiv_current_release_directory }}/contivk8s"
     dest: "{{ contiv_cni_bin_dir }}/contivk8s"
     state: link
+    force: yes
 
 - name: Netplugin | Copy CNI loopback bin
   copy:

--- a/roles/etcd/tasks/certificates/fetch_client_certificates_from_ca.yml
+++ b/roles/etcd/tasks/certificates/fetch_client_certificates_from_ca.yml
@@ -77,6 +77,7 @@
     src: "{{ etcd_ca_cert }}"
     dest: "{{ etcd_generated_certs_dir}}/{{ etcd_cert_subdir }}/{{ etcd_cert_prefix }}ca.crt"
     state: hard
+    force: yes
   when: etcd_client_certs_missing | bool
   delegate_to: "{{ etcd_ca_host }}"
 

--- a/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
+++ b/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
@@ -106,6 +106,7 @@
     src: "{{ etcd_ca_cert }}"
     dest: "{{ etcd_generated_certs_dir}}/{{ etcd_cert_subdir }}/{{ etcd_cert_prefix }}ca.crt"
     state: hard
+    force: yes
   when: etcd_server_certs_missing | bool
   delegate_to: "{{ etcd_ca_host }}"
 

--- a/roles/openshift_control_plane/tasks/upgrade.yml
+++ b/roles/openshift_control_plane/tasks/upgrade.yml
@@ -44,6 +44,7 @@
     src: "{{ openshift.common.config_base }}/master/ca-bundle.crt"
     path: "{{ openshift.common.config_base }}/master/ca.crt"
     state: link
+    force: yes
   when: ca_crt_stat.stat.isreg and not ca_bundle_stat.stat.exists
 
 - name: Find existing master sysconfig

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -234,4 +234,5 @@
     src: "{{ openshift.common.config_base }}/master/ca-bundle.crt"
     path: "{{ openshift.common.config_base }}/master/ca.crt"
     state: link
+    force: yes
   when: ca_crt_stat.stat.isreg and not ca_bundle_stat.stat.exists


### PR DESCRIPTION
When `state: hard` or `state: link` is used it should be forced to ensure the link is created even if the target is a file

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1579319