### PR TITLE
Set imagePolicyConfig.internalRegistryHostname

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -99,7 +99,7 @@ debug_level=2
 #openshift_master_oauth_template=/path/to/login-template.html
 
 # Configure imagePolicyConfig in the master config
-# See: https://godoc.org/github.com/openshift/origin/pkg/cmd/server/api#ImagePolicyConfig
+# See: https://docs.openshift.org/latest/admin_guide/image_policy.html
 #openshift_master_image_policy_config={"maxImagesBulkImportedPerRepository": 3, "disableScheduledImport": true}
 
 # Configure master API rate limits for external clients

--- a/roles/openshift_control_plane/tasks/upgrade.yml
+++ b/roles/openshift_control_plane/tasks/upgrade.yml
@@ -47,32 +47,13 @@
     force: yes
   when: ca_crt_stat.stat.isreg and not ca_bundle_stat.stat.exists
 
-- name: Find existing master sysconfig
-  find:
-    paths:
-    - /etc/sysconfig
-    patterns:
-    - openshift-master-api
-    - openshift-master-controllers
-    - origin-master-api
-    - origin-master-controllers
-  register: sysconfigs
-- when:
-  - sysconfigs is succeeded
-  - sysconfigs.matched > 0
-  name: Migrate OPENSHIFT_DEFAULT_REGISTRY from master sysconfig to master-config.yaml
-  block:
-  - name: Get master sysconfig contents
-    slurp:
-      src: "{{ sysconfigs.files[0].path }}"
-    register: sysconfig
-  # TODO: surely there is a better way
-  - name: Update imagePolicyConfig.internalRegistryHostname
-    yedit:
-      src: "{{ openshift.common.config_base }}/master/master-config.yaml"
-      key: "imagePolicyConfig.internalRegistryHostname"
-      value: "{{ item | regex_replace('^OPENSHIFT_DEFAULT_REGISTRY=\\s*([^#\\s]+).*','\\1') }}"
-    with_items: "{{ (sysconfig.content | b64decode).split('\n') | select('match','^OPENSHIFT_DEFAULT_REGISTRY=\\s*.+') | list }}"
+# Anyone upgrading to 3.7 or 3.9 should've had their certs updated to be
+# compatible with this so this is the only valid value for internal registry
+- name: Update imagePolicyConfig.internalRegistryHostname
+  yedit:
+    src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+    key: "imagePolicyConfig.internalRegistryHostname"
+    value: "docker-registry.default.svc.cluster.local:5000"
 
 # TODO(michaelgugino): Remove in 3.11
 - name: Add new network config section to master conf

--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -67,7 +67,7 @@ etcdStorageConfig:
 imageConfig:
   format: {{ openshift_imageconfig_format }}
   latest: {{ openshift_master_image_config_latest }}
-imagePolicyConfig:{{ openshift.master.image_policy_config | default({"internalRegistryHostname":"docker-registry.default.svc:5000"}) | lib_utils_to_padded_yaml(level=1) }}
+imagePolicyConfig:{{ openshift.master.image_policy_config | default({}) | combine({"internalRegistryHostname":"docker-registry.default.svc:5000"}) | lib_utils_to_padded_yaml(level=1) }}
 kubeletClientInfo:
 {# TODO: allow user specified kubelet port #}
   ca: ca-bundle.crt


### PR DESCRIPTION
There's only one value for this, set it during upgrade and merge it with
any defined openshift_master_image_policy_config

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1581876