### PR TITLE
Approve node CSRs during node upgrade

### DIFF
--- a/roles/openshift_node/tasks/upgrade/restart.yml
+++ b/roles/openshift_node/tasks/upgrade/restart.yml
@@ -30,11 +30,28 @@
   retries: 3
   delay: 30
 
-- name: Start services
-  service: name={{ item }} state=started
-  with_items:
-    - "{{ openshift_service_type }}-node"
+- name: Start node service
+  service:
+    name: "{{ openshift_service_type }}-node"
+    state: started
+  async: 1
+  poll: 0
+  register: node_service
   failed_when: false
+
+- name: Approve the node
+  oc_adm_csr:
+    nodes: ["{{ openshift.node.nodename }}"]
+    timeout: 60
+    fail_on_timeout: true
+  delegate_to: "{{ groups.oo_first_master.0 }}"
+
+- name: Check status of node service
+  async_status:
+    jid: "{{ node_service.ansible_job_id }}"
+  register: job_result
+  until: job_result.finished
+  retries: 30
 
 - name: Wait for master API to come back online
   wait_for:


### PR DESCRIPTION
Dedicated nodes create CSRs, which need to be approved when node service 
is started