### PR TITLE
bug 1572493. Update default logging NS in openshift_health_checker

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/logging/logging.py
+++ b/roles/openshift_health_checker/openshift_checks/logging/logging.py
@@ -68,7 +68,7 @@ class LoggingCheck(OpenShiftCheck):
 
     def logging_namespace(self):
         """Returns the namespace in which logging is configured to deploy."""
-        return self.get_var("openshift_logging_namespace", default="logging")
+        return self.get_var("openshift_logging_namespace", default="openshift-logging")
 
     def exec_oc(self, cmd_str="", extra_args=None, save_as_name=None):
         """


### PR DESCRIPTION
This PR updates the default logging namespace to fix https://bugzilla.redhat.com/show_bug.cgi?id=1572493