### PR TITLE
Don't set OAUTH_CLIENT_ID in console OAuth secret

### DIFF
--- a/roles/openshift_console/files/console-template.yaml
+++ b/roles/openshift_console/files/console-template.yaml
@@ -148,7 +148,6 @@ objects:
     labels:
       app: openshift-console
   stringData:
-    clientID: ${OAUTH_CLIENT_ID}
     clientSecret: ${OAUTH_SECRET}
 
 # to be able to assign powers to the process


### PR DESCRIPTION
This value is not needed and also not passed as a parameter to the
template. Remove it from the `console-oauth-config` secret.

/assign @vrutkovs 