### PR TITLE
Use OPENSHIFT_CLUSTER env in OpenStack uninstall

### DIFF
--- a/playbooks/openstack/openshift-cluster/uninstall.yml
+++ b/playbooks/openstack/openshift-cluster/uninstall.yml
@@ -29,6 +29,9 @@
 - name: Remove OpenStack resources
   hosts: localhost
   tasks:
+  - name: retrieve cluster name from the environment if present
+    set_fact:
+      openshift_openstack_stack_name: "{{ lookup('env', 'OPENSHIFT_CLUSTER') | ternary (lookup('env', 'OPENSHIFT_CLUSTER'), omit) }}"
   - name: Remove OpenStack resources
     import_role:
       name: openshift_openstack


### PR DESCRIPTION
The OpenStack's `provision.yml` playbook allows setting a different name
for the OpenShift cluster being created using the OPENSHIFT_CLUSTER
environment variable.

This variable was being ignored in the `uninstall.yml` playbook which
means it would try to remove a different set of OpenStack resources.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1598079