### PR TITLE
Be more accuracy for getting def_route_int and def_route_ip

### DIFF
--- a/roles/openshift_node/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node/files/networkmanager/99-origin-dns.sh
@@ -44,8 +44,8 @@ if [[ $2 =~ ^(up|dhcp4-change|dhcp6-change)$ ]]; then
   # couldn't find an existing method to determine if the interface owns the
   # default route
   def_route=$(/sbin/ip route list match 0.0.0.0/0 | awk '{print $3 }')
-  def_route_int=$(/sbin/ip route get to ${def_route} | awk '{print $3}')
-  def_route_ip=$(/sbin/ip route get to ${def_route} | awk '{print $5}')
+  def_route_int=$(/sbin/ip route get to ${def_route} | awk -F 'dev' '{print $2}' | head -n1 | awk '{print $1}')
+  def_route_ip=$(/sbin/ip route get to ${def_route}  | awk -F 'src' '{print $2}' | head -n1 | awk '{print $1}')
   if [[ ${DEVICE_IFACE} == ${def_route_int} ]]; then
     if [ ! -f /etc/dnsmasq.d/origin-dns.conf ]; then
       cat << EOF > /etc/dnsmasq.d/origin-dns.conf


### PR DESCRIPTION
Fix the BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1613094

If the `ip command` output is unexpected order, it can cause the issues about DNS due to pointing upstream DNS in the `resolv.conf`.

For suppressing issues due to dependence of output order, we should filter to get required values.