### PR TITLE
loopback_cluster_name: use api_hostname

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -389,7 +389,7 @@ def set_url_facts_if_unset(facts):
                                                                    host,
                                                                    ports[prefix]))
 
-        r_lhn = "{0}:{1}".format(hostname, ports['api']).replace('.', '-')
+        r_lhn = "{0}:{1}".format(api_hostname, ports['api']).replace('.', '-')
         r_lhu = "system:openshift-master/{0}:{1}".format(api_hostname, ports['api']).replace('.', '-')
         facts['master'].setdefault('loopback_cluster_name', r_lhn)
         facts['master'].setdefault('loopback_context_name', "default/{0}/system:openshift-master".format(r_lhn))


### PR DESCRIPTION
loopback address in openshift-master.kubeconfig should use API hostname, not 
(node) hostname (it already uses api hostname to form a user string). The difference is that API hostname can be any valid DNS 
hostname (e.g. uppercase letters), while node hostname has to be lowercased.

This PR would resolve issues where masters are setup on hosts with uppercase
symbols - this var would use correct loopback_context_name on upgrade from 
1.5 (where node names could contain uppercase)

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1583180