### PR TITLE
oc_obj should correctly identify  'results': [{}] as 'Object not found'

### DIFF
--- a/roles/lib_openshift/library/oc_obj.py
+++ b/roles/lib_openshift/library/oc_obj.py
@@ -1624,9 +1624,10 @@ class OCObject(OpenShiftCLI):
         # Delete
         ########
         if state == 'absent':
-            # verify its not in our results
+            # verify it's not in our results
             if (params['name'] is not None or params['selector'] is not None) and \
                (len(api_rval['results']) == 0 or \
+               (not api_rval['results'][0]) or \
                ('items' in api_rval['results'][0] and len(api_rval['results'][0]['items']) == 0)):
                 return {'changed': False, 'state': state}
 

--- a/roles/lib_openshift/src/class/oc_obj.py
+++ b/roles/lib_openshift/src/class/oc_obj.py
@@ -134,9 +134,10 @@ class OCObject(OpenShiftCLI):
         # Delete
         ########
         if state == 'absent':
-            # verify its not in our results
+            # verify it's not in our results
             if (params['name'] is not None or params['selector'] is not None) and \
                (len(api_rval['results']) == 0 or \
+               (not api_rval['results'][0]) or \
                ('items' in api_rval['results'][0] and len(api_rval['results'][0]['items']) == 0)):
                 return {'changed': False, 'state': state}
 


### PR DESCRIPTION
On 3.9 oc_obj currently attempts to re-delete missing objects and reports 'changed'.