### PR TITLE
Splitting output over using stdout_lines due to name formatting

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml
@@ -32,47 +32,49 @@
     --key {{ _logging_handler_tempdir.stdout }}/admin-key
     https://logging-{{ _cluster_component }}.{{ openshift_logging_elasticsearch_namespace }}.svc:9200/_cluster/health?pretty
   register: _pod_status
-  when: _cluster_pods.stdout_lines | count > 0
+  when:
+    - _cluster_pods.stdout
+    - _cluster_pods.stdout.split(' ') | count > 0
 
 - when:
-  - _pod_status.stdout is defined
-  - (_pod_status.stdout | from_json)['status'] in ['yellow', 'red'] or (_pod_status.stdout | from_json)['number_of_nodes'] != _cluster_pods.stdout_lines | count
+    - _pod_status.stdout is defined
+    - (_pod_status.stdout | from_json)['status'] in ['yellow', 'red'] or (_pod_status.stdout | from_json)['number_of_nodes'] != _cluster_pods.stdout.split(' ') | count
   block:
-  - name: Set Logging message to manually restart
-    run_once: true
-    set_stats:
-      data:
-        installer_phase_logging:
-          message: "Cluster logging-{{ _cluster_component }} was not in an optimal state and will not be automatically restarted. Please see documentation regarding doing a {{ 'full' if full_restart_cluster | bool else 'rolling'}} cluster restart."
+    - name: Set Logging message to manually restart
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_logging:
+            message: "Cluster logging-{{ _cluster_component }} was not in an optimal state and will not be automatically restarted. Please see documentation regarding doing a {{ 'full' if full_restart_cluster | bool else 'rolling'}} cluster restart."
 
-  - debug: msg="Cluster logging-{{ _cluster_component }} was not in an optimal state and will not be automatically restarted. Please see documentation regarding doing a {{ 'full' if full_restart_cluster | bool else 'rolling'}} cluster restart."
+    - debug: msg="Cluster logging-{{ _cluster_component }} was not in an optimal state and will not be automatically restarted. Please see documentation regarding doing a {{ 'full' if full_restart_cluster | bool else 'rolling'}} cluster restart."
 
-- when: _pod_status.stdout is undefined or ( (_pod_status.stdout | from_json)['status'] in ['green'] and (_pod_status.stdout | from_json)['number_of_nodes'] == _cluster_pods.stdout_lines | count )
+- when: _pod_status.stdout is undefined or ( (_pod_status.stdout | from_json)['status'] in ['green'] and (_pod_status.stdout | from_json)['number_of_nodes'] == _cluster_pods.stdout.split(' ') | count )
   block:
-  - command: >
-      {{ openshift_client_binary }}
-      --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-      get dc
-      -l component={{ _cluster_component }},provider=openshift
-      -n {{ openshift_logging_elasticsearch_namespace }}
-      -o jsonpath={.items[*].metadata.name}
-    register: _cluster_dcs
+    - command: >
+        {{ openshift_client_binary }}
+        --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+        get dc
+        -l component={{ _cluster_component }},provider=openshift
+        -n {{ openshift_logging_elasticsearch_namespace }}
+        -o jsonpath={.items[*].metadata.name}
+      register: _cluster_dcs
 
-  ## restart all dcs for full restart
-  - name: "Performing full cluster restart for {{ _cluster_component }} cluster"
-    include_tasks: full_cluster_restart.yml
-    vars:
-      logging_restart_cluster_dcs: "{{ _cluster_dcs.stdout_lines }}"
-    when:
-    - full_restart_cluster | bool
+    ## restart all dcs for full restart
+    - name: "Performing full cluster restart for {{ _cluster_component }} cluster"
+      include_tasks: full_cluster_restart.yml
+      vars:
+        logging_restart_cluster_dcs: "{{ _cluster_dcs.stdout_lines }}"
+      when:
+        - full_restart_cluster | bool
 
-  ## restart the node if it's dc is in the list of nodes to restart
-  - name: "Performing rolling cluster restart for {{ _cluster_component }} cluster"
-    include_tasks: rolling_cluster_restart.yml
-    vars:
-      logging_restart_cluster_dcs: "{{ _restart_logging_nodes | intersect(_cluster_dcs.stdout) }}"
-    when:
-    - not full_restart_cluster | bool
+    ## restart the node if it's dc is in the list of nodes to restart
+    - name: "Performing rolling cluster restart for {{ _cluster_component }} cluster"
+      include_tasks: rolling_cluster_restart.yml
+      vars:
+        logging_restart_cluster_dcs: "{{ _restart_logging_nodes | intersect(_cluster_dcs.stdout) }}"
+      when:
+        - not full_restart_cluster | bool
 
 # remove temp dir
 - name: Cleaning up temp dir


### PR DESCRIPTION
Addresses: https://bugzilla.redhat.com/show_bug.cgi?id=1578605#c12

Before:
```
ok: [m01.example.com] => {
    "_cluster_pods.stdout_lines": [
        "logging-es-data-master-u9y4czcw-3-np6sc logging-es-data-master-yjz1f4j1-3-stbd2"
    ]
}
```

After:
```
ok: [m01.example.com] => {
    "_cluster_pods.stdout.split(' ')": [
        "logging-es-data-master-u9y4czcw-5-548mt", 
        "logging-es-data-master-yjz1f4j1-5-bm7v6"
    ]
}
```