### PR TITLE
Fix prometheus SA and Route names

### DIFF
--- a/roles/openshift_grafana/defaults/main.yaml
+++ b/roles/openshift_grafana/defaults/main.yaml
@@ -7,8 +7,8 @@ openshift_grafana_state: present
 openshift_grafana_namespace: openshift-grafana
 openshift_grafana_pod_timeout: 300
 openshift_grafana_prometheus_namespace: "openshift-monitoring"
-openshift_grafana_prometheus_serviceaccount: "prometheus-k8s"
-openshift_grafana_prometheus_route: "prometheus-k8s"
+openshift_grafana_prometheus_serviceaccount: "prometheus"
+openshift_grafana_prometheus_route: "prometheus"
 openshift_grafana_serviceaccount_name: grafana
 openshift_grafana_serviceaccount_annotations: []
 l_openshift_grafana_serviceaccount_annotations:

--- a/roles/openshift_grafana/defaults/main.yaml
+++ b/roles/openshift_grafana/defaults/main.yaml
@@ -6,7 +6,7 @@ openshift_grafana_proxy_image: "{{ l2_os_logging_proxy_image }}"
 openshift_grafana_state: present
 openshift_grafana_namespace: openshift-grafana
 openshift_grafana_pod_timeout: 300
-openshift_grafana_prometheus_namespace: "openshift-monitoring"
+openshift_grafana_prometheus_namespace: "openshift-metrics"
 openshift_grafana_prometheus_serviceaccount: "prometheus"
 openshift_grafana_prometheus_route: "prometheus"
 openshift_grafana_serviceaccount_name: grafana


### PR DESCRIPTION
According to [1] and [2] prometheus' default serviceaccount name is `prometheus` instead `prometheus-k8s`.
Same for prometheus route name from [3].

[1] https://github.com/openshift/openshift-ansible/blob/53d6d02a64d5b617da16c581eb5816d1bb27d49f/roles/openshift_prometheus/tasks/install_prometheus.yaml#L39
[2] https://github.com/openshift/openshift-ansible/blob/53d6d02a64d5b617da16c581eb5816d1bb27d49f/roles/openshift_prometheus/defaults/main.yaml#L48
[3] https://github.com/openshift/openshift-ansible/blob/53d6d02a64d5b617da16c581eb5816d1bb27d49f/roles/openshift_prometheus/tasks/install_prometheus.yaml#L152