### PR TITLE
Fixes BZ 1596448

### DIFF
--- a/playbooks/common/openshift-cluster/evaluate_groups.yml
+++ b/playbooks/common/openshift-cluster/evaluate_groups.yml
@@ -46,7 +46,7 @@
         Running etcd as an embedded service is no longer supported. If this is a
         new install please define an 'etcd' group with either one, three or five
         hosts. These hosts may be the same hosts as your masters. If this is an
-        upgrade please see https://docs.openshift.com/container-platform/latest/install_config/upgrading/migrating_embedded_etcd.html
+        upgrade please see https://docs.openshift.com/container-platform/3.7/upgrading/migrating_embedded_etcd.html
         for documentation on how to migrate from embedded to external etcd.
     when:
     - g_etcd_hosts | default([]) | length == 0


### PR DESCRIPTION
Corrects the link for migrating away from embedded etcd.

https://bugzilla.redhat.com/show_bug.cgi?id=1596448