### PR TITLE
Add a components public playbook

### DIFF
--- a/playbooks/openshift-master/components.yml
+++ b/playbooks/openshift-master/components.yml
@@ -1,0 +1,4 @@
+---
+- import_playbook: ../init/main.yml
+
+- import_playbook: ../common/private/components.yml


### PR DESCRIPTION
I couldn't find another public entry point that only ran component installation.

Initial use case is to facilitate an install where SDN and all components are disabled, then a third party SDN is installed, then components are installed once the SDN comes up.