### PR TITLE
Fix glusterfs storageclass heketi url

### DIFF
--- a/roles/openshift_storage_glusterfs/templates/glusterfs-storageclass.yml.j2
+++ b/roles/openshift_storage_glusterfs/templates/glusterfs-storageclass.yml.j2
@@ -9,7 +9,7 @@ metadata:
 {% endif %}
 provisioner: kubernetes.io/glusterfs
 parameters:
-  resturl: "http://{% if glusterfs_heketi_is_native %}heketi-{{ glusterfs_name }}.{{ glusterfs_namespace }}.svc.svc.cluster.local:8080{% else %}{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}{% endif %}"
+  resturl: "http://{% if glusterfs_heketi_is_native %}heketi-{{ glusterfs_name }}.{{ glusterfs_namespace }}.svc.cluster.local:8080{% else %}{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}{% endif %}"
   restuser: "admin"
 {% if glusterfs_heketi_admin_key is defined %}
   secretNamespace: "{{ glusterfs_namespace }}"


### PR DESCRIPTION
This commit removes errant extra .svc from url
for glusterfs storageclass.