### PR TITLE
Fix openshift_logging on Python3

### DIFF
--- a/roles/openshift_logging/library/openshift_logging_facts.py
+++ b/roles/openshift_logging/library/openshift_logging_facts.py
@@ -76,6 +76,7 @@ class OCBaseCommand(object):
         try:
             process = Popen(cmd, stdout=PIPE, stderr=PIPE)   # noqa: F405
             out, err = process.communicate(cmd)
+            err = err.decode(encoding='utf8', errors='replace')
             if len(err) > 0:
                 if 'not found' in err:
                     return {'items': []}


### PR DESCRIPTION
Popen returns a byte object on Python 3 so we need to cast it before
doing comparison.

Closes #4163