### PR TITLE
Bind the node-proxier role to the SDN SA

### DIFF
--- a/roles/openshift_sdn/files/sdn-policy.yaml
+++ b/roles/openshift_sdn/files/sdn-policy.yaml
@@ -26,4 +26,14 @@ items:
   - kind: ServiceAccount
     name: sdn
     namespace: openshift-sdn
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: sdn-node-proxier
+  roleRef:
+    name: system:node-proxier
+  subjects:
+  - kind: ServiceAccount
+    name: sdn
+    namespace: openshift-sdn
 # TODO: PSP binding


### PR DESCRIPTION
The SDN pod is now running the kube-proxy code (at least for the time
being), so it should have the node-proxier role.  This was previously
not an issue, because other roles grant similar permissions to the
node-proxier role, but if people add permissions to the node-proxier
role (e.g. idling), they need to also apply to the SDN pod's SA.