### PR TITLE
Switch to oc set env, since oc env is now removed

### DIFF
--- a/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml
@@ -39,7 +39,7 @@
   # Replace dc/docker-registry environment variable certificate data if set.
   - name: Update docker-registry environment variables
     shell: >
-      {{ openshift_client_binary }} env dc/docker-registry
+      {{ openshift_client_binary }} set env dc/docker-registry
       OPENSHIFT_CA_DATA="$(cat /etc/origin/master/ca.crt)"
       OPENSHIFT_CERT_DATA="$(cat /etc/origin/master/openshift-registry.crt)"
       OPENSHIFT_KEY_DATA="$(cat /etc/origin/master/openshift-registry.key)"

--- a/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
@@ -52,7 +52,7 @@
 
   - name: Update router environment variables
     shell: >
-      {{ openshift_client_binary }} env dc/router
+      {{ openshift_client_binary }} set env dc/router
       OPENSHIFT_CA_DATA="$(cat /etc/origin/master/ca.crt)"
       OPENSHIFT_CERT_DATA="$(cat /etc/origin/master/openshift-router.crt)"
       OPENSHIFT_KEY_DATA="$(cat /etc/origin/master/openshift-router.key)"


### PR DESCRIPTION
In https://github.com/openshift/origin/pull/20139 I removed `oc env` and `oc volume`, this PR updates the ansible not to use them anymore.

/assign @sdodson 