### PR TITLE
openshift_is_containerized is not a defined variable.

### DIFF
--- a/playbooks/common/openshift-node/restart.yml
+++ b/playbooks/common/openshift-node/restart.yml
@@ -26,7 +26,7 @@
       name: openvswitch
       state: started
     when:
-    - openshift_is_containerized | bool
+    - l_is_containerized | bool
     - openshift_use_openshift_sdn | bool
 
   - name: Restart containerized services


### PR DESCRIPTION
Openshift_is_containerized is not a defined variable. The actual variable is l_is_containerized, hence modified the same. 
By this when deploying Openshift CA, the playbooks failed at this particular task stating the same.