### PR TITLE
cluster_monitoring_operator: Wait for CRD to be created

### DIFF
--- a/playbooks/common/private/components.yml
+++ b/playbooks/common/private/components.yml
@@ -19,6 +19,9 @@
 
 - import_playbook: ../../openshift-hosted/private/config.yml
 
+- import_playbook: ../../openshift-monitoring/private/config.yml
+  when: openshift_monitoring_deploy | default(false) | bool
+
 - import_playbook: ../../openshift-web-console/private/config.yml
   when: openshift_web_console_install | default(true) | bool
 
@@ -30,9 +33,6 @@
 
 - import_playbook: ../../openshift-prometheus/private/config.yml
   when: openshift_hosted_prometheus_deploy | default(false) | bool
-
-- import_playbook: ../../openshift-monitoring/private/config.yml
-  when: openshift_monitoring_deploy | default(false) | bool
 
 - import_playbook: ../../openshift-monitor-availability/private/config.yml
   when: openshift_monitor_availability_install | default(false) | bool

--- a/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
+++ b/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
@@ -39,6 +39,13 @@
   with_items:
   - cluster-monitoring-operator.yaml
 
+- name: Wait for the ServiceMonitor CRD to be created
+  command: "{{ openshift_client_binary }} get crd servicemonitors.monitoring.coreos.com -n openshift-monitoring --config={{ mktemp.stdout }}/admin.kubeconfig"
+  register: crd
+  until: crd.rc == 0
+  delay: 30
+  retries: 30
+
 - name: Delete temp directory
   file:
     name: "{{ mktemp.stdout }}"


### PR DESCRIPTION
Other OpenShift components who want to get monitored would install
ServiceMonitor objects. For that to work, we need to ensure
the cluster_monitoring_operator is installed first, and that
we wait for the CRD to be created before we continue installing
other components.

cc: @ironcladlou 