### PR TITLE
[3.10] Set sane defaults for node to API server message rates

### DIFF
--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -12,6 +12,10 @@ imageConfig:
   latest: {{ openshift_node_image_config_latest }}
 kind: NodeConfig
 kubeletArguments: {{  l2_openshift_node_kubelet_args  | default(None) | lib_utils_to_padded_yaml(level=1) }}
+  kube-api-qps:
+  - "100"
+  kube-api-burst:
+  - "200"
 {% if openshift_use_crio | bool %}
   container-runtime:
   - remote

--- a/roles/openshift_node_group/templates/node-config.yaml.j2
+++ b/roles/openshift_node_group/templates/node-config.yaml.j2
@@ -20,6 +20,10 @@ imageConfig:
   latest: false
 iptablesSyncPeriod: "{{ openshift_node_iptables_sync_period }}"
 kubeletArguments:
+  kube-api-qps:
+  - "100"
+  kube-api-burst:
+  - "200"
 {% if openshift_use_crio | bool %}
   container-runtime:
   - remote


### PR DESCRIPTION
This is to fix https://bugzilla.redhat.com/show_bug.cgi?id=1583673

Cherry-pick of #8790