### PR TITLE
[BZ 1550680] metrics cleanup fails

### DIFF
--- a/playbooks/common/openshift-cluster/openshift_metrics.yml
+++ b/playbooks/common/openshift-cluster/openshift_metrics.yml
@@ -14,4 +14,5 @@
     include_role:
       name: openshift_metrics
       tasks_from: update_master_config.yaml
+    when: openshift_metrics_install_metrics | bool
     static: true


### PR DESCRIPTION
Do not set up non-first master configs when uninstalling metrics. This is for [BZ 1550680](https://bugzilla.redhat.com/show_bug.cgi?id=1550680).