### PR TITLE
Suppress unexpected errors caused by non-English locale during CRI-O installation

### DIFF
--- a/roles/container_runtime/tasks/common/setup_docker_symlink.yml
+++ b/roles/container_runtime/tasks/common/setup_docker_symlink.yml
@@ -13,6 +13,8 @@
 
     - name: "Set the selinux context on {{ docker_alt_storage_path }}"
       command: "semanage fcontext -a -e {{ docker_default_storage_path }} {{ docker_alt_storage_path }}"
+      environment:
+        LANG: C
       register: results
       failed_when:
         - results.rc == 1


### PR DESCRIPTION
The `failed_when` have the condition checking rule based on error message strings, so non-English error message is not handled properly and it occurred error though it's same messages.

So I add "LANG=C" to fix it in order to print message in English without influence of OS locale.

And I also opened BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1598629