### PR TITLE
Allow the 9k-10k port range for Prometheus

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -142,6 +142,8 @@ default_r_openshift_node_os_firewall_allow:
 - service: Kubernetes service NodePort UDP
   port: "{{ openshift_node_port_range | default('') }}/udp"
   cond: "{{ openshift_node_port_range is defined }}"
+- service: Prometheus monitoring
+  port: 9000-10000/tcp
 # Allow multiple port ranges to be added to the role
 r_openshift_node_os_firewall_allow: "{{ default_r_openshift_node_os_firewall_allow | union(openshift_node_open_ports | default([])) }}"
 


### PR DESCRIPTION
As noted in https://github.com/openshift/openshift-ansible/pull/7860#issuecomment-397081742, the 9k-10k range should be open on all OpenShift clusters. It's already been done for GCP installs in https://github.com/openshift/openshift-ansible/pull/7862

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1563888

@smarterclayton is that what you had in mind?

cc @brancz @codificat @sdodson 