### PR TITLE
standalone etcds: make sure etcd facts are set before applying etcd config

### DIFF
--- a/playbooks/openshift-etcd/private/config.yml
+++ b/playbooks/openshift-etcd/private/config.yml
@@ -29,6 +29,10 @@
     - openshift_is_atomic | bool
     - not inventory_hostname in groups['oo_masters']
 
+  - import_role:
+      name: etcd
+      tasks_from: set_facts.yml
+
   # Setup etcd as a static pod if collocated with a master
   - import_role:
       name: etcd


### PR DESCRIPTION
This ensures standalone etcds can be added, without adding them to `[masters]` group