### PR TITLE
Add openshift_master_cluster_hostname to no_proxy list

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -832,6 +832,9 @@ def set_proxy_facts(facts):
             common['no_proxy'].append('.' + common['dns_domain'])
             common['no_proxy'].append('.svc')
             common['no_proxy'].append(common['hostname'])
+            if 'master' in facts:
+                if 'cluster_hostname' in facts['master']:
+                    common['no_proxy'].extend(facts['master']['cluster_hostname'])
             common['no_proxy'] = ','.join(sort_unique(common['no_proxy']))
         facts['common'] = common
 


### PR DESCRIPTION
If master has cluster hostname defined it should be added to NO_PROXY list

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1432020