### PR TITLE
Update console branding and doc URL for OKD

### DIFF
--- a/roles/openshift_console/defaults/main.yml
+++ b/roles/openshift_console/defaults/main.yml
@@ -18,11 +18,11 @@ openshift_console_auth_ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/c
 
 # Determines the logo and title used throughout the console.
 l_openshift_console_branding_dict:
-  origin: 'origin'
+  origin: 'okd'
   openshift-enterprise: 'ocp'
 openshift_console_branding: "{{ l_openshift_console_branding_dict[openshift_deployment_type] }}"
 
 l_openshift_console_documentation_url_dict:
-  origin: 'https://docs.openshift.org/3.11/'
+  origin: 'https://docs.okd.io/3.11/'
   openshift-enterprise: 'https://docs.openshift.com/container-platform/3.11/'
 openshift_console_documentation_base_url: "{{ l_openshift_console_documentation_url_dict[openshift_deployment_type] }}"


### PR DESCRIPTION
The value of the `branding` property should now be `okd` instead of `origin`. See https://github.com/openshift/console/pull/371

/assign @vrutkovs 