### PR TITLE
Fix PVC binding of NFS pv with default storageclass set

### DIFF
--- a/roles/lib_utils/action_plugins/generate_pv_pvcs_list.py
+++ b/roles/lib_utils/action_plugins/generate_pv_pvcs_list.py
@@ -45,7 +45,7 @@ class ActionModule(ActionBase):
         volume, size, labels, _, access_modes = self.build_common(varname=varname)
         directory = self.get_templated(str(varname) + '_nfs_directory')
         path = directory + '/' + volume
-        return dict(
+        result = dict(
             name="{0}-volume".format(volume),
             capacity=size,
             labels=labels,
@@ -54,6 +54,11 @@ class ActionModule(ActionBase):
                 nfs=dict(
                     server=host,
                     path=path)))
+        # Add claimref for NFS as default storageclass can be different
+        create_pvc = self.task_vars.get(str(varname) + '_create_pvc')
+        if create_pvc and self._templar.template(create_pvc):
+            result['storage']['claimName'] = "{0}-claim".format(volume)
+        return result
 
     def build_pv_openstack(self, varname=None):
         """Build pv dictionary for openstack storage type"""

--- a/roles/lib_utils/action_plugins/generate_pv_pvcs_list.py
+++ b/roles/lib_utils/action_plugins/generate_pv_pvcs_list.py
@@ -150,10 +150,15 @@ class ActionModule(ActionBase):
                     if kind != 'object' and create_pv and create_pvc:
                         volume, size, _, annotations, access_modes = self.build_common(varname=varname)
                         storageclass = self.task_vars.get(str(varname) + '_storageclass')
+                        # if storageclass is specified => use it
+                        # if kind is 'nfs' => set to empty
+                        # if any other kind => set to none
                         if storageclass:
                             storageclass = self._templar.template(storageclass)
-                        elif storageclass is None and kind != 'dynamic':
+                        elif kind == 'nfs':
                             storageclass = ''
+                        if kind == 'dynamic':
+                            storageclass = None
                         return dict(
                             name="{0}-claim".format(volume),
                             capacity=size,

--- a/roles/openshift_persistent_volumes/templates/persistent-volume-claim.yml.j2
+++ b/roles/openshift_persistent_volumes/templates/persistent-volume-claim.yml.j2
@@ -18,7 +18,7 @@ items:
     resources:
       requests:
         storage: "{{ claim.capacity }}"
-{% if claim.storageclass %}
+{% if claim.storageclass is not none %}
     storageClassName: "{{ claim.storageclass }}"
 {% endif %}
 {% endfor %}

--- a/roles/openshift_persistent_volumes/templates/persistent-volume-claim.yml.j2
+++ b/roles/openshift_persistent_volumes/templates/persistent-volume-claim.yml.j2
@@ -18,7 +18,7 @@ items:
     resources:
       requests:
         storage: "{{ claim.capacity }}"
-{% if claim.storageclass|length > 0 %}
+{% if claim.storageclass %}
     storageClassName: "{{ claim.storageclass }}"
 {% endif %}
 {% endfor %}

--- a/roles/openshift_persistent_volumes/templates/persistent-volume.yml.j2
+++ b/roles/openshift_persistent_volumes/templates/persistent-volume.yml.j2
@@ -18,4 +18,9 @@ items:
       storage: "{{ volume.capacity }}"
     accessModes: {{ volume.access_modes | lib_utils_to_padded_yaml(2, 2) }}
     {{ (volume.storage.keys() | list)[0] }}: {{ volume.storage[(volume.storage.keys() | list)[0]] | lib_utils_to_padded_yaml(3, 2) }}
+{% if 'claimName' in volume.storage %}
+    claimRef:
+      name: {{ volume.storage.claimName }}
+      namespace: default
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
This reverts #8854 and ensures an empty storageClass set for NFS mounts
Other kinds of storage won't have storageClasses added (thus using default 
storageclass).

It also adds `claimRef` to PVs so that PV could be bound by only specified PVC. This PR assumes all PVCs are created in `default` namespace - not sure if this is true for all cases though

@dav1x could you verify it won't break vsphere storage?

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1548163