### PR TITLE
Allow shared_non_ops as kibana index mode

### DIFF
--- a/roles/openshift_logging_elasticsearch/vars/main.yml
+++ b/roles/openshift_logging_elasticsearch/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 __allowed_es_types: ["data-master", "data-client", "master", "client"]
 __es_log_appenders: ['file', 'console']
-__kibana_index_modes: ["unique", "shared_ops"]
+__kibana_index_modes: ["unique", "shared_ops", "shared_non_ops"]
 
 __es_local_curl: "curl -s --cacert /etc/elasticsearch/secret/admin-ca --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key"
 


### PR DESCRIPTION
Included in openshift elasticsearch plugin 2.4.4
elasticsearch in 3.9 is using 2.4.4 as well.

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1608984