### PR TITLE
Openshift master identity providers check improvements

### DIFF
--- a/roles/lib_utils/action_plugins/sanity_checks.py
+++ b/roles/lib_utils/action_plugins/sanity_checks.py
@@ -275,6 +275,8 @@ class ActionModule(ActionBase):
             # If we don't find any identity_providers, nothing for us to do.
             return None
         old_keys = ('file', 'fileName', 'file_name', 'filename')
+        if not isinstance(idps, list):
+            raise errors.AnsibleModuleError("| not a list")
         for idp in idps:
             if idp['kind'] == 'HTPasswdPasswordIdentityProvider':
                 for old_key in old_keys:

--- a/roles/lib_utils/action_plugins/sanity_checks.py
+++ b/roles/lib_utils/action_plugins/sanity_checks.py
@@ -264,15 +264,15 @@ class ActionModule(ActionBase):
         kind HTPasswdPasswordIdentityProvider and
         openshift_master_manage_htpasswd is False"""
 
-        idps = self.template_var(
-            hostvars, host, 'openshift_master_identity_providers')
-        if not idps:
-            # If we don't find any identity_providers, nothing for us to do.
-            return None
         manage_pass = self.template_var(
             hostvars, host, 'openshift_master_manage_htpasswd')
         if to_bool(manage_pass):
             # If we manage the file, we can just generate in the new path.
+            return None
+        idps = self.template_var(
+            hostvars, host, 'openshift_master_identity_providers')
+        if not idps:
+            # If we don't find any identity_providers, nothing for us to do.
             return None
         old_keys = ('file', 'fileName', 'file_name', 'filename')
         for idp in idps:


### PR DESCRIPTION
* Check `openshift_master_manage_htpasswd` first, so that correct `last_checked_var` would be displayed (it uses the templated var)
* Throw exception before iterating `openshift_master_identity_providers` if its not a list - if the syntax is incorrect it would be set as a string

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1592651