### PR TITLE
Fix hostname check failure message

### DIFF
--- a/playbooks/init/validate_hostnames.yml
+++ b/playbooks/init/validate_hostnames.yml
@@ -18,7 +18,7 @@
         openshift_hostname variable to a hostname that when resolved on the host
         in question resolves to an IP address matching an interface on this host.
         This will ensure proper functionality of OpenShift networking features.
-        Inventory setting: openshift_hostname={{ openshift_hostname }}
+        Inventory setting: openshift_hostname={{ openshift_hostname | default ('undefined') }}
         This check can be overridden by setting openshift_hostname_check=false in
         the inventory.
         See https://docs.openshift.org/latest/install_config/install/advanced_install.html#configuring-host-variables


### PR DESCRIPTION
This commit ensures undefined error is not thrown when
openshift_hostname is not defined.

Fixes: https://github.com/openshift/openshift-ansible/issues/8738