### PR TITLE
[release-3.9] Fix conditional for cri-o system container removal

### DIFF
--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -30,9 +30,9 @@
   register: crio_result
   when: not openshift_is_atomic | bool
 
-# Remove system container cri-o
+# Remove cri-o system container
 - when:
-  - crio_result is defined
+  - crio_result.stat is defined
   - crio_result.stat.exists
   - not openshift_is_atomic | bool
   block:


### PR DESCRIPTION
On atomic nodes the previous task does not run which results in
crio_result.stat not being defined.  This adds logic to not fail on
atomic nodes.