### PR TITLE
Remove the reconcile-sccs check

### DIFF
--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -3,29 +3,6 @@
 # Upgrade Masters
 ###############################################################################
 
-# Some change makes critical outage on current cluster.
-- name: Confirm upgrade will not make critical changes
-  hosts: oo_first_master
-  tasks:
-  - name: Confirm Reconcile Security Context Constraints will not change current SCCs
-    command: >
-      {{ openshift_client_binary }} adm policy --config={{ openshift.common.config_base }}/master/admin.kubeconfig reconcile-sccs --additive-only=true -o name
-    register: check_reconcile_scc_result
-    when: openshift_reconcile_sccs_reject_change | default(true) | bool
-    until: check_reconcile_scc_result.rc == 0
-    retries: 3
-
-  - fail:
-      msg: >
-        Changes to bootstrapped SCCs have been detected. Please review the changes by running
-        "{{ openshift_client_binary }} adm policy --config={{ openshift.common.config_base }}/master/admin.kubeconfig reconcile-sccs --additive-only=true"
-        After reviewing the changes please apply those changes by adding the '--confirm' flag.
-        Do not modify the default SCCs. Customizing the default SCCs will cause this check to fail when upgrading.
-        If you require non standard SCCs please refer to https://docs.openshift.org/latest/admin_guide/manage_scc.html
-    when:
-    - openshift_reconcile_sccs_reject_change | default(true) | bool
-    - check_reconcile_scc_result.stdout != '' or check_reconcile_scc_result.rc != 0
-
 # Create service signer cert when missing. Service signer certificate
 # is added to master config in the master_config_upgrade hook.
 - name: Determine if service signer cert must be created


### PR DESCRIPTION
The reconcile-sccs command is being called with the `oc` binary
of the version to upgrade to. This does not make sense because
such a check would generate false positive every time the bootstrapped
SCCs change in the newer version (e.g. add a non-default value
to a new field).

Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1610496