### PR TITLE
WIP Increase etcd static pod to 30 seconds to sync with API server liveness check

### DIFF
--- a/roles/etcd/files/etcd.yaml
+++ b/roles/etcd/files/etcd.yaml
@@ -32,7 +32,7 @@ spec:
        name: master-data
     livenessProbe:
       exec:
-      initialDelaySeconds: 15
+      initialDelaySeconds: 45
       timeoutSeconds: 10
   volumes:
   - name: master-config


### PR DESCRIPTION
This seems to fix random API/etcd container restarts.
Currently if etcd won't come up in 15 seconds the container would be marked 
for removal by liveness check, but since it has termination grace period 
set to 30 seconds, it won't be shutdown immediately. 

As a result, API container would still try to reach it and fail 
if the old container is removed and new one is not yet up.

The PR would make sure etcd is checked earlier than API and etcd container is restarted instantly