### PR TITLE
Handle undefined variable in monitoring installer

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
+++ b/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
@@ -32,7 +32,7 @@
     - key: openshift.io/cluster-monitoring
       value: "true"
 
-- when: os_sdn_network_plugin_name == 'redhat/openshift-ovs-multitenant'
+- when: {{ os_sdn_network_plugin_name | default('') }} == 'redhat/openshift-ovs-multitenant'
   block:
   - name: Waiting for netnamespace openshift-monitoring to be ready
     oc_obj:


### PR DESCRIPTION
Handle the absence of the `os_sdn_network_plugin_name` variable.