### PR TITLE
Add default for openshift_cockpit_deployer_version

### DIFF
--- a/roles/cockpit-ui/defaults/main.yml
+++ b/roles/cockpit-ui/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 openshift_config_base: "/etc/origin"
+openshift_cockpit_deployer_version: "{{ openshift_image_tag }}"


### PR DESCRIPTION
If a version is not specified in inventory, the default in the template
is used which is 3.10.  This has the potential to install a different
version if a specific OpenShift version image tag was specified.