### PR TITLE
Commit to enable AWS multi avail zone

### DIFF
--- a/roles/lib_utils/filter_plugins/openshift_aws_filters.py
+++ b/roles/lib_utils/filter_plugins/openshift_aws_filters.py
@@ -67,24 +67,8 @@ class FilterModule(object):
 
         return tags
 
-    @staticmethod
-    def get_default_az(subnets):
-        ''' From a list of subnets/AZs in a specific region (from the VPC
-            structure), return the AZ that has the key/value
-            'default_az=True.' '''
-
-        for subnet in subnets:
-            if subnet.get('default_az'):
-                return subnet['az']
-
-        # if there was none marked with default_az=True, just return the first
-        # one. (this does mean we could possible return an item that has
-        # default_az=False set
-        return subnets[0]['az']
-
     def filters(self):
         ''' returns a mapping of filters to methods '''
         return {'build_instance_tags': self.build_instance_tags,
-                'get_default_az': self.get_default_az,
                 'scale_groups_match_capacity': self.scale_groups_match_capacity,
                 'scale_groups_serial': self.scale_groups_serial}

--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -46,6 +46,21 @@ openshift_aws_ami_tags:
 openshift_aws_s3_mode: create
 openshift_aws_s3_bucket_name: "{{ openshift_aws_clusterid }}-docker-registry"
 
+openshift_aws_vpc_tags:
+  Name: "{{ openshift_aws_vpc_name }}"
+
+openshift_aws_vpc:
+  name: "{{ openshift_aws_vpc_name }}"
+  cidr: 172.31.0.0/16
+  subnets:
+    us-east-1:
+    - cidr: 172.31.48.0/20
+      az: "us-east-1c"
+#    - cidr: 172.31.32.0/20
+#      az: "us-east-1e"
+#    - cidr: 172.31.16.0/20
+#      az: "us-east-1a"
+
 openshift_aws_elb_basename: "{{ openshift_aws_clusterid }}"
 openshift_aws_elb_master_external_name: "{{ openshift_aws_elb_basename }}-master-external"
 openshift_aws_elb_master_internal_name: "{{ openshift_aws_elb_basename }}-master-internal"
@@ -265,8 +280,8 @@ openshift_aws_node_security_groups:
       to_port: 22
       cidr_ip: 0.0.0.0/0
     - proto: all
-      from_port: all
-      to_port: all
+      from_port: 1
+      to_port: 65535
       group_name: "{{ openshift_aws_clusterid }}"
   master:
     name: "{{ openshift_aws_clusterid }}_master"
@@ -302,24 +317,6 @@ openshift_aws_node_security_groups:
   etcd:
     name: "{{ openshift_aws_clusterid }}_etcd"
     desc: "{{ openshift_aws_clusterid }} etcd instances"
-
-openshift_aws_vpc_tags:
-  Name: "{{ openshift_aws_vpc_name }}"
-
-openshift_aws_vpc:
-  name: "{{ openshift_aws_vpc_name }}"
-  cidr: 172.31.0.0/16
-  subnets:
-    us-east-1:
-    - cidr: 172.31.48.0/20
-      az: "us-east-1c"
-      default_az: true
-    - cidr: 172.31.32.0/20
-      az: "us-east-1e"
-    - cidr: 172.31.16.0/20
-      az: "us-east-1a"
-
-openshift_aws_subnet_az: "{{ openshift_aws_vpc.subnets[openshift_aws_region] | get_default_az }}"
 
 openshift_aws_node_run_bootstrap_startup: True
 openshift_aws_node_user_data: ''

--- a/roles/openshift_aws/tasks/elb_single.yml
+++ b/roles/openshift_aws/tasks/elb_single.yml
@@ -12,8 +12,7 @@
     security_group_names: "{{ l_elb_security_groups[l_elb_dict_item.key] }}"
     idle_timeout: "{{ item.value.idle_timeout }}"
     region: "{{ openshift_aws_region }}"
-    subnets:
-    - "{{ subnetout.subnets[0].id }}"
+    subnets: "{{ subnetout.results | map(attribute='subnets.0.subnet_id') | list }}"
     health_check: "{{ item.value.health_check }}"
     instance_ids: "{{ item.value.instance_ids | default(omit) }}"
     listeners: "{{ item.value.listeners }}"

--- a/roles/openshift_aws/tasks/provision_instance.yml
+++ b/roles/openshift_aws/tasks/provision_instance.yml
@@ -8,7 +8,7 @@
     key_name: "{{ openshift_aws_ssh_key_name }}"
     group: "{{ openshift_aws_build_ami_group }}"
     instance_type: "{{ openshift_aws_instance_type }}"
-    vpc_subnet_id: "{{ openshift_aws_subnet_id | default(subnetout.subnets[0].id) }}"
+    vpc_subnet_id: "{{ subnetout.results[0].subnets[0].id }}"
     image: "{{ openshift_aws_base_ami }}"
     volumes: "{{ openshift_aws_node_group_config_node_volumes }}"
     wait: yes

--- a/roles/openshift_aws/tasks/scale_group.yml
+++ b/roles/openshift_aws/tasks/scale_group.yml
@@ -24,7 +24,7 @@
     termination_policies: "{{ l_node_group_config[openshift_aws_node_group.group].termination_policy if 'termination_policy' in  l_node_group_config[openshift_aws_node_group.group] else omit }}"
     load_balancers: "{{ l_node_group_config[openshift_aws_node_group.group].elbs if 'elbs' in l_node_group_config[openshift_aws_node_group.group] else omit }}"
     wait_for_instances: "{{ l_node_group_config[openshift_aws_node_group.group].wait_for_instances | default(False)}}"
-    vpc_zone_identifier: "{{ subnetout.subnets[0].id }}"
+    vpc_zone_identifier: "{{ subnetout.results | map(attribute='subnets.0.subnet_id') | list }}"
     replace_instances: "{{ openshift_aws_node_group_replace_instances if openshift_aws_node_group_replace_instances != [] else omit }}"
     replace_all_instances: "{{ omit if openshift_aws_node_group_replace_instances != []
                                     else (l_node_group_config[openshift_aws_node_group.group].replace_all_instances | default(omit)) }}"

--- a/roles/openshift_aws/tasks/vpc.yml
+++ b/roles/openshift_aws/tasks/vpc.yml
@@ -1,4 +1,16 @@
 ---
+- name: query azs
+  aws_az_facts:
+  register: azs
+
+- fail:
+    msg: >
+      AWS VPC does NOT contain
+      {{ openshift_aws_vpc.subnets[openshift_aws_region] | map(attribute='az') | list | length }} availability zone(s).
+      Please pick another region!
+  when:
+  - ( azs.availability_zones | length ) < ( openshift_aws_vpc.subnets[openshift_aws_region] | map(attribute='az') | list | length )
+
 - name: Create AWS VPC
   ec2_vpc_net:
     state: present

--- a/roles/openshift_aws/tasks/vpc_and_subnet_id.yml
+++ b/roles/openshift_aws/tasks/vpc_and_subnet_id.yml
@@ -11,12 +11,14 @@
     var: vpcout
     verbosity: 1
 
-- name: fetch the default subnet id
+- name: fetch the subnet ids
   ec2_vpc_subnet_facts:
     region: "{{ openshift_aws_region }}"
     filters:
-      "availability-zone": "{{ openshift_aws_subnet_az }}"
       vpc-id: "{{ vpcout.vpcs[0].id }}"
+      "tag:Name": "{{ item }}"
+  with_items:
+  - "{{ openshift_aws_vpc.subnets[openshift_aws_region] | map(attribute='az') | list }}"
   register: subnetout
 
 - name: debug subnetout


### PR DESCRIPTION
Commit to enable AWS multi avail zone!

Changes -
- roles/openshift_aws/defaults/main.yml - Additional subnets in openshift_aws_vpc are unused. We should not deploy them! We will now comment them by default. Additional elements will trigger subnets, ELB subnets, and ASG subnets. VPC items are relocated near the top of the infrastructure component list.
- roles/openshift_aws/tasks/elb_single.yml - Ensure subnets listed in openshift_aws_vpc dict are deployed.
- roles/openshift_aws/tasks/scale_group.yml - Ensure subnets listed in openshift_aws_vpc dict are deployed.
- roles/openshift_aws/tasks/vpc.yml - Adding a quick check to ensure the number of az's in openshift_aws_vpc are available in the accounts region.
- roles/openshift_aws/tasks/vpc_and_subnet_id.yml - Add with_items loops to deploy subnets and attempt to retain "default subnet" behavior.

Sorry about closing pull/9366.  I had to move this to a branch to avoid conflicts.