### PR TITLE
Remove openshift_dns_ip configuration, not valid in 3.10

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -795,15 +795,6 @@ debug_level=2
 # interface other than the default network interface.
 #openshift_set_node_ip=True
 
-# Configure dnsIP in the node config.
-# This setting overrides the bind IP address used by each node's dnsmasq.
-# By default, this value is set to the IP which ansible uses to connect to the node.
-# Only update this variable if you need to bind dnsmasq on a different interface
-#
-# Example:
-# [nodes]
-# node.example.com openshift_dns_ip=172.30.0.1
-
 # Configure node kubelet arguments. pods-per-core is valid in OpenShift Origin 1.3 or OpenShift Container Platform 3.3 and later.
 #openshift_node_kubelet_args={'pods-per-core': ['10'], 'max-pods': ['250'], 'image-gc-high-threshold': ['85'], 'image-gc-low-threshold': ['80']}
 

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -22,8 +22,6 @@ openshift_oreg_url_default_dict:
 openshift_oreg_url_default: "{{ openshift_oreg_url_default_dict[openshift_deployment_type] }}"
 oreg_url_node: "{{ oreg_url | default(openshift_oreg_url_default) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
 
-openshift_dns_ip: "{{ ansible_default_ipv4['address'] }}"
-
 openshift_node_env_vars: {}
 
 # Create list of 'k=v' pairs.

--- a/roles/openshift_node/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node/files/networkmanager/99-origin-dns.sh
@@ -13,8 +13,6 @@
 #   8053 to avoid conflicts on port 53 and open port 8053 in the firewall
 # - Drop this script in /etc/NetworkManager/dispatcher.d/
 # - systemctl restart NetworkManager
-# - Configure node-config.yaml to set dnsIP: to the ip address of this
-#   node
 #
 # Test it:
 # host kubernetes.default.svc.cluster.local

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 dnsBindAddress: 127.0.0.1:53
 dnsRecursiveResolvConf: /etc/origin/node/resolv.conf
 dnsDomain: {{ openshift.common.dns_domain }}
-dnsIP: {{ openshift_dns_ip }}
+dnsIP: 0.0.0.0
 dockerConfig:
   execHandlerName: ""
 iptablesSyncPeriod: "{{ openshift_node_iptables_sync_period }}"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1586368