### PR TITLE
Configure kube-proxy and the SDN to expose metrics.

### DIFF
--- a/roles/openshift_node_group/templates/node-config.yaml.j2
+++ b/roles/openshift_node_group/templates/node-config.yaml.j2
@@ -77,3 +77,5 @@ volumeConfig:
   localQuota:
     perFSGroup: null
 volumeDirectory: {{ openshift_node_group_node_data_dir }}/openshift.local.volumes
+proxyArguments:
+  metrics-bind-address: [":11257"]


### PR DESCRIPTION
Right now, kube-proxy is configured to listen on a hard-coded port on localhost that conflicts with the kubelet (now that they are separate processes). Change it to listen on an unused port.

Fixes: bz1588420