### PR TITLE
update the default oauth-proxy image for logging

### DIFF
--- a/roles/openshift_logging_defaults/defaults/main.yml
+++ b/roles/openshift_logging_defaults/defaults/main.yml
@@ -13,7 +13,7 @@ l_os_logging_non_standard_reg_search_dict:
 l_os_logging_non_standard_reg_search: "{{ l_os_logging_non_standard_reg_search_dict[openshift_deployment_type] }}"
 
 l_os_logging_proxy_image_version_dict:
-  origin: 'v1.0.0'
+  origin: 'v1.1.0'
   openshift-enterprise: "{{ openshift_image_tag }}"
 l_os_logging_proxy_image_version: "{{ l_os_logging_proxy_image_version_dict[openshift_deployment_type] }}"
 


### PR DESCRIPTION
This updates the default oauth-proxy image for use in replaceing the logging auth proxy