### PR TITLE
Fixing missing _es_version variable

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -30,14 +30,14 @@
     full_restart_cluster: True
   when:
   - _es_installed_version is defined
-  - _es_installed_version.split('.')[0] | int < __es_version.split('.')[0] | int
+  - _es_installed_version.split('.')[0] | int < __es_major_version
   - not openshift_logging_elasticsearch_ops_deployment | default(false) | bool
 
 - set_fact:
     full_restart_cluster: True
   when:
   - _es_ops_installed_version is defined
-  - _es_ops_installed_version.split('.')[0] | int < __es_version.split('.')[0] | int
+  - _es_ops_installed_version.split('.')[0] | int < __es_major_version
   - openshift_logging_elasticsearch_ops_deployment | default(false) | bool
 
 # allow passing in a tempdir

--- a/roles/openshift_logging_elasticsearch/vars/main.yml
+++ b/roles/openshift_logging_elasticsearch/vars/main.yml
@@ -6,6 +6,7 @@ __kibana_index_modes: ["unique", "shared_ops"]
 __es_local_curl: "curl -s --cacert /etc/elasticsearch/secret/admin-ca --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key"
 
 __elasticsearch_ready_retries: "{{ openshift_logging_elasticsearch_poll_timeout_minutes | default(60) | int * 2 }}"
+__es_major_version: 5
 
 # TODO: integrate these
 es_node_quorum: "{{ openshift_logging_elasticsearch_replica_count | int/2 + 1 }}"


### PR DESCRIPTION
Found when doing a local upgrade from ES 2 -> ES 5