### PR TITLE
Refactor etcd_image to support oreg_url

### DIFF
--- a/inventory/dynamic/gcp/group_vars/all/00_defaults.yml
+++ b/inventory/dynamic/gcp/group_vars/all/00_defaults.yml
@@ -3,6 +3,7 @@
 ansible_become: yes
 
 openshift_deployment_type: origin
+osm_etcd_image: "{{ etcd_image_dict[openshift_deployment_type] }}"
 
 # Debugging settings
 debug_level: 2

--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -12,11 +12,15 @@ l_etcd_static_pod: "{{ not (r_etcd_common_skip_command_shim is defined and r_etc
 r_etcd_common_etcd_runtime: "{{ 'runc' if l_is_etcd_system_container else ('static_pod' if l_etcd_static_pod else ('docker' if openshift_is_containerized else 'host')) }}"
 
 r_etcd_default_version: "3.2.15"
-osm_etcd_image: "registry.access.redhat.com/rhel7/etcd:{{ r_etcd_upgrade_version | default(r_etcd_default_version) }}"
+# lib_utils_oo_etcd_image is a custom filter defined in roles/lib_utils/filter_plugins/oo_filters.py
+# This filter attempts to combine oreg_url host with project/component from etcd_image_dict.
+# "oreg.example.com/openshift3/ose-${component}:${version}"
+# becomes "oreg.example.com/rhel7/etcd:{{ r_etcd_upgrade_version | default(r_etcd_default_version) }}"
+osm_etcd_image: "{{ etcd_image_dict[openshift_deployment_type] | lib_utils_oo_etcd_image((oreg_url | default('None'))) }}"
 etcd_image_dict:
   origin: "quay.io/coreos/etcd:v{{ r_etcd_upgrade_version | default(r_etcd_default_version) }}"
-  openshift-enterprise: "{{ osm_etcd_image }}"
-etcd_image: "{{ etcd_image_dict[openshift_deployment_type] }}"
+  openshift-enterprise: "registry.access.redhat.com/rhel7/etcd:{{ r_etcd_upgrade_version | default(r_etcd_default_version) }}"
+etcd_image: "{{ osm_etcd_image }}"
 
 # etcd run on a host => use etcdctl command directly
 # etcd run as a docker container => use docker exec

--- a/roles/lib_utils/filter_plugins/oo_filters.py
+++ b/roles/lib_utils/filter_plugins/oo_filters.py
@@ -706,6 +706,29 @@ def lib_utils_mutate_htpass_provider(idps):
     return idps
 
 
+def lib_utils_oo_etcd_image(osm_etcd_image_default, oreg_url):
+    '''Converts default etcd image string to utilize oreg_url, if defined.
+       oreg_url should be passed in as string "None" if undefined.
+
+       Example input:  "quay.io/coreos/etcd:v99",
+                       "example.com/openshift/origin-${component}:${version}"
+       Example output: "example.com/coreos/etcd:v99"'''
+    # if no oreg_url is specified, we just return the original default
+    if oreg_url == 'None':
+        return osm_etcd_image_default
+    oreg_parts = oreg_url.split('/')
+    if len(oreg_parts) < 2:
+        raise errors.AnsibleFilterError("oreg_url malformed: {}".format(oreg_url))
+    if not (len(oreg_parts) >= 3 and '.' in oreg_parts[0]):
+        # oreg_url does not include host information; we'll just return etcd default
+        return osm_etcd_image_default
+
+    etcd_image_parts = osm_etcd_image_default.split('/')
+    if len(etcd_image_parts) < 3:
+        raise errors.AnsibleFilterError("etcd_image_dict malformed, do not adjust this value.")
+    return '/'.join([oreg_parts[0], etcd_image_parts[1], etcd_image_parts[2]])
+
+
 class FilterModule(object):
     """ Custom ansible filter mapping """
 
@@ -741,4 +764,5 @@ class FilterModule(object):
             "map_to_pairs": map_to_pairs,
             "lib_utils_oo_etcd_host_urls": lib_utils_oo_etcd_host_urls,
             "lib_utils_mutate_htpass_provider": lib_utils_mutate_htpass_provider,
+            "lib_utils_oo_etcd_image": lib_utils_oo_etcd_image,
         }


### PR DESCRIPTION
This commit refactors etcd_image to support oreg_url.

Unlike other components, etcd images are not found in
normal openshift project in respective registries.

This commit adds a custom filter to append proper project
and component name to oreg_url hostname.