### PR TITLE
Reconfigure web console after certificates were redeployed

### DIFF
--- a/playbooks/openshift-master/redeploy-certificates.yml
+++ b/playbooks/openshift-master/redeploy-certificates.yml
@@ -4,3 +4,6 @@
 - import_playbook: private/redeploy-certificates.yml
 
 - import_playbook: private/restart.yml
+
+- import_playbook: ../openshift-web-console/private/redeploy-certificates.yml
+  when: openshift_web_console_install | default(true) | bool

--- a/playbooks/redeploy-certificates.yml
+++ b/playbooks/redeploy-certificates.yml
@@ -24,6 +24,3 @@
 - import_playbook: openshift-master/private/revert-client-ca.yml
 
 - import_playbook: openshift-master/private/restart.yml
-
-- import_playbook: openshift-web-console/private/redeploy-certificates.yml
-  when: openshift_web_console_install | default(true) | bool

--- a/playbooks/redeploy-certificates.yml
+++ b/playbooks/redeploy-certificates.yml
@@ -24,3 +24,6 @@
 - import_playbook: openshift-master/private/revert-client-ca.yml
 
 - import_playbook: openshift-master/private/restart.yml
+
+- import_playbook: openshift-web-console/private/redeploy-certificates.yml
+  when: openshift_web_console_install | default(true) | bool


### PR DESCRIPTION
webconsole secret contains an outdated cert after certs were redeployed. This PR would make sure its removed and the pod is restarted. It also works if you redeploy only master certificates