### PR TITLE
GlusterFS fails on uninstall due to wrong filter name

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
@@ -47,7 +47,7 @@
     name: "{{ hostvars[item].openshift.node.nodename }}"
     kind: node
     state: absent
-    labels: "{{ glusterfs_nodeselector | lib_utils_oo_dict_to_list_of_dict }}"
+    labels: "{{ glusterfs_nodeselector | oo_dict_to_list_of_dict }}"
   with_items: "{{ groups.all }}"
   when: "'openshift' in hostvars[item]"
 


### PR DESCRIPTION

This is required due to wrong filter name mentioned [here](https://github.com/openshift/openshift-ansible/blob/release-3.7/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml#L50) 