### PR TITLE
Local Volume Storage format and setup

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -144,6 +144,12 @@ debug_level=2
 # Skip upgrading Docker during an OpenShift upgrade, leaves the current Docker version alone.
 # docker_upgrade=False
 
+# Specify a list of block devices to be formatted and mounted on the nodes
+# during prerequisites.yml. For each hash, "device", "path", "filesystem" are
+# required. To add devices only on certain classes of node, redefine
+# container_runtime_extra_storage as a group var.
+#container_runtime_extra_storage='[{"device":"/dev/vdc","path":"/var/lib/origin/openshift.local.volumes","filesystem":"xfs","options":"gquota"}]'
+
 # Enable etcd debug logging, defaults to false
 # etcd_debug=true
 # Set etcd log levels by package

--- a/playbooks/container-runtime/private/setup_storage.yml
+++ b/playbooks/container-runtime/private/setup_storage.yml
@@ -19,3 +19,6 @@
       when:
         - container_runtime_docker_storage_type|default('') == "overlay2"
         - openshift_docker_is_node_or_master | bool
+    - import_role:
+        name: container_runtime
+        tasks_from: extra_storage_setup.yml

--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -65,6 +65,7 @@ docker_storage_extra_options:
 - "{{ '--storage-opt overlay2.size=' ~ docker_storage_size if container_runtime_docker_storage_setup_device is defined and container_runtime_docker_storage_setup_device != '' else '' }}"
 - "--graph={{ docker_storage_path}}"
 
+container_runtime_extra_storage: []
 
 # Set local versions of facts that must be in json format for container-daemon.json
 # NOTE: When jinja2.9+ is used the container-daemon.json file can move to using tojson

--- a/roles/container_runtime/tasks/extra_storage_setup.yml
+++ b/roles/container_runtime/tasks/extra_storage_setup.yml
@@ -1,0 +1,17 @@
+---
+- name: Create file system on extra volume device
+  filesystem:
+    fstype: "{{ item.filesystem }}"
+    dev: "{{ item.device }}"
+    force: "{{ item.force|default(omit) }}"
+  with_items: "{{ container_runtime_extra_storage }}"
+
+
+- name: Create mount entry for extra volume
+  mount:
+    path: "{{ item.path }}"
+    src: "{{ item.device }}"
+    fstype: "{{ item.filesystem }}"
+    opts: "{{ item.options|default(omit) }}"
+    state: mounted
+  with_items: "{{ container_runtime_extra_storage }}"


### PR DESCRIPTION
This is a small subtask of the project to move unsupported code out of openshift-ansible-contrib into the supported openshift-ansible repository.

It is recommended as a best practice to have a separate volume with group quota support turned on for Pods' persistent local volume storage. Given nodes with an extra block device, this addition to the `container_runtime role` will make a file system (default xfs) on the device.

Variables:
  * `container_runtime_docker_local_volume_device`
    * Default undefined
    * Required to activate extra code
  * `container_runtime_docker_local_volume_fstype`
    * Default 'xfs'

Open Questions:
  * Should `container_runtime_docker_local_volume_fstype` be default undefined, and required in order to create fs? i.e. Do we need to be careful not to overwrite an existing file system on these devs?

CC @sdodson @cooktheryan 