### PR TITLE
Move metrics-server out of openshift-monitoring NS

### DIFF
--- a/roles/metrics_server/defaults/main.yaml
+++ b/roles/metrics_server/defaults/main.yaml
@@ -5,7 +5,7 @@ openshift_metrics_server_image: "{{ l_os_registry_url | regex_replace('${compone
 # and behave sanely for new installations by default.
 openshift_metrics_server_install: "{{ openshift_metrics_install_metrics | default(False) }}"
 openshift_metrics_server_resolution: 30s
-openshift_metrics_server_project: openshift-monitoring
+openshift_metrics_server_project: openshift-metrics-server
 
 #####
 # Caution should be taken for the following defaults before


### PR DESCRIPTION
It's useful to have metrics-server in a separate namespace so that
(un)installation of Prometheus doesn't interfere with metrics-server
(un)installation, and vice versa.