### PR TITLE
Add placeholder for openshift_node_group play

### DIFF
--- a/playbooks/openshift-master/openshift_node_group.yml
+++ b/playbooks/openshift-master/openshift_node_group.yml
@@ -1,0 +1,6 @@
+---
+- name: Setup node-group configmaps
+  hosts: oo_first_master
+  tasks:
+  - debug:
+      msg: "openshift_node_group play ran"


### PR DESCRIPTION
This commit adds a temporary place holder to allow updating
CI jobs without breaking them.