### PR TITLE
[Bug 1611818] Use openshift_image_tag for registry-console upgrade

### DIFF
--- a/roles/openshift_hosted/tasks/upgrade_registry.yml
+++ b/roles/openshift_hosted/tasks/upgrade_registry.yml
@@ -37,7 +37,7 @@
       spec.template.spec.containers[0].image: "{{ l_osh_registry_console_image }}"
   vars:
     l_osh_registry_console_image: "{{ openshift_hosted_registry_registryurl | regex_replace ( '(origin|ose)-\\${component}', 'registry-console') |
-                                      replace ( '${version}', 'v' ~ openshift_upgrade_target ) }}"
+                                      replace ( '${version}', openshift_image_tag ) }}"
   when:
   - openshift_deployment_type != 'origin'
   - _registry_console.results.results[0] != {}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1611818