### PR TITLE
Add rc code to docker_creds module

### DIFF
--- a/roles/lib_utils/library/docker_creds.py
+++ b/roles/lib_utils/library/docker_creds.py
@@ -224,7 +224,7 @@ def run_module():
     if changed:
         write_config(module, docker_config, dest)
 
-    result = {'changed': changed}
+    result = {'changed': changed, 'rc': 0}
 
     module.exit_json(**result)
 


### PR DESCRIPTION
This commit ensures that successful attempts at creating
registry credentials returns an rc == 0.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1602120