### PR TITLE
Ensure docker package always installed

### DIFF
--- a/roles/container_runtime/tasks/package_docker.yml
+++ b/roles/container_runtime/tasks/package_docker.yml
@@ -26,8 +26,6 @@
     state: present
   when:
   - not (openshift_is_atomic | bool)
-  - not (curr_docker_version is skipped)
-  - not (curr_docker_version.stdout != '')
   register: result
   until: result is succeeded
   vars:


### PR DESCRIPTION
This commit removes unnecessary booleans from docker package
install task.  These booleans are hold-overs from when
docker role was run multiple times in older version of
openshift-ansible due to meta-depends.