### PR TITLE
Refactor instance SSH key handling

### DIFF
--- a/playbooks/gcp/openshift-cluster/build_image.yml
+++ b/playbooks/gcp/openshift-cluster/build_image.yml
@@ -9,16 +9,6 @@
       msg: "A base image name or family is required for image building.  Please ensure `openshift_gcp_base_image` is defined."
     when: openshift_gcp_base_image is undefined
 
-- name: Provision ssh key
-  hosts: localhost
-  connection: local
-  gather_facts: no
-  tasks:
-  - name: Set up core host GCP configuration
-    import_role:
-      name: openshift_gcp
-      tasks_from: provision_ssh_keys.yml
-
 - name: Launch image build instance
   hosts: localhost
   connection: local
@@ -55,6 +45,11 @@
       disks:
       - "{{ openshift_gcp_prefix }}build-image-instance"
     register: gce
+
+  - name: Provision SSH keys
+    import_role:
+      name: openshift_gcp
+      tasks_from: provision_ssh_keys.yml
 
   - name: add host to nodes
     add_host:

--- a/roles/openshift_gcp/tasks/main.yml
+++ b/roles/openshift_gcp/tasks/main.yml
@@ -30,14 +30,14 @@
   when:
   - state | default('present') == 'present'
 
-- import_tasks: provision_ssh_keys.yml
-
 - name: Provision GCP resources
   command: /tmp/openshift_gcp_provision.sh
   args:
     chdir: "{{ files_dir }}"
   when:
   - state | default('present') == 'present'
+
+- import_tasks: provision_ssh_keys.yml
 
 - name: De-provision GCP resources
   command: /tmp/openshift_gcp_provision_remove.sh


### PR DESCRIPTION
Use instance-scoped ssh-key metadata to drive SSH key handling on instances.
Remove usage of the deprecated project-scoped `sshKeys` metadata. Eliminates
contention on a shared key and is more scalable (metdata value length is
limited).