### PR TITLE
Update Jinja tests used as filters

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/config.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/config.yml
@@ -59,7 +59,7 @@
   - fail: msg="Master running {{ openshift_current_version }} must be upgraded to {{ openshift_version }} before node upgrade can be run."
     when:
     - l_upgrade_nodes_only | default(False) | bool
-    - not (openshift_current_version | default('0.0') | match(openshift_version))
+    - not (openshift_current_version | default('0.0') is match(openshift_version))
 
 # If we're only upgrading nodes, skip this.
 - import_playbook: ../../../../openshift-master/private/validate_restart.yml

--- a/playbooks/openshift-node/private/join.yml
+++ b/playbooks/openshift-node/private/join.yml
@@ -33,7 +33,7 @@
     when:
     - l_nodes_to_join|length > 0
 
-  - when: not approve_out|succeeded
+  - when: approve_out is failed
     block:
     - name: Get CSRs
       command: >

--- a/roles/openshift_aws/tasks/elb_single.yml
+++ b/roles/openshift_aws/tasks/elb_single.yml
@@ -23,12 +23,12 @@
   register: new_elb
   retries: 20
   delay: 5
-  until: new_elb | succeeded
+  until: new_elb is succeeded
   ignore_errors: yes
 
 - fail:
     msg: "couldn't create ELB {{ item.value.name }}"
-  when: not new_elb | succeeded
+  when: new_elb is failed
 
 - debug:
     msg: "{{ new_elb }}"

--- a/roles/openshift_aws/tasks/uninstall_iam_cert.yml
+++ b/roles/openshift_aws/tasks/uninstall_iam_cert.yml
@@ -12,7 +12,7 @@
     register: elb_cert_chain
     retries: 20
     delay: 10
-    until: elb_cert_chain | succeeded
+    until: elb_cert_chain is succeeded
     ignore_errors: yes
 
   - debug:
@@ -22,4 +22,4 @@
   - name: check for iam cert error
     fail:
       msg: "Couldn't delete IAM cert {{ openshift_aws_iam_cert_name }}"
-    when: not elb_cert_chain | succeeded
+    when: elb_cert_chain is failed

--- a/roles/openshift_aws/tasks/uninstall_security_group.yml
+++ b/roles/openshift_aws/tasks/uninstall_security_group.yml
@@ -8,13 +8,13 @@
   register: sg_delete_result
   retries: 20
   delay: 10
-  until: sg_delete_result | succeeded
+  until: sg_delete_result is succeeded
   ignore_errors: yes
 
 - name: check for sg delete error
   fail:
     msg: "Couldn't delete SGs {{ openshift_aws_node_security_groups }}"
-  when: not sg_delete_result | succeeded
+  when: sg_delete_result is failed
 
 - name: delete the k8s sgs for the node group
   oo_ec2_group:
@@ -25,10 +25,10 @@
   register: sg_delete_result
   retries: 20
   delay: 10
-  until: sg_delete_result | succeeded
+  until: sg_delete_result is succeeded
   ignore_errors: yes
 
 - name: check for k8s sg delete error
   fail:
     msg: "Couldn't delete SGs {{ openshift_aws_node_security_groups }}"
-  when: not sg_delete_result | succeeded
+  when: sg_delete_result is failed

--- a/roles/openshift_control_plane/tasks/upgrade.yml
+++ b/roles/openshift_control_plane/tasks/upgrade.yml
@@ -56,7 +56,9 @@
     - origin-master-api
     - origin-master-controllers
   register: sysconfigs
-- when: sysconfigs|succeeded and sysconfigs.matched > 0
+- when:
+  - sysconfigs is succeeded
+  - sysconfigs.matched > 0
   name: Migrate OPENSHIFT_DEFAULT_REGISTRY from master sysconfig to master-config.yaml
   block:
   - name: Get master sysconfig contents
@@ -109,7 +111,7 @@
     src: "{{ openshift.common.config_base }}/master/master-config.yaml"
     key: 'projectConfig.defaultNodeSelector'
     value: '{{ hostvars[groups.oo_first_master.0].l_osm_default_node_selector }}'
-  when: openshift_upgrade_target | version_compare('3.9', '>=')
+  when: openshift_upgrade_target is version_compare('3.9', '>=')
 
 - name: Remove use of pod presets from master config
   yedit:

--- a/roles/openshift_openstack/tasks/provision.yml
+++ b/roles/openshift_openstack/tasks/provision.yml
@@ -12,47 +12,48 @@
 - name: validate the Heat template
   command: openstack orchestration template validate -t {{ stack_template_path }}
   register: template_validation_output
-  when: openstack_cli_exists|succeeded
+  when: openstack_cli_exists is succeeded
 
 - name: Check if the stack exists
   command: openstack stack show {{ openshift_openstack_stack_name }}
   ignore_errors: True
   register: stack_exists
-  when: openstack_cli_exists|succeeded
+  when: openstack_cli_exists is succeeded
 
 - name: Dry-run the stack (create)
   command: openstack stack create --dry-run -t {{ stack_template_path }} {{ openshift_openstack_stack_name }}
   ignore_errors: True
   register: stack_create_dry_run_output
   when:
-  - openstack_cli_exists|succeeded
-  - stack_exists|failed
+  - openstack_cli_exists is succeeded
+  - stack_exists is failed
 
 - name: Dry-run the stack (update)
   command: openstack stack update --dry-run -t {{ stack_template_path }} {{ openshift_openstack_stack_name }}
   ignore_errors: True
   register: stack_update_dry_run_output
   when:
-  - openstack_cli_exists|succeeded
-  - stack_exists|succeeded
+  - openstack_cli_exists is succeeded
+  - stack_exists is succeeded
 
 - name: Show the dry run errors (create)
   debug: var=stack_create_dry_run_output.stderr
   when:
-  - openstack_cli_exists|succeeded
-  - stack_create_dry_run_output|failed
+  - openstack_cli_exists is succeeded
+  - stack_create_dry_run_output is failed
 
 - name: Show the dry run errors (update)
   debug: var=stack_update_dry_run_output.stderr
   when:
-  - openstack_cli_exists|succeeded
-  - stack_update_dry_run_output|failed
+  - openstack_cli_exists is succeeded
+  - stack_update_dry_run_output is failed
 
 - fail:
     msg: The Heat stack creation failed. Please inspect the message above.
   when:
-  - openstack_cli_exists|succeeded
-  - (stack_create_dry_run_output|failed or stack_update_dry_run_output|failed)
+  - openstack_cli_exists is succeeded
+  - ( stack_create_dry_run_output is failed or
+      stack_update_dry_run_output is failed)
 
 - name: Handle the Stack (create/delete)
   ignore_errors: True
@@ -67,19 +68,19 @@
   command: openstack stack failures list {{ openshift_openstack_stack_name }}
   register: stack_create_failures
   when:
-  - openstack_cli_exists|succeeded
-  - stack_create|failed
+  - openstack_cli_exists is succeeded
+  - stack_create is failed
 
 - name: show errors in stack creation, if any
   debug: var=stack_create_failures
   when:
-  - openstack_cli_exists|succeeded
-  - stack_create|failed
+  - openstack_cli_exists is succeeded
+  - stack_create is failed
 
 - fail:
     msg: Stack creation failed
   when:
-  - stack_create|failed
+  - stack_create is failed
 
 - name: Add the new nodes to the inventory
   meta: refresh_inventory

--- a/roles/openshift_repos/tasks/rhel_repos.yml
+++ b/roles/openshift_repos/tasks/rhel_repos.yml
@@ -29,5 +29,5 @@
                --enable="rhel-7-server-ose-{{ ( openshift_version ).split('.')[0:2] | join('.') }}-rpms" \
                --enable="rhel-7-fast-datapath-rpms"
   register: subscribe_repos
-  until: subscribe_repos | succeeded
+  until: subscribe_repos is succeeded
   when: repo_rhel.changed


### PR DESCRIPTION
Change syntax of Jinja tests to new format for 2.5 to avoid deprecation
warnings in logs.

These changes were first implemented in #6484 however code creep has
led to new instances being committed.

* NOTE: This change is backwards compatible with Ansible 2.4. Changes in
test names are not changed to new names for 2.5.

https://docs.ansible.com/ansible/2.5/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters