### PR TITLE
Fix etcd restart commands

### DIFF
--- a/roles/etcd/tasks/restart.yml
+++ b/roles/etcd/tasks/restart.yml
@@ -1,3 +1,3 @@
 ---
 - name: restart etcd
-  command: /usr/local/bin/master-restart etcd
+  command: "{{ l_etcd_restart_command }}"

--- a/roles/etcd/tasks/upgrade/upgrade_image.yml
+++ b/roles/etcd/tasks/upgrade/upgrade_image.yml
@@ -23,7 +23,7 @@
 - import_tasks: validate_etcd_conf.yml
 
 - name: restart etcd
-  command: /usr/local/bin/master-restart etcd
+  command: "{{ l_etcd_restart_command }}"
 
 - name: Verify cluster is healthy
   command: "{{ etcdctlv2 }} cluster-health"

--- a/roles/etcd/tasks/upgrade/upgrade_rpm.yml
+++ b/roles/etcd/tasks/upgrade/upgrade_rpm.yml
@@ -24,7 +24,7 @@
 - import_tasks: validate_etcd_conf.yml
 
 - name: restart etcd
-  command: /usr/local/bin/master-restart etcd
+  command: "{{ l_etcd_restart_command }}"
 
 - name: Verify cluster is healthy
   command: "{{ etcdctlv2 }} cluster-health"


### PR DESCRIPTION
Some etcd restart commands are hard-coded and may be incorrect.

This commit ensures the proper command string is utilized
with each type of supported etcd install.