### PR TITLE
Enable metrics scraping of availability apps

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
+++ b/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
@@ -23,6 +23,15 @@
     description: Openshift Monitoring
     node_selector: ""
 
+- name: Label monitoring namespace
+  oc_label:
+    state: present
+    kind: namespace
+    name: openshift-monitoring
+    labels:
+    - key: openshift.io/cluster-monitoring
+      value: "true"
+
 - name: Apply the cluster monitoring operator template
   shell: >
     {{ openshift_client_binary }} process -f "{{ mktemp.stdout 	}}/{{ item }}"

--- a/roles/openshift_monitor_availability/files/monitor-app-create.yaml
+++ b/roles/openshift_monitor_availability/files/monitor-app-create.yaml
@@ -101,6 +101,30 @@ objects:
         availabilityRoute: django-psql-persistent
         parameters: # Empty, use template defaults
 
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    name: monitor-app-create
+    namespace: ${NAMESPACE}
+    labels:
+      k8s-app: monitor-app-create
+  spec:
+    jobLabel: k8s-app
+    endpoints:
+    - port: http-metrics
+      interval: 30s
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: monitor-app-create.openshift-monitor-availability.svc
+    selector:
+      matchLabels:
+        k8s-app: monitor-app-create
+    namespaceSelector:
+      matchNames:
+      - openshift-monitor-availability
+
 - apiVersion: extensions/v1beta1
   kind: Deployment
   metadata:

--- a/roles/openshift_monitor_availability/tasks/install.yaml
+++ b/roles/openshift_monitor_availability/tasks/install.yaml
@@ -5,6 +5,15 @@
     name: openshift-monitor-availability
     description: Openshift availability monitoring applications.
 
+- name: Label namespace
+  oc_label:
+    state: present
+    kind: namespace
+    name: openshift-monitor-availability
+    labels:
+    - key: openshift.io/cluster-monitoring
+      value: "true"
+
 - name: Create temp directory for doing work in on target
   command: mktemp -td openshift-monitor-availability-XXXXXX
   register: mktemp


### PR DESCRIPTION
Upgrade cluster-monitoring-operator and enable dynamic scraping of the
availability apps.

Blocked by https://github.com/openshift/openshift-ansible/pull/8531