### PR TITLE
Disable yum-cron by default on GCP

### DIFF
--- a/playbooks/gcp/openshift-cluster/build_base_image.yml
+++ b/playbooks/gcp/openshift-cluster/build_base_image.yml
@@ -111,6 +111,11 @@
     package:
       name: qemu-user-static
       state: present
+  - name: Disable yum-cron service (installed by Google Cloud by default)
+    systemd:
+      name: yum-cron
+      state: stopped
+      enabled: no
   - name: Start and enable systemd-binfmt service
     systemd:
       name: systemd-binfmt


### PR DESCRIPTION
When using golden images, having an auto-update can be disruptive and
result in things like docker being installed and restarting all the
workload processes. This is a GCP specific issue since Red Hat doesn't
enable yum-cron update by default on most VMs.