### PR TITLE
[3.9] registry-console: limit pods to masters

### DIFF
--- a/roles/openshift_hosted_templates/files/v3.6/origin/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.6/origin/registry-console.yaml
@@ -25,6 +25,8 @@ objects:
           labels:
             name: "registry-console"
         spec:
+          nodeSelector:
+            node-role.kubernetes.io/master: 'true'
           containers:
             - name: registry-console
               image: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}

--- a/roles/openshift_hosted_templates/files/v3.9/enterprise/registry-console.yaml
+++ b/roles/openshift_hosted_templates/files/v3.9/enterprise/registry-console.yaml
@@ -25,6 +25,8 @@ objects:
           labels:
             name: "registry-console"
         spec:
+          nodeSelector:
+            node-role.kubernetes.io/master: 'true'
           containers:
             - name: registry-console
               image: ${IMAGE_PREFIX}${IMAGE_BASENAME}:${IMAGE_VERSION}


### PR DESCRIPTION
Cherrypick of #8766

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1557345