### PR TITLE
change sc creation from none to len of the string

### DIFF
--- a/roles/openshift_persistent_volumes/templates/persistent-volume-claim.yml.j2
+++ b/roles/openshift_persistent_volumes/templates/persistent-volume-claim.yml.j2
@@ -18,7 +18,7 @@ items:
     resources:
       requests:
         storage: "{{ claim.capacity }}"
-{% if claim.storageclass is not none %}
+{% if claim.storageclass|length > 0 %}
     storageClassName: "{{ claim.storageclass }}"
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Fixes bz# 1548163

When a storageclass is not defined and not set to 'dynamic' the variable gets set to an empty var. 

The jinja2 template that adds the blank var to a line:
storageClassName: "{{ claim.storageclass }}"

```
>>> from jinja2 import Template
>>> tmpl = """{% if sc|length > 0 %} {{sc|length}} is > 0{% else %} {{sc|length}} <= 0{% endif %}"""
>>>  template = Template(tmpl)
>>> print template.render({"sc": ""})
 0 <= 0
>>> print template.render({"sc": "dynamic"})
 7 is > 0
```
