### PR TITLE
Avoid using deprecated syntax for filters in OLM

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
@@ -18,7 +18,7 @@
     when:
     - openshift_pkg_version is defined
     - openshift_pkg_version != ""
-    - openshift_pkg_version.split('-',1).1 is version_compare(openshift_upgrade_target ,'<')
+    - openshift_pkg_version.split('-',1).1 is version(openshift_upgrade_target ,'<')
 
   - fail:
       msg: >
@@ -27,7 +27,7 @@
     when:
     - openshift_image_tag is defined
     - openshift_image_tag != ""
-    - openshift_image_tag.split('v',1).1 is version_compare(openshift_upgrade_target ,'<')
+    - openshift_image_tag.split('v',1).1 is version(openshift_upgrade_target ,'<')
 
   - set_fact:
       openshift_release: "{{ openshift_release[1:] }}"
@@ -39,7 +39,7 @@
         valid release for a {{ openshift_upgrade_target }} upgrade
     when:
     - openshift_release is defined
-    - not (openshift_release is version_compare(openshift_upgrade_target ,'='))
+    - not (openshift_release is version(openshift_upgrade_target ,'='))
 
 - name: Verify master processes
   hosts: oo_masters_to_config

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -43,11 +43,11 @@
     fail:
       msg: "OpenShift {{ avail_openshift_version }} is available, but {{ openshift_upgrade_target }} or greater is required"
     when:
-    - (openshift_pkg_version | default('-0.0', True)).split('-')[1] is version_compare(openshift_upgrade_target, '<')
+    - (openshift_pkg_version | default('-0.0', True)).split('-')[1] is version(openshift_upgrade_target, '<')
 
 - name: Fail when openshift version does not meet minimum requirement for Origin upgrade
   fail:
     msg: "This upgrade playbook must be run against OpenShift {{ openshift_upgrade_min }} or later"
   when:
   - openshift_deployment_type == 'origin'
-  - openshift_current_version is version_compare(openshift_upgrade_min,'<')
+  - openshift_current_version is version(openshift_upgrade_min,'<')

--- a/playbooks/init/basic_facts.yml
+++ b/playbooks/init/basic_facts.yml
@@ -61,7 +61,7 @@
     - name: assert atomic host docker version is 1.12 or later
       assert:
         that:
-        - l_atomic_docker_version.stdout | replace('"', '') is version_compare('1.12','>=')
+        - l_atomic_docker_version.stdout | replace('"', '') is version('1.12','>=')
         msg: Installation on Atomic Host requires Docker 1.12 or later. Please upgrade and restart the Atomic Host.
 
 - name: Retrieve existing master configs and validate

--- a/playbooks/olm/private/config.yml
+++ b/playbooks/olm/private/config.yml
@@ -20,7 +20,7 @@
   tasks:
   - import_role:
       name: olm
-    when: openshift_version | version_compare('3.9', '>=')
+    when: openshift_version is version_compare('3.9', '>=')
 
 - name: OLM Install Checkpoint End
   hosts: all

--- a/playbooks/olm/private/config.yml
+++ b/playbooks/olm/private/config.yml
@@ -20,7 +20,7 @@
   tasks:
   - import_role:
       name: olm
-    when: openshift_version is version_compare('3.9', '>=')
+    when: openshift_version is version('3.9', '>=')
 
 - name: OLM Install Checkpoint End
   hosts: all

--- a/playbooks/openshift-etcd/private/upgrade_rpm_members.yml
+++ b/playbooks/openshift-etcd/private/upgrade_rpm_members.yml
@@ -12,5 +12,5 @@
       r_etcd_upgrade_version: "{{ etcd_upgrade_version }}"
       etcd_peer: "{{ openshift.common.hostname }}"
     when:
-    - etcd_rpm_version.stdout | default('99') is version_compare(etcd_upgrade_version, '<')
+    - etcd_rpm_version.stdout | default('99') is version(etcd_upgrade_version, '<')
     - ansible_distribution == 'RedHat'

--- a/playbooks/openshift-master/private/additional_config.yml
+++ b/playbooks/openshift-master/private/additional_config.yml
@@ -51,7 +51,7 @@
     when:
     - openshift_cloudprovider_kind is defined
     - openshift_cloudprovider_kind == 'vsphere'
-    - openshift_version is version_compare('3.9', '>=')
+    - openshift_version is version('3.9', '>=')
 
 - name: update vsphere provider master config
   hosts: oo_masters_to_config

--- a/roles/container_runtime/tasks/docker_sanity.yml
+++ b/roles/container_runtime/tasks/docker_sanity.yml
@@ -8,7 +8,7 @@
   when:
   - not (curr_docker_version is skipped)
   - curr_docker_version.stdout != ''
-  - curr_docker_version.stdout is version_compare(l_required_docker_version, '<')
+  - curr_docker_version.stdout is version(l_required_docker_version, '<')
   - not (docker_version is defined)
 
 - name: Error out if requested Docker is too old
@@ -16,4 +16,4 @@
     msg: "Docker {{ docker_version }} requested, but >= {{ l_required_docker_version }} is required."
   when:
   - docker_version is defined
-  - docker_version is version_compare(l_required_docker_version, '<')
+  - docker_version is version(l_required_docker_version, '<')

--- a/roles/container_runtime/tasks/docker_upgrade_check.yml
+++ b/roles/container_runtime/tasks/docker_upgrade_check.yml
@@ -45,7 +45,7 @@
     - docker_version is not defined
     - docker_upgrade | bool
     - pkg_check.rc == 0
-    - avail_docker_version.stdout == "" or avail_docker_version.stdout is version_compare(l_required_docker_version,'<')
+    - avail_docker_version.stdout == "" or avail_docker_version.stdout is version(l_required_docker_version,'<')
 
 # Default l_docker_upgrade to False, we'll set to True if an upgrade is required:
 - set_fact:
@@ -65,7 +65,7 @@
   when:
     - not openshift_is_atomic | bool
     - pkg_check.rc == 0
-    - curr_docker_version.stdout is version_compare(docker_version,'<')
+    - curr_docker_version.stdout is version(docker_version,'<')
 
 # Additional checks for Atomic hosts:
 - name: Determine available Docker
@@ -82,4 +82,4 @@
     msg: "This playbook requires access to Docker {{ l_required_docker_version }} or later"
   when:
     - openshift_is_atomic | bool
-    - l_docker_version.avail_version | default(l_docker_version.curr_version, true) is version_compare(l_required_docker_version,'<')
+    - l_docker_version.avail_version | default(l_docker_version.curr_version, true) is version(l_required_docker_version,'<')

--- a/roles/openshift_control_plane/tasks/upgrade.yml
+++ b/roles/openshift_control_plane/tasks/upgrade.yml
@@ -64,7 +64,7 @@
     src: "{{ openshift.common.config_base }}/master/master-config.yaml"
     key: 'projectConfig.defaultNodeSelector'
     value: '{{ hostvars[groups.oo_first_master.0].l_osm_default_node_selector }}'
-  when: openshift_upgrade_target is version_compare('3.9', '>=')
+  when: openshift_upgrade_target is version('3.9', '>=')
 
 - name: Remove use of pod presets from master config
   yedit:

--- a/roles/openshift_excluder/tasks/verify_excluder.yml
+++ b/roles/openshift_excluder/tasks/verify_excluder.yml
@@ -29,4 +29,4 @@
     msg: "Available {{ excluder }} version {{ excluder_version }} is higher than the upgrade target version"
   when:
   - excluder_version != ''
-  - excluder_version.split('.')[0:2] | join('.') is version_compare(r_openshift_excluder_upgrade_target.split('.')[0:2] | join('.'), '>', strict=True)
+  - excluder_version.split('.')[0:2] | join('.') is version(r_openshift_excluder_upgrade_target.split('.')[0:2] | join('.'), '>', strict=True)

--- a/roles/openshift_node/tasks/storage_plugins/glusterfs.yml
+++ b/roles/openshift_node/tasks/storage_plugins/glusterfs.yml
@@ -33,7 +33,7 @@
   # since getsebool prints the resolved name.  (At some point Ansible's seboolean module
   # should learn to deal with aliases)
   - item.item in item.stdout  # Boolean does not have an alias.
-  - ansible_python_version is version_compare('3', '<')
+  - ansible_python_version is version('3', '<')
   with_items: "{{ fusefs_getsebool_status.results }}"
 
 # Workaround for https://github.com/openshift/openshift-ansible/issues/4438
@@ -54,5 +54,5 @@
   # should learn to deal with aliases)
   - item.item in item.stdout  # Boolean does not have an alias.
   - ('--> off' in item.stdout)  # Boolean is currently off.
-  - ansible_python_version is version_compare('3', '>=')
+  - ansible_python_version is version('3', '>=')
   with_items: "{{ fusefs_getsebool_status.results }}"

--- a/roles/openshift_node/tasks/storage_plugins/nfs.yml
+++ b/roles/openshift_node/tasks/storage_plugins/nfs.yml
@@ -33,7 +33,7 @@
   # since getsebool prints the resolved name.  (At some point Ansible's seboolean module
   # should learn to deal with aliases)
   - item.item in item.stdout  # Boolean does not have an alias.
-  - ansible_python_version is version_compare('3', '<')
+  - ansible_python_version is version('3', '<')
   with_items: "{{ nfs_getsebool_status.results }}"
 
 # Workaround for https://github.com/openshift/openshift-ansible/issues/4438
@@ -53,5 +53,5 @@
   # should learn to deal with aliases)
   - item.item in item.stdout  # Boolean does not have an alias.
   - ('--> off' in item.stdout)  # Boolean is currently off.
-  - ansible_python_version is version_compare('3', '>=')
+  - ansible_python_version is version('3', '>=')
   with_items: "{{ nfs_getsebool_status.results }}"

--- a/roles/openshift_openstack/tasks/container-storage-setup.yml
+++ b/roles/openshift_openstack/tasks/container-storage-setup.yml
@@ -8,7 +8,7 @@
         group: root
         mode: 0644
   when:
-    - ansible_distribution_version is version_compare('7.4', '>=')
+    - ansible_distribution_version is version('7.4', '>=')
     - ansible_distribution == "RedHat"
 
 - block:
@@ -20,7 +20,7 @@
         group: root
         mode: 0644
   when:
-    - ansible_distribution_version is version_compare('7.4', '<')
+    - ansible_distribution_version is version('7.4', '<')
     - ansible_distribution == "RedHat"
 
 - block:


### PR DESCRIPTION
Ansible 2.6 has deprecated `|`-style syntax for filters.

This PR also uses `version` filter instead of `version_compare` ([updated in Ansible 2.5](https://docs.ansible.com/ansible/2.5/user_guide/playbooks_tests.html#version-comparison))