### PR TITLE
Setup cri-tools for docker

### DIFF
--- a/roles/container_runtime/tasks/package_docker.yml
+++ b/roles/container_runtime/tasks/package_docker.yml
@@ -31,6 +31,20 @@
   register: result
   until: result is succeeded
 
+- name: Install cri-tools
+  package:
+    name: "cri-tools"
+    state: latest
+
+- name: Configure cri-tools for dockershim
+  copy:
+    contents: |
+      runtime-endpoint: unix:///var/run/dockershim.sock
+      image-endpoint: unix:///var/run/dockershim.sock
+    dest: /etc/crictl.yaml
+  when:
+  - not (openshift_use_crio | bool)
+
 - block:
   # Extend the default Docker service unit file when using iptables-services
   - name: Ensure docker.service.d directory exists


### PR DESCRIPTION
This should be setup when docker is installed but cri-o isn't.

@sdodson PTAL

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>