### PR TITLE
[3.7] bz 1600859: default openshift_use_openshift_sdn to true in playbooks and roles

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/docker/tasks/restart.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/tasks/restart.yml
@@ -16,7 +16,7 @@
     state: started
   when:
     - openshift.common.is_containerized | bool
-    - openshift_use_openshift_sdn | bool
+    - openshift_use_openshift_sdn | default(true) | bool
 
 - name: Restart containerized services
   service: name={{ item }} state=started

--- a/playbooks/common/openshift-cluster/upgrades/docker/tasks/upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/docker/tasks/upgrade.yml
@@ -8,7 +8,7 @@
     state: stopped
   when:
     - openshift.common.is_containerized | bool
-    - openshift_use_openshift_sdn | bool
+    - openshift_use_openshift_sdn | default(true) | bool
 
 - name: Stop containerized services
   service: name={{ item }} state=stopped

--- a/playbooks/common/openshift-node/restart.yml
+++ b/playbooks/common/openshift-node/restart.yml
@@ -27,7 +27,7 @@
       state: started
     when:
     - openshift.common.is_containerized | bool
-    - openshift_use_openshift_sdn | bool
+    - openshift_use_openshift_sdn | default(true) | bool
 
   - name: Restart containerized services
     service:

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -81,7 +81,7 @@ default_r_openshift_node_os_firewall_allow:
   port: 443/tcp
 - service: OpenShift OVS sdn
   port: 4789/udp
-  cond: openshift_use_openshift_sdn | bool
+  cond: openshift_use_openshift_sdn | default(true) | bool
 - service: Calico BGP Port
   port: 179/tcp
   cond: "{{ openshift_node_use_calico }}"

--- a/roles/openshift_node_upgrade/handlers/main.yml
+++ b/roles/openshift_node_upgrade/handlers/main.yml
@@ -6,7 +6,7 @@
   when:
   - not skip_node_svc_handlers | default(False) | bool
   - not (ovs_service_status_changed | default(false) | bool)
-  - openshift_use_openshift_sdn | bool
+  - openshift_use_openshift_sdn | default(true) | bool
   register: l_openshift_node_upgrade_stop_openvswitch_result
   until: not l_openshift_node_upgrade_stop_openvswitch_result | failed
   retries: 3

--- a/roles/openshift_node_upgrade/tasks/main.yml
+++ b/roles/openshift_node_upgrade/tasks/main.yml
@@ -16,7 +16,7 @@
   service:
     name: openvswitch
     state: stopped
-  when: openshift_use_openshift_sdn | bool
+  when: openshift_use_openshift_sdn | default(true) | bool
 
 - name: Stop node service
   service:

--- a/roles/openshift_node_upgrade/tasks/restart.yml
+++ b/roles/openshift_node_upgrade/tasks/restart.yml
@@ -31,7 +31,7 @@
     name: openvswitch
     state: started
   when:
-    - openshift_use_openshift_sdn | bool
+    - openshift_use_openshift_sdn | default(true) | bool
 
 - name: Start services
   service: name={{ item }} state=started

--- a/roles/openshift_node_upgrade/tasks/systemd_units.yml
+++ b/roles/openshift_node_upgrade/tasks/systemd_units.yml
@@ -28,10 +28,10 @@
   when: openshift.common.is_containerized | bool
 
 - include: config/workaround-bz1331590-ovs-oom-fix.yml
-  when: openshift_use_openshift_sdn | bool
+  when: openshift_use_openshift_sdn | default(true) | bool
 
 - include: config/install-ovs-docker-service-file.yml
-  when: openshift.common.is_containerized | bool and openshift_use_openshift_sdn | bool
+  when: openshift.common.is_containerized | bool and openshift_use_openshift_sdn | default(true) | bool
 
 - include: config/configure-node-settings.yml
 - include: config/configure-proxy-settings.yml


### PR DESCRIPTION
`openshift_use_openshift_sdn` should default to True

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1600859#c5

There is no need to port this to 3.9 as the issue doesn't seem to be reproducible there