### PR TITLE
Fix OpenStack nsupdate zone handling

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -191,6 +191,17 @@ records, you must set at least one of:
 
 Otherwise the private records will be overwritten by the public ones.
 
+For example by leaving the *private* suffix empty and setting the *public* one
+to:
+
+```
+openshift_openstack_public_hostname_suffix: -public
+```
+
+The internal access to the first master node would be available with:
+`master-0.openshift.example.com`, while the public access using the floating IP
+address would be under `master-0-public.openshift.example.com`.
+
 Note that these suffixes are only applied to the OpenShift Node names
 as they appear in the DNS. They will not affect the actual hostnames.
 
@@ -201,7 +212,7 @@ If your nsupdate zone differs from the full OpenShift DNS name (e.g.
 your DNS' zone is "example.com" but you want your cluster to be at
 "openshift.example.com"), you can specify the zone in this parameter:
 
-* `openshift_openstack_nsupdate_zone`
+* `openshift_openstack_nsupdate_zone: example.com`
 
 If left out, it will be equal to the OpenShift cluster DNS.
 

--- a/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -4,9 +4,22 @@ openshift_deployment_type: origin
 #openshift_repos_enable_testing: true
 #openshift_deployment_type: openshift-enterprise
 #openshift_release: v3.5
-openshift_master_default_subdomain: "apps.{{ openshift_openstack_clusterid }}.{{ openshift_openstack_public_dns_domain }}"
 
-openshift_master_cluster_public_hostname: "console.{{ openshift_openstack_clusterid }}.{{ openshift_openstack_public_dns_domain }}"
+# Default domain to access the applications running on OpenShift.
+# This uses the `openshift_openstack_clusterid`
+# and `openshift_openstack_public_dns_domain` values from all.yml.
+# It will be set to `apps.openshift.example.com` by default.
+# Feel free to change this to a value you prefer. It should be under the
+# domain the OpenShift cluster is configured, though.
+openshift_master_default_subdomain: "apps.{{ (openshift_openstack_clusterid|trim == '') | ternary(openshift_openstack_public_dns_domain, openshift_openstack_clusterid + '.' + openshift_openstack_public_dns_domain) }}"
+
+# Domain to access the OpenShift UI and API.
+# This uses the `openshift_openstack_clusterid`
+# and `openshift_openstack_public_dns_domain` values from all.yml.
+# It will be set to `console.openshift.example.com` by default.
+# Feel free to change this to a value you prefer. It should be under the
+# domain the OpenShift cluster is configured, though.
+openshift_master_cluster_public_hostname: "console.{{ (openshift_openstack_clusterid|trim == '') | ternary(openshift_openstack_public_dns_domain, openshift_openstack_clusterid + '.' + openshift_openstack_public_dns_domain) }}"
 
 osm_default_node_selector: 'region=primary'
 

--- a/roles/openshift_openstack/defaults/main.yml
+++ b/roles/openshift_openstack/defaults/main.yml
@@ -51,7 +51,7 @@ openshift_openstack_public_hostname_suffix: ""
 openshift_openstack_private_hostname_suffix: ""
 openshift_openstack_public_dns_domain: "example.com"
 openshift_openstack_full_dns_domain: "{{ (openshift_openstack_clusterid|trim == '') | ternary(openshift_openstack_public_dns_domain, openshift_openstack_clusterid + '.' + openshift_openstack_public_dns_domain) }}"
-openshift_openstack_app_subdomain: "apps"
+openshift_openstack_nsupdate_zone: "{{ openshift_openstack_full_dns_domain }}"
 
 
 # heat vars

--- a/roles/openshift_openstack/tasks/check-prerequisites.yml
+++ b/roles/openshift_openstack/tasks/check-prerequisites.yml
@@ -117,3 +117,13 @@
       by your cloud.
   when: (openshift_openstack_use_lbaas_load_balancer and openshift_openstack_lbaasv2_provider == 'Neutron::LBaaS' and 'lbaasv2' not in openstack_network_extensions) or
         (openshift_openstack_use_lbaas_load_balancer and openshift_openstack_lbaasv2_provider == 'Octavia' and 'load-balancer' not in openstack_service_catalog)
+
+- name: Verify the nsupdate zone is a subset of the full cluster domain
+  fail:
+    msg: >
+      The `openshift_openstack_nsupdate_zone` ({{ openshift_openstack_nsupdate_zone }})
+      must be a substring of `openshift_openstack_full_dns_domain ({{ openshift_openstack_full_dns_domain }})`
+  when:
+  - openshift_openstack_nsupdate_zone is defined
+  - openshift_openstack_full_dns_domain is defined
+  - openshift_openstack_full_dns_domain is not match(".*" + openshift_openstack_nsupdate_zone + "$")

--- a/roles/openshift_openstack/tasks/clean-dns.yml
+++ b/roles/openshift_openstack/tasks/clean-dns.yml
@@ -9,7 +9,7 @@
     key_algorithm: "{{ item.0.key_algorithm }}"
     server: "{{ item.0.server }}"
     zone: "{{ item.0.zone }}"
-    record: "{{ item.1.hostname }}"
+    record: "{{ item.1.fqdn | replace('.' + openshift_openstack_nsupdate_zone, '') }}"
     value: "{{ item.1.ip }}"
     type: "{{ item.1.type }}"
     state: absent

--- a/roles/openshift_openstack/tasks/generate-dns.yml
+++ b/roles/openshift_openstack/tasks/generate-dns.yml
@@ -1,24 +1,25 @@
 ---
 - name: "Generate list of private A records"
   set_fact:
-    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': hostvars[item]['ansible_hostname'] + openshift_openstack_private_hostname_suffix, 'ip': hostvars[item]['private_v4'] } ] }}"
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'fqdn': hostvars[item]['ansible_hostname'] + openshift_openstack_private_hostname_suffix + '.' + openshift_openstack_full_dns_domain, 'ip': hostvars[item]['private_v4'] } ] }}"
   with_items: "{{ groups['cluster_hosts'] }}"
 
 - name: "Add wildcard records to the private A records for infrahosts"
   set_fact:
-    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': '*.' + openshift_openstack_app_subdomain, 'ip': hostvars[item]['private_v4'] } ] }}"
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'fqdn': '*.' + hostvars[groups.masters[0]].openshift_master_default_subdomain, 'ip': hostvars[item]['private_v4'] } ] }}"
   with_items: "{{ groups['infra_hosts'] }}"
+  when: openshift_openstack_public_router_ip is defined
 
 - name: "Add public master cluster hostname records to the private A records (single master)"
   set_fact:
-    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(openshift_openstack_full_dns_domain, ''))[:-1], 'ip': hostvars[groups.masters[0]].private_v4 } ] }}"
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'fqdn': hostvars[groups.masters[0]].openshift_master_cluster_public_hostname, 'ip': hostvars[groups.masters[0]].private_v4 } ] }}"
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openshift_openstack_num_masters == 1
 
 - name: "Add public master cluster hostname records to the private A records (multi-master)"
   set_fact:
-    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(openshift_openstack_full_dns_domain, ''))[:-1], 'ip': hostvars[groups.lb[0]].private_v4 } ] }}"
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'fqdn': hostvars[groups.masters[0]].openshift_master_cluster_public_hostname, 'ip': hostvars[groups.lb[0]].private_v4 } ] }}"
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openshift_openstack_num_masters > 1
@@ -28,7 +29,7 @@
     nsupdate_server_private: "{{ openshift_openstack_external_nsupdate_keys['private']['server'] }}"
     nsupdate_key_secret_private: "{{ openshift_openstack_external_nsupdate_keys['private']['key_secret'] }}"
     nsupdate_key_algorithm_private: "{{ openshift_openstack_external_nsupdate_keys['private']['key_algorithm'] }}"
-    nsupdate_private_key_name: "{{ openshift_openstack_external_nsupdate_keys['private']['key_name']|default('private-' + openshift_openstack_full_dns_domain) }}"
+    nsupdate_private_key_name: "{{ openshift_openstack_external_nsupdate_keys['private']['key_name'] }}"
   when:
     - openshift_openstack_external_nsupdate_keys['private'] is defined
 
@@ -37,9 +38,9 @@
   set_fact:
     private_named_records:
       - view: "private"
-        zone: "{{ openshift_openstack_full_dns_domain }}"
+        zone: "{{ openshift_openstack_nsupdate_zone }}"
         server: "{{ nsupdate_server_private }}"
-        key_name: "{{ nsupdate_private_key_name|default('private-' + openshift_openstack_full_dns_domain) }}"
+        key_name: "{{ nsupdate_private_key_name }}"
         key_secret: "{{ nsupdate_key_secret_private }}"
         key_algorithm: "{{ nsupdate_key_algorithm_private | lower }}"
         entries: "{{ private_records }}"
@@ -48,17 +49,18 @@
 
 - name: "Generate list of public A records"
   set_fact:
-    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': hostvars[item]['ansible_hostname'] + openshift_openstack_public_hostname_suffix, 'ip': hostvars[item]['public_v4'] } ] }}"
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'fqdn': hostvars[item]['ansible_hostname'] + openshift_openstack_public_hostname_suffix + '.' + openshift_openstack_full_dns_domain, 'ip': hostvars[item]['public_v4'] } ] }}"
   with_items: "{{ groups['cluster_hosts'] }}"
   when: hostvars[item]['public_v4'] is defined
 
 - name: "Add wildcard record to the public A records"
   set_fact:
-    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': '*.' + openshift_openstack_app_subdomain, 'ip': openshift_openstack_public_router_ip } ] }}"
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'fqdn': '*.' + hostvars[groups.masters[0]].openshift_master_default_subdomain, 'ip': openshift_openstack_public_router_ip } ] }}"
+  when: openshift_openstack_public_router_ip is defined
 
 - name: "Add the public API entry point record"
   set_fact:
-    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(openshift_openstack_full_dns_domain, ''))[:-1], 'ip': openshift_openstack_public_api_ip } ] }}"
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'fqdn': hostvars[groups.masters[0]].openshift_master_cluster_public_hostname, 'ip': openshift_openstack_public_api_ip } ] }}"
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
 
@@ -67,7 +69,7 @@
     nsupdate_server_public: "{{ openshift_openstack_external_nsupdate_keys['public']['server'] }}"
     nsupdate_key_secret_public: "{{ openshift_openstack_external_nsupdate_keys['public']['key_secret'] }}"
     nsupdate_key_algorithm_public: "{{ openshift_openstack_external_nsupdate_keys['public']['key_algorithm'] }}"
-    nsupdate_public_key_name: "{{ openshift_openstack_external_nsupdate_keys['public']['key_name']|default('public-' + openshift_openstack_full_dns_domain) }}"
+    nsupdate_public_key_name: "{{ openshift_openstack_external_nsupdate_keys['public']['key_name'] }}"
   when:
     - openshift_openstack_external_nsupdate_keys['public'] is defined
 
@@ -75,9 +77,9 @@
   set_fact:
     public_named_records:
       - view: "public"
-        zone: "{{ openshift_openstack_full_dns_domain }}"
+        zone: "{{ openshift_openstack_nsupdate_zone }}"
         server: "{{ nsupdate_server_public }}"
-        key_name: "{{ nsupdate_public_key_name|default('public-' + openshift_openstack_full_dns_domain) }}"
+        key_name: "{{ nsupdate_public_key_name }}"
         key_secret: "{{ nsupdate_key_secret_public }}"
         key_algorithm: "{{ nsupdate_key_algorithm_public | lower }}"
         entries: "{{ public_records }}"

--- a/roles/openshift_openstack/tasks/populate-dns.yml
+++ b/roles/openshift_openstack/tasks/populate-dns.yml
@@ -9,7 +9,7 @@
     key_algorithm: "{{ item.0.key_algorithm }}"
     server: "{{ item.0.server }}"
     zone: "{{ item.0.zone }}"
-    record: "{{ item.1.hostname }}"
+    record: "{{ item.1.fqdn | replace('.' + openshift_openstack_nsupdate_zone, '') }}"
     value: "{{ item.1.ip }}"
     type: "{{ item.1.type }}"
     state: present


### PR DESCRIPTION
Previously, the full cluster domain name of the OpenStack deployments (`openshift_openstack_clusterid` + `openshift_openstack_public_dns_domain`) had to match the nsupdate zone (the domain under the DNS server that allowed the dynamic updates).

That means a DNS server set up for `openshift.example.com` updates could only deploy OpenStack clusters with that domain name. No subdomains were allowed.

With this change, the nsupdate zone and the full cluster domain names are decoupled and the former can be a subset of the latter. E.g. if the DNS accepts `openshift.example.com`, we can deploy `testing.openshift.example.com` and `production.openshift.example.com` clusters.

This makes our nsupdate code more flexible. It no longer fails on an empty `openshift_openstack_clusterid` either.

Note that this is only relevant to the cases where the user relies on our nsupdate behaviour. They were always able to configure the DNS themselves. This option is now better documented.