### PR TITLE
Fix improper backport for lib_utils_oo_dict_to_list_of_dict

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
@@ -47,7 +47,7 @@
     name: "{{ hostvars[item].openshift.node.nodename }}"
     kind: node
     state: absent
-    labels: "{{ glusterfs_nodeselector | lib_utils_oo_dict_to_list_of_dict }}"
+    labels: "{{ glusterfs_nodeselector | oo_dict_to_list_of_dict }}"
   with_items: "{{ groups.all }}"
   when: "'openshift' in hostvars[item]"
 


### PR DESCRIPTION
In 3.9+ the filters were moved into lib_utils role and namespaced there,
but that's not the case in 3.7.