### PR TITLE
WIP: [1.10] AWS deploy 1.10 cluster restart master dns issue

### DIFF
--- a/roles/openshift_aws/tasks/provision.yml
+++ b/roles/openshift_aws/tasks/provision.yml
@@ -29,3 +29,18 @@
     search_regex: OpenSSH
   with_items: "{{ instancesout.instances }}"
   when: openshift_aws_wait_for_ssh | bool
+
+- when: openshift_aws_restart_after_creation | default(false) | bool
+  block:
+  - name: restart host
+    ec2:
+      instance_id: "{{ item.instance_id }}"
+      state: restarted
+      region: "{{ openshift_aws_region }}"
+    with_items: "{{ instancesout.instances }}"
+
+  - name: wait for ssh to become available
+    wait_for_connection:
+    delegate_to: "{{ item.public_dns_name }}"
+    with_items: "{{ instancesout.instances }}"
+    when: openshift_aws_wait_for_ssh | bool

--- a/roles/openshift_aws/tasks/scale_group.yml
+++ b/roles/openshift_aws/tasks/scale_group.yml
@@ -3,6 +3,14 @@
   set_fact:
     l_node_group_name: "{{ openshift_aws_node_group.name }} {{ l_deployment_serial }}"
 
+- set_fact:
+    l_openshift_aws_node_group_config_tags: "{{ openshift_aws_node_group_config_tags }}"
+
+- name: Set scale group instances autonaming
+  set_fact:
+    l_openshift_aws_node_group_config_tags: "{{ l_openshift_aws_node_group_config_tags | combine({'Name': l_node_group_name }) }}"
+  when: openshift_aws_autoname_scale_group_instances | default(false)
+
 - name: Create the scale group
   ec2_asg:
     name: "{{ l_node_group_name }}"
@@ -21,11 +29,10 @@
     replace_all_instances: "{{ omit if openshift_aws_node_group_replace_instances != []
                                     else (l_node_group_config[openshift_aws_node_group.group].replace_all_instances | default(omit)) }}"
     tags:
-    - "{{ openshift_aws_node_group_config_tags
+    - "{{ l_openshift_aws_node_group_config_tags
           | combine(openshift_aws_node_group.tags)
           | combine({'deployment_serial': l_deployment_serial, 'ami': openshift_aws_ami_map[openshift_aws_node_group.group] | default(openshift_aws_ami)})
           | combine({'openshift-node-group-config': openshift_aws_node_group.node_group_config | default('unset') }) }}"
-    - Name: "{{ openshift_aws_clusterid }} {{ l_node_group_name }}"
 
 - name: append the asg name to the openshift_aws_created_asgs fact
   set_fact:


### PR DESCRIPTION
The golden node images needs at least `container-selinux-2.66-1.el7_5` [1] which is already part of the `aos-3.10.15` golden image. It just seems the node is not restarted before it's baked. So I need to node to restart right after it is provisioned. My theory is the golden image is only a snapshot that is resume, not started from the start. Thus, the latest `container-selinux` rules will not get applied correctly.

This is meant to be the temporary fix. Though, it may be useful to restart an instance based on any golden image before it gets used further.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1591281

Backport of https://github.com/openshift/openshift-ansible/pull/9192