### PR TITLE
[WIP] Adding ability to skip etcd oreg filter plugin.

### DIFF
--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -16,7 +16,8 @@ r_etcd_default_version: "3.2.15"
 # This filter attempts to combine oreg_url host with project/component from etcd_image_dict.
 # "oreg.example.com/openshift3/ose-${component}:${version}"
 # becomes "oreg.example.com/rhel7/etcd:{{ r_etcd_upgrade_version | default(r_etcd_default_version) }}"
-osm_etcd_image: "{{ etcd_image_dict[openshift_deployment_type] | lib_utils_oo_oreg_image((oreg_url | default('None'))) }}"
+etcd_ignore_oreg_filter: False
+osm_etcd_image: "{{ etcd_image_dict[openshift_deployment_type] | lib_utils_oo_oreg_image((oreg_url | default('None')), etcd_ignore_oreg_filter) }}"
 etcd_image_dict:
   origin: "quay.io/coreos/etcd:v{{ r_etcd_upgrade_version | default(r_etcd_default_version) }}"
   openshift-enterprise: "registry.access.redhat.com/rhel7/etcd:{{ r_etcd_upgrade_version | default(r_etcd_default_version) }}"

--- a/roles/lib_utils/filter_plugins/oo_filters.py
+++ b/roles/lib_utils/filter_plugins/oo_filters.py
@@ -706,7 +706,7 @@ def lib_utils_mutate_htpass_provider(idps):
     return idps
 
 
-def lib_utils_oo_oreg_image(image_default, oreg_url):
+def lib_utils_oo_oreg_image(image_default, oreg_url, ignore_filter=False):
     '''Converts default image string to utilize oreg_url, if defined.
        oreg_url should be passed in as string "None" if undefined.
 
@@ -714,7 +714,7 @@ def lib_utils_oo_oreg_image(image_default, oreg_url):
                        "example.com/openshift/origin-${component}:${version}"
        Example output: "example.com/coreos/etcd:v99"'''
     # if no oreg_url is specified, we just return the original default
-    if oreg_url == 'None':
+    if oreg_url == 'None' or ignore_filter:
         return image_default
     oreg_parts = oreg_url.split('/')
     if len(oreg_parts) < 2:


### PR DESCRIPTION
When running through a conformance CI job, it builds containers for the current code.  The job then passes an `oreg_url` to the local registry with those containers as a build parameter:
```
-e 'oreg_url=registry.svc.ci.openshift.org/ci-pr-images/prtest-747e412-393-origin-${component}:v3.10'
```

The local registry for the CI does not build a container for etcd.  This result produces an etcd URL that is invalid since it is not in the local registry: 
```
"registry.svc.ci.openshift.org/coreos/etcd:v3.2.15"
```

 This PR allows an admin to ignore the oreg filter_plugin and take the role defaults for etcd.

@jim-minter @pweil-