### PR TITLE
Default openshift_is_atomic to false for openshift_repos.

### DIFF
--- a/roles/openshift_repos/tasks/main.yaml
+++ b/roles/openshift_repos/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 
-- when: not openshift_is_atomic
+- when: not (openshift_is_atomic | default(False))
   block:
   # TODO: This needs to be removed and placed into a role
   - name: Ensure libselinux-python is installed


### PR DESCRIPTION
`openshift_repos` role was independent of the `openshift_is_atomic` up until recently.  Default `openshift_is_atomic` to `false`.

This should fix our recent CI failures:
```
TASK [openshift_repos : Ensure libselinux-python is installed] *****************
Monday 23 July 2018  15:56:53 +0000 (0:00:00.051)       0:04:28.701 *********** 
fatal: [40.114.114.218]: FAILED! => {"msg": "The conditional check 'not openshift_is_atomic' failed. The error was: error while evaluating conditional (not openshift_is_atomic): 'openshift_is_atomic' is undefined\n\nThe error appears to have been in '/usr/share/ansible/openshift-ansible/roles/openshift_repos/tasks/main.yaml': line 6, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  # TODO: This needs to be removed and placed into a role\n  - name: Ensure libselinux-python is installed\n    ^ here\n"}
```

If we would like to check whether `openshift_repos` role should be called on hosts that are atomic then the `is_atomic` check should be called where we include `openshift_repos` and remove the logic from the role itself.