### PR TITLE
Disable the wifi collector in node_exporter

### DIFF
--- a/roles/openshift_prometheus/files/node-exporter-template.yaml
+++ b/roles/openshift_prometheus/files/node-exporter-template.yaml
@@ -65,6 +65,8 @@ objects:
         containers:
         - image: ${IMAGE}
           name: node-exporter
+          args:
+          - --no-collector.wifi
           ports:
           - containerPort: 9100
             name: scrape


### PR DESCRIPTION
This collector isn't useful for OpenShift and it produces AVC denials
from SELinux.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1593211