### PR TITLE
Fixed add_container_provider.yaml so it uses variable instead of set name

### DIFF
--- a/roles/openshift_management/tasks/add_container_provider.yml
+++ b/roles/openshift_management/tasks/add_container_provider.yml
@@ -46,7 +46,7 @@
   oc_route:
     state: list
     name: httpd
-    namespace: openshift-management
+    namespace: "{{ openshift_management_project }}"
   register: route
 
 - name: Ensure the management service route is saved


### PR DESCRIPTION
In add_container_provider.yaml in roles for openshift-management, how we check httpd route is through `namespace: openshift-managment`.  However, if the user chooses to use a variable we supply, `openshift_managment_project`, this will fail.  Changed it so we use the variable instead of the static name.

I searched this repo for any other case of us using openshift-managment instead of the variable as a namespace and couldn't find any so this should be fine.

Addresses bug: https://bugzilla.redhat.com/show_bug.cgi?id=1591966