### PR TITLE
Fix typo in install_prometheus.yaml file

### DIFF
--- a/roles/openshift_prometheus/tasks/install_prometheus.yaml
+++ b/roles/openshift_prometheus/tasks/install_prometheus.yaml
@@ -95,8 +95,8 @@
     labels:
       name: prometheus
     annotations:
-      oprometheus.io/scrape: 'true'
-      oprometheus.io/scheme: https
+      prometheus.io/scrape: 'true'
+      prometheus.io/scheme: https
       service.alpha.openshift.io/serving-cert-secret-name: prometheus-tls
     ports:
     - name: prometheus


### PR DESCRIPTION
There is not 'o' char prefix for prometheus.io/* annotations.