### PR TITLE
move from latest to versioned repo

### DIFF
--- a/playbooks/azure/openshift-cluster/group_vars/all/yum_repos.yml
+++ b/playbooks/azure/openshift-cluster/group_vars/all/yum_repos.yml
@@ -59,7 +59,7 @@ azure_node_repos:
 
   CentOS:
   # TODO: should be using a repo which only provides prerequisites
-  - name: openshift-origin
-    baseurl: http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/
+  - name: openshift-origin310
+    baseurl: http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin310/
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS
     enabled: yes


### PR DESCRIPTION
OSA - Move to the versioned repo to avoid package clash.

cc: @kwoodson , @kargakis 