### PR TITLE
Honor openshift_hosted_manage_registry

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -149,4 +149,7 @@
       state: started
 
 - include: ../registry_upgrade.yml
+  when:
+  - openshift_hosted_manage_registry | default(True) | bool
+
 - include: ../post_control_plane.yml


### PR DESCRIPTION
Don't proceed to the registry update if the registry is not managed by OCP.