### PR TITLE
apply the container_runtime for calico

### DIFF
--- a/roles/calico/meta/main.yml
+++ b/roles/calico/meta/main.yml
@@ -14,3 +14,4 @@ galaxy_info:
   - system
 dependencies:
 - role: openshift_facts
+- role: container_runtime


### PR DESCRIPTION
Add the correct container_runtime to fix calico build for release-3.10 branch. See https://github.com/openshift/openshift-ansible/pull/9392. 

Signed-off-by: derek mcquay <derekmcquay@gmail.com>