### PR TITLE
Deprecate openshift_node_kubelet_args and openshift_node_labels

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -807,8 +807,7 @@ debug_level=2
 # interface other than the default network interface.
 #openshift_set_node_ip=True
 
-# Configure node kubelet arguments. pods-per-core is valid in OpenShift Origin 1.3 or OpenShift Container Platform 3.3 and later.
-#openshift_node_kubelet_args={'pods-per-core': ['10'], 'max-pods': ['250'], 'image-gc-high-threshold': ['85'], 'image-gc-low-threshold': ['80']}
+#openshift_node_kubelet_args is deprecated, use node config edits instead
 
 # Configure logrotate scripts
 # See: https://github.com/nickhammond/ansible-logrotate

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -61,14 +61,8 @@ openshift_node_kubelet_args_dict:
   undefined:
     node-labels: "{{ l_node_kubelet_node_labels }}"
 
-l_node_kubelet_args_default: "{{ openshift_node_kubelet_args_dict[openshift_cloudprovider_kind | default('undefined')] }}"
+l2_openshift_node_kubelet_args: "{{ openshift_node_kubelet_args_dict[openshift_cloudprovider_kind | default('undefined')] }}"
 
-l_openshift_node_kubelet_args: "{{ openshift_node_kubelet_args | default({}) }}"
-# Combine the default kubelet_args dictionary (based on cloud provider, if provided)
-# with user-supplied openshift_node_kubelet_args.
-# openshift_node_kubelet_args will override the defaults, if keys and/or subkeys
-# are present in both.
-l2_openshift_node_kubelet_args: "{{ l_node_kubelet_args_default | combine(l_openshift_node_kubelet_args, recursive=True) }}"
 openshift_node_dnsmasq_install_network_manager_hook: true
 
 # lo must always be present in this list or dnsmasq will conflict with

--- a/roles/openshift_sanitize_inventory/vars/main.yml
+++ b/roles/openshift_sanitize_inventory/vars/main.yml
@@ -75,3 +75,6 @@ __warn_deprecated_vars:
   - 'openshift_hosted_metrics_deployer_prefix'
   - 'openshift_hosted_metrics_deployer_version'
   - 'openshift_hosted_metrics_public_url'
+  # labels and kubelet args
+  - 'openshift_node_labels'
+  - 'openshift_node_kubelet_args'


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1569476