### PR TITLE
openshift-logging use headless service for node discover

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -200,6 +200,7 @@
   vars:
     allow_cluster_reader: "{{ openshift_logging_elasticsearch_ops_allow_cluster_reader | lower | default('false') }}"
     es_kibana_index_mode: "{{ openshift_logging_elasticsearch_kibana_index_mode | default('unique') }}"
+    es_unicast_host: "logging-{{ es_component }}-cluster"
   changed_when: no
 
 # create diff between current configmap files and our current files
@@ -289,6 +290,9 @@
     state: present
     name: "logging-{{ es_component }}-cluster"
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    clusterip: 'None'
+    annotations:
+      service.alpha.kubernetes.io/tolerate-unready-endpoints: 'true'
     selector:
       component: "{{ es_component }}"
       provider: openshift
@@ -296,6 +300,16 @@
       logging-infra: 'support'
     ports:
     - port: 9300
+
+# equivalent to the unready-endpoints annotation
+- name: Edit logging-{{ es_component }}-cluster service
+  oc_edit:
+    state: present
+    kind: service
+    name: "logging-{{ es_component }}-cluster"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    content:
+      spec.publishNotReadyAddresses: "{{ true | bool }}"
 
 - name: Set logging-{{ es_component }} service
   oc_service:

--- a/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
@@ -20,7 +20,7 @@ cloud:
     namespace: ${NAMESPACE}
 
 discovery.zen:
-  hosts_provider: kubernetes
+  ping.unicast.hosts: {{ es_unicast_host }}
   minimum_master_nodes: ${NODE_QUORUM}
 
 gateway:


### PR DESCRIPTION
This PR removes the dependency on the [elasticsearch cloud kubernetes](https://github.com/fabric8io/elasticsearch-cloud-kubernetes) discovery plugin by utilizing headless services.  It only makes the change for the ES 5.x branch as I'm pretty certain we are broken for cluster sizes greater then 0.

We may wish to hold merging until after the 3.10 branch is created.

cc @t0ffel @richm @portante 
