### PR TITLE
Wait up to 10 minutes on image pulls

### DIFF
--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -151,8 +151,8 @@
   register: job_result
   until: job_result.finished
   when: control_plane_image.stdout_lines == []
-  retries: 30
-  delay: 10
+  retries: 20
+  delay: 30
   failed_when: false
 
 - name: Check status of etcd image pre-pull
@@ -164,8 +164,8 @@
   - etcd_image_exists is defined
   - "'stdout_lines' in etcd_image_exists"
   - etcd_image_exists.stdout_lines == []
-  retries: 30
-  delay: 10
+  retries: 20
+  delay: 30
   failed_when: false
 
 - name: Start and enable self-hosting node

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -59,6 +59,6 @@
   when:
   - node_image.stdout_lines == []
   - not openshift_is_atomic | bool
-  retries: 30
-  delay: 10
+  retries: 20
+  delay: 30
   failed_when: false

--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -24,8 +24,8 @@
   when:
   - node_image is defined
   - node_image.stdout_lines == []
-  retries: 30
-  delay: 10
+  retries: 20
+  delay: 30
   failed_when: false
 
 - name: Copy node container image to ostree storage


### PR DESCRIPTION
QE reports that with only 5 minute delay they're only successful 80% of the time. Increase the max wait to 10 minutes.
https://bugzilla.redhat.com/show_bug.cgi?id=1585018