### PR TITLE
Upgrade: check for node configmaps only if openshift is already 3.10+

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -15,6 +15,7 @@
   - import_role:
       name: openshift_node_group
       tasks_from: check_for_configs.yml
+    when: openshift_current_version | version_compare('3.10', '>=')
 
 - name: Ensure firewall is not switched during upgrade
   hosts: "{{ l_upgrade_no_switch_firewall_hosts | default('oo_all_hosts') }}"


### PR DESCRIPTION
3.9 cluster doesn't have node configmaps created, these should be verified on minor upgrades only

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1589941