### PR TITLE
[uninstall] Remove hyperkube package

### DIFF
--- a/playbooks/adhoc/uninstall_openshift.yml
+++ b/playbooks/adhoc/uninstall_openshift.yml
@@ -109,6 +109,7 @@
         - atomic-openshift-docker-excluder
         - atomic-openshift-node
         - atomic-openshift-sdn-ovs
+        - atomic-openshift-hyperkube
         - cockpit-bridge
         - cockpit-docker
         - cockpit-system
@@ -124,6 +125,7 @@
         - origin-clients
         - origin-node
         - origin-sdn-ovs
+        - origin-hyperkube
         - tuned-profiles-atomic-openshift-node
         - tuned-profiles-origin-node
         register: result


### PR DESCRIPTION
I run uninstall_openshift.yml playbook, but not deleted origin-hyperkube-{version}.