### PR TITLE
Enable container_manage_crgroup sebool

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -52,6 +52,15 @@
     sysctl_file: "/etc/sysctl.d/99-openshift.conf"
     reload: yes
 
+# Required in some selinux policy versions see
+# https://bugzilla.redhat.com/show_bug.cgi?id=1587825
+# https://bugzilla.redhat.com/show_bug.cgi?id=1549765
+- name: Setting sebool container_manage_cgroup
+  seboolean:
+    name: container_manage_cgroup
+    state: yes
+    persistent: yes
+
 - import_tasks: registry_auth.yml
 
 - name: include standard node config


### PR DESCRIPTION
Followup to #8423 this seems like something that we should enable regardless of whether management is enabled.

TODO: need to delete the code in the referenced pr

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1587825