### PR TITLE
Fix flaky use of `oc process`

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
+++ b/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
@@ -34,7 +34,7 @@
 
 - name: Apply the cluster monitoring operator template
   shell: >
-    {{ openshift_client_binary }} process -f "{{ mktemp.stdout 	}}/{{ item }}"
+    {{ openshift_client_binary }} process -n openshift-monitoring -f "{{ mktemp.stdout 	}}/{{ item }}"
     --param OPERATOR_IMAGE="{{ openshift_cluster_monitoring_operator_image }}"
     --param PROMETHEUS_OPERATOR_IMAGE="{{ openshift_cluster_monitoring_operator_prometheus_operator_repo }}"
     --param ALERTMANAGER_IMAGE="{{ openshift_cluster_monitoring_operator_alertmanager_repo }}"

--- a/roles/openshift_monitor_availability/tasks/install_monitor_app_create.yaml
+++ b/roles/openshift_monitor_availability/tasks/install_monitor_app_create.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Apply the app template
   shell: >
-    {{ openshift_client_binary }} process -f "{{ mktemp.stdout }}/monitor-app-create.yaml"
+    {{ openshift_client_binary }} process -n openshift-monitor-availability -f "{{ mktemp.stdout }}/monitor-app-create.yaml"
     --param IMAGE="{{ openshift_monitor_app_create_image }}"
     --param RUN_INTERVAL="{{ openshift_monitor_app_create_run_interval }}"
     --param TIMEOUT="{{ openshift_monitor_app_create_timeout }}"


### PR DESCRIPTION
Using `oc process` without an explicit namespace argument makes the call reliant
on the oc configuration context, which can change at runtime, leading to
indeterministic behavior.

Fix this flakiness by specifying a namespace for `oc process` calls.