### PR TITLE
Use registry short name rather than fqdn

### DIFF
--- a/roles/openshift_control_plane/tasks/upgrade.yml
+++ b/roles/openshift_control_plane/tasks/upgrade.yml
@@ -53,7 +53,7 @@
   yedit:
     src: "{{ openshift.common.config_base }}/master/master-config.yaml"
     key: "imagePolicyConfig.internalRegistryHostname"
-    value: "docker-registry.default.svc.cluster.local:5000"
+    value: "docker-registry.default.svc:5000"
 
 # TODO(michaelgugino): Remove in 3.11
 - name: Add new network config section to master conf


### PR DESCRIPTION
We're only generating push/pull secrets for the short name.

Fixes
```
Pulling image "docker-registry.default.svc.cluster.local:5000/openshift/nodejs@sha256:1a58eec8ed503c841666b35b745c05937e3ebe2dc72176d0b3822acdbff2ef32" ... pulling image error : unauthorized: authentication required error: build error: unable to get docker-registry.default.svc.cluster.local:5000/openshift/nodejs@sha256:1a58eec8ed503c841666b35b745c05937e3ebe2dc72176d0b3822acdbff2ef32
```