### PR TITLE
Quote openshift_release in example inventory.

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -51,7 +51,7 @@ openshift_deployment_type=origin
 # use this to lookup the latest exact version of the container images, which is the tag actually used to configure
 # the cluster. For RPM installations we just verify the version detected in your configured repos matches this
 # release.
-openshift_release=v3.9
+openshift_release="3.9"
 
 # default subdomain to use for exposed routes, you should have wildcard dns
 # for *.apps.test.example.com that points at your infra nodes which will run

--- a/roles/openshift_sanitize_inventory/tasks/main.yml
+++ b/roles/openshift_sanitize_inventory/tasks/main.yml
@@ -26,7 +26,7 @@
   fail:
     msg: |-
       openshift_release is "{{ openshift_release }}" which is not a valid version string.
-      Please set it to a version string like "3.4".
+      Please set openshift_release to a version string and ensure that the value is quoted, ex: openshift_release="3.4".
 
 - include_tasks: unsupported.yml
   when:


### PR DESCRIPTION
Also removed the leading `"v"` from the example inventory since we remove it when sanitizing the inventory.

https://bugzilla.redhat.com/show_bug.cgi?id=1579264