### PR TITLE
Openstack dynamic inventory - Filter hosts based on OPENSHIFT_CLUSTER env variable

### DIFF
--- a/playbooks/openstack/inventory.py
+++ b/playbooks/openstack/inventory.py
@@ -124,11 +124,11 @@ def build_inventory():
     '''Build the dynamic inventory.'''
     cloud = shade.openstack_cloud()
 
-    # TODO(shadower): filter the servers based on the `OPENSHIFT_CLUSTER`
-    # environment variable.
+    cluster_name = os.getenv('OPENSHIFT_CLUSTER', 'openshift-cluster')
     cluster_hosts = [
         server for server in cloud.list_servers()
-        if 'metadata' in server and 'clusterid' in server.metadata]
+        if 'metadata' in server and 'clusterid' in server.metadata
+        and server.metadata['clusterid'] == cluster_name]
 
     inventory = base_openshift_inventory(cluster_hosts)
 


### PR DESCRIPTION
This change supports having different openshift clusters in the same Openstack project. The `OPENSHIFT_CLUSTER` was already used by the script in some operations,