### PR TITLE
node kubelet args fail instead of warn

### DIFF
--- a/roles/lib_utils/action_plugins/sanity_checks.py
+++ b/roles/lib_utils/action_plugins/sanity_checks.py
@@ -112,6 +112,8 @@ REMOVED_VARIABLES = (
     ('openshift_hosted_metrics_deploy', 'openshift_metrics_install_metrics'),
     ('openshift_hosted_metrics_storage_kind', 'openshift_metrics_storage_kind'),
     ('openshift_hosted_metrics_public_url', 'openshift_metrics_hawkular_hostname'),
+    ('openshift_node_labels', 'openshift_node_groups[<item>].labels'),
+    ('openshift_node_kubelet_args', 'openshift_node_groups[<item>].edits'),
 )
 
 # JSON_FORMAT_VARIABLES does not intende to cover all json variables, but

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -18,45 +18,6 @@ system_osn_image: "{{ (system_images_registry == 'docker') | ternary('docker:' +
 
 openshift_node_env_vars: {}
 
-# Create list of 'k=v' pairs.
-l_node_kubelet_node_labels: "{{ openshift_node_labels | default({}) | lib_utils_oo_dict_to_keqv_list }}"
-
-openshift_node_kubelet_args_dict:
-  aws:
-    cloud-provider:
-    - aws
-    cloud-config:
-    - "{{ openshift_config_base ~ '/cloudprovider/aws.conf' }}"
-    node-labels: "{{ l_node_kubelet_node_labels }}"
-  openstack:
-    cloud-provider:
-    - openstack
-    cloud-config:
-    - "{{ openshift_config_base ~ '/cloudprovider/openstack.conf' }}"
-    node-labels: "{{ l_node_kubelet_node_labels }}"
-  gce:
-    cloud-provider:
-    - gce
-    cloud-config:
-    - "{{ openshift_config_base ~ '/cloudprovider/gce.conf' }}"
-    node-labels: "{{ l_node_kubelet_node_labels }}"
-  azure:
-    cloud-provider:
-    - azure
-    cloud-config:
-    - "{{ openshift_config_base ~ '/cloudprovider/azure.conf' }}"
-    node-labels: "{{ l_node_kubelet_node_labels }}"
-  vsphere:
-    cloud-provider:
-    - vsphere
-    cloud-config:
-    - "{{ openshift_config_base ~ '/cloudprovider/vsphere.conf' }}"
-    node-labels: "{{ l_node_kubelet_node_labels }}"
-  undefined:
-    node-labels: "{{ l_node_kubelet_node_labels }}"
-
-l2_openshift_node_kubelet_args: "{{ openshift_node_kubelet_args_dict[openshift_cloudprovider_kind | default('undefined')] }}"
-
 # lo must always be present in this list or dnsmasq will conflict with
 # the node's dns service.
 openshift_node_dnsmasq_except_interfaces:

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -18,11 +18,6 @@
 - name: Install the systemd units
   import_tasks: systemd_units.yml
 
-- file:
-    dest: "{{ l2_openshift_node_kubelet_args['config'] }}"
-    state: directory
-  when: ('config' in l2_openshift_node_kubelet_args) | bool
-
 - name: Configure Node Environment Variables
   lineinfile:
     dest: /etc/sysconfig/{{ openshift_service_type }}-node

--- a/roles/openshift_sanitize_inventory/vars/main.yml
+++ b/roles/openshift_sanitize_inventory/vars/main.yml
@@ -6,6 +6,3 @@ __deprecation_header: "[DEPRECATION WARNING]: The following are deprecated varia
 __warn_deprecated_vars:
   # logging
   - 'openshift_logging_namespace'
-  # labels and kubelet args
-  - 'openshift_node_labels'
-  - 'openshift_node_kubelet_args'


### PR DESCRIPTION
Currently, we only warn users if they are using openshift_node_kubelet_args
or openshift_node_labels.  These variables have zero effect
and their behavior was not migrated, simply removed.

This commit ensures we fail early if these variables are defined
so users understand that they must make the proper changes to
inventory to avoid deploying a cluster without the proper configs.