### PR TITLE
Increase the delay between checking for image pull success

### DIFF
--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -152,6 +152,8 @@
   until: job_result.finished
   when: control_plane_image.stdout_lines == []
   retries: 30
+  delay: 10
+  failed_when: false
 
 - name: Check status of etcd image pre-pull
   async_status:
@@ -163,6 +165,8 @@
   - "'stdout_lines' in etcd_image_exists"
   - etcd_image_exists.stdout_lines == []
   retries: 30
+  delay: 10
+  failed_when: false
 
 - name: Start and enable self-hosting node
   systemd:

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -60,3 +60,5 @@
   - node_image.stdout_lines == []
   - not openshift_is_atomic | bool
   retries: 30
+  delay: 10
+  failed_when: false

--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -25,6 +25,8 @@
   - node_image is defined
   - node_image.stdout_lines == []
   retries: 30
+  delay: 10
+  failed_when: false
 
 - name: Copy node container image to ostree storage
   command: >


### PR DESCRIPTION
Also, ignore the failure. We're really just trying to prime things so
that when pods start the start up faster. If the image pull is a failure
then we'll similarly fail to start the pods.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1585018

/cc @vrutkovs 