### PR TITLE
Ensure that etcd bash functions are deployed to static pod installs

### DIFF
--- a/roles/etcd/tasks/drop_etcdctl.yml
+++ b/roles/etcd/tasks/drop_etcdctl.yml
@@ -1,10 +1,4 @@
 ---
-- name: Install etcd for etcdctl
-  package: name=etcd state=present
-  when: not l_etcd_static_pod
-  register: result
-  until: result is succeeded
-
 - name: Configure etcd profile.d aliases
   template:
     dest: "/etc/profile.d/etcdctl.sh"

--- a/roles/etcd/tasks/rpm.yml
+++ b/roles/etcd/tasks/rpm.yml
@@ -10,11 +10,9 @@
   register: result
   until: result is succeeded
 
-- include_tasks: drop_etcdctl.yml
-  when:
-  - openshift_etcd_etcdctl_profile | default(true) | bool
+- import_tasks: drop_etcdctl.yml
 
-  # Start secondary etcd instance for third party integrations
+# Start secondary etcd instance for third party integrations
 # TODO: Determine an alternative to using thirdparty variable
 - block:
   - name: Create configuration directory

--- a/roles/etcd/tasks/static.yml
+++ b/roles/etcd/tasks/static.yml
@@ -17,6 +17,8 @@
   poll: 0
   register: etcd_prepull
 
+- import_tasks: drop_etcdctl.yml
+
 - name: setup firewall
   import_tasks: firewall.yml
 

--- a/roles/etcd/templates/etcdctl.sh.j2
+++ b/roles/etcd/templates/etcdctl.sh.j2
@@ -3,10 +3,19 @@
 # command flags are different between the two. Should work on stand
 # alone etcd hosts and master + etcd hosts too because we use the peer keys.
 etcdctl2() {
- /usr/bin/etcdctl --cert-file {{ etcd_peer_cert_file }} --key-file {{ etcd_peer_key_file }} --ca-file {{ etcd_peer_ca_file }} -C https://`hostname`:2379 ${@}
-
+ cmd="/usr/bin/etcdctl --cert-file {{ etcd_peer_cert_file }} --key-file {{ etcd_peer_key_file }} --ca-file { etcd_peer_ca_file }} -C https://`hostname`:2379 ${@}"
+ if [[ -f /usr/local/bin/master-exec ]]; then
+   /usr/local/bin/master-exec etcd etcd /bin/bash -c "$cmd"
+ else
+   /bin/bash -c "$cmd"
+ fi
 }
 
 etcdctl3() {
- ETCDCTL_API=3 /usr/bin/etcdctl --cert {{ etcd_peer_cert_file }} --key {{ etcd_peer_key_file }} --cacert {{ etcd_peer_ca_file }} --endpoints https://`hostname`:2379 ${@}
+ cmd="ETCDCTL_API=3 /usr/bin/etcdctl --cert {{ etcd_peer_cert_file }} --key {{ etcd_peer_key_file }} --cacert { etcd_peer_ca_file }} --endpoints https://`hostname`:2379 ${@}"
+ if [[ -f /usr/local/bin/master-exec ]]; then
+   /usr/local/bin/master-exec etcd etcd /bin/bash -c "$cmd"
+ else
+   /bin/bash -c "$cmd"
+ fi
 }


### PR DESCRIPTION
Runs etcdctl inside static pod if /usr/local/bin/master-exec exists otherwise runs it on the host.

Related https://bugzilla.redhat.com/show_bug.cgi?id=1610166