### PR TITLE
[release-3.6] Assign openshift_version from openshift_pkg_version with correct format

### DIFF
--- a/roles/openshift_ca/README.md
+++ b/roles/openshift_ca/README.md
@@ -11,14 +11,14 @@ Role Variables
 
 From this role:
 
-| Name                    | Default value                                 | Description                                                                 |
-|-------------------------|-----------------------------------------------|-----------------------------------------------------------------------------|
-| openshift_ca_host       | None (Required)                               | The hostname of the system where the OpenShift CA will be created.          |
-| openshift_ca_config_dir | `{{ openshift.common.config_base }}/master`   | CA certificate directory.                                                   |
-| openshift_ca_cert       | `{{ openshift_ca_config_dir }}/ca.crt`        | CA certificate path including CA certificate filename.                      |
-| openshift_ca_key        | `{{ openshift_ca_config_dir }}/ca.key`        | CA key path including CA key filename.                                      |
-| openshift_ca_serial     | `{{ openshift_ca_config_dir }}/ca.serial.txt` | CA serial path including CA serial filename.                                |
-| openshift_version       | `{{ openshift_pkg_version }}`                 | OpenShift package version.                                                  |
+| Name                    | Default value                                              | Description                                                                 |
+|-------------------------|------------------------------------------------------------|-----------------------------------------------------------------------------|
+| openshift_ca_host       | None (Required)                                            | The hostname of the system where the OpenShift CA will be created.          |
+| openshift_ca_config_dir | `{{ openshift.common.config_base }}/master`                | CA certificate directory.                                                   |
+| openshift_ca_cert       | `{{ openshift_ca_config_dir }}/ca.crt`                     | CA certificate path including CA certificate filename.                      |
+| openshift_ca_key        | `{{ openshift_ca_config_dir }}/ca.key`                     | CA key path including CA key filename.                                      |
+| openshift_ca_serial     | `{{ openshift_ca_config_dir }}/ca.serial.txt`              | CA serial path including CA serial filename.                                |
+| openshift_version       | `{{ openshift_pkg_version[1:].split('-')[0].strip('*') }}` | OpenShift package version.                                                  |
 | openshift_master_cert_expire_days | `730` (2 years)                     | Validity of the certificates in days. Works only with OpenShift version 1.5 (3.5) and later. |
 | openshift_ca_cert_expire_days     | `1825` (5 years)                    | Validity of the CA certificates in days. Works only with OpenShift version 1.5 (3.5) and later. |
 

--- a/roles/openshift_ca/vars/main.yml
+++ b/roles/openshift_ca/vars/main.yml
@@ -3,7 +3,7 @@ openshift_ca_config_dir: "{{ openshift.common.config_base }}/master"
 openshift_ca_cert: "{{ openshift_ca_config_dir }}/ca.crt"
 openshift_ca_key: "{{ openshift_ca_config_dir }}/ca.key"
 openshift_ca_serial: "{{ openshift_ca_config_dir }}/ca.serial.txt"
-openshift_version: "{{ openshift_pkg_version | default('') }}"
+openshift_version: "{{ openshift_pkg_version[1:].split('-')[0].strip('*') | default('') }}"
 
 openshift_master_loopback_config: "{{ openshift_ca_config_dir }}/openshift-master.kubeconfig"
 loopback_context_string: "current-context: {{ openshift.master.loopback_context_name }}"

--- a/roles/openshift_named_certificates/vars/main.yml
+++ b/roles/openshift_named_certificates/vars/main.yml
@@ -3,7 +3,7 @@ openshift_ca_config_dir: "{{ openshift.common.config_base }}/master"
 openshift_ca_cert: "{{ openshift_ca_config_dir }}/ca.crt"
 openshift_ca_key: "{{ openshift_ca_config_dir }}/ca.key"
 openshift_ca_serial: "{{ openshift_ca_config_dir }}/ca.serial.txt"
-openshift_version: "{{ openshift_pkg_version | default('') }}"
+openshift_version: "{{ openshift_pkg_version[1:].split('-')[0].strip('*') | default('') }}"
 
 overwrite_named_certs: "{{ openshift_master_overwrite_named_certificates | default(false) }}"
 named_certs_dir: "{{ openshift.common.config_base }}/master/named_certificates/"

--- a/roles/openshift_version/tasks/set_version_rpm.yml
+++ b/roles/openshift_version/tasks/set_version_rpm.yml
@@ -2,7 +2,7 @@
 - name: Set rpm version to configure if openshift_pkg_version specified
   set_fact:
     # Expects a leading "-" in inventory, strip it off here, and remove trailing release,
-    openshift_version: "{{ openshift_pkg_version[1:].split('-')[0] }}"
+    openshift_version: "{{ openshift_pkg_version[1:].split('-')[0].strip('*') }}"
   when:
   - openshift_pkg_version is defined
   - openshift_version is not defined


### PR DESCRIPTION
On release-3.6 `openshift_version` is assigned by
`openshift_pkg_version` when openshift_version was not set but
openshift_pkg_version was. However, The format of
`openshift_pkg_version` is different from openshift_version and could
contain `-` and `*` in front/end of the value. Due to this, some tasks
using openshift_version fail unexpectedly (e.g - bz#1592111).

To fix this issue (without breaking current behavior), this patch adds
normalization of openshift_version only when it was assigned by
openshift_pkg_version as:

  |openshift_pkg_version            | openshift_version  |
  |---------------------------------|--------------------|
  | -3.6.173.0.117-1.git.0.b1f7e54  | 3.6.173.0.117      |
  | -3.6.173.0.117                  | 3.6.173.0.117      |
  | -3.6*                           | 3.6                |

Fixes https://bugzilla.redhat.com/1592111 