### PR TITLE
Add EAP CD 13 imagestream and templates.

### DIFF
--- a/roles/openshift_examples/files/examples/v3.11/xpaas-streams/eap-cd-image-stream.json
+++ b/roles/openshift_examples/files/examples/v3.11/xpaas-streams/eap-cd-image-stream.json
@@ -17,14 +17,51 @@
                 "annotations": {
                     "openshift.io/display-name": "JBoss EAP continuous delivery",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "12.0"
+                    "version": "13.0"
                 }
             },
             "labels": {
-                "xpaas": "1.4.10"
+                "xpaas": "1.5.0"
             },
             "spec": {
                 "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "JBoss EAP continuous delivery Tech Preview S2I Image",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.2,javaee:7,java:8",
+                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts/openshift",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "openshift",
+                            "version": "latest",
+                            "openshift.io/display-name": "JBoss EAP continuous delivery (Tech Preview)"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/jboss-eap-7-tech-preview/eap-cd-openshift:latest"
+                        }
+                    },
+                    {
+                        "name": "13",
+                        "annotations": {
+                            "description": "The latest available build of JBoss EAP continuous delivery Tech Preview.",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.2,javaee:7,java:8",
+                            "sampleRepo": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "openshift",
+                            "version": "13",
+                            "openshift.io/display-name": "JBoss EAP continuous delivery (Tech Preview)"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "13.0"
+
+                        }
+                    },
                     {
                         "name": "12",
                         "annotations": {
@@ -45,24 +82,6 @@
                         }
                     },
                     {
-                        "name": "latest",
-                        "annotations": {
-                            "description": "JBoss EAP continuous delivery Tech Preview S2I Image",
-                            "iconClass": "icon-eap",
-                            "tags": "builder,eap,javaee,java,jboss,hidden",
-                            "supports": "eap:7.2,javaee:7,java:8",
-                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts/openshift",
-                            "sampleContextDir": "kitchensink",
-                            "sampleRef": "openshift",
-                            "version": "12.0",
-                            "openshift.io/display-name": "JBoss EAP continuous delivery (Tech Preview)"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/jboss-eap-7-tech-preview/eap-cd-openshift:latest"
-                        }
-                    },
-                    {
                         "name": "12.0",
                         "annotations": {
                             "description": "JBoss EAP continuous delivery Tech Preview S2I Image",
@@ -78,6 +97,24 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/jboss-eap-7-tech-preview/eap-cd-openshift:12.0"
+                        }
+                    },
+                    {
+                        "name": "13.0",
+                        "annotations": {
+                            "description": "JBoss EAP continuous delivery Tech Preview S2I Image",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.2,javaee:7,java:8",
+                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts/openshift",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "openshift",
+                            "version": "13.0",
+                            "openshift.io/display-name": "JBoss EAP continuous delivery (Tech Preview)"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/jboss-eap-7-tech-preview/eap-cd-openshift:13.0"
                         }
                     }
                 ]

--- a/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-amq-persistent-s2i.json
+++ b/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-amq-persistent-s2i.json
@@ -5,11 +5,11 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss",
-            "version": "1.4.10",
-            "openshift.io/display-name": "JBoss EAP CD + A-MQ (with https)",
+            "version": "1.5.0",
+            "openshift.io/display-name": "JBoss EAP CD + AMQ 7 (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example JBoss Enterprise Application Platform continuous delivery application using Red Hat JBoss A-MQ with persistence and secure communication using https. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc",
-            "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform continuous delivery based application, including a build configuration, application deployment configuration, using Red Hat JBoss A-MQ with persistence and secure communication using https.",
+            "description": "An example JBoss Enterprise Application Platform continuous delivery application using Red Hat JBoss AMQ with persistence and secure communication using https. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc",
+            "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform continuous delivery based application, including a build configuration, application deployment configuration, using Red Hat JBoss AMQ with persistence and secure communication using https.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
@@ -17,9 +17,9 @@
     },
     "labels": {
         "template": "eap-cd-amq-persistent-s2i",
-        "xpaas": "1.4.10"
+        "xpaas": "1.5.0"
     },
-    "message": "A new JBoss EAP CD and A-MQ persistent based application with SSL support has been created in your project. The username/password for accessing the A-MQ service is ${MQ_USERNAME}/${MQ_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
+    "message": "A new JBoss EAP CD and AMQ persistent based application with SSL support has been created in your project. The username/password for accessing the AMQ service is ${MQ_USERNAME}/${MQ_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
         {
             "displayName": "Application Name",
@@ -39,14 +39,14 @@
             "displayName": "Git Repository URL",
             "description": "Git source URI for application",
             "name": "SOURCE_REPOSITORY_URL",
-            "value": "https://github.com/jboss-openshift/openshift-quickstarts.git",
+            "value": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
             "required": true
         },
         {
             "displayName": "Git Reference",
             "description": "Git branch/tag reference",
             "name": "SOURCE_REPOSITORY_REF",
-            "value": "1.3",
+            "value": "openshift",
             "required": false
         },
         {
@@ -57,28 +57,28 @@
             "required": false
         },
         {
-            "displayName": "A-MQ Volume Size",
-            "description": "Size of the volume used by A-MQ for persisting messages.",
+            "displayName": "AMQ Volume Size",
+            "description": "Size of the volume used by AMQ for persisting messages.",
             "name": "VOLUME_CAPACITY",
             "value": "1Gi",
             "required": true
         },
         {
             "displayName": "JMS Connection Factory JNDI Name",
-            "description": "JNDI name for connection factory used by applications to connect to the broker, e.g. java:/ConnectionFactory",
+            "description": "JNDI name for connection factory used by applications to connect to the broker, e.g. java:jboss/DefaultJMSConnectionFactory",
             "name": "MQ_JNDI",
-            "value": "java:/ConnectionFactory",
+            "value": "java:jboss/DefaultJMSConnectionFactory",
             "required": false
         },
         {
-            "displayName": "Split Data?",
+            "displayName": "Split the data directory?",
             "description": "Split the data directory for each node in a mesh.",
             "name": "AMQ_SPLIT",
             "value": "false",
             "required": false
         },
         {
-            "displayName": "A-MQ Protocols",
+            "displayName": "AMQ Protocols",
             "description": "Broker protocols to configure, separated by commas. Allowed values are: `openwire`, `amqp`, `stomp` and `mqtt`. Only `openwire` is supported by EAP.",
             "name": "MQ_PROTOCOL",
             "value": "openwire",
@@ -86,20 +86,20 @@
         },
         {
             "displayName": "Queues",
-            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP.",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
-            "value": "HELLOWORLDMDBQueue",
+            "value": "HelloWorldMDBQueue",
             "required": false
         },
         {
             "displayName": "Topics",
-            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP.",
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
-            "value": "HELLOWORLDMDBTopic",
+            "value": "HelloWorldMDBTopic",
             "required": false
         },
         {
-            "displayName": "A-MQ Serializable Packages",
+            "displayName": "AMQ Serializable Packages",
             "description": "List of packages that are allowed to be serialized for use in ObjectMessage, separated by commas. If your app doesn't use ObjectMessages, leave this blank. This is a security enforcement. For the rationale, see http://activemq.apache.org/objectmessage.html",
             "name": "MQ_SERIALIZABLE_PACKAGES",
             "value": "",
@@ -141,7 +141,7 @@
             "required": false
         },
         {
-            "displayName": "A-MQ Username",
+            "displayName": "AMQ Username",
             "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
             "name": "MQ_USERNAME",
             "from": "user[a-zA-Z0-9]{3}",
@@ -149,7 +149,7 @@
             "required": false
         },
         {
-            "displayName": "A-MQ Password",
+            "displayName": "AMQ Password",
             "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
             "name": "MQ_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
@@ -157,15 +157,21 @@
             "required": false
         },
         {
-            "displayName": "A-MQ Mesh Discovery Type",
+            "displayName": "AMQ Role",
+            "description": "AMQ Role for authenticated user",
+            "name": "MQ_ROLE",
+            "value": "admin"
+        },
+        {
+            "displayName": "AMQ Mesh Discovery Type",
             "description": "The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace.",
             "name": "AMQ_MESH_DISCOVERY_TYPE",
             "value": "dns",
             "required": false
         },
         {
-            "displayName": "A-MQ Storage Limit",
-            "description": "The A-MQ storage usage limit",
+            "displayName": "AMQ Storage Limit",
+            "description": "The AMQ storage usage limit",
             "name": "AMQ_STORAGE_USAGE_LIMIT",
             "value": "100 gb",
             "required": false
@@ -247,7 +253,7 @@
             "displayName": "Maven Additional Arguments",
             "description": "Maven additional arguments to use for S2I builds",
             "name": "MAVEN_ARGS_APPEND",
-            "value": "",
+            "value": "-Dcom.redhat.xpaas.repo.jbossorg",            
             "required": false
         },
         {
@@ -481,7 +487,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "eap-cd-openshift:12"
+                            "name": "eap-cd-openshift:13"
                         }
                     }
                 },
@@ -625,7 +631,7 @@
                                 "env": [
                                     {
                                         "name": "MQ_SERVICE_PREFIX_MAPPING",
-                                        "value": "${APPLICATION_NAME}-amq=MQ"
+                                        "value": "${APPLICATION_NAME}-amq7=MQ"
                                     },
                                     {
                                         "name": "MQ_JNDI",
@@ -763,7 +769,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-amq-63:1.3"
+                                "name": "amq-broker-71-openshift:1.0"
                             }
                         }
                     },
@@ -788,7 +794,7 @@
                         "containers": [
                             {
                                 "name": "${APPLICATION_NAME}-amq",
-                                "image": "jboss-amq-63",
+                                "image": "amq-broker-71-openshift",
                                 "imagePullPolicy": "Always",
                                 "readinessProbe": {
                                     "exec": {
@@ -801,8 +807,8 @@
                                 },
                                 "ports": [
                                     {
-                                        "name": "jolokia",
-                                        "containerPort": 8778,
+                                        "name": "console-jolokia",
+                                        "containerPort": 8161,
                                         "protocol": "TCP"
                                     },
                                     {
@@ -857,6 +863,10 @@
                                         "value": "${MQ_PASSWORD}"
                                     },
                                     {
+                                        "name": "AMQ_ROLE",
+                                        "value": "${MQ_ROLE}"
+                                    },
+                                    {
                                         "name": "AMQ_TRANSPORTS",
                                         "value": "${MQ_PROTOCOL}"
                                     },
@@ -865,7 +875,7 @@
                                         "value": "${MQ_QUEUES}"
                                     },
                                     {
-                                        "name": "AMQ_TOPICS",
+                                        "name": "AMQ_ADDRESSES",
                                         "value": "${MQ_TOPICS}"
                                     },
                                     {

--- a/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-amq-s2i.json
+++ b/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-amq-s2i.json
@@ -5,11 +5,11 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.10",
-            "openshift.io/display-name": "JBoss EAP CD + A-MQ (with https)",
+            "version": "1.4.11",
+            "openshift.io/display-name": "JBoss EAP CD + AMQ 7 (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example JBoss Enterprise Application Platform continuous delivery application using Red Hat JBoss A-MQ. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc",
-            "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform continuous delivery based application, including a build configuration, application deployment configuration, using Red Hat JBoss A-MQ and secure communication using https.",
+            "description": "An example JBoss Enterprise Application Platform continuous delivery application using Red Hat JBoss AMQ. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc",
+            "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform continuous delivery based application, including a build configuration, application deployment configuration, using Red Hat JBoss AMQ and secure communication using https.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
@@ -17,9 +17,9 @@
     },
     "labels": {
         "template": "eap-cd-amq-s2i",
-        "xpaas": "1.4.10"
+        "xpaas": "1.5.0"
     },
-    "message": "A new JBoss EAP CD and A-MQ based application with SSL support has been created in your project. The username/password for accessing the A-MQ service is ${MQ_USERNAME}/${MQ_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
+    "message": "A new JBoss EAP CD and AMQ 7 based application with SSL support has been created in your project. The username/password for accessing the AMQ service is ${MQ_USERNAME}/${MQ_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
         {
             "displayName": "Application Name",
@@ -39,14 +39,14 @@
             "displayName": "Git Repository URL",
             "description": "Git source URI for application",
             "name": "SOURCE_REPOSITORY_URL",
-            "value": "https://github.com/jboss-openshift/openshift-quickstarts.git",
+            "value": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
             "required": true
         },
         {
             "displayName": "Git Reference",
             "description": "Git branch/tag reference",
             "name": "SOURCE_REPOSITORY_REF",
-            "value": "1.3",
+            "value": "openshift",
             "required": false
         },
         {
@@ -58,13 +58,13 @@
         },
         {
             "displayName": "JMS Connection Factory JNDI Name",
-            "description": "JNDI name for connection factory used by applications to connect to the broker, e.g. java:/ConnectionFactory",
+            "description": "JNDI name for connection factory used by applications to connect to the broker, e.g. java:jboss/DefaultJMSConnectionFactory",
             "name": "MQ_JNDI",
-            "value": "java:/ConnectionFactory",
+            "value": "java:jboss/DefaultJMSConnectionFactory",
             "required": false
         },
         {
-            "displayName": "A-MQ Protocols",
+            "displayName": "AMQ Protocols",
             "description": "Broker protocols to configure, separated by commas. Allowed values are: `openwire`, `amqp`, `stomp` and `mqtt`. Only `openwire` is supported by EAP.",
             "name": "MQ_PROTOCOL",
             "value": "openwire",
@@ -72,20 +72,20 @@
         },
         {
             "displayName": "Queues",
-            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP.",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
-            "value": "HELLOWORLDMDBQueue",
+            "value": "HelloWorldMDBQueue",
             "required": false
         },
         {
             "displayName": "Topics",
-            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP.",
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
-            "value": "HELLOWORLDMDBTopic",
+            "value": "HelloWorldMDBTopic",
             "required": false
         },
         {
-            "displayName": "A-MQ Serializable Packages",
+            "displayName": "AMQ Serializable Packages",
             "description": "List of packages that are allowed to be serialized for use in ObjectMessage, separated by commas. If your app doesn't use ObjectMessages, leave this blank. This is a security enforcement. For the rationale, see http://activemq.apache.org/objectmessage.html",
             "name": "MQ_SERIALIZABLE_PACKAGES",
             "value": "",
@@ -127,7 +127,7 @@
             "required": false
         },
         {
-            "displayName": "A-MQ Username",
+            "displayName": "AMQ Username",
             "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
             "name": "MQ_USERNAME",
             "from": "user[a-zA-Z0-9]{3}",
@@ -135,7 +135,7 @@
             "required": false
         },
         {
-            "displayName": "A-MQ Password",
+            "displayName": "AMQ Password",
             "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
             "name": "MQ_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
@@ -143,15 +143,15 @@
             "required": false
         },
         {
-            "displayName": "A-MQ Mesh Discovery Type",
+            "displayName": "AMQ Mesh Discovery Type",
             "description": "The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace.",
             "name": "AMQ_MESH_DISCOVERY_TYPE",
             "value": "dns",
             "required": false
         },
         {
-            "displayName": "A-MQ Storage Limit",
-            "description": "The A-MQ storage usage limit",
+            "displayName": "AMQ Storage Limit",
+            "description": "The AMQ storage usage limit",
             "name": "AMQ_STORAGE_USAGE_LIMIT",
             "value": "100 gb",
             "required": false
@@ -233,7 +233,7 @@
             "displayName": "Maven Additional Arguments",
             "description": "Maven additional arguments to use for S2I builds",
             "name": "MAVEN_ARGS_APPEND",
-            "value": "",
+            "value": "-Dcom.redhat.xpaas.repo.jbossorg",
             "required": false
         },
         {
@@ -467,7 +467,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "eap-cd-openshift:12"
+                            "name": "eap-cd-openshift:13"
                         }
                     }
                 },
@@ -611,7 +611,7 @@
                                 "env": [
                                     {
                                         "name": "MQ_SERVICE_PREFIX_MAPPING",
-                                        "value": "${APPLICATION_NAME}-amq=MQ"
+                                        "value": "${APPLICATION_NAME}-amq7=MQ"
                                     },
                                     {
                                         "name": "MQ_JNDI",
@@ -746,7 +746,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-amq-63:1.3"
+                                "name": "amq-broker-71-openshift:1.0"
                             }
                         }
                     },
@@ -771,7 +771,7 @@
                         "containers": [
                             {
                                 "name": "${APPLICATION_NAME}-amq",
-                                "image": "jboss-amq-63",
+                                "image": "amq-broker-71-openshift",
                                 "imagePullPolicy": "Always",
                                 "readinessProbe": {
                                     "exec": {
@@ -784,8 +784,8 @@
                                 },
                                 "ports": [
                                     {
-                                        "name": "jolokia",
-                                        "containerPort": 8778,
+                                        "name": "console-jolokia",
+                                        "containerPort": 8161,
                                         "protocol": "TCP"
                                     },
                                     {
@@ -842,7 +842,7 @@
                                         "value": "${MQ_QUEUES}"
                                     },
                                     {
-                                        "name": "AMQ_TOPICS",
+                                        "name": "AMQ_ADDRESSES",
                                         "value": "${MQ_TOPICS}"
                                     },
                                     {

--- a/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-basic-s2i.json
+++ b/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-basic-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss",
-            "version": "1.4.10",
+            "version": "1.5.0",
             "openshift.io/display-name": "JBoss EAP CD (no https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example JBoss Enterprise Application Platform continuous delivery application. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap-cd-basic-s2i",
-        "xpaas": "1.4.10"
+        "xpaas": "1.5.0"
     },
     "message": "A new JBoss EAP CD based application has been created in your project.",
     "parameters": [
@@ -51,21 +51,21 @@
         },
         {
             "displayName": "Queues",
-            "description": "Queue names",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
             "value": "",
             "required": false
         },
         {
             "displayName": "Topics",
-            "description": "Topic names",
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
             "value": "",
             "required": false
         },
         {
-            "displayName": "A-MQ cluster password",
-            "description": "A-MQ cluster admin password",
+            "displayName": "AMQ cluster password",
+            "description": "AMQ cluster admin password",
             "name": "MQ_CLUSTER_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -255,7 +255,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "eap-cd-openshift:12"
+                            "name": "eap-cd-openshift:13"
                         }
                     }
                 },

--- a/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-https-s2i.json
+++ b/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-https-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.10",
+            "version": "1.5.0",
             "openshift.io/display-name": "JBoss EAP CD (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example JBoss Enterprise Application Platform continuous delivery application configured with secure communication using HTTPS. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap-cd-https-s2i",
-        "xpaas": "1.4.10"
+        "xpaas": "1.5.0"
     },
     "message": "A new JBoss EAP CD based application with SSL support has been created in your project. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -58,14 +58,14 @@
         },
         {
             "displayName": "Queues",
-            "description": "Queue names",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
             "value": "",
             "required": false
         },
         {
             "displayName": "Topics",
-            "description": "Topic names",
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
             "value": "",
             "required": false
@@ -106,8 +106,8 @@
             "required": false
         },
         {
-            "displayName": "A-MQ cluster password",
-            "description": "A-MQ cluster admin password",
+            "displayName": "AMQ cluster password",
+            "description": "AMQ cluster admin password",
             "name": "MQ_CLUSTER_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -372,7 +372,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "eap-cd-openshift:12"
+                            "name": "eap-cd-openshift:13"
                         }
                     }
                 },

--- a/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-mongodb-persistent-s2i.json
+++ b/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-mongodb-persistent-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.10",
+            "version": "1.5.0",
             "openshift.io/display-name": "JBoss EAP CD + MongoDB (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example JBoss Enterprise Application Platform continuous delivery application with a MongoDB database. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap-cd-mongodb-persistent-s2i",
-        "xpaas": "1.4.10"
+        "xpaas": "1.5.0"
     },
     "message": "A new JBoss EAP CD and MongoDB persistent based application with SSL support has been created in your project. The username/password for accessing the MongoDB database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD} (Admin password is \"${DB_ADMIN_PASSWORD}\"). Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -79,14 +79,14 @@
         },
         {
             "displayName": "Queues",
-            "description": "Queue names",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
             "value": "",
             "required": false
         },
         {
             "displayName": "Topics",
-            "description": "Topic names",
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
             "value": "",
             "required": false
@@ -163,8 +163,8 @@
             "required": false
         },
         {
-            "displayName": "A-MQ cluster password",
-            "description": "A-MQ cluster admin password",
+            "displayName": "AMQ cluster password",
+            "description": "AMQ cluster admin password",
             "name": "MQ_CLUSTER_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -486,7 +486,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "eap-cd-openshift:12"
+                            "name": "eap-cd-openshift:13"
                         }
                     }
                 },

--- a/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-mongodb-s2i.json
+++ b/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-mongodb-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.10",
+            "version": "1.5.0",
             "openshift.io/display-name": "JBoss EAP CD + MongoDB (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example JBoss Enterprise Application Platform continuous delivery application with a MongoDB database. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap-cd-mongodb-s2i",
-        "xpaas": "1.4.10"
+        "xpaas": "1.5.0"
     },
     "message": "A new EAP CD and MongoDB based application with SSL support has been created in your project. The username/password for accessing the MongoDB database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD} (Admin password is \"${DB_ADMIN_PASSWORD}\"). Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -72,14 +72,14 @@
         },
         {
             "displayName": "Queues",
-            "description": "Queue names",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
             "value": "",
             "required": false
         },
         {
             "displayName": "Topics",
-            "description": "Topic names",
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
             "value": "",
             "required": false
@@ -156,8 +156,8 @@
             "required": false
         },
         {
-            "displayName": "A-MQ cluster password",
-            "description": "A-MQ cluster admin password",
+            "displayName": "AMQ cluster password",
+            "description": "AMQ cluster admin password",
             "name": "MQ_CLUSTER_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -479,7 +479,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "eap-cd-openshift:12"
+                            "name": "eap-cd-openshift:13"
                         }
                     }
                 },

--- a/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-mysql-persistent-s2i.json
+++ b/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-mysql-persistent-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss",
-            "version": "1.4.10",
+            "version": "1.5.0",
             "openshift.io/display-name": "JBoss EAP CD + MySQL (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example JBoss Enterprise Application Platform continuous delivery application with a MySQL database. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap-cd-mysql-persistent-s2i",
-        "xpaas": "1.4.10"
+        "xpaas": "1.5.0"
     },
     "message": "A new EAP CD and MySQL persistent based application with SSL support has been created in your project. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -79,14 +79,14 @@
         },
         {
             "displayName": "Queues",
-            "description": "Queue names",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
             "value": "",
             "required": false
         },
         {
             "displayName": "Topics",
-            "description": "Topic names",
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
             "value": "",
             "required": false
@@ -175,8 +175,8 @@
             "required": false
         },
         {
-            "displayName": "A-MQ cluster password",
-            "description": "A-MQ cluster admin password",
+            "displayName": "AMQ cluster password",
+            "description": "AMQ cluster admin password",
             "name": "MQ_CLUSTER_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -490,7 +490,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "eap-cd-openshift:12"
+                            "name": "eap-cd-openshift:13"
                         }
                     }
                 },

--- a/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-mysql-s2i.json
+++ b/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-mysql-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.10",
+            "version": "1.5.0",
             "openshift.io/display-name": "JBoss EAP CD + MySQL (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example JBoss Enterprise Application Platform continuous delivery application with a MySQL database. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap-cd-mysql-s2i",
-        "xpaas": "1.4.10"
+        "xpaas": "1.5.0"
     },
     "message": "A new EAP CD and MySQL based application with SSL support has been created in your project. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -72,14 +72,14 @@
         },
         {
             "displayName": "Queues",
-            "description": "Queue names",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
             "value": "",
             "required": false
         },
         {
             "displayName": "Topics",
-            "description": "Topic names",
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
             "value": "",
             "required": false
@@ -168,8 +168,8 @@
             "required": false
         },
         {
-            "displayName": "A-MQ cluster password",
-            "description": "A-MQ cluster admin password",
+            "displayName": "AMQ cluster password",
+            "description": "AMQ cluster admin password",
             "name": "MQ_CLUSTER_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -483,7 +483,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "eap-cd-openshift:12"
+                            "name": "eap-cd-openshift:13"
                         }
                     }
                 },

--- a/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-postgresql-persistent-s2i.json
+++ b/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-postgresql-persistent-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss",
-            "version": "1.4.10",
+            "version": "1.5.0",
             "openshift.io/display-name": "JBoss EAP CD + PostgreSQL (Persistent with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example JBoss Enterprise Application Platform continuous delivery application with a persistent PostgreSQL database. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap-cd-postgresql-persistent-s2i",
-        "xpaas": "1.4.10"
+        "xpaas": "1.5.0"
     },
     "message": "A new JBoss EAP CD and PostgreSQL persistent based application with SSL support has been created in your project. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -79,14 +79,14 @@
         },
         {
             "displayName": "Queues",
-            "description": "Queue names",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
             "value": "",
             "required": false
         },
         {
             "displayName": "Topics",
-            "description": "Topic names",
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
             "value": "",
             "required": false
@@ -157,8 +157,8 @@
             "required": false
         },
         {
-            "displayName": "A-MQ cluster password",
-            "description": "A-MQ cluster admin password",
+            "displayName": "AMQ cluster password",
+            "description": "AMQ cluster admin password",
             "name": "MQ_CLUSTER_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -472,7 +472,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "eap-cd-openshift:12"
+                            "name": "eap-cd-openshift:13"
                         }
                     }
                 },

--- a/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-postgresql-s2i.json
+++ b/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-postgresql-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.10",
+            "version": "1.5.0",
             "openshift.io/display-name": "JBoss EAP CD + PostgreSQL (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example JBoss Enterprise Application Platform continuous delivery application with an PostgreSQL database configured with secure communication using https and ephemeral storage. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap-cd-postgresql-s2i",
-        "xpaas": "1.4.10"
+        "xpaas": "1.5.0"
     },
     "message": "A new JBoss EAP CD and PostgreSQL based application with SSL support has been created in your project. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -72,14 +72,14 @@
         },
         {
             "displayName": "Queues",
-            "description": "Queue names",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
             "value": "",
             "required": false
         },
         {
             "displayName": "Topics",
-            "description": "Topic names",
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
             "value": "",
             "required": false
@@ -150,8 +150,8 @@
             "required": false
         },
         {
-            "displayName": "A-MQ cluster password",
-            "description": "A-MQ cluster admin password",
+            "displayName": "AMQ cluster password",
+            "description": "AMQ cluster admin password",
             "name": "MQ_CLUSTER_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -465,7 +465,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "eap-cd-openshift:12"
+                            "name": "eap-cd-openshift:13"
                         }
                     }
                 },

--- a/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-sso-s2i.json
+++ b/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-sso-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.10",
+            "version": "1.5.0",
             "openshift.io/display-name": "JBoss EAP CD + Single Sign-On (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example JBoss Enterprise Application Platform continuous delivery application Single Sign-On application. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap-cd-sso-s2i",
-        "xpaas": "1.4.10"
+        "xpaas": "1.5.0"
     },
     "message": "A new JBoss EAP CD based application with SSL and SSO support has been created in your project. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -58,21 +58,21 @@
         },
         {
             "displayName": "Queues",
-            "description": "Queue names",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
             "value": "",
             "required": false
         },
         {
             "displayName": "Topics",
-            "description": "Topic names",
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
             "value": "",
             "required": false
         },
         {
-            "displayName": "A-MQ cluster password",
-            "description": "A-MQ cluster admin password",
+            "displayName": "AMQ cluster password",
+            "description": "AMQ cluster admin password",
             "name": "MQ_CLUSTER_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -486,7 +486,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "eap-cd-openshift:12"
+                            "name": "eap-cd-openshift:13"
                         },
                         "env": [
                             {

--- a/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-third-party-db-s2i.json
+++ b/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-third-party-db-s2i.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "1.4.10",
+            "version": "1.5.0",
             "openshift.io/display-name": "JBoss EAP CD (with https, DB drivers)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example JBoss Enterprise Application Platform continuous delivery application. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap-cd-third-party-db-s2i",
-        "xpaas": "1.4.10"
+        "xpaas": "1.5.0"
     },
     "message": "A new EAP 7 based application with SSL support has been created in your project. Please be sure to create the following secrets:\"${CONFIGURATION_NAME}\" containing the datasource configuration details required by the deployed application(s);  \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -86,14 +86,14 @@
         },
         {
             "displayName": "Queue Names",
-            "description": "Queue names to preconfigure within Messaging subsystem.",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
             "value": "",
             "required": false
         },
         {
             "displayName": "Topic Names",
-            "description": "Topic names to preconfigure within Messaging subsystem.",
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
             "value": "",
             "required": false
@@ -419,7 +419,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "eap-cd-openshift:12"
+                            "name": "eap-cd-openshift:13"
                         }
                     }
                 },

--- a/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-tx-recovery-s2i.json
+++ b/roles/openshift_examples/files/examples/v3.11/xpaas-templates/eap-cd-tx-recovery-s2i.json
@@ -5,8 +5,8 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss",
-            "version": "1.4.10",
-            "openshift.io/display-name": "JBoss EAP CD (tx recovery)",
+            "version": "1.5.0",
+            "openshift.io/display-name": "JBoss EAP CD + AMQ 7 (tx recovery)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example JBoss Enterprise Application Platform continuous delivery application with transaction recovery configured. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc",
             "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform continuous delivery based application, including a build configuration, application deployment configuration and insecure communication using http.  The template also demonstrates how to enable automated transaction recovery on scale down of application pods.  Automated transaction recovery is currently Technology Preview.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "eap-cd-tx-recovery-s2i",
-        "xpaas": "1.4.10"
+        "xpaas": "1.5.0"
     },
     "message": "A new JBoss EAP CD based application has been created in your project.",
     "parameters": [
@@ -32,44 +32,122 @@
             "displayName": "Git Repository URL",
             "description": "Git source URI for application",
             "name": "SOURCE_REPOSITORY_URL",
-            "value": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+            "value": "https://github.com/jboss-openshift/openshift-quickstarts.git",
             "required": true
         },
         {
             "displayName": "Git Reference",
             "description": "Git branch/tag reference",
             "name": "SOURCE_REPOSITORY_REF",
-            "value": "openshift",
+            "value": "1.3",
+            "required": false
+        },
+        {
+            "displayName": "Custom install directories (see documentation).",
+            "description": "Additional directories from which to install.",
+            "name": "CUSTOM_INSTALL_DIRECTORIES",
+            "value": "extensions/*",
             "required": false
         },
         {
             "displayName": "Context Directory",
             "description": "Path within Git project to build; empty for root project directory.",
             "name": "CONTEXT_DIR",
-            "value": "kitchensink",
+            "value": "jta-crash-rec-eap7",
+            "required": false
+        },
+        {
+            "displayName": "AMQ Volume Size",
+            "description": "Size of the volume used by AMQ for persisting messages.",
+            "name": "VOLUME_CAPACITY",
+            "value": "1Gi",
+            "required": true
+        },
+        {
+            "displayName": "JMS Connection Factory JNDI Name",
+            "description": "JNDI name for connection factory used by applications to connect to the broker, e.g. java:jboss/DefaultJMSConnectionFactory",
+            "name": "MQ_JNDI",
+            "value": "java:jboss/DefaultJMSConnectionFactory",
+            "required": false
+        },
+        {
+            "displayName": "Split the data directory?",
+            "description": "Split the data directory for each node in a mesh.",
+            "name": "AMQ_SPLIT",
+            "value": "false",
+            "required": false
+        },
+        {
+            "displayName": "AMQ Protocols",
+            "description": "Broker protocols to configure, separated by commas. Allowed values are: `openwire`, `amqp`, `stomp` and `mqtt`. Only `openwire` is supported by EAP.",
+            "name": "MQ_PROTOCOL",
+            "value": "openwire",
             "required": false
         },
         {
             "displayName": "Queues",
-            "description": "Queue names",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
-            "value": "",
+            "value": "jta-crash-rec-quickstart",
             "required": false
         },
         {
             "displayName": "Topics",
-            "description": "Topic names",
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
             "value": "",
             "required": false
         },
         {
-            "displayName": "A-MQ cluster password",
-            "description": "A-MQ cluster admin password",
+            "displayName": "AMQ Serializable Packages",
+            "description": "List of packages that are allowed to be serialized for use in ObjectMessage, separated by commas. If your app doesn't use ObjectMessages, leave this blank. This is a security enforcement. For the rationale, see http://activemq.apache.org/objectmessage.html",
+            "name": "MQ_SERIALIZABLE_PACKAGES",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "AMQ cluster password",
+            "description": "AMQ cluster admin password",
             "name": "MQ_CLUSTER_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
             "required": true
+        },
+                {
+            "displayName": "AMQ Username",
+            "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+            "name": "MQ_USERNAME",
+            "from": "user[a-zA-Z0-9]{3}",
+            "generate": "expression",
+            "required": false
+        },
+        {
+            "displayName": "AMQ Password",
+            "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+            "name": "MQ_PASSWORD",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "required": false
+        },
+        {
+            "displayName": "AMQ Role",
+            "description": "AMQ Role for authenticated user",
+            "name": "MQ_ROLE",
+            "value": "admin"
+        },
+        {
+            "displayName": "AMQ Mesh Discovery Type",
+            "description": "The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace.",
+            "name": "AMQ_MESH_DISCOVERY_TYPE",
+            "value": "dns",
+            "required": false
+        },
+        {
+            "displayName": "AMQ Storage Limit",
+            "description": "The AMQ storage usage limit",
+            "name": "AMQ_STORAGE_USAGE_LIMIT",
+            "value": "100 gb",
+            "required": false
         },
         {
             "displayName": "Github Webhook Secret",
@@ -202,6 +280,56 @@
             }
         },
         {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
+                        "port": 61616,
+                        "targetPort": 61616
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-amq"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq-tcp",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The broker's OpenWire port."
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "clusterIP": "None",
+                "ports": [
+                    {
+                        "name": "mesh",
+                        "port": 61616
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-amq"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq-mesh",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+                    "description": "Supports node discovery for mesh formation."
+                }
+            }
+        },
+        {
             "kind": "Route",
             "apiVersion": "v1",
             "id": "${APPLICATION_NAME}-http",
@@ -269,7 +397,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "eap-cd-openshift:12"
+                            "name": "eap-cd-openshift:13"
                         }
                     }
                 },
@@ -401,6 +529,38 @@
                                 ],
                                 "env": [
                                     {
+                                        "name": "MQ_SERVICE_PREFIX_MAPPING",
+                                        "value": "${APPLICATION_NAME}-amq7=MQ"
+                                    },
+                                    {
+                                        "name": "MQ_JNDI",
+                                        "value": "${MQ_JNDI}"
+                                    },
+                                    {
+                                        "name": "MQ_USERNAME",
+                                        "value": "${MQ_USERNAME}"
+                                    },
+                                    {
+                                        "name": "MQ_PASSWORD",
+                                        "value": "${MQ_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MQ_PROTOCOL",
+                                        "value": "tcp"
+                                    },
+                                    {
+                                        "name": "MQ_QUEUES",
+                                        "value": "${MQ_QUEUES}"
+                                    },
+                                    {
+                                        "name": "MQ_TOPICS",
+                                        "value": "${MQ_TOPICS}"
+                                    },
+                                    {
+                                        "name": "MQ_SERIALIZABLE_PACKAGES",
+                                        "value": "${MQ_SERIALIZABLE_PACKAGES}"
+                                    },
+                                    {
                                         "name": "JGROUPS_PING_PROTOCOL",
                                         "value": "openshift.DNS_PING"
                                     },
@@ -417,12 +577,8 @@
                                         "value": "${MQ_CLUSTER_PASSWORD}"
                                     },
                                     {
-                                        "name": "MQ_QUEUES",
-                                        "value": "${MQ_QUEUES}"
-                                    },
-                                    {
-                                        "name": "MQ_TOPICS",
-                                        "value": "${MQ_TOPICS}"
+                                        "name": "MQ_SERIALIZABLE_PACKAGES",
+                                        "value": "${MQ_SERIALIZABLE_PACKAGES}"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
@@ -435,6 +591,10 @@
                                     {
                                         "name": "SPLIT_DATA",
                                         "value": "${SPLIT_DATA}"
+                                    },
+                                    {
+                                        "name": "CUSTOM_INSTALL_DIRECTORIES",
+                                        "value": "${CUSTOM_INSTALL_DIRECTORIES}"
                                     }
                                 ]
                             }
@@ -444,6 +604,185 @@
                                 "name": "${APPLICATION_NAME}-eap-pvol",
                                 "persistentVolumeClaim": {
                                     "claimName": "${APPLICATION_NAME}-eap-claim"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Rolling",
+                    "rollingParams": {
+                        "maxSurge": 0
+                    }
+                },
+                "triggers": [
+                    {
+                        "type": "ImageChange",
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "${APPLICATION_NAME}-amq"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "namespace": "${IMAGE_STREAM_NAMESPACE}",
+                                "name": "amq-broker-71-openshift:1.0"
+                            }
+                        }
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-amq"
+                },
+                "template": {
+                    "metadata": {
+                        "name": "${APPLICATION_NAME}-amq",
+                        "labels": {
+                            "deploymentConfig": "${APPLICATION_NAME}-amq",
+                            "application": "${APPLICATION_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "terminationGracePeriodSeconds": 60,
+                        "containers": [
+                            {
+                                "name": "${APPLICATION_NAME}-amq",
+                                "image": "amq-broker-71-openshift",
+                                "imagePullPolicy": "Always",
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "/opt/amq/bin/readinessProbe.sh"
+                                        ]
+                                    }
+                                },
+                                "ports": [
+                                    {
+                                        "name": "console-jolokia",
+                                        "containerPort": 8161,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "amqp",
+                                        "containerPort": 5672,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "amqp-ssl",
+                                        "containerPort": 5671,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "mqtt",
+                                        "containerPort": 1883,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "stomp",
+                                        "containerPort": 61613,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "stomp-ssl",
+                                        "containerPort": 61612,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "tcp",
+                                        "containerPort": 61616,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "tcp-ssl",
+                                        "containerPort": 61617,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/opt/amq/data/kahadb",
+                                        "name": "${APPLICATION_NAME}-amq-pvol"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "AMQ_USER",
+                                        "value": "${MQ_USERNAME}"
+                                    },
+                                    {
+                                        "name": "AMQ_PASSWORD",
+                                        "value": "${MQ_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AMQ_ROLE",
+                                        "value": "${MQ_ROLE}"
+                                    },
+                                    {
+                                        "name": "AMQ_TRANSPORTS",
+                                        "value": "${MQ_PROTOCOL}"
+                                    },
+                                    {
+                                        "name": "AMQ_QUEUES",
+                                        "value": "${MQ_QUEUES}"
+                                    },
+                                    {
+                                        "name": "AMQ_ADDRESSES",
+                                        "value": "${MQ_TOPICS}"
+                                    },
+                                    {
+                                        "name": "MQ_SERIALIZABLE_PACKAGES",
+                                        "value": "${MQ_SERIALIZABLE_PACKAGES}"
+                                    },
+                                    {
+                                        "name": "AMQ_SPLIT",
+                                        "value": "${AMQ_SPLIT}"
+                                    },
+                                    {
+                                        "name": "AMQ_MESH_DISCOVERY_TYPE",
+                                        "value": "${AMQ_MESH_DISCOVERY_TYPE}"
+                                    },
+                                    {
+                                        "name": "AMQ_MESH_SERVICE_NAME",
+                                        "value": "${APPLICATION_NAME}-amq-mesh"
+                                    },
+                                    {
+                                        "name": "AMQ_MESH_SERVICE_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "AMQ_STORAGE_USAGE_LIMIT",
+                                        "value": "${AMQ_STORAGE_USAGE_LIMIT}"
+                                    }
+                                ]
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "${APPLICATION_NAME}-amq-pvol",
+                                "persistentVolumeClaim": {
+                                    "claimName": "${APPLICATION_NAME}-amq-claim"
                                 }
                             }
                         ]
@@ -546,6 +885,25 @@
                                         "value": "8888"
                                     },
                                     {
+                                        "name": "MQ_SERVICE_PREFIX_MAPPING",
+                                        "value": "${APPLICATION_NAME}-amq7=MQ"
+                                    },
+                                    {
+                                        "name": "MQ_JNDI",
+                                        "value": "${MQ_JNDI}"
+                                    },
+                                    {   "name": "MQ_USERNAME",
+                                        "value": "${MQ_USERNAME}"
+                                    },
+                                    {
+                                        "name": "MQ_PASSWORD",
+                                        "value": "${MQ_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MQ_PROTOCOL",
+                                        "value": "tcp"
+                                    },
+                                    {
                                         "name": "MQ_CLUSTER_PASSWORD",
                                         "value": "${MQ_CLUSTER_PASSWORD}"
                                     },
@@ -589,6 +947,26 @@
             "kind": "PersistentVolumeClaim",
             "metadata": {
                 "name": "${APPLICATION_NAME}-eap-claim",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "accessModes": [
+                    "ReadWriteMany"
+                ],
+                "resources": {
+                    "requests": {
+                        "storage": "${VOLUME_CAPACITY}"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq-claim",
                 "labels": {
                     "application": "${APPLICATION_NAME}"
                 }


### PR DESCRIPTION
This update adds EAP CD 13 and associated templates into v3.11.

See: https://issues.jboss.org/browse/CLOUD-2555
and: https://errata.devel.redhat.com/advisory/34873

Signed-off-by: Ken Wills <kwills@redhat.com>