### PR TITLE
AWS: use vpc name instead of cluster id when creating security groups

### DIFF
--- a/roles/openshift_aws/tasks/security_group.yml
+++ b/roles/openshift_aws/tasks/security_group.yml
@@ -3,7 +3,7 @@
   ec2_vpc_net_facts:
     region: "{{ openshift_aws_region }}"
     filters:
-      "tag:Name": "{{ openshift_aws_clusterid }}"
+      "tag:Name": "{{ openshift_aws_vpc_name }}"
   register: vpcout
 
 - name: create the node group sgs


### PR DESCRIPTION
Don't assume that the vpc name is the clusterid when creating security groups