### PR TITLE
removing dnsmasq-node.conf.j2 since nothing is referencing it.

### DIFF
--- a/roles/openshift_node/templates/node-dnsmasq.conf.j2
+++ b/roles/openshift_node/templates/node-dnsmasq.conf.j2
@@ -1,2 +1,0 @@
-server=/in-addr.arpa/127.0.0.1
-server=/{{ openshift.common.dns_domain }}/127.0.0.1


### PR DESCRIPTION
With the recent changes to remove the dnsmasq settings https://github.com/openshift/openshift-ansible/pull/8409 we should also garbage collect the template file.
