### PR TITLE
Add atomic package to base and debug package lists

### DIFF
--- a/playbooks/gcp/openshift-cluster/build_base_image.yml
+++ b/playbooks/gcp/openshift-cluster/build_base_image.yml
@@ -148,6 +148,7 @@
     - iptables-services
     - bridge-utils
     - bash-completion
+    - atomic
   - name: Clean yum metadata
     command: yum clean all
     args:

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -118,6 +118,7 @@ default_r_openshift_node_image_prep_packages:
 - cockpit-docker
 - iscsi-initiator-utils
 - ceph-common
+- atomic
 r_openshift_node_image_prep_packages: "{{ default_r_openshift_node_image_prep_packages | union(openshift_node_image_prep_packages | default([])) }}"
 
 r_openshift_node_os_firewall_deny: []


### PR DESCRIPTION
Although atomic command is similar to docker command, it has some
richer functions. For example, `atomic mount` is very useful command
for troubleshootings.
More importantly, as atomic enthusiast support engineers, we do not
want to ask users if they installed atomic package or not before
instructing troubleshootings.

This patch adds atomic package to base and debug package lists.