### PR TITLE
[WIP] Add an optional manual verification to node restart playbooks

### DIFF
--- a/playbooks/openshift-node/private/restart.yml
+++ b/playbooks/openshift-node/private/restart.yml
@@ -64,3 +64,8 @@
     # Give the node two minutes to come back online.
     retries: 24
     delay: 5
+
+  - name: Manual verification
+    pause:
+      prompt: "Please verify that the node has restarted and it's acceptable to restart the next node"
+    when: openshift_node_manual_verification | default(false)


### PR DESCRIPTION
Set openshift_node_manual_verification=true to get a prompt before moving
on to restart the next node.