### PR TITLE
Correct the unexpected result when StorageClassName set to ""

### DIFF
--- a/roles/lib_openshift/library/oc_pvc.py
+++ b/roles/lib_openshift/library/oc_pvc.py
@@ -1483,7 +1483,7 @@ class PersistentVolumeClaimConfig(object):
         self.data['spec']['resources']['requests'] = {}
         self.data['spec']['resources']['requests']['storage'] = self.vol_capacity
 
-        if self.storage_class_name:
+        if self.storage_class_name or self.storage_class_name == '':
             self.data['spec']['storageClassName'] = self.storage_class_name
 
 # pylint: disable=too-many-instance-attributes,too-many-public-methods


### PR DESCRIPTION
The PVC has been defined with a default storage class name, though storage class name is "" (zero length string) [0]. It's not expected result. 

- Examples, it already configured glusterfs as default storage class as `glusterfs-storagefs` name
  - `name-pvc` : `storage_class_name: testclassname`
    - expected result is : `testclassname`
  - `none-pvc` did not have storage class name parameter in his definition.
    - expected result is : default storage class name, `glusterfs-storage` 
  - `zerostr-pvc` : `storage_class_name: ''`
    - expected result is : no storage class name

- Before
```
# oc get pvc
NAME          STATUS    VOLUME    CAPACITY   ACCESS MODES   STORAGECLASS        AGE
name-pvc      Pending                                       testclassname       41s
none-pvc      Pending                                       glusterfs-storage   43s
zerostr-pvc   Pending                                       glusterfs-storage   42s
```
- After 
~~~
# oc get pvc
NAME          STATUS    VOLUME    CAPACITY   ACCESS MODES   STORAGECLASS        AGE
name-pvc      Pending                                       testclassname       22s
none-pvc      Pending                                       glusterfs-storage   24s
zerostr-pvc   Pending                                                           23s
~~~


- [0][https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims]
> PVCs don’t necessarily have to request a class. A PVC with its storageClassName set equal to "" is always interpreted to be requesting a PV with no class, so it can only be bound to PVs with no class (no annotation or one set equal to ""). A PVC with no storageClassName is not quite the same and is treated differently by the cluster depending on whether the DefaultStorageClass admission plugin is turned on.

- Opened BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1607109
