### PR TITLE
Ensure sanity checks are run during upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
@@ -38,6 +38,12 @@
     l_upgrade_excluder_hosts: "oo_masters_to_config"
     openshift_protect_installed_version: False
 
+# Need to run sanity checks after version has been run.
+- import_playbook: ../../../../init/sanity_checks.yml
+  vars:
+    # oo_lb_to_config might not be present; Can't use !oo_nodes because masters are nodes.
+    l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) | union(groups['oo_lb_to_config'] | default([]) ) }}"
+
 - name: Flag pre-upgrade checks complete for hosts without errors
   hosts: oo_masters_to_config:oo_etcd_to_config
   tasks:

--- a/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_nodes.yml
@@ -24,6 +24,9 @@
     l_upgrade_excluder_hosts: "oo_nodes_to_config:!oo_masters_to_config"
     l_upgrade_nodes_only: True
 
+# Need to run sanity checks after version has been run.
+- import_playbook: ../../../../init/sanity_checks.yml
+
 - name: Flag pre-upgrade checks complete for hosts without errors
   hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
   tasks:


### PR DESCRIPTION
Currently, sanity checks are not run during upgrade.

This commit adds sanity checks after version role is
run during upgrade_control_plane.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1579898