### PR TITLE
Pass region to AWS az lookup

### DIFF
--- a/roles/openshift_aws/tasks/vpc.yml
+++ b/roles/openshift_aws/tasks/vpc.yml
@@ -1,6 +1,7 @@
 ---
 - name: query azs
   aws_az_facts:
+    region: "{{ openshift_aws_region }}"
   register: azs
 
 - fail:


### PR DESCRIPTION
If running the playbook in an environment that doesn't have AWS_REGION env var defined, the aws_az_facts fails.