### PR TITLE
Enable console picker

### DIFF
--- a/roles/openshift_console/tasks/install.yml
+++ b/roles/openshift_console/tasks/install.yml
@@ -42,6 +42,11 @@
     dest: "{{ mktemp.stdout }}/{{ __console_config_file }}"
   when: existing_config_map_data['console-config.yaml'] is defined
 
+- set_fact:
+    # Must have a trailing slash
+    console_picker_developer_console_public_url: "{{ openshift.master.public_console_url }}/"
+  when: openshift_web_console_install | default(true) | bool
+
 # Generate a new config when a config map is not defined.
 - name: Set web console config properties from inventory variables
   yedit:
@@ -53,6 +58,8 @@
       value: "{{ openshift_console_base_path | default('') }}"
     - key: clusterInfo#masterPublicURL
       value: "{{ openshift.master.public_api_url }}"
+    - key: clusterInfo#developerConsolePublicURL
+      value: "{{ console_picker_developer_console_public_url | default('') }}"
     - key: auth#oauthEndpointCAFile
       value: "{{ openshift_console_auth_ca_file }}"
     - key: auth#logoutRedirect

--- a/roles/openshift_web_console/tasks/install.yml
+++ b/roles/openshift_web_console/tasks/install.yml
@@ -59,6 +59,10 @@
   - set_fact:
       cro_plugin_enabled: "{{ config_to_migrate.admissionConfig is defined and config_to_migrate.admissionConfig.pluginConfig is defined and config_to_migrate.admissionConfig.pluginConfig.ClusterResourceOverrides is defined }}"
 
+  - set_fact:
+      console_picker_admin_console_public_url: "https://{{ openshift_console_hostname | default('console.{{openshift_master_default_subdomain}}') }}/"
+    when: openshift_console_install | default(true) | bool
+
   # Update properties in the config template based on inventory vars when the
   # asset config does not exist.
   - name: Set web console config properties from inventory variables
@@ -72,6 +76,8 @@
         value: "{{ openshift.master.public_api_url }}"
       - key: clusterInfo#logoutPublicURL
         value: "{{ openshift.master.logout_url | default('') }}"
+      - key: clusterInfo#adminConsolePublicURL
+        value: "{{ console_picker_admin_console_public_url | default('') }}"
       - key: features#inactivityTimeoutMinutes
         value: "{{ openshift_web_console_inactivity_timeout_minutes | default(0) }}"
       - key: features#clusterResourceOverridesEnabled


### PR DESCRIPTION
The admin and developer consoles link to each other. Add the URLs to the config for each console to enable the picker in the masthead.

![projects openshift origin 2018-08-01 13-24-28](https://user-images.githubusercontent.com/1167259/43537802-56b854fc-958e-11e8-9c77-615d44fc8789.png)

/assign @vrutkovs 
@sdodson fyi