### PR TITLE
Adding image info to /etc/origin/image.yml on Azure

### DIFF
--- a/playbooks/azure/openshift-cluster/build_node_image.yml
+++ b/playbooks/azure/openshift-cluster/build_node_image.yml
@@ -98,6 +98,18 @@
   tasks:
   - set_fact:
       openshift_rpm: "{{ hostvars[groups['nodes'][0]]['yum'].results | selectattr('name', 'match', '^(origin|atomic-openshift)$') | first }}"
+  - name: create a file with image name
+    copy:
+      content: |
+        ---
+        image_name: {{ openshift_azure_output_image_name }}
+        base_image: {{ (input_image.stdout | from_json).name }}
+        subscription: {{ lookup('env', 'AZURE_SUBSCRIPTION_ID') }}
+        resource_group: {{ openshift_azure_output_image_ns }}
+      dest: /etc/origin/image.yml
+      owner: root
+      group: root
+      mode: '0440'
 
   - name: create image
     import_tasks: tasks/create_image_from_vm.yml


### PR DESCRIPTION
Persist image metadata to a file.

Fixes https://github.com/openshift/openshift-ansible/issues/9371