### PR TITLE
change default sc name

### DIFF
--- a/roles/openshift_default_storage_class/defaults/main.yml
+++ b/roles/openshift_default_storage_class/defaults/main.yml
@@ -32,7 +32,7 @@ openshift_storageclass_defaults:
 
   vsphere:
     provisioner: vsphere-volume
-    name: standard
+    name: vsphere-standard
     parameters:
       datastore: "{{ openshift_cloudprovider_vsphere_datastore }}"
 


### PR DESCRIPTION
1. The use of the name "standard" for default storage class has been confusing for some people using vsphere cloud provider. 
2. Add the denotation of vsphere to the storage class name 