### PR TITLE
Fix master config migration module

### DIFF
--- a/roles/lib_utils/test/test_master_env_config_migrate.py
+++ b/roles/lib_utils/test/test_master_env_config_migrate.py
@@ -24,21 +24,13 @@ def test_read_write_ini():
 
     outfile = io.StringIO()
 
-    if master_env_config_migrate.CONFIG_PROXY_NEW:
-        config = master_env_config_migrate.SectionlessParser()
-    else:
-        config = master_env_config_migrate.SectionlessParserOld()
+    config = master_env_config_migrate.SectionlessParser()
 
     config.readfp(infile)
     config.write(outfile, False)
     print(outfile.getvalue())
     # TODO(michaelgugino): Come up with some clever way to assert the file is
     # correct.
-
-
-def test_read_write_ini_old():
-    master_env_config_migrate.CONFIG_PROXY_NEW = False
-    test_read_write_ini()
 
 # Contents for t.in:
 ############################
@@ -54,14 +46,9 @@ def test_read_write_ini_old():
 
 if __name__ == '__main__':
     test_read_write_ini()
-    test_read_write_ini_old()
+
     with open('t.in') as f:
         config = master_env_config_migrate.SectionlessParser()
-        config.readfp(f)
-    with open('t.out', 'w') as f:
-        config.write(f, False)
-    with open('t.in') as f:
-        config = master_env_config_migrate.SectionlessParserOld()
         config.readfp(f)
     with open('t2.out', 'w') as f:
         config.write(f, False)


### PR DESCRIPTION
Currently, master config migration module imports configparser
library from python 3x or python2.7-backports by default.  This
results in python 2-native version of ConfigParser never being
tested.

This commit swaps logic to ensure ConfigParser is used by default
and only in python 3 use the new library.  This will allow
better test coverage and more closely align with our use case.

Fixes: https://github.com/openshift/openshift-ansible/issues/9446