### PR TITLE
[release-3.10] Upgrade Prometheus and AlertManager image versions

### DIFF
--- a/roles/openshift_prometheus/defaults/main.yaml
+++ b/roles/openshift_prometheus/defaults/main.yaml
@@ -41,11 +41,6 @@ openshift_prometheus_hostname: prometheus-{{openshift_prometheus_namespace}}.{{o
 openshift_prometheus_alerts_hostname: alerts-{{openshift_prometheus_namespace}}.{{openshift_master_default_subdomain}}
 openshift_prometheus_alertmanager_hostname: alertmanager-{{openshift_prometheus_namespace}}.{{openshift_master_default_subdomain}}
 
-l_openshift_prometheus_image_version: "{{ openshift_prometheus_image_version | default('v2.3.2') }}"
-l_openshift_prometheus_alertmanager_image_version: "{{ openshift_prometheus_alertmanager_image_version | default('v0.15.1') }}"
-l_openshift_prometheus_alertbuffer_image_version: "{{ openshift_prometheus_alertbuffer_image_version | default('v0.0.2') }}"
-l_openshift_prometheus_node_exporter_image_version: "{{ openshift_prometheus_node_exporter_image_version | default('v0.15.2') }}"
-
 openshift_prometheus_node_selector: "{{ openshift_hosted_infra_selector | default('node-role.kubernetes.io/infra=true') | map_from_pairs }}"
 
 openshift_prometheus_service_port: 443

--- a/roles/openshift_prometheus/defaults/main.yaml
+++ b/roles/openshift_prometheus/defaults/main.yaml
@@ -8,8 +8,8 @@ openshift_prometheus_namespace: openshift-metrics
 # Need to standardise these tags
 l_openshift_prometheus_version_dict:
   origin:
-    prometheus: 'v2.2.1'
-    alert_manager: 'v0.14.0'
+    prometheus: 'v2.3.2'
+    alert_manager: 'v0.15.1'
     alert_buffer: 'v0.0.2'
     node_exporter: 'v0.15.2'
   openshift-enterprise:
@@ -41,8 +41,8 @@ openshift_prometheus_hostname: prometheus-{{openshift_prometheus_namespace}}.{{o
 openshift_prometheus_alerts_hostname: alerts-{{openshift_prometheus_namespace}}.{{openshift_master_default_subdomain}}
 openshift_prometheus_alertmanager_hostname: alertmanager-{{openshift_prometheus_namespace}}.{{openshift_master_default_subdomain}}
 
-l_openshift_prometheus_image_version: "{{ openshift_prometheus_image_version | default('v2.2.1') }}"
-l_openshift_prometheus_alertmanager_image_version: "{{ openshift_prometheus_alertmanager_image_version | default('v0.14.0') }}"
+l_openshift_prometheus_image_version: "{{ openshift_prometheus_image_version | default('v2.3.2') }}"
+l_openshift_prometheus_alertmanager_image_version: "{{ openshift_prometheus_alertmanager_image_version | default('v0.15.1') }}"
 l_openshift_prometheus_alertbuffer_image_version: "{{ openshift_prometheus_alertbuffer_image_version | default('v0.0.2') }}"
 l_openshift_prometheus_node_exporter_image_version: "{{ openshift_prometheus_node_exporter_image_version | default('v0.15.2') }}"
 


### PR DESCRIPTION
I've opened this pull request against `release-3.10` only because [openshift_prometheus](https://github.com/openshift/openshift-ansible/tree/master/roles/openshift_prometheus) is replaced by [openshift_monitoring](https://github.com/openshift/openshift-ansible/tree/master/roles/openshift_monitoring) in master.