### PR TITLE
Bug 1586366 - Use include_tasks for dynamic task file includes

### DIFF
--- a/roles/openshift_cloud_provider/tasks/main.yml
+++ b/roles/openshift_cloud_provider/tasks/main.yml
@@ -10,5 +10,7 @@
     path: "{{ openshift.common.config_base }}/cloudprovider"
     state: directory
 
+# Any files included here must use include_tasks instead of import_tasks due to
+# the dynamic nature of include_tasks
 - name: include the defined cloud provider files
   include_tasks: "{{ openshift_cloudprovider_kind }}.yml"

--- a/roles/openshift_cloud_provider/tasks/vsphere.yml
+++ b/roles/openshift_cloud_provider/tasks/vsphere.yml
@@ -11,11 +11,11 @@
   - openshift_cloudprovider_vsphere_datastore is defined
 
 - name: Configure vsphere svc account
-  import_tasks: vsphere-svc.yml
+  include_tasks: vsphere-svc.yml
   when:
   - openshift_version | version_compare('3.9', '>=')
   - inventory_hostname == openshift_master_hosts[0]
 
 - name: Modify controller args
-  import_tasks: update-vsphere.yml
+  include_tasks: update-vsphere.yml
   notify: restart master


### PR DESCRIPTION
Any task files which are dynamically included must use include_tasks
instead of import_tasks due to the dynamic nature of the include.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1586366