### PR TITLE
Ensure SkyDNS is enabled with Kuryr SDN

### DIFF
--- a/roles/kuryr/templates/cni-daemonset.yaml.j2
+++ b/roles/kuryr/templates/cni-daemonset.yaml.j2
@@ -11,7 +11,8 @@ metadata:
   annotations:
     image.openshift.io/triggers: |
       [
-        {"from":{"kind":"ImageStreamTag","name":"node:v3.10"},"fieldPath":"spec.template.spec.initContainers[?(@.name==\"install-cni-plugins\")].image"}
+        {"from":{"kind":"ImageStreamTag","name":"node:v3.10"},"fieldPath":"spec.template.spec.initContainers[?(@.name==\"install-cni-plugins\")].image"},
+        {"from":{"kind":"ImageStreamTag","name":"node:v3.10"},"fieldPath":"spec.template.spec.containers[?(@.name==\"sky-dns\")].image"}
       ]
 spec:
   template:
@@ -44,6 +45,70 @@ spec:
         securityContext:
           privileged: true
       containers:
+      - name: sky-dns
+        image: " "
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -ex
+
+          # if the node config doesn't exist yet, wait until it does
+          retries=0
+          while true; do
+            if [[ ! -f /etc/origin/node/node-config.yaml ]]; then
+              echo "warning: Cannot find existing node-config.yaml, waiting 15s ..." 2>&1
+              sleep 15 & wait
+              (( retries += 1 ))
+            else
+              break
+            fi
+            if [[ "${retries}" -gt 40 ]]; then
+              echo "error: No existing node-config.yaml, exiting" 2>&1
+              exit 1
+            fi
+          done
+
+          if [[ -f /etc/sysconfig/origin-node ]]; then
+            set -o allexport
+            source /etc/sysconfig/origin-node
+          fi
+
+          # use either the bootstrapped node kubeconfig or the static configuration
+          file=/etc/origin/node/node.kubeconfig
+          if [[ ! -f "${file}" ]]; then
+            # use the static node config if it exists
+            # TODO: remove when static node configuration is no longer supported
+            for f in /etc/origin/node/system*.kubeconfig; do
+              echo "info: Using ${f} for node configuration" 1>&2
+              file="${f}"
+              break
+            done
+          fi
+          # Use the same config as the node, but with the service account token
+          oc config "--config=${file}" view --flatten > /tmp/kubeconfig
+          oc config --config=/tmp/kubeconfig set-credentials sa "--token=$( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"
+          oc config --config=/tmp/kubeconfig set-context "$( oc config --config=/tmp/kubeconfig current-context )" --user=sa
+
+          # Launch the SkyDNS
+          exec openshift start network --enable=dns --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
+
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        env:
+        - name: OPENSHIFT_DNS_DOMAIN
+          value: cluster.local
+        volumeMounts:
+        - name: host-config
+          mountPath: /etc/origin/node
+          readOnly: true
+        - mountPath: /etc/sysconfing/origin-node
+          name: host-sysconfig-node
+          readOnly: true
+        - mountPath: /var/run
+          name: host-var-run
       - name: kuryr-cni
         image: {{ openshift_openstack_kuryr_cni_image }}
         imagePullPolicy: IfNotPresent
@@ -103,3 +168,12 @@ spec:
         - name: openvswitch
           hostPath:
             path: /var/run/openvswitch
+        - name: host-config
+          hostPath:
+            path: /etc/origin/node
+        - name: host-sysconfig-node
+          hostPath:
+            path: /etc/sysconfig/origin-node
+        - name: host-var-run
+          hostPath:
+            path: /var/run


### PR DESCRIPTION
This ensure SkyDNS is started when using Kuryr SDN by doing so
when deploying the kuryr-cni daemon set