### PR TITLE
Bug 1610224 - Unable to find container log in Elasticsearch when using cri-o

### DIFF
--- a/roles/openshift_logging_fluentd/templates/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/fluentd.j2
@@ -83,6 +83,9 @@ spec:
         - name: dockercfg
           mountPath: /etc/sysconfig/docker
           readOnly: true
+        - name: originnodecfg
+          mountPath: /etc/origin/node
+          readOnly: true
         - name: dockerdaemoncfg
           mountPath: /etc/docker
           readOnly: true
@@ -241,6 +244,9 @@ spec:
       - name: dockercfg
         hostPath:
           path: /etc/sysconfig/docker
+      - name: originnodecfg
+        hostPath:
+          path: /etc/origin/node
       - name: dockerdaemoncfg
         hostPath:
           path: /etc/docker


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1610224
The automatic detect of cri-o was broken in the merge of the
3.10 code to 3.11