### PR TITLE
Bug 1589015 - Switch to rolling deployment for web console

### DIFF
--- a/roles/openshift_web_console/files/console-template.yaml
+++ b/roles/openshift_web_console/files/console-template.yaml
@@ -37,7 +37,10 @@ objects:
   spec:
     replicas: "${{REPLICA_COUNT}}"
     strategy:
-      type: Recreate
+      type: RollingUpdate
+      rollingUpdate:
+        # behave like a recreate deployment, but don't wait for pods to terminate
+        maxUnavailable: 100%
     template:
       metadata:
         name: webconsole


### PR DESCRIPTION
Switch to a RollingUpdate deployment strategy for the web console. This
avoids the rollout getting blocked when a pod doesn't terminate.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1589015

/assign @sdodson 