### PR TITLE
Remove pod filtering

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -28,7 +28,6 @@
 
   - set_fact:
       haproxy_routers: "{{ all_routers.results.results[0]['items'] |
-                           oo_pods_match_component(openshift_deployment_type, 'haproxy-router') |
                            oo_select_keys_from_list(['metadata']) }}"
     when:
     - all_routers.results.returncode == 0


### PR DESCRIPTION
Setting image prefix while filtering pods can cause problems while
upgrading.

Fixes: rhbz#1612350