### PR TITLE
etcd: add clientAuth to server usage

### DIFF
--- a/roles/etcd/templates/openssl_append.j2
+++ b/roles/etcd/templates/openssl_append.j2
@@ -39,7 +39,7 @@ subjectKeyIdentifier   = hash
 [ {{ etcd_ca_exts_server }} ]
 authorityKeyIdentifier = keyid,issuer:always
 basicConstraints       = critical,CA:FALSE
-extendedKeyUsage       = serverAuth
+extendedKeyUsage       = serverAuth,clientAuth
 keyUsage               = digitalSignature,keyEncipherment
 subjectKeyIdentifier   = hash
 


### PR DESCRIPTION
Etcd requires clientAuth and serverAuth usage in the server certificate
due to the embedded grpc server.

[Source](https://github.com/coreos/etcd/issues/8603)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1593635