### PR TITLE
'Wait for node to be ready' task should check that all vars are defined

### DIFF
--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -74,8 +74,11 @@
   until:
   - node_output.results is defined
   - node_output.results.returncode is defined
-  - node_output.results.results is defined
   - node_output.results.returncode == 0
+  - node_output.results.results is defined
+  - node_output.results.results | length  > 0
+  - node_output.results.results[0].status is defined
+  - node_output.results.results[0].status.conditions is defined
   - node_output.results.results[0].status.conditions | selectattr('type', 'match', '^Ready$') | map(attribute='status') | join | bool == True
   # Give the node three minutes to come back online.
   retries: 36


### PR DESCRIPTION
Fixes #9508