### PR TITLE
Add support for environment variable OPENSHIFT_CLUSTER in OpenStack dynamic inventory

### DIFF
--- a/playbooks/openstack/README.md
+++ b/playbooks/openstack/README.md
@@ -184,7 +184,7 @@ Then run the provision + install playbook -- this will create the OpenStack
 resources:
 
 ```bash
-$ ansible-playbook --user openshift \
+$ OPENSHIFT_CLUSTER=openshift.example.com ansible-playbook --user openshift \
   -i openshift-ansible/playbooks/openstack/inventory.py \
   -i inventory \
   openshift-ansible/playbooks/openstack/openshift-cluster/provision_install.yml

--- a/playbooks/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/all.yml
@@ -1,4 +1,5 @@
 ---
+openshift_openstack_stackname: "{{ lookup('env', 'OPENSHIFT_CLUSTER')|default(None) }}"
 openshift_openstack_clusterid: "openshift"
 openshift_openstack_public_dns_domain: "example.com"
 openshift_openstack_dns_nameservers: []


### PR DESCRIPTION
This PR is to improve the dynamic inventory for OpenStack to filter the servers based on environment variable `OPENSHIFT_CLUSTER`