### PR TITLE
Ensure the top level mount point is unmounted before other tasks

### DIFF
--- a/roles/container_runtime/tasks/common/setup_docker_symlink.yml
+++ b/roles/container_runtime/tasks/common/setup_docker_symlink.yml
@@ -11,6 +11,11 @@
       failed_when:
         - results.rc != 0
 
+    - name: ensure the unmount of top level mount point
+      mount:
+        path: "{{ docker_default_storage_path }}"
+        state: unmounted
+
     - name: "Set the selinux context on {{ docker_alt_storage_path }}"
       command: "semanage fcontext -a -e {{ docker_default_storage_path }} {{ docker_alt_storage_path }}"
       environment:


### PR DESCRIPTION
- Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1574887

If you install `CRI-O` with `overlay2` docker storage, you can encounter this issue.
If the docker storage is using `devicemapper`, the `/var/lib/docker` is unmounted as stopping the `docker  service`.
But, `overlay2` docker storage have top level mount point, and it's not unmounted after stopping the `docker service`.

- Overlay2 mount status (running docker)
~~~
# findmnt
...
└─/var/lib/docker                     /dev/mapper/docker--vg-docker--lv
                                                                xfs        rw,relatime,seclabel,attr2,inode64,prjquota
  ├─/var/lib/docker/containers        /dev/mapper/docker--vg-docker--lv[/containers]
                                                                xfs        rw,relatime,seclabel,attr2,inode64,prjquota
  └─/var/lib/docker/overlay2          /dev/mapper/docker--vg-docker--lv[/overlay2]
                                                                xfs        rw,relatime,seclabel,attr2,inode64,prjquota
~~~

- stopped docker service
~~~
# findmnt
...
└─/var/lib/docker                     /dev/mapper/docker--vg-docker--lv
                                                                xfs        rw,relatime,seclabel,attr2,inode64,prjquota
~~~

The /var/lib/docker mount is remained and it would causes this issue.