### PR TITLE
[3.9] Make sure openshift_use_openshift_sdn is defined during 3.9 upgrade

### DIFF
--- a/roles/openshift_node/tasks/upgrade/rpm_upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade/rpm_upgrade.yml
@@ -22,4 +22,4 @@
   command: "{{ ansible_pkg_mgr }} update -y --downloadonly openvswitch"
   register: result
   until: result is succeeded
-  when: openshift_use_openshift_sdn | bool
+  when: openshift_use_openshift_sdn | default(true) | bool

--- a/roles/openshift_node/tasks/upgrade/rpm_upgrade_install.yml
+++ b/roles/openshift_node/tasks/upgrade/rpm_upgrade_install.yml
@@ -21,4 +21,4 @@
   command: "{{ ansible_pkg_mgr }} install -y openvswitch }}"
   register: result
   until: result is succeeded
-  when: openshift_use_openshift_sdn | bool
+  when: openshift_use_openshift_sdn | default(true) | bool


### PR DESCRIPTION
Make sure openshift_use_openshift_sdn is set to default true, as it might 
happen during the minor update

Doesn't require backporting to master or 3.7