### PR TITLE
Azure: use empty dict if input image has no tags

### DIFF
--- a/playbooks/azure/openshift-cluster/tasks/create_image_from_vm.yml
+++ b/playbooks/azure/openshift-cluster/tasks/create_image_from_vm.yml
@@ -43,7 +43,7 @@
 
 - name: calculate final tags
   set_fact:
-    final_tags: "{{ input_image_tags_no_valid | combine(image_tags) }}"
+    final_tags: "{{ input_image_tags_no_valid | default({}) | combine(image_tags) }}"
 
 - name: tag image
   command: >


### PR DESCRIPTION
Root images usually have only `valid: true` tag, which is ignored when setting
tags for the new image, thus when combining old tags with new, the variable
containing old tags would be undefined and the ansible task fails.