### PR TITLE
[3.9] webconsole redeploy: Remove service annotations

### DIFF
--- a/playbooks/openshift-web-console/private/redeploy-certificates.yml
+++ b/playbooks/openshift-web-console/private/redeploy-certificates.yml
@@ -20,6 +20,13 @@
       state: absent
       namespace: openshift-web-console
 
+  - name: Remove service annotation
+    command: >
+      {{ openshift_client_binary }} annotate service/webconsole
+      service.alpha.openshift.io/serving-cert-signed-by-
+      --config=/etc/origin/master/admin.kubeconfig
+      -n openshift-web-console
+
   - name: Verify that the console is running
     oc_obj:
       namespace: openshift-web-console


### PR DESCRIPTION
Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1596233

Controllers are using service annotations to verify if secret needs to be created, but sometimes they get stuck. Removing these annotations allows them to proceed and create new secret.

This is not required for master or 3.10 - controllers are working correctly there