### PR TITLE
control plane upgrade: don't remove -master package on Atomic

### DIFF
--- a/roles/openshift_control_plane/tasks/upgrade.yml
+++ b/roles/openshift_control_plane/tasks/upgrade.yml
@@ -138,6 +138,7 @@
   package:
     name: "{{ openshift_service_type }}-master"
     state: absent
+  when: not openshift_is_atomic | bool
 
 - name: Remove old service information
   file:


### PR DESCRIPTION
No need to cherrypick it to master - this part has already been removed there

Fixes #9719