### PR TITLE
SDN check: Ignore node's canonical name

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/sdn.py
+++ b/roles/openshift_health_checker/openshift_checks/sdn.py
@@ -119,7 +119,7 @@ class SDNCheck(OpenShiftCheck):
         """
         self.register_file(path, self.read_command_output(command))
 
-    def read_command_output(self, command):
+    def read_command_output(self, command, utf8=True):
         """Execute the provided command using the command module
         and return its output.
 
@@ -141,7 +141,9 @@ class SDNCheck(OpenShiftCheck):
                 'RemoteCommandFailure',
                 'Failed to execute command on remote host: %s' % command)
 
-        return result['stdout'].encode('utf-8')
+        if utf8:
+            return result['stdout'].encode('utf-8')
+        return result['stdout']
 
     def check_master(self):
         """Gather diagnostic information on a master and ensure it can connect
@@ -425,7 +427,7 @@ class SDNCheck(OpenShiftCheck):
         """Look up the given IPv4 address using getent."""
         command = ' '.join(['/bin/getent', 'ahostsv4', addr])
         try:
-            out = self.read_command_output(command)
+            out = self.read_command_output(command, False)
         except OpenShiftCheckException as exc:
             raise OpenShiftCheckException(
                 'NameResolutionError',
@@ -433,7 +435,7 @@ class SDNCheck(OpenShiftCheck):
 
         for line in out.splitlines():
             record = line.split()
-            if record[1:3] == ['STREAM', addr]:
+            if record[1] == 'STREAM':
                 return record[0]
 
         return None


### PR DESCRIPTION
When verifying that a node's preferred host name or address resolves to its internal IP address, ignore the canonical name returned by name resolution.  In some valid configurations, the node's preferred name or address differs from the canonical name.

This change makes the check more consistent with the behavior of the [`debug.sh`](https://github.com/openshift/openshift-sdn/blob/d55c72b668018492059a862bee06f11745de1f97/hack/debug.sh#L126) script on which the check was based.

This commit also fixes a problem with string encodings and comparisons that shows up on Python 3.

This commit fixes bug 1614261.

https://bugzilla.redhat.com/show_bug.cgi?id=1614261

* `roles/openshift_health_checker/openshift_checks/sdn.py` (`SDNCheck.read_command_output`): Add an optional parameter for UTF-8 encoding (default `True`).
(`SDNCheck.resolve_address`): Use `read_command_output`'s new parameter to disable UTF-8 encoding.  Ignore canonical name in result.
* `roles/openshift_health_checker/test/sdn_tests.py` (`test_resolve_address`): New test.