### PR TITLE
Updating node group mappings to use an openshift specific tag.

### DIFF
--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -154,8 +154,9 @@ openshift_aws_master_group:
   group: master
   tags:
     host-type: master
-    sub-host-type: master
+    sub-host-type: default
     runtime: docker
+    openshift-node-group-config: node-config-master
 
 openshift_aws_node_groups:
 - name: "{{ openshift_aws_clusterid }} compute group"
@@ -164,6 +165,7 @@ openshift_aws_node_groups:
     host-type: node
     sub-host-type: compute
     runtime: docker
+    openshift-node-group-config: node-config-compute
 
 - name: "{{ openshift_aws_clusterid }} infra group"
   group: infra
@@ -171,11 +173,7 @@ openshift_aws_node_groups:
     host-type: node
     sub-host-type: infra
     runtime: docker
-
-openshift_aws_node_group_mappings:
-  master: 'node-config-master'
-  compute: 'node-config-compute'
-  infra: 'node-config-infra'
+    openshift-node-group-config: node-config-infra
 
 openshift_aws_created_asgs: []
 openshift_aws_current_asgs: []

--- a/roles/openshift_aws/tasks/setup_master_group.yml
+++ b/roles/openshift_aws/tasks/setup_master_group.yml
@@ -26,7 +26,7 @@
     groups: "{{ openshift_aws_masters_groups }}"
     name: "{{ item.public_dns_name }}"
     hostname: "{{ openshift_aws_clusterid }}-master-{{ item.instance_id[:-5] }}"
-    openshift_node_group_name: "{{ openshift_aws_node_group_mappings[item.tags['sub-host-type']] }}"
+    openshift_node_group_name: "{{ item.tags['openshift-node-group-config'] }}"
   with_items: "{{ instancesout.instances }}"
 
 - name: wait for ssh to become available

--- a/roles/openshift_aws/tasks/setup_scale_group_facts.yml
+++ b/roles/openshift_aws/tasks/setup_scale_group_facts.yml
@@ -46,5 +46,5 @@
     ansible_ssh_host: "{{ item.public_dns_name }}"
     name: "{{ item.public_dns_name }}"
     hostname: "{{ item.public_dns_name }}"
-    openshift_node_group_name: "{{ openshift_aws_node_group_mappings[item.tags['sub-host-type']] }}"
+    openshift_node_group_name: "{{ item.tags['openshift-node-group-config'] }}"
   with_items: "{{ qinstances.instances }}"

--- a/roles/openshift_aws/templates/user_data.j2
+++ b/roles/openshift_aws/templates/user_data.j2
@@ -7,7 +7,7 @@ write_files:
   owner: 'root:root'
   permissions: '0640'
   content: |
-    openshift_group_type: {{ openshift_aws_node_group.group }}
+    openshift_node_config_name: {{ openshift_aws_node_group.tags['openshift-node-group-config'] }}
 {%   if openshift_aws_node_group.group != 'master' %}
 - path: /etc/origin/node/bootstrap.kubeconfig
   owner: 'root:root'

--- a/roles/openshift_node/templates/bootstrap.yml.j2
+++ b/roles/openshift_node/templates/bootstrap.yml.j2
@@ -44,7 +44,7 @@
         line: "{{ item.line }}"
         regexp: "{{ item.regexp }}"
       with_items:
-      - line: "BOOTSTRAP_CONFIG_NAME=node-config-{{ openshift_group_type }}"
+      - line: "BOOTSTRAP_CONFIG_NAME={{ openshift_node_config_name }}"
         regexp: "^BOOTSTRAP_CONFIG_NAME=.*"
 {% endraw %}
 


### PR DESCRIPTION
Proposal to fix recent updates to node-group-configs.

With the recent changes to the following lines we are now required to tie node groups to instances:
https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_aws/tasks/setup_master_group.yml#L29
https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_aws/tasks/setup_scale_group_facts.yml#L49

One viable way to tie an instance to a node group is to tag the instance.  If the above lines aren't required then we wouldn't need to tag instances.  Since they are currently required (maybe someone can speak to the why), specifying a specific openshift tag is preferred.

This would require any instances created previously to be tagged with an `openshift-node-config-name`.

Thoughts on this?

