### PR TITLE
Add infra secgroup rules to the flat secgrp rules

### DIFF
--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -421,6 +421,9 @@ resources:
 {% for rule in openshift_openstack_node_secgroup_rules|list %}
         - {{ rule|to_json }}
 {% endfor %}
+{% for rule in openshift_openstack_infra_secgroup_rules|list %}
+        - {{ rule|to_json }}
+{% endfor %}
 {% else %}
   master-secgrp:
     type: OS::Neutron::SecurityGroup
@@ -466,7 +469,6 @@ resources:
           params:
             cluster_id: {{ openshift_openstack_full_dns_domain }}
       rules: {{ openshift_openstack_node_secgroup_rules|to_json }}
-{% endif %}
 
   infra-secgrp:
     type: OS::Neutron::SecurityGroup
@@ -497,6 +499,7 @@ resources:
           params:
             cluster_id: {{ openshift_openstack_full_dns_domain }}
       rules: {{ openshift_openstack_cns_secgroup_rules|to_json }}
+{% endif %}
 
   lb-secgrp:
     type: OS::Neutron::SecurityGroup


### PR DESCRIPTION
Ensure infra nodes are reachable on the right ports when using the flat security group option at the inventory. Otherwise port 80, 443 or 1936 will not be openned and route will not work