### PR TITLE
[release-3.10] [Bug 1572857] Remove atomic-openshift-master package during upgrade

### DIFF
--- a/roles/openshift_control_plane/tasks/upgrade.yml
+++ b/roles/openshift_control_plane/tasks/upgrade.yml
@@ -132,6 +132,13 @@
     value: "{{ runtime_config.result | join(',') | regex_replace('(?:,)*apis/settings\\.k8s\\.io/v1alpha1=true','') }}"
   when: runtime_config.result
 
+# The master package gets updated due to the dependencies of the atomic-openshift
+# package when upgrading from 3.9 to 3.10.
+- name: Remove atomic-openshift-master package
+  package:
+    name: "{{ openshift_service_type }}-master"
+    state: absent
+
 - name: Remove old service information
   file:
     path: "{{ item }}"


### PR DESCRIPTION
During an upgrade from 3.9, when the node packages are updated, the
atomic-openshift package has a dependency on atomic-openshift-master
package.  This results in the master package being updated to 3.10.
This package is not necessary on 3.10 and is removed during the control
plane upgrade.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1572857