### PR TITLE
azure: tag working resource groups with "now", so that they will be p…

### DIFF
--- a/playbooks/azure/openshift-cluster/tasks/provision_instance.yml
+++ b/playbooks/azure/openshift-cluster/tasks/provision_instance.yml
@@ -3,6 +3,8 @@
   azure_rm_resourcegroup:
     name: "{{ openshift_azure_resource_group_name }}"
     location: "{{ openshift_azure_resource_location }}"
+    tags:
+      now: "{{ lookup('pipe', 'date +%s') }}"
 
 - name: create vnet
   azure_rm_virtualnetwork:


### PR DESCRIPTION
…runed if necessary