### PR TITLE
Remove duplicated bootstrapped SCC check

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane.yml
@@ -45,29 +45,6 @@
     # oo_lb_to_config might not be present; Can't use !oo_nodes because masters are nodes.
     l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) | union(groups['oo_lb_to_config'] | default([]) ) }}"
 
-# Some change makes critical outage on current cluster.
-- name: Confirm upgrade will not make critical changes
-  hosts: oo_first_master
-  tasks:
-  - name: Confirm Reconcile Security Context Constraints will not change current SCCs
-    command: >
-      {{ openshift_client_binary }} adm policy --config={{ openshift.common.config_base }}/master/admin.kubeconfig reconcile-sccs --additive-only=true -o name
-    register: check_reconcile_scc_result
-    when: openshift_reconcile_sccs_reject_change | default(true) | bool
-    until: check_reconcile_scc_result.rc == 0
-    retries: 3
-
-  - fail:
-      msg: >
-        Changes to bootstrapped SCCs have been detected. Please review the changes by running
-        "{{ openshift_client_binary }} adm policy --config={{ openshift.common.config_base }}/master/admin.kubeconfig reconcile-sccs --additive-only=true"
-        After reviewing the changes please apply those changes by adding the '--confirm' flag.
-        Do not modify the default SCCs. Customizing the default SCCs will cause this check to fail when upgrading.
-        If you require non standard SCCs please refer to https://docs.okd.io/latest/admin_guide/manage_scc.html
-    when:
-    - openshift_reconcile_sccs_reject_change | default(true) | bool
-    - check_reconcile_scc_result.stdout != '' or check_reconcile_scc_result.rc != 0
-
 - name: Flag pre-upgrade checks complete for hosts without errors
   hosts: oo_masters_to_config:oo_etcd_to_config
   tasks:


### PR DESCRIPTION
Its already being done in 
playbooks/openshift-master/private/upgrade.yml, which is called before 
oc has been updated

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1610496