### PR TITLE
Invalid openshift-client rpm due to missing dash

### DIFF
--- a/roles/openshift_cli/tasks/main.yml
+++ b/roles/openshift_cli/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install clients
-  package: name={{ openshift_service_type }}-clients{{ openshift_pkg_version | default('') }} state=present
+  package: name={{ openshift_service_type }}-clients-{{ openshift_pkg_version | default('') }} state=present
   when: not openshift_is_atomic | bool
   register: result
   until: result is succeeded


### PR DESCRIPTION
the rpm format is `origin-clients-3.10.0-0.alpha.0.el7.git.0.39204dc.x86_64.rpm` and not `origin-clients3.10.0-0.alpha.0.el7.git.0.39204dc.x86_64.rpm`, see dash between client and version