### PR TITLE
aws scale gruops: resume gracefully on upgrades

### DIFF
--- a/roles/openshift_aws/tasks/build_node_group.yml
+++ b/roles/openshift_aws/tasks/build_node_group.yml
@@ -27,26 +27,33 @@
     l_epoch_time: "{{ ansible_date_time.epoch }}"
 #
 # query asg's and determine if we need to create the others.
-# if we find more than 1 for each type, then exit
+# if we find more than 1 for each type, and this isn't an upgrade, then exit
 - name: query all asg's for this cluster
   ec2_asg_facts:
     region: "{{ openshift_aws_region }}"
     tags: "{{ {'kubernetes.io/cluster/' ~ openshift_aws_clusterid: openshift_aws_clusterid} | combine(openshift_aws_node_group.tags) }}"
   register: asgs
 
+- debug:
+    msg: "{{ asgs }}"
+
 - fail:
     msg: "Found more than 1 auto scaling group that matches the query for group: {{ openshift_aws_node_group }}"
   when:
+  - not openshift_aws_node_group_upgrade
   - asgs.results|length > 1
 
-- debug:
-    msg: "{{ asgs }}"
+- fail:
+    msg: "Upgrade: Found more than 2 auto scaling group that matches the query for group: {{ openshift_aws_node_group }}"
+  when:
+  - openshift_aws_node_group_upgrade
+  - asgs.results|length > 2
 
 - name: set the value for the deployment_serial and the current asgs
   set_fact:
     # scale_groups_serial is a custom filter in role lib_utils
     l_deployment_serial: "{{  openshift_aws_node_group_deployment_serial if openshift_aws_node_group_deployment_serial is defined else asgs.results | scale_groups_serial(openshift_aws_node_group_upgrade) }}"
-    openshift_aws_current_asgs: "{{ asgs.results | map(attribute='auto_scaling_group_name') | list | union(openshift_aws_current_asgs) }}"
+    openshift_aws_current_asgs: "{{ openshift_aws_current_asgs + [asgs.results[0]['auto_scaling_group_name']] if asgs.results else openshift_aws_current_asgs }}"
 
 - name: dump deployment serial
   debug:
@@ -56,11 +63,25 @@
   debug:
     msg: "openshift_aws_current_asgs: {{ openshift_aws_current_asgs }}"
 
-- when: openshift_aws_create_iam_role
+- name: set appropriate vars for upgrade resume
+  set_fact:
+    openshift_aws_created_asgs: "{{ [openshift_aws_node_group.name ~ ' ' ~  l_deployment_serial]
+                                    | union(openshift_aws_created_asgs) | list }}"
+  when:
+  - openshift_aws_node_group_upgrade | default(False)
+  - asgs.results|length == 2
+
+- when:
+  - openshift_aws_create_iam_role
+  - asgs.results|length != 2
   include_tasks: iam_role.yml
 
-- when: openshift_aws_create_launch_config
+- when:
+  - openshift_aws_create_launch_config
+  - asgs.results|length != 2
   include_tasks: launch_config.yml
 
-- when: openshift_aws_create_scale_group
+- when:
+  - openshift_aws_create_scale_group
+  - asgs.results|length != 2
   include_tasks: scale_group.yml

--- a/roles/openshift_aws/tasks/setup_master_group.yml
+++ b/roles/openshift_aws/tasks/setup_master_group.yml
@@ -7,7 +7,7 @@
   debug:
     msg: "openshift_aws_region={{ openshift_aws_region }}"
 
-- name: fetch newly created instances
+- name: fetch master instances
   ec2_instance_facts:
     region: "{{ openshift_aws_region }}"
     filters:

--- a/roles/openshift_aws/tasks/upgrade_node_group.yml
+++ b/roles/openshift_aws/tasks/upgrade_node_group.yml
@@ -2,8 +2,6 @@
 - include_tasks: provision_nodes.yml
   vars:
     openshift_aws_node_group_upgrade: True
-  when:
-  - openshift_aws_upgrade_provision_nodes | default(True)
 
 - debug: var=openshift_aws_current_asgs
 - debug: var=openshift_aws_created_asgs


### PR DESCRIPTION
This is an attempt to fix:

https://bugzilla.redhat.com/show_bug.cgi?id=1581356

Currently, when doing a scalegroup upgrade, if anything goes wrong in during the upgrade, the play will fail.  When you start up the upgrade again, the upgrader will give an immediate failure because there are already 2 scalegroups there. 

This PR attempts to retry the upgrade and use the 2nd scalegroup as it was created.