### PR TITLE
etcd: use etcdctl cluster-health cmd for liveness probe

### DIFF
--- a/roles/etcd/files/etcd.yaml
+++ b/roles/etcd/files/etcd.yaml
@@ -31,8 +31,9 @@ spec:
      - mountPath: /var/lib/etcd/
        name: master-data
     livenessProbe:
-      tcpSocket:
-        port: 2379
+      exec:
+      initialDelaySeconds: 15
+      timeoutSeconds: 10
   volumes:
   - name: master-config
     hostPath:

--- a/roles/etcd/tasks/static.yml
+++ b/roles/etcd/tasks/static.yml
@@ -54,6 +54,25 @@
   with_items:
   - etcd.yaml
 
+- name: Set etcd host as a probe target host
+  yedit:
+    src: "{{ mktemp.stdout }}/{{ item }}"
+    edits:
+    - key: spec.containers[0].livenessProbe.exec.command
+      value:
+      - "etcdctl"
+      - "--cert-file"
+      - "{{ etcd_peer_cert_file }}"
+      - "--key-file"
+      - "{{ etcd_peer_key_file }}"
+      - "--ca-file"
+      - "{{ etcd_peer_ca_file }}"
+      - "-C"
+      - "{{ etcd_peer_url_scheme }}://{{ etcd_ip }}:{{ etcd_client_port }}"
+      - "cluster-health"
+  with_items:
+  - etcd.yaml
+
 - name: Deploy etcd static pod
   copy:
     remote_src: true


### PR DESCRIPTION
This PR ensures liveness probe is using configured etcd IP and port

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1574677