### PR TITLE
Use openshift_is_atomic fact from delegated host

### DIFF
--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -7,7 +7,7 @@
   package:
     name: "{{ openshift_service_type }}{{ openshift_pkg_version | default('') | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
     state: present
-  when: not openshift_is_atomic | bool
+  when: not hostvars[openshift_ca_host].openshift_is_atomic | bool
   register: install_result
   until: install_result is succeeded
   delegate_to: "{{ openshift_ca_host }}"


### PR DESCRIPTION
This ensures scale up won't fail if new RHEL masters are being added to
a group of existing Atomic masters

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1595464

/cherrypick release-3.10