### PR TITLE
handle symlinks in openshift-ansible container image

### DIFF
--- a/images/installer/root/usr/local/bin/run
+++ b/images/installer/root/usr/local/bin/run
@@ -21,7 +21,7 @@ if [[ -v INVENTORY_FILE ]]; then
   cp ${INVENTORY_FILE} ${INVENTORY}
 elif [[ -v INVENTORY_DIR ]]; then
   INVENTORY="$(mktemp -d)"
-  cp -R ${INVENTORY_DIR}/* ${INVENTORY}
+  cp -RL ${INVENTORY_DIR}/* ${INVENTORY}
 elif [[ -v INVENTORY_URL ]]; then
   curl -o ${INVENTORY} ${INVENTORY_URL}
 elif [[ -v DYNAMIC_SCRIPT_URL ]]; then


### PR DESCRIPTION
when running the openshift-ansible container from within OpenShift, if you mount a configmap to the container with your host information and try to set INVENTORY_DIR for the container, it will copy the symlinks instead of the contents of the files being pointed to.

for example mounting a configmap with the files "hosts" "variables-for-all" at /ansible/inventory/*, the contents of /ansible/inventory/ will look like:

[jdiaz@goomba co (vars_as_inventory *%)]$ oc debug components-jdiaz-vhft4-w8zln-r6fk9 -c openshift-hosted -- ls -l /ansible/inventory
Debugging with pod/components-jdiaz-vhft4-w8zln-r6fk9-debug, original command: <image entrypoint>
Waiting for pod to start ...
total 0
lrwxrwxrwx. 1 root root 12 Jul 23 22:22 hosts -> ..data/hosts
lrwxrwxrwx. 1 root root 11 Jul 23 22:22 vars-for-all -> ..data/vars-for-all

when the container runs (/usr/local/bin/run) it will copy (cp -R) this directory to a temporary location, and the symlinks will be unresolvable

solve this by adding a '-L' to follow the symlinks and copy the contents of the files so that mounting data via configmaps can work