### PR TITLE
bug 1575903. Default ES memory to 16G

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -104,7 +104,7 @@ openshift_logging_es_cpu_limit: null
 openshift_logging_es_cpu_request: "1"
 # the logging appenders for the root loggers to write ES logs. Valid values: 'file', 'console'
 openshift_logging_es_log_appenders: ['file']
-openshift_logging_es_memory_limit: "8Gi"
+openshift_logging_es_memory_limit: "16Gi"
 openshift_logging_es_pv_selector: "{{ openshift_logging_storage_labels | default('') }}"
 openshift_logging_es_pvc_dynamic: "{{ openshift_logging_elasticsearch_pvc_dynamic | default(False) }}"
 openshift_logging_es_pvc_size: ''
@@ -141,7 +141,7 @@ openshift_logging_es_ops_client_cert: /etc/fluent/keys/cert
 openshift_logging_es_ops_client_key: /etc/fluent/keys/key
 openshift_logging_es_ops_cluster_size: "{{ openshift_logging_elasticsearch_ops_cluster_size | default(1) }}"
 openshift_logging_es_ops_cpu_limit: null
-openshift_logging_es_ops_memory_limit: 8Gi
+openshift_logging_es_ops_memory_limit: "16Gi"
 openshift_logging_es_ops_cpu_request: "1"
 openshift_logging_es_ops_pv_selector: "{{ openshift_loggingops_storage_labels | default('') }}"
 openshift_logging_es_ops_pvc_dynamic: "{{ openshift_logging_elasticsearch_ops_pvc_dynamic | default(False) }}"

--- a/roles/openshift_logging_elasticsearch/defaults/main.yml
+++ b/roles/openshift_logging_elasticsearch/defaults/main.yml
@@ -13,7 +13,7 @@ openshift_logging_elasticsearch_proxy_image: "{{ l2_os_logging_proxy_image }}"
 openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_nodeselector | default('') }}"
 openshift_logging_elasticsearch_cpu_limit: null
 openshift_logging_elasticsearch_cpu_request: "{{ openshift_logging_es_cpu_request | default('1000m') }}"
-openshift_logging_elasticsearch_memory_limit: "{{ openshift_logging_es_memory_limit | default('1Gi') }}"
+openshift_logging_elasticsearch_memory_limit: "{{ openshift_logging_es_memory_limit | default('16Gi') }}"
 openshift_logging_elasticsearch_recover_after_time: "{{ openshift_logging_es_recover_after_time | default('5m') }}"
 
 openshift_logging_elasticsearch_replica_count: 1


### PR DESCRIPTION
This bug resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=1575903

by bumping the default ES memory to 16G

cc @portante 