### PR TITLE
azure - do not tag node images as valid automatically

### DIFF
--- a/playbooks/azure/openshift-cluster/build_base_image.yml
+++ b/playbooks/azure/openshift-cluster/build_base_image.yml
@@ -4,9 +4,6 @@
   tasks:
   - name: provision resource group
     import_tasks: tasks/provision_instance.yml
-    vars:
-      image_prefix: "{{ openshift_azure_input_image_prefix }}"
-      image_resource_group: "{{ openshift_azure_input_image_ns }}"
 
 - hosts: nodes
   tasks:
@@ -34,20 +31,15 @@
 - hosts: localhost
   gather_facts: no
   tasks:
-  - name: get current date/time
-    shell: TZ=Etc/UTC date +%Y%m%d%H%M
-    register: now
-
-  - set_fact:
-      image_name: "{{ openshift_azure_output_image_prefix }}-{{ now.stdout }}"
-
   - name: create image
     import_tasks: tasks/create_image_from_vm.yml
     vars:
       image_resource_group: "{{ openshift_azure_output_image_ns }}"
+      image_name: "{{ openshift_azure_output_image_name }}"
       image_tags:
-        root_image: "{{ (input_image.stdout | from_json).name }}"
+        root_image: "{{ openshift_azure_input_image_name }}"
         kernel: "{{ hostvars[groups['nodes'][0]]['ansible_kernel'] }}"
+        valid: true
 
   - name: create blob
     import_tasks: tasks/create_blob_from_vm.yml

--- a/playbooks/azure/openshift-cluster/build_node_image.yml
+++ b/playbooks/azure/openshift-cluster/build_node_image.yml
@@ -5,8 +5,6 @@
   - name: provision resource group
     import_tasks: tasks/provision_instance.yml
     vars:
-      image_prefix: "{{ openshift_azure_input_image_prefix }}"
-      image_resource_group: "{{ openshift_azure_input_image_ns }}"
       create_args: --data-disk-sizes-gb 128
 
   - set_fact:
@@ -73,22 +71,16 @@
 - hosts: localhost
   gather_facts: no
   tasks:
-  - name: get current date/time
-    shell: TZ=Etc/UTC date +%Y%m%d%H%M
-    register: now
-
   - set_fact:
       openshift_rpm: "{{ hostvars[groups['nodes'][0]]['yum'].results | selectattr('name', 'match', '^(origin|atomic-openshift)$') | first }}"
-
-  - set_fact:
-      image_name: "{{ openshift_azure_output_image_prefix }}-{{ openshift_rpm.version | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}-{{ now.stdout }}"
 
   - name: create image
     import_tasks: tasks/create_image_from_vm.yml
     vars:
       image_resource_group: "{{ openshift_azure_output_image_ns }}"
+      image_name: "{{ openshift_azure_output_image_name }}"
       image_tags:
-        base_image: "{{ (input_image.stdout | from_json).name }}"
+        base_image: "{{ openshift_azure_input_image_name }}"
         kernel: "{{ hostvars[groups['nodes'][0]]['ansible_kernel'] }}"
         openshift: "{{ openshift_rpm.name }}-{{ openshift_rpm.version }}-{{ openshift_rpm.release }}.{{ openshift_rpm.arch }}"
 

--- a/playbooks/azure/openshift-cluster/launch.yml
+++ b/playbooks/azure/openshift-cluster/launch.yml
@@ -5,10 +5,6 @@
   - import_role:
       name: lib_utils
 
-  - name: calculate input image
-    command: az image list -g "{{ openshift_azure_input_image_ns }}" --query "[?starts_with(name, '{{ openshift_azure_input_image_prefix }}-') && tags.valid=='true'] | sort_by(@, &name) | [-1]"
-    register: input_image
-
   - name: create temporary directory
     tempfile:
       state: directory
@@ -51,17 +47,17 @@
       - key: properties.masterProfile.dnsPrefix
         value: "a{{ 16 | lib_utils_oo_random_word }}a"
       - key: properties.masterProfile.imageReference.name
-        value: "{{ (input_image.stdout | from_json).name }}"
+        value: "{{ openshift_azure_input_image_name }}"
       - key: properties.masterProfile.imageReference.resourceGroup
         value: "{{ openshift_azure_input_image_ns }}"
       # agentpool compute
       - key: properties.agentPoolProfiles[0].imageReference.name
-        value: "{{ (input_image.stdout | from_json).name }}"
+        value: "{{ openshift_azure_input_image_name }}"
       - key: properties.agentPoolProfiles[0].imageReference.resourceGroup
         value: "{{ openshift_azure_input_image_ns }}"
       # agentpool infra
       - key: properties.agentPoolProfiles[1].imageReference.name
-        value: "{{ (input_image.stdout | from_json).name }}"
+        value: "{{ openshift_azure_input_image_name }}"
       - key: properties.agentPoolProfiles[1].imageReference.resourceGroup
         value: "{{ openshift_azure_input_image_ns }}"
       # linuxprofile

--- a/playbooks/azure/openshift-cluster/provisioning_vars.yml.example
+++ b/playbooks/azure/openshift-cluster/provisioning_vars.yml.example
@@ -9,14 +9,19 @@ openshift_azure_resource_location: eastus
 # input image resource group
 openshift_azure_input_image_ns: images
 
-# input image prefix, e.g. centos7-root or centos7-base
+# input image prefix, needed by base and node image building playbooks,
+# e.g. centos7-root or centos7-base
 openshift_azure_input_image_prefix:
+
+# complete name of input image, needed by launch.yml playbook,
+# e.g. centos7-3.10-201806071434
+openshift_azure_input_image_name:
 
 # output image resource group
 openshift_azure_output_image_ns: images
 
-# output image prefix, e.g. centos7-base or centos7
-openshift_azure_output_image_prefix:
+# complete name of output image, e.g. centos7-base-201806071412 or centos7-3.10-201806071434
+openshift_azure_output_image_name:
 
 # ssh public key for VMs created by playbook; private key must be accessible to
 # ansible

--- a/playbooks/azure/openshift-cluster/tag_image_as_valid.yml
+++ b/playbooks/azure/openshift-cluster/tag_image_as_valid.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: add valid tag to the image
+    shell: >
+      jsonrtag=$(az resource show -g '{{ openshift_azure_input_image_ns }}' -n '{{ openshift_azure_input_image_name }}' --resource-type 'Microsoft.Compute/images' --query tags);
+      rt=$(echo $jsonrtag | tr -d '"{},' | sed 's/: /=/g');
+      az resource tag --tags $rt 'valid=true' -g '{{ openshift_azure_input_image_ns }}' -n '{{ openshift_azure_input_image_name }}' --resource-type 'Microsoft.Compute/images'

--- a/playbooks/azure/openshift-cluster/tasks/create_image_from_vm.yml
+++ b/playbooks/azure/openshift-cluster/tasks/create_image_from_vm.yml
@@ -31,9 +31,19 @@
     --source "{{ (vm.stdout | from_json).storageProfile.osDisk.managedDisk.id }}"
     --os-type Linux
 
-- name: calculate tags
+- name: get input image tags
+  command: az image show -g "{{ openshift_azure_input_image_ns }}" -n "{{ openshift_azure_input_image_name }}"
+  register: input_image_tags
+
+- name: remove valid tag from input image tags
   set_fact:
-    final_tags: "{{ (input_image.stdout | from_json).tags | combine(image_tags) }}"
+    input_image_tags_no_valid: "{{ {} | combine({item.key: item.value}) }}"
+  when: item.key not in ['valid']
+  with_dict: "{{ (input_image_tags.stdout | from_json).tags }}"
+
+- name: calculate final tags
+  set_fact:
+    final_tags: "{{ input_image_tags_no_valid | combine(image_tags) }}"
 
 - name: tag image
   command: >

--- a/playbooks/azure/openshift-cluster/tasks/provision_instance.yml
+++ b/playbooks/azure/openshift-cluster/tasks/provision_instance.yml
@@ -21,7 +21,7 @@
     address_prefix: 192.168.0.0/24
 
 - name: calculate input image
-  command: az image list -g "{{ image_resource_group }}" --query "[?starts_with(name, '{{ image_prefix }}-') && tags.valid=='true'] | sort_by(@, &name) | [-1]"
+  command: az image list -g "{{ openshift_azure_input_image_ns }}" --query "[?starts_with(name, '{{ openshift_azure_input_image_prefix }}-') && tags.valid=='true'] | sort_by(@, &name) | [-1]"
   register: input_image
 
 - name: create vm


### PR DESCRIPTION
* base images are still tagged as valid
* build_node_image.yml requires `openshift_azure_output_image_name`
  variable
* launch.yml requires `openshift_azure_input_image_name`
  variable
* there is a new `tag_image_as_valid.yml` playbook