### PR TITLE
Reorder master install tasks

### DIFF
--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -13,8 +13,6 @@
           status: "In Progress"
           start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- import_playbook: certificates.yml
-
 - name: Disable excluders and gather facts
   hosts: oo_masters_to_config
   roles:
@@ -61,6 +59,8 @@
         console_url: "{{ openshift_master_console_url | default(None) }}"
         console_use_ssl: "{{ openshift_master_console_use_ssl | default(None) }}"
         public_console_url: "{{ openshift_master_public_console_url | default(None) }}"
+
+- import_playbook: certificates.yml
 
 - name: Generate or retrieve existing session secrets
   hosts: oo_first_master


### PR DESCRIPTION
Fix order of execution to disable excluders at the beginning of the
master install tasks.  The openshift_ca role requires installing
openshift packages which fail if the excluders are enabled.