### PR TITLE
Fix audit config interpolation

### DIFF
--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -19,8 +19,8 @@ authConfig:
     - X-Remote-Extra-
 apiLevels:
 - v1
-{% if openshift_master_audit_config is defined %}
-auditConfig:{{ openshift_master_audit_config | lib_utils_to_padded_yaml(level=1) }}
+{% if openshift.master.audit_config is defined %}
+auditConfig:{{ openshift.master.audit_config | lib_utils_to_padded_yaml(level=1) }}
 {% endif %}
 controllerConfig:
   election:

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -52,6 +52,7 @@
       kube_admission_plugin_config: "{{openshift_master_kube_admission_plugin_config | default(None) }}"  # deprecated, merged with admission_plugin_config
       image_policy_config: "{{ openshift_master_image_policy_config | default(None) }}"
       image_policy_allowed_registries_for_import: "{{ openshift_master_image_policy_allowed_registries_for_import | default(None) }}"
+      audit_config: "{{ openshift_master_audit_config | default(None) }}"
 
 - name: Determine if scheduler config present
   stat:


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-ansible/issues/9619

By default, string values from the inventory files aren't parsed as JSON values, but `lib_utils_to_padded_yaml` expects objects. With `local_facts` conversion you get what you expect. Value from `openshift_master_audit_config` will be loaded as an object and placed correctly in master config.

I have tested this change manually.