### PR TITLE
Ensure kernel-modules not installed on atomic

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/kernel_modules.yml
+++ b/roles/openshift_storage_glusterfs/tasks/kernel_modules.yml
@@ -7,7 +7,9 @@
 
 - name: Install kernel modules package on Fedora
   shell: "dnf install kernel-modules-$(uname -r) -y"
-  when: ansible_distribution == "Fedora"
+  when:
+  - ansible_distribution == "Fedora"
+  - not (openshift_is_atomic | bool)
 
 - name: load kernel modules
   systemd:


### PR DESCRIPTION
This commit ensures we don't attempt to dnf install
kernel modules on Fedora Atomic Host.