### PR TITLE
WIP iptables: mask and disable firewalld is a separate task, otherwise it has changes

### DIFF
--- a/roles/os_firewall/tasks/iptables.yml
+++ b/roles/os_firewall/tasks/iptables.yml
@@ -4,17 +4,26 @@
   systemd:
     name: firewalld
     state: stopped
-    enabled: no
-    masked: yes
   register: task_result
   failed_when:
     - task_result is failed
     - ('could not' not in task_result.msg|lower)
 
+# These tasks are split in two, as changing masked and enabled status
+# would mutate `changed` field, so it needs to be performed in two tasks
+- name: Mask and disable firewalld service
+  systemd:
+    name: firewalld
+    enabled: no
+    masked: yes
+  when: not task_result.failed_when_result
+
 - name: Wait 10 seconds after disabling firewalld
   pause:
     seconds: 10
-  when: task_result is changed
+  when:
+    - not task_result.failed_when_result
+    - task_result is changed
 
 - name: Install iptables packages
   package:


### PR DESCRIPTION
Previous task stops, disables and masks firewalld. By default the service is 
not masked and disabled, so `changed` becomes true and causes 10 sec pause

The tasks use `failed_when_result` as it would be set to `false` when the service doesn't exist