### PR TITLE
Accept client certs from node, system:admin, and bootstrap SA

### DIFF
--- a/roles/lib_openshift/library/oc_adm_csr.py
+++ b/roles/lib_openshift/library/oc_adm_csr.py
@@ -1558,13 +1558,14 @@ class OCcsr(OpenShiftCLI):
             if node['name'] in self.get_csr_request(csr['spec']['request']):
                 node['csrs'][csr['metadata']['name']] = csr
 
-                # server: check that the username is the node and type is 'Approved'
-                if node['name'] in csr['spec']['username'] and csr['status']:
-                    if csr['status']['conditions'][0]['type'] == 'Approved':
+                # client certs may come in as either the service_account or as the node during upgrade
+                # server certs always come in as the node
+                if ((node['name'] in csr['spec']['username'] or
+                     csr['spec']['username'] in [self.service_account, 'system:admin']) and
+                        csr['status'] and csr['status']['conditions'][0]['type'] == 'Approved'):
+                    if 'server auth' in csr['spec']['usages']:
                         node['server_accepted'] = True
-                # client: check that the username is not the node and type is 'Approved'
-                if node['name'] not in csr['spec']['username'] and csr['status']:
-                    if csr['status']['conditions'][0]['type'] == 'Approved':
+                    if 'client auth' in csr['spec']['usages']:
                         node['client_accepted'] = True
                 # check type is 'Denied' and mark node as such
                 if csr['status'] and csr['status']['conditions'][0]['type'] == 'Denied':
@@ -1615,11 +1616,12 @@ class OCcsr(OpenShiftCLI):
 
                     # mark node as accepted in our list of nodes
                     # we will use {client,server}_accepted fields to determine if we're finished
-                    if node['name'] not in csr['spec']['username']:
-                        node['client_accepted'] = True
-
-                    if node['name'] in csr['spec']['username']:
-                        node['server_accepted'] = True
+                    if (node['name'] in csr['spec']['username'] or
+                            csr['spec']['username'] in [self.service_account, 'system:admin']):
+                        if 'server auth' in csr['spec']['usages']:
+                            node['server_accepted'] = True
+                        if 'client auth' in csr['spec']['usages']:
+                            node['client_accepted'] = True
 
                 results.append(result)
 
@@ -1705,7 +1707,7 @@ def main():
             nodes=dict(default=None, type='list'),
             timeout=dict(default=30, type='int'),
             approve_all=dict(default=False, type='bool'),
-            service_account=dict(default='node-bootstrapper', type='str'),
+            service_account=dict(default='system:serviceaccount:openshift-infra:node-bootstrapper', type='str'),
             fail_on_timeout=dict(default=False, type='bool'),
         ),
         supports_check_mode=True,

--- a/roles/lib_openshift/src/ansible/oc_adm_csr.py
+++ b/roles/lib_openshift/src/ansible/oc_adm_csr.py
@@ -15,7 +15,7 @@ def main():
             nodes=dict(default=None, type='list'),
             timeout=dict(default=30, type='int'),
             approve_all=dict(default=False, type='bool'),
-            service_account=dict(default='node-bootstrapper', type='str'),
+            service_account=dict(default='system:serviceaccount:openshift-infra:node-bootstrapper', type='str'),
             fail_on_timeout=dict(default=False, type='bool'),
         ),
         supports_check_mode=True,


### PR DESCRIPTION
During greenfield installs the node's client certificate is generated by the bootstrap CA. However in certain situations during an upgrade we see that the client certificate is generated using the node's identity. So approve those as well.

/cc @abutcher @smarterclayton @sjenning 