### PR TITLE
Initialise repos before installing packages

### DIFF
--- a/playbooks/init/main.yml
+++ b/playbooks/init/main.yml
@@ -22,6 +22,10 @@
 
 - import_playbook: basic_facts.yml
 
+# NOTE: we must call init repos before installing base packages
+# because they may come from the repos.
+- import_playbook: repos.yml
+
 # base_packages needs to be setup for openshift_facts.py to run correctly.
 - import_playbook: base_packages.yml
   when: l_install_base_packages | default(False) | bool

--- a/playbooks/prerequisites.yml
+++ b/playbooks/prerequisites.yml
@@ -8,8 +8,6 @@
 - import_playbook: init/validate_hostnames.yml
   when: not (skip_validate_hostnames | default(False))
 
-- import_playbook: init/repos.yml
-
 # This is required for container runtime for crio, only needs to run once.
 - name: Configure os_firewall
   hosts: "{{ l_scale_up_hosts | default(l_default_firewall_hosts) }}"


### PR DESCRIPTION
The `prerequisites.yml` playbook installs packages that may only come
from the `openshift_additional_repos` (e.g. "python-docker" on RHEL).

Since `init/repos.yml` was called after `init/main.yml`, the playbook
would fail in those cases.

This makes sure we initialise the repositories before installing
anything.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1584608