### PR TITLE
Set openshift_node_group_name for AWS host groups.

### DIFF
--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -121,21 +121,21 @@ openshift_aws_elb_dict:
 openshift_aws_node_group_config_master_volumes:
 - device_name: /dev/sda1
   volume_size: 100
-  device_type: gp2
+  volume_type: gp2
   delete_on_termination: False
 - device_name: /dev/sdb
   volume_size: 100
-  device_type: gp2
+  volume_type: gp2
   delete_on_termination: False
 
 openshift_aws_node_group_config_node_volumes:
 - device_name: /dev/sda1
   volume_size: 100
-  device_type: gp2
+  volume_type: gp2
   delete_on_termination: True
 - device_name: /dev/sdb
   volume_size: 100
-  device_type: gp2
+  volume_type: gp2
   delete_on_termination: True
 
 # build_instance_tags is a custom filter in role lib_utils

--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -154,7 +154,7 @@ openshift_aws_master_group:
   group: master
   tags:
     host-type: master
-    sub-host-type: default
+    sub-host-type: master
     runtime: docker
 
 openshift_aws_node_groups:
@@ -171,6 +171,11 @@ openshift_aws_node_groups:
     host-type: node
     sub-host-type: infra
     runtime: docker
+
+openshift_aws_node_group_mappings:
+  master: 'node-config-master'
+  compute: 'node-config-compute'
+  infra: 'node-config-infra'
 
 openshift_aws_created_asgs: []
 openshift_aws_current_asgs: []

--- a/roles/openshift_aws/tasks/setup_master_group.yml
+++ b/roles/openshift_aws/tasks/setup_master_group.yml
@@ -26,6 +26,7 @@
     groups: "{{ openshift_aws_masters_groups }}"
     name: "{{ item.public_dns_name }}"
     hostname: "{{ openshift_aws_clusterid }}-master-{{ item.instance_id[:-5] }}"
+    openshift_node_group_name: "{{ openshift_aws_node_group_mappings[item.tags['sub-host-type']] }}"
   with_items: "{{ instancesout.instances }}"
 
 - name: wait for ssh to become available

--- a/roles/openshift_aws/tasks/setup_scale_group_facts.yml
+++ b/roles/openshift_aws/tasks/setup_scale_group_facts.yml
@@ -46,4 +46,5 @@
     ansible_ssh_host: "{{ item.public_dns_name }}"
     name: "{{ item.public_dns_name }}"
     hostname: "{{ item.public_dns_name }}"
+    openshift_node_group_name: "{{ openshift_aws_node_group_mappings[item.tags['sub-host-type']] }}"
   with_items: "{{ qinstances.instances }}"


### PR DESCRIPTION
* Set `openshift_node_group_name` for AWS host groups.
  * `openshift_aws_node_group_mappings` based on `sub-host-type` instance tag.
  * Changed master group `sub-host-type` from `default` to `master`.
* Switch `device_type` to `volume_type` for launch config.