### PR TITLE
SDN check: Use openshift_client_binary

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/sdn.py
+++ b/roles/openshift_health_checker/openshift_checks/sdn.py
@@ -58,7 +58,10 @@ class SDNCheck(OpenShiftCheck):
                 if not self.get_var('openshift_use_crio_only', default=False):
                     self.save_command_output('docker-version',
                                              ['/bin/docker', 'version'])
-                self.save_command_output('oc-version', ['/bin/oc', 'version'])
+                oc_executable = self.get_var('openshift_client_binary',
+                                             default='/bin/oc')
+                self.save_command_output('oc-version', [oc_executable,
+                                                        'version'])
                 self.register_file('os-version', None,
                                    '/etc/system-release-cpe')
             except OpenShiftCheckException as exc:


### PR DESCRIPTION
This commit fixes bug 1615705.

https://bugzilla.redhat.com/show_bug.cgi?id=1615705

* `roles/openshift_health_checker/openshift_checks/sdn.py` (`SDNCheck.run`): Replace a hard-coded OpenShift client binary path `/bin/oc` with the `openshift_client_binary` variable.