### PR TITLE
Ensure linux linefeeds in case people use windows per default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto eol=lf
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat text eol=crlf
+*.ps text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.gif binary
+*.zip binary
+*.tar binary
+*.tgz binary
+*.exe binary
+*.msi binary


### PR DESCRIPTION
Well if you deploy linux repo files with windows linefeeds yum will not work. What do you expect. Therefore I would try to set linux linefeeds per default