### PR TITLE
Certificates signed by admins should be approved

### DIFF
--- a/roles/openshift_bootstrap_autoapprover/files/openshift-bootstrap-controller.yaml
+++ b/roles/openshift_bootstrap_autoapprover/files/openshift-bootstrap-controller.yaml
@@ -49,7 +49,7 @@ spec:
           username=\${4}
 
           # auto approve
-          if [[ -z "\${condition}" && ("\${username}" == "system:serviceaccount:openshift-infra:node-bootstrapper" || "\${username}" == "system:node:"* ) ]]; then
+          if [[ -z "\${condition}" && ("\${username}" == "system:serviceaccount:openshift-infra:node-bootstrapper" || "\${username}" == "system:node:"* || "\${username}" == "system:admin" ) ]]; then
             oc adm certificate approve "\${name}"
             exit 0
           fi


### PR DESCRIPTION
In Kubernetes 1.11, server certificates are not autoapproved by the controller autoapprover. We have to do that ourselves.

@liggitt