### PR TITLE
[release-3.9] Don't call check_available_rpms.yml when containeriazed installation

### DIFF
--- a/roles/openshift_version/tasks/masters_and_nodes.yml
+++ b/roles/openshift_version/tasks/masters_and_nodes.yml
@@ -10,7 +10,9 @@
     # Both versions have the same string representation
     when: rpm_results.results.versions.available_versions.0 != openshift_version
   # block when
-  when: not openshift_is_atomic | bool
+  when:
+  - not openshift_is_atomic | bool
+  - not openshift_is_containerized | bool
 
 # We can't map an openshift_release to full rpm version like we can with containers; make sure
 # the rpm version we looked up matches the release requested and error out if not.

--- a/roles/openshift_version/tasks/masters_and_nodes.yml
+++ b/roles/openshift_version/tasks/masters_and_nodes.yml
@@ -11,7 +11,6 @@
     when: rpm_results.results.versions.available_versions.0 != openshift_version
   # block when
   when:
-  - not openshift_is_atomic | bool
   - not openshift_is_containerized | bool
 
 # We can't map an openshift_release to full rpm version like we can with containers; make sure


### PR DESCRIPTION
In containerized installation, we do not expect to check RPM packages
in the repository.

This patch stopps call check_available.yml in containerized
installation.