### PR TITLE
Fix issue when a non-root user's homedir is mounted from a remote file system.

### DIFF
--- a/playbooks/adhoc/uninstall.yml
+++ b/playbooks/adhoc/uninstall.yml
@@ -425,6 +425,8 @@
     file:
       path: "~{{ item }}/.kube"
       state: absent
+    become: yes
+    become_user: "{{ item }}"
     with_items:
     - "{{ client_users }}"
 

--- a/playbooks/openshift-master/private/redeploy-openshift-ca.yml
+++ b/playbooks/openshift-master/private/redeploy-openshift-ca.yml
@@ -191,23 +191,53 @@
     file:
       path: "~{{ item }}/.kube"
       state: directory
-      mode: 0700
+      mode: 0777
       owner: "{{ item }}"
-      group: "{{ 'root' if item == 'root' else _ansible_ssh_user_gid.stdout  }}"
+      group: "{{ 'root' if item == 'root' else _ansible_ssh_user_gid.stdout }}"
+    become: yes
+    become_user: "{{ item }}"
     with_items: "{{ client_users }}"
+
+  - name: Create temp file for config
+    command: mktemp /tmp/openshift-ansible-XXXXXXX
+    register: _config_temp_file
+
+  - name: Copy the admin client config(s) to a temporary file
+    copy:
+      src: "{{ openshift_master_config_dir }}/admin.kubeconfig"
+      dest: "{{ _config_temp_file.stdout }}"
+      remote_src: yes
+      mode: 0777
+
+  # TODO: Update this file if the contents of the source file are not present in
+  # the dest file, will need to make sure to ignore things that could be added
   - name: Copy the admin client config(s)
     copy:
-      src: "{{ openshift.common.config_base }}/master/admin.kubeconfig"
+      src: "{{ _config_temp_file.stdout }}"
       dest: "~{{ item }}/.kube/config"
       remote_src: yes
+      owner: "{{ item }}"
+      group: "{{ 'root' if item == 'root' else _ansible_ssh_user_gid.stdout }}"
+      force: "{{ openshift_certificates_redeploy | default(false) }}"
+    become: yes
+    become_user: "{{ item }}"
     with_items: "{{ client_users }}"
+
+  - name: Remove temp file with config
+    file:
+      path: "{{ _config_temp_file.stdout }}"
+      state: absent
+
   - name: Update the permissions on the admin client config(s)
     file:
-      path: "~{{ item }}/.kube/config"
-      state: file
+      path: "~{{ item }}/.kube"
+      state: directory
       mode: 0700
       owner: "{{ item }}"
-      group: "{{ 'root' if item == 'root' else _ansible_ssh_user_gid.stdout  }}"
+      group: "{{ 'root' if item == 'root' else _ansible_ssh_user_gid.stdout }}"
+      recurse: yes
+    become: yes
+    become_user: "{{ item }}"
     with_items: "{{ client_users }}"
 
 - import_playbook: restart.yml

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -166,28 +166,53 @@
   file:
     path: "~{{ item }}/.kube"
     state: directory
-    mode: 0700
+    mode: 0777
     owner: "{{ item }}"
-    group: "{{ 'root' if item == 'root' else _ansible_ssh_user_gid.stdout  }}"
+    group: "{{ 'root' if item == 'root' else _ansible_ssh_user_gid.stdout }}"
+  become: yes
+  become_user: "{{ item }}"
   with_items: "{{ client_users }}"
+
+- name: Create temp file for config
+  command: mktemp /tmp/openshift-ansible-XXXXXXX
+  register: _config_temp_file
+
+- name: Copy the admin client config(s) to a temporary file
+  copy:
+    src: "{{ openshift_master_config_dir }}/admin.kubeconfig"
+    dest: "{{ _config_temp_file.stdout }}"
+    remote_src: yes
+    mode: 0777
 
 # TODO: Update this file if the contents of the source file are not present in
 # the dest file, will need to make sure to ignore things that could be added
 - name: Copy the admin client config(s)
   copy:
-    src: "{{ openshift_master_config_dir }}/admin.kubeconfig"
+    src: "{{ _config_temp_file.stdout }}"
     dest: "~{{ item }}/.kube/config"
     remote_src: yes
+    owner: "{{ item }}"
+    group: "{{ 'root' if item == 'root' else _ansible_ssh_user_gid.stdout }}"
     force: "{{ openshift_certificates_redeploy | default(false) }}"
+  become: yes
+  become_user: "{{ item }}"
   with_items: "{{ client_users }}"
+
+- name: Remove temp file with config
+  file:
+    path: "{{ _config_temp_file.stdout }}"
+    state: absent
 
 - name: Update the permissions on the admin client config(s)
   file:
-    path: "~{{ item }}/.kube/config"
-    state: file
+    path: "~{{ item }}/.kube"
+    state: directory
     mode: 0700
     owner: "{{ item }}"
-    group: "{{ 'root' if item == 'root' else _ansible_ssh_user_gid.stdout  }}"
+    group: "{{ 'root' if item == 'root' else _ansible_ssh_user_gid.stdout }}"
+    recurse: yes
+  become: yes
+  become_user: "{{ item }}"
   with_items: "{{ client_users }}"
 
 # Ensure ca-bundle exists for 3.2+ configuration


### PR DESCRIPTION
Fix issue when using a non-root user whose homedir is mounted from a remote file system.

Previous this commit, the modified playbooks/roles run as root when creating dirs and files to configure ~$user/.kube for the non-root user. When this non-root user's homedir is mounted from a remote dir, root has no permission to execute this modification and the playbook fails.

This pull request implement the following steps:

- create the .kube dir using the flag become_user set to the user;
- copy the admin.kubeconfig to a temporary file with permissions for user to read;
- using the flag become_user set to the non-root user, copy the file to its own homedir;
- remove the tempory file;
- correct permissions