### PR TITLE
Fix master scaleup play init_fact hosts

### DIFF
--- a/playbooks/openshift-master/scaleup.yml
+++ b/playbooks/openshift-master/scaleup.yml
@@ -33,8 +33,9 @@
   vars:
     l_scale_up_hosts: "oo_nodes_to_config:oo_masters_to_config"
     l_base_packages_hosts: "oo_nodes_to_config:oo_masters_to_config"
-    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_nodes_to_config"
-    l_sanity_check_hosts: "{{ groups['oo_nodes_to_config'] | union(groups['oo_masters_to_config']) }}"
+    # oo_masters contains both existing and new masters; oo_masters_to_config just new.
+    l_init_fact_hosts: "oo_masters:oo_etcd_to_config:oo_lb_to_config:oo_nodes_to_config"
+    l_sanity_check_hosts: "{{ groups['oo_nodes_to_config'] | union(groups['oo_masters']) }}"
 
 - import_playbook: ../init/version.yml
   vars:


### PR DESCRIPTION
Currently, master scaleup play only operates on oo_masters_to_config,
which does not initialize facts for existing masters.

This commit ensures facts are initialized on existing masters.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1581388