### PR TITLE
Increase maximum number of open file descriptors for dnsmasq

### DIFF
--- a/roles/openshift_node/tasks/dnsmasq.yml
+++ b/roles/openshift_node/tasks/dnsmasq.yml
@@ -15,6 +15,19 @@
   when: openshift_node_dnsmasq_additional_config_file is defined
   notify: restart dnsmasq
 
+- name: Create override dnsmasq systemd unit directory
+  file:
+    path: /etc/systemd/system/dnsmasq.service.d
+    state: directory
+
+- name: Copy systemd dnsmasq unit override file
+  copy:
+    src: override.conf
+    dest: /etc/systemd/system/dnsmasq.service.d/override.conf
+  notify:
+    - reload systemd units
+    - restart dnsmasq
+
 - name: Enable dnsmasq
   systemd:
     name: dnsmasq

--- a/roles/openshift_node/tasks/files/override.conf
+++ b/roles/openshift_node/tasks/files/override.conf
@@ -1,0 +1,2 @@
+[Service]
+LimitNOFILE=65535


### PR DESCRIPTION
dnsmasq has problems releasing it's file descriptors when it reaches
the maximum number of open file descriptors, this is caused by the
OpenShift Extended Comformance Tests followed by the Node Vertical Test.

This patch mitigates the problem by increasing the maximim number of
open file descriptors so the node can pass the tests.

NOTE:
The real fix should be done in dnsmasq.

Fixes: rhbz#1608571