### PR TITLE
Remove haproxy from node package set

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -96,7 +96,6 @@ default_r_openshift_node_image_prep_packages:
 - ansible
 - bash-completion
 - docker
-- haproxy
 - dnsmasq
 - ntp
 - logrotate


### PR DESCRIPTION
The only place we use haproxy is for the load balancer hosts and those
are pretty unique host definition and I can think of no reason one would
want to use haproxy in the cloud rather than a cloud native load
balancer.

Related https://bugzilla.redhat.com/show_bug.cgi?id=1592134

/cc @mtnbikenc @smarterclayton 