### PR TITLE
Add option to pass OpenStack CA cert to Kuryr

### DIFF
--- a/roles/kuryr/README.md
+++ b/roles/kuryr/README.md
@@ -26,6 +26,7 @@ pods. This allows to have interconnectivity between pods and OpenStack VMs.
 * ``kuryr_openstack_project_id=project_uuid``
 * ``kuryr_openstack_username=kuryr``
 * ``kuryr_openstack_password=kuryr_pass``
+* ``kuryr_openstack_ca=/etc/ssl/ca.crt` (defaults to ``OS_CACERT`` env var)
 * ``kuryr_openstack_pod_sg_id=pod_security_group_uuid``
 * ``kuryr_openstack_pod_subnet_id=pod_subnet_uuid``
 * ``kuryr_openstack_pod_service_id=service_subnet_uuid``

--- a/roles/kuryr/tasks/master.yaml
+++ b/roles/kuryr/tasks/master.yaml
@@ -13,6 +13,17 @@
     src: node-images.yaml.j2
     dest: "{{ manifests_tmpdir.stdout }}/node-images.yaml"
 
+- name: Set certificate contents as fact
+  set_fact:
+    kuryr_ca_certificate: "{{ lookup('file', kuryr_openstack_ca | default(lookup('env', 'OS_CACERT'))) }}"
+  ignore_errors: yes
+
+- name: Create Kuryr certificates Secret manifest
+  become: yes
+  template:
+    src: certificates-secret.yaml.j2
+    dest: "{{ manifests_tmpdir.stdout }}/certificates-secret.yaml"
+
 - name: Create kuryr ConfigMap manifest
   become: yes
   template:
@@ -41,6 +52,16 @@
     - "{{ manifests_tmpdir.stdout }}/node-images.yaml"
   run_once: true
   ignore_errors: yes
+
+- name: Apply Kuryr certificates Secret
+  oc_obj:
+    state: present
+    kind: Secret
+    name: "kuryr-certificates"
+    namespace: "{{ kuryr_namespace }}"
+    files:
+    - "{{ manifests_tmpdir.stdout }}/certificates-secret.yaml"
+  run_once: true
 
 - name: Apply ConfigMap manifest
   oc_obj:

--- a/roles/kuryr/templates/certificates-secret.yaml.j2
+++ b/roles/kuryr/templates/certificates-secret.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kuryr-certificates
+  namespace: {{ kuryr_namespace }}
+type: Opaque
+data:
+  kuryr-ca-bundle.crt: "{{ kuryr_ca_certificate | default('') | b64encode }}"

--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -247,6 +247,12 @@ data:
     # Deprecated group/name - [neutron]/auth_plugin
     auth_type = password
 
+{% if kuryr_ca_certificate is defined %}
+    # PEM encoded Certificate Authority to use when verifying HTTPs connections.
+    # (string value)
+    cafile = /etc/ssl/certs/kuryr-ca-bundle.crt
+{% endif %}
+
     # Domain ID to scope to (string value)
     user_domain_name = {{ kuryr_openstack_user_domain_name }}
 

--- a/roles/kuryr/templates/controller-deployment.yaml.j2
+++ b/roles/kuryr/templates/controller-deployment.yaml.j2
@@ -45,9 +45,16 @@ spec:
         - name: config-volume
           mountPath: "/etc/kuryr/kuryr.conf"
           subPath: kuryr.conf
+        - name: certificates-volume
+          mountPath: "/etc/ssl/certs/kuryr-ca-bundle.crt"
+          subPath: kuryr-ca-bundle.crt
+          readOnly: true
       volumes:
       - name: config-volume
         configMap:
           name: kuryr-config
           defaultMode: 0666
+      - name: certificates-volume
+        secret:
+          secretName: kuryr-certificates
       restartPolicy: Always


### PR DESCRIPTION
This commit adds possiblity to provide OpenStack CA certificate for
Kuryr. This will enable support for OpenStack clouds with SSL enabled.