### PR TITLE
Fix ordering of etcd stop and mask

### DIFF
--- a/roles/etcd/tasks/upgrade_static.yml
+++ b/roles/etcd/tasks/upgrade_static.yml
@@ -16,6 +16,18 @@
   - "/etc/systemd/system/etcd_container.service"
   register: old_svc_files
 
+# We removed the ability to detect what was previously 'containerized'
+# Need to stop and disable this service, but might not be present.
+- name: Stop, disable and mask old etcd service
+  systemd:
+    name: "{{ item }}"
+    state: stopped
+    enabled: no
+  with_items:
+  - etcd
+  - etcd_container
+  failed_when: False
+
 - name: Remove old etcd service files
   file:
     path: "{{ item.stat.path }}"
@@ -26,13 +38,9 @@
   - item.stat.exists
   - item.stat.isreg
 
-# We removed the ability to detect what was previously 'containerized'
-# Need to stop and disable this service, but might not be present.
-- name: Stop, disable and mask old etcd service
+- name: Mask old etcd service
   systemd:
     name: "{{ item }}"
-    state: stopped
-    enabled: no
     masked: yes
     daemon_reload: yes
   with_items:


### PR DESCRIPTION
During upgrades, removing a service unit file and
then calling stop and daemon reload at the same
time results in the inability of systemd to stop
an already-running service.

This commit reorders operations to ensure we stop
the running services before removing the systemd
service files.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1591805