### PR TITLE
Clean cloud-init path

### DIFF
--- a/playbooks/openshift-node/private/clean_image.yml
+++ b/playbooks/openshift-node/private/clean_image.yml
@@ -8,3 +8,7 @@
       state: absent
     with_items:
     - openshift.fact
+  - name: Clean cloud-init path
+    file:
+      state: absent
+      path: "/var/lib/cloud/"


### PR DESCRIPTION
This patch will resolve the issue of cloud-init failing to execute due to a dirty /var/lib/cloud path on newly created AWS EC2s

https://bugzilla.redhat.com/show_bug.cgi?id=1599354