### PR TITLE
Update openshift.json acsengine file with unstable for master.

### DIFF
--- a/playbooks/azure/BRANCH.md
+++ b/playbooks/azure/BRANCH.md
@@ -1,0 +1,3 @@
+When a release branch is cut we need to perform the following actions:
+- update the playbooks/azure/openshift-cluster/groups_vars/all/yum_repos.yml to reflect the new package location.
+- update the playbooks/azure/openshift-cluster/launch.yml to update the acs-engine's openshift.json parameters to match $release.

--- a/playbooks/azure/openshift-cluster/launch.yml
+++ b/playbooks/azure/openshift-cluster/launch.yml
@@ -36,6 +36,8 @@
         value: demo
       - key: properties.orchestratorProfile.openShiftConfig.clusterPassword
         value: "{{ 16 | lib_utils_oo_random_word }}"
+      - key: properties.orchestratorProfile.orchestratorVersion
+        value: unstable
       # azProfile
       - key: properties.azProfile.tenantId
         value: "{{ lookup('env', 'AZURE_TENANT') }}"


### PR DESCRIPTION
When on master branch we need to set the acs-engine openshift.json params file to use `unstable` so we can test master.