### PR TITLE
Specify external URL for Prometheus

### DIFF
--- a/roles/openshift_prometheus/templates/prometheus.j2
+++ b/roles/openshift_prometheus/templates/prometheus.j2
@@ -233,6 +233,7 @@ spec:
       - name: alertmanager
         args:
         - --config.file=/etc/alertmanager/alertmanager.yml
+        - --web.external-url=https://{{ openshift_prometheus_alertmanager_hostname }}
         image: "{{ openshift_prometheus_alertmanager_image }}"
         imagePullPolicy: IfNotPresent
         resources:


### PR DESCRIPTION
Any links coming from prometheus or alert manager need an external URL, otherwise they end up pointing directly at the pod (`http://prometheus-0:9090/graph`).