### PR TITLE
Unify openshift_service_catalog image to standard format

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -889,13 +889,10 @@ debug_level=2
 # Enable template service broker (requires service catalog to be enabled, above)
 #template_service_broker_install=true
 
-# Force a specific prefix (IE: registry) to use when pulling the service catalog image
-# NOTE: The registry all the way up to the start of the image name must be provided. Two examples
-# below are provided.
-#openshift_service_catalog_image_prefix=docker.io/openshift/origin-
-#openshift_service_catalog_image_prefix=registry.access.redhat.com/openshift3/ose-
-# Force a specific image version to use when pulling the service catalog image
-#openshift_service_catalog_image_version=v3.9
+# Specify an openshift_service_catalog image
+# (defaults for origin and openshift-enterprise, repsectively)
+#openshift_service_catalog_image="docker.io/openshift/origin-service-catalog:{{ openshift_image_tag }}""
+#openshift_service_catalog_image="registry.access.redhat.com/openshift3/ose-service-catalog:{{ openshift_image_tag }}"
 
 # TSB image tag
 #template_service_broker_version='v3.9'

--- a/roles/ansible_service_broker/defaults/main.yml
+++ b/roles/ansible_service_broker/defaults/main.yml
@@ -21,3 +21,12 @@ ansible_service_broker_image_pull_policy: Always
 ansible_service_broker_sandbox_role: edit
 ansible_service_broker_auto_escalate: false
 ansible_service_broker_local_registry_whitelist: []
+
+l_asb_default_images_dict:
+  origin: 'docker.io/ansibleplaybookbundle/origin-ansible-service-broker:latest'
+  openshift-enterprise: 'registry.access.redhat.com/openshift3/ose-ansible-service-broker:${version}'
+
+l_asb_default_images_default: "{{ l_asb_default_images_dict[openshift_deployment_type] }}"
+l_asb_image_url: "{{ oreg_url | default(l_asb_default_images_default) | regex_replace('${version}' | regex_escape, openshift_image_tag) }}"
+
+ansible_service_broker_image: "{{ l_asb_image_url | regex_replace('${component}' | regex_escape, 'ansible-service-broker') }}"

--- a/roles/ansible_service_broker/tasks/facts.yml
+++ b/roles/ansible_service_broker/tasks/facts.yml
@@ -8,9 +8,6 @@
 
 - name: set ansible_service_broker facts
   set_fact:
-    ansible_service_broker_image_prefix: "{{ ansible_service_broker_image_prefix | default(__ansible_service_broker_image_prefix) }}"
-    ansible_service_broker_image_tag: "{{ ansible_service_broker_image_tag | default(__ansible_service_broker_image_tag) }}"
-
     ansible_service_broker_registry_type: "{{ ansible_service_broker_registry_type | default(__ansible_service_broker_registry_type) }}"
     ansible_service_broker_registry_name: "{{ ansible_service_broker_registry_name | default(__ansible_service_broker_registry_name) }}"
     ansible_service_broker_registry_url: "{{ ansible_service_broker_registry_url | default(__ansible_service_broker_registry_url) }}"
@@ -19,11 +16,5 @@
     ansible_service_broker_registry_organization: "{{ ansible_service_broker_registry_organization | default(__ansible_service_broker_registry_organization) }}"
     ansible_service_broker_registry_tag: "{{ ansible_service_broker_registry_tag | default(__ansible_service_broker_registry_tag) }}"
     ansible_service_broker_registry_whitelist: "{{ ansible_service_broker_registry_whitelist | default(__ansible_service_broker_registry_whitelist) }}"
-
-- name: set ansible-service-broker image facts using set prefix and tag
-  set_fact:
-    ansible_service_broker_image: '{{ ansible_service_broker_image | default(__ansible_service_broker_image) }}'
-  vars:
-    __ansible_service_broker_image: "{{ ansible_service_broker_image_prefix }}ansible-service-broker:{{ ansible_service_broker_image_tag }}"
 
 - include_tasks: validate_facts.yml

--- a/roles/ansible_service_broker/vars/default_images.yml
+++ b/roles/ansible_service_broker/vars/default_images.yml
@@ -1,12 +1,4 @@
 ---
-
-__ansible_service_broker_image_prefix: ansibleplaybookbundle/origin-
-__ansible_service_broker_image_tag: latest
-
-__ansible_service_broker_etcd_image_prefix: quay.io/coreos/
-__ansible_service_broker_etcd_image_tag: latest
-__ansible_service_broker_etcd_image_etcd_path: /usr/local/bin/etcd
-
 __ansible_service_broker_registry_type: dockerhub
 __ansible_service_broker_registry_name: dh
 __ansible_service_broker_registry_url: null

--- a/roles/ansible_service_broker/vars/openshift-enterprise.yml
+++ b/roles/ansible_service_broker/vars/openshift-enterprise.yml
@@ -1,13 +1,4 @@
 ---
-
-__ansible_service_broker_image_prefix: registry.access.redhat.com/openshift3/ose-
-__ansible_service_broker_image_tag: "{{ openshift_image_tag }}"
-
-__ansible_service_broker_etcd_image_prefix: registry.access.redhat.com/rhel7/
-__ansible_service_broker_etcd_image_tag: latest
-__ansible_service_broker_etcd_image_etcd_path: /bin/etcd
-
-
 __ansible_service_broker_registry_type: rhcc
 __ansible_service_broker_registry_name: rh
 __ansible_service_broker_registry_url: "https://registry.access.redhat.com"

--- a/roles/openshift_service_catalog/defaults/main.yml
+++ b/roles/openshift_service_catalog/defaults/main.yml
@@ -5,3 +5,5 @@ openshift_service_catalog_async_bindings_enabled: true
 openshift_use_openshift_sdn: True
 # os_sdn_network_plugin_name: "{% if openshift_use_openshift_sdn %}redhat/openshift-ovs-subnet{% else %}{% endif %}"
 os_sdn_network_plugin_name: "redhat/openshift-ovs-subnet"
+
+openshift_service_catalog_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'service-catalog') }}"

--- a/roles/openshift_service_catalog/tasks/install.yml
+++ b/roles/openshift_service_catalog/tasks/install.yml
@@ -5,17 +5,6 @@
   register: mktemp
   changed_when: False
 
-- name: Set default image variables based on openshift_deployment_type
-  include_vars: "{{ item }}"
-  with_first_found:
-  - "{{ openshift_deployment_type }}.yml"
-  - "default_images.yml"
-
-- name: Set service_catalog image facts
-  set_fact:
-    openshift_service_catalog_image_prefix: "{{ openshift_service_catalog_image_prefix | default(__openshift_service_catalog_image_prefix) }}"
-    openshift_service_catalog_image_version: "{{ openshift_service_catalog_image_version | default(__openshift_service_catalog_image_version) }}"
-
 - name: Set Service Catalog namespace
   oc_project:
     state: present

--- a/roles/openshift_service_catalog/templates/api_server.j2
+++ b/roles/openshift_service_catalog/templates/api_server.j2
@@ -47,7 +47,7 @@ spec:
         - KubernetesNamespaceLifecycle,DefaultServicePlan,ServiceBindingsLifecycle,ServicePlanChangeValidator,BrokerAuthSarCheck
         - --feature-gates
         - OriginatingIdentity=true
-        image: {{ openshift_service_catalog_image_prefix }}service-catalog:{{ openshift_service_catalog_image_version }}
+        image: {{ openshift_service_catalog_image }}
         command: ["/usr/bin/service-catalog"]
         imagePullPolicy: IfNotPresent
         name: apiserver

--- a/roles/openshift_service_catalog/templates/controller_manager.j2
+++ b/roles/openshift_service_catalog/templates/controller_manager.j2
@@ -47,7 +47,7 @@ spec:
         - --feature-gates
         - AsyncBindingOperations=true
 {% endif %}
-        image: {{ openshift_service_catalog_image_prefix }}service-catalog:{{ openshift_service_catalog_image_version }}
+        image: {{ openshift_service_catalog_image }}
         command: ["/usr/bin/service-catalog"]
         imagePullPolicy: IfNotPresent
         name: controller-manager

--- a/roles/openshift_service_catalog/vars/default_images.yml
+++ b/roles/openshift_service_catalog/vars/default_images.yml
@@ -1,3 +1,0 @@
----
-__openshift_service_catalog_image_prefix: "docker.io/openshift/origin-"
-__openshift_service_catalog_image_version: "{{ openshift_service_catalog_image_version | default('v0.1') }}"

--- a/roles/openshift_service_catalog/vars/openshift-enterprise.yml
+++ b/roles/openshift_service_catalog/vars/openshift-enterprise.yml
@@ -1,3 +1,0 @@
----
-__openshift_service_catalog_image_prefix: "registry.access.redhat.com/openshift3/ose-"
-__openshift_service_catalog_image_version: "{{ openshift_service_catalog_image_version | default(openshift_image_tag) }}"

--- a/roles/template_service_broker/defaults/main.yml
+++ b/roles/template_service_broker/defaults/main.yml
@@ -8,16 +8,4 @@ __tsb_config_file: "apiserver-config.yaml"
 __tsb_rbac_file: "rbac-template.yaml"
 __tsb_broker_file: "template-service-broker-registration.yaml"
 
-l_tsb_image_dict:
-  origin:
-    prefix: "docker.io/openshift/origin-"
-    version: "{{ openshift_image_tag }}"
-    image_name: "template-service-broker"
-  openshift-enterprise:
-    prefix: "registry.access.redhat.com/openshift3/ose-"
-    version: "{{ openshift_image_tag }}"
-    image_name: "template-service-broker"
-
-template_service_broker_prefix: "{{ l_tsb_image_dict[openshift_deployment_type]['prefix'] }}"
-template_service_broker_version: "{{ l_tsb_image_dict[openshift_deployment_type]['version'] }}"
-template_service_broker_image_name: "{{ l_tsb_image_dict[openshift_deployment_type]['image_name'] }}"
+template_service_broker_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'template-service-broker') }}"

--- a/roles/template_service_broker/tasks/deploy.yml
+++ b/roles/template_service_broker/tasks/deploy.yml
@@ -38,7 +38,7 @@
     {{ openshift_client_binary }} process --config={{ mktemp.stdout }}/admin.kubeconfig
     -f "{{ mktemp.stdout }}/{{ __tsb_template_file }}" -n openshift-template-service-broker
     --param API_SERVER_CONFIG="{{ config['content'] | b64decode }}"
-    --param IMAGE="{{ template_service_broker_prefix }}{{ template_service_broker_image_name }}:{{ template_service_broker_version }}"
+    --param IMAGE="{{ template_service_broker_image }}"
     --param NODE_SELECTOR={{ {'node-role.kubernetes.io/master':'true'} | to_json | quote }}
     | {{ openshift_client_binary }} apply --config={{ mktemp.stdout }}/admin.kubeconfig -f -
 


### PR DESCRIPTION
This commit removes openshift_service_catalog_image_version
and openshift_service_catalog_image_prefix to simpler override
of openshift_service_catalog_image.  This will allow users to
utilize oreg_url for this component by default.