### PR TITLE
Avoid to call install_node_exporter task during uninstallation.

### DIFF
--- a/roles/openshift_prometheus/tasks/main.yaml
+++ b/roles/openshift_prometheus/tasks/main.yaml
@@ -24,7 +24,7 @@
   when: openshift_prometheus_state == 'absent'
 
 - include_tasks: install_node_exporter.yaml
-  when: openshift_prometheus_node_exporter_install | default(true) | bool
+  when: openshift_prometheus_node_exporter_install | default(true) | bool and openshift_prometheus_state == 'present'
 
 - name: Delete temp directory
   file:


### PR DESCRIPTION
### Description
During Prometheus uninstall process the following error is displayed: 

`TASK [openshift_prometheus : Apply the node exporter template file] ***********************************************************************************************************************************************
fatal: [rhocpm-01.extlab.io]: FAILED! => {"changed": true, "cmd": "oc process -f \"/tmp/prometheus-ansible-CzvsPv/node-exporter-template.yaml\" --param IMAGE=\"registry.access.redhat.com/openshift3/prometheus-node-exporter:v3.9.33\" --param MEMORY_REQUESTS=\"30Mi\" --param CPU_REQUESTS=\"100m\" --param MEMORY_LIMITS=\"50Mi\" --param CPU_LIMITS=\"200m\" --config=/tmp/prometheus-ansible-CzvsPv/admin.kubeconfig -n \"openshift-metrics\" | oc apply --config=/tmp/prometheus-ansible-CzvsPv/admin.kubeconfig -f - -n \"openshift-metrics\"", "delta": "0:00:02.449086", "end": "2018-07-29 13:02:00.623063", "msg": "non-zero return code", "rc": 1, "start": "2018-07-29 13:01:58.173977", "stderr": "error: unable to process template\n  processedtemplates.template.openshift.io \"prometheus-node-exporter\" is forbidden: unable to create new content in namespace openshift-metrics because it is being terminated.\nerror: no objects passed to apply", "stderr_lines": ["error: unable to process template", "  processedtemplates.template.openshift.io \"prometheus-node-exporter\" is forbidden: unable to create new content in namespace openshift-metrics because it is being terminated.", "error: no objects passed to apply"], "stdout": "", "stdout_lines": []}
`
### How to reproduce
Run the config playbook with the variable **openshift_prometheus_state=absent**.

`
ansible-playbook -i path/to/inventory path/to/openshift-ansible/playbooks/openshift-prometheus/config.yml -e openshift_prometheus_state=absent
`

### Cause
This happens because the included task file **install_node_exporter.yml** is called after invoking the uninstall tasks (**uninstall_prometheus.yaml**) when the condition **openshift_prometheus_state** is evaluated to true.

### Solution
To avoid this error I added an and condition to test if **openshift_prometheus_state == 'present'** **inopenshift_prometheus/tasks/main.yaml**

`
when: openshift_prometheus_node_exporter_install | default(true) | bool and openshift_prometheus_state == 'present'
`

