### PR TITLE
Ensure repos only run during prerequisites.yml

### DIFF
--- a/playbooks/init/repos.yml
+++ b/playbooks/init/repos.yml
@@ -1,8 +1,8 @@
 ---
-# l_scale_up_hosts may be passed in via prerequisites.yml during scaleup plays.
+# l_repo_hosts is passed in via prerequisites.yml.
 
 - name: Setup yum repositories for all hosts
-  hosts: "{{ l_scale_up_hosts | default('oo_all_hosts') }}"
+  hosts: "{{ l_repo_hosts | default('all:!all') }}"
   gather_facts: no
   tasks:
   - name: subscribe instances to Red Hat Subscription Manager

--- a/playbooks/prerequisites.yml
+++ b/playbooks/prerequisites.yml
@@ -4,6 +4,7 @@
 - import_playbook: init/main.yml
   vars:
     l_install_base_packages: True
+    l_repo_hosts: "{{ l_scale_up_hosts | default('oo_all_hosts') }}"
 
 - import_playbook: init/validate_hostnames.yml
   when: not (skip_validate_hostnames | default(False))


### PR DESCRIPTION
Recent reordering of plays causes repo play to run
against oo_all_hosts during operation playbooks, such
as playbooks/openshift-logging/config.yml.

This commit refactors host groups to ensure that the
repos are only called during prerequisites.yml and
scaleup plays.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1585967