### PR TITLE
Update playbooks for Calico in OpenShift 3.10

### DIFF
--- a/playbooks/openshift-node/private/join.yml
+++ b/playbooks/openshift-node/private/join.yml
@@ -65,6 +65,21 @@
     openshift_master_host: "{{ groups.oo_first_master.0 }}"
     openshift_manage_node_is_master: "{{ ('oo_masters_to_config' in group_names) | bool }}"
 
+- name: Create additional node network plugin groups
+  hosts: "{{ openshift_node_scale_up_group | default('oo_nodes_to_config') }}"
+  tasks:
+  # Creating these node groups will prevent a ton of skipped tasks.
+  # Create group for calico nodes
+  - group_by:
+      key: oo_nodes_use_{{ (openshift_use_calico | default(False)) | ternary('calico','nothing') }}
+    changed_when: False
+
+- name: Additional calico node config
+  hosts: oo_nodes_use_calico
+  roles:
+  - role: calico
+    when: openshift_use_calico | default(false) | bool
+
 - name: Node Join Checkpoint End
   hosts: all
   gather_facts: false

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -26,7 +26,7 @@
 # TODO: Move into shared vars file
 - name: Load default node image
   set_fact:
-    calico_node_image: "quay.io/calico/node:v2.6.7"
+    calico_node_image: "quay.io/calico/node:v3.1.3"
   when: calico_node_image is not defined
 
 - name: Prepull Images

--- a/roles/calico_master/templates/calicov3.yml.j2
+++ b/roles/calico_master/templates/calicov3.yml.j2
@@ -290,7 +290,7 @@ spec:
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within '--cluster-cidr'.
             - name: CALICO_IPV4POOL_CIDR
-              value: "{{ openshift.master.sdn_cluster_network_cidr }}"
+              value: "{{ openshift_cluster_network_cidr }}"
             - name: CALICO_IPV4POOL_IPIP
               value: "{{ calico_ipv4pool_ipip }}"
             # Disable IPv6 on Kubernetes.


### PR DESCRIPTION
Adds back in the node selector that prevents calico from starting on nodes and fixes the outdated use of `openshift.master.sdn_cluster_network_cidr`.

Since it does not seem that the `calico` role (the important part is the check for the legacy systemd service) gets run during an upgrade from OpenShift 3.9 to 3.10, we will still need to keep that role and the node selector (as per https://github.com/openshift/openshift-ansible/pull/9435#issuecomment-411178796).

Calico will also require the changes made in https://github.com/openshift/openshift-ansible/pull/9621 to function properly.