### PR TITLE
Don't require some RPMs to be available in the repos due to switch to static pods

### DIFF
--- a/playbooks/azure/openshift-cluster/group_vars/all/yum_repos.yml
+++ b/playbooks/azure/openshift-cluster/group_vars/all/yum_repos.yml
@@ -33,13 +33,6 @@ azure_node_repos:
     sslclientkey: /var/lib/yum/client-key.pem
     enabled: yes
 
-  - name: rhel-7-fast-datapath-rpms
-    baseurl: https://mirror.openshift.com/enterprise/rhel/rhel-7-fast-datapath-rpms/
-    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-    sslclientcert: /var/lib/yum/client-cert.pem
-    sslclientkey: /var/lib/yum/client-key.pem
-    enabled: yes
-
   - name: rhel-7-server-ansible-2.4-rpms
     baseurl: https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.4-rpms/
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/roles/openshift_health_checker/openshift_checks/package_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/package_availability.py
@@ -36,7 +36,7 @@ class PackageAvailability(NotContainerizedMixin, OpenShiftCheck):
         return [
             "{rpm_prefix}".format(rpm_prefix=rpm_prefix),
             "{rpm_prefix}-clients".format(rpm_prefix=rpm_prefix),
-            "{rpm_prefix}-master".format(rpm_prefix=rpm_prefix),
+            "{rpm_prefix}-hyperkube".format(rpm_prefix=rpm_prefix),
             "bash-completion",
             "cockpit-bridge",
             "cockpit-docker",

--- a/roles/openshift_health_checker/openshift_checks/package_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/package_availability.py
@@ -42,7 +42,6 @@ class PackageAvailability(NotContainerizedMixin, OpenShiftCheck):
             "cockpit-docker",
             "cockpit-system",
             "cockpit-ws",
-            "etcd",
             "httpd-tools",
         ]
 

--- a/roles/openshift_health_checker/openshift_checks/package_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/package_availability.py
@@ -52,7 +52,6 @@ class PackageAvailability(NotContainerizedMixin, OpenShiftCheck):
         return [
             "{rpm_prefix}".format(rpm_prefix=rpm_prefix),
             "{rpm_prefix}-node".format(rpm_prefix=rpm_prefix),
-            "{rpm_prefix}-sdn-ovs".format(rpm_prefix=rpm_prefix),
             "bind",
             "ceph-common",
             "dnsmasq",

--- a/roles/openshift_health_checker/test/package_availability_test.py
+++ b/roles/openshift_health_checker/test/package_availability_test.py
@@ -21,14 +21,14 @@ def test_is_active(pkg_mgr, openshift_is_atomic, is_active):
     (
         dict(openshift_service_type='origin'),
         set(),
-        set(['openshift-master', 'openshift-node']),
+        set(['openshift-hyperkube', 'openshift-node']),
     ),
     (
         dict(
             openshift_service_type='origin',
             group_names=['oo_masters_to_config'],
         ),
-        set(['origin-master']),
+        set(['origin-hyperkube']),
         set(['origin-node']),
     ),
     (
@@ -37,14 +37,14 @@ def test_is_active(pkg_mgr, openshift_is_atomic, is_active):
             group_names=['oo_nodes_to_config'],
         ),
         set(['atomic-openshift-node']),
-        set(['atomic-openshift-master']),
+        set(['atomic-openshift-hyperkube']),
     ),
     (
         dict(
             openshift_service_type='atomic-openshift',
             group_names=['oo_masters_to_config', 'oo_nodes_to_config'],
         ),
-        set(['atomic-openshift-master', 'atomic-openshift-node']),
+        set(['atomic-openshift-hyperkube', 'atomic-openshift-node']),
         set(),
     ),
 ])

--- a/roles/openshift_repos/tasks/rhel_repos.yml
+++ b/roles/openshift_repos/tasks/rhel_repos.yml
@@ -26,8 +26,7 @@
   command: subscription-manager repos \
                --enable="rhel-7-server-rpms" \
                --enable="rhel-7-server-extras-rpms" \
-               --enable="rhel-7-server-ose-{{ ( openshift_version ).split('.')[0:2] | join('.') }}-rpms" \
-               --enable="rhel-7-fast-datapath-rpms"
+               --enable="rhel-7-server-ose-{{ ( openshift_version ).split('.')[0:2] | join('.') }}-rpms"
   register: subscribe_repos
   until: subscribe_repos is succeeded
   when: repo_rhel.changed


### PR DESCRIPTION
* -sdn-ovs, etcd and -master RPMs are no longer required to be present it repos
* Don't setup fast-datapath channel in RHEL
  This channel would install openvswitch, which is now present in SDN images
* Master hosts should be able to install `-hyperkube` RPMs

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1613123

I think some more RPMs can be removed from node/master list, but I'm not entirely sure:

* `cockpit-*` (except `cockpit-bridge`) is provided by images?
* `docker` and `iptables` depend on install options - do we need to check these?