### PR TITLE
[3.7] TSB and ASB should use openshift_hosted_infra_selector by default

### DIFF
--- a/roles/template_service_broker/defaults/main.yml
+++ b/roles/template_service_broker/defaults/main.yml
@@ -3,4 +3,4 @@
 template_service_broker_remove: False
 template_service_broker_install: True
 openshift_template_service_broker_namespaces: ['openshift']
-template_service_broker_selector: { "region": "infra" }
+template_service_broker_selector: "{{ openshift_hosted_infra_selector | default('region=infra') | map_from_pairs }}"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1538616

This seems to be already implemented in 3.9+ so no need to cherrypick