### PR TITLE
Add extensions to included task file directives

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
@@ -61,7 +61,7 @@
   - name: Place shim commands on the masters before we begin the upgrade
     import_role:
       name: openshift_control_plane
-      tasks_from: static_shim
+      tasks_from: static_shim.yml
 
 # TODO: need to verify settings about the bootstrap configs
 # 1. Does network policy match the master config
@@ -74,11 +74,11 @@
   - name: Ensure the master bootstrap config has bootstrapping config
     import_role:
       name: openshift_node_group
-      tasks_from: upgrade
+      tasks_from: upgrade.yml
   - name: Enable node configuration reconciliation
     import_role:
       name: openshift_node_group
-      tasks_from: sync
+      tasks_from: sync.yml
   roles:
   - role: openshift_sdn
     when: openshift_use_openshift_sdn | default(True) | bool
@@ -89,10 +89,10 @@
   tasks:
   - import_role:
       name: openshift_node
-      tasks_from: upgrade_pre
+      tasks_from: upgrade_pre.yml
   - import_role:
       name: openshift_node
-      tasks_from: upgrade
+      tasks_from: upgrade.yml
 
 - import_playbook: ../upgrade_control_plane.yml
   vars:
@@ -104,7 +104,7 @@
   tasks:
   - import_role:
       name: openshift_web_console
-      tasks_from: remove_old_asset_config
+      tasks_from: remove_old_asset_config.yml
 
 # This is a one time migration. No need to save it in the 3.11.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1565736

--- a/playbooks/openshift-descheduler/private/uninstall.yml
+++ b/playbooks/openshift-descheduler/private/uninstall.yml
@@ -5,4 +5,4 @@
   - name: Run the Descheduler Uninstall Role Tasks
     include_role:
       name: openshift_descheduler
-      tasks_from: uninstall_descheduler
+      tasks_from: uninstall_descheduler.yaml

--- a/playbooks/openshift-grafana/private/uninstall.yml
+++ b/playbooks/openshift-grafana/private/uninstall.yml
@@ -7,4 +7,4 @@
   - name: Run the Grafana Uninstall Role Tasks
     include_role:
       name: openshift_grafana
-      tasks_from: uninstall_grafana
+      tasks_from: uninstall_grafana.yaml

--- a/playbooks/openshift-management/add_many_container_providers.yml
+++ b/playbooks/openshift-management/add_many_container_providers.yml
@@ -29,7 +29,7 @@
   # Include openshift_management for access to filter_plugins.
   - import_role:
       name: openshift_management
-      tasks_from: noop
+      tasks_from: noop.yml
 
   - name: print each result
     debug:

--- a/playbooks/openshift-management/private/add_container_provider.yml
+++ b/playbooks/openshift-management/private/add_container_provider.yml
@@ -5,4 +5,4 @@
   - name: Run the Management Integration Tasks
     import_role:
       name: openshift_management
-      tasks_from: add_container_provider
+      tasks_from: add_container_provider.yml

--- a/playbooks/openshift-management/private/uninstall.yml
+++ b/playbooks/openshift-management/private/uninstall.yml
@@ -5,4 +5,4 @@
   - name: Run the CFME Uninstall Role Tasks
     import_role:
       name: openshift_management
-      tasks_from: uninstall
+      tasks_from: uninstall.yml

--- a/playbooks/openshift-master/private/additional_config.yml
+++ b/playbooks/openshift-master/private/additional_config.yml
@@ -45,7 +45,7 @@
   tasks:
   - import_role:
       name: openshift_cloud_provider
-      tasks_from: vsphere-svc
+      tasks_from: vsphere-svc.yml
     when:
     - openshift_cloudprovider_kind is defined
     - openshift_cloudprovider_kind == 'vsphere'
@@ -56,7 +56,7 @@
   tasks:
   - import_role:
       name: openshift_cloud_provider
-      tasks_from: update-vsphere
+      tasks_from: update-vsphere.yml
     when:
     - openshift_cloudprovider_kind is defined
     - openshift_cloudprovider_kind == 'vsphere'

--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -79,11 +79,11 @@
   - name: Prepare the bootstrap node config on masters for self-hosting
     import_role:
       name: openshift_node_group
-      tasks_from: bootstrap
+      tasks_from: bootstrap.yml
   - name: Have the masters automatically pull their configuration
     import_role:
       name: openshift_node_group
-      tasks_from: bootstrap_config
+      tasks_from: bootstrap_config.yml
 
   roles:
   - role: openshift_master_facts
@@ -106,7 +106,7 @@
   tasks:
   - import_role:
       name: kuryr
-      tasks_from: master
+      tasks_from: master.yaml
     when: openshift_use_kuryr | default(false) | bool
 
   - name: setup bootstrap settings
@@ -137,7 +137,7 @@
     run_once: True
     import_role:
       name: openshift_node_group
-      tasks_from: sync
+      tasks_from: sync.yml
 
 - name: Ensure inventory labels are assigned to masters
   hosts: oo_masters_to_config

--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -96,7 +96,7 @@
   tasks:
   - import_role:
       name: openshift_cloud_provider
-      tasks_from: vsphere-svc
+      tasks_from: vsphere-svc.yml
     when:
     - openshift_cloudprovider_kind is defined
     - openshift_cloudprovider_kind == 'vsphere'
@@ -118,12 +118,12 @@
 
   - import_role:
       name: openshift_control_plane
-      tasks_from: upgrade
+      tasks_from: upgrade.yml
 
   - name: update vsphere provider master config
     import_role:
       name: openshift_cloud_provider
-      tasks_from: update-vsphere
+      tasks_from: update-vsphere.yml
     when:
     - openshift_cloudprovider_kind is defined
     - openshift_cloudprovider_kind == 'vsphere'

--- a/playbooks/openshift-node-problem-detector/private/uninstall.yml
+++ b/playbooks/openshift-node-problem-detector/private/uninstall.yml
@@ -7,4 +7,4 @@
   - name: Run the Node Problem Detector Uninstall Role Tasks
     include_role:
       name: openshift_node_problem_detector
-      tasks_from: uninstall
+      tasks_from: uninstall.yaml

--- a/playbooks/openshift-node/private/configure_bootstrap.yml
+++ b/playbooks/openshift-node/private/configure_bootstrap.yml
@@ -4,13 +4,13 @@
   tasks:
   - import_role:
       name: openshift_node
-      tasks_from: bootstrap
+      tasks_from: bootstrap.yml
   - import_role:
       name: openshift_node_group
-      tasks_from: bootstrap
+      tasks_from: bootstrap.yml
   - name: Have the nodes automatically pull their configuration
     import_role:
       name: openshift_node_group
-      tasks_from: bootstrap_config
+      tasks_from: bootstrap_config.yml
   - set_fact:
       openshift_is_bootstrapped: True

--- a/playbooks/openshift-prometheus/private/uninstall.yml
+++ b/playbooks/openshift-prometheus/private/uninstall.yml
@@ -5,4 +5,4 @@
   - name: Run the Prometheus Uninstall Role Tasks
     include_role:
       name: openshift_prometheus
-      tasks_from: uninstall_prometheus
+      tasks_from: uninstall_prometheus.yaml

--- a/roles/nuage_master/tasks/etcd_certificates.yml
+++ b/roles/nuage_master/tasks/etcd_certificates.yml
@@ -3,7 +3,7 @@
   become: yes
   include_role:
     name: etcd
-    tasks_from: client_certificates
+    tasks_from: client_certificates.yml
   vars:
     etcd_cert_prefix: nuageEtcd-
     etcd_cert_config_dir: "{{ cert_output_dir }}"

--- a/roles/openshift_management/tasks/storage/nfs.yml
+++ b/roles/openshift_management/tasks/storage/nfs.yml
@@ -7,14 +7,14 @@
     - name: Include the NFS Setup role tasks
       import_role:
         role: openshift_nfs
-        tasks_from: setup
+        tasks_from: setup.yml
       vars:
         l_nfs_base_dir: "{{ openshift_management_storage_nfs_base_dir }}"
 
     - name: Create the App export
       import_role:
         role: openshift_nfs
-        tasks_from: create_export
+        tasks_from: create_export.yml
       vars:
         l_nfs_base_dir: "{{ openshift_management_storage_nfs_base_dir }}"
         l_nfs_export_config: "{{ __openshift_management_flavor_short }}"
@@ -24,7 +24,7 @@
     - name: Create the DB export
       import_role:
         role: openshift_nfs
-        tasks_from: create_export
+        tasks_from: create_export.yml
       vars:
         l_nfs_base_dir: "{{ openshift_management_storage_nfs_base_dir }}"
         l_nfs_export_config: "{{ __openshift_management_flavor_short }}"

--- a/roles/openshift_nfs/tasks/create_export.yml
+++ b/roles/openshift_nfs/tasks/create_export.yml
@@ -5,7 +5,7 @@
 #
 # import_role:
 #   role: openshift_nfs
-#   tasks_from: create_export
+#   tasks_from: create_export.yml
 # vars:
 #   l_nfs_base_dir: Base dir to exports
 #   l_nfs_export_config: Name to prefix the .exports file with


### PR DESCRIPTION
Please use extensions when including task files.  It makes it much
easier to support the code, such as trying to find all instances where a
file is included.

For finding offending lines, regex: 'tasks_from: .+(?<!ml)$'