### PR TITLE
Add kuryr namespace isolation support

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -620,16 +620,20 @@ openshift_node_groups:
 ```
 
 
-### Namespace Subnet driver
+### Namespace Isolation drivers
 
 By default, kuryr is configured with the default subnet driver where all the
 pods are deployed on the same Neutron subnet. However, there is an option of
 enabling a different subnet driver, named namespace, which makes pods to be
-allocated on different subnets depending on the namespace they belong to. To
-enable this new kuryr subnet driver you need to uncomment:
+allocated on different subnets depending on the namespace they belong to.
+In addition to the subnet driver, to properly enable isolation between
+different namespaces (through OpenStack security groups) there is a need of
+also enabling the related security group driver for namespaces.
+To enable this new kuryr namespace isolation capability you need to uncomment:
 
 ```yaml
 openshift_kuryr_subnet_driver: namespace
+openshift_kuryr_sg_driver: namespace
 ```
 
 
@@ -856,7 +860,7 @@ openshift_openstack_num_nodes: 8  # 5 existing and 3 new
 
 ### 2. Scale the Cluster
 
-Next, run the appropriate playbook - either 
+Next, run the appropriate playbook - either
 `openshift-ansible/playbooks/openstack/openshift-cluster/master-scaleup.yml`
 for master nodes or
 `openshift-ansible/playbooks/openstack/openshift-cluster/node-scaleup.yml`

--- a/playbooks/openstack/inventory.py
+++ b/playbooks/openstack/inventory.py
@@ -199,6 +199,12 @@ def _get_kuryr_vars(cloud_client, data):
     if 'pod_subnet_pool' in data:
         settings['kuryr_openstack_pod_subnet_pool_id'] = data[
             'pod_subnet_pool']
+    if 'sg_allow_from_default' in data:
+        settings['kuryr_openstack_sg_allow_from_default_id'] = data[
+            'sg_allow_from_default']
+    if 'sg_allow_from_namespace' in data:
+        settings['kuryr_openstack_sg_allow_from_namespace_id'] = data[
+            'sg_allow_from_namespace']
     settings['kuryr_openstack_pod_router_id'] = data['pod_router']
     settings['kuryr_openstack_worker_nodes_subnet_id'] = data['vm_subnet']
     settings['kuryr_openstack_service_subnet_id'] = data['service_subnet']

--- a/playbooks/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/all.yml
@@ -53,6 +53,7 @@ openshift_openstack_external_network_name: "public"
 
 # # Kuryr can use a different subnet per namespace
 # openshift_kuryr_subnet_driver: namespace
+# openshift_kuryr_sg_driver: namespace
 
 # If you VM images will name the ethernet device different than 'eth0',
 # override this

--- a/roles/kuryr/README.md
+++ b/roles/kuryr/README.md
@@ -42,6 +42,7 @@ pods. This allows to have interconnectivity between pods and OpenStack VMs.
 * ``openshift_kuryr_precreate_subports=5``
 * ``openshift_kuryr_device_owner=compute:kuryr``
 * ``openshift_kuryr_subnet_driver=default``
+* ``openshift_kuryr_sg_driver=default``
 
 ## OpenShift API loadbalancer
 

--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -222,10 +222,10 @@ data:
     service_subnets_driver = default
 
     # The driver to determine Neutron security groups for pods (string value)
-    pod_security_groups_driver = default
+    pod_security_groups_driver = {{ openshift_kuryr_sg_driver|default('default') }}
 
     # The driver to determine Neutron security groups for services (string value)
-    service_security_groups_driver = default
+    service_security_groups_driver = {{ openshift_kuryr_sg_driver|default('default') }}
 
     # The driver that provides VIFs for Kubernetes Pods. (string value)
     pod_vif_driver = nested-vlan
@@ -316,6 +316,12 @@ data:
     [namespace_subnet]
     pod_subnet_pool = {{ kuryr_openstack_pod_subnet_pool_id }}
     pod_router = {{ kuryr_openstack_pod_router_id }}
+{% endif %}
+
+{% if openshift_kuryr_sg_driver|default('default') == 'namespace' %}
+    [namespace_sg]
+    sg_allow_from_namespaces = {{ kuryr_openstack_sg_allow_from_namespace_id }}
+    sg_allow_from_default = {{ kuryr_openstack_sg_allow_from_default_id }}
 {% endif %}
 
     # Time (in seconds) that Kuryr controller waits for LBaaS to be activated

--- a/roles/openshift_openstack/library/os_namespace_resources_deletion.py
+++ b/roles/openshift_openstack/library/os_namespace_resources_deletion.py
@@ -35,7 +35,8 @@ DOCUMENTATION = '''
 module: os_namespace_resources_deletion
 short_description: Delete network resources associated to the namespace
 description:
-    - Detach namespace's subnet from the router and delete the network
+    - Detach namespace's subnet from the router and delete the network and the
+      associated security groups
 author:
     - "Luis Tomas Bolivar <ltomasbo@redhat.com>"
 '''
@@ -51,6 +52,7 @@ def main():
             router_id=dict(default=False, type='str'),
             subnet_id=dict(default=False, type='str'),
             net_id=dict(default=False, type='str'),
+            sg_id=dict(default=False, type='str'),
         ),
         supports_check_mode=True,
     )
@@ -89,6 +91,12 @@ def main():
     # pylint: disable=broad-except
     except Exception:
         module.fail_json(msg='Failed to delete Neutron Network associated to the namespace')
+
+    try:
+        adapter.delete('/security-groups/' + module.params['sg_id'])
+    # pylint: disable=broad-except
+    except Exception:
+        module.fail_json(msg='Failed to delete Security groups associated to the namespace')
 
     module.exit_json(
         changed=True)

--- a/roles/openshift_openstack/tasks/unprovision.yml
+++ b/roles/openshift_openstack/tasks/unprovision.yml
@@ -38,15 +38,17 @@
 
 # NOTE(ltomasbo) This only works for nested deployments.
 # Moreover the pods should not have FIPs attached
-- name: Detach namespace subnets from router
+- name: Delete namespaced resources
   os_namespace_resources_deletion:
     router_id: "{{ item.spec.routerId }}"
     subnet_id: "{{ item.spec.subnetId }}"
     net_id: "{{ item.spec.netId }}"
+    sg_id: "{{ item.spec.sgId }}"
   with_items: "{{ svc_output.results.results[0]['items'] if 'results' in svc_output else [] }}"
   when:
     - openshift_use_kuryr|default(false) == true
     - openshift_kuryr_subnet_driver|default("default") == 'namespace'
+    - openshift_kuryr_sg_driver|default("default") == 'namespace'
     - item.metadata.annotations is defined
 
 - name: Delete the Stack

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -111,6 +111,16 @@ outputs:
     value: { get_resource: pod_subnet_pool }
 {% endif %}
 
+{% if openshift_kuryr_sg_driver|default('default') == 'namespace' %}
+  sg_allow_from_default:
+    description: ID of the security group to enable access from default namespace
+    value: { get_resource: sg_allow_from_default}
+
+  sg_allow_from_namespace:
+    description: ID of the security group to enable access from namespaces to default namespace
+    value: { get_resource: sg_allow_from_namespace}
+{% endif %}
+
   pod_access_sg_id:
     description: Id of the security group for services to be able to reach pods
     value: { get_resource: pod_access_sg }
@@ -216,6 +226,54 @@ resources:
           params:
             cluster_id: {{ openshift_openstack_full_dns_domain }}
 {% endif %}
+
+{% if openshift_kuryr_sg_driver|default('default') == 'namespace' %}
+  sg_allow_from_default:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      name:
+        str_replace:
+          template: openshift-ansible-cluster_id-allow_from_default
+          params:
+            cluster_id: {{ openshift_openstack_full_dns_domain }}
+      description: Give access to the services and pods from the default namespace
+
+  sg_allow_from_namespace:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      name:
+        str_replace:
+          template: openshift-ansible-cluster_id-allow_from_namespace
+          params:
+            cluster_id: {{ openshift_openstack_full_dns_domain }}
+      description: Give access to the services and pods on the default namespace from the other namespaces
+      rules:
+      - ethertype: IPv4
+        remote_group_id: { get_resource: sg_allow_from_default }
+        remote_mode: remote_group_id
+
+  sg_allow_from_default_rule:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: sg_allow_from_default }
+      ethertype: IPv4
+      remote_group: { get_resource: sg_allow_from_namespace }
+
+  common-secgrp_namespace_rule:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: common-secgrp }
+      ethertype: IPv4
+      remote_group: { get_resource: sg_allow_from_namespace }
+
+  common-secgrp_default_rule:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: common-secgrp }
+      ethertype: IPv4
+      remote_group: { get_resource: sg_allow_from_default }
+{% endif %}
+
 
   pod_subnet:
     type: OS::Neutron::Subnet
@@ -393,8 +451,10 @@ resources:
         remote_ip_prefix: {{ openshift_openstack_kuryr_service_subnet_cidr }}
       - ethertype: IPv4
         remote_ip_prefix: {{ openshift_openstack_subnet_cidr }}
+{% if openshift_kuryr_sg_driver|default('default') != 'namespace' %}
       - ethertype: IPv4
         remote_mode: remote_group_id
+{% endif %}
 {% endif %}
 
 {% if openshift_openstack_flat_secgrp|default(False)|bool %}


### PR DESCRIPTION
This PR adds support for the kuryr namespace isolation functionality.
It configures the required drivers (subnet and security groups) as well
as it modifies the security groups being applied.

It also includes the required modifications to clean up the namespace
resources upon unprovision playbook execution.