### PR TITLE
[3.10] AWS: reboot instance before sealing

### DIFF
--- a/playbooks/aws/openshift-cluster/build_ami.yml
+++ b/playbooks/aws/openshift-cluster/build_ami.yml
@@ -34,6 +34,8 @@
 # This is the part that installs all of the software and configs for the instance
 # to become a node.
 - import_playbook: ../../openshift-node/private/image_prep.yml
+  vars:
+    openshift_node_reboot_instance_before_cleanup: true
 
 - import_playbook: seal_ami.yml
   vars:

--- a/playbooks/openshift-node/private/clean_image.yml
+++ b/playbooks/openshift-node/private/clean_image.yml
@@ -1,4 +1,19 @@
 ---
+- name: Reboot instance
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  # After installing certain packages rebooting the instance is a must before all
+  # changes (e.g. new Selinux rules) get properly applied and propagated.
+  # Must be done before the cloud-init is cleaned.
+  # Otherwise, the cloud-init will be run again.
+  - name: Reboot instance
+    import_role:
+      name: openshift_aws
+      tasks_from: reboot_instance.yml
+    when: openshift_node_reboot_instance_before_cleanup | default(false)
+
 - name: Configure nodes
   hosts: "{{ l_node_group }}"
   tasks:

--- a/roles/openshift_aws/tasks/reboot_instance.yml
+++ b/roles/openshift_aws/tasks/reboot_instance.yml
@@ -1,0 +1,24 @@
+---
+- name: fetch newly created instances
+  ec2_instance_facts:
+    region: "{{ openshift_aws_region }}"
+    filters:
+      "tag:Name": "{{ openshift_aws_base_ami_name }}"
+      instance-state-name: running
+  register: instancesout
+  retries: 20
+  delay: 3
+  until: instancesout.instances|length > 0
+
+- name: reboot hosts
+  shell: ( sleep 2 && reboot ) &
+  delegate_to: "{{ item.public_dns_name }}"
+  with_items: "{{ instancesout.instances }}"
+
+- name: wait for ssh to become available
+  wait_for_connection:
+    delay: 10
+    timeout: 600
+  delegate_to: "{{ item.public_dns_name }}"
+  with_items: "{{ instancesout.instances }}"
+  when: openshift_aws_wait_for_ssh | bool


### PR DESCRIPTION
After installing certain packages rebooting the instance is a must before all changes (e.g. new Selinux rules) get properly applied and propagated.

In my case I had to reboot an instance every time after installing/updating container-selinux before SDN/OVS started to work properly.

backport of https://github.com/openshift/openshift-ansible/pull/9294