### PR TITLE
Fix flex volume location in openshift installs

### DIFF
--- a/roles/lib_utils/action_plugins/master_check_paths_in_config.py
+++ b/roles/lib_utils/action_plugins/master_check_paths_in_config.py
@@ -33,6 +33,7 @@ ALLOWED_DIRS = (
     '/var/lib/origin',
     '/etc/origin/cloudprovider',
     '/etc/origin/kubelet-plugins',
+    '/usr/libexec/kubernetes/kubelet-plugins',
 )
 
 ALLOWED_DIRS_STRING = ', '.join(ALLOWED_DIRS)

--- a/roles/lib_utils/action_plugins/master_check_paths_in_config.py
+++ b/roles/lib_utils/action_plugins/master_check_paths_in_config.py
@@ -32,6 +32,7 @@ ALLOWED_DIRS = (
     '/etc/origin/master/',
     '/var/lib/origin',
     '/etc/origin/cloudprovider',
+    '/etc/origin/kubelet-plugins',
 )
 
 ALLOWED_DIRS_STRING = ', '.join(ALLOWED_DIRS)

--- a/roles/openshift_control_plane/files/controller.yaml
+++ b/roles/openshift_control_plane/files/controller.yaml
@@ -33,6 +33,8 @@ spec:
        name: master-cloud-provider
      - mountPath: /etc/containers/registries.d/
        name: signature-import
+     - mountPath: /etc/origin/kubelet-plugins
+       name: kubelet-plugins
     livenessProbe:
       httpGet:
         scheme: HTTPS
@@ -50,3 +52,6 @@ spec:
   - hostPath:
       path: /etc/containers/registries.d
     name: signature-import
+  - name: kubelet-plugins
+    hostPath:
+      path: /etc/origin/kubelet-plugins

--- a/roles/openshift_control_plane/files/controller.yaml
+++ b/roles/openshift_control_plane/files/controller.yaml
@@ -33,7 +33,7 @@ spec:
        name: master-cloud-provider
      - mountPath: /etc/containers/registries.d/
        name: signature-import
-     - mountPath: /etc/origin/kubelet-plugins
+     - mountPath: /usr/libexec/kubernetes/kubelet-plugins
        name: kubelet-plugins
     livenessProbe:
       httpGet:
@@ -54,4 +54,4 @@ spec:
     name: signature-import
   - name: kubelet-plugins
     hostPath:
-      path: /etc/origin/kubelet-plugins
+      path: /usr/libexec/kubernetes/kubelet-plugins

--- a/roles/openshift_control_plane/files/controller.yaml
+++ b/roles/openshift_control_plane/files/controller.yaml
@@ -35,6 +35,7 @@ spec:
        name: signature-import
      - mountPath: /usr/libexec/kubernetes/kubelet-plugins
        name: kubelet-plugins
+       mountPropagation: "HostToContainer"
     livenessProbe:
       httpGet:
         scheme: HTTPS

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -45,6 +45,12 @@
     path: "/etc/origin/master"
     state: directory
 
+- name: Create flexvolume directory when containerized
+  file:
+    state: directory
+    path: "{{ openshift_flexvolume_container_directory_default }}/volume/exec"
+    mode: '0750'
+
 - name: Create the policy file if it does not already exist
   command: >
     {{ openshift_client_binary }} adm create-bootstrap-policy-file

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -45,11 +45,19 @@
     path: "/etc/origin/master"
     state: directory
 
-- name: Create flexvolume directory when containerized
+- name: Create flexvolume directory when on atomic hosts
   file:
     state: directory
     path: "{{ openshift_flexvolume_container_directory_default }}/volume/exec"
     mode: '0750'
+  when: openshift_is_atomic | bool
+
+- name: Flex volume directory on non-atomic host
+  file:
+    state: directory
+    path: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
+    mode: '0750'
+  when: not openshift_is_atomic | bool
 
 - name: Create the policy file if it does not already exist
   command: >

--- a/roles/openshift_control_plane/tasks/static.yml
+++ b/roles/openshift_control_plane/tasks/static.yml
@@ -45,6 +45,16 @@
     - key: spec.containers[0].readinessProbe.httpGet.port
       value: "{{ openshift_master_api_port }}"
 
+- name: Update controller-manager static pod on atomic host
+  yedit:
+    src: "{{ mktemp.stdout }}/controller.yaml"
+    edits:
+    - key: spec.volumes[3].hostPath.path
+      value: "{{ openshift_flexvolume_container_directory_default }}"
+    - key: spec.containers[0].volumeMounts[3].mountPath
+      value: "{{ openshift_flexvolume_container_directory_default }}"
+  when: openshift_is_atomic | bool
+
 - name: ensure pod location exists
   file:
     path: "{{ openshift_control_plane_static_pod_location }}"

--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -83,8 +83,10 @@ kubernetesMasterConfig:
     - VolumeScheduling=true
 {% endif %}
   controllerArguments: {{ openshift.master.controller_args | default(None) | lib_utils_to_padded_yaml( level=2 ) }}
+{% if openshift_is_atomic | bool %}
     flex-volume-plugin-dir:
     - "{{ openshift_flexvolume_container_directory_default }}/volume/exec"
+{% end %}
 {% if openshift_master_use_persistentlocalvolumes | bool %}
     feature-gates:
     - PersistentLocalVolumes=true

--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -86,7 +86,7 @@ kubernetesMasterConfig:
 {% if openshift_is_atomic | bool %}
     flex-volume-plugin-dir:
     - "{{ openshift_flexvolume_container_directory_default }}/volume/exec"
-{% end %}
+{% endif %}
 {% if openshift_master_use_persistentlocalvolumes | bool %}
     feature-gates:
     - PersistentLocalVolumes=true

--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -83,6 +83,8 @@ kubernetesMasterConfig:
     - VolumeScheduling=true
 {% endif %}
   controllerArguments: {{ openshift.master.controller_args | default(None) | lib_utils_to_padded_yaml( level=2 ) }}
+    flex-volume-plugin-dir:
+    - "{{ openshift_flexvolume_container_directory_default }}/volume/exec"
 {% if openshift_master_use_persistentlocalvolumes | bool %}
     feature-gates:
     - PersistentLocalVolumes=true

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -141,3 +141,4 @@ openshift_node_groups:
       - 'node-role.kubernetes.io/infra=true,node-role.kubernetes.io/master=true,node-role.kubernetes.io/compute=true'
     edits: []
 openshift_master_manage_htpasswd: True
+openshift_flexvolume_container_directory_default: "/etc/origin/kubelet-plugins"

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -47,6 +47,13 @@
     state: directory
     mode: 0755
 
+- name: Create flexvolume directory when running on atomic
+  file:
+    state: directory
+    path: "{{ openshift_flexvolume_container_directory_default }}/volume/exec"
+    mode: '0750'
+  when: openshift_is_atomic | bool
+
 - name: include aws provider credentials
   import_tasks: aws.yml
   when: not (openshift_node_use_instance_profiles | default(False))

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -12,6 +12,10 @@ imageConfig:
   latest: {{ openshift_node_image_config_latest }}
 kind: NodeConfig
 kubeletArguments: {{  l2_openshift_node_kubelet_args  | default(None) | lib_utils_to_padded_yaml(level=1) }}
+{% if openshift_is_atomic | bool %}
+  volume-plugin-dir:
+  - "{{ openshift_flexvolume_container_directory_default }}/volume/exec"
+{% endif %}
 {% if openshift_use_crio | bool %}
   container-runtime:
   - remote

--- a/roles/openshift_node_group/templates/node-config.yaml.j2
+++ b/roles/openshift_node_group/templates/node-config.yaml.j2
@@ -20,6 +20,10 @@ imageConfig:
   latest: false
 iptablesSyncPeriod: "{{ openshift_node_iptables_sync_period }}"
 kubeletArguments:
+{% if openshift_is_atomic | bool %}
+  volume-plugin-dir:
+  - "{{ openshift_flexvolume_container_directory_default }}/volume/exec"
+{% endif %}
 {% if openshift_use_crio | bool %}
   container-runtime:
   - remote


### PR DESCRIPTION
This fixes flexvolume installation on both containerized and non-containerized hosts.

However on atomic hosts or environments where kubelet runs as system container - https://github.com/openshift/origin/pull/20095 is also needed for making everything work.
