### PR TITLE
Adds openshift_fs_inotify_max_user_instances to the node tuned profile.

### DIFF
--- a/roles/tuned/defaults/main.yml
+++ b/roles/tuned/defaults/main.yml
@@ -2,3 +2,4 @@
 tuned_etc_directory: '/etc/tuned'
 tuned_templates_source: '../templates'
 openshift_fs_inotify_max_user_watches: 65536
+openshift_fs_inotify_max_user_instances: 8192

--- a/roles/tuned/templates/openshift-node/tuned.conf
+++ b/roles/tuned/templates/openshift-node/tuned.conf
@@ -9,3 +9,4 @@ include=openshift
 [sysctl]
 net.ipv4.tcp_fastopen=3
 fs.inotify.max_user_watches={{ openshift_fs_inotify_max_user_watches }}
+fs.inotify.max_user_instances={{ openshift_fs_inotify_max_user_instances }}


### PR DESCRIPTION
Work around for: https://github.com/kubernetes/kubernetes/issues/64315

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1559061