### PR TITLE
ASB nodeselector needs to be converted to json

### DIFF
--- a/roles/ansible_service_broker/templates/asb_dc.yaml.j2
+++ b/roles/ansible_service_broker/templates/asb_dc.yaml.j2
@@ -18,7 +18,7 @@ spec:
         app: openshift-ansible-service-broker
         service: asb
     spec:
-      nodeSelector: {{ ansible_service_broker_node_selector }}
+      nodeSelector: {{ ansible_service_broker_node_selector | to_json }}
       serviceAccount: asb
       containers:
 {% if ansible_service_broker_enable_dashboard_redirector %}
@@ -78,4 +78,3 @@ spec:
         - name: asb-tls
           secret:
             secretName: asb-tls
-


### PR DESCRIPTION
This would resolve possible python unicode issues: some installs might have `{u'node-role.kubernetes.io/infra': u'true'}` set there, if `ansible_service_broker_node_selector` is unset and being inherited from `openshift_hosted_infra_selector`