### PR TITLE
Drop --confirm from migrate storage invocation

### DIFF
--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -63,7 +63,7 @@
   - name: Upgrade all storage
     command: >
       {{ openshift_client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-      migrate storage --include=* --confirm
+      migrate storage --include=*
     register: l_pb_upgrade_control_plane_pre_upgrade_storage
     when: openshift_upgrade_pre_storage_migration_enabled | default(true) | bool
     failed_when:
@@ -197,7 +197,7 @@
   - name: Migrate storage post policy reconciliation
     command: >
       {{ openshift_client_binary }} adm --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-      migrate storage --include=* --confirm
+      migrate storage --include=*
     run_once: true
     register: l_pb_upgrade_control_plane_post_upgrade_storage
     when: openshift_upgrade_post_storage_migration_enabled | default(true) | bool


### PR DESCRIPTION
Per https://github.com/openshift/origin/pull/19691 drop the `--confirm` flag from storage migration operations.

/assign @sdodson @vrutkovs 