### PR TITLE
Remove podman from install it creates problems

### DIFF
--- a/roles/container_runtime/tasks/package_crio.yml
+++ b/roles/container_runtime/tasks/package_crio.yml
@@ -40,7 +40,6 @@
     crio_pkgs:
       - "cri-o"
       - "cri-tools"
-      - "podman"
 
 - name: Remove CRI-O default configuration files
   file:


### PR DESCRIPTION
It was requested in https://bugzilla.redhat.com/show_bug.cgi?id=1583591
and I added it in #8618 while trying to unblock the porting of master shims to cri-tools but it's not necessary there either.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1589013
