### PR TITLE
[release-3.10] [Bug 1618425] Remove system container cri-o during 3.10 upgrade

### DIFF
--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -20,6 +20,33 @@
   - l_docker_upgrade is defined
   - l_docker_upgrade | bool
 
+- name: Check if cri-o is running as a system container
+  stat:
+    path: "/etc/systemd/system/cri-o.service"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
+  register: crio_result
+  when: not openshift_is_atomic | bool
+
+# Remove system container cri-o
+- when:
+  - crio_result is defined
+  - crio_result.stat.exists
+  - not openshift_is_atomic | bool
+  block:
+  - name: Uninstall cri-o system container
+    command: atomic uninstall cri-o
+
+  - name: List cri-o atomic image
+    command: atomic images list -f repo=cri-o --json
+    register: crio_images_list
+
+  - name: Delete cri-o system container image
+    command: atomic -y images delete -f {{ crio_image_id }}
+    vars:
+      crio_image_id: "{{ (crio_images_list.stdout | from_json)[0].id }}"
+
 - name: Ensure cri-o is updated
   package:
     name: "{{ crio_pkgs | join (',') }}"

--- a/roles/openshift_node/tasks/upgrade/restart.yml
+++ b/roles/openshift_node/tasks/upgrade/restart.yml
@@ -34,6 +34,7 @@
   service:
     name: cri-o
     state: started
+    enabled: true
   when: openshift_use_crio | bool
 
 - name: Start node service


### PR DESCRIPTION
Running cri-o as a system container is unsupported. In the event an
upgrade is performed on a node running cri-o as a system container, the
node will be converted to run cri-o from an RPM.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1618425