### PR TITLE
[release-1.5] Bug 1544783 - Specify all packages during upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/rpm_upgrade.yml
@@ -23,17 +23,3 @@
   when:
     - component == "master"
     - not openshift.common.is_atomic | bool
-
-- name: Upgrade node packages
-  package: name={{ node_pkgs | join(',') }} state=present
-  vars:
-    node_pkgs:
-      - "{{ openshift.common.service_type }}{{ openshift_pkg_version }}"
-      - "{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
-      - "{{ openshift.common.service_type }}-sdn-ovs{{ openshift_pkg_version }}"
-      - "{{ openshift.common.service_type }}-clients{{ openshift_pkg_version }}"
-      - "tuned-profiles-{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
-      - PyYAML
-  when:
-    - component == "node"
-    - not openshift.common.is_atomic | bool

--- a/roles/openshift_node_upgrade/tasks/main.yml
+++ b/roles/openshift_node_upgrade/tasks/main.yml
@@ -59,9 +59,6 @@
   when: node_config_hook is defined
 
 - include: rpm_upgrade.yml
-  vars:
-    component: "node"
-    openshift_version: "{{ openshift_pkg_version | default('') }}"
   when: not openshift.common.is_containerized | bool
 
 - name: Remove obsolete docker-sdn-ovs.conf

--- a/roles/openshift_node_upgrade/tasks/rpm_upgrade.yml
+++ b/roles/openshift_node_upgrade/tasks/rpm_upgrade.yml
@@ -1,13 +1,27 @@
 ---
 # input variables:
 # - openshift.common.service_type
-# - component
 # - openshift_pkg_version
 # - openshift.common.is_atomic
 
-# We verified latest rpm available is suitable, so just yum update.
+# When we update package "a-${version}" and a requires b >= ${version} if we
+# don't specify the version of b yum will choose the latest version of b
+# available and the whole set of dependencies end up at the latest version.
+# Since the package module, unlike the yum module, doesn't flatten a list
+# of packages into one transaction we need to do that explicitly. The ansible
+# core team tells us not to rely on yum module transaction flattening anyway.
+
 - name: Upgrade packages
-  package: "name={{ openshift.common.service_type }}-{{ component }}{{ openshift_pkg_version }} state=present"
+  command: "{{ ansible_pkg_mgr }} install -y {{ openshift_node_upgrade_rpm_list | join(' ')}}"
+  register: result
+  until: result is succeeded
+  vars:
+    openshift_node_upgrade_rpm_list:
+      - "{{ openshift.common.service_type }}{{ openshift_pkg_version }}"
+      - "{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
+      - "{{ openshift.common.service_type + '-sdn-ovs' + openshift_pkg_version if openshift_use_openshift_sdn | default(true) | bool else '' }}"
+      - "{{ openshift.common.service_type }}-clients{{ openshift_pkg_version }}"
+      - "tuned-profiles-{{ openshift.common.service_type }}-node{{ openshift_pkg_version }}"
 
 - name: Ensure python-yaml present for config upgrade
   package: name=PyYAML state=present


### PR DESCRIPTION
When we update package "a-${version}" and a requires b >= ${version} if we
don't specify the version of b yum will choose the latest version of b
available and the whole set of dependencies end up at the latest version.
Since the package module, unlike the yum module, doesn't flatten a list
of packages into one transaction we need to do that explicitly. The ansible
core team tells us not to rely on yum module transaction flattening anyway.

Backports #8879