### PR TITLE
Set `openshift_node_group_name` for the CNS nodes

### DIFF
--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -890,6 +890,7 @@ resources:
                 k8s_type: cns
                 cluster_id: {{ openshift_openstack_full_dns_domain }}
           type:        cns
+          openshift_node_group_name: node-config-compute
           image:       {{ openshift_openstack_cns_image }}
           flavor:      {{ openshift_openstack_cns_flavor }}
           key_name:    {{ openshift_openstack_keypair_name }}


### PR DESCRIPTION
This sets `openshift_node_group_name` for the CNS nodes in the OpenStack dynamic inventory.

Fixes: #8799