### PR TITLE
[release-3.6] Add a block to set openshift_push_via_dns when running upgrade_control

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -57,6 +57,20 @@
   roles:
   - openshift_master_facts
 
+  post_tasks:
+  # This is an ugly hack to verify settings are in a file without modifying them with lineinfile.
+  # The template file will stomp any other settings made.
+  # roles/openshift_master/tasks/main.yml has a same block for a new installation/scale up.
+  - block:
+    - name: check whether our docker-registry setting exists in the env file
+      command: "awk '/^OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000/' /etc/sysconfig/{{ openshift.common.service_type }}-master"
+      ignore_errors: true
+      changed_when: false
+      register: already_set
+
+    - set_fact:
+        openshift_push_via_dns: "{{ (openshift_use_dnsmasq | default(true) and openshift.common.version_gte_3_6) or (already_set.stdout | match('OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000')) }}"
+
 # The main master upgrade play. Should handle all changes to the system in one pass, with
 # support for optional hooks to be defined.
 - name: Upgrade master


### PR DESCRIPTION
Although the task `TASK [Create the ha systemd unit files for api and
controller services]` is always called from upgrade_control_plane.yml
playbook, it does not call
`roles/openshift_master/tasks/main.yml`. Hence, `openshift_push_via_dns`
becomes vacant and upgrade_control_plane playbook drops
`OPENSHIFT_DEFAULT_REGISTRY=docker-registry.default.svc:5000` from
/etc/sysconfig/atomic-openshift-master-{api,controllers}.

To fix it, this patch adds a block to set openshift_push_via_dns in
upgrade_control_plane.yml.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1580354