### PR TITLE
cri-o: If defaulting to openshift_release prefix it with v

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -84,7 +84,7 @@ openshift_use_crio: False
 openshift_crio_use_rpm: False
 openshift_use_crio_only: False
 
-l_openshift_image_tag_default: "{{ openshift_release | default('latest') }}"
+l_openshift_image_tag_default: "{{ 'v' ~ openshift_release if openshift_release is defined else 'latest' }}"
 l_openshift_image_tag: "{{ openshift_image_tag | default(l_openshift_image_tag_default) | string}}"
 
 l_required_docker_version: '1.12'


### PR DESCRIPTION
We normalize openshift_release down to be X.Y rather than vX.Y so if
we're defaulting to using the release then we need to prefix it with v.