### PR TITLE
[3.9] Default openshift_use_openshift_sdn to True in openshift_facts

### DIFF
--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -100,3 +100,4 @@ openshift_service_type_dict:
   openshift-enterprise: atomic-openshift
 
 openshift_service_type: "{{ openshift_service_type_dict[openshift_deployment_type] }}"
+openshift_use_openshift_sdn: true


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/openshift-ansible/pull/8484 on 3.9

Minor upgrade might throw `openshift_use_openshift_sdn is not defined` during minor upgrade