### PR TITLE
[release-3.9]: Invalid openshift-client rpm due to missing dash

### DIFF
--- a/roles/openshift_cli/tasks/main.yml
+++ b/roles/openshift_cli/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install clients
-  package: name={{ openshift_service_type }}-clients{{ openshift_pkg_version | default('') }} state=present
+  package: name={{ openshift_service_type }}-clients-{{ openshift_pkg_version | default('') }} state=present
   when: not openshift_is_containerized | bool
   register: result
   until: result is succeeded


### PR DESCRIPTION
Cherry pick of https://github.com/openshift/openshift-ansible/pull/8748

credit goes to @rimolive for finding the bug