### PR TITLE
Additional cleanup of v1beta1 rbac.authorization

### DIFF
--- a/roles/openshift_metering/files/operator/metering-helm-operator-role.yaml
+++ b/roles/openshift_metering/files/operator/metering-helm-operator-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: metering-helm-operator

--- a/roles/openshift_metering/files/operator/metering-helm-operator-rolebinding.yaml
+++ b/roles/openshift_metering/files/operator/metering-helm-operator-rolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metering-helm-operator


### PR DESCRIPTION
When testing https://bugzilla.redhat.com/show_bug.cgi?id=1597334 QE observed that we've subsequently added some v1beta1 rbac definitions in since the initial scrub.

/cc @chancez @deads2k 