### PR TITLE
When the node process is down, don't exit

### DIFF
--- a/roles/openshift_node_group/files/sync.yaml
+++ b/roles/openshift_node_group/files/sync.yaml
@@ -129,11 +129,16 @@ spec:
                   fi
                 fi
               else
-                echo "error: The downloaded node configuration is invalid, exiting" 2>&1
-                exit 1
+                echo "error: The downloaded node configuration is invalid, retrying later" 2>&1
+                sleep 10 &
+                wait $!
+                continue
               fi
-              if ! kill $(pgrep -U 0 -f '^/usr/bin/hyperkube kubelet ' | head -n1); then
+              if ! pkill -U 0 -f '(^|/)hyperkube kubelet '; then
                 echo "error: Unable to restart Kubelet" 2>&1
+                sleep 10 &
+                wait $!
+                continue
               fi
             fi
             cp -f /tmp/.new /tmp/.old


### PR DESCRIPTION
If the kubelet is down and we exit, we won't get restarted. Stay up
even if no kubelet processes are found. Also, use a simpler formulation
for finding the hyperkube process.

Without this, if a node-config.yaml is invalid the kubelet will stop and not come back up, which means an admin who is trying to correct the issue will have to manually copy the config file down. Instead, stay up.

@liggitt this is why api.ci went down and I had to manually tweak stuff