### PR TITLE
Remove alternative oreg vars and update logic

### DIFF
--- a/DEPLOYMENT_TYPES.md
+++ b/DEPLOYMENT_TYPES.md
@@ -13,5 +13,4 @@ The table below outlines the defaults per `openshift_deployment_type`:
 | **openshift_service_type** (also used for package names)        | origin                                   | atomic-openshift                       |
 | **openshift.common.config_base**                                | /etc/origin                              | /etc/origin                            |
 | **openshift_data_dir**                                          | /var/lib/origin                          | /var/lib/origin                        |
-| **openshift.master.registry_url oreg_url_node**                 | openshift/origin-${component}:${version} | openshift3/ose-${component}:${version} |
 | **Image Streams**                                               | centos                                   | rhel                                   |

--- a/roles/lib_utils/action_plugins/sanity_checks.py
+++ b/roles/lib_utils/action_plugins/sanity_checks.py
@@ -64,7 +64,10 @@ ALLOWED_REGISTRIES_VAR = "openshift_master_image_policy_allowed_registries_for_i
 
 REMOVED_VARIABLES = (
     # TODO(michaelgugino): Remove in 3.12
-    ('oreg_auth_credentials_replace', 'Removed: Credentials are now always updated')
+    ('oreg_auth_credentials_replace', 'Removed: Credentials are now always updated'),
+    ('oreg_url_master', 'oreg_url'),
+    ('oreg_url_node', 'oreg_url'),
+
 )
 
 # JSON_FORMAT_VARIABLES does not intende to cover all json variables, but
@@ -189,7 +192,7 @@ class ActionModule(ActionBase):
 
         unmatched_registries = []
         for regvar in (
-                "oreg_url_master", "oreg_url_node", "oreg_url"
+                "oreg_url"
                 "openshift_cockpit_deployer_prefix",
                 "openshift_metrics_image_prefix",
                 "openshift_logging_image_prefix",
@@ -403,16 +406,12 @@ class ActionModule(ActionBase):
             return None
 
         oreg_url = self.template_var(hostvars, host, 'oreg_url')
-        oreg_url_master = self.template_var(hostvars, host, 'oreg_url_master')
-        oreg_url_node = self.template_var(hostvars, host, 'oreg_url_node')
-        oreg_url_found = False
-        for url in (oreg_url, oreg_url_master, oreg_url_node):
-            if url is not None:
-                oreg_url_found = True
-                if reg_to_check in url:
-                    raise errors.AnsibleModuleError(err_msg2)
 
-        if not oreg_url_found and odt == 'openshift-enterprise':
+        if oreg_url is not None:
+            if reg_to_check in oreg_url:
+                raise errors.AnsibleModuleError(err_msg2)
+
+        elif odt == 'openshift-enterprise':
             # We're not using an oreg_url, we're using default enterprise
             # registry.  We require oreg_user and oreg_password
             raise errors.AnsibleModuleError(err_msg)

--- a/roles/openshift_control_plane/README.md
+++ b/roles/openshift_control_plane/README.md
@@ -19,9 +19,7 @@ From this role:
 | Name                                             | Default value         |                                                                               |
 |---------------------------------------------------|-----------------------|-------------------------------------------------------------------------------|
 | openshift_node_ips                                | []                    | List of the openshift node ip addresses to pre-register when master starts up |
-| oreg_url                                          | UNDEF                 | Default docker registry to use                                                |
-| oreg_url_master                                   | UNDEF                 | Default docker registry to use, specifically on the master                    |
-|                                                                               |
+| oreg_url                                          | UNDEF                 | Default docker registry to use                                                |                                                                               |
 | openshift_master_console_port                     | UNDEF                 |                                                                               |
 | openshift_master_api_url                          | UNDEF                 |                                                                               |
 | openshift_master_console_url                      | UNDEF                 |                                                                               |

--- a/roles/openshift_control_plane/defaults/main.yml
+++ b/roles/openshift_control_plane/defaults/main.yml
@@ -7,7 +7,7 @@ openshift_master_debug_level: "{{ debug_level | default(2) }}"
 r_openshift_master_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
 r_openshift_master_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
-openshift_imageconfig_format: "{{ oreg_url_master | default(oreg_url) | default(l_osm_registry_url_default) }}"
+openshift_imageconfig_format: "{{ oreg_url | default(l_osm_registry_url_default) }}"
 
 l_osm_id_providers_dict:
   openshift-enterprise:

--- a/roles/openshift_control_plane/tasks/upgrade.yml
+++ b/roles/openshift_control_plane/tasks/upgrade.yml
@@ -56,8 +56,8 @@
   yedit:
     src: "{{ openshift.common.config_base }}/master/master-config.yaml"
     key: 'imageConfig.format'
-    value: "{{ oreg_url | default(oreg_url_master) }}"
-  when: oreg_url is defined or oreg_url_master is defined
+    value: "{{ oreg_url }}"
+  when: oreg_url is defined
 
 - name: Change default node selector to compute=true
   yedit:

--- a/roles/openshift_examples/defaults/main.yml
+++ b/roles/openshift_examples/defaults/main.yml
@@ -30,4 +30,4 @@ registry_host: "{{ openshift_examples_registryurl.split('/')[0] if '.' in opensh
 openshift_hosted_images_dict:
   origin: 'docker.io/openshift/origin-${component}:${version}'
   openshift-enterprise: 'registry.redhat.io/openshift3/ose-${component}:${version}'
-openshift_examples_registryurl: "{{ oreg_url_master | default(oreg_url) | default(openshift_hosted_images_dict[openshift_deployment_type]) }}"
+openshift_examples_registryurl: "{{ oreg_url | default(openshift_hosted_images_dict[openshift_deployment_type]) }}"

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -10,11 +10,12 @@ l_openshift_images_dict:
   origin: 'docker.io/openshift/origin-${component}:${version}'
   openshift-enterprise: 'registry.redhat.io/openshift3/ose-${component}:${version}'
 
-# oreg_url is defined by user input.
-oreg_host: "{{ oreg_url.split('/')[0] if (oreg_url is defined and '.' in oreg_url.split('/')[0]) else '' }}"
-
 l_osm_registry_url_default: "{{ l_openshift_images_dict[openshift_deployment_type] }}"
-l_osm_registry_url: "{{ oreg_url_master | default(oreg_url) | default(l_osm_registry_url_default) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
+l_oreg_host_temp: "{{ oreg_url | default(l_osm_registry_url_default) }}"
+# oreg_url is defined by user input.
+oreg_host: "{{ l_oreg_host_temp.split('/')[0] }}"
+
+l_osm_registry_url: "{{ oreg_url | default(l_osm_registry_url_default) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
 l_os_registry_url: "{{ oreg_url | default(l_osm_registry_url_default) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
 openshift_image_default: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'node') }}"
 # not sure why this one is more complicated than other images

--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -46,7 +46,7 @@ openshift_hosted_router_edits:
   value: 21600
   action: put
 
-openshift_hosted_router_registryurl: "{{ oreg_url_master | default(oreg_url) | default(openshift_hosted_images_dict[openshift_deployment_type]) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
+openshift_hosted_router_registryurl: "{{ oreg_url | default(openshift_hosted_images_dict[openshift_deployment_type]) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
 openshift_hosted_routers:
 - name: router
   replicas: "{{ replicas | default(1) }}"
@@ -73,7 +73,7 @@ r_openshift_hosted_router_os_firewall_allow: []
 ############
 
 openshift_hosted_registry_selector: "{{ openshift_registry_selector | default(openshift_hosted_infra_selector) }}"
-openshift_hosted_registry_registryurl: "{{ oreg_url_master | default(oreg_url) | default(openshift_hosted_images_dict[openshift_deployment_type]) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
+openshift_hosted_registry_registryurl: "{{ oreg_url | default(openshift_hosted_images_dict[openshift_deployment_type]) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
 openshift_hosted_registry_routecertificates: {}
 openshift_hosted_registry_routetermination: "passthrough"
 

--- a/roles/openshift_hosted_templates/defaults/main.yml
+++ b/roles/openshift_hosted_templates/defaults/main.yml
@@ -8,7 +8,7 @@ openshift_hosted_images_dict:
   origin: 'docker.io/openshift/origin-${component}:${version}'
   openshift-enterprise: 'registry.redhat.io/openshift3/ose-${component}:${version}'
 
-openshift_hosted_templates_registryurl: "{{ oreg_url_master | default(oreg_url) | default(openshift_hosted_images_dict[openshift_deployment_type]) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
+openshift_hosted_templates_registryurl: "{{ oreg_url | default(openshift_hosted_images_dict[openshift_deployment_type]) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
 registry_host: "{{ openshift_hosted_templates_registryurl.split('/')[0] if '.' in openshift_hosted_templates_registryurl.split('/')[0] else '' }}"
 
 openshift_hosted_templates_import_command: 'create'

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -43,7 +43,7 @@
       session_name: "{{ openshift_master_session_name | default(None) }}"
       ldap_ca: "{{ openshift_master_ldap_ca | default(lookup('file', openshift_master_ldap_ca_file) if openshift_master_ldap_ca_file is defined else None) }}"
       openid_ca: "{{ openshift_master_openid_ca | default(lookup('file', openshift_master_openid_ca_file) if openshift_master_openid_ca_file is defined else None) }}"
-      registry_url: "{{ oreg_url_master | default(oreg_url) | default(None) }}"
+      registry_url: "{{ oreg_url | default(None) }}"
       registry_selector: "{{ openshift_registry_selector | default(None) }}"
       api_server_args: "{{ osm_api_server_args | default(None) }}"
       controller_args: "{{ osm_controller_args | default(None) }}"

--- a/roles/openshift_node/README.md
+++ b/roles/openshift_node/README.md
@@ -19,7 +19,6 @@ From this role:
 |------------------------------------------|-----------------------|----------------------------------------------------------|
 | openshift_node_start_options             | UNDEF (Optional)      | Options to pass to node start cmdline                    |
 | oreg_url                                 | UNDEF (Optional)      | Default docker registry to use                           |
-| oreg_url_node                            | UNDEF (Optional)      | Default docker registry to use, specifically on the node |
 | openshift_persistentlocalstorage_enabled | false                 | Enable the persistent local storage                      |
 
 openshift_node_start_options can be used for passing any start node option, e.g.:

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -16,12 +16,6 @@ system_images_registry: "docker"
 l_osn_image: "{{ (system_images_registry == 'docker') | ternary(osn_image, (osn_image.split('/')|length==2) | ternary(system_images_registry + '/' + osn_image, osn_image)) }}"
 system_osn_image: "{{ (system_images_registry == 'docker') | ternary('docker:' + l_osn_image, l_osn_image) }}"
 
-openshift_oreg_url_default_dict:
-  origin: "docker.io/openshift/origin-${component}:${version}"
-  openshift-enterprise: "registry.access.redhat.com/openshift3/ose-${component}:${version}"
-openshift_oreg_url_default: "{{ openshift_oreg_url_default_dict[openshift_deployment_type] }}"
-oreg_url_node: "{{ oreg_url | default(openshift_oreg_url_default) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
-
 openshift_node_env_vars: {}
 
 # Create list of 'k=v' pairs.


### PR DESCRIPTION
This commit removes oreg_url_master and oreg_url_node
in favor of only retaining oreg_url.  It is still possible
to use inventory to have a different value for oreg_url
for masters and nodes, if desired.

Additionally, this commit fixes logic for oreg_host,
which should account for new enterprise registry.