### PR TITLE
docker: Fixup graph directory labels after docker starts

### DIFF
--- a/roles/container_runtime/tasks/package_docker.yml
+++ b/roles/container_runtime/tasks/package_docker.yml
@@ -137,17 +137,6 @@
   changed_when: False
   register: r_docker_already_running_result
 
-- name: Check for docker_storage_path/overlay2
-  stat:
-    path: "{{ docker_storage_path }}/overlay2"
-  register: dsp_stat
-
-- name: Fixup SELinux permissions for docker
-  shell: |
-           semanage fcontext -a -e /var/lib/docker/overlay2 "{{ docker_storage_path }}/overlay2"
-           restorecon -R -v "{{ docker_storage_path }}/overlay2"
-  when: dsp_stat.stat.exists
-
 - name: Start the Docker service
   systemd:
     name: docker
@@ -161,5 +150,16 @@
 
 - set_fact:
     docker_service_status_changed: "{{ (r_docker_package_docker_start_result is changed) and (r_docker_already_running_result.stdout != 'ActiveState=active' ) }}"
+
+- name: Check for docker_storage_path/overlay2
+  stat:
+    path: "{{ docker_storage_path }}/overlay2"
+  register: dsp_stat
+
+- name: Fixup SELinux permissions for docker
+  shell: |
+           semanage fcontext -a -e /var/lib/docker/overlay2 "{{ docker_storage_path }}/overlay2"
+           restorecon -R -v "{{ docker_storage_path }}/overlay2"
+  when: dsp_stat.stat.exists
 
 - import_tasks: common/post.yml


### PR DESCRIPTION
The directory doesn't exist before docker starts.
@runcom @mwoodson @sdodson @rhatdan PTAL.
cc: @jupierce 
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>