### PR TITLE
Add a license parameter to gcloud command

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -294,6 +294,10 @@ debug_level=2
 # openshift_gcp_prefix is a unique string to identify each openshift cluster.
 #openshift_gcp_prefix=
 #openshift_gcp_multizone=False
+# Note: To enable nested virtualization in gcp use the following variable and url
+#openshift_gcp_licenses="https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
+# Additional details regarding nested virtualization are available:
+# https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances
 #
 # vSphere
 #openshift_cloudprovider_kind=vsphere

--- a/playbooks/gcp/openshift-cluster/build_image.yml
+++ b/playbooks/gcp/openshift-cluster/build_image.yml
@@ -112,8 +112,16 @@
       zone: "{{ openshift_gcp_zone }}"
       instance_names: "{{ openshift_gcp_prefix }}build-image-instance"
       state: absent
+
   - name: Save the new image
-    command: gcloud --project "{{ openshift_gcp_project}}" compute images create "{{ openshift_gcp_image_name | default(openshift_gcp_image + '-' + lookup('pipe','date +%Y%m%d-%H%M%S')) }}" --source-disk "{{ openshift_gcp_prefix }}build-image-instance" --source-disk-zone "{{ openshift_gcp_zone }}" --family "{{ openshift_gcp_image }}"
+    command: >
+      gcloud
+      --project {{ openshift_gcp_project}} compute images create {{ (openshift_gcp_image_name | default(openshift_gcp_image + '-' + lookup('pipe','date +%Y%m%d-%H%M%S'))) | quote }}
+      --source-disk {{ (openshift_gcp_prefix + 'build-image-instance') | quote }}
+      --source-disk-zone {{ openshift_gcp_zone | quote }}
+      --family {{ openshift_gcp_image | quote }}
+      {% if openshift_gcp_licenses is defined %} --licenses {{ openshift_gcp_licenses | quote }}{% endif %}
+
   - name: Remove the image instance disk
     gce_pd:
       service_account_email: "{{ (lookup('file', openshift_gcp_iam_service_account_keyfile ) | from_json ).client_email }}"


### PR DESCRIPTION
Adding `openshift_gcp_licenses` parameter will allow the enablement of nested virtualization in a gcp instance.  This will allow openshift / kubevirt users to test virtual machines on gcp.

```
openshift_gcp_licenses: https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx
```