### PR TITLE
Support specifying the rolebinding name

### DIFF
--- a/roles/lib_openshift/library/oc_adm_policy_group.py
+++ b/roles/lib_openshift/library/oc_adm_policy_group.py
@@ -73,6 +73,12 @@ options:
     required: false
     default: None
     aliases: []
+  rolebinding_name:
+    description:
+    - The name of the rolebinding object for roles
+    required: false
+    default: None
+    aliases: []
   debug:
     description:
     - Turn on debug output.
@@ -2087,6 +2093,9 @@ class PolicyGroup(OpenShiftCLI):
             return False
 
         for binding in bindings:
+            if self.config.config_options['rolebinding_name']['value'] is not None and \
+                    binding['metadata']['name'] != self.config.config_options['rolebinding_name']['value']:
+                continue
             if binding['roleRef']['name'] == self.config.config_options['name']['value'] and \
                     binding['groupNames'] is not None and \
                     self.config.config_options['group']['value'] in binding['groupNames']:
@@ -2128,6 +2137,9 @@ class PolicyGroup(OpenShiftCLI):
                self.config.config_options['name']['value'],
                self.config.config_options['group']['value']]
 
+        if self.config.config_options['rolebinding_name']['value'] is not None:
+            cmd.extend(['--rolebinding-name', self.config.config_options['rolebinding_name']['value']])
+
         return self.openshift_cmd(cmd, oadm=True)
 
     @staticmethod
@@ -2148,6 +2160,7 @@ class PolicyGroup(OpenShiftCLI):
                                      'group': {'value': params['group'], 'include': False},
                                      'resource_kind': {'value': params['resource_kind'], 'include': False},
                                      'name': {'value': params['resource_name'], 'include': False},
+                                     'rolebinding_name': {'value': params['rolebinding_name'], 'include': False},
                                     })
 
         policygroup = PolicyGroup(nconfig, params['debug'])
@@ -2216,6 +2229,7 @@ def main():
 
             group=dict(required=True, type='str'),
             resource_kind=dict(required=True, choices=['role', 'cluster-role', 'scc'], type='str'),
+            rolebinding_name=dict(default=None, type='str'),
         ),
         supports_check_mode=True,
     )

--- a/roles/lib_openshift/library/oc_adm_policy_user.py
+++ b/roles/lib_openshift/library/oc_adm_policy_user.py
@@ -79,6 +79,12 @@ options:
     required: false
     default: None
     aliases: []
+  rolebinding_name:
+    description:
+    - The name of the rolebinding object for roles
+    required: false
+    default: None
+    aliases: []
   debug:
     description:
     - Turn on debug output.
@@ -2095,6 +2101,9 @@ class PolicyUser(OpenShiftCLI):
             return False
 
         for binding in bindings:
+            if self.config.config_options['rolebinding_name']['value'] is not None and \
+                    binding['metadata']['name'] != self.config.config_options['rolebinding_name']['value']:
+                continue
             if binding['roleRef']['name'] == self.config.config_options['name']['value'] and \
                     'userNames' in binding and binding['userNames'] is not None and \
                     self.config.config_options['user']['value'] in binding['userNames']:
@@ -2139,6 +2148,9 @@ class PolicyUser(OpenShiftCLI):
         if self.config.config_options['role_namespace']['value'] is not None:
             cmd.extend(['--role-namespace', self.config.config_options['role_namespace']['value']])
 
+        if self.config.config_options['rolebinding_name']['value'] is not None:
+            cmd.extend(['--rolebinding-name', self.config.config_options['rolebinding_name']['value']])
+
         return self.openshift_cmd(cmd, oadm=True)
 
     @staticmethod
@@ -2160,6 +2172,7 @@ class PolicyUser(OpenShiftCLI):
                                     'resource_kind': {'value': params['resource_kind'], 'include': False},
                                     'name': {'value': params['resource_name'], 'include': False},
                                     'role_namespace': {'value': params['role_namespace'], 'include': False},
+                                    'rolebinding_name': {'value': params['rolebinding_name'], 'include': False},
                                    })
 
         policyuser = PolicyUser(nconfig, params['debug'])
@@ -2225,6 +2238,7 @@ def main():
             resource_name=dict(required=True, type='str'),
             namespace=dict(default='default', type='str'),
             role_namespace=dict(default=None, type='str'),
+            rolebinding_name=dict(default=None, type='str'),
             kubeconfig=dict(default='/etc/origin/master/admin.kubeconfig', type='str'),
 
             user=dict(required=True, type='str'),

--- a/roles/lib_openshift/src/ansible/oc_adm_policy_group.py
+++ b/roles/lib_openshift/src/ansible/oc_adm_policy_group.py
@@ -18,6 +18,7 @@ def main():
 
             group=dict(required=True, type='str'),
             resource_kind=dict(required=True, choices=['role', 'cluster-role', 'scc'], type='str'),
+            rolebinding_name=dict(default=None, type='str'),
         ),
         supports_check_mode=True,
     )

--- a/roles/lib_openshift/src/ansible/oc_adm_policy_user.py
+++ b/roles/lib_openshift/src/ansible/oc_adm_policy_user.py
@@ -15,6 +15,7 @@ def main():
             resource_name=dict(required=True, type='str'),
             namespace=dict(default='default', type='str'),
             role_namespace=dict(default=None, type='str'),
+            rolebinding_name=dict(default=None, type='str'),
             kubeconfig=dict(default='/etc/origin/master/admin.kubeconfig', type='str'),
 
             user=dict(required=True, type='str'),

--- a/roles/lib_openshift/src/class/oc_adm_policy_group.py
+++ b/roles/lib_openshift/src/class/oc_adm_policy_group.py
@@ -113,6 +113,9 @@ class PolicyGroup(OpenShiftCLI):
             return False
 
         for binding in bindings:
+            if self.config.config_options['rolebinding_name']['value'] is not None and \
+                    binding['metadata']['name'] != self.config.config_options['rolebinding_name']['value']:
+                continue
             if binding['roleRef']['name'] == self.config.config_options['name']['value'] and \
                     binding['groupNames'] is not None and \
                     self.config.config_options['group']['value'] in binding['groupNames']:
@@ -154,6 +157,9 @@ class PolicyGroup(OpenShiftCLI):
                self.config.config_options['name']['value'],
                self.config.config_options['group']['value']]
 
+        if self.config.config_options['rolebinding_name']['value'] is not None:
+            cmd.extend(['--rolebinding-name', self.config.config_options['rolebinding_name']['value']])
+
         return self.openshift_cmd(cmd, oadm=True)
 
     @staticmethod
@@ -174,6 +180,7 @@ class PolicyGroup(OpenShiftCLI):
                                      'group': {'value': params['group'], 'include': False},
                                      'resource_kind': {'value': params['resource_kind'], 'include': False},
                                      'name': {'value': params['resource_name'], 'include': False},
+                                     'rolebinding_name': {'value': params['rolebinding_name'], 'include': False},
                                     })
 
         policygroup = PolicyGroup(nconfig, params['debug'])

--- a/roles/lib_openshift/src/class/oc_adm_policy_user.py
+++ b/roles/lib_openshift/src/class/oc_adm_policy_user.py
@@ -107,6 +107,9 @@ class PolicyUser(OpenShiftCLI):
             return False
 
         for binding in bindings:
+            if self.config.config_options['rolebinding_name']['value'] is not None and \
+                    binding['metadata']['name'] != self.config.config_options['rolebinding_name']['value']:
+                continue
             if binding['roleRef']['name'] == self.config.config_options['name']['value'] and \
                     'userNames' in binding and binding['userNames'] is not None and \
                     self.config.config_options['user']['value'] in binding['userNames']:
@@ -151,6 +154,9 @@ class PolicyUser(OpenShiftCLI):
         if self.config.config_options['role_namespace']['value'] is not None:
             cmd.extend(['--role-namespace', self.config.config_options['role_namespace']['value']])
 
+        if self.config.config_options['rolebinding_name']['value'] is not None:
+            cmd.extend(['--rolebinding-name', self.config.config_options['rolebinding_name']['value']])
+
         return self.openshift_cmd(cmd, oadm=True)
 
     @staticmethod
@@ -172,6 +178,7 @@ class PolicyUser(OpenShiftCLI):
                                     'resource_kind': {'value': params['resource_kind'], 'include': False},
                                     'name': {'value': params['resource_name'], 'include': False},
                                     'role_namespace': {'value': params['role_namespace'], 'include': False},
+                                    'rolebinding_name': {'value': params['rolebinding_name'], 'include': False},
                                    })
 
         policyuser = PolicyUser(nconfig, params['debug'])

--- a/roles/lib_openshift/src/doc/policy_group
+++ b/roles/lib_openshift/src/doc/policy_group
@@ -20,6 +20,12 @@ options:
     required: false
     default: None
     aliases: []
+  rolebinding_name:
+    description:
+    - The name of the rolebinding object for roles
+    required: false
+    default: None
+    aliases: []
   debug:
     description:
     - Turn on debug output.

--- a/roles/lib_openshift/src/doc/policy_user
+++ b/roles/lib_openshift/src/doc/policy_user
@@ -26,6 +26,12 @@ options:
     required: false
     default: None
     aliases: []
+  rolebinding_name:
+    description:
+    - The name of the rolebinding object for roles
+    required: false
+    default: None
+    aliases: []
   debug:
     description:
     - Turn on debug output.


### PR DESCRIPTION
Example use case: 

If the self-provisioners cluster-role doesn't exist OpenShift will automatically re-create it.
To prevent this the 'self-provisioners' role must exist and be appropriately annotated.
* Grant 'system:admin' the self-provisioner role specifically on the selfprovisioners ClusterRoleBinding
* ensure the 'system:authenticated' and 'system:authenticated:oauth' groups do not have the cluster-role
* Annotate the clusterrolebinding