### PR TITLE
Check console pod readiness rather than /healthz endpoint

### DIFF
--- a/roles/openshift_web_console/tasks/install.yml
+++ b/roles/openshift_web_console/tasks/install.yml
@@ -134,15 +134,16 @@
   # Skip if the project didn't exist since there was no previous deployment.
   when: not create_console_project.changed
 
-- name: Verify that the web console is running
-  uri:
-    url: https://webconsole.openshift-web-console.svc/healthz
-    validate_certs: no
-    return_content: yes
-  environment:
-    no_proxy: '*'
-  register: console_health
-  until: "'ok' in console_health.content"
+- name: Verify that the console is running
+  oc_obj:
+    namespace: openshift-web-console
+    kind: deployment
+    state: list
+    name: webconsole
+  register: console_deployment
+  until:
+  - console_deployment.results.results[0].status.readyReplicas is defined
+  - console_deployment.results.results[0].status.readyReplicas > 0
   retries: 60
   delay: 10
   changed_when: false
@@ -150,7 +151,7 @@
   ignore_errors: yes
 
 # Log the result of `oc status`, `oc get pods`, `oc get events`, and `oc logs deployment/webconsole` for troubleshooting failures.
-- when: "'ok' not in console_health.content"
+- when: (console_deployment.results.results[0].status.readyReplicas is not defined) or (console_deployment.results.results[0].status.readyReplicas == 0)
   block:
   - name: Check status in the openshift-web-console namespace
     command: >
@@ -190,4 +191,4 @@
 - name: Report console errors
   fail:
     msg: Console install failed.
-  when: "'ok' not in console_health.content"
+  when: (console_deployment.results.results[0].status.readyReplicas is not defined) or (console_deployment.results.results[0].status.readyReplicas == 0)


### PR DESCRIPTION
Avoids problems where curling the service can fail. 3.9 backport of #8274

/assign @sdodson 