### PR TITLE
service-catalog: use K8s NamespaceLifecycle admission controller

### DIFF
--- a/roles/openshift_service_catalog/templates/api_server.j2
+++ b/roles/openshift_service_catalog/templates/api_server.j2
@@ -44,7 +44,7 @@ spec:
         - --cors-allowed-origins
         - {{ cors_allowed_origin }}
         - --enable-admission-plugins
-        - KubernetesNamespaceLifecycle,DefaultServicePlan,ServiceBindingsLifecycle,ServicePlanChangeValidator,BrokerAuthSarCheck
+        - NamespaceLifecycle,DefaultServicePlan,ServiceBindingsLifecycle,ServicePlanChangeValidator,BrokerAuthSarCheck
         - --feature-gates
         - OriginatingIdentity=true
 {% if openshift_service_catalog_namespaced_service_brokers_enabled | bool %}


### PR DESCRIPTION
matches the change in origin:  https://github.com/openshift/origin/pull/20673
we dropped using a Service Catalog admission controller that did the same thing and are now picking up this AC from K8s. 