### PR TITLE
Revert "Make SDN read config file from sysconfig"

### DIFF
--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -27,9 +27,6 @@
   # add the kubeconfig
   - line: "KUBECONFIG={{ openshift_node_config_dir }}/bootstrap.kubeconfig"
     regexp: "^KUBECONFIG=.*"
-  # remove the config file.  This comes from openshift_facts
-  - line: "CONFIG_FILE={{ openshift_node_config_dir }}/bootstrap-node-config.yaml"
-    regexp: "^CONFIG_FILE=.*"
 
 - name: include aws sysconfig credentials
   import_tasks: aws.yml

--- a/roles/openshift_node/tasks/config/configure-node-settings.yml
+++ b/roles/openshift_node/tasks/config/configure-node-settings.yml
@@ -10,7 +10,5 @@
     line: "OPTIONS={{ openshift_node_start_options | default('') }}"
   - regex: '^DEBUG_LOGLEVEL='
     line: "DEBUG_LOGLEVEL={{ openshift_node_debug_level }}"
-  - regex: '^CONFIG_FILE='
-    line: "CONFIG_FILE={{ openshift.common.config_base }}/node/node-config.yaml"
   - regex: '^IMAGE_VERSION='
     line: "IMAGE_VERSION={{ openshift_image_tag }}"

--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -37,7 +37,7 @@ spec:
       # It relies on an up to date node-config.yaml being present.
       - name: sdn
         image: " "
-        command:
+        command: 
         - /bin/bash
         - -c
         - |
@@ -63,23 +63,7 @@ spec:
           # if the node config doesn't exist yet, wait until it does
           retries=0
           while true; do
-            file=/etc/sysconfig/origin-node
-            if [[ -f /etc/sysconfig/atomic-openshift-node ]]; then
-              file=/etc/sysconfig/atomic-openshift-node
-            elif [[ -f /etc/sysconfig/origin-node ]]; then
-              file=/etc/sysconfig/origin-node
-            else
-              echo "info: Waiting for the node sysconfig file to be created" 2>&1
-              sleep 15 & wait
-              continue
-            fi
-            config_file="$(sed -nE 's|^CONFIG_FILE=([^#].+)|\1|p' "${file}" | head -1)"
-            if [[ -z "${config_file}" ]]; then
-              echo "info: Waiting for CONFIG_FILE to be set" 2>&1
-              sleep 15 & wait
-              continue
-            fi
-            if [[ ! -f ${config_file} ]]; then
+            if [[ ! -f /etc/origin/node/node-config.yaml ]]; then
               echo "warning: Cannot find existing node-config.yaml, waiting 15s ..." 2>&1
               sleep 15 & wait
               (( retries += 1 ))
@@ -118,7 +102,7 @@ spec:
           oc config --config=/tmp/kubeconfig set-credentials sa "--token=$( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"
           oc config --config=/tmp/kubeconfig set-context "$( oc config --config=/tmp/kubeconfig current-context )" --user=sa
           # Launch the network process
-          exec openshift start network --config=${config_file} --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
+          exec openshift start network --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
 
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
This reverts commit 5c6f01c7018c3068c985bdd8e6b6530dc932d080.

https://bugzilla.redhat.com/show_bug.cgi?id=1590918

There is no scenario where CONFIG_FILE is allowed to be changed