### PR TITLE
Update pause image value in crio.conf after upgrade

### DIFF
--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -27,6 +27,18 @@
 - name: Update systemd units
   import_tasks: ../systemd_units.yml
 
+# Get stat of /etc/crio/crio.conf
+- stat: path=/etc/crio/crio.conf
+  register: crio_conf
+# Update the cri-o pause image to use latest version after an upgrade
+# if cri-o is the container runtime i.e /etc/crio/crio.conf exists
+- name: Update cri-o pause image
+  lineinfile:
+    dest: /etc/crio/crio.conf
+    line: pause_image = "{{ openshift_crio_pause_image }}"
+    regexp: '^pause_image ='
+  when: crio_conf.stat.exists == True
+
 # NOTE: This is needed to make sure we are using the correct set
 #       of systemd unit files. The RPMs lay down defaults but
 #       the install/upgrade may override them in /etc/systemd/system/.


### PR DESCRIPTION
Add a task to update the value of the crio pause image
in /etc/crio/crio.conf after an upgrade is done.

Signed-off-by: umohnani8 <umohnani@redhat.com>