### PR TITLE
Grafana: oauth-proxy for OCP deployments should default to openshift_image_tag

### DIFF
--- a/roles/openshift_grafana/vars/openshift-enterprise.yml
+++ b/roles/openshift_grafana/vars/openshift-enterprise.yml
@@ -6,4 +6,4 @@ l_openshift_grafana_image: "{{ openshift_grafana_image| default('grafana-ocp') }
 
 # image version defaults
 l_openshift_grafana_image_version: "{{ openshift_grafana_image_version | default('latest') }}"
-l_openshift_grafana_proxy_image_version: "{{ openshift_grafana_proxy_image_version | default('v1.0.0') }}"
+l_openshift_grafana_proxy_image_version: "{{ openshift_grafana_proxy_image_version | default(openshift_image_tag) }}"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1579415