### PR TITLE
Adapt role to latest version of cluster-monitoring-operator

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/defaults/main.yml
+++ b/roles/openshift_cluster_monitoring_operator/defaults/main.yml
@@ -1,14 +1,59 @@
 ---
-openshift_cluster_monitoring_operator_image: quay.io/coreos/cluster-monitoring-operator:v0.0.6
-openshift_cluster_monitoring_operator_prometheus_operator_repo: quay.io/coreos/prometheus-operator
-openshift_cluster_monitoring_operator_prometheus_repo: quay.io/prometheus/prometheus
-openshift_cluster_monitoring_operator_alertmanager_repo: quay.io/prometheus/alertmanager
-openshift_cluster_monitoring_operator_prometheus_reloader_repo: quay.io/coreos/prometheus-config-reloader
-openshift_cluster_monitoring_operator_configmap_reloader_repo: quay.io/coreos/configmap-reload
+openshift_cluster_monitoring_operator_namespace: openshift-monitoring
+
+l_openshift_cluster_monitoring_operator_ocp_image_registry: "{{ system_images_registry_dict[openshift_deployment_type] }}/openshift3/"
+
+l_openshift_cluster_monitoring_operator_image_dicts:
+  origin: quay.io/coreos/cluster-monitoring-operator
+  openshift-enterprise: "{{l_openshift_cluster_monitoring_operator_ocp_image_registry}}ose-cluster-monitoring-operator"
+
+l_openshift_cluster_monitoring_operator_version_dicts:
+  origin: v0.1.0
+  openshift-enterprise: "{{ openshift_image_tag }}"
+
+openshift_cluster_monitoring_operator_image: "{{ l_openshift_cluster_monitoring_operator_image_dicts[openshift_deployment_type] }}:{{ l_openshift_cluster_monitoring_operator_version_dicts[openshift_deployment_type] }}"
+
+l_openshift_cluster_monitoring_image_dicts:
+  origin:
+    prometheus_operator: quay.io/coreos/prometheus-operator
+    prometheus: openshift/prometheus
+    alertmanager: openshift/prometheus-alertmanager
+    node_exporter: openshift/prometheus-node-exporter
+    prometheus_config_reloader: quay.io/coreos/prometheus-config-reloader
+    configmap_reloader: quay.io/coreos/configmap-reload
+    grafana: grafana/grafana
+    kube_state_metrics: quay.io/coreos/kube-state-metrics
+    kube_rbac_proxy: quay.io/coreos/kube-rbac-proxy
+    oauth_proxy: openshift/oauth-proxy
+  openshift-enterprise:
+    prometheus_operator: "{{l_openshift_cluster_monitoring_operator_ocp_image_registry}}ose-prometheus-operator"
+    prometheus: "{{l_openshift_cluster_monitoring_operator_ocp_image_registry}}prometheus"
+    alertmanager: "{{l_openshift_cluster_monitoring_operator_ocp_image_registry}}prometheus-alertmanager"
+    node_exporter: "{{l_openshift_cluster_monitoring_operator_ocp_image_registry}}prometheus-node-exporter"
+    prometheus_config_reloader: "{{l_openshift_cluster_monitoring_operator_ocp_image_registry}}ose-prometheus-config-reloader"
+    configmap_reloader: "{{l_openshift_cluster_monitoring_operator_ocp_image_registry}}ose-configmap-reload"
+    grafana: "{{l_openshift_cluster_monitoring_operator_ocp_image_registry}}ose-grafana"
+    kube_state_metrics: "{{l_openshift_cluster_monitoring_operator_ocp_image_registry}}ose-kube-state-metrics"
+    kube_rbac_proxy: "{{l_openshift_cluster_monitoring_operator_ocp_image_registry}}ose-kube-rbac-proxy"
+    oauth_proxy: "{{l_openshift_cluster_monitoring_operator_ocp_image_registry}}oauth-proxy"
+
+openshift_cluster_monitoring_operator_prometheus_operator_repo: "{{l_openshift_cluster_monitoring_image_dicts[openshift_deployment_type]['prometheus_operator']}}"
+openshift_cluster_monitoring_operator_prometheus_repo: "{{l_openshift_cluster_monitoring_image_dicts[openshift_deployment_type]['prometheus']}}"
+openshift_cluster_monitoring_operator_alertmanager_repo: "{{l_openshift_cluster_monitoring_image_dicts[openshift_deployment_type]['alertmanager']}}"
+openshift_cluster_monitoring_operator_node_exporter_repo: "{{l_openshift_cluster_monitoring_image_dicts[openshift_deployment_type]['node_exporter']}}"
+openshift_cluster_monitoring_operator_prometheus_reloader_repo: "{{l_openshift_cluster_monitoring_image_dicts[openshift_deployment_type]['prometheus_config_reloader']}}"
+openshift_cluster_monitoring_operator_configmap_reloader_repo: "{{l_openshift_cluster_monitoring_image_dicts[openshift_deployment_type]['configmap_reloader']}}"
+openshift_cluster_monitoring_operator_grafana_image: "{{l_openshift_cluster_monitoring_image_dicts[openshift_deployment_type]['grafana']}}"
+openshift_cluster_monitoring_operator_kube_state_metrics_image: "{{l_openshift_cluster_monitoring_image_dicts[openshift_deployment_type]['kube_state_metrics']}}"
+openshift_cluster_monitoring_operator_kube_rbac_proxy_image: "{{l_openshift_cluster_monitoring_image_dicts[openshift_deployment_type]['kube_rbac_proxy']}}"
+openshift_cluster_monitoring_operator_proxy_image: "{{l_openshift_cluster_monitoring_image_dicts[openshift_deployment_type]['oauth_proxy']}}"
+
 openshift_cluster_monitoring_operator_prometheus_storage_capacity: "50Gi"
 openshift_cluster_monitoring_operator_alertmanager_storage_capacity: "2Gi"
 
 openshift_cluster_monitoring_operator_cluster_id: "{{ openshift_clusterid | default(openshift_master_cluster_public_hostname, true) | default(openshift_master_cluster_hostname, true) | default('openshift', true) }}"
+
+openshift_cluster_monitoring_operator_node_selector: "{{ openshift_hosted_infra_selector | default('node-role.kubernetes.io/infra=true') | map_from_pairs }}"
 
 openshift_cluster_monitoring_operator_alertmanager_config: |+
   global:

--- a/roles/openshift_cluster_monitoring_operator/files/cluster-monitoring-operator.yaml
+++ b/roles/openshift_cluster_monitoring_operator/files/cluster-monitoring-operator.yaml
@@ -12,61 +12,15 @@ metadata:
     openshift.io/support-url: https://access.redhat.com
 openshift.io/provider-display-name: Red Hat, Inc.
 parameters:
-- name: OPERATOR_IMAGE
-  value: quay.io/coreos/cluster-monitoring-operator:v0.0.6
-- name: PROMETHEUS_OPERATOR_IMAGE
-  value: quay.io/coreos/prometheus-operator
-- name: ALERTMANAGER_IMAGE
-  value: quay.io/prometheus/alertmanager
-- name: ALERTMANAGER_STORAGE_CAPACITY
-  required: true
-- name: PROMETHEUS_IMAGE
-  value: quay.io/prometheus/prometheus
-- name: PROMETHEUS_STORAGE_CAPACITY
-  required: true
-- name: PROMETHEUS_CONFIG_RELOADER_IMAGE
-  value: quay.io/coreos/prometheus-config-reloader
-- name: CONFIG_RELOADER_IMAGE
-  value: quay.io/coreos/configmap-reload
 - name: ALERTMANAGER_CONFIG
   required: true
   description: A complete (base64-encoded) Alertmanager configuration YAML file.
-- name: CLUSTER_ID
-  description: Identifies the cluster being monitored; the value is added to a `cluster` label in every alert.
-  required: true
 - name: NAMESPACE
   # This namespace cannot be changed. Only `openshift-monitoring` is supported.
+  required: true
   value: openshift-monitoring
 
 objects:
-# Configures the Cluster Monitoring Operator.
-- apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: cluster-monitoring-config
-    namespace: ${NAMESPACE}
-  data:
-    config.yaml: |+
-      prometheusOperator:
-        baseImage: ${PROMETHEUS_OPERATOR_IMAGE}
-        prometheusConfigReloaderBaseImage: ${PROMETHEUS_CONFIG_RELOADER_IMAGE}
-        configReloaderBaseImage: ${CONFIG_RELOADER_IMAGE}
-      prometheusK8s:
-        baseImage: ${PROMETHEUS_IMAGE}
-        externalLabels:
-          cluster: ${CLUSTER_ID}
-        volumeClaimTemplate:
-          spec:
-            resources:
-              requests:
-                storage: "${PROMETHEUS_STORAGE_CAPACITY}"
-      alertmanagerMain:
-        baseImage: ${ALERTMANAGER_IMAGE}
-        volumeClaimTemplate:
-          spec:
-            resources:
-              requests:
-                storage: "${ALERTMANAGER_STORAGE_CAPACITY}"
 
 # Configures Alertmanager.
 - apiVersion: v1
@@ -199,36 +153,3 @@ objects:
   - kind: ServiceAccount
     name: cluster-monitoring-operator
     namespace: ${NAMESPACE}
-- apiVersion: extensions/v1beta1
-  kind: Deployment
-  metadata:
-    name: cluster-monitoring-operator
-    namespace: ${NAMESPACE}
-    labels:
-      app: cluster-monitoring-operator
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: cluster-monitoring-operator
-    template:
-      metadata:
-        labels:
-          app: cluster-monitoring-operator
-      spec:
-        serviceAccountName: cluster-monitoring-operator
-        containers:
-        - image: ${OPERATOR_IMAGE}
-          name: cluster-monitoring-operator
-          args:
-          - "-namespace=${NAMESPACE}"
-          - "-configmap=cluster-monitoring-config"
-          - "-logtostderr=true"
-          - "-v=4"
-          resources:
-            limits:
-              cpu: 20m
-              memory: 50Mi
-            requests:
-              cpu: 20m
-              memory: 50Mi

--- a/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
+++ b/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
@@ -4,12 +4,24 @@
   register: mktemp
   changed_when: False
 
+- set_fact:
+    tempdir: "{{ mktemp.stdout }}"
+
 - name: Copy files to temp directory
   copy:
     src: "{{ item }}"
-    dest: "{{ mktemp.stdout }}/{{ item }}"
+    dest: "{{ tempdir }}/{{ item }}"
   with_items:
   - cluster-monitoring-operator.yaml
+
+- name: Create templates subdirectory
+  file:
+    state: directory
+    path: "{{ tempdir }}/{{ item }}"
+    mode: 0755
+  changed_when: False
+  with_items:
+  - templates
 
 - name: Copy admin client config
   command: >
@@ -49,23 +61,48 @@
     command: >
       {{ openshift_client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig adm pod-network make-projects-global openshift-monitoring
 
-- name: Apply the cluster monitoring operator template
+- name: Apply the cluster monitoring operator ServiceAccount, Roles and Alertmanager config
   shell: >
     {{ openshift_client_binary }} process -n openshift-monitoring -f "{{ mktemp.stdout 	}}/{{ item }}"
-    --param OPERATOR_IMAGE="{{ openshift_cluster_monitoring_operator_image }}"
-    --param PROMETHEUS_OPERATOR_IMAGE="{{ openshift_cluster_monitoring_operator_prometheus_operator_repo }}"
-    --param ALERTMANAGER_IMAGE="{{ openshift_cluster_monitoring_operator_alertmanager_repo }}"
-    --param PROMETHEUS_IMAGE="{{ openshift_cluster_monitoring_operator_prometheus_repo }}"
-    --param PROMETHEUS_CONFIG_RELOADER_IMAGE="{{ openshift_cluster_monitoring_operator_prometheus_reloader_repo }}"
-    --param CONFIG_RELOADER_IMAGE="{{ openshift_cluster_monitoring_operator_configmap_reloader_repo }}"
     --param ALERTMANAGER_CONFIG="{{ openshift_cluster_monitoring_operator_alertmanager_config | b64encode }}"
-    --param CLUSTER_ID="{{ openshift_cluster_monitoring_operator_cluster_id }}"
-    --param PROMETHEUS_STORAGE_CAPACITY="{{ openshift_cluster_monitoring_operator_prometheus_storage_capacity }}"
-    --param ALERTMANAGER_STORAGE_CAPACITY="{{ openshift_cluster_monitoring_operator_alertmanager_storage_capacity }}"
+    --param NAMESPACE="{{ openshift_cluster_monitoring_operator_namespace }}"
     --config={{ mktemp.stdout }}/admin.kubeconfig
     | {{ openshift_client_binary }} apply --config={{ mktemp.stdout }}/admin.kubeconfig -f -
   with_items:
   - cluster-monitoring-operator.yaml
+
+- name: Set cluster-monitoring-operator configmap template
+  template:
+    src: cluster-monitoring-operator-config.j2
+    dest: "{{ tempdir }}/templates/cluster-monitoring-operator-config.yaml"
+  changed_when: no
+
+- name: Set cluster-monitoring-operator configmap
+  oc_obj:
+    state: present
+    name: "cluster-monitoring-config"
+    namespace: "{{ openshift_cluster_monitoring_operator_namespace }}"
+    kind: configmap
+    files:
+    - "{{ tempdir }}/templates/cluster-monitoring-operator-config.yaml"
+    delete_after: true
+
+- name: Set cluster-monitoring-operator template
+  template:
+    src: cluster-monitoring-operator-deployment.j2
+    dest: "{{ tempdir }}/templates/cluster-monitoring-operator-deployment.yaml"
+  vars:
+    namespace: "{{ openshift_cluster_monitoring_operator_namespace }}"
+
+- name: Set cluster-monitoring-operator template
+  oc_obj:
+    state: present
+    name: "cluster-monitoring-operator"
+    namespace: "{{ openshift_cluster_monitoring_operator_namespace }}"
+    kind: deployment
+    files:
+    - "{{ tempdir }}/templates/cluster-monitoring-operator-deployment.yaml"
+    delete_after: true
 
 - name: Wait for the ServiceMonitor CRD to be created
   command: "{{ openshift_client_binary }} get crd servicemonitors.monitoring.coreos.com -n openshift-monitoring --config={{ mktemp.stdout }}/admin.kubeconfig"

--- a/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-config.j2
+++ b/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-config.j2
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: {{ openshift_cluster_monitoring_operator_namespace }}
+data:
+  config.yaml: |+
+    prometheusOperator:
+      baseImage: {{ openshift_cluster_monitoring_operator_prometheus_operator_repo }}
+      prometheusConfigReloaderBaseImage: {{ openshift_cluster_monitoring_operator_prometheus_reloader_repo }}
+      configReloaderBaseImage: {{ openshift_cluster_monitoring_operator_configmap_reloader_repo }}
+{% if openshift_cluster_monitoring_operator_node_selector is iterable and openshift_cluster_monitoring_operator_node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in openshift_cluster_monitoring_operator_node_selector.items() %}
+        {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}
+    prometheusK8s:
+      baseImage: {{ openshift_cluster_monitoring_operator_prometheus_repo }}
+{% if openshift_cluster_monitoring_operator_node_selector is iterable and openshift_cluster_monitoring_operator_node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in openshift_cluster_monitoring_operator_node_selector.items() %}
+        {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}
+      externalLabels:
+        cluster: {{ openshift_cluster_monitoring_operator_cluster_id }}
+      volumeClaimTemplate:
+        spec:
+          resources:
+            requests:
+              storage: {{ openshift_cluster_monitoring_operator_prometheus_storage_capacity }}
+    alertmanagerMain:
+      baseImage: {{ openshift_cluster_monitoring_operator_alertmanager_repo }}
+{% if openshift_cluster_monitoring_operator_node_selector is iterable and openshift_cluster_monitoring_operator_node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in openshift_cluster_monitoring_operator_node_selector.items() %}
+        {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}
+      volumeClaimTemplate:
+        spec:
+          resources:
+            requests:
+              storage: {{ openshift_cluster_monitoring_operator_alertmanager_storage_capacity }}
+    nodeExporter:
+      baseImage: {{ openshift_cluster_monitoring_operator_node_exporter_repo }}
+    grafana:
+      baseImage: {{ openshift_cluster_monitoring_operator_grafana_image }}
+{% if openshift_cluster_monitoring_operator_node_selector is iterable and openshift_cluster_monitoring_operator_node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in openshift_cluster_monitoring_operator_node_selector.items() %}
+        {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}
+    kubeStateMetrics:
+      baseImage: {{ openshift_cluster_monitoring_operator_kube_state_metrics_image }}
+{% if openshift_cluster_monitoring_operator_node_selector is iterable and openshift_cluster_monitoring_operator_node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in openshift_cluster_monitoring_operator_node_selector.items() %}
+        {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}
+    kubeRbacProxy:
+      baseImage: {{ openshift_cluster_monitoring_operator_kube_rbac_proxy_image }}
+    auth:
+      baseImage: {{ openshift_cluster_monitoring_operator_proxy_image }}

--- a/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-deployment.j2
+++ b/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-deployment.j2
@@ -1,0 +1,51 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cluster-monitoring-operator
+  namespace: {{ openshift_cluster_monitoring_operator_namespace }}
+  labels:
+    app: cluster-monitoring-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-monitoring-operator
+  template:
+    metadata:
+      labels:
+        app: cluster-monitoring-operator
+    spec:
+      serviceAccountName: cluster-monitoring-operator
+{% if openshift_cluster_monitoring_operator_node_selector is iterable and openshift_cluster_monitoring_operator_node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in openshift_cluster_monitoring_operator_node_selector.items() %}
+        {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}
+      containers:
+      - image: "{{ openshift_cluster_monitoring_operator_image }}"
+        name: cluster-monitoring-operator
+        args:
+        - "-namespace={{ openshift_cluster_monitoring_operator_namespace }}"
+        - "-configmap=cluster-monitoring-config"
+        - "-logtostderr=true"
+        - "-v=4"
+{% if openshift_deployment_type == 'openshift-enterprise' %}
+        - "-tags=prometheus-operator={{ openshift_image_tag }}"
+        - "-tags=prometheus-config-reloader={{ openshift_image_tag }}"
+        - "-tags=config-reloader={{ openshift_image_tag }}"
+        - "-tags=prometheus={{ openshift_image_tag }}"
+        - "-tags=alertmanager={{ openshift_image_tag }}"
+        - "-tags=grafana={{ openshift_image_tag }}"
+        - "-tags=oauth-proxy={{ openshift_image_tag }}"
+        - "-tags=node-exporter={{ openshift_image_tag }}"
+        - "-tags=kube-state-metrics={{ openshift_image_tag }}"
+        - "-tags=kube-rbac-proxy={{ openshift_image_tag }}"
+{% endif %}
+        resources:
+          limits:
+            cpu: 20m
+            memory: 50Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi


### PR DESCRIPTION
This is a WIP pull request to already get a review out for the ansible changes for the cluster-monitoring-operator changes. The cluster-monitoring-operator version still needs to be bumped.

Note that I haven't been able to create a cluster from `openshift/origin-ansible:latest`, so I haven't been able to test this on a cluster yet.

@mxinden @squat @ironcladlou @elad661 