### PR TITLE
Cleanup node bootstrap / scaleup code

### DIFF
--- a/playbooks/azure/openshift-cluster/build_node_image.yml
+++ b/playbooks/azure/openshift-cluster/build_node_image.yml
@@ -11,15 +11,11 @@
     vars:
       create_args: --data-disk-sizes-gb 128
 
-  - set_fact:
-      openshift_node_bootstrap: True
-
 - hosts: nodes
   tasks:
   - set_fact:
       openshift_deployment_type: "{{ 'openshift-enterprise' if ansible_distribution == 'RedHat' else 'origin' }}"
       openshift_enable_origin_repo: False
-      openshift_node_bootstrap: True
       skip_node_svc_handlers: True
       openshift_additional_repos: "{{ azure_node_repos[ansible_distribution] }}"
       openshift_node_open_ports: [{"service":"Node exporter metrics", "port":"9100/tcp"}]

--- a/playbooks/init/evaluate_groups.yml
+++ b/playbooks/init/evaluate_groups.yml
@@ -101,28 +101,6 @@
     with_items: "{{ g_new_node_hosts | default(g_node_hosts | default([], true), true) }}"
     changed_when: no
 
-  - name: Evaluate oo_nodes_to_bootstrap
-    add_host:
-      name: "{{ item }}"
-      groups: oo_nodes_to_bootstrap
-      ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
-      ansible_become: "{{ g_sudo | default(omit) }}"
-    with_items: "{{ g_new_node_hosts | default(g_node_hosts | default([], true), true) }}"
-    changed_when: no
-
-  - name: Add masters to oo_nodes_to_bootstrap
-    add_host:
-      name: "{{ item }}"
-      groups: oo_nodes_to_bootstrap
-      ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
-      ansible_become: "{{ g_sudo | default(omit) }}"
-    with_items: "{{ g_new_master_hosts | default(g_master_hosts | default([], true), true) }}"
-    when:
-    # Add masters to oo_nodes_to_bootstrap when we are not scaling up.
-    # Add new masters to oo_nodes_to_bootstrap when we are scaling up masters.
-    - g_new_node_hosts | length == 0 or g_new_master_hosts | length > 0
-    changed_when: no
-
   - name: Evaluate oo_lb_to_config
     add_host:
       name: "{{ item }}"

--- a/playbooks/openshift-node/private/bootstrap.yml
+++ b/playbooks/openshift-node/private/bootstrap.yml
@@ -21,23 +21,23 @@
       groups: oo_exclude_bootstrapped_nodes
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_become: "{{ g_sudo | default(omit) }}"
-    with_items: "{{ groups.oo_nodes_to_bootstrap | default([]) }}"
+    with_items: "{{ groups.oo_nodes_to_config | default([]) }}"
     changed_when: no
     when: hostvars[item].openshift_is_bootstrapped | default(False) | bool
 
 - import_playbook: disable_excluders.yml
   vars:
-    l_node_group: oo_nodes_to_bootstrap:!oo_exclude_bootstrapped_nodes
+    l_node_group: oo_nodes_to_config:!oo_exclude_bootstrapped_nodes
 
 - import_playbook: configure_nodes.yml
   vars:
-    l_node_group: oo_nodes_to_bootstrap:!oo_exclude_bootstrapped_nodes
+    l_node_group: oo_nodes_to_config:!oo_exclude_bootstrapped_nodes
 
 - import_playbook: configure_bootstrap.yml
 
 - import_playbook: enable_excluders.yml
   vars:
-    l_node_group: oo_nodes_to_bootstrap:!oo_exclude_bootstrapped_nodes
+    l_node_group: oo_nodes_to_config:!oo_exclude_bootstrapped_nodes
 
 - name: Node Bootstrap Preparation Checkpoint End
   hosts: all

--- a/playbooks/openshift-node/private/certificates-backup.yml
+++ b/playbooks/openshift-node/private/certificates-backup.yml
@@ -14,7 +14,7 @@
       warn: no
 
 - name: Redeploy node certificates
-  hosts: oo_nodes_to_config:!oo_nodes_to_bootstrap
+  hosts: oo_nodes_to_config
   pre_tasks:
   - name: Remove CA certificate
     file:

--- a/playbooks/openshift-node/private/certificates.yml
+++ b/playbooks/openshift-node/private/certificates.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create OpenShift certificates for node hosts
-  hosts: oo_nodes_to_config:!oo_nodes_to_bootstrap
+  hosts: oo_nodes_to_config
   gather_facts: no
   roles:
   - role: openshift_node_certificates

--- a/playbooks/openshift-node/private/configure_bootstrap.yml
+++ b/playbooks/openshift-node/private/configure_bootstrap.yml
@@ -1,6 +1,6 @@
 ---
 - name: node bootstrap config
-  hosts: oo_nodes_to_bootstrap:!oo_exclude_bootstrapped_nodes
+  hosts: oo_nodes_to_config:!oo_exclude_bootstrapped_nodes
   tasks:
   - import_role:
       name: openshift_node

--- a/playbooks/openshift-node/private/join.yml
+++ b/playbooks/openshift-node/private/join.yml
@@ -14,7 +14,7 @@
           start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
 - name: Distribute bootstrap and start nodes
-  hosts: oo_nodes_to_bootstrap
+  hosts: oo_nodes_to_config
   gather_facts: no
   tasks:
   - import_role:
@@ -27,11 +27,11 @@
   tasks:
   - name: Dump all candidate bootstrap hostnames
     debug:
-      msg: "{{ groups['oo_nodes_to_bootstrap'] | default([]) }}"
+      msg: "{{ groups['oo_nodes_to_config'] | default([]) }}"
 
   - name: Find all hostnames for bootstrapping
     set_fact:
-      l_nodes_to_join: "{{ groups['oo_nodes_to_bootstrap'] | default([]) | map('extract', hostvars) | map(attribute='openshift.node.nodename') | list }}"
+      l_nodes_to_join: "{{ groups['oo_nodes_to_config'] | default([]) | map('extract', hostvars) | map(attribute='openshift.node.nodename') | list }}"
 
   - name: Dump the bootstrap hostnames
     debug:
@@ -57,7 +57,7 @@
         msg: Node approval failed
 
 - name: Ensure any inventory labels are applied to the nodes
-  hosts: oo_nodes_to_bootstrap
+  hosts: oo_nodes_to_config
   vars:
     openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
   roles:

--- a/roles/openshift_node/tasks/distribute_bootstrap.yml
+++ b/roles/openshift_node/tasks/distribute_bootstrap.yml
@@ -41,25 +41,3 @@
       msg: "{{ logs_node.stdout_lines }}"
   - fail:
       msg: Node start failed.
-
-# The restart above triggers previously approved nodes to go NotReady
-# We should wait for previously approved nodes to go Ready again
-- name: Wait for node to be ready
-  oc_obj:
-    state: list
-    kind: node
-    name: "{{ openshift.node.nodename | lower }}"
-  register: node_output
-  delegate_to: "{{ groups.oo_first_master.0 }}"
-  when: inventory_hostname in groups.oo_nodes_to_config
-  until:
-  - node_output.results is defined
-  - node_output.results.returncode is defined
-  - node_output.results.results is defined
-  - node_output.results.returncode == 0
-  - node_output.results.results[0].status is defined
-  - node_output.results.results[0].status.conditions | selectattr('type', 'match', '^Ready$') | map(attribute='status') | join | bool == True
-  # Give the node three minutes to come back online.
-  retries: 36
-  delay: 5
-  failed_when: False


### PR DESCRIPTION
This commit removes oo_nodes_to_bootstrap group
as it is unnecessary; all nodes are bootstrap nodes now.

This commit also resolves condition of attempting to
approve csr's for existing nodes (such as masters) during
scaleup.