### PR TITLE
Release 3.7 fix svc

### DIFF
--- a/roles/openshift_service_catalog/tasks/start_api_server.yml
+++ b/roles/openshift_service_catalog/tasks/start_api_server.yml
@@ -10,7 +10,7 @@
 # wait to see that the apiserver is available
 - name: wait for api server to be ready
   uri:
-    url: https://apiserver.kube-service-catalog.svc/healthz
+    url: https://apiserver.kube-service-catalog.svc.cluster.local/healthz
     validate_certs: no
     return_content: yes
   environment:


### PR DESCRIPTION
This fixes issue in deployments where people  have custom /etc/resolvconf so .svc can be defaulted to other than cluster.local resulting in verifying service catalog failing