### PR TITLE
Added container_manage_cgroup in order for systemd to run in pods

### DIFF
--- a/playbooks/openshift-management/private/config-sebool.yml
+++ b/playbooks/openshift-management/private/config-sebool.yml
@@ -1,0 +1,11 @@
+---
+- name: Enable sebool container_manage_cgroup
+  hosts: oo_nodes_to_config
+  gather_facts: false
+  become: yes
+  tasks:
+  - name: Setting sebool container_manage_cgroup
+    seboolean:
+      name: container_manage_cgroup
+      state: yes
+      persistent: yes

--- a/playbooks/openshift-management/private/config.yml
+++ b/playbooks/openshift-management/private/config.yml
@@ -13,6 +13,8 @@
           status: "In Progress"
           start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
+- import_playbook: config-sebool.yml
+
 - name: Setup CFME
   hosts: oo_first_master
   pre_tasks:


### PR DESCRIPTION
Due to https://access.redhat.com/solutions/3387631 and kind of addresses https://bugzilla.redhat.com/show_bug.cgi?id=1578537 if they were to use the installer that comes with openshift.

Let me know if this is not the appropriate place to put it.  Not sure if I was supposed to put it here or the openshift_manageiq role.

That particular task needs to be enabled on all nodes.