### PR TITLE
Fix openshift_node_config_name in bootstrap.yml.

### DIFF
--- a/roles/openshift_node/templates/bootstrap.yml.j2
+++ b/roles/openshift_node/templates/bootstrap.yml.j2
@@ -25,9 +25,8 @@
     with_items: "{{ origin_dns.lines }}"
 
   - when:
-    - openshift_group_type is defined
-    - openshift_group_type != ''
-    - openshift_group_type != 'master'
+    - openshift_node_config_name is defined
+    - openshift_node_config_name != ''
     block:
     - name: determine the openshift_service_type
       stat:


### PR DESCRIPTION
Fixing a variable name that wasn't changed in #8785. This PR updates the bootstrap playbook to check for `openshift_node_config_name` which matches what we configure in a [settings file created by user data](https://github.com/openshift/openshift-ansible/blob/0c20ac6490c0182316f0afaf2d01444c75dbcbf3/roles/openshift_aws/templates/user_data.j2#L10).