### PR TITLE
registry-console: limit pods to masters

### DIFF
--- a/roles/openshift_hosted_templates/files/v3.10/enterprise/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.10/enterprise/registry-console.yaml
@@ -25,6 +25,8 @@ objects:
           labels:
             name: "registry-console"
         spec:
+          nodeSelector:
+            node-role.kubernetes.io/master: 'true'
           containers:
             - name: registry-console
               image: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}

--- a/roles/openshift_hosted_templates/files/v3.10/origin/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.10/origin/registry-console.yaml
@@ -25,6 +25,8 @@ objects:
           labels:
             name: "registry-console"
         spec:
+          nodeSelector:
+            node-role.kubernetes.io/master: 'true'
           containers:
             - name: registry-console
               image: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}


### PR DESCRIPTION
registry-console pods should run on masters only

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1425022
Fixes  #8438