### PR TITLE
Port 10256 must be open for service load balancers to work

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -133,6 +133,8 @@ r_openshift_node_os_firewall_deny: []
 default_r_openshift_node_os_firewall_allow:
 - service: Kubernetes kubelet
   port: 10250/tcp
+- service: Kubernetes kube-proxy health check for service load balancers
+  port: 10256/tcp
 - service: http
   port: 80/tcp
 - service: https


### PR DESCRIPTION
The cloud provider uses port 10256 to do health checks for kube-proxying