### PR TITLE
Staticly configure dnsmasq to send cluster-local to 127.0.0.1

### DIFF
--- a/roles/openshift_node/templates/origin-dns.conf.j2
+++ b/roles/openshift_node/templates/origin-dns.conf.j2
@@ -13,4 +13,5 @@ bind-dynamic
 {% for interface in openshift_node_dnsmasq_except_interfaces %}
 except-interface={{ interface }}
 {% endfor %}
+server=/{{ openshift.common.dns_domain }}/127.0.0.1
 # End of config


### PR DESCRIPTION
This was removed because the node should configure this via dbus but we're seeing signs that this isn't working for one reason or another.
