### PR TITLE
upgrade: init facts on nodes so that NO_PROXY would include node hostnames

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
@@ -14,7 +14,7 @@
 - import_playbook: ../init.yml
   vars:
     l_upgrade_no_switch_firewall_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
-    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_nodes_to_config"
     l_base_packages_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
 
 - name: Configure the upgrade target for the common upgrade tasks 3.10


### PR DESCRIPTION
Node hostnames need to be added to NO_PROXY list, as its required for 
SDN to work in proxy environments. Currently facts from nodes are not 
collected on major upgrade, so only master hostnames are added in the 
list

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1589734