### PR TITLE
cluster monitoring operator: add nodeselector

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/defaults/main.yml
+++ b/roles/openshift_cluster_monitoring_operator/defaults/main.yml
@@ -10,6 +10,8 @@ openshift_cluster_monitoring_operator_alertmanager_storage_capacity: "2Gi"
 
 openshift_cluster_monitoring_operator_cluster_id: "{{ openshift_clusterid | default(openshift_master_cluster_public_hostname, true) | default(openshift_master_cluster_hostname, true) | default('openshift', true) }}"
 
+openshift_cluster_monitoring_operator_node_selector: "{{ openshift_hosted_infra_selector | default('node-role.kubernetes.io/infra=true') | map_from_pairs }}"
+
 openshift_cluster_monitoring_operator_alertmanager_config: |+
   global:
     resolve_timeout: 5m


### PR DESCRIPTION
Add default setting for openshift_cluster_monitoring_operator_node_selector.

This is a partial cherrypick of #9234, which didn't make it in 3.10