### PR TITLE
Redeploy registry certs only when needed.

### DIFF
--- a/playbooks/openshift-hosted/private/upgrade_poll_and_check_certs.yml
+++ b/playbooks/openshift-hosted/private/upgrade_poll_and_check_certs.yml
@@ -11,7 +11,9 @@
   - openshift_facts
   tasks:
   # Do not perform these tasks when the registry is insecure.  The default registry is insecure in openshift_hosted/defaults/main.yml
-  - when: not (openshift_docker_hosted_registry_insecure | default(False))
+  - when:
+    - openshift_hosted_manage_registry | default(True) | bool
+    - not (openshift_docker_hosted_registry_insecure | default(False)) | bool
     block:
     # we need to migrate customers to the new pattern of pushing to the registry via dns
     # Step 1: verify the certificates have the docker registry service name
@@ -28,5 +30,7 @@
       set_fact:
         openshift_hosted_rollout_certs_and_registry: "{{ cert_output.rc != 0  }}"
 
-- when: (hostvars[groups.oo_first_master.0].openshift_hosted_rollout_certs_and_registry | default(False)) | bool
+- when:
+  - openshift_hosted_manage_registry | default(True) | bool
+  - (hostvars[groups.oo_first_master.0].openshift_hosted_rollout_certs_and_registry | default(False)) | bool
   import_playbook: redeploy-registry-certificates.yml


### PR DESCRIPTION
Makes redeploy-registry-certificates consistent with openshift_hosted_manage_registry=False.

Now certificates are being redeployed always during OCP control plane upgrades,
even when openshift_hosted_manage_registry=False.

Addresses this [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1559248)