### PR TITLE
fixing error when using provider networks

### DIFF
--- a/roles/openshift_openstack/tasks/generate-dns.yml
+++ b/roles/openshift_openstack/tasks/generate-dns.yml
@@ -18,6 +18,9 @@
     - openshift_openstack_public_router_ip is defined
     - openshift_openstack_public_router_ip is not none
     - openshift_openstack_public_router_ip | string
+    - hostvars[item]['private_v4'] is defined
+    - hostvars[item]['private_v4'] is not none
+    - hostvars[item]['private_v4'] | string
 
 - debug: var=openshift_openstack_private_api_ip
 - name: "Add public master cluster hostname records to the private A records"


### PR DESCRIPTION
This PR will fix handling of DNS records when using provider (e.g. no private IP) networks.

It fixes issue #9195 