### PR TITLE
Revert "update dns parameter check to check for ."

### DIFF
--- a/roles/openshift_openstack/tasks/check-prerequisites.yml
+++ b/roles/openshift_openstack/tasks/check-prerequisites.yml
@@ -126,4 +126,4 @@
   when:
   - openshift_openstack_nsupdate_zone is defined
   - openshift_openstack_full_dns_domain is defined
-  - openshift_openstack_full_dns_domain is not match(".*\." + openshift_openstack_nsupdate_zone + "$")
+  - openshift_openstack_full_dns_domain is not match(".*" + openshift_openstack_nsupdate_zone + "$")


### PR DESCRIPTION
Reverts openshift/openshift-ansible#8735

The prerequisite check is failing when `openshift_openstack_full_dns_domain` and `openshift_openstack_nsupdate_zone` are equal.

Reverting for now, we can write this properly later.