### PR TITLE
Clean up docker-storage in a reliable mannger

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -328,8 +328,8 @@
       dest=/etc/sysconfig/docker
       regexp='(ADD_REGISTRY|BLOCK_REGISTRY|INSECURE_REGISTRY)=.*'
 
-  - name: Umount docker storage
-    shell: umount /var/lib/docker/volumes
+  - name: Umount docker storage if mounted
+    shell: umount /var/lib/docker
     register: umount_result
     failed_when: umount_result.rc != 0 and "not mounted" not in umount_result.stderr
 

--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -277,12 +277,12 @@
   - shell: systemctl daemon-reload
     changed_when: False
 
-  - name: restart container-engine
+  - name: Stop container-engine service
     service: name=container-engine state=stopped enabled=no
     failed_when: false
     register: container_engine
 
-  - name: restart docker
+  - name: Stop docker service
     service: name=docker state=stopped enabled=no
     failed_when: false
     when: not (container_engine is changed)
@@ -312,7 +312,6 @@
     - /etc/systemd/system/origin-node-dep.service
     - /etc/systemd/system/origin-node.service
     - /etc/systemd/system/origin-node.service.wants
-    - /var/lib/docker/*
 
   - name: Rebuild ca-trust
     command: update-ca-trust
@@ -329,21 +328,16 @@
       dest=/etc/sysconfig/docker
       regexp='(ADD_REGISTRY|BLOCK_REGISTRY|INSECURE_REGISTRY)=.*'
 
-  - name: Detect Docker storage configuration
-    shell: vgs -o name | grep docker
-    register: docker_vg_name
-    failed_when: false
-    changed_when: false
+  - name: Umount docker storage
+    shell: umount /var/lib/docker/volumes
+    register: umount_result
+    failed_when: umount_result.rc != 0 and "not mounted" not in umount_result.stderr
 
-  - name: Wipe out Docker storage contents
-    command: vgremove -f {{ item }}
-    with_items: "{{ docker_vg_name.stdout_lines }}"
-    when: docker_vg_name.rc == 0
+  - name: Remove docker storage contents
+    shell: rm -rf /var/lib/docker
 
-  - name: Wipe out Docker storage configuration
-    file: path=/etc/sysconfig/docker-storage state=absent
-    when: docker_vg_name.rc == 0
-
+  - name: Reset docker-storage-setup
+    shell: docker-storage-setup --reset
 
 - hosts: masters
   become: yes

--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -328,11 +328,6 @@
       dest=/etc/sysconfig/docker
       regexp='(ADD_REGISTRY|BLOCK_REGISTRY|INSECURE_REGISTRY)=.*'
 
-  - name: Umount docker storage if mounted
-    shell: umount /var/lib/docker
-    register: umount_result
-    failed_when: umount_result.rc != 0 and "not mounted" not in umount_result.stderr
-
   - name: Remove docker storage contents
     shell: rm -rf /var/lib/docker
 


### PR DESCRIPTION
Currently uninstall playbook deletes docker-storage contents by find vg
which contains docker in the name. Additionally, it runs vgremove -f
without umount volumes. Although it could clean up storage, it failed
sometimies.

This patch changes:
- Umount /var/lib/docker/volumes
- (After unmount docker volumes) Remove /var/lib/docker/ by `rm -rf`
- Reset docker-storage by `docker-storage-setup --reset`
- Stop removing VG which contins docker in the name