### PR TITLE
[release-3.10] Fix order for invoking the hostpath storage task for registry

### DIFF
--- a/roles/openshift_hosted/tasks/registry.yml
+++ b/roles/openshift_hosted/tasks/registry.yml
@@ -96,7 +96,3 @@
     volume_mounts: "{{ openshift_hosted_registry_volumes }}"
     edits: "{{ openshift_hosted_registry_edits }}"
     force: "{{ True|bool in openshift_hosted_registry_force }}"
-
-- include_tasks: storage/hostpath.yml
-  when:
-  - openshift_hosted_registry_storage_kind | default(none) in ['hostpath']

--- a/roles/openshift_hosted/tasks/registry_storage.yml
+++ b/roles/openshift_hosted/tasks/registry_storage.yml
@@ -2,3 +2,7 @@
 - include_tasks: storage/glusterfs.yml
   when:
   - openshift_hosted_registry_storage_kind | default(none) == 'glusterfs' or openshift_hosted_registry_storage_glusterfs_swap
+
+- include_tasks: storage/hostpath.yml
+  when:
+  - openshift_hosted_registry_storage_kind | default(none) in ['hostpath']


### PR DESCRIPTION
This is a manual cherry-pick of #9296 for release-3.10 since the automated one failed.