### PR TITLE
Update Calico versions to the latest (v3.1.3) in OpenShift 3.10 versions

### DIFF
--- a/roles/calico_master/defaults/main.yaml
+++ b/roles/calico_master/defaults/main.yaml
@@ -2,8 +2,8 @@
 cni_conf_dir: "/etc/cni/net.d/"
 cni_bin_dir: "/opt/cni/bin/"
 
-calico_url_policy_controller: "quay.io/calico/kube-controllers:v1.0.3"
-calico_node_image: "quay.io/calico/node:v2.6.7"
-calico_cni_image: "quay.io/calico/cni:v1.11.2"
+calico_url_policy_controller: "quay.io/calico/kube-controllers:v3.1.3"
+calico_node_image: "quay.io/calico/node:v3.1.3"
+calico_cni_image: "quay.io/calico/cni:v3.1.3"
 calico_upgrade_image: "quay.io/calico/upgrade:v1.0.5"
 calico_ipv4pool_ipip: "always"


### PR DESCRIPTION
This PR updates the default Calico versions from v2 to v3 so any new Calico installation will default to a v3 implementation and will not require a re-run of the playbooks to upgrade.

This is a copy of https://github.com/openshift/openshift-ansible/pull/9275 in order to add these changes to the `release-3.10` branch.