### PR TITLE
Bug 1615275. Regenerate session_secret if it can't be used with oauth-proxy

### DIFF
--- a/roles/openshift_logging_kibana/tasks/main.yaml
+++ b/roles/openshift_logging_kibana/tasks/main.yaml
@@ -71,8 +71,7 @@
   copy:
     content: "{{ 32 | lib_utils_oo_random_word }}"
     dest: "{{ generated_certs_dir }}/session_secret"
-  when:
-    - not session_secret_file.stat.exists
+  when: not session_secret_file.stat.exists or session_secret_file.stat.size > 50
 
 # gen oauth_secret if necessary
 - name: Generate oauth secret


### PR DESCRIPTION
session_secret generated by 3.10 is 200 bytes. oauth-proxy can use 16, 24 or 32
bytes session_secret.

@jcantrill @ewolinetz @josefkarasek 

https://bugzilla.redhat.com/show_bug.cgi?id=1615275