### PR TITLE
Fix default logging namespace for prometheus

### DIFF
--- a/roles/openshift_prometheus/templates/prometheus.yml.j2
+++ b/roles/openshift_prometheus/templates/prometheus.yml.j2
@@ -146,7 +146,7 @@ scrape_configs:
     # drop logging components managed by other scrape targets
     - source_labels: [__meta_kubernetes_namespace]
       action: drop
-      regex: '{{ openshift_logging_namespace | default('logging') }}'
+      regex: '{{ openshift_logging_namespace | default('openshift-logging') }}'
     # drop infrastructure components managed by other scrape targets
     - source_labels: [__meta_kubernetes_service_name]
       action: drop
@@ -199,7 +199,7 @@ scrape_configs:
   - role: endpoints
     namespaces:
       names:
-      - '{{ openshift_logging_namespace | default('logging') }}'
+      - '{{ openshift_logging_namespace | default('openshift-logging') }}'
 
   relabel_configs:
     # drop infrastructure components managed by other scrape targets


### PR DESCRIPTION
This PR fixes the default namespace for prometheus to resolve:

Ref. https://bugzilla.redhat.com/show_bug.cgi?id=1616278