### PR TITLE
Output cert check file to more sensible location

### DIFF
--- a/roles/openshift_certificate_expiry/defaults/main.yml
+++ b/roles/openshift_certificate_expiry/defaults/main.yml
@@ -3,7 +3,7 @@ openshift_certificate_expiry_config_base: "/etc/origin"
 openshift_certificate_expiry_warning_days: 365
 openshift_certificate_expiry_show_all: no
 openshift_certificate_expiry_generate_html_report: no
-openshift_certificate_expiry_html_report_path: "/tmp/cert-expiry-report.html"
+openshift_certificate_expiry_html_report_path: "{{ lookup('env', 'HOME') }}/cert-expiry-report.{{ ansible_date_time.iso8601_basic_short }}.html"
 openshift_certificate_expiry_save_json_results: no
-openshift_certificate_expiry_json_results_path: "/tmp/cert-expiry-report.json"
+openshift_certificate_expiry_json_results_path: "{{ lookup('env', 'HOME') }}/cert-expiry-report.{{ ansible_date_time.iso8601_basic_short }}.json"
 openshift_certificate_expiry_fail_on_warn: True


### PR DESCRIPTION
This commit ensures cert report is placed in user's
home directory + data-time stamp in filename to ensure
multiple runs and multiple users don't overwrite reports
by mistake.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1612093