### PR TITLE
Commit to remove openshift_master_cluster_hostname override

### DIFF
--- a/roles/openshift_aws/tasks/master_facts.yml
+++ b/roles/openshift_aws/tasks/master_facts.yml
@@ -12,9 +12,7 @@
 
 - name: set fact
   set_fact:
-    openshift_master_cluster_hostname: "{{ elbs.elbs[0].dns_name }}"
     osm_custom_cors_origins:
-    - "{{ elbs.elbs[0].dns_name }}"
     - "console.{{ openshift_aws_clusterid | default('default') }}.openshift.com"
     - "api.{{ openshift_aws_clusterid | default('default') }}.openshift.com"
   with_items: "{{ groups['masters'] }}"


### PR DESCRIPTION
Commit to remove openshift_master_cluster_hostname override - Bugzilla [1569635](https://bugzilla.redhat.com/show_bug.cgi?id=1569635)