### PR TITLE
no_proxy: use 'append' to properly add a string to a list

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -834,7 +834,7 @@ def set_proxy_facts(facts):
             common['no_proxy'].append(common['hostname'])
             if 'master' in facts:
                 if 'cluster_hostname' in facts['master']:
-                    common['no_proxy'].extend(facts['master']['cluster_hostname'])
+                    common['no_proxy'].append(facts['master']['cluster_hostname'])
             common['no_proxy'] = ','.join(sort_unique(common['no_proxy']))
         facts['common'] = common
 


### PR DESCRIPTION
cluster_hostname is a string, so it should be added via 'append()',
using 'extend()' would add all chars from this string

/priority p1

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1432020