### PR TITLE
Docker registry: redeploy certs and update DC env vars only when registry is managed

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
@@ -115,6 +115,8 @@
   - import_role:
       name: openshift_hosted
       tasks_from: registry_service_account.yml
+    when: openshift_hosted_manage_registry | default(True) | bool
   - import_role:
       name: openshift_hosted
       tasks_from: remove_legacy_env_variables.yml
+    when: openshift_hosted_manage_registry | default(True) | bool

--- a/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml
@@ -92,6 +92,7 @@
       {{ openshift_client_binary }} rollout latest dc/docker-registry
       --config={{ mktemp.stdout }}/admin.kubeconfig
       -n default
+    when: l_docker_registry_dc.rc == 0
 
   - name: Delete temp directory
     file:


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1559248