### PR TITLE
API liveness probe: set timeout to 10 sec to prevent API restart if the system is busy

### DIFF
--- a/roles/openshift_control_plane/files/apiserver.yaml
+++ b/roles/openshift_control_plane/files/apiserver.yaml
@@ -39,12 +39,14 @@ spec:
         port: 8443
         path: healthz
       initialDelaySeconds: 45
+      timeoutSeconds: 10
     readinessProbe:
       httpGet:
         scheme: HTTPS
         port: 8443
         path: healthz/ready
       initialDelaySeconds: 10
+      timeoutSeconds: 10
   volumes:
   - name: master-config
     hostPath:


### PR DESCRIPTION
API container could restart at any time during deploy due to failed liveness probe.

This would set a timeout of 10 secs to prevent this from happennig due to node load and such

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1579261