### PR TITLE
Update Prometheus to scrape the router metrics

### DIFF
--- a/roles/openshift_prometheus/tasks/install_prometheus.yaml
+++ b/roles/openshift_prometheus/tasks/install_prometheus.yaml
@@ -56,14 +56,27 @@
   with_items:
     "{{ openshift_prometheus_serviceaccount_annotations }}"
 
+# add required permissions to prometheus for scraping router metrics
+- name: Create router-metrics cluster role
+  oc_clusterrole:
+    state: present
+    name: router-metrics
+    rules:
+    - apiGroups: ["route.openshift.io"]
+      resources: ["routers/metrics"]
+      verbs: ["get"]
+
 # create clusterrolebinding for prometheus serviceaccount
-- name: Set cluster-reader permissions for prometheus
+- name: Set clusterrole permissions for prometheus
   oc_adm_policy_user:
     state: present
     namespace: "{{ openshift_prometheus_namespace }}"
     resource_kind: cluster-role
-    resource_name: cluster-reader
+    resource_name: "{{ item }}"
     user: "system:serviceaccount:{{ openshift_prometheus_namespace }}:{{ openshift_prometheus_service_name }}"
+  with_items:
+  - cluster-reader
+  - router-metrics
 
 # create view role for prometheus-reader serviceaccount
 - name: Set view permissions for prometheus reader

--- a/roles/openshift_prometheus/tasks/uninstall_prometheus.yaml
+++ b/roles/openshift_prometheus/tasks/uninstall_prometheus.yaml
@@ -1,4 +1,9 @@
 ---
+- name: delete router-metrics cluster role
+  oc_obj:
+    state: absent
+    kind: clusterrole
+    name: router-metrics
 
 # remove namespace - This will delete all the objects inside the namespace
 - name: Remove prometheus project

--- a/roles/openshift_prometheus/templates/prometheus.yml.j2
+++ b/roles/openshift_prometheus/templates/prometheus.yml.j2
@@ -237,6 +237,25 @@ scrape_configs:
     action: keep
     regex: apiserver;https
 
+# Scrape config for the router
+- job_name: 'openshift-router'
+  scheme: https
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+    server_name: router.default.svc
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - default
+
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+    action: keep
+    regex: router;1936-tcp
+
 alerting:
   alertmanagers:
   - scheme: http


### PR DESCRIPTION
Partial fix for #7986.
Bugzilla reference: https://bugzilla.redhat.com/show_bug.cgi?id=1565095

As of https://github.com/openshift/origin/pull/19318, Prometheus needs a specific scrape configuration as well as additional permissions to get the router's metrics.