### PR TITLE
Remove unused imagestream of registry-console

### DIFF
--- a/roles/openshift_hosted_templates/files/v3.10/enterprise/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.10/enterprise/registry-console.yaml
@@ -17,6 +17,14 @@ objects:
     spec:
       triggers:
       - type: ConfigChange
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+          - "registry-console"
+          from:
+            kind: ImageStreamTag
+            name: registry-console:${IMAGE_VERSION}
       replicas: 1
       selector:
         name: "registry-console"
@@ -27,7 +35,7 @@ objects:
         spec:
           containers:
             - name: registry-console
-              image: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
+              image: ""
               ports:
                 - containerPort: 9090
                   protocol: TCP
@@ -78,6 +86,19 @@ objects:
           targetPort: 9090
       selector:
         name: "registry-console"
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: registry-console
+      annotations:
+        description: Atomic Registry console
+    spec:
+      tags:
+        - annotations: null
+          from:
+            kind: DockerImage
+            name: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
+          name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
     metadata:

--- a/roles/openshift_hosted_templates/files/v3.10/enterprise/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.10/enterprise/registry-console.yaml
@@ -78,19 +78,6 @@ objects:
           targetPort: 9090
       selector:
         name: "registry-console"
-  - kind: ImageStream
-    apiVersion: v1
-    metadata:
-      name: registry-console
-      annotations:
-        description: Atomic Registry console
-    spec:
-      tags:
-        - annotations: null
-          from:
-            kind: DockerImage
-            name: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
-          name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
     metadata:

--- a/roles/openshift_hosted_templates/files/v3.10/origin/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.10/origin/registry-console.yaml
@@ -17,6 +17,14 @@ objects:
     spec:
       triggers:
       - type: ConfigChange
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+          - "registry-console"
+          from:
+            kind: ImageStreamTag
+            name: registry-console:${IMAGE_VERSION}
       replicas: 1
       selector:
         name: "registry-console"
@@ -27,7 +35,7 @@ objects:
         spec:
           containers:
             - name: registry-console
-              image: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
+              image: ""
               ports:
                 - containerPort: 9090
                   protocol: TCP
@@ -78,6 +86,19 @@ objects:
           targetPort: 9090
       selector:
         name: "registry-console"
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: registry-console
+      annotations:
+        description: Atomic Registry console
+    spec:
+      tags:
+        - annotations: null
+          from:
+            kind: DockerImage
+            name: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
+          name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
     metadata:

--- a/roles/openshift_hosted_templates/files/v3.10/origin/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.10/origin/registry-console.yaml
@@ -78,19 +78,6 @@ objects:
           targetPort: 9090
       selector:
         name: "registry-console"
-  - kind: ImageStream
-    apiVersion: v1
-    metadata:
-      name: registry-console
-      annotations:
-        description: Atomic Registry console
-    spec:
-      tags:
-        - annotations: null
-          from:
-            kind: DockerImage
-            name: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
-          name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
     metadata:


### PR DESCRIPTION
Currently ImageStream was configured in registry-console template
(registry-console.yaml), however the ImageStream was not used from any
resources. DC in the template refers image on
registry.access.redhat.com or dockerhub.

This patch removes the unused ImageStream to avoid confusion.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1583093