### PR TITLE
Don't get file checksum, attributes and mime type in stat module calls

### DIFF
--- a/playbooks/byo/calico/legacy_upgrade.yml
+++ b/playbooks/byo/calico/legacy_upgrade.yml
@@ -5,6 +5,9 @@
   - name: Check legacy upgrade exists
     stat:
       path: /lib/systemd/system/calico.service
+      get_checksum: false
+      get_attributes: false
+      get_mime: false
     register: sym
   - fail:
       msg: No service to upgrade

--- a/playbooks/init/basic_facts.yml
+++ b/playbooks/init/basic_facts.yml
@@ -19,6 +19,9 @@
   - name: Detecting Operating System from ostree_booted
     stat:
       path: /run/ostree-booted
+      get_checksum: false
+      get_attributes: false
+      get_mime: false
     register: ostree_booted
 
   # TODO(michaelgugino) remove this line once CI is updated.
@@ -32,6 +35,9 @@
   - name: check for node already bootstrapped
     stat:
       path: "/etc/origin/node/bootstrap-node-config.yaml"
+      get_checksum: false
+      get_attributes: false
+      get_mime: false
     register: bootstrap_node_config_path_check
   - name: initialize_facts set fact openshift_is_bootstrapped
     set_fact:

--- a/playbooks/openshift-master/private/certificates-backup.yml
+++ b/playbooks/openshift-master/private/certificates-backup.yml
@@ -7,6 +7,9 @@
   pre_tasks:
   - stat:
       path: "{{ openshift.common.config_base }}/generated-configs"
+      get_checksum: false
+      get_attributes: false
+      get_mime: false
     register: openshift_generated_configs_dir_stat
   - name: Backup generated certificate and config directories
     command: >

--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -29,6 +29,9 @@
   - name: Check for RPM generated config marker file .config_managed
     stat:
       path: /etc/origin/.config_managed
+      get_checksum: false
+      get_attributes: false
+      get_mime: false
     register: rpmgenerated_config
 
   - name: Remove RPM generated config files if present

--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -34,6 +34,9 @@
   - name: Determine if service signer certificate must be created
     stat:
       path: "{{ openshift.common.config_base }}/master/service-signer.crt"
+      get_checksum: false
+      get_attributes: false
+      get_mime: false
     register: service_signer_cert_stat
     changed_when: false
   - name: verify api server

--- a/playbooks/openshift-master/private/validate_restart.yml
+++ b/playbooks/openshift-master/private/validate_restart.yml
@@ -23,7 +23,11 @@
 - name: Check if temp file exists on any masters
   hosts: oo_masters_to_config
   tasks:
-  - stat: path="{{ hostvars.localhost.mktemp.stdout }}"
+  - stat:
+      path: "{{ hostvars.localhost.mktemp.stdout }}"
+      get_checksum: false
+      get_attributes: false
+      get_mime: false
     register: exists
     changed_when: false
     when: "'stdout' in hostvars.localhost.mktemp"

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: Check for legacy service
   stat:
     path: /lib/systemd/system/calico.service
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: sym
 - fail:
     msg: You are running a systemd based installation of Calico. Please run the calico upgrade playbook to upgrade to a self-hosted installation.

--- a/roles/calico_master/tasks/certs.yml
+++ b/roles/calico_master/tasks/certs.yml
@@ -31,6 +31,9 @@
 - name: Calico Node | Assure the calico certs are present
   stat:
     path: "{{ item }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   with_items:
   - "{{ calico_etcd_ca_cert_file }}"
   - "{{ calico_etcd_cert_file }}"

--- a/roles/container_runtime/tasks/common/post.yml
+++ b/roles/container_runtime/tasks/common/post.yml
@@ -18,6 +18,8 @@
 - name: stat the docker data dir
   stat:
     path: "{{ docker_default_storage_path }}"
+    get_checksum: false
+    get_mime: false
   register: dockerstat
 
 - import_tasks: setup_docker_symlink.yml

--- a/roles/container_runtime/tasks/package_docker.yml
+++ b/roles/container_runtime/tasks/package_docker.yml
@@ -46,7 +46,10 @@
     - restart container runtime
   when: not (os_firewall_use_firewalld | default(False)) | bool
 
-- stat: path=/etc/sysconfig/docker
+- stat:
+    path: /etc/sysconfig/docker
+    get_checksum: false
+    get_mime: false
   register: docker_check
 
 - name: Set registry params
@@ -115,7 +118,10 @@
   notify:
   - restart container runtime
 
-- stat: path=/etc/sysconfig/docker-network
+- stat:
+    path: /etc/sysconfig/docker-network
+    get_checksum: false
+    get_mime: false
   register: sysconfig_docker_network_check
 
 - name: Configure Docker Network OPTIONS

--- a/roles/contiv/tasks/old_version_cleanup.yml
+++ b/roles/contiv/tasks/old_version_cleanup.yml
@@ -2,6 +2,9 @@
 - name: Old version cleanup | Check if old auth proxy service exists
   stat:
     path: /etc/systemd/system/auth-proxy.service
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: auth_proxy_stat
 
 - name: Old version cleanup | Stop old auth proxy
@@ -16,6 +19,9 @@
 - name: Old version cleanup | Check if old contiv-etcd service exists
   stat:
     path: /etc/systemd/system/contiv-etcd.service
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: contiv_etcd_stat
 
 - name: Old version cleanup | Stop old contiv-etcd

--- a/roles/contiv_facts/tasks/main.yml
+++ b/roles/contiv_facts/tasks/main.yml
@@ -29,7 +29,11 @@
     state: directory
 
 - name: Determine if has rpm
-  stat: path=/usr/bin/rpm
+  stat:
+    path: /usr/bin/rpm
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: s
   changed_when: false
   check_mode: no

--- a/roles/etcd/tasks/backup/backup.yml
+++ b/roles/etcd/tasks/backup/backup.yml
@@ -54,6 +54,9 @@
 - name: Check for v3 data store
   stat:
     path: "{{ etcd_data_dir }}/member/snap/db"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: l_v3_db
 
 - name: Copy etcd v3 data store

--- a/roles/etcd/tasks/certificates/backup_ca_certificates.yml
+++ b/roles/etcd/tasks/certificates/backup_ca_certificates.yml
@@ -2,6 +2,9 @@
 - name: Determine if CA certificate directory exists
   stat:
     path: "{{ etcd_ca_dir }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: etcd_ca_certs_dir_stat
 - name: Backup generated etcd certificates
   command: >

--- a/roles/etcd/tasks/certificates/backup_generated_certificates.yml
+++ b/roles/etcd/tasks/certificates/backup_generated_certificates.yml
@@ -2,6 +2,9 @@
 - name: Determine if generated etcd certificates exist
   stat:
     path: "{{ etcd_conf_dir }}/generated_certs"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: etcd_generated_certs_dir_stat
 
 - name: Backup generated etcd certificates

--- a/roles/etcd/tasks/certificates/deploy_ca.yml
+++ b/roles/etcd/tasks/certificates/deploy_ca.yml
@@ -43,7 +43,10 @@
   run_once: true
 
 - name: Check etcd_ca_db exist
-  stat: path="{{ etcd_ca_db }}"
+  stat:
+    path: "{{ etcd_ca_db }}"
+    get_checksum: false
+    get_mime: false
   register: etcd_ca_db_check
   changed_when: false
   delegate_to: "{{ etcd_ca_host }}"

--- a/roles/etcd/tasks/certificates/fetch_client_certificates_from_ca.yml
+++ b/roles/etcd/tasks/certificates/fetch_client_certificates_from_ca.yml
@@ -2,6 +2,9 @@
 - name: Ensure CA certificate exists on etcd_ca_host
   stat:
     path: "{{ etcd_ca_cert }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: g_ca_cert_stat_result
   delegate_to: "{{ etcd_ca_host }}"
   run_once: true
@@ -17,6 +20,9 @@
 - name: Check status of external etcd certificatees
   stat:
     path: "{{ etcd_cert_config_dir }}/{{ item }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   with_items:
   - "{{ etcd_cert_prefix }}client.crt"
   - "{{ etcd_cert_prefix }}client.key"

--- a/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
+++ b/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
@@ -12,6 +12,9 @@
 - name: Check status of etcd certificates
   stat:
     path: "{{ item }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   with_items:
   - "{{ etcd_cert_config_dir }}/{{ etcd_cert_prefix }}server.crt"
   - "{{ etcd_cert_config_dir }}/{{ etcd_cert_prefix }}peer.crt"

--- a/roles/etcd/tasks/upgrade_static.yml
+++ b/roles/etcd/tasks/upgrade_static.yml
@@ -9,6 +9,9 @@
 - name: Check for old etcd service files
   stat:
     path: "{{ item }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   with_items:
   - "/etc/systemd/system/etcd.service"
   - "/etc/systemd/system/etcd_container.service"

--- a/roles/lib_utils/src/test/integration/yedit.yml
+++ b/roles/lib_utils/src/test/integration/yedit.yml
@@ -299,6 +299,9 @@
   - name: stat file
     stat:
       path: "{{ test_file }}.orig"
+      get_checksum: false
+      get_attributes: false
+      get_mime: false
     register: statout
 
   - assert:
@@ -320,6 +323,9 @@
   - name: stat file
     stat:
       path: "{{ test_file }}{{ date_str }}"
+      get_checksum: false
+      get_attributes: false
+      get_mime: false
     register: statout
 
   - assert:

--- a/roles/nuage_ca/tasks/main.yaml
+++ b/roles/nuage_ca/tasks/main.yaml
@@ -16,7 +16,11 @@
   delegate_to: "{{ nuage_ca_master }}"
 
 - name: Check if the CA key already exists
-  stat: path="{{ nuage_ca_key }}"
+  stat:
+    path: "{{ nuage_ca_key }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: nuage_ca_key_check
   delegate_to: "{{ nuage_ca_master }}"
 
@@ -27,7 +31,11 @@
   when: nuage_ca_key_check.stat.exists is defined and nuage_ca_key_check.stat.exists == False
 
 - name: Check if the CA crt already exists
-  stat: path="{{ nuage_ca_crt }}"
+  stat:
+    path: "{{ nuage_ca_crt }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: nuage_ca_crt_check
   delegate_to: "{{ nuage_ca_master }}"
 

--- a/roles/nuage_master/tasks/etcd_certificates.yml
+++ b/roles/nuage_master/tasks/etcd_certificates.yml
@@ -13,6 +13,9 @@
 - name: Error if etcd certs are not copied
   stat:
     path: "{{ item }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   with_items:
   - "{{ cert_output_dir }}/nuageEtcd-ca.crt"
   - "{{ cert_output_dir }}/nuageEtcd-client.crt"

--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -28,6 +28,9 @@
 - name: Determine if CA must be created
   stat:
     path: "{{ openshift_ca_config_dir }}/{{ item }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: g_master_ca_stat_result
   with_items:
   - ca-bundle.crt
@@ -39,6 +42,9 @@
 - name: Determine if front-proxy CA must be created
   stat:
     path: "{{ openshift_ca_config_dir }}/{{ item }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: g_master_front_proxy_ca_stat_result
   with_items:
   - front-proxy-ca.crt

--- a/roles/openshift_control_plane/tasks/check_existing_config.yml
+++ b/roles/openshift_control_plane/tasks/check_existing_config.yml
@@ -2,6 +2,9 @@
 # We need to scrape existing config and check some items.
 - stat:
     path: "/etc/origin/master/master-config.yaml"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: master_config_path_check
 
 - slurp:

--- a/roles/openshift_control_plane/tasks/generate_session_secrets.yml
+++ b/roles/openshift_control_plane/tasks/generate_session_secrets.yml
@@ -5,6 +5,9 @@
 - name: Determine if sessions secrets already in place
   stat:
     path: "{{ openshift_master_session_secrets_file }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: l_osm_session_secrets_stat
 
 - name: slurp session secrets if defined

--- a/roles/openshift_control_plane/tasks/upgrade.yml
+++ b/roles/openshift_control_plane/tasks/upgrade.yml
@@ -21,12 +21,17 @@
 - name: Check for ca-bundle.crt
   stat:
     path: "{{ openshift.common.config_base }}/master/ca-bundle.crt"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: ca_bundle_stat
   failed_when: false
 
 - name: Check for ca.crt
   stat:
     path: "{{ openshift.common.config_base }}/master/ca.crt"
+    get_checksum: false
+    get_mime: false
   register: ca_crt_stat
   failed_when: false
 

--- a/roles/openshift_excluder/tasks/exclude.yml
+++ b/roles/openshift_excluder/tasks/exclude.yml
@@ -2,6 +2,9 @@
 - name: Check for docker-excluder
   stat:
     path: /sbin/{{ r_openshift_excluder_service_type }}-docker-excluder
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: docker_excluder_stat
 
 - name: Enable docker excluder
@@ -13,6 +16,9 @@
 - name: Check for openshift excluder
   stat:
     path: /sbin/{{ r_openshift_excluder_service_type }}-excluder
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: openshift_excluder_stat
 
 - name: Enable openshift excluder

--- a/roles/openshift_excluder/tasks/unexclude.yml
+++ b/roles/openshift_excluder/tasks/unexclude.yml
@@ -6,6 +6,9 @@
 - name: Check for docker-excluder
   stat:
     path: /sbin/{{ r_openshift_excluder_service_type }}-docker-excluder
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: docker_excluder_stat
 
 - name: disable docker excluder
@@ -17,6 +20,9 @@
 - name: Check for openshift excluder
   stat:
     path: /sbin/{{ r_openshift_excluder_service_type }}-excluder
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: openshift_excluder_stat
 
 - name: disable openshift excluder

--- a/roles/openshift_logging/tasks/generate_certs.yaml
+++ b/roles/openshift_logging/tasks/generate_certs.yaml
@@ -1,17 +1,29 @@
 ---
 # we will ensure our secrets and configmaps are set up here first
 - name: Checking for ca.key
-  stat: path="{{generated_certs_dir}}/ca.key"
+  stat:
+    path: "{{generated_certs_dir}}/ca.key"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: ca_key_file
   check_mode: no
 
 - name: Checking for ca.crt
-  stat: path="{{generated_certs_dir}}/ca.crt"
+  stat:
+    path: "{{generated_certs_dir}}/ca.crt"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: ca_cert_file
   check_mode: no
 
 - name: Checking for ca.serial.txt
-  stat: path="{{generated_certs_dir}}/ca.serial.txt"
+  stat:
+    path: "{{generated_certs_dir}}/ca.serial.txt"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: ca_serial_file
   check_mode: no
 
@@ -27,7 +39,11 @@
     - not ca_serial_file.stat.exists
 
 - name: Checking for signing.conf
-  stat: path="{{generated_certs_dir}}/signing.conf"
+  stat:
+    path: "{{generated_certs_dir}}/signing.conf"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: signing_conf_file
   check_mode: no
 
@@ -89,7 +105,11 @@
   check_mode: no
 
 - name: Checking for ca.db
-  stat: path="{{generated_certs_dir}}/ca.db"
+  stat:
+    path: "{{generated_certs_dir}}/ca.db"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: ca_db_file
   check_mode: no
 
@@ -99,7 +119,11 @@
     - not ca_db_file.stat.exists
 
 - name: Checking for ca.crl.srl
-  stat: path="{{generated_certs_dir}}/ca.crl.srl"
+  stat:
+    path: "{{generated_certs_dir}}/ca.crl.srl"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: ca_crl_srl_file
   check_mode: no
 

--- a/roles/openshift_logging/tasks/generate_jks.yaml
+++ b/roles/openshift_logging/tasks/generate_jks.yaml
@@ -31,22 +31,38 @@
         msg: "Elasticsearch external hostname {{ openshift_logging_es_ops_hostname }} contains invalid characters for certificate subject Alt Name.  Not adding to Elasticsearch certificate."
 
 - name: Checking for elasticsearch.jks
-  stat: path="{{generated_certs_dir}}/elasticsearch.jks"
+  stat:
+    path: "{{generated_certs_dir}}/elasticsearch.jks"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: elasticsearch_jks
   check_mode: no
 
 - name: Checking for logging-es.jks
-  stat: path="{{generated_certs_dir}}/logging-es.jks"
+  stat:
+    path: "{{generated_certs_dir}}/logging-es.jks"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: logging_es_jks
   check_mode: no
 
 - name: Checking for system.admin.jks
-  stat: path="{{generated_certs_dir}}/system.admin.jks"
+  stat:
+    path: "{{generated_certs_dir}}/system.admin.jks"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: system_admin_jks
   check_mode: no
 
 - name: Checking for truststore.jks
-  stat: path="{{generated_certs_dir}}/truststore.jks"
+  stat:
+    path: "{{generated_certs_dir}}/truststore.jks"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: truststore_jks
   check_mode: no
 

--- a/roles/openshift_logging/tasks/generate_pems.yaml
+++ b/roles/openshift_logging/tasks/generate_pems.yaml
@@ -1,11 +1,19 @@
 ---
 - name: Checking for {{component}}.key
-  stat: path="{{generated_certs_dir}}/{{component}}.key"
+  stat:
+    path: "{{generated_certs_dir}}/{{component}}.key"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: key_file
   check_mode: no
 
 - name: Checking for {{component}}.crt
-  stat: path="{{generated_certs_dir}}/{{component}}.crt"
+  stat:
+    path: "{{generated_certs_dir}}/{{component}}.crt"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: cert_file
   check_mode: no
 

--- a/roles/openshift_logging/tasks/procure_server_certs.yaml
+++ b/roles/openshift_logging/tasks/procure_server_certs.yaml
@@ -1,11 +1,19 @@
 ---
 - name: Checking for {{ cert_info.procure_component }}.crt
-  stat: path="{{generated_certs_dir}}/{{ cert_info.procure_component }}.crt"
+  stat:
+    path: "{{generated_certs_dir}}/{{ cert_info.procure_component }}.crt"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: component_cert_file
   check_mode: no
 
 - name: Checking for {{ cert_info.procure_component }}.key
-  stat: path="{{generated_certs_dir}}/{{ cert_info.procure_component }}.key"
+  stat:
+    path: "{{generated_certs_dir}}/{{ cert_info.procure_component }}.key"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: component_key_file
   check_mode: no
 

--- a/roles/openshift_logging/tasks/procure_shared_key.yaml
+++ b/roles/openshift_logging/tasks/procure_shared_key.yaml
@@ -1,6 +1,10 @@
 ---
 - name: Checking for {{ shared_key_info.procure_component }}_shared_key
-  stat: path="{{generated_certs_dir}}/{{ shared_key_info.procure_component }}_shared_key"
+  stat:
+    path: "{{generated_certs_dir}}/{{ shared_key_info.procure_component }}_shared_key"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: component_shared_key_file
   check_mode: no
 

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -138,7 +138,11 @@
     delete_after: true
 
 - name: Checking for passwd.yml
-  stat: path="{{ generated_certs_dir }}/passwd.yml"
+  stat:
+    path: "{{ generated_certs_dir }}/passwd.yml"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: passwd_file
   check_mode: no
 

--- a/roles/openshift_logging_kibana/tasks/main.yaml
+++ b/roles/openshift_logging_kibana/tasks/main.yaml
@@ -51,11 +51,19 @@
 
 # Check {{ generated_certs_dir }} for session_secret and oauth_secret
 - name: Checking for session_secret
-  stat: path="{{generated_certs_dir}}/session_secret"
+  stat:
+    path: "{{generated_certs_dir}}/session_secret"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: session_secret_file
 
 - name: Checking for oauth_secret
-  stat: path="{{generated_certs_dir}}/oauth_secret"
+  stat:
+    path: "{{generated_certs_dir}}/oauth_secret"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: oauth_secret_file
 
 # gen session_secret if necessary

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: Check status of master certificates
   stat:
     path: "/etc/origin/master/{{ item }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   with_items:
   - admin.crt
   - ca.crt
@@ -214,12 +217,18 @@
 - name: Check for ca-bundle.crt
   stat:
     path: "{{ openshift.common.config_base }}/master/ca-bundle.crt"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: ca_bundle_stat
   failed_when: false
 
 - name: Check for ca.crt
   stat:
     path: "{{ openshift.common.config_base }}/master/ca.crt"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: ca_crt_stat
   failed_when: false
 

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -56,6 +56,9 @@
 - name: Determine if scheduler config present
   stat:
     path: "{{ openshift_master_scheduler_conf }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: scheduler_config_stat
 
 - name: Set Default scheduler predicates and priorities

--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -42,6 +42,9 @@
 - name: Check for RPM generated config marker file .config_managed
   stat:
     path: /etc/origin/.config_managed
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: rpmgenerated_config
 
 - name: create directories for bootstrapping

--- a/roles/openshift_node/tasks/journald.yml
+++ b/roles/openshift_node/tasks/journald.yml
@@ -1,6 +1,10 @@
 ---
 - name: Checking for journald.conf
-  stat: path=/etc/systemd/journald.conf
+  stat:
+    path: /etc/systemd/journald.conf
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: journald_conf_file
 
 - name: Create journald persistence directories

--- a/roles/openshift_node/tasks/registry_auth.yml
+++ b/roles/openshift_node/tasks/registry_auth.yml
@@ -4,6 +4,9 @@
 - name: Check for credentials file for registry auth
   stat:
     path: "{{ oreg_auth_credentials_path }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   when: oreg_auth_user is defined
   register: node_oreg_auth_credentials_stat
 

--- a/roles/openshift_node/templates/bootstrap.yml.j2
+++ b/roles/openshift_node/templates/bootstrap.yml.j2
@@ -31,6 +31,9 @@
     - name: determine the openshift_service_type
       stat:
         path: /etc/sysconfig/atomic-openshift-node
+        get_checksum: false
+        get_attributes: false
+        get_mime: false
       register: service_type_results
 
     - name: set openshift_service_type fact based on stat results

--- a/roles/openshift_node_certificates/tasks/main.yml
+++ b/roles/openshift_node_certificates/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: Ensure CA certificate exists on openshift_ca_host
   stat:
     path: "{{ openshift_ca_cert }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: g_ca_cert_stat_result
   delegate_to: "{{ openshift_ca_host }}"
   run_once: true
@@ -17,6 +20,9 @@
 - name: Check status of node certificates
   stat:
     path: "{{ openshift.common.config_base }}/node/{{ item }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   with_items:
   - "system:node:{{ openshift.common.hostname | lower }}.crt"
   - "system:node:{{ openshift.common.hostname | lower }}.key"

--- a/roles/openshift_prometheus/tasks/install_prometheus.yaml
+++ b/roles/openshift_prometheus/tasks/install_prometheus.yaml
@@ -200,6 +200,9 @@
 
 - stat:
     path: "{{ tempdir }}/prometheus.additional.rules"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: additional_rules_stat
 
 - template:

--- a/roles/openshift_service_catalog/tasks/install.yml
+++ b/roles/openshift_service_catalog/tasks/install.yml
@@ -92,6 +92,9 @@
 - name: Checking for master.etcd-ca.crt
   stat:
     path: /etc/origin/master/master.etcd-ca.crt
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
   register: etcd_ca_crt
   check_mode: no
 


### PR DESCRIPTION
In most cases this module is used to find out if the file exits, so no need 
to waste CPU on checksum and attributes