### PR TITLE
Only dump oreg_url when value is defined.

### DIFF
--- a/playbooks/azure/openshift-cluster/build_node_image.yml
+++ b/playbooks/azure/openshift-cluster/build_node_image.yml
@@ -82,6 +82,7 @@
       dest: "/etc/origin/oreg_url"
       content: |
         "{{ oreg_url }}"
+    when: oreg_url is defined
 
   - name: run waagent deprovision
     shell: sleep 2 && waagent -deprovision+user -force


### PR DESCRIPTION
Only dump the oreg_url when it is  defined.

fixes https://github.com/openshift/openshift-ansible/issues/8930