### PR TITLE
Fix sanity_checks typos

### DIFF
--- a/roles/lib_utils/action_plugins/sanity_checks.py
+++ b/roles/lib_utils/action_plugins/sanity_checks.py
@@ -69,8 +69,10 @@ REMOVED_VARIABLES = (
     ('openshift_prometheus_image_version', 'openshift_prometheus_image'),
     ('openshift_prometheus_proxy_image_prefix', 'openshift_prometheus_proxy_image'),
     ('openshift_prometheus_proxy_image_version', 'openshift_prometheus_proxy_image'),
-    ('openshift_prometheus_altermanager_image_prefix', 'openshift_prometheus_altermanager_image'),
-    ('openshift_prometheus_altermanager_image_version', 'openshift_prometheus_altermanager_image'),
+    ('openshift_prometheus_altermanager_image_prefix', 'openshift_prometheus_alertmanager_image'),
+    # A typo was introduced at some point, need to warn for this older version.
+    ('openshift_prometheus_altermanager_image_prefix', 'openshift_prometheus_alertmanager_image'),
+    ('openshift_prometheus_alertmanager_image_version', 'openshift_prometheus_alertmanager_image'),
     ('openshift_prometheus_alertbuffer_image_prefix', 'openshift_prometheus_alertbuffer_image'),
     ('openshift_prometheus_alertbuffer_image_version', 'openshift_prometheus_alertbuffer_image'),
     ('openshift_prometheus_node_exporter_image_prefix', 'openshift_prometheus_node_exporter_image'),


### PR DESCRIPTION
Fix typos to for openshift_prometheus_altermanager_image_prefix,
should be openshift_prometheus_alertmanager_image_prefix.

Also, 'altermanager' was used in some cases in previous releases,
need to check for presence and warn.