### PR TITLE
Get cluster resources for SDN check in health.yml

### DIFF
--- a/playbooks/openshift-checks/private/health.yml
+++ b/playbooks/openshift-checks/private/health.yml
@@ -3,10 +3,28 @@
   hosts: oo_all_hosts
 
   roles:
+  - lib_openshift
   - openshift_health_checker
   vars:
   - r_openshift_health_checker_playbook_context: health
   post_tasks:
+  - name: Get cluster resources
+    delegate_to: "{{ groups.oo_first_master.0 }}"
+    run_once: True
+    oc_obj:
+      state: list
+      kind: "{{ item }}"
+      all_namespaces: True
+    register: resources
+    with_items:
+    - nodes
+    - pods
+    - services
+    - endpoints
+    - routes
+    - clusternetworks
+    - hostsubnets
+    - netnamespaces
   - name: Run health checks (@health)
     action: openshift_health_check
     args:


### PR DESCRIPTION
Get cluster resources for the SDN check in `health.yml`, same as in `adhoc.yml`.

This commit fixes bug 1619563.

https://bugzilla.redhat.com/show_bug.cgi?id=1619563

* `playbooks/openshift-checks/private/health.yml`: Add task to get cluster resources for the SDN check.