### PR TITLE
gcp: add custom repo when building image

### DIFF
--- a/playbooks/gcp/openshift-cluster/build_image.yml
+++ b/playbooks/gcp/openshift-cluster/build_image.yml
@@ -77,6 +77,15 @@
   tasks:
   - wait_for_connection:
 
+- name: Add custom repositories
+  hosts: nodes
+  handlers:
+  - import_tasks: ../../roles/openshift_repos/handlers/main.yml
+  tasks:
+  - include_role:
+      name: openshift_gcp
+      tasks_from: add_custom_repositories.yml
+
 # This is the part that installs all of the software and configs for the instance
 # to become a node.
 - import_playbook: ../../openshift-node/private/image_prep.yml


### PR DESCRIPTION
While testing https://github.com/openshift/release/pull/1030, we noticed that the snippet in `provision_custom_repositories` wasn't being picked  at gcp image build and the gcp provision was failing with failed to install the cri-o RPM.

@mrunalp @smarterclayton PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>