### PR TITLE
CRIO minor fixes for 3.10

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -119,6 +119,7 @@ debug_level=2
 #openshift_docker_blocked_registries=registry.hacker.com
 # Install and run cri-o.
 #openshift_use_crio=False
+#openshift_use_crio_only=False
 # The following two variables are used when openshift_use_crio is True
 # and cleans up after builds that pass through docker. When openshift_use_crio is True
 # these variables are set to the defaults shown. You may override them here.

--- a/playbooks/init/basic_facts.yml
+++ b/playbooks/init/basic_facts.yml
@@ -42,12 +42,6 @@
       openshift_is_atomic: "{{ ostree_booted.stat.exists }}"
       openshift_is_containerized: "{{ ostree_booted.stat.exists or (containerized | default(false) | bool) }}"
 
-  - name: Set use_crio to True if cri-o rpm is requested
-    set_fact:
-      openshift_use_crio: True
-    when:
-    - openshift_crio_use_rpm | default(False) | bool
-
   # TODO: Should this be moved into health checks??
   # Seems as though any check that happens with a corresponding fail should move into health_checks
   # Fail as early as possible if Atomic and old version of Docker

--- a/roles/openshift_cli/defaults/main.yml
+++ b/roles/openshift_cli/defaults/main.yml
@@ -14,7 +14,4 @@ openshift_image_default: "{{ l_os_registry_url | regex_replace('${component}' | 
 openshift_cli_image: "{{ (system_images_registry == 'docker') | ternary(openshift_image_default, (openshift_image_default.split('/')|length==2) | ternary(system_images_registry + '/' + openshift_image_default, openshift_image_default)) }}"
 system_openshift_cli_image: "{{ (system_images_registry == 'docker') | ternary('docker:' + openshift_cli_image, openshift_cli_image) }}"
 
-openshift_crio_use_rpm: False
-
-l_use_cli_atomic_image: "{{ (openshift_use_crio_only | bool and not openshift_crio_use_rpm | bool) }}"
-l_openshift_cli_image_backend: "{{ (l_use_cli_atomic_image | bool) | ternary('atomic', 'docker') }}"
+l_openshift_cli_image_backend: "{{ (openshift_use_crio_only | bool) | ternary('atomic', 'docker') }}"

--- a/roles/openshift_cli/tasks/main.yml
+++ b/roles/openshift_cli/tasks/main.yml
@@ -9,14 +9,14 @@
   - name: Pull CLI Image (docker)
     docker_image:
       name: "{{ openshift_cli_image }}"
-    when: not l_use_cli_atomic_image | bool
+    when: not openshift_use_crio_only | bool
 
   - name: Pull CLI Image (atomic)
     command: >
       atomic pull --storage ostree {{ system_openshift_cli_image }}
     register: pull_result
     changed_when: "'Pulling layer' in pull_result.stdout"
-    when: l_use_cli_atomic_image | bool
+    when: openshift_use_crio_only | bool
 
   # openshift_container_binary_sync is a custom module in lib_utils
   - name: Copy client binaries/symlinks out of CLI image for use on the host

--- a/roles/openshift_health_checker/action_plugins/openshift_health_check.py
+++ b/roles/openshift_health_checker/action_plugins/openshift_health_check.py
@@ -70,6 +70,9 @@ class ActionModule(ActionBase):
         result["checks"] = check_results = {}
 
         user_disabled_checks = normalize(task_vars.get('openshift_disable_check', []))
+        # Automatically add docker_storage if only CRIO is used, as docker service would be stopped
+        if task_vars.get('openshift_use_crio_only'):
+            user_disabled_checks.append('docker_storage')
 
         for name in resolved_checks:
             display.banner("CHECK [{} : {}]".format(name, task_vars["ansible_host"]))


### PR DESCRIPTION
* Remove openshift_crio_use_rpm as RPM is the only way to use CRIO now
* Update hosts.example with crio vars
* Ignore errors in docker storage when openshift_use_crio_only is on