### PR TITLE
Sync grafana deployment to openshift-monitoring.

### DIFF
--- a/roles/openshift_grafana/defaults/main.yaml
+++ b/roles/openshift_grafana/defaults/main.yaml
@@ -6,8 +6,9 @@ openshift_grafana_proxy_image: "{{ l2_os_logging_proxy_image }}"
 openshift_grafana_state: present
 openshift_grafana_namespace: openshift-grafana
 openshift_grafana_pod_timeout: 300
-openshift_grafana_prometheus_namespace: "{{ openshift_prometheus_namespace | default('openshift-metrics') }}"
-openshift_grafana_prometheus_serviceaccount: prometheus-reader
+openshift_grafana_prometheus_namespace: "openshift-monitoring"
+openshift_grafana_prometheus_serviceaccount: "prometheus-k8s"
+openshift_grafana_prometheus_route: "prometheus-k8s"
 openshift_grafana_serviceaccount_name: grafana
 openshift_grafana_serviceaccount_annotations: []
 l_openshift_grafana_serviceaccount_annotations:

--- a/roles/openshift_grafana/tasks/facts.yaml
+++ b/roles/openshift_grafana/tasks/facts.yaml
@@ -5,6 +5,7 @@
     grafana_timeout: "{{ openshift_grafana_pod_timeout }}"
     grafana_prometheus_namespace: "{{ openshift_grafana_prometheus_namespace }}"
     grafana_prometheus_serviceaccount: "{{ openshift_grafana_prometheus_serviceaccount }}"
+    grafana_prometheus_route: "{{ openshift_grafana_prometheus_route }}"
     grafana_serviceaccount_name: "{{ openshift_grafana_serviceaccount_name }}"
     grafana_datasource_name: "{{ openshift_grafana_datasource_name }}"
     grafana_node_exporter: "{{ openshift_grafana_node_exporter }}"

--- a/roles/openshift_grafana/tasks/install_grafana.yaml
+++ b/roles/openshift_grafana/tasks/install_grafana.yaml
@@ -150,7 +150,7 @@
 - name: Get prometheus route
   oc_route:
     state: list
-    name: prometheus
+    name: "{{ grafana_prometheus_route }}"
     namespace: "{{ grafana_prometheus_namespace }}"
   register: prometheus_route
 


### PR DESCRIPTION
this work fits only to 3.10 and above.