### PR TITLE
Fix to pass quoted unsafe strings (with characters like *,<,%) correctly to kubelet

### DIFF
--- a/roles/openshift_node/files/openshift-node
+++ b/roles/openshift_node/files/openshift-node
@@ -15,4 +15,4 @@ if [[ -f /etc/origin/node/node-config.yaml ]]; then
   config=/etc/origin/node/node-config.yaml
 fi
 flags=$( /usr/bin/openshift-node-config "--config=${config}" )
-exec /usr/bin/hyperkube kubelet --v=${DEBUG_LOGLEVEL:-2} ${flags}
+eval "exec /usr/bin/hyperkube kubelet --v=${DEBUG_LOGLEVEL:-2} ${flags}"


### PR DESCRIPTION
Fix rhbz https://bugzilla.redhat.com/show_bug.cgi?id=1587824. 

@sjenning @smarterclayton 

Related PR to origin: https://github.com/openshift/origin/pull/19951