### PR TITLE
Sanity check htpasswd respect default

### DIFF
--- a/roles/lib_utils/action_plugins/sanity_checks.py
+++ b/roles/lib_utils/action_plugins/sanity_checks.py
@@ -266,7 +266,8 @@ class ActionModule(ActionBase):
 
         manage_pass = self.template_var(
             hostvars, host, 'openshift_master_manage_htpasswd')
-        if to_bool(manage_pass):
+        # default for openshift_master_manage_htpasswd is True.
+        if to_bool(manage_pass) or manage_pass is None:
             # If we manage the file, we can just generate in the new path.
             return None
         idps = self.template_var(


### PR DESCRIPTION
Currently, sanity check fails if openshift_master_manage_htpasswd
is undefined in inventory and HTPasswdPasswordIdentityProvider + filename
is provided.

This commit ensures that we migrate the htpasswd file in
the default cause (openshift_master_manage_htpasswd=True).

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1570539