### PR TITLE
[3.8] Adding min-port to dnsmasq configuration

### DIFF
--- a/roles/openshift_node/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node/files/networkmanager/99-origin-dns.sh
@@ -56,6 +56,7 @@ server=/30.172.in-addr.arpa/172.30.0.1
 enable-dbus
 dns-forward-max=5000
 cache-size=5000
+min-port=1024
 EOF
       # New config file, must restart
       NEEDS_RESTART=1

--- a/roles/openshift_node/templates/origin-dns.conf.j2
+++ b/roles/openshift_node/templates/origin-dns.conf.j2
@@ -6,6 +6,7 @@ enable-dbus
 dns-forward-max=5000
 cache-size=5000
 bind-dynamic
+min-port=1024
 {% for interface in openshift_node_dnsmasq_except_interfaces %}
 except-interface={{ interface }}
 {% endfor %}


### PR DESCRIPTION
By default, older versions of dnsmasq can use lower-numbered source ports for outbound DNS queries.  This sometimes creates problems; for example, firewall rules may drop queries coming from these reserved ports.

To avoid these problems, we can set the minimum port number for outbound queries using dnsmasq's `min-port` setting.  dnsmasq 2.79 defaults `min-port` to 1024; for older versions of dnsmasq, we must set min-port to 1024.

This commit fixes bug 1614981.

https://bugzilla.redhat.com/show_bug.cgi?id=1614981

---

Cherry-picked from https://github.com/openshift/openshift-ansible/pull/9505