### PR TITLE
master config: remove PodPreset

### DIFF
--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -2,11 +2,6 @@ kind: MasterConfig
 apiVersion: v1
 admissionConfig:
   pluginConfig:{{ openshift.master.admission_plugin_config | default(None) | lib_utils_to_padded_yaml(level=2) }}
-    PodPreset:
-      configuration:
-        kind: DefaultAdmissionConfig
-        apiVersion: v1
-        disable: true
 aggregatorConfig:
   proxyClientInfo:
     certFile: aggregator-front-proxy.crt


### PR DESCRIPTION
`PodPreset` field is not required anymore and being removed during 3.9 -> 3.10 install

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1581115