### PR TITLE
add conditional clauses for handling cnx versions

### DIFF
--- a/roles/calico_master/tasks/main.yml
+++ b/roles/calico_master/tasks/main.yml
@@ -36,18 +36,21 @@
 - name: Calico Master | Parse node version
   set_fact:
     node_version: "{{ calico_node_image | regex_replace('^.*node:v?(.*)$', '\\1') }}"
+    cnx: "{{ calico_node_image | regex_replace('[^-]*', '\\0') }}"
 
 - name: Calico Master | Write Calico v2
   template:
     dest: "{{ mktemp.stdout }}/calico.yml"
     src: calico.yml.j2
-  when: node_version | regex_search('^[0-9]\.[0-9]\.[0-9]') and node_version < '3.0.0'
+  when:
+    - node_version | regex_search('^[0-9]\.[0-9]\.[0-9]') and node_version < '3.0.0'
+    - cnx != "cnx"
 
 - name: Calico Master | Write Calico v3
   template:
     dest: "{{ mktemp.stdout }}/calico.yml"
     src: calicov3.yml.j2
-  when: (node_version | regex_search('^[0-9]\.[0-9]\.[0-9]') and node_version >= '3.0.0') or node_version == 'master'
+  when: (node_version | regex_search('^[0-9]\.[0-9]\.[0-9]') and node_version >= '3.0.0') or (node_version == 'master') or (cnx == "cnx" and node_version >= '2.0.0')
 
 - name: Calico Master | Launch Calico
   command: >


### PR DESCRIPTION
Update conditional clauses for cnx version. Since cnx is requires calico v3, this change allows for the detection of whether a user is using cnx and handles it correctly for release-3.10. See https://github.com/openshift/openshift-ansible/pull/9416

