### PR TITLE
Set openshift_node_group_name in OpenStack inventory

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -56,15 +56,6 @@ In `inventory/group_vars/all.yml`:
   * `openshift_openstack_lb_hostname` Defaults to `lb`.
   * `openshift_openstack_etcd_hostname` Defaults to `etcd`.
 * `openshift_openstack_external_network_name` OpenStack network providing external connectivity.
-* `openshift_openstack_cluster_node_labels` Custom labels for openshift cluster node groups; currently supports app and infra node groups.
-The default value of this variable sets `region: primary` to app nodes and `region: infra` to infra nodes. An example of setting a customized label:
-
-```
-openshift_openstack_cluster_node_labels:
-  app:
-    mylabel: myvalue
-```
-
 * `openshift_openstack_provision_user_commands` Allows users to execute shell commands via cloud-init for all of the created Nova servers in the Heat stack, before they are available for SSH connections. Note that you should use [custom Ansible playbooks](./post-install.md#run-custom-post-provision-actions) whenever possible. User specified shell commands for cloud-init need to be either strings or lists:
 
 ```
@@ -386,18 +377,28 @@ On the other hand, there is a multi driver support to enable hybrid
 deployments with different pools drivers. In order to enable the kuryr
 `multi-pool` driver support, we need to also tag the nodes with their
 corresponding `pod_vif` labels so that the right kuryr pool driver is used
-for each VM/node. To do that, uncomment:
+for each VM/node.
+
+To do that, set this in `inventory/group_vars/OSEv3.yml`:
 
 ```yaml
 kuryr_openstack_pool_driver: multi
 
-openshift_openstack_cluster_node_labels:
-  app:
-    region: primary
-    pod_vif: nested-vlan
-  infra:
-    region: infra
-    pod_vif: nested-vlan
+openshift_node_groups:
+  - name: node-config-master
+    labels:
+      - 'node-role.kubernetes.io/master=true'
+    edits: []
+  - name: node-config-infra
+    labels:
+      - 'node-role.kubernetes.io/infra=true'
+      - 'pod_vif=nested-vlan'
+    edits: []
+  - name: node-config-compute
+    labels:
+      - 'node-role.kubernetes.io/compute=true'
+      - 'pod_vif=nested-vlan'
+    edits: []
 ```
 
 

--- a/playbooks/openstack/inventory.py
+++ b/playbooks/openstack/inventory.py
@@ -9,7 +9,6 @@ environment.
 
 from __future__ import print_function
 
-from collections import Mapping
 import json
 import os
 

--- a/playbooks/openstack/inventory.py
+++ b/playbooks/openstack/inventory.py
@@ -105,13 +105,8 @@ def _get_hostvars(server, docker_storage_mountpoints):
     if server.metadata['host-type'] == 'cns':
         hostvars['glusterfs_devices'] = ['/dev/nvme0n1']
 
-    node_labels = server.metadata.get('node_labels')
-    # NOTE(shadower): the node_labels value must be a dict not string
-    if not isinstance(node_labels, Mapping):
-        node_labels = json.loads(node_labels)
-
-    if node_labels:
-        hostvars['openshift_node_labels'] = node_labels
+    group_name = server.metadata.get('openshift_node_group_name')
+    hostvars['openshift_node_group_name'] = group_name
 
     # check for attached docker storage volumes
     if 'os-extended-volumes:volumes_attached' in server:

--- a/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -21,7 +21,6 @@ openshift_master_default_subdomain: "apps.{{ (openshift_openstack_clusterid|trim
 # domain the OpenShift cluster is configured, though.
 openshift_master_cluster_public_hostname: "console.{{ (openshift_openstack_clusterid|trim == '') | ternary(openshift_openstack_public_dns_domain, openshift_openstack_clusterid + '.' + openshift_openstack_public_dns_domain) }}"
 
-osm_default_node_selector: 'region=primary'
 
 openshift_hosted_router_wait: True
 openshift_hosted_registry_wait: True

--- a/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -26,6 +26,27 @@ osm_default_node_selector: 'region=primary'
 openshift_hosted_router_wait: True
 openshift_hosted_registry_wait: True
 
+
+## Kuryr label configuration
+#kuryr_openstack_pool_driver: multi
+#
+#openshift_node_groups:
+#  - name: node-config-master
+#    labels:
+#      - 'node-role.kubernetes.io/master=true'
+#    edits: []
+#  - name: node-config-infra
+#    labels:
+#      - 'node-role.kubernetes.io/infra=true'
+#      - 'pod_vif=nested-vlan'
+#    edits: []
+#  - name: node-config-compute
+#    labels:
+#      - 'node-role.kubernetes.io/compute=true'
+#      - 'pod_vif=nested-vlan'
+#    edits: []
+
+
 ## Openstack credentials
 #openshift_cloudprovider_kind: openstack
 #openshift_cloudprovider_openstack_auth_url: "{{ lookup('env','OS_AUTH_URL') }}"

--- a/playbooks/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/all.yml
@@ -184,19 +184,6 @@ ansible_user: openshift
 # NOTE: this is for testing only! Your data will be gone once the VM disappears!
 # openshift_openstack_ephemeral_volumes: false
 
-# # OpenShift node labels
-# # - in order to customise node labels for app and/or infra group, set the
-# #   openshift_openstack_cluster_node_labels variable
-# # - to enable the multi-pool driver support at Kuryr the driver for the pod
-#  #  pod vif need to be added as a node label
-#openshift_openstack_cluster_node_labels:
-#  app:
-#    region: primary
-#    pod_vif: nested-vlan
-#  infra:
-#    region: infra
-#    pod_vif: nested-vlan
-
 ## cloud config
 openshift_openstack_disable_root: true
 openshift_openstack_user: openshift

--- a/roles/openshift_openstack/defaults/main.yml
+++ b/roles/openshift_openstack/defaults/main.yml
@@ -16,12 +16,6 @@ openshift_openstack_use_lbaas_load_balancer: false
 openshift_openstack_lbaasv2_provider: Octavia
 openshift_openstack_use_vm_load_balancer: false
 
-openshift_openstack_cluster_node_labels:
-  app:
-    region: primary
-  infra:
-    region: infra
-
 openshift_openstack_install_debug_packages: false
 openshift_openstack_required_packages:
   - NetworkManager

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -650,6 +650,7 @@ resources:
                 k8s_type: masters
                 cluster_id: {{ openshift_openstack_full_dns_domain }}
           type:        master
+          openshift_node_group_name: node-config-master
           image:       {{ openshift_openstack_master_image }}
           flavor:      {{ openshift_openstack_master_flavor }}
           key_name:    {{ openshift_openstack_keypair_name }}
@@ -738,10 +739,7 @@ resources:
                 cluster_id: {{ openshift_openstack_full_dns_domain }}
           type:        node
           subtype:     app
-          node_labels:
-{% for k, v in openshift_openstack_cluster_node_labels.app.items() %}
-            {{ k|e }}: {{ v|e }}
-{% endfor %}
+          openshift_node_group_name: node-config-compute
           image:       {{ openshift_openstack_node_image }}
           flavor:      {{ openshift_openstack_node_flavor }}
           key_name:    {{ openshift_openstack_keypair_name }}
@@ -810,10 +808,7 @@ resources:
                 cluster_id: {{ openshift_openstack_full_dns_domain }}
           type:        node
           subtype:     infra
-          node_labels:
-{% for k, v in openshift_openstack_cluster_node_labels.infra.items() %}
-            {{ k|e }}: {{ v|e }}
-{% endfor %}
+          openshift_node_group_name: node-config-infra
           image:       {{ openshift_openstack_infra_image }}
           flavor:      {{ openshift_openstack_infra_flavor }}
           key_name:    {{ openshift_openstack_keypair_name }}

--- a/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
@@ -159,10 +159,10 @@ parameters:
       - range: { min: 1, max: 1024 }
         description: must be between 1 and 1024 Gb.
 
-  node_labels:
-    type: json
-    description: OpenShift Node Labels
-    default: {"region": "default" }
+  openshift_node_group_name:
+    type: string
+    default: ''
+    description: The openshift node group name for this server.
 
   scheduler_hints:
     type: json
@@ -240,7 +240,7 @@ resources:
         clusterid: { get_param: cluster_id }
         host-type: { get_param: type }
         sub-host-type:    { get_param: subtype }
-        node_labels: { get_param: node_labels }
+        openshift_node_group_name: { get_param: openshift_node_group_name }
 {% if openshift_openstack_dns_nameservers %}
         openshift_hostname: { get_param: name }
 {% endif %}


### PR DESCRIPTION
Since commit a8047aa305c8ebe97bfa79b16f93f0aded45e61c, each node must have the
`openshift_node_group_name` defined. In addition, `openshift_node_labels` has
been removed in favour of `openshift_node_groups`.

This updates our inventory to set the right group as well as the documentation
on how to set the Kuryr labels now.

Fixes #8683