### PR TITLE
[3.9] add a playbook to regenerate service-catalog certs

### DIFF
--- a/playbooks/openshift-service-catalog/private/redeploy-certificates.yml
+++ b/playbooks/openshift-service-catalog/private/redeploy-certificates.yml
@@ -1,0 +1,27 @@
+---
+- name: Update service catalog certificates
+  hosts: oo_first_master
+  vars:
+  roles:
+    - lib_openshift
+    - openshift_facts
+  tasks:
+    - name: Remove existing SC and ASB certificates
+      import_role:
+        name: ansible_service_broker
+        tasks_from: delete_secrets.yml
+
+    - name: Generate new service catalog certificates
+      import_role:
+        name: ansible_service_broker
+        tasks_from: generate_certs.yml
+
+    - name: Update secrets
+      import_role:
+        name: ansible_service_broker
+        tasks_from: update_secrets.yml
+
+    - name: Generate new service catalog certificates
+      import_role:
+        name: ansible_service_broker
+        tasks_from: restart_pods.yml

--- a/playbooks/openshift-service-catalog/redeploy-certificates.yml
+++ b/playbooks/openshift-service-catalog/redeploy-certificates.yml
@@ -1,0 +1,9 @@
+---
+- import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
+
+- import_playbook: private/redeploy-certificates.yml

--- a/playbooks/redeploy-certificates.yml
+++ b/playbooks/redeploy-certificates.yml
@@ -21,6 +21,9 @@
 - import_playbook: openshift-hosted/private/redeploy-registry-certificates.yml
   when: openshift_hosted_manage_registry | default(true) | bool
 
+- import_playbook: openshift-service-catalog/private/redeploy-certificates.yml
+  when: not openshift_service_catalog_remove | default(false) | bool
+
 - import_playbook: openshift-master/private/revert-client-ca.yml
 
 - import_playbook: openshift-master/private/restart.yml

--- a/roles/ansible_service_broker/tasks/delete_secrets.yml
+++ b/roles/ansible_service_broker/tasks/delete_secrets.yml
@@ -1,0 +1,22 @@
+---
+- name: Delete existing secrets
+  oc_secret:
+    name: "{{ item }}"
+    namespace: openshift-ansible-service-broker
+    state: absent
+  with_items:
+    - etcd-auth-secret
+    - broker-etcd-auth-secret
+    - asb-client
+    - asb-tls
+    - etcd-tls
+
+- name: Delete master certs
+  file:
+    path: "{{ openshift.common.config_base }}/ansible-service-broker/{{ item }}"
+    state: absent
+  with_items:
+    - cert.pem
+    - client.key
+    - client.csr
+    - client.pem

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -30,9 +30,9 @@
     ansible_service_broker_image: "{{ ansible_service_broker_image_prefix }}ansible-service-broker:{{ ansible_service_broker_image_tag }}"
     ansible_service_broker_etcd_image: "{{ ansible_service_broker_etcd_image_prefix }}etcd:{{ ansible_service_broker_etcd_image_tag }}"
 
-- include_tasks: validate_facts.yml
+- import_tasks: validate_facts.yml
 
-- include_tasks: generate_certs.yml
+- import_tasks: generate_certs.yml
 
 # Deployment of ansible-service-broker starts here
 - name: create openshift-ansible-service-broker project
@@ -113,50 +113,7 @@
     resource_name: asb-access
     user: "system:serviceaccount:openshift-ansible-service-broker:asb-client"
 
-- name: create asb-client token secret
-  oc_obj:
-    name: asb-client
-    namespace: openshift-ansible-service-broker
-    state: present
-    kind: Secret
-    content:
-      path: /tmp/asbclientsecretout
-      data:
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          name: asb-client
-          namespace: openshift-ansible-service-broker
-          annotations:
-            kubernetes.io/service-account.name: asb-client
-        type: kubernetes.io/service-account-token
-
-- name: Create etcd-auth secret
-  oc_secret:
-    name: etcd-auth-secret
-    namespace: openshift-ansible-service-broker
-    contents:
-      - path: ca.crt
-        data: '{{ etcd_ca_cert }}'
-
-- name: Create broker-etcd-auth secret
-  oc_secret:
-    name: broker-etcd-auth-secret
-    namespace: openshift-ansible-service-broker
-    contents:
-      - path: client.crt
-        data: '{{ etcd_client_cert }}'
-      - path: client.key
-        data: '{{ etcd_client_key }}'
-
-- oc_secret:
-    state: list
-    namespace: openshift-ansible-service-broker
-    name: asb-client
-  register: asb_client_secret
-
-- set_fact:
-    service_ca_crt: "{{ asb_client_secret.results.results.0.data['service-ca.crt'] }}"
+- import_tasks: update_secrets.yml
 
 - name: create ansible-service-broker service
   oc_service:

--- a/roles/ansible_service_broker/tasks/restart_pods.yml
+++ b/roles/ansible_service_broker/tasks/restart_pods.yml
@@ -1,0 +1,37 @@
+---
+- name: Remove 'signed-by' service annotations to regenerate TLS secrets
+  command: >
+    {{ openshift_client_binary }} annotate service/{{ item }}
+    service.alpha.openshift.io/serving-cert-signed-by-
+    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    -n openshift-ansible-service-broker
+  with_items:
+    - asb
+    - asb-etcd
+
+- name: Remove ASB pods
+  oc_obj:
+    selector: "deploymentconfig={{ item }}"
+    kind: pod
+    state: absent
+    namespace: openshift-ansible-service-broker
+  with_items:
+    - asb
+    - asb-etcd
+
+- name: Verify that the ASB is running
+  oc_obj:
+    namespace: openshift-ansible-service-broker
+    kind: deploymentconfig
+    state: list
+    name: "{{ item }}"
+  register: asb_deployment
+  until:
+    - asb_deployment.results.results[0].status.readyReplicas is defined
+    - asb_deployment.results.results[0].status.readyReplicas > 0
+  retries: 60
+  delay: 10
+  changed_when: false
+  with_items:
+    - asb
+    - asb-etcd

--- a/roles/ansible_service_broker/tasks/update_secrets.yml
+++ b/roles/ansible_service_broker/tasks/update_secrets.yml
@@ -1,0 +1,83 @@
+---
+- name: create asb-client token secret
+  oc_obj:
+    name: asb-client
+    namespace: openshift-ansible-service-broker
+    state: present
+    kind: Secret
+    content:
+      path: /tmp/asbclientsecretout
+      data:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: asb-client
+          namespace: openshift-ansible-service-broker
+          annotations:
+            kubernetes.io/service-account.name: asb-client
+        type: kubernetes.io/service-account-token
+
+- oc_secret:
+    state: list
+    namespace: openshift-ansible-service-broker
+    name: asb-client
+  register: asb_client_secret
+
+- set_fact:
+    service_ca_crt: "{{ asb_client_secret.results.results.0.data['service-ca.crt'] }}"
+
+- name: Create etcd-auth secret
+  oc_secret:
+    name: etcd-auth-secret
+    namespace: openshift-ansible-service-broker
+    contents:
+      - path: ca.crt
+        data: '{{ etcd_ca_cert }}'
+
+- name: Create broker-etcd-auth secret
+  oc_secret:
+    name: broker-etcd-auth-secret
+    namespace: openshift-ansible-service-broker
+    contents:
+      - path: client.crt
+        data: '{{ etcd_client_cert }}'
+      - path: client.key
+        data: '{{ etcd_client_key }}'
+
+# The annotation would create asb-tls secret
+- name: create ansible-service-broker service
+  oc_service:
+    name: asb
+    namespace: openshift-ansible-service-broker
+    labels:
+      app: openshift-ansible-service-broker
+      service: asb
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: asb-tls
+    ports:
+      - name: port-1338
+        port: 1338
+        targetPort: 1338
+        protocol: TCP
+    selector:
+      app: openshift-ansible-service-broker
+      service: asb
+
+# The annotation would create etcd-tls secret
+- name: create asb-etcd service
+  oc_service:
+    name: asb-etcd
+    namespace: openshift-ansible-service-broker
+    labels:
+      app: etcd
+      service: asb-etcd
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: etcd-tls
+    ports:
+      - name: port-2379
+        port: 2379
+        targetPort: 2379
+        protocol: TCP
+    selector:
+      app: etcd
+      service: asb-etcd


### PR DESCRIPTION
ASB pods need to have their secrets regenerated during redeploy-certificates.yml
playbook run

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1596557

This is not necessary for 3.10+ as they use CRDs instead of etcd server