### PR TITLE
Rename console logoImageName -> branding

### DIFF
--- a/roles/openshift_console/defaults/main.yml
+++ b/roles/openshift_console/defaults/main.yml
@@ -13,13 +13,13 @@ openshift_console_hostname: "console.{{openshift_master_default_subdomain}}"
 
 openshift_console_auth_ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
-# The logo to use in the masthead.
-l_openshift_logo_image_names_dict:
+# Determines the logo and title used throughout the console.
+l_openshift_console_branding_dict:
   origin: 'origin'
   openshift-enterprise: 'ocp'
-openshift_console_logo_image_name: "{{ l_openshift_logo_image_names_dict[openshift_deployment_type] }}"
+openshift_console_branding: "{{ l_openshift_console_branding_dict[openshift_deployment_type] }}"
 
-l_openshift_documentation_url_dict:
+l_openshift_console_documentation_url_dict:
   origin: 'https://docs.openshift.org/3.11/'
   openshift-enterprise: 'https://docs.openshift.com/container-platform/3.11/'
-openshift_console_documentation_base_url: "{{ l_openshift_documentation_url_dict[openshift_deployment_type] }}"
+openshift_console_documentation_base_url: "{{ l_openshift_console_documentation_url_dict[openshift_deployment_type] }}"

--- a/roles/openshift_console/files/console-config.yaml
+++ b/roles/openshift_console/files/console-config.yaml
@@ -10,4 +10,4 @@ auth:
   clientID: openshift-console
   clientSecretFile: /var/oauth-config/clientSecret
 customization:
-  logoImageName: os-origin
+  branding: origin

--- a/roles/openshift_console/tasks/install.yml
+++ b/roles/openshift_console/tasks/install.yml
@@ -57,8 +57,8 @@
       value: "{{ openshift_console_auth_ca_file }}"
     - key: auth#logoutRedirect
       value: "{{ openshift.master.logout_url | default('') }}"
-    - key: customization#logoImageName
-      value: "{{ openshift_console_logo_image_name }}"
+    - key: customization#branding
+      value: "{{ openshift_console_branding }}"
     - key: customization#documentationBaseURL
       value: "{{ openshift_console_documentation_base_url }}"
     separator: '#'


### PR DESCRIPTION
Update the console config property `customization.logoImageName` to `customization.branding`.

Required for https://github.com/openshift/console/pull/217

/assign @vrutkovs 