### PR TITLE
Limiting additional fact collection to non-masters

### DIFF
--- a/playbooks/openshift-logging/private/config.yml
+++ b/playbooks/openshift-logging/private/config.yml
@@ -16,7 +16,7 @@
 # Normally we only collect this information for our master group entries
 # we want to also collect this for nodes so we can match group entries to nodes
 - name: Get common IP facts when necessary
-  hosts: all
+  hosts: oo_nodes_to_config:!oo_masters
   gather_facts: false
   tasks:
   - name: Gather Cluster facts


### PR DESCRIPTION
since we already collect that information for masters

Addresses issue seen by @jupierce where running the logging playbook with `-vvv` [1] dramatically increased log size. We will still have noisy logs as the amount of nodes in a system increases, however this limits the fact collection to just non-masters.

[1] https://cr.ops.openshift.com:8443/job/cluster-upgrade-ocp/103/consoleText