### PR TITLE
Force rebuild of config when upgrading to es5

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -222,6 +222,7 @@
       new_file: "{{ tempdir }}/elasticsearch.yml"
     - current_file: "log4j2.properties"
       new_file: "{{ tempdir }}/log4j2.properties"
+  when: not full_restart_cluster | default(false) | bool
 
 - slurp:
     src: "{{ tempdir }}/elasticsearch.yml"


### PR DESCRIPTION
Seen locally when upgrading from ES2 -> ES5

`index` level settings were persisted in the config when upgrading from es2 -> es5 which causes ES5 to not start up.