### PR TITLE
Rework node initialization procedure to fit non-network tasks after prepull

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -1,20 +1,4 @@
 ---
-- name: Check that node image is present
-  command: 'docker images -q "{{ osn_image }}"'
-  register: node_image
-
-# This task runs async to save time while the node is being configured
-- name: Pre-pull node image
-  docker_image:
-    name: "{{ osn_image }}"
-  environment:
-    NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
-  when: node_image.stdout_lines == []
-  # 10 minutes to pull the image
-  async: 600
-  poll: 0
-  register: image_prepull
-
 - name: Install the systemd units
   import_tasks: systemd_units.yml
 

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -6,25 +6,14 @@
     - openshift_deployment_type == 'openshift-enterprise'
     - not openshift_use_crio | bool
 
+- name: Start node image prepull
+  import_tasks: prepull.yml
+
 - import_tasks: dnsmasq_install.yml
 - import_tasks: dnsmasq.yml
 
 - name: setup firewall
   import_tasks: firewall.yml
-
-- name: Update journald config
-  import_tasks: journald.yml
-
-#### Disable SWAP #####
-# https://docs.openshift.com/container-platform/3.4/admin_guide/overcommit.html#disabling-swap-memory
-# swapoff is a custom module in lib_utils that comments out swap entries in
-# /etc/fstab and runs swapoff -a, if necessary.
-- name: Disable swap
-  swapoff: {}
-  when: openshift_disable_swap | default(true) | bool
-
-- name: include node installer
-  import_tasks: install.yml
 
 - name: Restart cri-o
   systemd:
@@ -42,6 +31,20 @@
     name: NetworkManager
     enabled: yes
     state: restarted
+
+- name: include node installer
+  import_tasks: install.yml
+
+- name: Update journald config
+  import_tasks: journald.yml
+
+#### Disable SWAP #####
+# https://docs.openshift.com/container-platform/3.4/admin_guide/overcommit.html#disabling-swap-memory
+# swapoff is a custom module in lib_utils that comments out swap entries in
+# /etc/fstab and runs swapoff -a, if necessary.
+- name: Disable swap
+  swapoff: {}
+  when: openshift_disable_swap | default(true) | bool
 
 # The atomic-openshift-node service will set this parameter on
 # startup, but if the network service is restarted this setting is

--- a/roles/openshift_node/tasks/prepull.yml
+++ b/roles/openshift_node/tasks/prepull.yml
@@ -1,0 +1,16 @@
+---
+- name: Check that node image is present
+  command: 'docker images -q "{{ osn_image }}"'
+  register: node_image
+
+# This task runs async to save time while the node is being configured
+- name: Pre-pull node image
+  docker_image:
+    name: "{{ osn_image }}"
+  environment:
+    NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
+  when: node_image.stdout_lines == []
+  # 10 minutes to pull the image
+  async: 600
+  poll: 0
+  register: image_prepull


### PR DESCRIPTION
Currently there's just two tasks between pre-pull start and finish, while 
other tasks could be put in between

TODO:
* [x] Check if prepull can start sooner than dnsmasq/firewall/crio config