### PR TITLE
azure: don't try to print deployment failure message when there isn't…

### DIFF
--- a/playbooks/azure/openshift-cluster/launch.yml
+++ b/playbooks/azure/openshift-cluster/launch.yml
@@ -107,6 +107,7 @@
 
     - debug:
         msg: "{{ (message.stdout | from_json).error.details[0].message }}"
+      when: message.stdout != ""
 
     - assert:
         that: "{{ not deploy.failed }}"


### PR DESCRIPTION
… one

example problem: https://ci.openshift.redhat.com/jenkins/job/test_branch_origin_extended_conformance_azure/64/console

this PR is intended just to fix the failure to print the message after the job already failed, it doesn't deal with the underlying cause