### PR TITLE
Ensure public net id is configured for Kuryr SDN

### DIFF
--- a/roles/openshift_openstack/tasks/net_vars_check.yaml
+++ b/roles/openshift_openstack/tasks/net_vars_check.yaml
@@ -12,3 +12,10 @@
   when:
     - openstack_private_data_network_name is defined
     - not openshift_use_flannel|default(False)|bool
+
+- name: Check the kuryr public net configuration
+  fail:
+    msg: "kuryr_openstack_public_net_id must be set when using Kuryr SDN"
+  when:
+    - openshift_use_kuryr|default(False)|bool
+    - not kuryr_openstack_public_net_id is defined


### PR DESCRIPTION
This PR ensures the playbook execution will fail soon, at the
prerequisites checkings, if the public net id is not configured when
the Kuryr SDN is used.