### PR TITLE
make logging rely on a single SG index

### DIFF
--- a/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
@@ -52,7 +52,7 @@ path:
 searchguard:
   authcz.admin_dn:
   - CN=system.admin,OU=OpenShift,O=Logging
-  config_index_name: ".searchguard.${DC_NAME}"
+  config_index_name: ".searchguard"
   ssl:
     transport:
       enabled: true


### PR DESCRIPTION
This PR resolves:
* the configuration parts of https://trello.com/c/d3Fadd6D to make SG rely in a single index for all node instances.  
* Enables https://github.com/openshift/origin-aggregated-logging/pull/1177

We now rely on the default index which is '.searchguard'