### PR TITLE
Bug 1586197 - Increase async timeout

### DIFF
--- a/roles/openshift_node/tasks/upgrade/restart.yml
+++ b/roles/openshift_node/tasks/upgrade/restart.yml
@@ -34,7 +34,7 @@
   service:
     name: "{{ openshift_service_type }}-node"
     state: started
-  async: 1
+  async: 100
   poll: 0
   register: node_service
   failed_when: false


### PR DESCRIPTION
The async timeout was set to 1 second which would cause the job to terminate and then not be available for the status check later.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1586197