### PR TITLE
Allow proxies to be rendered via openshift_provisioners_efs variables

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -831,7 +831,7 @@ debug_level=2
 # options like 'strict-order' to alter dnsmasq configuration.
 #openshift_node_dnsmasq_additional_config_file=/home/bob/ose-dnsmasq.conf
 
-# Global Proxy Configuration
+# Global Proxy Configuration*
 # These options configure HTTP_PROXY, HTTPS_PROXY, and NOPROXY environment
 # variables for docker and master services.
 #
@@ -841,6 +841,11 @@ debug_level=2
 #openshift_http_proxy=http://USER:PASSWORD@IPADDR:PORT
 #openshift_https_proxy=https://USER:PASSWORD@IPADDR:PORT
 #openshift_no_proxy='.hosts.example.com,some-host.com'
+#
+# When using EFS Provisioners the container will boot and check if the efs-id is valid but will hang in an environment with a proxy:
+#openshift_provisioners_efs_http_proxy=http://USER:PASSWORD@IPADDR:PORT
+#openshift_provisioners_efs_https_proxy=https://USER:PASSWORD@IPADDR:PORT
+#openshift_provisioners_efs_no_proxy='.cluster.local,.svc,169.254.169.254,plus your own exclusions'
 #
 # Most environments don't require a proxy between openshift masters, nodes, and
 # etcd hosts. So automatically add those hostnames to the openshift_no_proxy list.

--- a/roles/openshift_provisioners/templates/efs.j2
+++ b/roles/openshift_provisioners/templates/efs.j2
@@ -46,6 +46,18 @@ spec:
               value: "{{openshift_provisioners_efs_region}}"
             - name: PROVISIONER_NAME
               value: "{{openshift_provisioners_efs_name}}"
+{% if openshift_provisioners_efs_http_proxy is defined %}
+            - name: HTTP_PROXY
+              value: "{{openshift_provisioners_efs_http_proxy}}"
+{% endif %}
+{% if openshift_provisioners_efs_https_proxy is defined %}
+            - name: HTTPS_PROXY
+              value: "{{openshift_provisioners_efs_https_proxy}}"
+{% endif %}
+{% if openshift_provisioners_efs_no_proxy is defined %}
+            - name: NO_PROXY
+              value: "{{openshift_provisioners_efs_no_proxy}}"
+{% endif %}
           volumeMounts:
             - name: pv-volume
               mountPath: /persistentvolumes


### PR DESCRIPTION
When using EFS within an environment with Proxies (usually enterprise environments) the provisioner service stalls as the system is unable to confirm that the EFS volume exists when doing an AWS describe efs volume.

To resolve this requires manually adding proxy environment variables to the container config, however the template out of the box doesnt allow for this and requires some post DeploymentConfig patching. 

So I have decided to contribute my first change to this project.

Happy if you have another solution in mind?