### PR TITLE
Update sdn, sdn-ovs, sync, fluentd, descheduler to have system-cluster/node-critical priority classes.

### DIFF
--- a/roles/openshift_daemonset_config/templates/daemonset.yml.j2
+++ b/roles/openshift_daemonset_config/templates/daemonset.yml.j2
@@ -31,6 +31,7 @@ spec:
       hostNetwork: true
       hostPID: true
       hostIPC: true
+      priorityClassName: system-node-critical
       containers:
       - name: config
         image: "{{ openshift_daemonset_config_image }}"

--- a/roles/openshift_descheduler/templates/descheduler-cronjob.yaml.j2
+++ b/roles/openshift_descheduler/templates/descheduler-cronjob.yaml.j2
@@ -13,6 +13,7 @@ spec:
             scheduler.alpha.kubernetes.io/critical-pod: ''
           name: "{{ openshift_descheduler_cronjob_name }}"
         spec:
+          priorityClassName: system-cluster-critical
           containers:
           - name: descheduler
             image: "{{ openshift_descheduler_image }}"

--- a/roles/openshift_logging_fluentd/templates/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/fluentd.j2
@@ -29,6 +29,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: "{{ daemonset_serviceAccount }}"
       nodeSelector:
         {{ fluentd_nodeselector_key }}: "{{ fluentd_nodeselector_value }}"

--- a/roles/openshift_node_group/files/sync.yaml
+++ b/roles/openshift_node_group/files/sync.yaml
@@ -34,6 +34,7 @@ spec:
       hostPID: true
       # Must be hostNetwork in order to schedule before any network plugins are loaded.
       hostNetwork: true
+      priorityClassName: system-node-critical
       containers:
 
       # The sync container is a temporary config loop until Kubelet dynamic config is implemented. It refreshes

--- a/roles/openshift_sdn/files/sdn-ovs.yaml
+++ b/roles/openshift_sdn/files/sdn-ovs.yaml
@@ -29,6 +29,7 @@ spec:
       serviceAccountName: sdn
       hostNetwork: true
       hostPID: true
+      priorityClassName: system-node-critical
       containers:
       - name: openvswitch
         image: " "

--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -32,6 +32,7 @@ spec:
       serviceAccountName: sdn
       hostNetwork: true
       hostPID: true
+      priorityClassName: system-node-critical
       containers:
       # The network container launches the openshift-sdn process, the kube-proxy, and the local DNS service.
       # It relies on an up to date node-config.yaml being present.


### PR DESCRIPTION
@derekwaynecarr @sjenning @ravisantoshgudimetla 