### PR TITLE
Restore AWS configuration when a node is being updated

### DIFF
--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -27,6 +27,9 @@
 - name: Update systemd units
   import_tasks: ../systemd_units.yml
 
+- name: Add AWS configuration
+  import_tasks: ../aws.yml
+
 # NOTE: This is needed to make sure we are using the correct set
 #       of systemd unit files. The RPMs lay down defaults but
 #       the install/upgrade may override them in /etc/systemd/system/.


### PR DESCRIPTION
During 3.10 -> 3.11 upgrade the RPM update erases settings in 
/etc/sysconfig/origin-node, so AWS settings need to be written again there

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1618420