### PR TITLE
openshift_monitor_availability: use oc_obj and oc_process

### DIFF
--- a/roles/openshift_monitor_availability/tasks/install.yaml
+++ b/roles/openshift_monitor_availability/tasks/install.yaml
@@ -29,7 +29,15 @@
   command: >
     {{ openshift_client_binary }} apply --config={{ mktemp.stdout }}/admin.kubeconfig -f {{ mktemp.stdout }}/prometheus-k8s-role-binding.yaml
 
-- import_tasks: install_monitor_app_create.yaml
+- name: Create Monitor app
+  oc_process:
+    namespace: openshift-monitor-availability
+    template_name: openshift-monitor-app-create
+    params:
+      IMAGE: "{{ openshift_monitor_app_create_image }}"
+      RUN_INTERVAL: "{{ openshift_monitor_app_create_run_interval }}"
+      TIMEOUT: "{{ openshift_monitor_app_create_timeout }}"
+      LOG_LEVEL: "{{ openshift_monitor_app_create_log_level }}"
 
 - name: Delete temp directory
   file:


### PR DESCRIPTION
Avoid using `oc` to create and apply template.

Note, that this doesn't get tested via CI most likely