### PR TITLE
Gather master facts to make sure cluster_hostname gets appended to no_proxy list on nodes

### DIFF
--- a/roles/openshift_node/tasks/config/configure-proxy-settings.yml
+++ b/roles/openshift_node/tasks/config/configure-proxy-settings.yml
@@ -1,4 +1,9 @@
 ---
+- openshift_facts:
+    role: master
+    local_facts:
+      cluster_hostname: "{{ openshift_master_cluster_hostname | default(None) }}"
+
 - name: Configure Proxy Settings
   lineinfile:
     dest: /etc/sysconfig/{{ openshift_service_type }}-node


### PR DESCRIPTION
Before updating `no_proxy` env var for kubelet nodes should gather master facts, as otherwise `openshift_master_cluster_hostname` won't be appended

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1594726