### PR TITLE
Add CloudForms configmap-generator templates

### DIFF
--- a/roles/openshift_examples/files/examples/v3.10/cfme-templates/httpd-configmap-generator-template.yaml
+++ b/roles/openshift_examples/files/examples/v3.10/cfme-templates/httpd-configmap-generator-template.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: httpd-configmap-generator
+metadata:
+  name: httpd-configmap-generator
+  annotations:
+    description: Httpd Configmap Generator
+    tags: httpd,httpd-configmap-generator
+    iconClass: icon-rails
+objects:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: httpd-configmap-generator
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+    annotations:
+      description: Exposes the httpd configmap generator server
+      service.alpha.openshift.io/dependencies: '[{"name":"${NAME}","namespace":"","kind":"Service"}]'
+  spec:
+    ports:
+    - name: httpd-configmap-generator
+      port: 80
+      targetPort: 80
+    selector:
+      name: httpd-configmap-generator
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+    annotations:
+      description: Defines how to deploy httpd
+  spec:
+    strategy:
+      type: Recreate
+      recreateParams:
+        timeoutSeconds: 1200
+    triggers:
+    - type: ConfigChange
+    replicas: 1
+    selector:
+      name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+    template:
+      metadata:
+        name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+        labels:
+          name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+      spec:
+        containers:
+        - name: httpd-configmap-generator
+          image: "${HTTPD_CONFIGMAP_GENERATOR_IMG_NAME}:${HTTPD_CONFIGMAP_GENERATOR_IMG_TAG}"
+          ports:
+          - containerPort: 80
+            protocol: TCP
+          - containerPort: 8080
+            protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - pidof
+              - httpd
+            initialDelaySeconds: 15
+            timeoutSeconds: 3
+          readinessProbe:
+            tcpSocket:
+              port: 80
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+          resources:
+            requests:
+              memory: "${HTTPD_CONFIGMAP_GENERATOR_MEM_REQ}"
+              cpu: "${HTTPD_CONFIGMAP_GENERATOR_CPU_REQ}"
+            limits:
+              memory: "${HTTPD_CONFIGMAP_GENERATOR_MEM_LIMIT}"
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - "/usr/bin/save-container-environment"
+        serviceAccount: httpd-configmap-generator
+        serviceAccountName: httpd-configmap-generator
+parameters:
+- name: HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME
+  required: true
+  displayName: Httpd Configmap Generator Service Name
+  description: The name of the OpenShift Service exposed for the httpd configmap generator container.
+  value: httpd-configmap-generator
+- name: HTTPD_CONFIGMAP_GENERATOR_IMG_NAME
+  displayName: Httpd Configmap Generator Image Name
+  description: This is the httpd configmap generator image name requested to deploy.
+  value: registry.access.redhat.com/cloudforms46/cfme-httpd-configmap-generator
+- name: HTTPD_CONFIGMAP_GENERATOR_IMG_TAG
+  displayName: Httpd Configmap Generator Image Tag
+  description: This is the httpd configmap generator image tag/version requested to deploy.
+  value: latest
+- name: HTTPD_CONFIGMAP_GENERATOR_CPU_REQ
+  displayName: Httpd Configmap Generator Min CPU Requested
+  required: true
+  description: Minimum amount of CPU time the httpd configmap generator container will need (expressed in millicores).
+  value: 500m
+- name: HTTPD_CONFIGMAP_GENERATOR_MEM_REQ
+  displayName: Httpd Configmap Generator Min RAM Requested
+  required: true
+  description: Minimum amount of memory the httpd configmap generator will need.
+  value: 512Mi
+- name: HTTPD_CONFIGMAP_GENERATOR_MEM_LIMIT
+  displayName: Httpd Configmap Generator Max RAM Limit
+  required: true
+  description: Maximum amount of memory the httpd configmap generator container can consume.
+  value: 8192Mi

--- a/roles/openshift_examples/files/examples/v3.10/cfme-templates/httpd-scc-sysadmin.yaml
+++ b/roles/openshift_examples/files/examples/v3.10/cfme-templates/httpd-scc-sysadmin.yaml
@@ -1,0 +1,38 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+apiVersion: v1
+defaultAddCapabilities:
+- SYS_ADMIN
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: httpd-scc-sysadmin provides all features of the anyuid SCC but allows users to have SYS_ADMIN capabilities. This is the required scc for Pods requiring to run with systemd and the message bus.
+  creationTimestamp:
+  name: httpd-scc-sysadmin
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+- SYS_CHROOT
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- secret

--- a/roles/openshift_examples/files/examples/v3.11/cfme-templates/httpd-configmap-generator-template.yaml
+++ b/roles/openshift_examples/files/examples/v3.11/cfme-templates/httpd-configmap-generator-template.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: httpd-configmap-generator
+metadata:
+  name: httpd-configmap-generator
+  annotations:
+    description: Httpd Configmap Generator
+    tags: httpd,httpd-configmap-generator
+    iconClass: icon-rails
+objects:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: httpd-configmap-generator
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+    annotations:
+      description: Exposes the httpd configmap generator server
+      service.alpha.openshift.io/dependencies: '[{"name":"${NAME}","namespace":"","kind":"Service"}]'
+  spec:
+    ports:
+    - name: httpd-configmap-generator
+      port: 80
+      targetPort: 80
+    selector:
+      name: httpd-configmap-generator
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+    annotations:
+      description: Defines how to deploy httpd
+  spec:
+    strategy:
+      type: Recreate
+      recreateParams:
+        timeoutSeconds: 1200
+    triggers:
+    - type: ConfigChange
+    replicas: 1
+    selector:
+      name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+    template:
+      metadata:
+        name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+        labels:
+          name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+      spec:
+        containers:
+        - name: httpd-configmap-generator
+          image: "${HTTPD_CONFIGMAP_GENERATOR_IMG_NAME}:${HTTPD_CONFIGMAP_GENERATOR_IMG_TAG}"
+          ports:
+          - containerPort: 80
+            protocol: TCP
+          - containerPort: 8080
+            protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - pidof
+              - httpd
+            initialDelaySeconds: 15
+            timeoutSeconds: 3
+          readinessProbe:
+            tcpSocket:
+              port: 80
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+          resources:
+            requests:
+              memory: "${HTTPD_CONFIGMAP_GENERATOR_MEM_REQ}"
+              cpu: "${HTTPD_CONFIGMAP_GENERATOR_CPU_REQ}"
+            limits:
+              memory: "${HTTPD_CONFIGMAP_GENERATOR_MEM_LIMIT}"
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - "/usr/bin/save-container-environment"
+        serviceAccount: httpd-configmap-generator
+        serviceAccountName: httpd-configmap-generator
+parameters:
+- name: HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME
+  required: true
+  displayName: Httpd Configmap Generator Service Name
+  description: The name of the OpenShift Service exposed for the httpd configmap generator container.
+  value: httpd-configmap-generator
+- name: HTTPD_CONFIGMAP_GENERATOR_IMG_NAME
+  displayName: Httpd Configmap Generator Image Name
+  description: This is the httpd configmap generator image name requested to deploy.
+  value: registry.access.redhat.com/cloudforms46/cfme-httpd-configmap-generator
+- name: HTTPD_CONFIGMAP_GENERATOR_IMG_TAG
+  displayName: Httpd Configmap Generator Image Tag
+  description: This is the httpd configmap generator image tag/version requested to deploy.
+  value: latest
+- name: HTTPD_CONFIGMAP_GENERATOR_CPU_REQ
+  displayName: Httpd Configmap Generator Min CPU Requested
+  required: true
+  description: Minimum amount of CPU time the httpd configmap generator container will need (expressed in millicores).
+  value: 500m
+- name: HTTPD_CONFIGMAP_GENERATOR_MEM_REQ
+  displayName: Httpd Configmap Generator Min RAM Requested
+  required: true
+  description: Minimum amount of memory the httpd configmap generator will need.
+  value: 512Mi
+- name: HTTPD_CONFIGMAP_GENERATOR_MEM_LIMIT
+  displayName: Httpd Configmap Generator Max RAM Limit
+  required: true
+  description: Maximum amount of memory the httpd configmap generator container can consume.
+  value: 8192Mi

--- a/roles/openshift_examples/files/examples/v3.11/cfme-templates/httpd-scc-sysadmin.yaml
+++ b/roles/openshift_examples/files/examples/v3.11/cfme-templates/httpd-scc-sysadmin.yaml
@@ -1,0 +1,38 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+apiVersion: v1
+defaultAddCapabilities:
+- SYS_ADMIN
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: httpd-scc-sysadmin provides all features of the anyuid SCC but allows users to have SYS_ADMIN capabilities. This is the required scc for Pods requiring to run with systemd and the message bus.
+  creationTimestamp:
+  name: httpd-scc-sysadmin
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+- SYS_CHROOT
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- secret

--- a/roles/openshift_management/files/templates/cloudforms/httpd-configmap-generator-template.yaml
+++ b/roles/openshift_management/files/templates/cloudforms/httpd-configmap-generator-template.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: httpd-configmap-generator
+metadata:
+  name: httpd-configmap-generator
+  annotations:
+    description: Httpd Configmap Generator
+    tags: httpd,httpd-configmap-generator
+    iconClass: icon-rails
+objects:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: httpd-configmap-generator
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+    annotations:
+      description: Exposes the httpd configmap generator server
+      service.alpha.openshift.io/dependencies: '[{"name":"${NAME}","namespace":"","kind":"Service"}]'
+  spec:
+    ports:
+    - name: httpd-configmap-generator
+      port: 80
+      targetPort: 80
+    selector:
+      name: httpd-configmap-generator
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+    annotations:
+      description: Defines how to deploy httpd
+  spec:
+    strategy:
+      type: Recreate
+      recreateParams:
+        timeoutSeconds: 1200
+    triggers:
+    - type: ConfigChange
+    replicas: 1
+    selector:
+      name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+    template:
+      metadata:
+        name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+        labels:
+          name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
+      spec:
+        containers:
+        - name: httpd-configmap-generator
+          image: "${HTTPD_CONFIGMAP_GENERATOR_IMG_NAME}:${HTTPD_CONFIGMAP_GENERATOR_IMG_TAG}"
+          ports:
+          - containerPort: 80
+            protocol: TCP
+          - containerPort: 8080
+            protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - pidof
+              - httpd
+            initialDelaySeconds: 15
+            timeoutSeconds: 3
+          readinessProbe:
+            tcpSocket:
+              port: 80
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+          resources:
+            requests:
+              memory: "${HTTPD_CONFIGMAP_GENERATOR_MEM_REQ}"
+              cpu: "${HTTPD_CONFIGMAP_GENERATOR_CPU_REQ}"
+            limits:
+              memory: "${HTTPD_CONFIGMAP_GENERATOR_MEM_LIMIT}"
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - "/usr/bin/save-container-environment"
+        serviceAccount: httpd-configmap-generator
+        serviceAccountName: httpd-configmap-generator
+parameters:
+- name: HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME
+  required: true
+  displayName: Httpd Configmap Generator Service Name
+  description: The name of the OpenShift Service exposed for the httpd configmap generator container.
+  value: httpd-configmap-generator
+- name: HTTPD_CONFIGMAP_GENERATOR_IMG_NAME
+  displayName: Httpd Configmap Generator Image Name
+  description: This is the httpd configmap generator image name requested to deploy.
+  value: registry.access.redhat.com/cloudforms46/cfme-httpd-configmap-generator
+- name: HTTPD_CONFIGMAP_GENERATOR_IMG_TAG
+  displayName: Httpd Configmap Generator Image Tag
+  description: This is the httpd configmap generator image tag/version requested to deploy.
+  value: latest
+- name: HTTPD_CONFIGMAP_GENERATOR_CPU_REQ
+  displayName: Httpd Configmap Generator Min CPU Requested
+  required: true
+  description: Minimum amount of CPU time the httpd configmap generator container will need (expressed in millicores).
+  value: 500m
+- name: HTTPD_CONFIGMAP_GENERATOR_MEM_REQ
+  displayName: Httpd Configmap Generator Min RAM Requested
+  required: true
+  description: Minimum amount of memory the httpd configmap generator will need.
+  value: 512Mi
+- name: HTTPD_CONFIGMAP_GENERATOR_MEM_LIMIT
+  displayName: Httpd Configmap Generator Max RAM Limit
+  required: true
+  description: Maximum amount of memory the httpd configmap generator container can consume.
+  value: 8192Mi

--- a/roles/openshift_management/files/templates/cloudforms/httpd-scc-sysadmin.yaml
+++ b/roles/openshift_management/files/templates/cloudforms/httpd-scc-sysadmin.yaml
@@ -1,0 +1,38 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+apiVersion: v1
+defaultAddCapabilities:
+- SYS_ADMIN
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: httpd-scc-sysadmin provides all features of the anyuid SCC but allows users to have SYS_ADMIN capabilities. This is the required scc for Pods requiring to run with systemd and the message bus.
+  creationTimestamp:
+  name: httpd-scc-sysadmin
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+- SYS_CHROOT
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- secret


### PR DESCRIPTION
httpd-configmap-generator templates for CF 4.6.
Please backport to wherever other CF 4.6 templates are included (3.7 and 3.9?)

cc @sdodson 