### PR TITLE
Exclude masters from node list for CSR approval.

### DIFF
--- a/playbooks/init/evaluate_groups.yml
+++ b/playbooks/init/evaluate_groups.yml
@@ -146,7 +146,11 @@
       groups: oo_nodes_to_bootstrap
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_become: "{{ g_sudo | default(omit) }}"
-    with_items: "{{ groups.oo_masters | default([]) }}"
+    with_items: "{{ g_new_master_hosts | default(g_master_hosts | default([], true), true) }}"
+    when:
+    # Add masters to oo_nodes_to_bootstrap when we are not scaling up.
+    # Add new masters to oo_nodes_to_bootstrap when we are scaling up masters.
+    - g_new_node_hosts | length == 0 or g_new_master_hosts | length > 0
     changed_when: no
 
   - name: Evaluate oo_lb_to_config


### PR DESCRIPTION
When scaling up nodes, currently, we look for CSRs for the masters needlessly. This creates a problem because CSRs that have been previously approved are removed from the API after one hour. So we look for CSRs for hosts that won't have any. We have existing protections for this where we first check whether there's a node in ready state for a host and based on that assume that the node is fully approved. However, in the node scaleup playbooks we're finding that the masters are restarted and may not have marked themselves Ready yet so this too fails.