### PR TITLE
Record etcd static pod version only if master-exec has stdout

### DIFF
--- a/roles/etcd/tasks/version_detect.yml
+++ b/roles/etcd/tasks/version_detect.yml
@@ -65,8 +65,10 @@
       etcd_container_version: "{{ etcd_container_version_static_pod.stdout }}"
     when:
     - l_etcd_static_pod | bool
+    - "'stdout' in etcd_container_version_static_pod"
 
   - debug:
       msg: "Etcd containerized version {{ etcd_container_version }} detected"
+    when: etcd_container_version is defined
   when:
   - openshift_is_containerized | bool


### PR DESCRIPTION
Note, that this would skip etcd version detection on dedicated containerized etcd nodes - these should be properly converted into nodes

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1578294