### PR TITLE
Copying acs-engine output to known location

### DIFF
--- a/playbooks/azure/openshift-cluster/launch.yml
+++ b/playbooks/azure/openshift-cluster/launch.yml
@@ -86,6 +86,7 @@
         --auth-method client_secret \
         --client-id {{ lookup('env', 'AZURE_CLIENT_ID') }} \
         --client-secret {{ lookup('env', 'AZURE_SECRET') }} \
+        --output-directory {{ tmp.path }}/deploy \
         {{ tmp.path }}/openshift.json
     no_log: true
     ignore_errors: yes
@@ -100,14 +101,11 @@
   # This code attempts to persist the data to /var/tmp which is bind
   # mounted into the calling container.  This enables the CI to reuse
   # the cluster created in the previous steps to perform the e2e tests
-  - name: persist the parameters file
+  - name: persist the acs-engine generated artifacts
     copy:
-      src: "{{ item.src }}"
-      dest: "{{ item.dest }}"
+      src: "{{ tmp.path }}/deploy"
+      dest: /var/tmp/
     when: openshift_ci_persist_artifacts | default(False)
-    with_items:
-    - src: "{{ tmp.path }}/_output/{{ openshift_azure_resource_group_name }}/apimodel.json"
-      dest: "/var/tmp/{{ openshift_azure_resource_group_name }}.json"
 
   - name: delete temporary directory
     file:


### PR DESCRIPTION
Another attempt at persisting the acs-engine output.  The command is now told a destination location to store its output.  This location is then copied to /var/tmp from the container.  

This error indicates that the acs-engine run did not store its output in the created tmp directory but instead wherever the command module ran.  This is now writing to the `tmp.path/deploy` location.
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AnsibleFileNotFound: Could not find or access '/tmp/ansible.oMcPCn/_output/ci-test_branch_openshift_ansible_extended_c_azure-21/apimodel.json'
```

@pweil- @kargakis @jim-minter 