### PR TITLE
prometheus: upgrade prometheus components

### DIFF
--- a/roles/openshift_prometheus/defaults/main.yaml
+++ b/roles/openshift_prometheus/defaults/main.yaml
@@ -11,7 +11,7 @@ l_openshift_prometheus_version_dict:
     prometheus: 'v2.2.1'
     alert_manager: 'v0.14.0'
     alert_buffer: 'v0.0.2'
-    node_exporter: 'v0.15.2'
+    node_exporter: 'v0.16.0'
   openshift-enterprise:
     prometheus: "{{ openshift_image_tag }}"
     alert_manager: "{{ openshift_image_tag }}"
@@ -44,7 +44,6 @@ openshift_prometheus_alertmanager_hostname: alertmanager-{{openshift_prometheus_
 l_openshift_prometheus_image_version: "{{ openshift_prometheus_image_version | default('v2.2.1') }}"
 l_openshift_prometheus_alertmanager_image_version: "{{ openshift_prometheus_alertmanager_image_version | default('v0.14.0') }}"
 l_openshift_prometheus_alertbuffer_image_version: "{{ openshift_prometheus_alertbuffer_image_version | default('v0.0.2') }}"
-l_openshift_prometheus_node_exporter_image_version: "{{ openshift_prometheus_node_exporter_image_version | default('v0.15.2') }}"
 
 openshift_prometheus_node_selector: "{{ openshift_hosted_infra_selector | default('node-role.kubernetes.io/infra=true') | map_from_pairs }}"
 

--- a/roles/openshift_prometheus/defaults/main.yaml
+++ b/roles/openshift_prometheus/defaults/main.yaml
@@ -8,7 +8,7 @@ openshift_prometheus_namespace: openshift-metrics
 # Need to standardise these tags
 l_openshift_prometheus_version_dict:
   origin:
-    prometheus: 'v2.2.1'
+    prometheus: 'v2.3.1'
     alert_manager: 'v0.15.0'
     alert_buffer: 'v0.0.2'
     node_exporter: 'v0.16.0'
@@ -40,9 +40,6 @@ openshift_prometheus_proxy_image: "{{ l2_os_logging_proxy_image }}"
 openshift_prometheus_hostname: prometheus-{{openshift_prometheus_namespace}}.{{openshift_master_default_subdomain}}
 openshift_prometheus_alerts_hostname: alerts-{{openshift_prometheus_namespace}}.{{openshift_master_default_subdomain}}
 openshift_prometheus_alertmanager_hostname: alertmanager-{{openshift_prometheus_namespace}}.{{openshift_master_default_subdomain}}
-
-l_openshift_prometheus_image_version: "{{ openshift_prometheus_image_version | default('v2.2.1') }}"
-l_openshift_prometheus_alertbuffer_image_version: "{{ openshift_prometheus_alertbuffer_image_version | default('v0.0.2') }}"
 
 openshift_prometheus_node_selector: "{{ openshift_hosted_infra_selector | default('node-role.kubernetes.io/infra=true') | map_from_pairs }}"
 

--- a/roles/openshift_prometheus/defaults/main.yaml
+++ b/roles/openshift_prometheus/defaults/main.yaml
@@ -9,7 +9,7 @@ openshift_prometheus_namespace: openshift-metrics
 l_openshift_prometheus_version_dict:
   origin:
     prometheus: 'v2.2.1'
-    alert_manager: 'v0.14.0'
+    alert_manager: 'v0.15.0'
     alert_buffer: 'v0.0.2'
     node_exporter: 'v0.16.0'
   openshift-enterprise:
@@ -42,7 +42,6 @@ openshift_prometheus_alerts_hostname: alerts-{{openshift_prometheus_namespace}}.
 openshift_prometheus_alertmanager_hostname: alertmanager-{{openshift_prometheus_namespace}}.{{openshift_master_default_subdomain}}
 
 l_openshift_prometheus_image_version: "{{ openshift_prometheus_image_version | default('v2.2.1') }}"
-l_openshift_prometheus_alertmanager_image_version: "{{ openshift_prometheus_alertmanager_image_version | default('v0.14.0') }}"
 l_openshift_prometheus_alertbuffer_image_version: "{{ openshift_prometheus_alertbuffer_image_version | default('v0.0.2') }}"
 
 openshift_prometheus_node_selector: "{{ openshift_hosted_infra_selector | default('node-role.kubernetes.io/infra=true') | map_from_pairs }}"

--- a/roles/openshift_prometheus/files/node-exporter-template.yaml
+++ b/roles/openshift_prometheus/files/node-exporter-template.yaml
@@ -11,7 +11,7 @@ metadata:
     openshift.io/provider-display-name: Red Hat, Inc.
 parameters:
 - name: IMAGE
-  value: openshift/prometheus-node-exporter:v0.15.2
+  value: openshift/prometheus-node-exporter:v0.16.0
 - name: MEMORY_REQUESTS
   value: 30Mi
 - name: CPU_REQUESTS


### PR DESCRIPTION
prometheus 2.2.1 -> 2.3.1
alertmanager 0.14.0 -> 0.15.0
node_exporter 0.15.2 -> 0.16.0