### PR TITLE
additional changes to remove discovery plugin from logging

### DIFF
--- a/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
@@ -14,11 +14,6 @@ node:
 network:
   host: 0.0.0.0
 
-cloud:
-  kubernetes:
-    service: ${SERVICE_DNS}
-    namespace: ${NAMESPACE}
-
 discovery.zen:
   ping.unicast.hosts: {{ es_unicast_host }}
   minimum_master_nodes: ${NODE_QUORUM}


### PR DESCRIPTION
This PRs is required for us to remove the custom discovery plugin from es5.x .  Removing of the plugin alone causes a deployment failure because the config is still there.