### PR TITLE
Defining a default for logging_elasticsearch_rollout_override var in es handler

### DIFF
--- a/roles/openshift_logging_elasticsearch/handlers/main.yml
+++ b/roles/openshift_logging_elasticsearch/handlers/main.yml
@@ -5,7 +5,7 @@
   with_items: "{{ _restart_logging_components }}"
   loop_control:
     loop_var: _cluster_component
-  when: not logging_elasticsearch_rollout_override | bool
+  when: not logging_elasticsearch_rollout_override | default(false) | bool
 
 ## Stop this from running more than once
 - set_fact:


### PR DESCRIPTION
Should address issue seen in Ansible 2.6.0 where `logging_elasticsearch_rollout_override | bool` does not evaluate to `false` when undefined.

https://github.com/openshift/openshift-ansible/issues/9100