### PR TITLE
Fix OpenStack all-in-one cluster deployment

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -305,11 +305,8 @@ The options here define a new OpenShift node group that has the labels for all
 three roles: master, infra and compute. And we create a single node and assign
 this new group to it.
 
-It doesn't matter which node role you choose. You can do the equivalent by
-setting `openshift_openstack_num_infra: 1` and
-`openshift_openstack_infra_group_name: node-config-all-in-one` or
-`openshift_openstack_num_nodes: 1` and `openshift_openstack_compute_group_name:
-node-config-all-in-one`.
+Note that the "all in one" node must be the "master". openshift-ansible
+expects at least one node in the `masters` Ansible group.
 
 
 

--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -14,6 +14,7 @@ Environment variables may also be used.
 * [OpenShift Configuration](#openshift-configuration)
 * [Stack Name Configuration](#stack-name-configuration)
 * [DNS Configuration](#dns-configuration)
+* [All-in-one Deployment Configuration](#all-in-one-deployment-configuration)
 * [Kuryr Networking Configuration](#kuryr-networking-configuration)
 * [Provider Network Configuration](#provider-network-configuration)
 * [Multi-Master Configuration](#multi-master-configuration)
@@ -268,6 +269,48 @@ console.openshift.cool.    10.40.128.137
 
 These must point to the publicly-accessible IP addresses of your
 master and infra nodes or preferably to the load balancers.
+
+
+## All-in-one Deployment Configuration
+
+If you want to deploy OpenShift on a single node (e.g. for quick evaluation),
+you can do so with a few configuration changes.
+
+First, set the node counts and labels like so in
+`inventory/group_vars/all.yml`:
+
+```
+openshift_openstack_num_masters: 1
+openshift_openstack_num_infra: 0
+openshift_openstack_num_nodes: 0
+
+openshift_openstack_master_group_name: node-config-all-in-one
+```
+
+Next, define the `node-config-all-in-one` group in `OSEv3.yml`:
+
+```
+openshift_node_groups:
+- name: node-config-all-in-one
+  labels:
+  - 'node-role.kubernetes.io/master=true'
+  - 'node-role.kubernetes.io/infra=true'
+  - 'node-role.kubernetes.io/compute=true'
+```
+
+Then run the deployment playbooks as usual. At the end, you will have an
+OpenShift running on a single OpenStack VM.
+
+The options here define a new OpenShift node group that has the labels for all
+three roles: master, infra and compute. And we create a single node and assign
+this new group to it.
+
+It doesn't matter which node role you choose. You can do the equivalent by
+setting `openshift_openstack_num_infra: 1` and
+`openshift_openstack_infra_group_name: node-config-all-in-one` or
+`openshift_openstack_num_nodes: 1` and `openshift_openstack_compute_group_name:
+node-config-all-in-one`.
+
 
 
 ## Kuryr Networking Configuration

--- a/roles/openshift_openstack/defaults/main.yml
+++ b/roles/openshift_openstack/defaults/main.yml
@@ -97,6 +97,9 @@ openshift_openstack_node_volume_size: "{{ openshift_openstack_docker_volume_size
 openshift_openstack_etcd_volume_size: 2
 openshift_openstack_lb_volume_size: 5
 openshift_openstack_ephemeral_volumes: false
+openshift_openstack_master_group_name: node-config-master
+openshift_openstack_infra_group_name: node-config-infra
+openshift_openstack_compute_group_name: node-config-compute
 
 # User commands for cloud-init executed on all Nova servers provisioned
 openshift_openstack_provision_user_commands: []

--- a/roles/openshift_openstack/tasks/generate-dns.yml
+++ b/roles/openshift_openstack/tasks/generate-dns.yml
@@ -3,19 +3,32 @@
   set_fact:
     private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'fqdn': hostvars[item]['ansible_hostname'] + openshift_openstack_private_hostname_suffix + '.' + openshift_openstack_full_dns_domain, 'ip': hostvars[item]['private_v4'] } ] }}"
   with_items: "{{ groups['cluster_hosts'] }}"
+  when:
+  - hostvars[item]['private_v4'] is defined
+  - hostvars[item]['private_v4'] is not none
+  - hostvars[item]['private_v4'] | string
 
 - name: "Add wildcard records to the private A records for infrahosts"
   set_fact:
     private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'fqdn': '*.' + hostvars[groups.masters[0]].openshift_master_default_subdomain, 'ip': hostvars[item]['private_v4'] } ] }}"
   with_items: "{{ groups['infra_hosts'] }}"
-  when: openshift_openstack_public_router_ip is defined
+  when:
+  - groups.masters
+  - hostvars[groups.masters[0]].openshift_master_default_subdomain is defined
+  - openshift_openstack_public_router_ip is defined
+  - openshift_openstack_public_router_ip is not none
+  - openshift_openstack_public_router_ip | string
 
+- debug: var=openshift_openstack_private_api_ip
 - name: "Add public master cluster hostname records to the private A records"
   set_fact:
     private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'fqdn': hostvars[groups.masters[0]].openshift_master_cluster_public_hostname, 'ip': openshift_openstack_private_api_ip } ] }}"
   when:
+    - groups.masters
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openshift_openstack_private_api_ip is defined
+    - openshift_openstack_private_api_ip is not none
+    - openshift_openstack_private_api_ip | string
 
 - name: "Set the private DNS server to use the external value (if provided)"
   set_fact:
@@ -39,24 +52,35 @@
         entries: "{{ private_records }}"
   when:
     - openshift_openstack_external_nsupdate_keys['private'] is defined
+    - private_records is defined
 
 - name: "Generate list of public A records"
   set_fact:
     public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'fqdn': hostvars[item]['ansible_hostname'] + openshift_openstack_public_hostname_suffix + '.' + openshift_openstack_full_dns_domain, 'ip': hostvars[item]['public_v4'] } ] }}"
   with_items: "{{ groups['cluster_hosts'] }}"
-  when: hostvars[item]['public_v4'] is defined
+  when:
+  - hostvars[item]['public_v4'] is defined
+  - hostvars[item]['public_v4'] | string
 
 - name: "Add wildcard record to the public A records"
   set_fact:
     public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'fqdn': '*.' + hostvars[groups.masters[0]].openshift_master_default_subdomain, 'ip': openshift_openstack_public_router_ip } ] }}"
-  when: openshift_openstack_public_router_ip is defined
+  when:
+  - groups.masters
+  - hostvars[groups.masters[0]].openshift_master_default_subdomain is defined
+  - openshift_openstack_public_router_ip is defined
+  - openshift_openstack_public_router_ip is not none
+  - openshift_openstack_public_router_ip | string
 
 - name: "Add the public API entry point record"
   set_fact:
     public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'fqdn': hostvars[groups.masters[0]].openshift_master_cluster_public_hostname, 'ip': openshift_openstack_public_api_ip } ] }}"
   when:
+    - groups.masters
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openshift_openstack_public_api_ip is defined
+    - openshift_openstack_public_api_ip is not none
+    - openshift_openstack_public_api_ip | string
 
 - name: "Set the public DNS server details to use the external value (if provided)"
   set_fact:
@@ -79,6 +103,7 @@
         entries: "{{ public_records }}"
   when:
     - openshift_openstack_external_nsupdate_keys['public'] is defined
+    - public_records is defined
 
 
 - name: "Generate the final openshift_openstack_dns_records"

--- a/roles/openshift_openstack/tasks/generate-dns.yml
+++ b/roles/openshift_openstack/tasks/generate-dns.yml
@@ -4,20 +4,20 @@
     private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'fqdn': hostvars[item]['ansible_hostname'] + openshift_openstack_private_hostname_suffix + '.' + openshift_openstack_full_dns_domain, 'ip': hostvars[item]['private_v4'] } ] }}"
   with_items: "{{ groups['cluster_hosts'] }}"
   when:
-  - hostvars[item]['private_v4'] is defined
-  - hostvars[item]['private_v4'] is not none
-  - hostvars[item]['private_v4'] | string
+    - hostvars[item]['private_v4'] is defined
+    - hostvars[item]['private_v4'] is not none
+    - hostvars[item]['private_v4'] | string
 
 - name: "Add wildcard records to the private A records for infrahosts"
   set_fact:
     private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'fqdn': '*.' + hostvars[groups.masters[0]].openshift_master_default_subdomain, 'ip': hostvars[item]['private_v4'] } ] }}"
   with_items: "{{ groups['infra_hosts'] }}"
   when:
-  - groups.masters
-  - hostvars[groups.masters[0]].openshift_master_default_subdomain is defined
-  - openshift_openstack_public_router_ip is defined
-  - openshift_openstack_public_router_ip is not none
-  - openshift_openstack_public_router_ip | string
+    - groups.masters
+    - hostvars[groups.masters[0]].openshift_master_default_subdomain is defined
+    - openshift_openstack_public_router_ip is defined
+    - openshift_openstack_public_router_ip is not none
+    - openshift_openstack_public_router_ip | string
 
 - debug: var=openshift_openstack_private_api_ip
 - name: "Add public master cluster hostname records to the private A records"
@@ -59,18 +59,18 @@
     public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'fqdn': hostvars[item]['ansible_hostname'] + openshift_openstack_public_hostname_suffix + '.' + openshift_openstack_full_dns_domain, 'ip': hostvars[item]['public_v4'] } ] }}"
   with_items: "{{ groups['cluster_hosts'] }}"
   when:
-  - hostvars[item]['public_v4'] is defined
-  - hostvars[item]['public_v4'] | string
+    - hostvars[item]['public_v4'] is defined
+    - hostvars[item]['public_v4'] | string
 
 - name: "Add wildcard record to the public A records"
   set_fact:
     public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'fqdn': '*.' + hostvars[groups.masters[0]].openshift_master_default_subdomain, 'ip': openshift_openstack_public_router_ip } ] }}"
   when:
-  - groups.masters
-  - hostvars[groups.masters[0]].openshift_master_default_subdomain is defined
-  - openshift_openstack_public_router_ip is defined
-  - openshift_openstack_public_router_ip is not none
-  - openshift_openstack_public_router_ip | string
+    - groups.masters
+    - hostvars[groups.masters[0]].openshift_master_default_subdomain is defined
+    - openshift_openstack_public_router_ip is defined
+    - openshift_openstack_public_router_ip is not none
+    - openshift_openstack_public_router_ip | string
 
 - name: "Add the public API entry point record"
   set_fact:

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -650,7 +650,7 @@ resources:
                 k8s_type: masters
                 cluster_id: {{ openshift_openstack_full_dns_domain }}
           type:        master
-          openshift_node_group_name: node-config-master
+          openshift_node_group_name: {{ openshift_openstack_master_group_name }}
           image:       {{ openshift_openstack_master_image }}
           flavor:      {{ openshift_openstack_master_flavor }}
           key_name:    {{ openshift_openstack_keypair_name }}
@@ -739,7 +739,7 @@ resources:
                 cluster_id: {{ openshift_openstack_full_dns_domain }}
           type:        node
           subtype:     app
-          openshift_node_group_name: node-config-compute
+          openshift_node_group_name: {{ openshift_openstack_compute_group_name }}
           image:       {{ openshift_openstack_node_image }}
           flavor:      {{ openshift_openstack_node_flavor }}
           key_name:    {{ openshift_openstack_keypair_name }}
@@ -808,7 +808,7 @@ resources:
                 cluster_id: {{ openshift_openstack_full_dns_domain }}
           type:        node
           subtype:     infra
-          openshift_node_group_name: node-config-infra
+          openshift_node_group_name: {{ openshift_openstack_infra_group_name }}
           image:       {{ openshift_openstack_infra_image }}
           flavor:      {{ openshift_openstack_infra_flavor }}
           key_name:    {{ openshift_openstack_keypair_name }}


### PR DESCRIPTION
In order to do an all-in-one deployment, we must be able to set custom
labels on the master nodes. We also need to handle the case where labels
are set for one role and not the others.

It also fixes the wildcard DNS configuration when there are no infra
nodes.