### PR TITLE
BZ-1608216 Set timeoutSeconds for readinessProbe on Cassandra RCs

### DIFF
--- a/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
@@ -120,6 +120,7 @@ spec:
           exec:
             command:
             - "/opt/apache-cassandra/bin/cassandra-docker-ready.sh"
+          timeoutSeconds: 10
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
BZ LInk: https://bugzilla.redhat.com/show_bug.cgi?id=1608216

This also should be backported to 3.10
