### PR TITLE
[Bug 1609127] Add bool filter to all instances of openshift_use_crio

### DIFF
--- a/playbooks/openshift-hosted/private/config.yml
+++ b/playbooks/openshift-hosted/private/config.yml
@@ -30,9 +30,6 @@
 - import_playbook: cockpit-ui.yml
 
 - import_playbook: install_docker_gc.yml
-  when:
-  - openshift_use_crio | default(False) | bool
-  - openshift_crio_enable_docker_gc | default(True) | bool
 
 - name: Hosted Install Checkpoint End
   hosts: all

--- a/playbooks/openshift-hosted/private/install_docker_gc.yml
+++ b/playbooks/openshift-hosted/private/install_docker_gc.yml
@@ -2,6 +2,11 @@
 - name: Install docker gc
   hosts: oo_first_master
   gather_facts: false
+  roles:
+  - openshift_facts
   tasks:
-    - import_role:
-        name: openshift_docker_gc
+  - import_role:
+      name: openshift_docker_gc
+    when:
+    - openshift_use_crio | bool
+    - openshift_crio_enable_docker_gc | bool

--- a/playbooks/openshift-hosted/private/upgrade.yml
+++ b/playbooks/openshift-hosted/private/upgrade.yml
@@ -17,5 +17,5 @@
   - import_role:
       name: openshift_docker_gc
     when:
-    - openshift_use_crio | default(False) | bool
-    - openshift_crio_enable_docker_gc | default(True) | bool
+    - openshift_use_crio | bool
+    - openshift_crio_enable_docker_gc | bool

--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -75,8 +75,6 @@ docker_http_proxy: "{{ openshift_http_proxy | default('') }}"
 docker_https_proxy: "{{ openshift.common.https_proxy | default('') }}"
 docker_no_proxy: "{{ openshift.common.no_proxy | default('') }}"
 
-openshift_use_crio: False
-
 # Set pause_image variable for crio.conf.j2 required to start the crio service in package_crio.yml
 l_openshift_image_tag_default: "{{ 'v' ~ openshift_release if openshift_release is defined else 'latest' }}"
 l_openshift_image_tag: "{{ openshift_image_tag | default(l_openshift_image_tag_default) | string}}"

--- a/roles/openshift_control_plane/tasks/static_shim.yml
+++ b/roles/openshift_control_plane/tasks/static_shim.yml
@@ -10,10 +10,10 @@
   - "scripts/{{ l_runtime }}/master-logs"
   - "scripts/{{ l_runtime }}/master-restart"
   vars:
-    l_runtime: "{{ 'crio' if openshift_use_crio | default(False) else 'docker' }}"
+    l_runtime: "{{ 'crio' if (openshift_use_crio | bool) else 'docker' }}"
 
 - name: Ensure cri-tools installed
   package:
     name: cri-tools
     state: present
-  when: openshift_use_crio | default(False)
+  when: openshift_use_crio | bool

--- a/roles/openshift_docker_gc/defaults/main.yml
+++ b/roles/openshift_docker_gc/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-r_enable_docker_gc: "{{ openshift_crio_enable_docker_gc | default(True) }}"
+r_enable_docker_gc: "{{ openshift_crio_enable_docker_gc }}"
 r_docker_gc_node_selectors: "{{ openshift_crio_docker_gc_node_selector | default({'runtime': 'cri-o'}) }}"
 
 openshift_docker_gc_image_dict:

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -27,7 +27,9 @@ osm_image: "{{ l_osm_registry_url | regex_replace('${component}' | regex_escape,
 repoquery_cmd: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --latest-limit 1 -d 0', 'repoquery --plugins') }}"
 repoquery_installed: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --latest-limit 1 -d 0 --disableexcludes=all --installed', 'repoquery --plugins --installed') }}"
 
+openshift_use_crio: False
 openshift_use_crio_only: False
+openshift_crio_enable_docker_gc: True
 
 # osm_default_subdomain is an old migrated fact, can probably be removed.
 osm_default_subdomain: "router.default.svc.cluster.local"

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -145,7 +145,6 @@ r_openshift_node_os_firewall_allow: "{{ default_r_openshift_node_os_firewall_all
 # oreg_url is defined by user input
 oreg_auth_credentials_path: "{{ openshift_node_data_dir }}/.docker"
 l_bind_docker_reg_auth: False
-openshift_use_crio: False
 l_crio_var_sock: "/var/run/crio/crio.sock"
 
 openshift_docker_service_name: "docker"

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -25,7 +25,7 @@
     name: "{{ crio_pkgs | join (',') }}"
     state: latest
   when:
-  - openshift_use_crio | default(False)
+  - openshift_use_crio | bool
   register: crio_update
   vars:
     crio_pkgs:

--- a/roles/openshift_node/tasks/upgrade/restart.yml
+++ b/roles/openshift_node/tasks/upgrade/restart.yml
@@ -34,7 +34,7 @@
   service:
     name: cri-o
     state: started
-  when: openshift_use_crio | default(False)
+  when: openshift_use_crio | bool
 
 - name: Start node service
   service:

--- a/roles/openshift_node/tasks/upgrade/stop_services.yml
+++ b/roles/openshift_node/tasks/upgrade/stop_services.yml
@@ -23,11 +23,11 @@
   service:
     name: cri-o
     state: stopped
-  when: openshift_use_crio | default(False)
+  when: openshift_use_crio | bool
 
 # TODO: Need to determine if this is needed long term or just 3.9 to 3.10
 # Upgrading cri-o, at least from 1.9 to 1.10, requires that all
 # pods be stopped
 - name: Clean up cri-o pods
   script: clean-up-crio-pods.sh
-  when: openshift_use_crio | default(False)
+  when: openshift_use_crio | bool

--- a/roles/openshift_node/tasks/upgrade_pre.yml
+++ b/roles/openshift_node/tasks/upgrade_pre.yml
@@ -39,7 +39,7 @@
   register: result
   until: result is succeeded
   when:
-  - openshift_use_crio | default(False)
+  - openshift_use_crio | bool
   vars:
     crio_pkgs:
     - "cri-o"

--- a/roles/openshift_node_group/defaults/main.yml
+++ b/roles/openshift_node_group/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-openshift_use_crio: False
 l_crio_var_sock: "/var/run/crio/crio.sock"
 
 openshift_node_group_cloud_provider: "{{ openshift_cloudprovider_kind | default('') }}"


### PR DESCRIPTION
If the openshift_use_crio variable is specified in an INI style
inventory as "false", the value is treated as a string and not a
boolean.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1609127