### PR TITLE
Fix use of undefined variable

### DIFF
--- a/roles/openshift_logging_elasticsearch/handlers/main.yml
+++ b/roles/openshift_logging_elasticsearch/handlers/main.yml
@@ -5,7 +5,7 @@
   with_items: "{{ _restart_logging_components }}"
   loop_control:
     loop_var: _cluster_component
-  when: not logging_elasticsearch_rollout_override | bool
+  when: not logging_elasticsearch_rollout_override | default(false) | bool
 
 ## Stop this from running more than once
 - set_fact:


### PR DESCRIPTION
The `logging_elasticsearch_rollout_override` variable is being used without being initialized first.