### PR TITLE
Remove exclude-bootstrapped logic

### DIFF
--- a/playbooks/openshift-node/private/bootstrap.yml
+++ b/playbooks/openshift-node/private/bootstrap.yml
@@ -16,28 +16,14 @@
 - name: Only target nodes that have not yet been bootstrapped
   hosts: localhost
   tasks:
-  - add_host:
-      name: "{{ item }}"
-      groups: oo_exclude_bootstrapped_nodes
-      ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
-      ansible_become: "{{ g_sudo | default(omit) }}"
-    with_items: "{{ groups.oo_nodes_to_config | default([]) }}"
-    changed_when: no
-    when: hostvars[item].openshift_is_bootstrapped | default(False) | bool
 
 - import_playbook: disable_excluders.yml
-  vars:
-    l_node_group: oo_nodes_to_config:!oo_exclude_bootstrapped_nodes
 
 - import_playbook: configure_nodes.yml
-  vars:
-    l_node_group: oo_nodes_to_config:!oo_exclude_bootstrapped_nodes
 
 - import_playbook: configure_bootstrap.yml
 
 - import_playbook: enable_excluders.yml
-  vars:
-    l_node_group: oo_nodes_to_config:!oo_exclude_bootstrapped_nodes
 
 - name: Node Bootstrap Preparation Checkpoint End
   hosts: all

--- a/playbooks/openshift-node/private/clean_image.yml
+++ b/playbooks/openshift-node/private/clean_image.yml
@@ -15,7 +15,7 @@
     when: openshift_node_reboot_instance_before_cleanup | default(false)
 
 - name: Configure nodes
-  hosts: "{{ l_node_group }}"
+  hosts: oo_nodes_to_config
   tasks:
   - name: Remove any ansible facts created during AMI creation
     file:

--- a/playbooks/openshift-node/private/configure_bootstrap.yml
+++ b/playbooks/openshift-node/private/configure_bootstrap.yml
@@ -1,6 +1,6 @@
 ---
 - name: node bootstrap config
-  hosts: oo_nodes_to_config:!oo_exclude_bootstrapped_nodes
+  hosts: oo_nodes_to_config
   tasks:
   - import_role:
       name: openshift_node

--- a/playbooks/openshift-node/private/configure_nodes.yml
+++ b/playbooks/openshift-node/private/configure_nodes.yml
@@ -1,6 +1,6 @@
 ---
 - name: Configure nodes
-  hosts: "{{ l_node_group }}"
+  hosts: oo_nodes_to_config
   vars:
     openshift_node_master_api_url: "{{ hostvars[groups.oo_first_master.0].openshift.master.api_url }}"
     openshift_node_first_master_ip: "{{ hostvars[groups.oo_first_master.0].openshift.common.ip }}"

--- a/playbooks/openshift-node/private/disable_excluders.yml
+++ b/playbooks/openshift-node/private/disable_excluders.yml
@@ -1,6 +1,6 @@
 ---
 - name: Disable excluders
-  hosts: "{{ l_node_group }}"
+  hosts: oo_nodes_to_config
   gather_facts: no
   roles:
   - role: openshift_excluder

--- a/playbooks/openshift-node/private/enable_excluders.yml
+++ b/playbooks/openshift-node/private/enable_excluders.yml
@@ -1,6 +1,6 @@
 ---
 - name: Re-enable excluder if it was previously enabled
-  hosts: "{{ l_node_group }}"
+  hosts: oo_nodes_to_config
   gather_facts: no
   roles:
   - role: openshift_excluder

--- a/playbooks/openshift-node/private/image_prep.yml
+++ b/playbooks/openshift-node/private/image_prep.yml
@@ -9,13 +9,9 @@
 
 - name: run node config setup
   import_playbook: disable_excluders.yml
-  vars:
-    l_node_group: oo_nodes_to_config
 
 - name: run node config
   import_playbook: configure_nodes.yml
-  vars:
-    l_node_group: oo_nodes_to_config
 
 - name: node bootstrap config
   hosts: oo_nodes_to_config
@@ -46,10 +42,6 @@
 
 - name: Re-enable excluders
   import_playbook: enable_excluders.yml
-  vars:
-    l_node_group: oo_nodes_to_config
 
 - name: Remove any undesired artifacts from build
   import_playbook: clean_image.yml
-  vars:
-    l_node_group: oo_nodes_to_config


### PR DESCRIPTION
This logic merely prevents users from successfully
re-running parts of the install in case of problems.

This commit removes this logic.