### PR TITLE
Fix ASB user and password defaults

### DIFF
--- a/roles/ansible_service_broker/vars/openshift-enterprise.yml
+++ b/roles/ansible_service_broker/vars/openshift-enterprise.yml
@@ -2,8 +2,8 @@
 __ansible_service_broker_registry_type: rhcc
 __ansible_service_broker_registry_name: rh
 __ansible_service_broker_registry_url: "https://registry.redhat.io"
-__ansible_service_broker_registry_user: "{{ oreg_auth_user | default(null) }}"
-__ansible_service_broker_registry_password: "{{ oreg_auth_password | default(null) }}"
+__ansible_service_broker_registry_user: "{{ oreg_auth_user | default(None) }}"
+__ansible_service_broker_registry_password: "{{ oreg_auth_password | default(None) }}"
 __ansible_service_broker_registry_organization: null
 __ansible_service_broker_registry_tag: "{{ openshift_image_tag }}"
 __ansible_service_broker_registry_whitelist:


### PR DESCRIPTION
@fabianvf @sdodson This should be the python null, `None`. Not the ansible null, `null`.

The task then passes successfully:

```
TASK [ansible_service_broker : Set default image variables based on deployment type] ******************************************************************************************************************************
task path: /usr/share/ansible/openshift-ansible/roles/ansible_service_broker/tasks/facts.yml:3
ok: [192.168.121.126.nip.io] => (item=/usr/share/ansible/openshift-ansible/roles/ansible_service_broker/vars/openshift-enterprise.yml) => {
    "ansible_facts": {
        "__ansible_service_broker_registry_name": "rh", 
        "__ansible_service_broker_registry_organization": null, 
        "__ansible_service_broker_registry_password": "{{ oreg_auth_password | default(None) }}", 
        "__ansible_service_broker_registry_tag": "{{ openshift_image_tag }}", 
        "__ansible_service_broker_registry_type": "rhcc", 
        "__ansible_service_broker_registry_url": "https://registry.redhat.io", 
        "__ansible_service_broker_registry_user": "{{ oreg_auth_user | default(None) }}", 
        "__ansible_service_broker_registry_whitelist": [
            ".*-apb$"
        ]
    }, 
    "ansible_included_var_files": [
        "/usr/share/ansible/openshift-ansible/roles/ansible_service_broker/vars/openshift-enterprise.yml"
    ], 
    "changed": false, 
    "item": "/usr/share/ansible/openshift-ansible/roles/ansible_service_broker/vars/openshift-enterprise.yml"
}

TASK [ansible_service_broker : set ansible_service_broker facts] **************************************************************************************************************************************************
task path: /usr/share/ansible/openshift-ansible/roles/ansible_service_broker/tasks/facts.yml:9
ok: [192.168.121.126.nip.io] => {
    "ansible_facts": {
        "ansible_service_broker_registry_name": "dh", 
        "ansible_service_broker_registry_organization": "", 
        "ansible_service_broker_registry_password": "", 
        "ansible_service_broker_registry_tag": "v3.11.0", 
        "ansible_service_broker_registry_type": "rhcc", 
        "ansible_service_broker_registry_url": "http://asb-registry.usersys.redhat.com:5000", 
        "ansible_service_broker_registry_user": "", 
        "ansible_service_broker_registry_whitelist": [
            ".*-apb$"
        ]
    }, 
    "changed": false
}
```