### PR TITLE
Don't upgrade nodes which only have dedicated etcd

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
@@ -42,5 +42,8 @@
       groups: oo_nodes_to_upgrade
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_become: "{{ g_sudo | default(omit) }}"
+    when: item not in dedicated_etcds
+    vars:
+      dedicated_etcds: "{{ groups['oo_etcd_to_config'] | difference(groups['oo_masters']) }}"
     with_items: "{{ groups['temp_nodes_to_upgrade'] | default(groups['oo_nodes_to_config']) }}"
     changed_when: False

--- a/playbooks/common/openshift-cluster/upgrades/pre/config.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/config.yml
@@ -71,6 +71,9 @@
   - role: openshift_facts
   tasks:
   - import_tasks: verify_upgrade_targets.yml
+    vars:
+      dedicated_etcds: "{{ groups['oo_etcd_to_config'] | difference(groups['oo_masters']) }}"
+    when: inventory_hostname not in dedicated_etcds
 
 - name: Verify docker upgrade targets
   hosts: "{{ l_upgrade_docker_target_hosts }}"


### PR DESCRIPTION
Dedicated etcd are in node groups, but they don't have kubelet, so node upgrade fails when openshift version is detected.

This PR would skip the nodes, which are in etcd group, but not in master.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1578294