### PR TITLE
glusterfs reorganize wait for pod

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
@@ -48,6 +48,30 @@
   - glusterfs_heketi_deploy_is_missing
   - glusterfs_heketi_is_missing
 
+# We wait for pod here because if heketi_deploy_part1 is skipped, our registerd
+# value for deploy_heketi_pod becomes skipped as well.
+- name: Wait for deploy-heketi pod
+  oc_obj:
+    namespace: "{{ glusterfs_namespace }}"
+    kind: pod
+    state: list
+    selector: "glusterfs=deploy-heketi-{{ glusterfs_name }}-pod"
+  register: deploy_heketi_pod_wait
+  until:
+  - "deploy_heketi_pod_wait.results.results[0]['items'] | count > 0"
+  # Pod's 'Ready' status must be True
+  - "deploy_heketi_pod_wait.results.results[0]['items'] | lib_utils_oo_collect(attribute='status.conditions') | lib_utils_oo_collect(attribute='status', filters={'type': 'Ready'}) | map('bool') | select | list | count == 1"
+  delay: 10
+  retries: "{{ (glusterfs_timeout | int / 10) | int }}"
+  when:
+  - glusterfs_heketi_is_native
+
+- name: Update deploy-heketi pod result
+  set_fact:
+    deploy_heketi_pod: "{{ deploy_heketi_pod_wait.results.results[0]['items'][0] }}"
+  when:
+  - glusterfs_heketi_is_native
+
 - import_tasks: heketi_load.yml
   when:
   - glusterfs_heketi_topology_load

--- a/roles/openshift_storage_glusterfs/tasks/heketi_init_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_init_deploy.yml
@@ -29,24 +29,6 @@
       HEKETI_FSTAB: "{{ glusterfs_heketi_fstab }}"
       CLUSTER_NAME: "{{ glusterfs_name }}"
 
-- name: Wait for deploy-heketi pod
-  oc_obj:
-    namespace: "{{ glusterfs_namespace }}"
-    kind: pod
-    state: list
-    selector: "glusterfs=deploy-heketi-{{ glusterfs_name }}-pod"
-  register: deploy_heketi_pod_wait
-  until:
-  - "deploy_heketi_pod_wait.results.results[0]['items'] | count > 0"
-  # Pod's 'Ready' status must be True
-  - "deploy_heketi_pod_wait.results.results[0]['items'] | lib_utils_oo_collect(attribute='status.conditions') | lib_utils_oo_collect(attribute='status', filters={'type': 'Ready'}) | map('bool') | select | list | count == 1"
-  delay: 10
-  retries: "{{ (glusterfs_timeout | int / 10) | int }}"
-
-- name: Update deploy-heketi pod result
-  set_fact:
-    deploy_heketi_pod: "{{ deploy_heketi_pod_wait.results.results[0]['items'][0] }}"
-
 - name: Set deploy-heketi deployed fact
   set_fact:
     glusterfs_heketi_deploy_is_missing: False


### PR DESCRIPTION
Currently, heketi_deploy_part1.yml may be skipped
in some cases.  This causes a previously registered
variable to be overwritten with a skipped value.

This commit moves waiting for new pod into glusterfs_common.yml
to ensure it is always run instead of skipped.