### PR TITLE
catalog:  add -cluster-id-configmap-namespace=kube-service-catalog flag

### DIFF
--- a/roles/openshift_service_catalog/templates/controller_manager.j2
+++ b/roles/openshift_service_catalog/templates/controller_manager.j2
@@ -38,6 +38,7 @@ spec:
         - kube-service-catalog
         - --leader-elect-resource-lock
         - configmaps
+        - --cluster-id-configmap-namespace=kube-service-catalog
         - --broker-relist-interval
         - "5m"
         - --feature-gates


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1578936

I0516 14:16:29.464865 1 controller.go:294] error getting the cluster info configmap: "configmaps "cluster-info" is forbidden: User "system:serviceaccount:kube-service-catalog:service-catalog-controller" cannot get configmaps in the namespace "default": User "system:serviceaccount:kube-service-catalog:service-catalog-controller" cannot get configmaps in project "default""