### PR TITLE
Revert "loopback_cluster_name: use api_hostname"

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -389,7 +389,7 @@ def set_url_facts_if_unset(facts):
                                                                    host,
                                                                    ports[prefix]))
 
-        r_lhn = "{0}:{1}".format(api_hostname, ports['api']).replace('.', '-')
+        r_lhn = "{0}:{1}".format(hostname, ports['api']).replace('.', '-')
         r_lhu = "system:openshift-master/{0}:{1}".format(api_hostname, ports['api']).replace('.', '-')
         facts['master'].setdefault('loopback_cluster_name', r_lhn)
         facts['master'].setdefault('loopback_context_name', "default/{0}/system:openshift-master".format(r_lhn))


### PR DESCRIPTION
Reverts openshift/openshift-ansible#9487, as it breaks LB installs
