### PR TITLE
SDN check: Fix parsing time stamp's time zone

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/sdn.py
+++ b/roles/openshift_health_checker/openshift_checks/sdn.py
@@ -337,8 +337,14 @@ class SDNCheck(OpenShiftCheck):
             self.register_failure('%s is not started.' % service_name)
             return
 
+        # The timestamp should be in the format "%a %Y-%m-%d %H:%M:%S %Z".
+        # However, Python cannot reliably parse timezone names
+        # (see <https://bugs.python.org/issue22377>), so we must drop the
+        # timezone name before parsing the timestamp.
+        start_timestamp = ' '.join(start_timestamp.split()[0:3])
+
         since_date = datetime.datetime.strptime(start_timestamp,
-                                                '%a %Y-%m-%d %H:%M:%S %Z')
+                                                '%a %Y-%m-%d %H:%M:%S')
         until_date = since_date + datetime.timedelta(minutes=5)
         since = since_date.strftime(time_fmt)
         until = until_date.strftime(time_fmt)


### PR DESCRIPTION
Before this commit, if the control machine and the target machine were in different time zones and the target machine's time zone were neither UTC nor GMT, the SDN check would raise a ValueError exception when parsing a systemd unit's ExecMainStartTimestamp property:

    ValueError: time data 'Tue 2018-08-07 23:09:46 EDT' does not match format '%a %Y-%m-%d %H:%M:%S %Z'

The problem is that Python's `strptime` cannot reliably parse time zones: https://bugs.python.org/issue22377

The solution is to drop the time zone prior to parsing the time stamp.

This commit fixes bug 1613752.

https://bugzilla.redhat.com/show_bug.cgi?id=1613752

* `roles/openshift_health_checker/openshift_checks/sdn.py` (`SDNCheck.save_service_logs`): Omit time zone before parsing time stamp.