### PR TITLE
GlusterFS: Run kernel_modules.yml for all nodes

### DIFF
--- a/playbooks/openshift-glusterfs/private/setup_nodes.yml
+++ b/playbooks/openshift-glusterfs/private/setup_nodes.yml
@@ -14,5 +14,4 @@
       name: openshift_storage_glusterfs
       tasks_from: kernel_modules.yml
     when:
-    - "inventory_hostname not in groups['glusterfs']"
-    - "inventory_hostname not in groups['glusterfs_registry']"
+    - "inventory_hostname not in groups['oo_glusterfs_to_config']"


### PR DESCRIPTION
The `glusterfs.conf` is already written to account for being copied to a host that is running Gluster. It should not be excluded form those hosts, as we need to ensure they also load specific modules.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1619402

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>