### PR TITLE
Add patch to installer image

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -8,7 +8,7 @@ USER root
 COPY images/installer/origin-extra-root /
 
 # install ansible and deps
-RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl java-1.8.0-openjdk-headless python2-passlib httpd-tools openssh-clients origin-clients iproute" \
+RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl java-1.8.0-openjdk-headless python2-passlib httpd-tools openssh-clients origin-clients iproute patch" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
  && EPEL_PKGS="python2-boto python2-boto3 python2-crypto which python2-pip.noarch python-scandir python2-packaging azure-cli" \
  && EPEL_TESTING_PKGS="ansible" \


### PR DESCRIPTION
We should really find a way to just install openshift-ansible via RPM
inside the container so we don't have to keep chasing dependencies in
two places

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1579434