### PR TITLE
Confirm service status by ansible module

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -24,14 +24,15 @@
   - name: set currently installed version
     set_fact:
       openshift_currently_installed_version: "{{ openshift_master_installed_version }}"
-  - name: Check if iptables is running
-    command: systemctl status iptables
-    changed_when: false
-    failed_when: false
-    register: service_iptables_status
-    check_mode: no
+
+  - name: Get iptable service details
+    systemd:
+      name: "iptables"
+    ignore_errors: true
+    register: iptables_service
 
   - name: Set fact os_firewall_use_firewalld FALSE for iptables
     set_fact:
       os_firewall_use_firewalld: false
-    when: service_iptables_status.rc != 0
+    when:
+    - iptables_service.status.ActiveState != 'active'

--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -29,8 +29,9 @@
     changed_when: false
     failed_when: false
     register: service_iptables_status
+    check_mode: no
 
   - name: Set fact os_firewall_use_firewalld FALSE for iptables
     set_fact:
       os_firewall_use_firewalld: false
-    when: "'Active: active' in service_iptables_status.stdout"
+    when: service_iptables_status.rc != 0

--- a/roles/contiv_facts/tasks/rpm.yml
+++ b/roles/contiv_facts/tasks/rpm.yml
@@ -7,16 +7,15 @@
   check_mode: no
 
 - name: RPM | Determine if firewalld enabled
-  command: "systemctl status firewalld.service"
+  systemd:
+    name: "firewalld"
+  ignore_errors: true
   register: ss
-  changed_when: false
-  failed_when: false
-  check_mode: no
 
 - name: Set the contiv_has_firewalld fact
   set_fact:
     contiv_has_firewalld: true
-  when: s.rc == 0 and ss.rc == 0
+  when: s.rc == 0 and ss.status.ActiveState == 'active'
 
 - name: Determine if iptables-services installed
   command: "rpm -q iptables-services"


### PR DESCRIPTION
Currently `upgrades/init.yml` checks iptables status by checking
if `"'Active: active' in service_iptables_status.stdout"` is in
the command output of `systemctl status iptables`. It is not usual and
should be consistent with other codes in the same playbook.

This patch changes iptable service check by ansible module.