### PR TITLE
Sync daemonset should start after node configmaps are created to avoid race conditions

### DIFF
--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -104,11 +104,6 @@
   - role: calico_master
     when: openshift_use_calico | default(false) | bool
   tasks:
-  - name: Set up automatic node config reconcilation
-    run_once: True
-    import_role:
-      name: openshift_node_group
-      tasks_from: sync
   - import_role:
       name: kuryr
       tasks_from: master
@@ -133,6 +128,16 @@
   tasks:
   - name: setup bootstrap settings
     import_tasks: tasks/enable_bootstrap_config.yml
+
+- name: Create sync daemonset
+  hosts: oo_first_master
+  gather_facts: no
+  tasks:
+  - name: Set up automatic node config reconcilation
+    run_once: True
+    import_role:
+      name: openshift_node_group
+      tasks_from: sync
 
 - name: Ensure inventory labels are assigned to masters
   hosts: oo_masters_to_config


### PR DESCRIPTION
Starting sync DS after node config maps are created should prevent several 
race conditions between sync and ansible. Sync DS would wait for 15 secs 
between configmap presence checks, so meanwhile ansible may apply wrong labels 
to the nodes

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1590740