### PR TITLE
Ensure skopeo and atomic are installed in crt role

### DIFF
--- a/roles/container_runtime/tasks/package_crio.yml
+++ b/roles/container_runtime/tasks/package_crio.yml
@@ -40,6 +40,8 @@
     crio_pkgs:
       - "cri-o"
       - "cri-tools"
+      - atomic
+      - skopeo
 
 - name: Remove CRI-O default configuration files
   file:

--- a/roles/container_runtime/tasks/package_docker.yml
+++ b/roles/container_runtime/tasks/package_docker.yml
@@ -22,7 +22,7 @@
 # Note: The curr_docker_version.stdout check can be removed when https://github.com/ansible/ansible/issues/33187 gets fixed.
 - name: Install Docker
   package:
-    name: "docker{{ '-' + docker_version if docker_version is defined else '' }}"
+    name: "{{ l_docker_pkg_list | join(',') }}"
     state: present
   when:
   - not (openshift_is_atomic | bool)
@@ -30,6 +30,11 @@
   - not (curr_docker_version.stdout != '')
   register: result
   until: result is succeeded
+  vars:
+    l_docker_pkg_list:
+    - "docker{{ '-' + docker_version if docker_version is defined else '' }}"
+    - atomic
+    - skopeo
 
 - block:
   # Extend the default Docker service unit file when using iptables-services


### PR DESCRIPTION
This commit ensures skopeo and atomic are installed during
container runtime role.  This ensures docker_creds module
can complete.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1612104