### PR TITLE
Beginning deprecation of INSTANCE_RAM var

### DIFF
--- a/roles/openshift_logging_elasticsearch/templates/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/es.j2
@@ -142,6 +142,9 @@ spec:
               readOnly: true
             - name: elasticsearch-storage
               mountPath: /elasticsearch/persistent
+            - name: podinfo
+              mountPath: /etc/podinfo
+              readOnly: true
           readinessProbe:
             exec:
               command:
@@ -195,6 +198,13 @@ spec:
         - name: elasticsearch-config
           configMap:
             name: logging-elasticsearch
+        - name: podinfo
+          downwardAPI:
+            items:
+              - path: "mem_limit"
+                resourceFieldRef:
+                  containerName: elasticsearch
+                  resource: limits.memory
         - name: elasticsearch-storage
 {% if openshift_logging_elasticsearch_storage_type == 'pvc' %}
           persistentVolumeClaim:


### PR DESCRIPTION
in favor of downwardAPI provided mem limit vol mount. This will create a volume mount on the ES container with the value of it's memory limit in Bytes (unfortunately when specifying a divisor the lowest value would be `1` even in cases where we should be left with a fraction, and we do not maintain the unit suffix)

ES image changes will be required to consume this

Will resolve RFE https://bugzilla.redhat.com/show_bug.cgi?id=1602819