### PR TITLE
Default CFME nodeselector should be a list of str, not a dict

### DIFF
--- a/roles/openshift_management/defaults/main.yml
+++ b/roles/openshift_management/defaults/main.yml
@@ -6,7 +6,7 @@ openshift_management_project_description: CloudForms Management Engine
 # Number of retries when waiting for the app to start (retried every 30 seconds)
 openshift_management_pod_rollout_retries: 30
 # Node selector for project:
-openshift_management_nodeselector: "{{ openshift_hosted_infra_selector | default('node-role.kubernetes.io/infra=true') | map_from_pairs }}"
+openshift_management_nodeselector: "{{ openshift_hosted_infra_selector | default(['node-role.kubernetes.io/infra=true'])}}"
 
 ######################################################################
 # BASE TEMPLATE AND DATABASE OPTIONS


### PR DESCRIPTION
This nodeselector is used in `oc_project`, which requires a list of strings instead of a dict

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1613754