### PR TITLE
The l_glusterfs_count is a string need to cast to int for comparison.

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/wait_for_pods.yml
+++ b/roles/openshift_storage_glusterfs/tasks/wait_for_pods.yml
@@ -9,8 +9,8 @@
   until:
   - "glusterfs_pods_wait.results.results[0]['items'] | count > 0"
   # There must be as many pods with 'Ready' staus  True as there are nodes expecting those pods
-  - "glusterfs_pods_wait.results.results[0]['items'] | lib_utils_oo_collect(attribute='status.conditions') | lib_utils_oo_collect(attribute='status', filters={'type': 'Ready'}) | map('bool') | select | list | count == l_glusterfs_count"
+  - "glusterfs_pods_wait.results.results[0]['items'] | lib_utils_oo_collect(attribute='status.conditions') | lib_utils_oo_collect(attribute='status', filters={'type': 'Ready'}) | map('bool') | select | list | count == l_glusterfs_count | int"
   delay: 10
   retries: "{{ (glusterfs_timeout | int / 10) | int }}"
   vars:
-    l_glusterfs_count: "{{ glusterfs_count | default(glusterfs_nodes | count) | int }}"
+    l_glusterfs_count: "{{ glusterfs_count | default(glusterfs_nodes | count) }}"


### PR DESCRIPTION
This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1615982 where the `Wait for GlusterFS pods` task failed after maximum retries.

I tested a deploy with this branch and the task completed after 8 attempts:
```
FAILED - RETRYING: Wait for GlusterFS pods (24 retries left).Result was: {
    "attempts": 7,
...
                        "status": {
                            "conditions": [
...
                                    "status": "True",
                                    "type": "Ready"
...
                                    "status": "False",
                                    "type": "Ready"
...
                                    "status": "True",
                                    "type": "Ready"
...
ok: [master-1.scale-ci.example.com] => {
    "attempts": 8,
...
                        "status": {
                            "conditions": [
...
                                    "status": "True",
                                    "type": "Ready"
...
                                    "status": "True",
                                    "type": "Ready"
...
                                    "status": "True",
                                    "type": "Ready"
```