### PR TITLE
Added support for ak when registering hosts

### DIFF
--- a/roles/rhel_subscribe/README.md
+++ b/roles/rhel_subscribe/README.md
@@ -6,6 +6,12 @@ Subscribes the RHEL servers and add the OpenShift enterprise repos.
 Role variables
 --------------
 
+**NOTE**: `rhsub_user`/`rhsub_pass` and `rhsub_ak`/`rhsub_orgid` are mutually exclusive:
+* If you want to use user/password to register the instance, it is required to
+configure the `rhsub_user` and `rhsub_pass`.
+* If you want to use an activation key to register the instance, it is required to
+configure the `rhsub_ak` and `rhsub_orgid`.
+
 ### `rhsub_user`
 
 Username for the subscription-manager.
@@ -13,6 +19,14 @@ Username for the subscription-manager.
 ### `rhsub_pass`
 
 Password for the subscription-manager.
+
+### `rhsub_ak`
+
+Activation key for the subscription-manager.
+
+### `rhsub_orgid`
+
+Organization ID for the subscription-manager.
 
 ### `rhsub_pool`
 

--- a/roles/rhel_subscribe/tasks/main.yml
+++ b/roles/rhel_subscribe/tasks/main.yml
@@ -15,7 +15,7 @@
   register: rh_subscribed
   changed_when: False
 
-- name: Register host
+- name: Register host using user/password
   redhat_subscription:
     username: "{{ rhsub_user }}"
     password: "{{ rhsub_pass }}"
@@ -23,6 +23,19 @@
   until: rh_subscription is succeeded
   when:
     - "'not registered' in rh_subscribed.stdout"
+    - rhsub_user is defined
+    - rhsub_pass is defined
+
+- name: Register host using activation key
+  redhat_subscription:
+    activationkey: "{{ rhsub_ak }}"
+    org_id: "{{ rhsub_orgid }}"
+  register: rh_subscription
+  until: rh_subscription is succeeded
+  when:
+    - "'not registered' in rh_subscribed.stdout"
+    - rhsub_ak is defined
+    - rhsub_orgid is defined
 
 - fail:
     msg: 'Unable to register host with Red Hat Subscription Manager'


### PR DESCRIPTION
When you subscribe a system to the RHN, you can use user/pass or orgid/ak which is pretty more convenient than using passwords.

The current rhel_subscribe role doesn't support aks https://github.com/openshift/openshift-ansible/tree/master/roles/rhel_subscribe

Fixes #9578
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1615807