### PR TITLE
Add functionality for AWS DNS framework and route53 provider

### DIFF
--- a/playbooks/aws/openshift-cluster/provision.yml
+++ b/playbooks/aws/openshift-cluster/provision.yml
@@ -21,3 +21,5 @@
     import_role:
       name: openshift_aws
       tasks_from: provision.yml
+
+- import_playbook: provision_dns.yml

--- a/playbooks/aws/openshift-cluster/provision_dns.yml
+++ b/playbooks/aws/openshift-cluster/provision_dns.yml
@@ -1,0 +1,9 @@
+---
+- name: provision dns
+  hosts: localhost
+  connection: local
+  tasks:
+  - name: provision dns
+    import_role:
+      name: openshift_aws
+      tasks_from: provision_dns.yml

--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -61,6 +61,48 @@ openshift_aws_vpc:
 #    - cidr: 172.31.16.0/20
 #      az: "us-east-1a"
 
+openshift_aws_create_dns: False
+openshift_aws_dns_provider: "route53"
+# openshift_aws_dns_zone: ""
+# ie. openshift_aws_dns_zone: "{{ openshift_aws_clusterid }}.example.com"
+
+openshift_aws_dns_records:
+# Pertains to inventory file key: openshift_master_cluster_public_hostname
+- record: 'api'
+  elb_name: "{{ openshift_aws_elb_dict['master']['external']['name'] }}"
+  type: 'CNAME'
+  kind: 'elb'
+  private_zone: False
+# Pertains to inventory file key: openshift_master_cluster_hostname
+- record: 'internal.api'
+  elb_name: "{{ openshift_aws_elb_dict['master']['internal']['name'] }}"
+  type: 'CNAME'
+  kind: 'elb'
+  private_zone: False
+# Pertains to inventory file key: openshift_master_default_subdomain
+- record: '*.apps'
+  elb_name: "{{ openshift_aws_elb_dict['infra']['external']['name'] }}"
+  type: "CNAME"
+  kind: "elb"
+  private_zone: False
+- record: 'logs'
+  elb_name: "{{ openshift_aws_elb_dict['infra']['external']['name'] }}"
+  type: "CNAME"
+  kind: "elb"
+  private_zone: False
+- record: 'metrics'
+  elb_name: "{{ openshift_aws_elb_dict['infra']['external']['name'] }}"
+  type: "CNAME"
+  kind: "elb"
+  private_zone: False
+- record: 'registry'
+  elb_name: "{{ openshift_aws_elb_dict['infra']['external']['name'] }}"
+  type: "CNAME"
+  kind: "elb"
+  private_zone: False
+# A public or private vpc attached Route53 zone will be created based on
+# private_zone boolean.  Split-tier dns is supported.
+
 openshift_aws_elb_basename: "{{ openshift_aws_clusterid }}"
 openshift_aws_elb_master_external_name: "{{ openshift_aws_elb_basename }}-master-external"
 openshift_aws_elb_master_internal_name: "{{ openshift_aws_elb_basename }}-master-internal"

--- a/roles/openshift_aws/tasks/dns.yml
+++ b/roles/openshift_aws/tasks/dns.yml
@@ -1,0 +1,6 @@
+---
+- import_tasks: vpc_and_subnet_id.yml
+
+- name: provision route53
+  import_tasks: dns_route53.yml
+  when: "'route53' in openshift_aws_dns_provider"

--- a/roles/openshift_aws/tasks/dns_route53.yml
+++ b/roles/openshift_aws/tasks/dns_route53.yml
@@ -1,0 +1,17 @@
+---
+- name: creating route53 zone(s)
+  route53_zone:
+    comment: "{{ openshift_aws_dns_zone }}"
+    state: present
+    vpc_id: "{{ ( l_openshift_aws_route53_scheme | ternary(vpcout.vpcs.0.id, '') ) }}"
+    vpc_region: "{{ openshift_aws_region }}"
+    zone: "{{ openshift_aws_dns_zone }}"
+  loop: "{{ openshift_aws_dns_records | selectattr('private_zone','defined') | map(attribute='private_zone') | list | unique  }}"
+  loop_control:
+    loop_var: l_openshift_aws_route53_scheme
+
+- name: creating route53 record(s)
+  include_task: dns_route53_record.yml
+  with_items: "{{ openshift_aws_dns_records }}"
+  loop_control:
+    loop_var: l_openshift_aws_dns_element

--- a/roles/openshift_aws/tasks/dns_route53.yml
+++ b/roles/openshift_aws/tasks/dns_route53.yml
@@ -11,7 +11,7 @@
     loop_var: l_openshift_aws_route53_scheme
 
 - name: creating route53 record(s)
-  include_task: dns_route53_record.yml
+  include_tasks: dns_route53_record.yml
   with_items: "{{ openshift_aws_dns_records }}"
   loop_control:
     loop_var: l_openshift_aws_dns_element

--- a/roles/openshift_aws/tasks/dns_route53_record.yml
+++ b/roles/openshift_aws/tasks/dns_route53_record.yml
@@ -1,0 +1,22 @@
+---
+- debug: msg="{{ l_openshift_aws_dns_element }}"
+
+- name: querying elb
+  ec2_elb_facts:
+    names: "{{ l_openshift_aws_dns_element['elb_name'] }}"
+    region: "{{ openshift_aws_region }}"
+  register: elb_facts
+  when:
+    - "l_openshift_aws_dns_element.kind == 'elb'"
+    - "l_openshift_aws_dns_element.type == 'CNAME'"
+
+- name: creating record
+  route53:
+    command: create
+    overwrite: no
+    private_zone: "{{ l_openshift_aws_dns_element['private_zone'] }}"
+    record: "{{ l_openshift_aws_dns_element['record'] }}.{{ openshift_aws_dns_zone }}"
+    type: "{{ l_openshift_aws_dns_element['type'] }}"
+    ttl: 300
+    value: "{{ elb_facts.elbs[0].dns_name }}"
+    zone: "{{ openshift_aws_dns_zone }}"

--- a/roles/openshift_aws/tasks/provision_dns.yml
+++ b/roles/openshift_aws/tasks/provision_dns.yml
@@ -1,0 +1,4 @@
+---
+- name: provision dns
+  import_tasks: dns.yml
+  when: openshift_aws_create_dns | bool


### PR DESCRIPTION
https://trello.com/c/R6yaXLpF/666-aws-dns-hook

### Scenario:
As an openshift Ops admin
I want AWS provisioning to include a DNS hook and create the CNAME for the ELB so that I can browse to openshift_master_cluster_public_hostname or openshift_master_cluster_hostname when installer completes.

### Acceptance Criteria
- provision_install play should deploy all AWS infrastructure
- provision_install play should install OpenShift

### Notes:
- https://bugzilla.redhat.com/show_bug.cgi?id=1569635
- https://bugzilla.redhat.com/show_bug.cgi?id=1569631

Sorry about closing pull/9194.  After consulting with the team the fix for the scenario ended up being very easy.  
Sorry about closing pull/9264.  I created another rebase/commit to my forks master and wiped out the linked commit.  Amateur hour on my part.