### PR TITLE
Reconfigure web console after certificates were redeployed

### DIFF
--- a/playbooks/openshift-web-console/private/redeploy-certificates.yml
+++ b/playbooks/openshift-web-console/private/redeploy-certificates.yml
@@ -1,0 +1,35 @@
+---
+- name: Update web console certificates
+  hosts: oo_first_master
+  vars:
+  roles:
+  - lib_openshift
+  - openshift_facts
+  tasks:
+  - name: Remove certificates secret
+    oc_obj:
+      name: webconsole-serving-cert
+      kind: secret
+      state: absent
+      namespace: openshift-web-console
+
+  - name: Remove web console pods
+    oc_obj:
+      selector: "webconsole=true"
+      kind: pod
+      state: absent
+      namespace: openshift-web-console
+
+  - name: Verify that the console is running
+    oc_obj:
+      namespace: openshift-web-console
+      kind: deployment
+      state: list
+      name: webconsole
+    register: console_deployment
+    until:
+    - console_deployment.results.results[0].status.readyReplicas is defined
+    - console_deployment.results.results[0].status.readyReplicas > 0
+    retries: 60
+    delay: 10
+    changed_when: false

--- a/playbooks/redeploy-certificates.yml
+++ b/playbooks/redeploy-certificates.yml
@@ -24,3 +24,6 @@
 - import_playbook: openshift-master/private/revert-client-ca.yml
 
 - import_playbook: openshift-master/private/restart.yml
+
+- import_playbook: openshift-web-console/private/redeploy-certificates.yml
+  when: openshift_web_console_install | default(true) | bool


### PR DESCRIPTION
webconsole secret contains an outdated cert after certs were redeployed. This PR would make sure its removed and the pod is restarted

Fixes #8784
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1592303