### PR TITLE
Correct a wrong PVC definition of the Cassandra based on the StorageClasses

### DIFF
--- a/roles/openshift_metrics/tasks/generate_cassandra_pvcs.yaml
+++ b/roles/openshift_metrics/tasks/generate_cassandra_pvcs.yaml
@@ -13,6 +13,8 @@
 - when:
     - _metrics_pvc.results.stderr is defined
   block:
+    # storageclasses are used by default but if static then disable
+    # storageclasses with the storageClassName set to "" in pvc.j2
     - name: generate hawkular-cassandra persistent volume claims
       template:
         src: pvc.j2
@@ -30,6 +32,7 @@
         - openshift_metrics_cassandra_storage_type != 'dynamic'
       changed_when: false
 
+    # Storageclasses are used by default if configured
     - name: generate hawkular-cassandra persistent volume claims (dynamic)
       template:
         src: pvc.j2
@@ -41,6 +44,5 @@
         access_modes: "{{ openshift_metrics_cassandra_pvc_access | list }}"
         size: "{{ openshift_metrics_cassandra_pvc_size }}"
         pv_selector: "{{ openshift_metrics_cassandra_pv_selector }}"
-        storage_class_name: "{{ openshift_metrics_cassanda_pvc_storage_class_name | default('', true) }}"
       when: openshift_metrics_cassandra_storage_type == 'dynamic'
       changed_when: false


### PR DESCRIPTION
Correction of wrong PVC definition based on upstream specification [0] in the Cluster Metrics roles.

- Modification list
  - Removing the wrong `storage_class_name` parameter in dynamic provision rules on  the playbook's task.
  - Adding helpful comments.

[0] Persistent Volume Claim [ https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims ]
> PVCs don’t necessarily have to request a class. A PVC with its storageClassName set equal to "" is always interpreted to be requesting a PV with no class, so it can only be bound to PVs with no class (no annotation or one set equal to ""). A PVC with no storageClassName is not quite the same and is treated differently by the cluster depending on whether the DefaultStorageClass admission plugin is turned on.
