### PR TITLE
requirements: downgrade cmd2, as cmd2-0.9.0 required py3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ pyOpenSSL==17.5.0
 # We need to disable ruamel.yaml for now because of test failures
 #ruamel.yaml
 six==1.10.0
+cmd2==0.8.7
 shade==1.24.0
 passlib==1.6.5


### PR DESCRIPTION
This is required for tox / Travis CI tests to pass