### PR TITLE
[release-3.9] Support oreg_url for default image prefix of webconsole

### DIFF
--- a/roles/openshift_web_console/defaults/main.yml
+++ b/roles/openshift_web_console/defaults/main.yml
@@ -14,7 +14,7 @@ openshift_web_console_image_dict:
     version: "{{ openshift_image_tag }}"
     image_name: "web-console"
 
-openshift_web_console_prefix: "{{ openshift_web_console_image_dict[openshift_deployment_type]['prefix'] }}"
+openshift_web_console_prefix: "{{ oreg_url | default(openshift_web_console_image_dict[openshift_deployment_type]['prefix']) }}"
 openshift_web_console_version: "{{ openshift_web_console_image_dict[openshift_deployment_type]['version'] }}"
 openshift_web_console_image_name: "{{ openshift_web_console_image_dict[openshift_deployment_type]['image_name'] }}"
 # Default the replica count to the number of masters.


### PR DESCRIPTION
Even though webconsole is a core component and it has a prefix of
`registry.access.redhat.com/openshift3/ose-*` or
`docker.io/openshift/origin-`, it does not take oreg_url for the
prefix.

This patch adds oreg_url for openshift_web_console_prefix, but does
not make any change for default value.