### PR TITLE
Add max-size to docker log opts

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -23,7 +23,10 @@ openshift_docker_ent_reg: 'registry.access.redhat.com'
 
 openshift_docker_options: False  # str
 openshift_docker_log_driver: False  # str
-openshift_docker_log_options: []
+openshift_docker_log_options_defaults:
+  json:
+  - "max-size=50m"
+openshift_docker_log_options: "{{ openshift_docker_log_options_defaults[openshift_docker_log_driver] | default([]) }}"
 
 # The l2_docker_* variables convert csv strings to lists, if
 # necessary.  These variables should be used in place of their respective


### PR DESCRIPTION
The docker logs didn't have a max-value set so the log file
was ending up to be super huge and filling up disk space.
Setting the max value to 50m

Signed-off-by: umohnani8 <umohnani@redhat.com>