### PR TITLE
[Bug 1609907] Remove node CSR approval from upgrade in 3.11

### DIFF
--- a/roles/openshift_node/tasks/upgrade/restart.yml
+++ b/roles/openshift_node/tasks/upgrade/restart.yml
@@ -45,13 +45,6 @@
   register: node_service
   failed_when: false
 
-- name: Approve the node
-  oc_adm_csr:
-    nodes: ["{{ openshift.node.nodename }}"]
-    timeout: 60
-    fail_on_timeout: true
-  delegate_to: "{{ groups.oo_first_master.0 }}"
-
 - name: Check status of node service
   async_status:
     jid: "{{ node_service.ansible_job_id }}"


### PR DESCRIPTION
Node CSR approval is not required once nodes are at 3.10.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1609907