### PR TITLE
container_runtime: do not depend on iptables when using firewalld

### DIFF
--- a/roles/container_runtime/templates/systemcontainercustom.conf.j2
+++ b/roles/container_runtime/templates/systemcontainercustom.conf.j2
@@ -10,7 +10,7 @@ Environment=HTTPS_PROXY={{ docker_http_proxy }}
 {% if "no_proxy" in openshift.common %}
 Environment=NO_PROXY={{ docker_no_proxy }}
 {% endif %}
-{%- if os_firewall_use_firewalld|default(false) %}
+{%- if not (os_firewall_use_firewalld | default(False)) | bool %}
 [Unit]
 Wants=iptables.service
 After=iptables.service


### PR DESCRIPTION
Current logic for `systemcontainercustom.conf` template causes iptables service to be added as a dependency for systemcontainer. This causes the following benign errors.

```
[root@openshift-master-node-1 openshift]# systemctl status iptables
● iptables.service
   Loaded: masked (/dev/null; bad)
   Active: inactive (dead)

May 31 12:14:15 openshift-master-node-1 systemd[1]: Cannot add dependency job for unit iptables.service, ignoring: Unit is masked.
```