### PR TITLE
azure: pass image_name into tasks/create_blob_from_vm.yml

### DIFF
--- a/playbooks/azure/openshift-cluster/build_base_image.yml
+++ b/playbooks/azure/openshift-cluster/build_base_image.yml
@@ -47,4 +47,6 @@
 
   - name: create blob
     import_tasks: tasks/create_blob_from_vm.yml
+    vars:
+      image_name: "{{ openshift_azure_output_image_name }}"
     when: openshift_azure_storage_account is defined and openshift_azure_storage_account

--- a/playbooks/azure/openshift-cluster/build_node_image.yml
+++ b/playbooks/azure/openshift-cluster/build_node_image.yml
@@ -90,4 +90,6 @@
 
   - name: create blob
     import_tasks: tasks/create_blob_from_vm.yml
+    vars:
+      image_name: "{{ openshift_azure_output_image_name }}"
     when: openshift_azure_storage_account is defined and openshift_azure_storage_account


### PR DESCRIPTION
fix

```
TASK [start copy] **************************************************************
Thursday 14 June 2018  13:09:33 +0000 (0:00:33.922)       0:13:53.365 ********* 
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'image_name' is undefined\n\nThe error appears to have been in '/usr/share/ansible/openshift-ansible/playbooks/azure/openshift-cluster/tasks/create_blob_from_vm.yml': line 23, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: start copy\n  ^ here\n"}
```

example: https://ci.openshift.redhat.com/jenkins/job/azure_build_node_image_centos_39/33/console