### PR TITLE
[release-3.9] Verify openshift_version and openshift.common.version by minor version only

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/config.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/config.yml
@@ -64,7 +64,9 @@
   - fail: msg="Master running {{ openshift.common.version }} must be upgraded to {{ openshift_version }} before node upgrade can be run."
     when:
     - l_upgrade_nodes_only | default(False) | bool
-    - not openshift.common.version | match(openshift_version)
+    # we may get openshift_version as 3.x, 3.x.y, 3.x.y.z. Just run minor version check.
+    - openshift.common.version.split('.')[0:2] != openshift_version.split('.')[0:2]
+
 
 # If we're only upgrading nodes, skip this.
 - import_playbook: ../../../../openshift-master/private/validate_restart.yml


### PR DESCRIPTION
When playbook runs with `containerized=true`,
`first_master_containerized_version.yml` assigns `openshift_version`
to the version with x.y.z format. This behavior fails version check on
Task "Verify masters are already upgraded", if we specified
openshift_release with x.y format.

To avoid this issue, this patch changes Task "Verify masters are
already upgraded" to verify the version by minor version.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1597528