### PR TITLE
Remove traces of containerized install

### DIFF
--- a/playbooks/adhoc/uninstall_docker.yml
+++ b/playbooks/adhoc/uninstall_docker.yml
@@ -19,7 +19,6 @@
   # Since we're not calling openshift_facts we'll do this for now
   - set_fact:
       openshift_is_atomic: "{{ ostree_output.rc == 0 }}"
-      openshift_is_containerized: "{{ ostree_output.rc == 0 or containerized | default(false) | bool }}"
 
 - hosts: nodes:masters
   become: yes

--- a/playbooks/adhoc/uninstall_openshift.yml
+++ b/playbooks/adhoc/uninstall_openshift.yml
@@ -19,7 +19,6 @@
   # Since we're not calling openshift_facts we'll do this for now
   - set_fact:
       openshift_is_atomic: "{{ ostree_output.rc == 0 }}"
-      openshift_is_containerized: "{{ ostree_output.rc == 0 or containerized | default(false) | bool }}"
 
 # Stop services on all hosts prior to removing files.
 - hosts: nodes
@@ -430,13 +429,6 @@
     - etcd
     - etcd3
     - firewalld
-
-  - name: Stop additional atomic services
-    service: name={{ item }} state=stopped
-    when: openshift_is_containerized | bool
-    with_items:
-    - etcd_container
-    failed_when: false
 
   - name: Remove packages
     package:

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -14,9 +14,9 @@
   command: "{{ openshift_container_cli }} pull {{ openshift_cli_image }}"
   register: pull_result
   changed_when: "'Downloaded newer image' in pull_result.stdout"
-  when: openshift_is_containerized | bool
+  when: openshift_is_atomic | bool
 
-- when: not openshift_is_containerized | bool
+- when: not openshift_is_atomic | bool
   block:
   - name: Check latest available OpenShift RPM version
     repoquery:

--- a/playbooks/init/basic_facts.yml
+++ b/playbooks/init/basic_facts.yml
@@ -32,10 +32,9 @@
     - openshift_deployment_type is undefined
     - deployment_type is defined
 
-  - name: initialize_facts set fact openshift_is_atomic and openshift_is_containerized
+  - name: initialize_facts set fact openshift_is_atomic
     set_fact:
       openshift_is_atomic: "{{ ostree_booted.stat.exists }}"
-      openshift_is_containerized: "{{ ostree_booted.stat.exists or (containerized | default(false) | bool) }}"
 
   # TODO: Should this be moved into health checks??
   # Seems as though any check that happens with a corresponding fail should move into health_checks

--- a/roles/openshift_examples/defaults/main.yml
+++ b/roles/openshift_examples/defaults/main.yml
@@ -6,7 +6,7 @@ openshift_examples_load_db_templates: true
 openshift_examples_load_xpaas: "{{ openshift_deployment_type != 'origin' }}"
 openshift_examples_load_quickstarts: true
 
-examples_base: "{{ openshift.common.config_base if openshift_is_containerized | bool else '/usr/share/openshift' }}/examples"
+examples_base: "{{ openshift.common.config_base if openshift_is_atomic | bool else '/usr/share/openshift' }}/examples"
 image_streams_base: "{{ examples_base }}/image-streams"
 centos_image_streams:
   - "{{ image_streams_base }}/image-streams-centos7.json"

--- a/roles/openshift_health_checker/openshift_checks/etcd_traffic.py
+++ b/roles/openshift_health_checker/openshift_checks/etcd_traffic.py
@@ -20,8 +20,8 @@ class EtcdTraffic(OpenShiftCheck):
         return super(EtcdTraffic, self).is_active() and valid_group_names and valid_version
 
     def run(self):
-        openshift_is_containerized = self.get_var("openshift_is_containerized")
-        unit = "etcd_container" if openshift_is_containerized else "etcd"
+        openshift_is_atomic = self.get_var("openshift_is_atomic")
+        unit = "etcd_container" if openshift_is_atomic else "etcd"
 
         log_matchers = [{
             "start_regexp": r"Starting Etcd Server",

--- a/roles/openshift_health_checker/test/etcd_traffic_test.py
+++ b/roles/openshift_health_checker/test/etcd_traffic_test.py
@@ -36,7 +36,7 @@ def test_log_matches_high_traffic_msg(group_names, matched, failed, extra_words)
 
     task_vars = dict(
         group_names=group_names,
-        openshift_is_containerized=False,
+        openshift_is_atomic=False,
         openshift_service_type="origin"
     )
 
@@ -48,13 +48,13 @@ def test_log_matches_high_traffic_msg(group_names, matched, failed, extra_words)
     assert result.get("failed", False) == failed
 
 
-@pytest.mark.parametrize('openshift_is_containerized,expected_unit_value', [
+@pytest.mark.parametrize('openshift_is_atomic,expected_unit_value', [
     (False, "etcd"),
     (True, "etcd_container"),
 ])
-def test_systemd_unit_matches_deployment_type(openshift_is_containerized, expected_unit_value):
+def test_systemd_unit_matches_deployment_type(openshift_is_atomic, expected_unit_value):
     task_vars = dict(
-        openshift_is_containerized=openshift_is_containerized
+        openshift_is_atomic=openshift_is_atomic
     )
 
     def execute_module(module_name, args, *_):

--- a/roles/openshift_loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/openshift_loadbalancer/templates/haproxy.cfg.j2
@@ -3,7 +3,7 @@
 global
     maxconn     {{ openshift_loadbalancer_global_maxconn | default(20000) }}
     log         /dev/log local0 info
-{% if openshift_is_containerized | bool %}
+{% if openshift_is_atomic | bool %}
     stats socket /var/lib/haproxy/run/haproxy.sock mode 600 level admin
 {% else %}
     chroot      /var/lib/haproxy


### PR DESCRIPTION
Containerized method has been [removed](https://docs.openshift.com/container-platform/3.10/release_notes/ocp_3_10_release_notes.html#ocp-310-containerized-installation-removed) in 3.10, no need to keep in 3.11