### PR TITLE
openshift-prometheus: change node_exporter service port to 9101

### DIFF
--- a/roles/openshift_prometheus/files/node-exporter-template.yaml
+++ b/roles/openshift_prometheus/files/node-exporter-template.yaml
@@ -37,9 +37,9 @@ objects:
     clusterIP: None
     ports:
     - name: scrape
-      port: 9100
+      port: 9101
       protocol: TCP
-      targetPort: 9100
+      targetPort: 9101
     selector:
       app: prometheus-node-exporter
 - apiVersion: extensions/v1beta1
@@ -67,8 +67,9 @@ objects:
           name: node-exporter
           args:
           - --no-collector.wifi
+          - --web.listen-address=:9101
           ports:
-          - containerPort: 9100
+          - containerPort: 9101
             name: scrape
           resources:
             requests:

--- a/roles/openshift_prometheus/templates/prometheus.yml.j2
+++ b/roles/openshift_prometheus/templates/prometheus.yml.j2
@@ -232,7 +232,7 @@ scrape_configs:
       action: replace
       target_label: kubernetes_name
 
-# Scrape config for node-exporter, which is expected to be running on port 9100.
+# Scrape config for node-exporter, which is expected to be running on port 9101.
 - job_name: 'kubernetes-nodes-exporter'
 
   tls_config:
@@ -270,7 +270,7 @@ scrape_configs:
   relabel_configs:
   - source_labels: [__address__]
     regex: '(.*):10250'
-    replacement: '${1}:9100'
+    replacement: '${1}:9101'
     target_label: __address__
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
     target_label: __instance__


### PR DESCRIPTION
This avoids port conflict with prometheus node_exporter installed
by the newer openshift monitoring system.
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1608288