### PR TITLE
Increase lbaas_activation_timeout for kuryr-controller

### DIFF
--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -318,6 +318,9 @@ data:
     pod_router = {{ kuryr_openstack_pod_router_id }}
 {% endif %}
 
+    # Time (in seconds) that Kuryr controller waits for LBaaS to be activated
+    lbaas_activation_timeout = 1200
+
     [pod_vif_nested]
 
     worker_nodes_subnet = {{ kuryr_openstack_worker_nodes_subnet_id }}


### PR DESCRIPTION
When using Octavia as LBaaS on slow (or busy) environments it may take
longer than the default 300 seconds for the Amphora VM to be
provisioned.

If this timeout is reached, kuryr will retry the action. However, as the
LBaaS creation was already triggered and due to a bug in Octavia
(https://storyboard.openstack.org/#!/story/2001944) when trying to list
existing load balancers with filtering, the kuryr controller will fail
to perform the remaining operations.

This commit increases that timeout to 1200 seconds by default.