### PR TITLE
Allow to override full Ansible Service Broker config map

### DIFF
--- a/roles/ansible_service_broker/defaults/main.yml
+++ b/roles/ansible_service_broker/defaults/main.yml
@@ -23,6 +23,9 @@ ansible_service_broker_auto_escalate: false
 ansible_service_broker_local_registry_whitelist: []
 ansible_service_broker_local_registry_namespaces: ["openshift"]
 
+
+ansible_service_broker_full_broker_config_map: "{{ lookup('template', 'configmap.yaml.j2') | from_yaml }}"
+
 l_asb_default_images_dict:
   origin: 'docker.io/ansibleplaybookbundle/origin-ansible-service-broker:latest'
   openshift-enterprise: 'registry.redhat.io/openshift3/ose-ansible-service-broker:${version}'

--- a/roles/ansible_service_broker/defaults/main.yml
+++ b/roles/ansible_service_broker/defaults/main.yml
@@ -23,9 +23,6 @@ ansible_service_broker_auto_escalate: false
 ansible_service_broker_local_registry_whitelist: []
 ansible_service_broker_local_registry_namespaces: ["openshift"]
 
-
-ansible_service_broker_full_broker_config_map: "{{ lookup('template', 'configmap.yaml.j2') | from_yaml }}"
-
 l_asb_default_images_dict:
   origin: 'docker.io/ansibleplaybookbundle/origin-ansible-service-broker:latest'
   openshift-enterprise: 'registry.redhat.io/openshift3/ose-ansible-service-broker:${version}'

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -210,7 +210,7 @@
     kind: ConfigMap
     content:
       path: /tmp/cmout
-      data: "{{ lookup('template', 'configmap.yaml.j2') | from_yaml }}"
+      data: "{{ ansible_service_broker_full_broker_config }}"
 
 - oc_secret:
     name: asb-registry-auth

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -210,7 +210,7 @@
     kind: ConfigMap
     content:
       path: /tmp/cmout
-      data: "{{ ansible_service_broker_full_broker_config_map }}"
+      data: "{{ ansible_service_broker_full_broker_config_map | default(lookup('template', 'configmap.yaml.j2') | from_yaml) }}"
 
 - oc_secret:
     name: asb-registry-auth

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -210,7 +210,7 @@
     kind: ConfigMap
     content:
       path: /tmp/cmout
-      data: "{{ ansible_service_broker_full_broker_config }}"
+      data: "{{ ansible_service_broker_full_broker_config_map }}"
 
 - oc_secret:
     name: asb-registry-auth


### PR DESCRIPTION
Through variable `ansible_service_broker_full_broker_config_map`, allow to completely override the Ansible service broker ConfigMap. 

The current template defined in  https://github.com/openshift/openshift-ansible/blob/master/roles/ansible_service_broker/templates/configmap.yaml.j2 does not provide sufficient flexibility for some cases, includin ours, where we can to have multiple registry types.