### PR TITLE
[release-3.9] [1579513] Fix install or upgrade to specified openshift_pkg_version

### DIFF
--- a/playbooks/init/version.yml
+++ b/playbooks/init/version.yml
@@ -6,7 +6,6 @@
   - include_role:
       name: openshift_version
       tasks_from: first_master.yml
-  - debug: msg="openshift_pkg_version set to {{ openshift_pkg_version | default('') }}"
 
 # NOTE: We set this even on etcd hosts as they may also later run as masters,
 # and we don't want to install wrong version of docker and have to downgrade

--- a/roles/openshift_master/tasks/upgrade/rpm_upgrade.yml
+++ b/roles/openshift_master/tasks/upgrade/rpm_upgrade.yml
@@ -15,7 +15,7 @@
       - "{{ openshift_service_type }}{{ openshift_pkg_version | default('') }}"
       - "{{ openshift_service_type }}-master{{ openshift_pkg_version | default('') }}"
       - "{{ openshift_service_type }}-node{{ openshift_pkg_version | default('') }}"
-      - "{{ openshift_service_type + '-sdn-ovs' + openshift_pkg_version | default('') if openshift_use_openshift_sdn | default(true) | bool else openshift.common.service_type + openshift_pkg_version }}"
+      - "{{ openshift_service_type + '-sdn-ovs' + openshift_pkg_version | default('') if openshift_use_openshift_sdn | default(true) | bool else '' }}"
       - "{{ openshift_service_type }}-clients{{ openshift_pkg_version | default('') }}"
   register: result
   until: result is succeeded
@@ -30,7 +30,7 @@
       - "{{ openshift_service_type }}{{ openshift_pkg_version }}"
       - "{{ openshift_service_type }}-master{{ openshift_pkg_version }}"
       - "{{ openshift_service_type }}-node{{ openshift_pkg_version }}"
-      - "{{ openshift_service_type + '-sdn-ovs' + openshift_pkg_version | default('') if openshift_use_openshift_sdn | default(true) | bool else openshift.common.service_type + openshift_pkg_version}}"
+      - "{{ openshift_service_type + '-sdn-ovs' + openshift_pkg_version | default('') if openshift_use_openshift_sdn | default(true) | bool else '' }}"
       - "{{ openshift_service_type }}-clients{{ openshift_pkg_version }}"
   register: result
   until: result is succeeded

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -23,10 +23,7 @@
 
 - name: install pre-pulled rpms.
   import_tasks: upgrade/rpm_upgrade_install.yml
-  vars:
-    openshift_version: "{{ openshift_pkg_version | default('') }}"
   when: not openshift_is_containerized | bool
-
 
 - include_tasks: "{{ node_config_hook }}"
   when: node_config_hook is defined

--- a/roles/openshift_node/tasks/upgrade/rpm_upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade/rpm_upgrade.yml
@@ -5,6 +5,13 @@
 # - openshift_pkg_version
 # - openshift_is_atomic
 
+# When we update package "a-${version}" and a requires b >= ${version} if we
+# don't specify the version of b yum will choose the latest version of b
+# available and the whole set of dependencies end up at the latest version.
+# Since the package module, unlike the yum module, doesn't flatten a list
+# of packages into one transaction we need to do that explicitly. The ansible
+# core team tells us not to rely on yum module transaction flattening anyway.
+
 # Pre-pull new node rpm, but don't install
 - name: download new node packages
   command: "{{ ansible_pkg_mgr }} install -y --downloadonly {{ openshift_node_upgrade_rpm_list | join(' ')}}"
@@ -12,7 +19,10 @@
   until: result is succeeded
   vars:
     openshift_node_upgrade_rpm_list:
+      - "{{ openshift_service_type }}{{ openshift_pkg_version | default('') }}"
       - "{{ openshift_service_type }}-node{{ openshift_pkg_version | default('') }}"
+      - "{{ openshift_service_type + '-sdn-ovs' + openshift_pkg_version | default('') if openshift_use_openshift_sdn | default(true) | bool else '' }}"
+      - "{{ openshift_service_type }}-clients{{ openshift_pkg_version | default('') }}"
       - "PyYAML"
       - "dnsmasq"
 

--- a/roles/openshift_node/tasks/upgrade/rpm_upgrade_install.yml
+++ b/roles/openshift_node/tasks/upgrade/rpm_upgrade_install.yml
@@ -5,6 +5,13 @@
 # - openshift_pkg_version
 # - openshift_is_atomic
 
+# When we update package "a-${version}" and a requires b >= ${version} if we
+# don't specify the version of b yum will choose the latest version of b
+# available and the whole set of dependencies end up at the latest version.
+# Since the package module, unlike the yum module, doesn't flatten a list
+# of packages into one transaction we need to do that explicitly. The ansible
+# core team tells us not to rely on yum module transaction flattening anyway.
+
 # Install the pre-pulled RPM
 # Note: dnsmasq is covered in it's own play.  openvswitch is included here
 # because once we have the latest rpm downloaded, it will happily be installed.
@@ -14,7 +21,10 @@
   until: result is succeeded
   vars:
     openshift_node_upgrade_rpm_list:
+      - "{{ openshift_service_type }}{{ openshift_pkg_version | default('') }}"
       - "{{ openshift_service_type }}-node{{ openshift_pkg_version | default('') }}"
+      - "{{ openshift_service_type + '-sdn-ovs' + openshift_pkg_version | default('') if openshift_use_openshift_sdn | default(true) | bool else '' }}"
+      - "{{ openshift_service_type }}-clients{{ openshift_pkg_version | default('') }}"
       - "PyYAML"
 
 - name: install new openvswitch

--- a/roles/openshift_node/tasks/upgrade_pre.yml
+++ b/roles/openshift_node/tasks/upgrade_pre.yml
@@ -38,6 +38,4 @@
   - l_docker_upgrade | bool
 
 - import_tasks: upgrade/rpm_upgrade.yml
-  vars:
-    openshift_version: "{{ openshift_pkg_version | default('') }}"
   when: not openshift_is_containerized | bool

--- a/roles/openshift_version/tasks/check_available_rpms.yml
+++ b/roles/openshift_version/tasks/check_available_rpms.yml
@@ -1,7 +1,7 @@
 ---
-- name: Get available {{ openshift_service_type}} version
+- name: Get available RPM version
   repoquery:
-    name: "{{ openshift_service_type}}{{ '-' ~ openshift_release ~ '*' if openshift_release is defined else '' }}"
+    name: "{{ openshift_service_type }}{% if openshift_version is defined %}-{{ openshift_version }}*{% elif openshift_release is defined %}-{{ openshift_release }}*{% endif %}"
     ignore_excluders: true
   register: rpm_results
 

--- a/roles/openshift_version/tasks/first_master.yml
+++ b/roles/openshift_version/tasks/first_master.yml
@@ -14,7 +14,7 @@
 - include_tasks: "{{ l_first_master_version_task_file }}"
 
 # When double upgrade is in process, we want to set everything to match
-# openshift_verison.
+# openshift_version.
 - block:
   - debug:
       msg: "openshift_pkg_version was not defined. Falling back to -{{ openshift_version }}"
@@ -24,7 +24,7 @@
   - openshift_pkg_version is not defined or l_double_upgrade_cp_reset_version
 
 # When double upgrade is in process, we want to set everything to match
-# openshift_verison.
+# openshift_version.
 - block:
   - debug:
       msg: "openshift_image_tag was not defined. Falling back to v{{ openshift_version }}"
@@ -32,7 +32,7 @@
       openshift_image_tag: "v{{ openshift_version }}"
   when: openshift_image_tag is not defined or l_double_upgrade_cp_reset_version
 
-# The end result of these three variables is quite important so make sure they are displayed and logged:
+# The end result of these variables is quite important so make sure they are displayed and logged:
 - debug: var=openshift_release
 
 - debug: var=openshift_image_tag

--- a/roles/openshift_version/tasks/masters_and_nodes.yml
+++ b/roles/openshift_version/tasks/masters_and_nodes.yml
@@ -37,3 +37,5 @@
 - debug: var=openshift_image_tag
 
 - debug: var=openshift_pkg_version
+
+- debug: var=openshift_version


### PR DESCRIPTION
repoquery should use openshift_version and not openshift_release when
querying available packages.

Bug 1579513 | https://bugzilla.redhat.com/show_bug.cgi?id=1579513

3.7 -> 3.9 Upgrade with openshift_pkg_version:
- [ ] Install OCP 3.7
- [ ] Enable released OCP repo with multiple versions (3.9.14, 3.9.25, 3.9.27)
- [ ] Upgrade 3.7 to 3.9 with openshift_pkg_version=-3.9.25 results in a cluster running 3.9.25, not 3.9.27

3.7 -> 3.9 Upgrade with no openshift_pkg_version:
- [ ] Install OCP 3.7
- [ ] Enable released OCP repo with multiple versions (3.9.14, 3.9.25, 3.9.27)
- [ ] Upgrade 3.7 to 3.9 with no openshift_pkg_version set results in latest 3.9

3.9 Install/Upgrade:
- [x] Enable released OCP repo with multiple versions (3.9.14, 3.9.25, 3.9.27)
- [x] Install OCP 3.9 with openshift_pkg_version=-3.9.14 results in 3.9.14 cluster
- [x] Upgrade 3.9.14 cluster with openshift_pkg_version=-3.9.25 results in a 3.9.25 cluster
- [x] Upgrade 3.9.14 cluster with openshift_pkg_version unset results in latest (3.9.27) cluster
