### PR TITLE
cri-o: If defaulting to openshift_release prefix it with v

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -82,7 +82,7 @@ docker_no_proxy: "{{ openshift.common.no_proxy | default('') }}"
 openshift_use_crio: False
 
 # Set pause_image variable for crio.conf.j2 required to start the crio service in package_crio.yml
-l_openshift_image_tag_default: "{{ openshift_release | default('latest') }}"
+l_openshift_image_tag_default: "{{ 'v' ~ openshift_release if openshift_release is defined else 'latest' }}"
 l_openshift_image_tag: "{{ openshift_image_tag | default(l_openshift_image_tag_default) | string}}"
 
 l_crio_pause_images_dict:


### PR DESCRIPTION
We normalize openshift_release down to be X.Y rather than vX.Y so if
we're defaulting to using the release then we need to prefix it with v.