### PR TITLE
[BACKPORT] Update routers that are defined in openshift_hosted_routers

### DIFF
--- a/roles/openshift_hosted/tasks/upgrade_routers.yml
+++ b/roles/openshift_hosted/tasks/upgrade_routers.yml
@@ -1,33 +1,14 @@
 ---
-- name: Collect all routers
-  oc_obj:
-    state: list
-    kind: pods
-    all_namespaces: True
-    selector: 'router'
-  register: all_routers
-
-- set_fact:
-    haproxy_routers: "{{ all_routers.results.results[0]['items'] |
-                         lib_utils_oo_pods_match_component(openshift_deployment_type, 'haproxy-router') |
-                         lib_utils_oo_select_keys_from_list(['metadata']) }}"
-  when:
-  - all_routers.results.returncode == 0
-
-- set_fact: haproxy_routers=[]
-  when:
-  - all_routers.results.returncode != 0
-
 - name: Update router image to current version
   oc_edit:
     kind: dc
-    name: "{{ item['labels']['deploymentconfig'] }}"
+    name: "{{ item['name'] }}"
     namespace: "{{ item['namespace'] }}"
     content:
       spec.template.spec.containers[0].image: "{{ l_osh_router_image }}"
-  with_items: "{{ haproxy_routers }}"
+  with_items: "{{ openshift_hosted_routers }}"
   vars:
     l_osh_router_image: "{{ openshift_hosted_router_registryurl | replace( '${component}', 'haproxy-router' ) |
                             replace ( '${version}', openshift_image_tag ) }}"
   when:
-  - all_routers.results.returncode == 0
+  - openshift_hosted_routers | length > 0


### PR DESCRIPTION
Previously we updated routers based on matching pods in the default
namespace against, however we should already know the list of routers
that we're responsible for.

Fixes: rhbz#1612350