### PR TITLE
Add max-size to docker log opts

### DIFF
--- a/roles/container_runtime/templates/daemon.json
+++ b/roles/container_runtime/templates/daemon.json
@@ -5,10 +5,15 @@
     "disable-legacy-registry": false,
     "exec-opts": ["native.cgroupdriver=systemd"],
     "insecure-registries": {{ l_docker_insecure_registries }},
-{% if openshift_docker_log_driver  %}
-    "log-driver": "{{ openshift_docker_log_driver }}",
-{%- endif %}
-    "log-opts": {{ l_docker_log_options_dict }},
+    {% if openshift_docker_log_driver  %}
+        "log-driver": "{{ openshift_docker_log_driver }}",
+    {%- endif %}
+    {% if 'max-size' in l_docker_log_options_dict | from_json -%}
+        "log-opts": {{ l_docker_log_options_dict }},
+    {% else -%}
+        {% set new_opts = l_docker_log_options_dict | from_json | combine({'max-size': '50m'}) -%}
+        "log-opts": {{ new_opts | to_json}},
+    {% endif %}
     "runtimes": {
 	"oci": {
 	    "path": "/usr/libexec/docker/docker-runc-current"


### PR DESCRIPTION
The docker logs didn't have a max-value set so the log file
was ending up to be super huge and filling up disk space.
Setting the max value to 50m

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1594678

Signed-off-by: umohnani8 <umohnani@redhat.com>