### PR TITLE
fixing image defaults for logging

### DIFF
--- a/roles/openshift_logging_defaults/defaults/main.yml
+++ b/roles/openshift_logging_defaults/defaults/main.yml
@@ -22,10 +22,10 @@ l_os_logging_proxy_image: "{{ l_os_logging_non_standard_reg_url | regex_replace(
 # We need to regex_replace the origin-${component} with 'oauth-proxy'
 l2_os_logging_proxy_image: "{{ l_os_logging_proxy_image | regex_replace(l_os_logging_non_standard_reg_search | regex_escape, 'oauth-proxy') }}"
 
-openshift_logging_curator_image: "{{ l_os_registry_url | regex_replace(l_openshift_logging_search | regex_escape, 'logging-curator5') }}"
-openshift_logging_elasticsearch_image: "{{ l_os_registry_url | regex_replace(l_openshift_logging_search | regex_escape, 'logging-elasticsearch5') }}"
+openshift_logging_curator_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'logging-curator5') }}"
+openshift_logging_elasticsearch_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'logging-elasticsearch5') }}"
 openshift_logging_elasticsearch_proxy_image: "{{ l2_os_logging_proxy_image }}"
-openshift_logging_fluentd_image: "{{ l_os_registry_url | regex_replace(l_openshift_logging_search | regex_escape, 'logging-fluentd') }}"
-openshift_logging_kibana_image: "{{ l_os_registry_url | regex_replace(l_openshift_logging_search | regex_escape, 'logging-kibana5') }}"
+openshift_logging_fluentd_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'logging-fluentd') }}"
+openshift_logging_kibana_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'logging-kibana5') }}"
 openshift_logging_kibana_proxy_image: "{{ l2_os_logging_proxy_image }}"
 openshift_logging_mux_image: "{{ openshift_logging_fluentd_image }}"


### PR DESCRIPTION
the logging components should have the prefix with "ose-" in it for enterprise installations, event-router however still does not use that prefix.