### PR TITLE
Add prometheus port annotation for Grafana service

### DIFF
--- a/roles/openshift_grafana/tasks/install_grafana.yaml
+++ b/roles/openshift_grafana/tasks/install_grafana.yaml
@@ -61,6 +61,7 @@
     annotations:
       prometheus.io/scrape: "true"
       prometheus.io/scheme: https
+      prometheus.io/port: "{{ grafana_service_targetport }}"
       service.alpha.openshift.io/serving-cert-secret-name: grafana-tls
     ports:
     - name: grafana


### PR DESCRIPTION
All three ports were being scraped by Prometheus but only one worked.

Related to https://github.com/openshift/openshift-ansible/issues/7986