### PR TITLE
Updating link to Origin install documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ created for you automatically.
 ## Complete Production Installation Documentation:
 
 - [OpenShift Enterprise](https://docs.openshift.com/enterprise/latest/install_config/install/advanced_install.html)
-- [OpenShift Origin](https://docs.openshift.org/latest/install_config/install/advanced_install.html)
+- [OpenShift Origin](https://docs.openshift.org/latest/install/index.html)
 
 ## Containerized OpenShift Ansible
 


### PR DESCRIPTION
Minor change: fixing link in the README.md to reflect new path to install documentation and the change from "advanced install".

`[OpenShift Origin](https://docs.openshift.org/latest/install/index.html)`

Fixes #9000 

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>