### PR TITLE
Update Kuryr CNI template to 3.11

### DIFF
--- a/roles/kuryr/templates/cni-daemonset.yaml.j2
+++ b/roles/kuryr/templates/cni-daemonset.yaml.j2
@@ -11,7 +11,7 @@ metadata:
   annotations:
     image.openshift.io/triggers: |
       [
-        {"from":{"kind":"ImageStreamTag","name":"node:v3.10"},"fieldPath":"spec.template.spec.initContainers[?(@.name==\"install-cni-plugins\")].image"}
+        {"from":{"kind":"ImageStreamTag","name":"node:v3.11"},"fieldPath":"spec.template.spec.initContainers[?(@.name==\"install-cni-plugins\")].image"}
       ]
 spec:
   template:


### PR DESCRIPTION
Seems like Kuryr CNI template was ommitted when doing s/3.10/3.11/. This
commit fixes that.