### PR TITLE
Upgrade cri-o during node upgrade

### DIFF
--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -20,6 +20,22 @@
   - l_docker_upgrade is defined
   - l_docker_upgrade | bool
 
+- name: Ensure cri-o is updated
+  package:
+    name: cri-o
+    state: latest
+  when:
+  - openshift_use_crio | default(False)
+  register: crio_update
+
+- name: Restart cri-o
+  systemd:
+    name: cri-o
+    state: restarted
+  when:
+  - openshift_use_crio | default(False)
+  - crio_update is changed
+
 - name: install pre-pulled rpms.
   import_tasks: upgrade/rpm_upgrade_install.yml
   when: not openshift_is_atomic | bool

--- a/roles/openshift_node/tasks/upgrade_pre.yml
+++ b/roles/openshift_node/tasks/upgrade_pre.yml
@@ -34,5 +34,12 @@
   - l_docker_upgrade is defined
   - l_docker_upgrade | bool
 
+- name: Stage cri-o updates
+  command: "{{ ansible_pkg_mgr }} install -y --downloadonly cri-o"
+  register: result
+  until: result is succeeded
+  when:
+  - openshift_use_crio | default(False)
+
 - import_tasks: upgrade/rpm_upgrade.yml
   when: not openshift_is_atomic | bool


### PR DESCRIPTION
CRI-O ships in our channels and as such we should be safe to assume that the latest version of cri-o package available will work.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1585062
/cc @mrunalp @michaelgugino 