### PR TITLE
Bug 1589134- Namespace the CRD variable to prevent collision

### DIFF
--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -118,14 +118,14 @@
 
 - name: Create custom resource definitions for asb
   oc_obj:
-    name: '{{ crd.metadata.name }}'
+    name: '{{ asb_crd.metadata.name }}'
     kind: CustomResourceDefinition
     state: present
     content:
-      path: /tmp/{{ crd.metadata.name }}
-      data: '{{ crd }}'
+      path: /tmp/{{ asb_crd.metadata.name }}
+      data: '{{ asb_crd }}'
   vars:
-    crd: "{{ lookup('file', item) | from_yaml }}"
+    asb_crd: "{{ lookup('file', item) | from_yaml }}"
   with_fileglob:
     - 'files/*.automationbroker.io.yaml'
 

--- a/roles/ansible_service_broker/tasks/migrate.yml
+++ b/roles/ansible_service_broker/tasks/migrate.yml
@@ -43,14 +43,14 @@
 
     - name: Create custom resource definitions for asb
       oc_obj:
-        name: '{{ crd.metadata.name }}'
+        name: '{{ asb_crd.metadata.name }}'
         kind: CustomResourceDefinition
         state: present
         content:
-          path: /tmp/{{ crd.metadata.name }}
-          data: '{{ crd }}'
+          path: /tmp/{{ asb_crd.metadata.name }}
+          data: '{{ asb_crd }}'
       vars:
-        crd: "{{ lookup('file', item) | from_yaml }}"
+        asb_crd: "{{ lookup('file', item) | from_yaml }}"
       with_fileglob:
         - 'files/*.automationbroker.io.yaml'
 

--- a/roles/ansible_service_broker/tasks/remove.yml
+++ b/roles/ansible_service_broker/tasks/remove.yml
@@ -99,11 +99,11 @@
 
 - name: remove custom resource definitions for asb
   oc_obj:
-    name: '{{ crd.metadata.name }}'
+    name: '{{ asb_crd.metadata.name }}'
     kind: CustomResourceDefinition
     state: absent
   vars:
-    crd: "{{ lookup('file', item) | from_yaml }}"
+    asb_crd: "{{ lookup('file', item) | from_yaml }}"
   with_fileglob:
     - 'files/*.automationbroker.io.yaml'
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1589134

The `crd` name in the ASB role conflicted with:

https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_cluster_monitoring_operator/tasks/install.yaml#L72