### PR TITLE
installer_checkpoint: filter out phases without title and start time in ansible 2.6

### DIFF
--- a/playbooks/metrics-server/private/config.yml
+++ b/playbooks/metrics-server/private/config.yml
@@ -26,6 +26,6 @@
     run_once: true
     set_stats:
       data:
-        installer_phase_metrics_service:
+        installer_phase_metrics_server:
           status: "Complete"
           end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"

--- a/roles/installer_checkpoint/callback_plugins/installer_checkpoint.py
+++ b/roles/installer_checkpoint/callback_plugins/installer_checkpoint.py
@@ -24,21 +24,22 @@ class CallbackModule(CallbackBase):
         # Find the longest phase title
         max_column = 0
         for phase in phases:
-            max_column = max(max_column, len(phases[phase]['title']))
+            max_column = max(max_column, len(phases[phase].get('title', '')))
 
         # Sort the phases by start time
-        ordered_phases = sorted(phases, key=lambda x: (phases[x]['start']))
+        ordered_phases = sorted(phases, key=lambda x: (phases[x].get('start', 0)))
 
         self._display.banner('INSTALLER STATUS')
         # Display status information for each phase
         for phase in ordered_phases:
-            phase_title = phases[phase]['title']
+            phase_title = phases[phase].get('title', '')
             padding = max_column - len(phase_title) + 2
             phase_status = phases[phase]['status']
             phase_time = phase_time_delta(phases[phase])
-            self._display.display(
-                '{}{}: {} ({})'.format(phase_title, ' ' * padding, phase_status, phase_time),
-                color=self.phase_color(phase_status))
+            if phase_title:
+                self._display.display(
+                    '{}{}: {} ({})'.format(phase_title, ' ' * padding, phase_status, phase_time),
+                    color=self.phase_color(phase_status))
             # If the phase is not complete, tell the user what playbook to rerun
             if phase_status == 'In Progress' and phase != 'installer_phase_initialize':
                 self._display.display(
@@ -72,6 +73,8 @@ class CallbackModule(CallbackBase):
 
 def phase_time_delta(phase):
     """ Calculate the difference between phase start and end times """
+    if not phase.get('start'):
+        return ''
     time_format = '%Y%m%d%H%M%SZ'
     phase_start = datetime.strptime(phase['start'], time_format)
     if 'end' not in phase:


### PR DESCRIPTION
Ansible 2.6 runs produce
```
 [WARNING]: Failure using method (v2_playbook_on_stats) in callback plugin (<an
sible.plugins.callback./var/tmp/checkout/roles/installer_checkpoint/callback_pl
ugins/installer_checkpoint.CallbackModule object at 0x7f516cc01d10>): 'title'
```

Stages without title and start time should not be displayed.

This also fixes a typo in metrics-server playbook to show the completed stage correctly