### PR TITLE
Fix openshift_openstack: Add public API Record

### DIFF
--- a/roles/openshift_openstack/tasks/populate-dns.yml
+++ b/roles/openshift_openstack/tasks/populate-dns.yml
@@ -84,6 +84,7 @@
   retries: 10
   delay: 1
   when:
+    - openshift_openstack_external_nsupdate_keys['public'] is defined
     - groups.masters
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openshift_openstack_public_api_ip is defined


### PR DESCRIPTION
Task "Add public API Record" does not check if
openshift_openstack_external_nsupdate_keys contains
key public