### PR TITLE
Default openshift_use_openshift_sdn to True in openshift_facts

### DIFF
--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -115,3 +115,4 @@ openshift_service_type_dict:
 openshift_service_type: "{{ openshift_service_type_dict[openshift_deployment_type] }}"
 openshift_master_api_port: "8443"
 openshift_ca_host: "{{ groups.oo_first_master.0 }}"
+openshift_use_openshift_sdn: true


### PR DESCRIPTION
Minor upgrade might throw `openshift_use_openshift_sdn is not defined` during minor upgrade