### PR TITLE
Decrease timeout for rc phase to 3 min

### DIFF
--- a/roles/openshift_hosted/tasks/wait_for_pod.yml
+++ b/roles/openshift_hosted/tasks/wait_for_pod.yml
@@ -29,7 +29,7 @@
     register: openshift_hosted_wfp_rc_phase
     until: "'Complete' in openshift_hosted_wfp_rc_phase.stdout"
     delay: 10
-    retries: 60
+    retries: 18
     failed_when: "'Failed' in openshift_hosted_wfp_rc_phase.stdout"
     with_together:
     - "{{ l_openshift_hosted_wfp_items }}"


### PR DESCRIPTION
When task `Poll for OpenShift pod deployment success` failed, current
timeout is 10 interval * 60 times = 10 minutes. It takes too long time
to know the failure of ansible playbook.

This patch decreases the retry to 18 times and so timeout will become
3 minutes. It still has a few minutes as it may pull docker image.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1599041