### PR TITLE
Disable papr on pull requests

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -42,6 +42,9 @@ tests:
 artifacts:
   - journals/
 
+pulls: false
+required: false
+
 ---
 inherit: true
 context: 'fedora/27/atomic/upgrade_minor'


### PR DESCRIPTION
These tests have been subject to persistent failure. The failures do not directly correlate to our switch from older deployment methods to static pods but instead seem to have starter happening weeks after that change happened. Performance of these instances does not seem to be sufficient in order to deliver reliable test results.