### PR TITLE
Remove asb-user-access cluster-role when uninstalling ASB

### DIFF
--- a/roles/ansible_service_broker/tasks/remove.yml
+++ b/roles/ansible_service_broker/tasks/remove.yml
@@ -46,6 +46,11 @@
     state: absent
     name: asb-access
 
+- name: remove asb-user-access cluster role
+  oc_clusterrole:
+    state: absent
+    name: asb-user-access
+
 - name: remove asb-registry auth secret
   oc_secret:
     state: absent


### PR DESCRIPTION
This is for BZ 1615278 (https://bugzilla.redhat.com/show_bug.cgi?id=1615278)