### PR TITLE
Remove openshift_docker_is_node_or_master - all masters and etcd hosts are now nodes

### DIFF
--- a/playbooks/container-runtime/private/config.yml
+++ b/playbooks/container-runtime/private/config.yml
@@ -25,4 +25,3 @@
         tasks_from: package_crio.yml
       when:
         - openshift_use_crio | bool
-        - openshift_docker_is_node_or_master | bool

--- a/playbooks/container-runtime/private/config.yml
+++ b/playbooks/container-runtime/private/config.yml
@@ -3,9 +3,7 @@
 # l_etcd_scale_up_crt_hosts may be passed in via prerequisites.yml during etcd
 # scaleup plays.
 
-- hosts: "{{ l_etcd_scale_up_crt_hosts | default(l_scale_up_hosts) | default(l_default_container_runtime_hosts) }}"
-  vars:
-    l_default_container_runtime_hosts: "oo_nodes_to_config"
+- hosts: "{{ l_etcd_scale_up_crt_hosts | default(l_scale_up_hosts) | default('oo_nodes_to_config') }}"
   roles:
     - role: container_runtime
   tasks:

--- a/playbooks/container-runtime/private/setup_storage.yml
+++ b/playbooks/container-runtime/private/setup_storage.yml
@@ -4,9 +4,6 @@
 # scaleup plays.
 
 - hosts: "{{ l_etcd_scale_up_crt_hosts | default(l_scale_up_hosts) | default('oo_nodes_to_config') }}"
-  vars:
-    l_chg_temp: "{{ hostvars[groups['oo_first_master'][0]]['openshift_containerized_host_groups'] | default([]) }}"
-    l_containerized_host_groups: "{{ (['oo_nodes_to_config'] | union(l_chg_temp)) | join(':') }}"
   # role: container_runtime is necessary  here to bring role default variables
   # into the play scope.
   roles:

--- a/playbooks/container-runtime/private/setup_storage.yml
+++ b/playbooks/container-runtime/private/setup_storage.yml
@@ -17,7 +17,6 @@
         tasks_from: docker_storage_setup_overlay.yml
       when:
         - container_runtime_docker_storage_type|default('') == "overlay2"
-        - openshift_docker_is_node_or_master | bool
     - import_role:
         name: container_runtime
         tasks_from: extra_storage_setup.yml

--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -44,8 +44,6 @@ r_crio_os_firewall_allow:
 
 r_crio_use_openshift_sdn: "{{ openshift_use_openshift_sdn | default(True) }}"
 
-openshift_docker_is_node_or_master: "{{ True if inventory_hostname in (groups['oo_masters_to_config']|default([])) or inventory_hostname in (groups['oo_nodes_to_config']|default([])) else False | bool }}"
-
 docker_alt_storage_path: /var/lib/containers/docker
 docker_default_storage_path: /var/lib/docker
 docker_storage_path: "{{ docker_default_storage_path }}"


### PR DESCRIPTION
This var is no longer required, as all hosts are now nodes