### PR TITLE
openshift_cert_check: check that dict elements are not None

### DIFF
--- a/roles/openshift_certificate_expiry/library/openshift_cert_expiry.py
+++ b/roles/openshift_certificate_expiry/library/openshift_cert_expiry.py
@@ -720,7 +720,9 @@ an OpenShift Container Platform cluster
         # Not present
         pass
     else:
-        if cfg.get('etcdConfig', {}).get('servingInfo', {}).get('certFile', None) is not None:
+        if isinstance(cfg.get('etcdConfig'), dict) and \
+           isinstance(cfg.get('etcdConfig', {}).get('servingInfo'), dict) and \
+           cfg.get('etcdConfig', {}).get('servingInfo', {}).get('certFile') is not None:
             # This is embedded
             etcd_crt_name = cfg['etcdConfig']['servingInfo']['certFile']
         else:


### PR DESCRIPTION
This prevents errors like:
`AttributeError: 'NoneType' object has no attribute 'get'`, when `etcdConfig` exists, but is not a dict

This happens after embedded etcd in 3.5 has been migrated to external -
it leaves empty 'etcdConfig:' section.


This issue would only affect 3.5 -> 3.6 clusters, so it doesn't need to be 
cherry-picked

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1509859