### PR TITLE
Remove resource limits from Prometheus

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/files/cluster-monitoring-operator.yaml
+++ b/roles/openshift_cluster_monitoring_operator/files/cluster-monitoring-operator.yaml
@@ -51,6 +51,7 @@ objects:
         baseImage: ${PROMETHEUS_IMAGE}
         externalLabels:
           cluster: ${CLUSTER_ID}
+        resources: {}
       alertmanagerMain:
         baseImage: ${ALERTMANAGER_IMAGE}
 


### PR DESCRIPTION
The cluster monitoring Prometheus memory requirements are highly variable, and
should work in large clusters out of the box. Remove the default limits.