### PR TITLE
[Bug 1609027] Add quotes to docker gc node selector

### DIFF
--- a/roles/openshift_docker_gc/templates/dockergc-ds.yaml.j2
+++ b/roles/openshift_docker_gc/templates/dockergc-ds.yaml.j2
@@ -26,7 +26,7 @@ items:
 {% if r_docker_gc_node_selectors %}
         nodeSelector:
 {% for k,v in r_docker_gc_node_selectors.items() %}
-          {{ k }}: {{ v }}{% endfor %}{% endif %}
+          {{ k }}: "{{ v }}"{% endfor %}{% endif %}
 
         serviceAccountName: dockergc
         containers:


### PR DESCRIPTION
Node selectors must be strings, therefore the provided value must be
quoted to ensure booleans are not returned.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1609027