### PR TITLE
Fix `cpu_limit` check in event router template

### DIFF
--- a/roles/openshift_logging_eventrouter/templates/eventrouter-template.j2
+++ b/roles/openshift_logging_eventrouter/templates/eventrouter-template.j2
@@ -65,7 +65,7 @@ objects:
               imagePullPolicy: IfNotPresent
               resources:
                 limits:
-{% if cpu_limit is defined %}
+{% if cpu_limit is not none and cpu_limit != '' %}
                   cpu: ${CPU_LIMIT}
 {% endif %}
                   memory: ${MEMORY}


### PR DESCRIPTION
`cpu_limit` is a task var, so its always defined, the template should be checking for `not none` instead

Fixes #9224 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1600041