### PR TITLE
Fix master env migrate module comments

### DIFF
--- a/roles/lib_utils/library/master_env_config_migrate.py
+++ b/roles/lib_utils/library/master_env_config_migrate.py
@@ -112,8 +112,8 @@ class SectionlessParser(configparser.RawConfigParser):
         sectname = '__none_sect'
         self._sections[sectname] = cursect
         self._set_proxies(sectname)
-        self._inline_comment_prefixes = ()
-        self._comment_prefixes = ()
+        self._inline_comment_prefixes = ('#',)
+        self._comment_prefixes = ('#',)
         self._empty_lines_in_values = True
         self.NONSPACECRE = re.compile(r"\S")
         self.default_section = 'DEFAULT'

--- a/roles/lib_utils/test/test_master_env_config_migrate.py
+++ b/roles/lib_utils/test/test_master_env_config_migrate.py
@@ -12,10 +12,11 @@ t1=Yes
 t2=A Space
 t3=An\ escaped
 t4="A quoted space"
-t5="a quoted \\
+t5="a quoted \\ # in-line comment
   escaped line"
 t6 = an unquoted multiline \\
   string
+# comment line
 """
 
 


### PR DESCRIPTION
This comment ensures config parser can
process comments and inline comments.