### PR TITLE
Remove masters from nodes we expect CSRs from

### DIFF
--- a/playbooks/openshift-node/private/join.yml
+++ b/playbooks/openshift-node/private/join.yml
@@ -31,7 +31,7 @@
 
   - name: Find all hostnames for bootstrapping
     set_fact:
-      l_nodes_to_join: "{{ groups['oo_nodes_to_bootstrap'] | default([]) | map('extract', hostvars) | map(attribute='openshift.node.nodename') | list }}"
+      l_nodes_to_join: "{{ groups['oo_nodes_to_bootstrap']:!groups['oo_masters_to_config'] | default([]) | map('extract', hostvars) | map(attribute='openshift.node.nodename') | list }}"
 
   - name: Dump the bootstrap hostnames
     debug:


### PR DESCRIPTION
When scaling up nodes don't look for masters to have CSRs. They've likely already been approved and purged after an hour.

Potential fix for https://bugzilla.redhat.com/show_bug.cgi?id=1597908