### PR TITLE
WIP Remove existing container during master-restart

### DIFF
--- a/roles/openshift_control_plane/files/scripts/docker/master-restart
+++ b/roles/openshift_control_plane/files/scripts/docker/master-restart
@@ -34,4 +34,4 @@ if [[ -z "${child_container}" ]]; then
   echo "Component ${1} is already stopped" 1>&2
   exit 0
 fi
-exec timeout 60 docker wait $child_container
+exec timeout 60 docker rm -f $child_container


### PR DESCRIPTION
During `master-restart` the container may refuse to come up, as the name is already taken. This PR ensures the stopped container is removed so that 3.10 -> 3.11 upgrade would pass.

Fixes #8808 

First run - PASS - https://s3.amazonaws.com/aos-ci/ghprb/openshift/openshift-ansible/ed48a78896fccbccb30092f18a19ec31b661302c.2.1529413760639734825/index.html
Second run - PASS - https://s3.amazonaws.com/aos-ci/ghprb/openshift/openshift-ansible/ed48a78896fccbccb30092f18a19ec31b661302c.2.1529428426882618059/index.html
Third run - PASS - https://s3.amazonaws.com/aos-ci/ghprb/openshift/openshift-ansible/ed48a78896fccbccb30092f18a19ec31b661302c.2.1529488824790009554/index.html
Fourth run - FAIL - https://s3.amazonaws.com/aos-ci/ghprb/openshift/openshift-ansible/ed48a78896fccbccb30092f18a19ec31b661302c.2.1529492379491828348/index.html - API server died