### PR TITLE
Fix ansible_service_broker role, needs openshift_facts

### DIFF
--- a/roles/ansible_service_broker/meta/main.yml
+++ b/roles/ansible_service_broker/meta/main.yml
@@ -12,5 +12,6 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
+- role: openshift_facts
 - role: lib_utils
 - role: lib_openshift


### PR DESCRIPTION
The ASB role depends on openshift_master_default_subdomain which is
defaulted in openshift_facts.