### PR TITLE
Use service name for heketi url

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
@@ -292,12 +292,6 @@
     when:
     - glusterfs_heketi_is_native
 
-  - name: Determine StorageClass heketi URL
-    set_fact:
-      glusterfs_heketi_route: "{{ heketi_route.results.results[0]['spec']['host'] }}"
-    when:
-    - glusterfs_heketi_is_native
-
   - name: Generate GlusterFS StorageClass file
     template:
       src: "glusterfs-storageclass.yml.j2"
@@ -339,12 +333,6 @@
       state: list
       name: "heketi-{{ glusterfs_name }}"
     register: heketi_route
-    when:
-    - glusterfs_heketi_is_native
-
-  - name: Determine StorageClass heketi URL
-    set_fact:
-      glusterfs_heketi_route: "{{ heketi_route.results.results[0]['spec']['host'] }}"
     when:
     - glusterfs_heketi_is_native
 

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
@@ -282,16 +282,6 @@
     when:
     - glusterfs_heketi_admin_key is defined
 
-  - name: Get heketi route
-    oc_obj:
-      namespace: "{{ glusterfs_namespace }}"
-      kind: route
-      state: list
-      name: "heketi-{{ glusterfs_name }}"
-    register: heketi_route
-    when:
-    - glusterfs_heketi_is_native
-
   - name: Generate GlusterFS StorageClass file
     template:
       src: "glusterfs-storageclass.yml.j2"
@@ -325,16 +315,6 @@
       - path: key
         data: "{{ glusterfs_heketi_admin_key }}"
     when: glusterfs_heketi_admin_key is defined
-
-  - name: Get heketi route
-    oc_obj:
-      namespace: "{{ glusterfs_namespace }}"
-      kind: route
-      state: list
-      name: "heketi-{{ glusterfs_name }}"
-    register: heketi_route
-    when:
-    - glusterfs_heketi_is_native
 
   - name: Generate Gluster Block StorageClass file
     template:

--- a/roles/openshift_storage_glusterfs/templates/gluster-block-storageclass.yml.j2
+++ b/roles/openshift_storage_glusterfs/templates/gluster-block-storageclass.yml.j2
@@ -9,7 +9,7 @@ metadata:
 {% endif %}
 provisioner: gluster.org/glusterblock
 parameters:
-  resturl: "http://{% if glusterfs_heketi_is_native %}{{ glusterfs_heketi_route }}{% else %}{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}{% endif %}"
+  resturl: "http://{% if glusterfs_heketi_is_native %}heketi-storage.glusterfs.svc.cluster.local:8080{% else %}{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}{% endif %}"
   restuser: "admin"
   chapauthenabled: "true"
   hacount: "3"

--- a/roles/openshift_storage_glusterfs/templates/gluster-block-storageclass.yml.j2
+++ b/roles/openshift_storage_glusterfs/templates/gluster-block-storageclass.yml.j2
@@ -9,7 +9,7 @@ metadata:
 {% endif %}
 provisioner: gluster.org/glusterblock
 parameters:
-  resturl: "http://{% if glusterfs_heketi_is_native %}heketi-storage.glusterfs.svc.cluster.local:8080{% else %}{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}{% endif %}"
+  resturl: "http://{% if glusterfs_heketi_is_native %}heketi-{{ glusterfs_name }}.{{ glusterfs_namespace }}.svc:8080{% else %}{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}{% endif %}"
   restuser: "admin"
   chapauthenabled: "true"
   hacount: "3"

--- a/roles/openshift_storage_glusterfs/templates/glusterfs-storageclass.yml.j2
+++ b/roles/openshift_storage_glusterfs/templates/glusterfs-storageclass.yml.j2
@@ -9,7 +9,7 @@ metadata:
 {% endif %}
 provisioner: kubernetes.io/glusterfs
 parameters:
-  resturl: "http://{% if glusterfs_heketi_is_native %}heketi-storage.glusterfs.svc.cluster.local:8080{% else %}{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}{% endif %}"
+  resturl: "http://{% if glusterfs_heketi_is_native %}heketi-{{ glusterfs_name }}.{{ glusterfs_namespace }}.svc.svc.cluster.local:8080{% else %}{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}{% endif %}"
   restuser: "admin"
 {% if glusterfs_heketi_admin_key is defined %}
   secretNamespace: "{{ glusterfs_namespace }}"

--- a/roles/openshift_storage_glusterfs/templates/glusterfs-storageclass.yml.j2
+++ b/roles/openshift_storage_glusterfs/templates/glusterfs-storageclass.yml.j2
@@ -9,7 +9,7 @@ metadata:
 {% endif %}
 provisioner: kubernetes.io/glusterfs
 parameters:
-  resturl: "http://{% if glusterfs_heketi_is_native %}{{ glusterfs_heketi_route }}{% else %}{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}{% endif %}"
+  resturl: "http://{% if glusterfs_heketi_is_native %}heketi-storage.glusterfs.svc.cluster.local:8080{% else %}{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}{% endif %}"
   restuser: "admin"
 {% if glusterfs_heketi_admin_key is defined %}
   secretNamespace: "{{ glusterfs_namespace }}"


### PR DESCRIPTION
Currently glusterfs-storage uses external heketi URL for its rest
access point, even when native heketi is used. This means that when
route was not accessible (due to the issue of DNS, router pod,
external network and so on), storage class is also down. Also, it does
not make sense to use external route, even though it can use internal
service access.

Hence this replaces heketi external route with internal service name.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1599554