### PR TITLE
Grafana: convert grafana_service_targetport in annotations

### DIFF
--- a/roles/openshift_grafana/tasks/install_grafana.yaml
+++ b/roles/openshift_grafana/tasks/install_grafana.yaml
@@ -61,7 +61,7 @@
     annotations:
       prometheus.io/scrape: "true"
       prometheus.io/scheme: https
-      prometheus.io/port: "{{ grafana_service_targetport }}"
+      prometheus.io/port: "{{ grafana_service_targetport | int }}"
       service.alpha.openshift.io/serving-cert-secret-name: grafana-tls
     ports:
     - name: grafana


### PR DESCRIPTION
This is required for ansible to quote it properly

/cc mrsiano