### PR TITLE
Revert "openshift_loadbalancer: remove unused vars"

### DIFF
--- a/roles/openshift_loadbalancer/defaults/main.yml
+++ b/roles/openshift_loadbalancer/defaults/main.yml
@@ -2,6 +2,17 @@
 r_openshift_loadbalancer_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
 r_openshift_loadbalancer_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
+openshift_loadbalancer_frontends: "{{ (openshift_master_api_port
+                                       | lib_utils_oo_loadbalancer_frontends(hostvars | lib_utils_oo_select_keys(groups['oo_masters']),
+                                                                             openshift_use_nuage | default(false),
+                                                                             nuage_mon_rest_server_port | default(none)))
+                                       + openshift_loadbalancer_additional_frontends | default([]) }}"
+openshift_loadbalancer_backends: "{{ (openshift_master_api_port
+                                      | lib_utils_oo_loadbalancer_backends(hostvars | lib_utils_oo_select_keys(groups['oo_masters']),
+                                                                           openshift_use_nuage | default(false),
+                                                                           nuage_mon_rest_server_port | default(none)))
+                                      + openshift_loadbalancer_additional_backends | default([]) }}"
+
 r_openshift_loadbalancer_os_firewall_deny: []
 r_openshift_loadbalancer_os_firewall_allow:
 - service: haproxy stats


### PR DESCRIPTION
This reverts commit 9510f99ce0dcfa1fcab5b2319cbaabd3bb217958.

`openshift_loadbalancer_frontends` and `openshift_loadbalancer_backends`
are actually used to setup a load balancer

Fixes https://github.com/openshift/openshift-ansible/commit/9510f99ce0dcfa1fcab5b2319cbaabd3bb217958#commitcomment-30017675

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1613981