### PR TITLE
Remove old openshift binaries from containerized upgragde

### DIFF
--- a/roles/openshift_cli/tasks/main.yml
+++ b/roles/openshift_cli/tasks/main.yml
@@ -30,3 +30,14 @@
   when: not openshift_is_atomic | bool
   register: result
   until: result is succeeded
+
+# TODO(michaelgugino) Remove in 3.11.
+- name: Ensure binaries from containerized deployments are cleaned up.
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+  - /usr/local/bin/oc
+  - /usr/local/bin/openshift
+  - /usr/local/bin/kubectl
+  when: not openshift_is_atomic


### PR DESCRIPTION
This commit removes openshift and oc binaries from
/usr/local/bin when upgrading a previously containerized
installation to an RPM based install.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1579144