### PR TITLE
Specify additional node groups

### DIFF
--- a/.papr.inventory
+++ b/.papr.inventory
@@ -15,6 +15,12 @@ openshift_portal_net=172.30.0.0/16
 debug_level=4
 
 [all:vars]
+# custom node config group
+my_node_group1_labels=['node-role.kubernetes.io/infra=true', 'node-role.kubernetes.io/compute=true']
+my_node_group1={'name': 'node-config-compute-infra', 'labels': {{ my_node_group1_labels }} }
+
+openshift_additional_node_groups=[{{ my_node_group1 }}]
+
 # bootstrap configs
 openshift_master_bootstrap_auto_approve=true
 openshift_master_bootstrap_auto_approver_node_selector={"node-role.kubernetes.io/master":"true"}
@@ -29,5 +35,5 @@ ocp-master
 
 [nodes]
 ocp-master openshift_schedulable=true openshift_node_group_name="node-config-master-infra"
-ocp-node1 openshift_node_group_name="node-config-infra" openshift_node_group_name="node-config-compute"
-ocp-node2 openshift_node_group_name="node-config-infra" openshift_node_group_name="node-config-compute"
+ocp-node1 openshift_node_group_name="node-config-compute-infra"
+ocp-node2 openshift_node_group_name="node-config-compute-infra"

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -117,7 +117,7 @@ openshift_master_api_port: "8443"
 openshift_ca_host: "{{ groups.oo_first_master.0 }}"
 openshift_use_openshift_sdn: true
 
-openshift_node_groups:
+openshift_default_node_groups:
   - name: node-config-master
     labels:
       - 'node-role.kubernetes.io/master=true'
@@ -138,4 +138,7 @@ openshift_node_groups:
     labels:
       - 'node-role.kubernetes.io/infra=true,node-role.kubernetes.io/master=true,node-role.kubernetes.io/compute=true'
     edits: []
+
+openshift_node_groups: "{{ openshift_default_node_groups }} + {{ openshift_additional_node_groups | default([]) }}"
+
 openshift_master_manage_htpasswd: True


### PR DESCRIPTION
Currently in order to add new node groups the admin has to redefine `openshift_node_groups` entirely, including default node groups.

This PR adds a new var `openshift_additional_node_groups`, which would be appended to `openshift_default_node_groups`:

```
openshift_additional_node_groups:
  - name: node-config-compute-infra
    labels:
    - 'node-role.kubernetes.io/infra=true,node-role.kubernetes.io/compute=true'
    edits: []
```

Resulting `openshift_node_groups` would include default node groups and `node-config-compute-infra`