### PR TITLE
add build lock for osa runs

### DIFF
--- a/playbooks/azure/openshift-cluster/build_node_image.yml
+++ b/playbooks/azure/openshift-cluster/build_node_image.yml
@@ -54,10 +54,24 @@
     vars:
       os_update_latest_reboot: True
 
-- name: install openshift
+- name: install openshift GA
   import_playbook: ../../openshift-node/private/image_prep.yml
   vars:
     etcd_image: "{{ etcd_image_dict[openshift_deployment_type] }}"
+  when: openshift_azure_dev_registry_token == ""
+
+- name: install openshift DEV
+  import_playbook: ../../openshift-node/private/image_prep.yml
+  vars:
+    etcd_image: "{{ etcd_image_dict[openshift_deployment_type] }}"
+    openshift_image_tag: "v{{ openshift_azure_release }}"
+    openshift_version: "{{ openshift_azure_release }}"
+    openshift_release: "{{ openshift_azure_release }}"
+    # This is only for dev rhel branch (non GA)
+    oreg_url: "registry.reg-aws.openshift.com/openshift3/ose-${component}:${version}"
+    oreg_auth_user: notused
+    oreg_auth_password: "{{ openshift_azure_dev_registry_token }}"
+  when: openshift_azure_dev_registry_token != ""
 
 - hosts: nodes
   tasks:

--- a/playbooks/azure/openshift-cluster/group_vars/all/generic.yml
+++ b/playbooks/azure/openshift-cluster/group_vars/all/generic.yml
@@ -1,0 +1,3 @@
+---
+openshift_azure_release: 3.10
+openshift_azure_dev_registry_token: ""

--- a/playbooks/azure/openshift-cluster/group_vars/all/yum_repos.yml
+++ b/playbooks/azure/openshift-cluster/group_vars/all/yum_repos.yml
@@ -47,12 +47,13 @@ azure_node_repos:
     sslclientkey: /var/lib/yum/client-key.pem
     enabled: yes
 
-  #- name: rhel-server-7-ose-3.10
-  #  baseurl: https://mirror.openshift.com/libra/rhui-rhel-server-7-ose-3.10/
-  #  gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-  #  sslclientcert: /var/lib/yum/client-cert.pem
-  #  sslclientkey: /var/lib/yum/client-key.pem
-  #  enabled: yes
+  - name: rhel-server-7-ose-3.10
+    baseurl: https://mirror.openshift.com/enterprise/all/3.10/latest/x86_64/os
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+    gpgcheck: false
+    sslclientcert: /var/lib/yum/client-cert.pem
+    sslclientkey: /var/lib/yum/client-key.pem
+    enabled: yes
 
   CentOS:
   # TODO: should be using a repo which only provides prerequisites


### PR DESCRIPTION
This enables to build 3.10 builds and ignore package conflicts. 

Same will need to be added for 3.9 
Repos will need to be updated on each release branch. 

cc: @openshift/sig-azure 

This will not enable us to build rhel images in CI, because we still need secret for it