### PR TITLE
Change ansible variable for flexvolume location

### DIFF
--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -48,7 +48,7 @@
 - name: Create flexvolume directory when on atomic hosts
   file:
     state: directory
-    path: "{{ openshift_flexvolume_container_directory_default }}/volume/exec"
+    path: "/etc/origin/kubelet-plugins/volume/exec"
     mode: '0750'
   when: openshift_is_atomic | bool
 

--- a/roles/openshift_control_plane/tasks/static.yml
+++ b/roles/openshift_control_plane/tasks/static.yml
@@ -50,9 +50,9 @@
     src: "{{ mktemp.stdout }}/controller.yaml"
     edits:
     - key: spec.volumes[3].hostPath.path
-      value: "{{ openshift_flexvolume_container_directory_default }}"
+      value: "/etc/origin/kubelet-plugins"
     - key: spec.containers[0].volumeMounts[3].mountPath
-      value: "{{ openshift_flexvolume_container_directory_default }}"
+      value: "/etc/origin/kubelet-plugins"
   when: openshift_is_atomic | bool
 
 - name: ensure pod location exists

--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -85,7 +85,7 @@ kubernetesMasterConfig:
   controllerArguments: {{ openshift.master.controller_args | default(None) | lib_utils_to_padded_yaml( level=2 ) }}
 {% if openshift_is_atomic | bool %}
     flex-volume-plugin-dir:
-    - "{{ openshift_flexvolume_container_directory_default }}/volume/exec"
+    - "/etc/origin/kubelet-plugins/volume/exec"
 {% endif %}
 {% if openshift_master_use_persistentlocalvolumes | bool %}
     feature-gates:

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -142,4 +142,3 @@ openshift_node_groups:
       - 'node-role.kubernetes.io/infra=true,node-role.kubernetes.io/master=true,node-role.kubernetes.io/compute=true'
     edits: []
 openshift_master_manage_htpasswd: True
-openshift_flexvolume_container_directory_default: "/etc/origin/kubelet-plugins"

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -50,7 +50,7 @@
 - name: Create flexvolume directory when running on atomic
   file:
     state: directory
-    path: "{{ openshift_flexvolume_container_directory_default }}/volume/exec"
+    path: "/etc/origin/kubelet-plugins/volume/exec"
     mode: '0750'
   when: openshift_is_atomic | bool
 

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -14,7 +14,7 @@ kind: NodeConfig
 kubeletArguments: {{  l2_openshift_node_kubelet_args  | default(None) | lib_utils_to_padded_yaml(level=1) }}
 {% if openshift_is_atomic | bool %}
   volume-plugin-dir:
-  - "{{ openshift_flexvolume_container_directory_default }}/volume/exec"
+  - "/etc/origin/kubelet-plugins/volume/exec"
 {% endif %}
 {% if openshift_use_crio | bool %}
   container-runtime:

--- a/roles/openshift_node_group/templates/node-config.yaml.j2
+++ b/roles/openshift_node_group/templates/node-config.yaml.j2
@@ -22,7 +22,7 @@ iptablesSyncPeriod: "{{ openshift_node_iptables_sync_period }}"
 kubeletArguments:
 {% if openshift_is_atomic | bool %}
   volume-plugin-dir:
-  - "{{ openshift_flexvolume_container_directory_default }}/volume/exec"
+  - "/etc/origin/kubelet-plugins/volume/exec"
 {% endif %}
 {% if openshift_use_crio | bool %}
   container-runtime:


### PR DESCRIPTION
Fixes left over comment from https://github.com/openshift/openshift-ansible/pull/8964

This will enable user to configure flexvolume location on atomic hosts. But on non-atomic hosts the default will be used and users will not be able to configure the location on non-atomic hosts.

cc @sdodson @vrutkovs 
