### PR TITLE
Avoid kuryr healthcheck ports collision

### DIFF
--- a/roles/kuryr/defaults/main.yaml
+++ b/roles/kuryr/defaults/main.yaml
@@ -15,7 +15,9 @@ kuryr_openstack_project_domain_name: default
 kuryr_namespace: openshift-infra
 
 # Kuryr health check server port
-kuryr_healthcheck_port: 8082
+kuryr_controller_healthcheck_port: 8082
+kuryr_cni_healthcheck_port: 8090
+
 
 # Whether to run the cni plugin in debug mode
 kuryr_cni_debug: "false"

--- a/roles/kuryr/templates/cni-daemonset.yaml.j2
+++ b/roles/kuryr/templates/cni-daemonset.yaml.j2
@@ -77,14 +77,14 @@ spec:
         readinessProbe:
           httpGet:
             path: /ready
-            port: {{ kuryr_healthcheck_port }}
+            port: {{ kuryr_cni_healthcheck_port }}
             scheme: HTTP
           initialDelaySeconds: 15
           timeoutSeconds: 5
         livenessProbe:
           httpGet:
             path: /alive
-            port: {{ kuryr_healthcheck_port }}
+            port: {{ kuryr_cni_healthcheck_port }}
           initialDelaySeconds: 15
 {% endif %}
       volumes:

--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -337,7 +337,7 @@ data:
     pools_vif_drivers = nested:nested-vlan,neutron:neutron-vif
 
     [health_server]
-    port = {{ kuryr_healthcheck_port }}
+    port = {{ kuryr_controller_healthcheck_port }}
 
   kuryr-cni.conf: |+
     [DEFAULT]
@@ -658,7 +658,7 @@ data:
     ports_pool_update_frequency = {{ kuryr_openstack_pool_update_frequency | default(20) }}
 
     [cni_health_server]
-    port = {{ kuryr_healthcheck_port }}
+    port = {{ kuryr_cni_healthcheck_port }}
 
     # Maximum memory usage (MiB) before kuryr-daemon is marked as unhealthy
     max_memory_usage = -1

--- a/roles/kuryr/templates/controller-deployment.yaml.j2
+++ b/roles/kuryr/templates/controller-deployment.yaml.j2
@@ -26,13 +26,13 @@ spec:
         readinessProbe:
           httpGet:
             path: /ready
-            port: {{ kuryr_healthcheck_port }}
+            port: {{ kuryr_controller_healthcheck_port }}
             scheme: HTTP
           timeoutSeconds: 5
         livenessProbe:
           httpGet:
             path: /alive
-            port: {{ kuryr_healthcheck_port }}
+            port: {{ kuryr_controller_healthcheck_port }}
           initialDelaySeconds: 15
 {% endif %}
         terminationMessagePath: "/dev/termination-log"


### PR DESCRIPTION
As both kuryr-controller and kuryr-cni are running with host-networking,
they cannot listen on the same port for the healthcheck probes.
This PR adds a different port for kuryr-controller and cni probes to
avoid this collision.