### PR TITLE
Increase watch_retry_timeout for kuryr-daemon

### DIFF
--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -568,6 +568,9 @@ data:
     # The driver that manages VIFs pools for Kubernetes Pods (string value)
     vif_pool_driver = {{ kuryr_openstack_pool_driver }}
 
+    # Time (in seconds) the watcher retries watching for. (integer value)
+    watch_retry_timeout = 3600
+
     [neutron]
     # Configuration options for OpenStack Neutron
 


### PR DESCRIPTION
When deploying on OpenStack, we're putting OpenShift API behind Octavia
load balancer. Octavia is sometimes very slow with allowing the traffic
to pass.

Now kuryr-daemon container is connecting to OpenShift API through that
load balancer. In case of LB not being ready at the moment it retries
for 60 seconds and then stops. For Octavia this is sometimes not enough.

This commit increases that timeout to 3600 seconds, to make kuryr-daemon
retry virtually forever.