### PR TITLE
Remove mentions of oo_hosts_containerized_managed_true group

### DIFF
--- a/playbooks/container-runtime/private/setup_storage.yml
+++ b/playbooks/container-runtime/private/setup_storage.yml
@@ -3,9 +3,8 @@
 # l_etcd_scale_up_crt_hosts may be passed in via prerequisites.yml during etcd
 # scaleup plays.
 
-- hosts: "{{ l_etcd_scale_up_crt_hosts | default(l_scale_up_hosts) | default(l_default_container_storage_hosts) }}"
+- hosts: "{{ l_etcd_scale_up_crt_hosts | default(l_scale_up_hosts) | default('oo_nodes_to_config') }}"
   vars:
-    l_default_container_storage_hosts: "oo_nodes_to_config"
     l_chg_temp: "{{ hostvars[groups['oo_first_master'][0]]['openshift_containerized_host_groups'] | default([]) }}"
     l_containerized_host_groups: "{{ (['oo_nodes_to_config'] | union(l_chg_temp)) | join(':') }}"
   # role: container_runtime is necessary  here to bring role default variables

--- a/playbooks/container-runtime/private/setup_storage.yml
+++ b/playbooks/container-runtime/private/setup_storage.yml
@@ -5,7 +5,7 @@
 
 - hosts: "{{ l_etcd_scale_up_crt_hosts | default(l_scale_up_hosts) | default(l_default_container_storage_hosts) }}"
   vars:
-    l_default_container_storage_hosts: "oo_nodes_to_config:oo_hosts_containerized_managed_true"
+    l_default_container_storage_hosts: "oo_nodes_to_config"
     l_chg_temp: "{{ hostvars[groups['oo_first_master'][0]]['openshift_containerized_host_groups'] | default([]) }}"
     l_containerized_host_groups: "{{ (['oo_nodes_to_config'] | union(l_chg_temp)) | join(':') }}"
   # role: container_runtime is necessary  here to bring role default variables

--- a/test/tox-inventory.txt
+++ b/test/tox-inventory.txt
@@ -13,7 +13,6 @@ oo_first_etcd
 oo_etcd_hosts_to_backup
 oo_etcd_hosts_to_upgrade
 oo_etcd_to_migrate
-oo_hosts_containerized_managed_true
 oo_masters
 oo_masters_to_config
 oo_first_master
@@ -99,7 +98,4 @@ localhost
 localhost
 
 [glusterfs_registry]
-localhost
-
-[oo_hosts_containerized_managed_true]
 localhost


### PR DESCRIPTION
Its not being used anywhere anymore. This also removes unused 
l_default_container_storage_hosts var, which is now set to oo_nodes_to_config