### PR TITLE
Fedora: Install kernel-modules

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/kernel_modules.yml
+++ b/roles/openshift_storage_glusterfs/tasks/kernel_modules.yml
@@ -5,6 +5,10 @@
     dest: /etc/modules-load.d/glusterfs.conf
   register: km
 
+- name: Install kernel modules package on Fedora
+  shell: "dnf install kernel-modules-$(uname -r) -y"
+  when: ansible_distribution == "Fedora"
+
 - name: load kernel modules
   systemd:
     name: systemd-modules-load.service


### PR DESCRIPTION
Necessary module for gluster is not installed by default
in fedora.

This commit ensures the proper package is installed.