### PR TITLE
Bug 1583157 - Add openshift-node entry-point playbooks

### DIFF
--- a/playbooks/openshift-node/bootstrap.yml
+++ b/playbooks/openshift-node/bootstrap.yml
@@ -1,0 +1,4 @@
+---
+- import_playbook: ../init/main.yml
+
+- import_playbook: private/bootstrap.yml

--- a/playbooks/openshift-node/join.yml
+++ b/playbooks/openshift-node/join.yml
@@ -1,0 +1,4 @@
+---
+- import_playbook: ../init/main.yml
+
+- import_playbook: private/join.yml

--- a/playbooks/openshift-node/private/bootstrap.yml
+++ b/playbooks/openshift-node/private/bootstrap.yml
@@ -1,15 +1,15 @@
 ---
-- name: Node Preparation Checkpoint Start
+- name: Node Bootstrap Preparation Checkpoint Start
   hosts: all
   gather_facts: false
   tasks:
-  - name: Set Node preparation 'In Progress'
+  - name: Set Node Bootstrap Preparation 'In Progress'
     run_once: true
     set_stats:
       data:
-        installer_phase_node:
-          title: "Node Preparation"
-          playbook: "(no entry point playbook)"
+        installer_phase_node_bootstrap:
+          title: "Node Bootstrap Preparation"
+          playbook: "playbooks/openshift-node/bootstrap.yml"
           status: "In Progress"
           start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
@@ -39,14 +39,14 @@
   vars:
     l_node_group: oo_nodes_to_bootstrap:!oo_exclude_bootstrapped_nodes
 
-- name: Node Preparation Checkpoint End
+- name: Node Bootstrap Preparation Checkpoint End
   hosts: all
   gather_facts: false
   tasks:
-  - name: Set Node preparation 'Complete'
+  - name: Set Node Bootstrap Preparation 'Complete'
     run_once: true
     set_stats:
       data:
-        installer_phase_node:
+        installer_phase_node_bootstrap:
           status: "Complete"
           end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"

--- a/playbooks/openshift-node/private/join.yml
+++ b/playbooks/openshift-node/private/join.yml
@@ -1,4 +1,18 @@
 ---
+- name: Node Join Checkpoint Start
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Set Node Join 'In Progress'
+    run_once: true
+    set_stats:
+      data:
+        installer_phase_node_join:
+          title: "Node Join"
+          playbook: "playbooks/openshift-node/join.yml"
+          status: "In Progress"
+          start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+
 - name: Distribute bootstrap and start nodes
   hosts: oo_nodes_to_bootstrap
   gather_facts: no
@@ -50,3 +64,15 @@
   - role: openshift_manage_node
     openshift_master_host: "{{ groups.oo_first_master.0 }}"
     openshift_manage_node_is_master: "{{ ('oo_masters_to_config' in group_names) | bool }}"
+
+- name: Node Join Checkpoint End
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Set Node Join 'Complete'
+    run_once: true
+    set_stats:
+      data:
+        installer_phase_node_join:
+          status: "Complete"
+          end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"


### PR DESCRIPTION
- bootstrap.yml
- join.yml

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1583157

Current list of individual playbooks:
openshift-checks/pre-install.yml
openshift-node/bootstrap.yml
openshift-etcd/config.yml
openshift-nfs/config.yml
openshift-loadbalancer/config.yml
openshift-master/config.yml
openshift-master/additional_config.yml
openshift-node/join.yml
openshift-glusterfs/config.yml
openshift-hosted/config.yml
openshift-monitoring/config.yml
openshift-web-console/config.yml
openshift-metrics/config.yml
openshift-logging/config.yml
openshift-prometheus/config.yml
openshift-monitoring/config.yml
openshift-monitor-availability/config.yml
openshift-service-catalog/config.yml
openshift-management/config.yml
openshift-descheduler/config.yml
openshift-node-problem-detector/config.yml
openshift-autoheal/config.yml