### PR TITLE
Fix docker reg auth bugs

### DIFF
--- a/roles/container_runtime/tasks/registry_auth.yml
+++ b/roles/container_runtime/tasks/registry_auth.yml
@@ -10,9 +10,11 @@
     password: "{{ oreg_auth_password }}"
     # Test that we can actually connect with provided info
     test_login: "{{ oreg_test_login | default(True) }}"
+    proxy_vars: "{{ l_docker_creds_proxy_vars }}"
+    image_name: "{{ l_docker_creds_image_name }}"
   when:
   - oreg_auth_user is defined
   register: crt_oreg_auth_credentials_create
   retries: 3
   delay: 5
-  until: crt_oreg_auth_credentials_create.rc == 0
+  until: crt_oreg_auth_credentials_create is succeeded

--- a/roles/openshift_control_plane/tasks/registry_auth.yml
+++ b/roles/openshift_control_plane/tasks/registry_auth.yml
@@ -10,10 +10,12 @@
     password: "{{ oreg_auth_password }}"
     # Test that we can actually connect with provided info
     test_login: "{{ oreg_test_login | default(True) }}"
+    proxy_vars: "{{ l_docker_creds_proxy_vars }}"
+    image_name: "{{ l_docker_creds_image_name }}"
   when:
   - oreg_auth_user is defined
   register: master_oreg_auth_credentials_create
   notify: restart master
   retries: 3
   delay: 5
-  until: master_oreg_auth_credentials_create.rc == 0
+  until: master_oreg_auth_credentials_create is succeeded

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -15,6 +15,16 @@ l_oreg_host_temp: "{{ oreg_url | default(l_osm_registry_url_default) }}"
 # oreg_url is defined by user input.
 oreg_host: "{{ l_oreg_host_temp.split('/')[0] }}"
 
+l_docker_creds_image_dict:
+  openshift-enterprise: 'openshift3/ose'
+  origin: 'openshift/origin'
+l_docker_creds_image_name: "{{ l_docker_creds_image_dict[openshift_deployment_type] }}"
+
+l_docker_creds_http_proxy: "{{ 'HTTP_PROXY=' ~ openshift.common.http_proxy if openshift.common.http_proxy is defined and openshift.common.http_proxy != '' else ''}}"
+l_docker_creds_https_proxy: "{{ 'HTTPS_PROXY=' ~ openshift.common.https_proxy if openshift.common.https_proxy is defined and openshift.common.https_proxy != '' else ''}}"
+l_docker_creds_no_proxy: "{{ 'NO_PROXY=' ~ openshift.common.no_proxy if openshift.common.no_proxy is defined and openshift.common.no_proxy != '' else ''}}"
+l_docker_creds_proxy_vars: "{{ l_docker_creds_http_proxy }} {{ l_docker_creds_https_proxy }} {{ l_docker_creds_no_proxy }}"
+
 l_osm_registry_url: "{{ oreg_url | default(l_osm_registry_url_default) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
 l_os_registry_url: "{{ oreg_url | default(l_osm_registry_url_default) | regex_replace('${version}' | regex_escape, openshift_image_tag | default('${version}')) }}"
 openshift_image_default: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'node') }}"

--- a/roles/openshift_node/tasks/registry_auth.yml
+++ b/roles/openshift_node/tasks/registry_auth.yml
@@ -18,12 +18,14 @@
     password: "{{ oreg_auth_password }}"
     # Test that we can actually connect with provided info
     test_login: "{{ oreg_test_login | default(True) }}"
+    proxy_vars: "{{ l_docker_creds_proxy_vars }}"
+    image_name: "{{ l_docker_creds_image_name }}"
   when:
     - oreg_auth_user is defined
   register: node_oreg_auth_credentials_create
   retries: 3
   delay: 5
-  until: node_oreg_auth_credentials_create.rc == 0
+  until: node_oreg_auth_credentials_create is succeeded
 
 # Container images may need the registry credentials
 - name: Setup ro mount of /root/.docker for containerized hosts


### PR DESCRIPTION
This commit updates docker_creds custom module
to account for correct retry condition in task files.

This commit also updates the module's code to
test registry credentials with skopeo instead of
using a more simplistic python-request based approach.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1602120