### PR TITLE
Clean /etc/target directory as part of glusterfs uninstall to

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
@@ -106,6 +106,13 @@
     selector: "glusterblock"
   failed_when: False
 
+- name: Delete pre-existing glusterblock config
+  file:
+    path: /etc/target
+    state: absent
+  delegate_to: "{{ item }}"
+  with_items: "{{ glusterfs_nodes | default([]) }}"
+
 - name: Delete gluster-s3 resources
   oc_obj:
     namespace: "{{ glusterfs_namespace }}"


### PR DESCRIPTION
Clean /etc/target directory as part of glusterfs uninstall to remove all gluster-block related configutation details.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>