### PR TITLE
sync: don't match the script PID when attempting to kill kubelet

### DIFF
--- a/roles/openshift_node_group/files/sync.yaml
+++ b/roles/openshift_node_group/files/sync.yaml
@@ -132,7 +132,7 @@ spec:
                 echo "error: The downloaded node configuration is invalid, exiting" 2>&1
                 exit 1
               fi
-              if ! pgrep -U 0 -f 'hyperkube kubelet ' | xargs kill; then
+              if ! kill $(pgrep -U 0 -f '^/usr/bin/hyperkube kubelet ' | head -n1); then
                 echo "error: Unable to restart Kubelet" 2>&1
               fi
             fi


### PR DESCRIPTION
Sync container tried to kill all processes, which contain 'hyperkube kubelet' in cmd line. It also matches itself, which causes the container restart.

This PR would ensure the cmd line starts with `/usr/bin/hyperkube kubelet` and would use only the first matched PID instead