### PR TITLE
Update openshift-metering to 0.7.0-latest

### DIFF
--- a/playbooks/openshift-metering/README.md
+++ b/playbooks/openshift-metering/README.md
@@ -13,20 +13,15 @@ openshift_monitoring_deploy: true
 
 ## Installation
 
-To install Openshift Metering, set this variable:
-
-```yaml
-openshift_metering_install: true
-```
-
-To uninstall, set:
-
-```yaml
-openshift_metering_install: false
-```
-
-Then run:
+To install Openshift Metering, run the install playbook:
 
 ```bash
 ansible-playbook playbooks/openshift-metering/config.yml
 ```
+
+To uninstall, run the uninstall playbook:
+
+```bash
+ansible-playbook playbooks/openshift-metering/uninstall.yml
+```
+

--- a/roles/openshift_metering/README.md
+++ b/roles/openshift_metering/README.md
@@ -6,17 +6,9 @@ This role installs the OpenShift [Metering](https://github.com/operator-framewor
 
 ## Installation
 
-To install Openshift Metering, set this variable:
+To install Openshift Metering, include the `install.yml` taskfile from your
+playbook, to uninstall use the `uninstall.yml` taskfile from your playbook.
 
-```yaml
-openshift_metering_install: true
-```
-
-To uninstall, set:
-
-```yaml
-openshift_metering_install: false
-```
 
 ## Configuration
 
@@ -27,9 +19,10 @@ For example:
 
 ```
 openshift_metering_config:
-  metering-operator:
-    config:
-      awsAccessKeyID: "REPLACEME"
+  reporting-operator:
+    spec:
+      config:
+        awsAccessKeyID: "REPLACEME"
 ```
 
 Updating the operator itself to a custom image can be done by setting `openshift_metering_operator_image` to a docker image and tag that should be used.
@@ -37,7 +30,7 @@ Updating the operator itself to a custom image can be done by setting `openshift
 For example:
 
 ```
-openshift_metering_operator_image: quay.io/coreos/chargeback-helm-operator:latest
+openshift_metering_operator_image: quay.io/coreos/metering-helm-operator:latest
 ```
 
 Using a custom project/namespace can be done by specifying `__openshift_metering_namespace`.

--- a/roles/openshift_metering/files/crds/metering.crd.yaml
+++ b/roles/openshift_metering/files/crds/metering.crd.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: meterings.chargeback.coreos.com
+  name: meterings.metering.openshift.io
   annotations:
     catalog.app.coreos.com/description: An instance of Metering
     catalog.app.coreos.com/displayName: Metering
 spec:
-  group: chargeback.coreos.com
+  group: metering.openshift.io
   version: v1alpha1
   scope: Namespaced
   names:

--- a/roles/openshift_metering/files/crds/prestotable.crd.yaml
+++ b/roles/openshift_metering/files/crds/prestotable.crd.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: prestotables.chargeback.coreos.com
+  name: prestotables.metering.openshift.io
   annotations:
     catalog.app.coreos.com/displayName: "Chargeback Presto Table"
     catalog.app.coreos.com/description: "A table within PrestoDB"
 spec:
-  group: chargeback.coreos.com
+  group: metering.openshift.io
   version: v1alpha1
   scope: Namespaced
   names:

--- a/roles/openshift_metering/files/crds/report.crd.yaml
+++ b/roles/openshift_metering/files/crds/report.crd.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: reports.chargeback.coreos.com
+  name: reports.metering.openshift.io
   annotations:
     catalog.app.coreos.com/displayName: "Chargeback Report"
-    catalog.app.coreos.com/description: "A chargeback report for a specific time interval"
+    catalog.app.coreos.com/description: "A metering report for a specific time interval"
 spec:
-  group: chargeback.coreos.com
+  group: metering.openshift.io
   version: v1alpha1
   scope: Namespaced
   names:

--- a/roles/openshift_metering/files/crds/reportdatasource.crd.yaml
+++ b/roles/openshift_metering/files/crds/reportdatasource.crd.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: reportdatasources.chargeback.coreos.com
+  name: reportdatasources.metering.openshift.io
   annotations:
     catalog.app.coreos.com/displayName: "Chargeback data source"
     catalog.app.coreos.com/description: "A resource describing a source of data for usage by Report Generation Queries"
 spec:
-  group: chargeback.coreos.com
+  group: metering.openshift.io
   version: v1alpha1
   scope: Namespaced
   names:

--- a/roles/openshift_metering/files/crds/reportgenerationquery.crd.yaml
+++ b/roles/openshift_metering/files/crds/reportgenerationquery.crd.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: reportgenerationqueries.chargeback.coreos.com
+  name: reportgenerationqueries.metering.openshift.io
   annotations:
     catalog.app.coreos.com/displayName: "Chargeback generation query"
     catalog.app.coreos.com/description: "A SQL query used by Chargeback to generate reports"
 spec:
-  group: chargeback.coreos.com
+  group: metering.openshift.io
   version: v1alpha1
   scope: Namespaced
   names:

--- a/roles/openshift_metering/files/crds/reportprometheusquery.crd.yaml
+++ b/roles/openshift_metering/files/crds/reportprometheusquery.crd.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: reportprometheusqueries.chargeback.coreos.com
+  name: reportprometheusqueries.metering.openshift.io
   annotations:
     catalog.app.coreos.com/displayName: "Chargeback prometheus query"
     catalog.app.coreos.com/description: "A Prometheus query by Chargeback to do metering"
 spec:
-  group: chargeback.coreos.com
+  group: metering.openshift.io
   version: v1alpha1
   scope: Namespaced
   names:

--- a/roles/openshift_metering/files/crds/scheduledreport.crd.yaml
+++ b/roles/openshift_metering/files/crds/scheduledreport.crd.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: scheduledreports.chargeback.coreos.com
+  name: scheduledreports.metering.openshift.io
   annotations:
     catalog.app.coreos.com/displayName: "Chargeback Scheduled Report"
-    catalog.app.coreos.com/description: "A chargeback report that runs on a scheduled interval"
+    catalog.app.coreos.com/description: "A metering report that runs on a scheduled interval"
 spec:
-  group: chargeback.coreos.com
+  group: metering.openshift.io
   version: v1alpha1
   scope: Namespaced
   names:

--- a/roles/openshift_metering/files/crds/storagelocation.crd.yaml
+++ b/roles/openshift_metering/files/crds/storagelocation.crd.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: storagelocations.chargeback.coreos.com
+  name: storagelocations.metering.openshift.io
   annotations:
     catalog.app.coreos.com/displayName: "Chargeback storage location"
     catalog.app.coreos.com/description: "Represents a configurable storage location for Chargeback to store metering and report data"
 spec:
-  group: chargeback.coreos.com
+  group: metering.openshift.io
   version: v1alpha1
   scope: Namespaced
   names:

--- a/roles/openshift_metering/files/operator/metering-helm-operator-role.yaml
+++ b/roles/openshift_metering/files/operator/metering-helm-operator-role.yaml
@@ -142,3 +142,14 @@ rules:
     - patch
     - update
     - watch
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+    - delete

--- a/roles/openshift_metering/files/operator/metering-operator-deployment.yaml
+++ b/roles/openshift_metering/files/operator/metering-operator-deployment.yaml
@@ -1,33 +1,33 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: metering-helm-operator
+  name: metering-operator
   labels:
-    app: metering-helm-operator
+    app: metering-operator
 spec:
   replicas: 1
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      app: metering-helm-operator
+      app: metering-operator
   template:
     metadata:
       labels:
-        app: metering-helm-operator
+        app: metering-operator
     spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - name: metering-helm-operator
-        image: "quay.io/coreos/chargeback-helm-operator:0.6.1-latest"
+      - name: metering-operator
+        image: "quay.io/coreos/metering-helm-operator:0.7.0-latest"
         args: ["run-operator.sh"]
         imagePullPolicy: Always
         env:
         - name: HELM_RELEASE_CRD_NAME
           value: Metering
         - name: HELM_RELEASE_CRD_API_GROUP
-          value: chargeback.coreos.com
+          value: metering.openshift.io
         - name: HELM_CHART_PATH
           value: /openshift-metering-0.1.0.tgz
         - name: MY_POD_NAME
@@ -54,7 +54,7 @@ spec:
             memory: "25Mi"
             cpu: "50m"
       - name: tiller
-        image: "quay.io/coreos/chargeback-helm-operator:0.6.1-latest"
+        image: "quay.io/coreos/metering-helm-operator:0.7.0-latest"
         args: ["/tiller"]
         imagePullPolicy: Always
         env:
@@ -93,4 +93,4 @@ spec:
           timeoutSeconds: 1
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
-      serviceAccount: metering-helm-operator
+      serviceAccount: metering-operator

--- a/roles/openshift_metering/files/operator/metering-operator-role.yaml
+++ b/roles/openshift_metering/files/operator/metering-operator-role.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: metering-helm-operator
+  name: metering-operator
 rules:
   - apiGroups:
-    - chargeback.coreos.com
+    - metering.openshift.io
     resources:
     - '*'
     verbs:

--- a/roles/openshift_metering/files/operator/metering-operator-rolebinding.yaml
+++ b/roles/openshift_metering/files/operator/metering-operator-rolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: metering-helm-operator
+  name: metering-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: metering-helm-operator
+  name: metering-operator
 subjects:
 - kind: ServiceAccount
-  name: metering-helm-operator
+  name: metering-operator

--- a/roles/openshift_metering/files/operator/metering-operator-service-account.yaml
+++ b/roles/openshift_metering/files/operator/metering-operator-service-account.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: metering-helm-operator
+  name: metering-operator

--- a/roles/openshift_metering/files/operator/metering.yaml
+++ b/roles/openshift_metering/files/operator/metering.yaml
@@ -1,4 +1,4 @@
-apiVersion: chargeback.coreos.com/v1alpha1
+apiVersion: metering.openshift.io/v1alpha1
 kind: Metering
 metadata:
   name: openshift-metering

--- a/roles/openshift_metering/tasks/operator-install.yml
+++ b/roles/openshift_metering/tasks/operator-install.yml
@@ -19,9 +19,9 @@
   - "files/operator/*.yaml"
   register: temp_operator_files
 
-- name: Update Metering Helm Operator deployment image
+- name: Update Metering Operator deployment image
   yedit:
-    src: "{{ mktemp.stdout }}/metering-manifests/operator/metering-helm-operator-deployment.yaml"
+    src: "{{ mktemp.stdout }}/metering-manifests/operator/metering-operator-deployment.yaml"
     edits:
     - key: spec.template.spec.containers[0].image
       value: "{{ openshift_metering_operator_image }}"
@@ -41,13 +41,13 @@
   yedit:
     src: "{{ mktemp.stdout }}/metering-manifests/operator/metering.yaml"
     edits:
-    - key: spec.presto.hive.config.dbConnectionURL
+    - key: spec.presto.spec.hive.config.dbConnectionURL
       value: "{{ openshift_metering_hive_metastore_db_url }}"
-    - key: spec.presto.hive.config.dbDriver
+    - key: spec.presto.spec.hive.config.dbDriver
       value: "{{ openshift_metering_hive_metastore_db_driver }}"
-    - key: spec.presto.hive.config.dbConnectionUsername
+    - key: spec.presto.spec.hive.config.dbConnectionUsername
       value: "{{ openshift_metering_hive_metastore_db_username }}"
-    - key: spec.presto.hive.config.dbConnectionPassword
+    - key: spec.presto.spec.hive.config.dbConnectionPassword
       value: "{{ openshift_metering_hive_metastore_db_password }}"
   when: openshift_metering_hive_metastore_db_use_custom | bool
 
@@ -55,13 +55,13 @@
   yedit:
     src: "{{ mktemp.stdout }}/metering-manifests/operator/metering.yaml"
     edits:
-    - key: spec.metering-operator.config.defaultStorage
+    - key: spec.reporting-operator.spec.config.defaultStorage
       value:
         create: true
         isDefault: true
         name: "{{ openshift_metering_default_storage_name }}"
         type: "{{ openshift_metering_default_storage_type }}"
-    - key: "spec.metering-operator.config.defaultStorage.{{ openshift_metering_default_storage_type }}"
+    - key: "spec.reporting-operator.spec.config.defaultStorage.{{ openshift_metering_default_storage_type }}"
       value: "{{ openshift_metering_default_storage_config[openshift_metering_default_storage_type] }}"
   when: openshift_metering_default_storage_use_custom | bool
 
@@ -83,13 +83,13 @@
   # make the edit
   when: item.value != ""
   with_items:
-  - key: spec.metering-operator.config.awsAccessKeyID
+  - key: spec.reporting-operator.spec.config.awsAccessKeyID
     value: "{{ openshift_metering_aws_access_key_id }}"
-  - key: spec.metering-operator.config.awsSecretAccessKey
+  - key: spec.reporting-operator.spec.config.awsSecretAccessKey
     value: "{{ openshift_metering_aws_secret_access_key }}"
-  - key: spec.presto.config.awsAccessKeyID
+  - key: spec.presto.spec.config.awsAccessKeyID
     value: "{{ openshift_metering_aws_access_key_id }}"
-  - key: spec.presto.config.awsSecretAccessKey
+  - key: spec.presto.spec.config.awsSecretAccessKey
     value: "{{ openshift_metering_aws_secret_access_key }}"
   # Hide secrets
   no_log: True
@@ -111,34 +111,52 @@
     description: Openshift Metering
     node_selector: ""
 
-- name: Create metering namespace viewer cluster role
+- name: Create reporting operator cluster role
   oc_clusterrole:
     state: present
-    name: "openshift-metering-namespace-viewer-{{ __openshift_metering_namespace }}"
+    name: "openshift-reporting-operator-{{ __openshift_metering_namespace }}"
     rules:
+    # Grant namespace viewer access to allow authing to cluster monitoring Prometheus
     - apiGroups: [""]
       resources: ["namespaces"]
       verbs: ["get"]
+    # Grant subject access review and token review access to allow metering
+    # auth-proxy to authenticate requests using openshift authentication
+    # methods
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - subjectaccessreviews
+      verbs:
+      - create
+    - apiGroups:
+      - authentication.k8s.io
+      resources:
+      - tokenreviews
+      verbs:
+      - create
 
-- name: Create namespace viewer clusterrolebinding
+# Grant access to reporting-operator so it can talk to prometheus and
+# authenticate it's API using auth-proxy
+- name: Create reporting operator clusterrolebinding
   oc_obj:
     state: present
     kind: ClusterRoleBinding
-    name: "openshift-metering-namespace-viewer-{{ __openshift_metering_namespace }}"
+    name: "openshift-reporting-operator-{{ __openshift_metering_namespace }}"
     content:
-      path: "{{ mktemp.stdout }}/openshift-metering-namespace-viewer-{{ __openshift_metering_namespace }}"
+      path: "{{ mktemp.stdout }}/openshift-reporting-operator-{{ __openshift_metering_namespace }}"
       data:
         apiVersion: v1
         kind: ClusterRoleBinding
         metadata:
-          name: "openshift-metering-namespace-viewer-{{ __openshift_metering_namespace }}"
+          name: "openshift-reporting-operator-{{ __openshift_metering_namespace }}"
         roleRef:
           apiGroup: rbac.authorization.k8s.io
           kind: ClusterRole
-          name: "openshift-metering-namespace-viewer-{{ __openshift_metering_namespace }}"
+          name: "openshift-reporting-operator-{{ __openshift_metering_namespace }}"
         subjects:
         - kind: ServiceAccount
-          name: metering
+          name: reporting-operator
           namespace: "{{ __openshift_metering_namespace }}"
 
 - name: Install Metering CRDs
@@ -155,7 +173,7 @@
   with_fileglob:
   - "files/crds/*.yaml"
 
-- name: Install Metering Helm Operator
+- name: Install Metering Operator
   oc_obj:
     state: present
     kind: "{{ obj.kind }}"


### PR DESCRIPTION
Between 0.6.1 and 0.7.0 we've made a few breaking changes to prepare for
4.0, and added support for routes. This PR just updates all the
manifests to match the latest upstream operator-metering ones to make it
easier for users to install and try out. Note: we're not even in tech-preview yet,
thus these breaking changes are accepted as no one is actively using this yet.