### PR TITLE
 bug 1590920. Bump fluent default memory to 756M

### DIFF
--- a/roles/openshift_logging_fluentd/defaults/main.yml
+++ b/roles/openshift_logging_fluentd/defaults/main.yml
@@ -9,7 +9,7 @@ openshift_logging_fluentd_namespace: openshift-logging
 openshift_logging_fluentd_nodeselector: "{{ openshift_hosted_logging_fluentd_nodeselector_label | default('logging-infra-fluentd=true') | map_from_pairs }}"
 openshift_logging_fluentd_cpu_limit: null
 openshift_logging_fluentd_cpu_request: 100m
-openshift_logging_fluentd_memory_limit: 512Mi
+openshift_logging_fluentd_memory_limit: 756Mi
 openshift_logging_fluentd_hosts: ['--all']
 
 # float time in seconds to wait between node labelling


### PR DESCRIPTION
This resolves https://bugzilla.redhat.com/show_bug.cgi?id=1590920 by bumping the default OOTB memory for fluent to support prometheus metrics and buffer retry q's