### PR TITLE
Fix predicates module for 3.11

### DIFF
--- a/roles/lib_utils/lookup_plugins/openshift_master_facts_default_predicates.py
+++ b/roles/lib_utils/lookup_plugins/openshift_master_facts_default_predicates.py
@@ -27,11 +27,11 @@ class LookupModule(LookupBase):
                 # pylint: disable=line-too-long
                 raise AnsibleError("Either OpenShift needs to be installed or openshift_release needs to be specified")
 
-        if short_version not in ['3.6', '3.7', '3.8', '3.9', '3.10', 'latest']:
+        if short_version not in ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', 'latest']:
             raise AnsibleError("Unknown short_version %s" % short_version)
 
         if short_version == 'latest':
-            short_version = '3.10'
+            short_version = '3.11'
 
         # Predicates ordered according to OpenShift Origin source:
         # origin/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -64,7 +64,7 @@ class LookupModule(LookupBase):
                 {'name': 'NoVolumeNodeConflict'},
             ])
 
-        if short_version in ['3.9', '3.10']:
+        if short_version in ['3.9', '3.10', '3.11']:
             predicates.extend([
                 {'name': 'NoVolumeZoneConflict'},
                 {'name': 'MaxEBSVolumeCount'},


### PR DESCRIPTION
```
TASK [openshift_master_facts : Set Default scheduler predicates and priorities] ***
task path: /usr/share/ansible/openshift-ansible/roles/openshift_master_facts/tasks/main.yml:60
fatal: [localhost]: FAILED! => {
    "generated_timestamp": "2018-06-15 19:32:31.070582", 
    "msg": "An unhandled exception occurred while running the lookup plugin 'openshift_master_facts_default_predicates'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Unknown short_version 3.11"
}
```