### PR TITLE
Azure: calculate input image for base and node image 3.9

### DIFF
--- a/playbooks/azure/openshift-cluster/build_base_image.yml
+++ b/playbooks/azure/openshift-cluster/build_base_image.yml
@@ -2,6 +2,10 @@
 - hosts: localhost
   gather_facts: no
   tasks:
+  - name: calculate input image
+    command: az image list -g "{{ openshift_azure_input_image_ns }}" --query "[?starts_with(name, '{{ openshift_azure_input_image_prefix }}-') && tags.valid=='true'] | sort_by(@, &name) | [-1]"
+    register: input_image
+
   - name: provision resource group
     import_tasks: tasks/provision_instance.yml
 
@@ -37,7 +41,7 @@
       image_resource_group: "{{ openshift_azure_output_image_ns }}"
       image_name: "{{ openshift_azure_output_image_name }}"
       image_tags:
-        root_image: "{{ openshift_azure_input_image_name }}"
+        root_image: "{{ (input_image.stdout | from_json).name }}"
         kernel: "{{ hostvars[groups['nodes'][0]]['ansible_kernel'] }}"
         valid: true
 

--- a/playbooks/azure/openshift-cluster/build_node_image.yml
+++ b/playbooks/azure/openshift-cluster/build_node_image.yml
@@ -2,6 +2,10 @@
 - hosts: localhost
   gather_facts: no
   tasks:
+  - name: calculate input image
+    command: az image list -g "{{ openshift_azure_input_image_ns }}" --query "[?starts_with(name, '{{ openshift_azure_input_image_prefix }}-') && tags.valid=='true'] | sort_by(@, &name) | [-1]"
+    register: input_image
+
   - name: provision resource group
     import_tasks: tasks/provision_instance.yml
     vars:
@@ -80,7 +84,7 @@
       image_resource_group: "{{ openshift_azure_output_image_ns }}"
       image_name: "{{ openshift_azure_output_image_name }}"
       image_tags:
-        base_image: "{{ openshift_azure_input_image_name }}"
+        base_image: "{{ (input_image.stdout | from_json).name }}"
         kernel: "{{ hostvars[groups['nodes'][0]]['ansible_kernel'] }}"
         openshift: "{{ openshift_rpm.name }}-{{ openshift_rpm.version }}-{{ openshift_rpm.release }}.{{ openshift_rpm.arch }}"
 

--- a/playbooks/azure/openshift-cluster/tasks/create_image_from_vm.yml
+++ b/playbooks/azure/openshift-cluster/tasks/create_image_from_vm.yml
@@ -32,7 +32,7 @@
     --os-type Linux
 
 - name: get input image tags
-  command: az image show -g "{{ openshift_azure_input_image_ns }}" -n "{{ openshift_azure_input_image_name }}"
+  command: az image show -g "{{ openshift_azure_input_image_ns }}" -n "{{ (input_image.stdout | from_json).name }}"
   register: input_image_tags
 
 - name: remove valid tag from input image tags

--- a/playbooks/azure/openshift-cluster/tasks/provision_instance.yml
+++ b/playbooks/azure/openshift-cluster/tasks/provision_instance.yml
@@ -18,10 +18,6 @@
     virtual_network: vnet
     address_prefix: 192.168.0.0/24
 
-- name: calculate input image
-  command: az image list -g "{{ openshift_azure_input_image_ns }}" --query "[?starts_with(name, '{{ openshift_azure_input_image_prefix }}-') && tags.valid=='true'] | sort_by(@, &name) | [-1]"
-  register: input_image
-
 - name: create vm
   command: >
     az vm create


### PR DESCRIPTION
Input images for base and node image building playbooks (root and base image
respectively) can still be automatically computed. This is a benefit because
these two images (root and base) are built on a weekly bases in separate jobs.
Determining the input image name during ci job is possible, but requires
invoking the `az` command, thus must be called from docker container, which
adds unnecessary complexity to the mentioned ci job.

This PR computes input image only once during base and node image build
playbook and uses that output for `provision_instance` and
`create_image_from_vm` tasks files.