### PR TITLE
AWS deploy 1.11 cluster restart master dns issue

### DIFF
--- a/roles/openshift_aws/tasks/provision.yml
+++ b/roles/openshift_aws/tasks/provision.yml
@@ -29,3 +29,18 @@
     search_regex: OpenSSH
   with_items: "{{ instancesout.instances }}"
   when: openshift_aws_wait_for_ssh | bool
+
+- when: openshift_aws_restart_after_creation | default(false) | bool
+  block:
+  - name: restart host
+    ec2:
+      instance_id: "{{ item.instance_id }}"
+      state: restarted
+      region: "{{ openshift_aws_region }}"
+    with_items: "{{ instancesout.instances }}"
+
+  - name: wait for ssh to become available
+    wait_for_connection:
+    delegate_to: "{{ item.public_dns_name }}"
+    with_items: "{{ instancesout.instances }}"
+    when: openshift_aws_wait_for_ssh | bool


### PR DESCRIPTION
The golden node images needs at least `container-selinux-2.66-1.el7_5` [1] which is already part of the `aos-3.10.15` golden image. It just seems the node is not restarted before it's baked. So I need to node to restart right after it is provisioned. My theory is the golden image is only a snapshot that is resume, not started from the start. Thus, the latest `container-selinux` rules will not get applied correctly.

This is meant to be the temporary fix. Though, it may be useful to restart an instance based on any golden image before it gets used further.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1591281