### PR TITLE
Requires: ansible >= 2.6.2

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -17,7 +17,7 @@ URL:            https://github.com/openshift/openshift-ansible
 Source0:        https://github.com/openshift/openshift-ansible/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-Requires:      ansible >= 2.6
+Requires:      ansible >= 2.6.2
 Requires:      python2
 Requires:      python-six
 Requires:      tar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.6.0.0
+ansible==2.6.2.0
 boto==2.44.0
 click==6.7
 pyOpenSSL==17.5.0

--- a/roles/lib_utils/callback_plugins/aa_version_requirement.py
+++ b/roles/lib_utils/callback_plugins/aa_version_requirement.py
@@ -29,7 +29,7 @@ else:
 
 
 # Set to minimum required Ansible version
-REQUIRED_VERSION = '2.6.0'
+REQUIRED_VERSION = '2.6.2'
 DESCRIPTION = "Supported versions: %s or newer" % REQUIRED_VERSION
 
 


### PR DESCRIPTION
Just to reduce the scope of testing. There are no known bugs in
2.6.0-2.6.1 but no sense in allowing anything older than the latest
avaialble at the time of code freeze.

/cc @mtnbikenc 