### PR TITLE
Make Kuryr connect to OpenShift API through LB

### DIFF
--- a/playbooks/openstack/inventory.py
+++ b/playbooks/openstack/inventory.py
@@ -210,6 +210,7 @@ def _get_kuryr_vars(cloud_client, data):
     settings['kuryr_openstack_pod_sg_id'] = data['pod_access_sg_id']
     settings['kuryr_openstack_pod_project_id'] = (
         cloud_client.current_project_id)
+    settings['kuryr_openstack_api_lb_ip'] = data['private_api_ip']
 
     settings['kuryr_openstack_auth_url'] = cloud_client.auth['auth_url']
     settings['kuryr_openstack_username'] = cloud_client.auth['username']

--- a/roles/kuryr/README.md
+++ b/roles/kuryr/README.md
@@ -39,6 +39,21 @@ pods. This allows to have interconnectivity between pods and OpenStack VMs.
 * ``openshift_kuryr_precreate_subports=5``
 * ``openshift_kuryr_device_owner=compute:kuryr``
 
+## OpenShift API loadbalancer
+
+Kuryr is connecting to OpenShift API through the load balancer created by
+OpenStack playbook. Both Octavia and Neutron LBaaS v2 hardcode 50 seconds as
+client and server inactivity timeout. This is a low value for Kuryr, which is
+watching K8s API forever. If connection will get closed by the LB, Kuryr will
+restart it with some messages about it in the logs.
+
+If you have access to your OpenStack cloud configuration you can disable the
+timeouts by providing custom HA proxy templates to your LBaaS v2 or Octavia
+installations. It's controlled by ``[haproxy]jinja_config_template`` option in
+Neutron LBaaS v2 and ``[haproxy_amphora]haproxy_template`` in Octavia's config.
+Please note that such configuration change will affect all the load balancers
+created in the cloud.
+
 ## Kuryr resources
 
 * [Kuryr documentation](https://docs.openstack.org/kuryr-kubernetes/latest/)

--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -191,7 +191,7 @@ data:
     #
 
     # The root URL of the Kubernetes API (string value)
-    api_root = {{ openshift.master.api_url }}
+    api_root = https://{{ kuryr_openstack_api_lb_ip }}:{{openshift_master_api_port}}
 
     # Absolute path to client cert to connect to HTTPS K8S_API (string value)
     # ssl_client_crt_file = /etc/kuryr/controller.crt
@@ -520,7 +520,7 @@ data:
     #
 
     # The root URL of the Kubernetes API (string value)
-    api_root = {{ openshift.master.api_url }}
+    api_root = https://{{ kuryr_openstack_api_lb_ip }}:{{openshift_master_api_port}}
 
     # Absolute path to client cert to connect to HTTPS K8S_API (string value)
     # ssl_client_crt_file = /etc/kuryr/controller.crt

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -80,7 +80,7 @@ outputs:
     description: >
       The address of the private OpenShift API. This is used during OpenShift
       deployment and for API access by the internal pods and services.
-{% if openshift_openstack_use_lbaas_load_balancer %}
+{% if openshift_openstack_use_lbaas_load_balancer or openshift_use_kuryr|default(false)|bool %}
     value: { get_attr: [api_lb, vip_address] }
 {% elif openshift_openstack_use_vm_load_balancer %}
     value: { get_attr: [loadbalancer, resource.0, private_ip] }


### PR DESCRIPTION
Kuryr connected to OpenShift API using openshift.master.api_url. This is
fine only when we have a single master. This commit makes it connect
through the LB that we create for that purpose in OpenStack playbook.