### PR TITLE
Setup logrotate on nodes once

### DIFF
--- a/playbooks/openshift-etcd/private/config.yml
+++ b/playbooks/openshift-etcd/private/config.yml
@@ -50,9 +50,6 @@
       etcd_peers: "{{ groups.oo_etcd_to_config | default([], true) }}"
       etcd_certificates_etcd_hosts: "{{ groups.oo_etcd_to_config | default([], true) }}"
 
-  - import_role:
-      name: nickhammond.logrotate
-
 - name: etcd Install Checkpoint End
   hosts: all
   gather_facts: false

--- a/playbooks/openshift-etcd/private/scaleup.yml
+++ b/playbooks/openshift-etcd/private/scaleup.yml
@@ -28,10 +28,6 @@
       etcd_initial_cluster: "{{ etcd_add_check.stdout_lines[3] | regex_replace('ETCD_INITIAL_CLUSTER=','') | regex_replace('\"','') }}"
       etcd_ca_setup: False
 
-  - import_role:
-      name: nickhammond.logrotate
-    when: etcd_add_check.rc == 0
-
   # etcd_hostname fact is set in add_new_member.yml called above.
   - name: Verify cluster is stable
     command: >

--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -91,7 +91,6 @@
     when: openshift_cloudprovider_kind is defined
   - role: openshift_builddefaults
   - role: openshift_buildoverrides
-  - role: nickhammond.logrotate
 
   - role: openshift_control_plane
   - role: tuned


### PR DESCRIPTION
Since all components are now in nodes group, its sufficient to setup 
logrotate once on nodes

/cherrypick release-3.10