### PR TITLE
prerequisites: install python-docker-py

### DIFF
--- a/playbooks/init/base_packages.yml
+++ b/playbooks/init/base_packages.yml
@@ -39,7 +39,7 @@
       - "{{ 'python-ipaddress' if ansible_distribution != 'Fedora' else '' }}"
       - libsemanage-python
       - yum-utils
-      - "{{ 'python3-docker' if ansible_distribution == 'Fedora' else 'python-docker' }}"
+      - "{{ 'python3-docker' if ansible_distribution == 'Fedora' else 'python-docker-py' }}"
       when: item != ''
       register: result
       until: result is succeeded


### PR DESCRIPTION
There are two versions of docker API, in some cases an older version needs to be installed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1583594