### PR TITLE
Cope with OpenShift returning no value when an environment variable is an empty string

### DIFF
--- a/roles/lib_openshift/library/oc_adm_registry.py
+++ b/roles/lib_openshift/library/oc_adm_registry.py
@@ -1669,8 +1669,12 @@ spec:
             return False
 
         for result in results:
-            if result['name'] == key and result['value'] == value:
-                return True
+            if result['name'] == key:
+                if 'value' not in result:
+                    if value == "" or value is None:
+                        return True
+                elif result['value'] == value:
+                    return True
 
         return False
 

--- a/roles/lib_openshift/library/oc_adm_router.py
+++ b/roles/lib_openshift/library/oc_adm_router.py
@@ -1878,8 +1878,12 @@ spec:
             return False
 
         for result in results:
-            if result['name'] == key and result['value'] == value:
-                return True
+            if result['name'] == key:
+                if 'value' not in result:
+                    if value == "" or value is None:
+                        return True
+                elif result['value'] == value:
+                    return True
 
         return False
 

--- a/roles/lib_openshift/library/oc_env.py
+++ b/roles/lib_openshift/library/oc_env.py
@@ -1560,8 +1560,12 @@ spec:
             return False
 
         for result in results:
-            if result['name'] == key and result['value'] == value:
-                return True
+            if result['name'] == key:
+                if 'value' not in result:
+                    if value == "" or value is None:
+                        return True
+                elif result['value'] == value:
+                    return True
 
         return False
 

--- a/roles/lib_openshift/library/oc_scale.py
+++ b/roles/lib_openshift/library/oc_scale.py
@@ -1547,8 +1547,12 @@ spec:
             return False
 
         for result in results:
-            if result['name'] == key and result['value'] == value:
-                return True
+            if result['name'] == key:
+                if 'value' not in result:
+                    if value == "" or value is None:
+                        return True
+                elif result['value'] == value:
+                    return True
 
         return False
 

--- a/roles/lib_openshift/library/oc_volume.py
+++ b/roles/lib_openshift/library/oc_volume.py
@@ -1594,8 +1594,12 @@ spec:
             return False
 
         for result in results:
-            if result['name'] == key and result['value'] == value:
-                return True
+            if result['name'] == key:
+                if 'value' not in result:
+                    if value == "" or value is None:
+                        return True
+                elif result['value'] == value:
+                    return True
 
         return False
 

--- a/roles/lib_openshift/src/lib/deploymentconfig.py
+++ b/roles/lib_openshift/src/lib/deploymentconfig.py
@@ -88,8 +88,12 @@ spec:
             return False
 
         for result in results:
-            if result['name'] == key and result['value'] == value:
-                return True
+            if result['name'] == key:
+                if 'value' not in result:
+                    if value == "" or value is None:
+                        return True
+                elif result['value'] == value:
+                    return True
 
         return False
 


### PR DESCRIPTION
oc get -o json will return only the key name when that value is an empty string (tested against OpenShift 3.9 client)

Without testing that "value" exists it's possible to trigger an exception.  Classic example here is the OpenShift routers, where the environment variables often remain set but without a value.