### PR TITLE
Support setting dns_domain in inventory

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -61,7 +61,8 @@ openshift_master_default_subdomain=apps.test.example.com
 #Set cluster_hostname to point at your load balancer
 openshift_master_cluster_hostname=ose3-lb.test.example.com
 
-
+# Change cluster domain from cluster.local
+#dns_domain="cluster1.example.com"
 
 ###############################################################################
 # Additional configuration variables follow                                   #

--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -62,7 +62,7 @@ openshift_master_default_subdomain=apps.test.example.com
 openshift_master_cluster_hostname=ose3-lb.test.example.com
 
 # Change cluster domain from cluster.local
-#dns_domain="cluster1.example.com"
+#openshift_dns_domain="cluster1.example.com"
 
 ###############################################################################
 # Additional configuration variables follow                                   #

--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -21,7 +21,7 @@
         https_proxy: "{{ openshift_https_proxy | default(None) }}"
         no_proxy: "{{ openshift_no_proxy | default(None) }}"
         generate_no_proxy_hosts: "{{ openshift_generate_no_proxy_hosts | default(True) }}"
-        dns_domain: "{{ dns_domain | default(None) }}"
+        dns_domain: "{{ openshift_dns_domain | default(None) }}"
 
   - name: Set fact of no_proxy_internal_hostnames
     openshift_facts:

--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -21,6 +21,7 @@
         https_proxy: "{{ openshift_https_proxy | default(None) }}"
         no_proxy: "{{ openshift_no_proxy | default(None) }}"
         generate_no_proxy_hosts: "{{ openshift_generate_no_proxy_hosts | default(True) }}"
+        dns_domain: "{{ dns_domain | default(None) }}"
 
   - name: Set fact of no_proxy_internal_hostnames
     openshift_facts:

--- a/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml
@@ -68,7 +68,7 @@
         --signer-key={{ openshift.common.config_base }}/master/ca.key
         --signer-serial={{ openshift.common.config_base }}/master/ca.serial.txt
         --config={{ mktemp.stdout }}/admin.kubeconfig
-        --hostnames="{{ docker_registry_service_ip.results.clusterip }},docker-registry.default.svc,docker-registry.default.svc.cluster.local,{{ docker_registry_route_hostname }}"
+        --hostnames="{{ docker_registry_service_ip.results.clusterip }},docker-registry.default.svc,docker-registry.default.svc.{{openshift.common.dns_domain}},{{ docker_registry_route_hostname }}"
         --cert={{ openshift.common.config_base }}/master/registry.crt
         --key={{ openshift.common.config_base }}/master/registry.key
         --expire-days={{ openshift_hosted_registry_cert_expire_days | default(730) }}

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -11,7 +11,7 @@ repoquery_installed: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --l
 openshift_cli_image: "{{ osm_image | default(openshift_cli_image_dict[openshift_deployment_type]) }}"
 
 # osm_default_subdomain is an old migrated fact, can probably be removed.
-osm_default_subdomain: "router.default.svc.cluster.local"
+osm_default_subdomain: "router.default.svc.{{ openshift.common.dns_domain }}"
 openshift_master_default_subdomain: "{{ osm_default_subdomain }}"
 
 openshift_hosted_etcd_storage_nfs_directory: '/exports'

--- a/roles/openshift_logging/tasks/generate_jks.yaml
+++ b/roles/openshift_logging/tasks/generate_jks.yaml
@@ -93,8 +93,12 @@
   become: false
   when: not elasticsearch_jks.stat.exists or not logging_es_jks.stat.exists or not system_admin_jks.stat.exists or not truststore_jks.stat.exists
 
+- name: Create JKS generation script
+  local_action: template src=generate-jks.sh.j2 dest={{local_tmp.stdout}}/generate-jks.sh
+  when: not elasticsearch_jks.stat.exists or not logging_es_jks.stat.exists or not system_admin_jks.stat.exists or not truststore_jks.stat.exists
+
 - name: Run JKS generation script
-  local_action: script generate-jks.sh {{local_tmp.stdout}} {{openshift_logging_namespace}} {{openshift_logging_es_hostname | default()}} {{openshift_logging_es_ops_hostname | default()}}
+  local_action: script {{local_tmp.stdout}}/generate-jks.sh {{local_tmp.stdout}} {{openshift_logging_namespace}} {{openshift_logging_es_hostname | default()}} {{openshift_logging_es_ops_hostname | default()}}
   check_mode: no
   become: false
   when: not elasticsearch_jks.stat.exists or not logging_es_jks.stat.exists or not system_admin_jks.stat.exists or not truststore_jks.stat.exists

--- a/roles/openshift_logging/templates/generate-jks.sh.j2
+++ b/roles/openshift_logging/templates/generate-jks.sh.j2
@@ -192,7 +192,7 @@ if [[ ! -f $dir/elasticsearch.jks || -z "$(keytool -list -keystore $dir/elastics
 fi
 
 if [[ ! -f $dir/logging-es.jks || -z "$(keytool -list -keystore $dir/logging-es.jks -storepass kspass | grep sig-ca)" ]]; then
-  generate_JKS_chain false logging-es "$(join , logging-es{,-ops}{,-cluster}{,.${PROJECT}.svc.cluster.local})"${escomma}${MORE_ES_NAMES}${esopscomma}${MORE_ES_OPS_NAMES}
+  generate_JKS_chain false logging-es "$(join , logging-es{,-ops}{,-cluster}{,.${PROJECT}.svc.{{openshift.common.dns_domain}}})"${escomma}${MORE_ES_NAMES}${esopscomma}${MORE_ES_OPS_NAMES}
 fi
 
 [ ! -f $dir/truststore.jks ] && createTruststore

--- a/roles/openshift_logging_curator/defaults/main.yml
+++ b/roles/openshift_logging_curator/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ### General logging settings
 openshift_logging_curator_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"
-openshift_logging_curator_master_url: "https://kubernetes.default.svc.cluster.local"
+openshift_logging_curator_master_url: "https://kubernetes.default.svc.{{openshift.common.dns_domain}}"
 
 openshift_logging_curator_namespace: logging
 

--- a/roles/openshift_logging_kibana/defaults/main.yml
+++ b/roles/openshift_logging_kibana/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ### Common settings
-openshift_logging_kibana_master_url: "https://kubernetes.default.svc.cluster.local"
-openshift_logging_kibana_master_public_url: "https://kubernetes.default.svc.cluster.local"
+openshift_logging_kibana_master_url: "https://kubernetes.default.svc.{{openshift.common.dns_domain}}"
+openshift_logging_kibana_master_public_url: "https://kubernetes.default.svc.{{openshift.common.dns_domain}}"
 openshift_logging_kibana_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"
 openshift_logging_kibana_namespace: logging
 

--- a/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
@@ -3,7 +3,7 @@
   include_tasks: setup_certificate.yaml
   vars:
     component: hawkular-metrics
-    hostnames: "hawkular-metrics,hawkular-metrics.{{ openshift_metrics_project }}.svc.cluster.local,{{ openshift_metrics_hawkular_hostname }}"
+    hostnames: "hawkular-metrics,hawkular-metrics.{{ openshift_metrics_project }}.svc.{{openshift.common.dns_domain}},{{ openshift_metrics_hawkular_hostname }}"
   changed_when: no
 
 - name: generate hawkular-cassandra certificates

--- a/roles/openshift_metrics/templates/hawkular_openshift_agent_cm.j2
+++ b/roles/openshift_metrics/templates/hawkular_openshift_agent_cm.j2
@@ -12,7 +12,7 @@ data:
     kubernetes:
       tenant: ${POD:namespace_name}
     hawkular_server:
-      url: https://hawkular-metrics.openshift-infra.svc.cluster.local       
+      url: https://hawkular-metrics.openshift-infra.svc.{{openshift.common.dns_domain}}       
       credentials:
         username: secret:openshift-infra/hawkular-metrics-account/hawkular-metrics.username
         password: secret:openshift-infra/hawkular-metrics-account/hawkular-metrics.password

--- a/roles/openshift_node/tasks/dnsmasq/network-manager.yml
+++ b/roles/openshift_node/tasks/dnsmasq/network-manager.yml
@@ -2,7 +2,7 @@
 - name: Install network manager dispatch script
   template:
     src: networkmanager/99-origin-dns.sh.j2
-    dest: /etc/NetworkManager/dispatcher.d/
+    dest: /etc/NetworkManager/dispatcher.d/99-origin-dns.sh
     mode: 0755
   notify: restart NetworkManager
   when: openshift_node_dnsmasq_install_network_manager_hook | default(true) | bool

--- a/roles/openshift_node/tasks/dnsmasq/network-manager.yml
+++ b/roles/openshift_node/tasks/dnsmasq/network-manager.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install network manager dispatch script
-  copy:
-    src: networkmanager/99-origin-dns.sh
+  template:
+    src: networkmanager/99-origin-dns.sh.j2
     dest: /etc/NetworkManager/dispatcher.d/
     mode: 0755
   notify: restart NetworkManager

--- a/roles/openshift_node/templates/bootstrap.yml.j2
+++ b/roles/openshift_node/templates/bootstrap.yml.j2
@@ -1,22 +1,22 @@
 {% raw %}
 #!/usr/bin/ansible-playbook
 ---
-- hosts: localhost
-  gather_facts: yes
-  vars:
-    origin_dns:
-      file: /etc/dnsmasq.d/origin-dns.conf
-      lines:
-      - regex: ^listen-address
-        state: present
-        line: "listen-address={{ ansible_default_ipv4.address }}"
-    node_dns:
-      file: /etc/dnsmasq.d/node-dnsmasq.conf
-      lines:
-      - regex: "^server=/in-addr.arpa/127.0.0.1$"
-        line: server=/in-addr.arpa/127.0.0.1
-      - regex: "^server=/cluster.local/127.0.0.1$"
-        line: server=/cluster.local/127.0.0.1
+	- hosts: localhost
+	  gather_facts: yes
+	  vars:
+	    origin_dns:
+	      file: /etc/dnsmasq.d/origin-dns.conf
+	      lines:
+	      - regex: ^listen-address
+	        state: present
+	        line: "listen-address={{ ansible_default_ipv4.address }}"
+	    node_dns:
+	      file: /etc/dnsmasq.d/node-dnsmasq.conf
+	      lines:
+	      - regex: "^server=/in-addr.arpa/127.0.0.1$"
+	        line: server=/in-addr.arpa/127.0.0.1
+	      - regex: "^server=/{{openshift.common.dns_domain}}/127.0.0.1$"
+	        line: server=/{{openshift.common.dns_domain}}/127.0.0.1
 
   tasks:
   - include_vars: openshift_settings.yaml

--- a/roles/openshift_node/templates/bootstrap.yml.j2
+++ b/roles/openshift_node/templates/bootstrap.yml.j2
@@ -1,22 +1,22 @@
 {% raw %}
 #!/usr/bin/ansible-playbook
 ---
-	- hosts: localhost
-	  gather_facts: yes
-	  vars:
-	    origin_dns:
-	      file: /etc/dnsmasq.d/origin-dns.conf
-	      lines:
-	      - regex: ^listen-address
-	        state: present
-	        line: "listen-address={{ ansible_default_ipv4.address }}"
-	    node_dns:
-	      file: /etc/dnsmasq.d/node-dnsmasq.conf
-	      lines:
-	      - regex: "^server=/in-addr.arpa/127.0.0.1$"
-	        line: server=/in-addr.arpa/127.0.0.1
-	      - regex: "^server=/{{openshift.common.dns_domain}}/127.0.0.1$"
-	        line: server=/{{openshift.common.dns_domain}}/127.0.0.1
+- hosts: localhost
+  gather_facts: yes
+  vars:
+    origin_dns:
+      file: /etc/dnsmasq.d/origin-dns.conf
+      lines:
+      - regex: ^listen-address
+        state: present
+        line: "listen-address={{ ansible_default_ipv4.address }}"
+    node_dns:
+      file: /etc/dnsmasq.d/node-dnsmasq.conf
+      lines:
+      - regex: "^server=/in-addr.arpa/127.0.0.1$"
+        line: server=/in-addr.arpa/127.0.0.1
+      - regex: "^server=/{{openshift.common.dns_domain}}/127.0.0.1$"
+        line: server=/{{openshift.common.dns_domain}}/127.0.0.1
 
   tasks:
   - include_vars: openshift_settings.yaml

--- a/roles/openshift_node/templates/networkmanager/99-origin-dns.sh.j2
+++ b/roles/openshift_node/templates/networkmanager/99-origin-dns.sh.j2
@@ -17,7 +17,7 @@
 #   node
 #
 # Test it:
-# host kubernetes.default.svc.cluster.local
+# host kubernetes.default.svc.{{openshift.common.dns_domain}}
 # host google.com
 #
 # TODO: I think this would be easy to add as a config option in NetworkManager
@@ -51,7 +51,7 @@ if [[ $2 =~ ^(up|dhcp4-change|dhcp6-change)$ ]]; then
       cat << EOF > /etc/dnsmasq.d/origin-dns.conf
 no-resolv
 domain-needed
-server=/cluster.local/172.30.0.1
+server=/{{openshift.common.dns_domain}}/172.30.0.1
 server=/30.172.in-addr.arpa/172.30.0.1
 enable-dbus
 dns-forward-max=5000
@@ -115,10 +115,10 @@ EOF
       sed -e '/^nameserver.*$/d' /etc/resolv.conf >> ${NEW_RESOLV_CONF}
       echo "nameserver "${def_route_ip}"" >> ${NEW_RESOLV_CONF}
       if ! grep -qw search ${NEW_RESOLV_CONF}; then
-        echo 'search cluster.local' >> ${NEW_RESOLV_CONF}
-      elif ! grep -q 'search cluster.local' ${NEW_RESOLV_CONF}; then
-        # cluster.local should be in first three DNS names so that glibc resolver would work
-        sed -i -e 's/^search \(.\+\)\( cluster\.local\)\{0,1\}$/search cluster.local \1/' ${NEW_RESOLV_CONF}
+        echo 'search {{openshift.common.dns_domain}}' >> ${NEW_RESOLV_CONF}
+      elif ! grep -q 'search {{openshift.common.dns_domain}}' ${NEW_RESOLV_CONF}; then
+        # {{openshift.common.dns_domain}} should be in first three DNS names so that glibc resolver would work
+        sed -i -e 's/^search \(.\+\)\( {{openshift.common.dns_domain}}\)\{0,1\}$/search {{openshift.common.dns_domain}} \1/' ${NEW_RESOLV_CONF}
       fi
       cp -Z ${NEW_RESOLV_CONF} /etc/resolv.conf
     fi

--- a/roles/openshift_node_group/templates/node-config.yaml.j2
+++ b/roles/openshift_node_group/templates/node-config.yaml.j2
@@ -6,7 +6,7 @@ authConfig:
   authorizationCacheSize: 1000
   authorizationCacheTTL: 5m
 dnsBindAddress: "127.0.0.1:53"
-dnsDomain: cluster.local
+dnsDomain: {{openshift.common.dns_domain}}
 dnsIP: 0.0.0.0
 dnsNameservers: null
 dnsRecursiveResolvConf: /etc/origin/node/resolv.conf

--- a/roles/openshift_service_catalog/tasks/generate_certs.yml
+++ b/roles/openshift_service_catalog/tasks/generate_certs.yml
@@ -30,7 +30,7 @@
   oc_adm_ca_server_cert:
     cert: "{{ generated_certs_dir }}/apiserver.crt"
     key: "{{ generated_certs_dir }}/apiserver.key"
-    hostnames: "apiserver.kube-service-catalog.svc,apiserver.kube-service-catalog.svc.cluster.local,apiserver.kube-service-catalog"
+    hostnames: "apiserver.kube-service-catalog.svc,apiserver.kube-service-catalog.svc.{{openshift.common.dns_domain}},apiserver.kube-service-catalog"
     signer_cert: "{{ generated_certs_dir }}/ca.crt"
     signer_key: "{{ generated_certs_dir }}/ca.key"
     signer_serial: "{{ generated_certs_dir }}/apiserver.serial.txt"


### PR DESCRIPTION
This pull requests makes the changes required to be able to change the cluster domain of a local installation from the default cluster.local to something you specify in the Ansible inventory file using the dns_domain parameter.

The pull request consists of two changes:
1. Added setting the local fact openshift.common.dns_domain based on the dns_domain variable in the inventory OSEv3:vars section.
2. Changed the network manager configuration task from copying a configuration file to creating a configuration file based on a template. This will eventually create a /etc/resolv.conf containing the correct search domain instead of using hardcoded cluster.local