### PR TITLE
Wait for node start before try to approve nodes

### DIFF
--- a/playbooks/openshift-node/private/join.yml
+++ b/playbooks/openshift-node/private/join.yml
@@ -37,6 +37,10 @@
     debug:
       msg: "{{ l_nodes_to_join }}"
 
+  - name: Wait for node start
+    pause:
+      seconds: 5
+
   - name: Approve bootstrap nodes
     oc_adm_csr:
       nodes: "{{ l_nodes_to_join }}"


### PR DESCRIPTION
After [node restart](https://github.com/openshift/openshift-ansible/blob/master/playbooks/openshift-node/private/join.yml#L16) we should wait till nodes, that are already part of a cluster, are started and [announce to be ready](https://github.com/openshift/openshift-ansible/blob/master/roles/lib_openshift/library/oc_adm_csr.py#L1512).
Fixes: https://github.com/openshift/origin/issues/20570