### PR TITLE
[BZ 1570583] Install metrics components in different namespace

### DIFF
--- a/roles/openshift_metrics/defaults/main.yaml
+++ b/roles/openshift_metrics/defaults/main.yaml
@@ -60,7 +60,7 @@ openshift_metrics_resolution: 30s
 
 openshift_metrics_master_url: https://kubernetes.default.svc
 openshift_metrics_node_id: nodename
-openshift_metrics_project: openshift-infra
+openshift_metrics_project: openshift-metrics
 
 openshift_metrics_cassandra_pvc_prefix: metrics-cassandra
 openshift_metrics_cassandra_pvc_access: "{{ openshift_metrics_storage_access_modes | default(['ReadWriteOnce']) }}"

--- a/roles/openshift_metrics/tasks/install_metrics.yaml
+++ b/roles/openshift_metrics/tasks/install_metrics.yaml
@@ -1,6 +1,12 @@
 ---
 - include_tasks: pre_install.yaml
 
+- name: Set metrics project
+  oc_project:
+    state: present
+    name: "{{ openshift_metrics_project }}"
+    node_selector: ""
+
 - name: Install Metrics
   include_tasks: "install_{{ include_file }}.yaml"
   with_items:


### PR DESCRIPTION
Metrics components can no longer go in openshift-infra. This commit puts them in openshift-metrics.

@ewolinetz can you please review this?

I am operating under the assumption that additional changes will be needed, but things seem to be working after my initial smoke test.