### PR TITLE
Do not delete IAM cert if explicitely requested

### DIFF
--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 openshift_aws_create_s3: True
 openshift_aws_create_iam_cert: True
+openshift_aws_delete_iam_cert: "{{ openshift_aws_create_iam_cert }}"
 openshift_aws_create_iam_role: False
 openshift_aws_create_security_groups: True
 openshift_aws_create_launch_config: True

--- a/roles/openshift_aws/tasks/uninstall_iam_cert.yml
+++ b/roles/openshift_aws/tasks/uninstall_iam_cert.yml
@@ -1,6 +1,6 @@
 ---
 - when:
-  - openshift_aws_create_iam_cert | bool
+  - openshift_aws_delete_iam_cert | bool
   - openshift_aws_iam_cert_path != ''
   - openshift_aws_iam_cert_key_path != ''
   - openshift_aws_elb_cert_arn == ''


### PR DESCRIPTION
Given the number of server certificates uploaded to AWS is limited (40 at the moment),
intensive testing can exhaust all available slots. Thus, it should be allowed
to reuse the certificates among deployments. Thus, allowing the skip the deletion.