### PR TITLE
[bz1552516] set the external url of prometheus

### DIFF
--- a/roles/openshift_prometheus/templates/prometheus.j2
+++ b/roles/openshift_prometheus/templates/prometheus.j2
@@ -80,6 +80,7 @@ spec:
 {% endfor %}
         - --config.file=/etc/prometheus/prometheus.yml
         - --web.listen-address=localhost:9090
+        - --web.external-url=https://{{ openshift_prometheus_hostname }}
         image: "{{ openshift_prometheus_image }}"
         imagePullPolicy: IfNotPresent
         livenessProbe:


### PR DESCRIPTION
This allows the alertmanager to correctly link back to prometheus.
https://bugzilla.redhat.com/show_bug.cgi?id=1552516