### PR TITLE
Uninstall cri-o system container block: check that crio_result.stat exists

### DIFF
--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -31,9 +31,10 @@
 
 # Remove system container cri-o
 - when:
-  - crio_result is defined
-  - crio_result.stat.exists
   - not openshift_is_atomic | bool
+  - crio_result is defined
+  - crio_result.stat is defined
+  - crio_result.stat.exists
   block:
   - name: Uninstall cri-o system container
     command: atomic uninstall cri-o


### PR DESCRIPTION
'Check if cri-o is running as a system container' task might be skipped, 
so `crio_result` would have `skipped: true`.
This commit would ensure `.stat` and `.stat.exists` are defined


System containers are removed in master/3.11, so it doesn't need to be 
cherrypicked there (not sure about 3.9).

Fixes https://github.com/openshift/openshift-ansible/commit/b9c9a004f19da451eac79ab8a25cd543c2a95850#r30208650

Replaced by #9698