### PR TITLE
ignore failing dns clean errors when running openstack uninstall

### DIFF
--- a/playbooks/openstack/openshift-cluster/uninstall.yml
+++ b/playbooks/openstack/openshift-cluster/uninstall.yml
@@ -17,6 +17,7 @@
 
 - name: Clean DNS entries
   hosts: localhost
+  ignore_errors: True
   tasks:
   - name: Clean DNS entries
     import_role:


### PR DESCRIPTION
If the heat stack fails but partially deploys, running the uninstall playbook will fail when trying to clean DNS. Allow the clean DNS task to fail and move on.