### PR TITLE
Use groups.oo_nodes_use_nothing rather than []

### DIFF
--- a/playbooks/openshift-node/private/additional_config.yml
+++ b/playbooks/openshift-node/private/additional_config.yml
@@ -55,7 +55,7 @@
     when: openshift_use_contiv | default(false) | bool
 
 - name: Configure rest of Contiv nodes
-  hosts: "{{ groups.oo_nodes_use_contiv | default([]) | difference(groups.oo_masters_to_config) }}"
+  hosts: oo_nodes_use_contiv:!oo_masters_to_config
   roles:
   - role: contiv
     when: openshift_use_contiv | default(false) | bool


### PR DESCRIPTION
When using an inventory which contains additional hosts
'hosts: []' can pull in unexpected additional hosts