### PR TITLE
Update routers that are defined in openshift_hosted_routers

### DIFF
--- a/roles/openshift_hosted/tasks/upgrade_routers.yml
+++ b/roles/openshift_hosted/tasks/upgrade_routers.yml
@@ -1,33 +1,14 @@
 ---
-- name: Collect all routers
-  oc_obj:
-    state: list
-    kind: pods
-    all_namespaces: True
-    selector: 'router'
-  register: all_routers
-
-- set_fact:
-    haproxy_routers: "{{ all_routers.results.results[0]['items'] |
-                         lib_utils_oo_pods_match_component(openshift_deployment_type, 'haproxy-router') |
-                         lib_utils_oo_select_keys_from_list(['metadata']) }}"
-  when:
-  - all_routers.results.returncode == 0
-
-- set_fact: haproxy_routers=[]
-  when:
-  - all_routers.results.returncode != 0
-
 - name: Update router image to current version
   oc_edit:
     kind: dc
-    name: "{{ item['labels']['deploymentconfig'] }}"
+    name: "{{ item['name'] }}"
     namespace: "{{ item['namespace'] }}"
     content:
       spec.template.spec.containers[0].image: "{{ l_osh_router_image }}"
-  with_items: "{{ haproxy_routers }}"
+  with_items: "{{ openshift_hosted_routers }}"
   vars:
     l_osh_router_image: "{{ openshift_hosted_router_registryurl | replace( '${component}', 'haproxy-router' ) |
                             replace ( '${version}', openshift_image_tag ) }}"
   when:
-  - all_routers.results.returncode == 0
+  - openshift_hosted_routers | length > 0


### PR DESCRIPTION
Previously we looked for all pods in all namespaces that had a label of `router` defined for them. We then matched the image spec on those pods to `openshift3/ose-haproxy-router` or `openshift/origin-haproxy-router` for ocp and origin respectively. From that set of pods we gathered the list of deployment configs. This failed when the image used was moved to be fully qualified and it would also fail in situations where they're not using an image name that matches the pattern otherwise.

As implemented, this change moves to update routers that are defined in the `openshift_hosted_routers` variable which is the standard mechanism for defining routers in openshift-ansible. This means, that if another router had been created that's not defined in that variable it will not be upgraded. 

An alternative would be to look for deployment configs that have a label of `router` defined for them and update the image on all of those, however I'm not certain whether or not we should be managing routers that we're not informed of.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1593787

/cc @mtnbikenc 