### PR TITLE
Allow to configure BlockStorage.ignore-volume-az for Openstack Cloud Provider

### DIFF
--- a/roles/openshift_cloud_provider/defaults/main.yml
+++ b/roles/openshift_cloud_provider/defaults/main.yml
@@ -4,3 +4,4 @@ openshift_gcp_prefix: ''
 openshift_gcp_network_name: "{{ openshift_gcp_prefix }}network"
 openshift_gcp_multizone: False
 openshift_openstack_ca_file_path: '/etc/origin/cloudprovider/openstack.crt'
+openshift_cloudprovider_openstack_blockstorage_ignore_volume_az: "no"

--- a/roles/openshift_cloud_provider/templates/openstack.conf.j2
+++ b/roles/openshift_cloud_provider/templates/openstack.conf.j2
@@ -22,7 +22,8 @@ ca-file = {{ openshift_openstack_ca_file_path }}
 [LoadBalancer]
 subnet-id = {{ openshift_cloudprovider_openstack_lb_subnet_id }}
 {% endif %}
-{% if openshift_cloudprovider_openstack_blockstorage_version is defined %}
 [BlockStorage]
+ignore-volume-az = {{ openshift_cloudprovider_openstack_blockstorage_ignore_volume_az }}
+{% if openshift_cloudprovider_openstack_blockstorage_version is defined %}
 bs-version={{ openshift_cloudprovider_openstack_blockstorage_version }}
 {% endif %}


### PR DESCRIPTION
Allows to disable the Cinder volume labels as described in: https://docs.okd.io/latest/install_config/configuring_openstack.html#openstack-configuring-zone-labels directly with the Ansible playbook.

The default option is the same as it was before.