### PR TITLE
Fix order for invoking the hostpath storage task for registry

### DIFF
--- a/roles/openshift_hosted/tasks/registry.yml
+++ b/roles/openshift_hosted/tasks/registry.yml
@@ -101,7 +101,3 @@
     volume_mounts: "{{ openshift_hosted_registry_volumes }}"
     edits: "{{ openshift_hosted_registry_edits }}"
     force: "{{ True|bool in openshift_hosted_registry_force }}"
-
-- include_tasks: storage/hostpath.yml
-  when:
-  - openshift_hosted_registry_storage_kind | default(none) in ['hostpath']

--- a/roles/openshift_hosted/tasks/registry_storage.yml
+++ b/roles/openshift_hosted/tasks/registry_storage.yml
@@ -3,6 +3,10 @@
   when:
   - openshift_hosted_registry_storage_kind | default(none) == 'glusterfs' or openshift_hosted_registry_storage_glusterfs_swap
 
+- include_tasks: storage/hostpath.yml
+  when:
+  - openshift_hosted_registry_storage_kind | default(none) in ['hostpath']
+
 - when:
   - openshift_hosted_registry_storage_kind | default(none) == 'nfs'
   block:


### PR DESCRIPTION
When attempting to using the hostpath storage for the registry for an all-in-one setup, the playbook would fail due to an ordering issue that caused it to not be able to correctly wait for the pods to come
online after configuring.

This change moves it to the correct place, and unbreaks hostpath storage for all-in-one PoC configurations.

This is also needed for openshift-ansible in the 3.10 branch to fix it there.
