### PR TITLE
Updating kibana proxy image to match reg url pattern of other components

### DIFF
--- a/roles/openshift_logging_kibana/defaults/main.yml
+++ b/roles/openshift_logging_kibana/defaults/main.yml
@@ -8,7 +8,7 @@ openshift_logging_kibana_namespace: logging
 openshift_logging_es5_techpreview: False
 l_openshift_kibana_image_replace: "{{ (openshift_logging_es5_techpreview | bool) | ternary('logging-kibana5', 'logging-kibana') }}"
 openshift_logging_kibana_image: "{{ l_os_registry_url | regex_replace(l_openshift_logging_search | regex_escape, l_openshift_kibana_image_replace) }}"
-openshift_logging_kibana_proxy_image: "{{ l_os_logging_proxy_image | regex_replace(l_os_logging_non_standard_reg_search | regex_escape, 'logging-auth-proxy') }}"
+openshift_logging_kibana_proxy_image: "{{ l_os_registry_url | regex_replace(l_openshift_logging_search | regex_escape, 'logging-auth-proxy') }}"
 
 openshift_logging_kibana_nodeselector: ""
 openshift_logging_kibana_cpu_limit: null


### PR DESCRIPTION
The Kibana proxy is built and provided by us, so it should match the image pattern of the other logging components.