### PR TITLE
Ensure master-shim are created in /usr/local/sbin

### DIFF
--- a/roles/openshift_control_plane/tasks/static_shim.yml
+++ b/roles/openshift_control_plane/tasks/static_shim.yml
@@ -3,7 +3,7 @@
 - name: Copy static master scripts
   copy:
     src: "{{ item }}"
-    dest: "/usr/local/bin/"
+    dest: "/usr/local/sbin/"
     mode: 0500
   with_items:
   - "scripts/{{ l_runtime }}/master-exec"


### PR DESCRIPTION
With this change, root can access master shims without modifying its PATH.

Proposed change for https://bugzilla.redhat.com/show_bug.cgi?id=1611662