### PR TITLE
Renames CRI-O pause_image to openshift_crio_pause_image.

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -75,16 +75,7 @@ docker_http_proxy: "{{ openshift_http_proxy | default('') }}"
 docker_https_proxy: "{{ openshift.common.https_proxy | default('') }}"
 docker_no_proxy: "{{ openshift.common.no_proxy | default('') }}"
 
-# Set pause_image variable for crio.conf.j2 required to start the crio service in package_crio.yml
-l_openshift_image_tag_default: "{{ 'v' ~ openshift_release if openshift_release is defined else 'latest' }}"
-l_openshift_image_tag: "{{ openshift_image_tag | default(l_openshift_image_tag_default) | string}}"
-
-l_crio_pause_images_dict:
-  origin: 'docker.io/openshift/origin-${component}:${version}'
-  openshift-enterprise: 'registry.redhat.io/openshift3/ose-${component}:${version}'
-l_pause_registry_url_default: "{{ l_crio_pause_images_dict[openshift_deployment_type] }}"
-
-pause_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'pod') }}"
+openshift_crio_pause_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'pod') }}"
 
 l_required_docker_version: '1.13'
 

--- a/roles/container_runtime/templates/crio.conf.j2
+++ b/roles/container_runtime/templates/crio.conf.j2
@@ -124,7 +124,7 @@ log_size_max = 52428800
 default_transport = "docker://"
 
 # pause_image is the image which we use to instantiate infra containers.
-pause_image = "{{ pause_image }}"
+pause_image = "{{ openshift_crio_pause_image }}"
 
 # pause_command is the command to run in a pause_image to have a container just
 # sit there.  If the image contains the necessary information, this value need


### PR DESCRIPTION
Purpose of this PR is to keep naming consistency for variables,
and also to state clearly that this variable can be overridden. 
A must for disconnected installations.

Cleanup some left-over (unusued) vars as well.