### PR TITLE
Package pre-downloads should cause failure if required packages can not be found

### DIFF
--- a/roles/openshift_node/tasks/upgrade/rpm_upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade/rpm_upgrade.yml
@@ -10,6 +10,8 @@
   command: "{{ ansible_pkg_mgr }} install -y --downloadonly {{ openshift_node_upgrade_rpm_list | join(' ')}}"
   register: result
   until: result is succeeded
+  failed_when:
+    - result.stdout is search(".*No package .* available.*") or result is failed
   vars:
     openshift_node_upgrade_rpm_list:
       - "{{ openshift_service_type }}-node{{ openshift_pkg_version | default('') }}"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1581140

(*I think*)

I'm using the https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html#testing-strings approach which I haven't seen before. I'm used to using the `var | function()` method. Please let me know if this is incorrect.