### PR TITLE
prepull: set async to 0 so that task wouldn't block others and prepull etcd

### DIFF
--- a/roles/etcd/tasks/static.yml
+++ b/roles/etcd/tasks/static.yml
@@ -2,6 +2,21 @@
 # Set some facts to reference from hostvars
 - import_tasks: set_facts.yml
 
+- name: Check that etcd image is present
+  command: 'docker images -q "{{ etcd_image }}"'
+  register: etcd_image_exists
+
+- name: Pre-pull etcd image
+  docker_image:
+    name: "{{ etcd_image }}"
+  environment:
+    NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
+  when: etcd_image_exists.stdout_lines == []
+  # 10 minutes to pull the image
+  async: 600
+  poll: 0
+  register: etcd_prepull
+
 - name: setup firewall
   import_tasks: firewall.yml
 

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -153,6 +153,14 @@
   when: control_plane_image.stdout_lines == []
   retries: 30
 
+- name: Check status of etcd image pre-pull
+  async_status:
+    jid: "{{ etcd_prepull.ansible_job_id }}"
+  register: job_result
+  until: job_result.finished
+  when: etcd_image_exists.stdout_lines == []
+  retries: 30
+
 - name: Start and enable self-hosting node
   systemd:
     name: "{{ openshift_service_type }}-node"

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -23,7 +23,7 @@
   when: control_plane_image.stdout_lines == []
   # 10 minutes to pull the image
   async: 600
-  poll: 10
+  poll: 0
   register: image_prepull
 
 - name: Open up firewall ports

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -12,7 +12,7 @@
   when: node_image.stdout_lines == []
   # 10 minutes to pull the image
   async: 600
-  poll: 10
+  poll: 0
   register: image_prepull
 
 - name: Install the systemd units


### PR DESCRIPTION
This would speed up pulling images, as currently `async: 10` doesn't really make this task truly async.

Prepull etcd image to avoid the race condition between API server and etcd readiness