### PR TITLE
Add retries to SCC check on upgrade

### DIFF
--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -12,6 +12,8 @@
       {{ openshift_client_binary }} adm policy --config={{ openshift.common.config_base }}/master/admin.kubeconfig reconcile-sccs --additive-only=true -o name
     register: check_reconcile_scc_result
     when: openshift_reconcile_sccs_reject_change | default(true) | bool
+    until: check_reconcile_scc_result.rc == 0
+    retries: 3
 
   - fail:
       msg: >


### PR DESCRIPTION
The API may be busy/overloaded at this point in the upgrade which can
result in this task occasionally failing.

Error result:
error: Failed to GET reconcile SCC namespace openshift-infra: Get
https://ip-172-18-15-108.ec2.internal:8443/api/v1/namespaces/openshift-infra:
dial tcp 172.18.15.108:8443: getsockopt: connection refused