### PR TITLE
fix bug 1608269

### DIFF
--- a/roles/olm/tasks/remove_components.yaml
+++ b/roles/olm/tasks/remove_components.yaml
@@ -13,34 +13,6 @@
     name: alm-operator-binding
     namespace: operator-lifecycle-manager
 
-- name: Remove clusterserviceversion-v1s.app.coreos.com CustomResourceDefinition manifest
-  oc_obj:
-    state: absent
-    kind: CustomResourceDefinition
-    name: clusterserviceversion-v1s.app.coreos.com
-    namespace: operator-lifecycle-manager
-
-- name: Remove catalogsource-v1s.app.coreos.com CustomResourceDefinition manifest
-  oc_obj:
-    state: absent
-    kind: CustomResourceDefinition
-    name: catalogsource-v1s.app.coreos.com
-    namespace: operator-lifecycle-manager
-
-- name: Remove installplan-v1s.app.coreos.com CustomResourceDefinition manifest
-  oc_obj:
-    state: absent
-    kind: CustomResourceDefinition
-    name: installplan-v1s.app.coreos.com
-    namespace: operator-lifecycle-manager
-
-- name: Remove subscription-v1s.app.coreos.com CustomResourceDefinition manifest
-  oc_obj:
-    state: absent
-    kind: CustomResourceDefinition
-    name: subscription-v1s.app.coreos.com
-    namespace: operator-lifecycle-manager
-
 - name: Remove tectonic-ocs ConfigMap manifest
   oc_obj:
     state: absent
@@ -81,4 +53,32 @@
     state: absent
     kind: CatalogSource-v1
     name: upstream-components
+    namespace: operator-lifecycle-manager
+
+- name: Remove clusterserviceversion-v1s.app.coreos.com CustomResourceDefinition manifest
+  oc_obj:
+    state: absent
+    kind: CustomResourceDefinition
+    name: clusterserviceversion-v1s.app.coreos.com
+    namespace: operator-lifecycle-manager
+
+- name: Remove catalogsource-v1s.app.coreos.com CustomResourceDefinition manifest
+  oc_obj:
+    state: absent
+    kind: CustomResourceDefinition
+    name: catalogsource-v1s.app.coreos.com
+    namespace: operator-lifecycle-manager
+
+- name: Remove installplan-v1s.app.coreos.com CustomResourceDefinition manifest
+  oc_obj:
+    state: absent
+    kind: CustomResourceDefinition
+    name: installplan-v1s.app.coreos.com
+    namespace: operator-lifecycle-manager
+
+- name: Remove subscription-v1s.app.coreos.com CustomResourceDefinition manifest
+  oc_obj:
+    state: absent
+    kind: CustomResourceDefinition
+    name: subscription-v1s.app.coreos.com
     namespace: operator-lifecycle-manager


### PR DESCRIPTION
Got below errors when uninstalling the olm via ansible.
```
"Error from server (NotFound): the server could not find the requested resource (delete catalogsource-v1s.app.coreos.com tectonic-ocs)\n".
```
Before the uninstalling, the "tectonic-ocs" did exist, I think we should put this removing before the CRD removing. This PR will fix this issue. Please refer bug [1608269](https://bugzilla.redhat.com/show_bug.cgi?id=1608269) for details.