### PR TITLE
Remove unused registry-console's imagestream

### DIFF
--- a/roles/openshift_hosted_templates/files/v3.10/enterprise/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.10/enterprise/registry-console.yaml
@@ -78,19 +78,6 @@ objects:
           targetPort: 9090
       selector:
         name: "registry-console"
-  - kind: ImageStream
-    apiVersion: v1
-    metadata:
-      name: registry-console
-      annotations:
-        description: Atomic Registry console
-    spec:
-      tags:
-        - annotations: null
-          from:
-            kind: DockerImage
-            name: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
-          name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
     metadata:

--- a/roles/openshift_hosted_templates/files/v3.10/origin/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.10/origin/registry-console.yaml
@@ -78,19 +78,6 @@ objects:
           targetPort: 9090
       selector:
         name: "registry-console"
-  - kind: ImageStream
-    apiVersion: v1
-    metadata:
-      name: registry-console
-      annotations:
-        description: Atomic Registry console
-    spec:
-      tags:
-        - annotations: null
-          from:
-            kind: DockerImage
-            name: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}
-          name: ${IMAGE_VERSION}
   - kind: OAuthClient
     apiVersion: v1
     metadata:


### PR DESCRIPTION
Currently ImageStream was configured in registry-console template
(registry-console.yaml), however the ImageStream was not used from any
resources. DC in the template refers image on
registry.access.redhat.com or dockerhub.

Hence, this patch removes the unused ImageStream again to avoid
confusion.

Though 6fde298 removed the imagestream once but it was reverted by
09e288c. 09e288c had an issue discussed in bz#1584966, so this commit
delete the imagestream again.