### PR TITLE
Adding min-port to dnsmasq configuration.

### DIFF
--- a/roles/openshift_node/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node/files/networkmanager/99-origin-dns.sh
@@ -54,6 +54,7 @@ server=/30.172.in-addr.arpa/172.30.0.1
 enable-dbus
 dns-forward-max=5000
 cache-size=5000
+min-port=1024
 EOF
       # New config file, must restart
       NEEDS_RESTART=1

--- a/roles/openshift_node/templates/origin-dns.conf.j2
+++ b/roles/openshift_node/templates/origin-dns.conf.j2
@@ -10,6 +10,7 @@ enable-dbus
 dns-forward-max=10000
 cache-size=10000
 bind-dynamic
+min-port=1024
 {% for interface in openshift_node_dnsmasq_except_interfaces %}
 except-interface={{ interface }}
 {% endfor %}


### PR DESCRIPTION
By default dnsmasq uses lower port (for source port) for it's communications.
This sometimes create problem when the forward server is bind or
firewalls dropping queries coming from these reserved ports.

Upstream dnsmasq defaults setting min-port to 1024, for older versions
of dnsmasq setting min-port to 1024 is needed, to avoid random drops.

https://bugzilla.redhat.com/show_bug.cgi?id=1600551
https://bugzilla.redhat.com/show_bug.cgi?id=1614331