### PR TITLE
Remove old code related to Atomic Enterprise changes

### DIFF
--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -26,26 +26,6 @@
     vars:
       r_openshift_excluder_action: disable
 
-  - name: Check for RPM generated config marker file .config_managed
-    stat:
-      path: /etc/origin/.config_managed
-      get_checksum: false
-      get_attributes: false
-      get_mime: false
-    register: rpmgenerated_config
-
-  - name: Remove RPM generated config files if present
-    file:
-      path: "/etc/origin/{{ item }}"
-      state: absent
-    when:
-    - rpmgenerated_config.stat.exists == true
-    - openshift_deployment_type == 'openshift-enterprise'
-    with_items:
-    - master
-    - node
-    - .config_managed
-
   - openshift_facts:
       role: master
       local_facts:

--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -39,14 +39,6 @@
   with_items:
   - "{{ openshift_service_type }}-node.service"
 
-- name: Check for RPM generated config marker file .config_managed
-  stat:
-    path: /etc/origin/.config_managed
-    get_checksum: false
-    get_attributes: false
-    get_mime: false
-  register: rpmgenerated_config
-
 - name: create directories for bootstrapping
   file:
     state: directory
@@ -69,29 +61,3 @@
     state: link
     force: yes
     follow: no
-
-- when: rpmgenerated_config.stat.exists
-  block:
-  - name: Remove RPM generated config files if present
-    file:
-      path: "/etc/origin/{{ item }}"
-      state: absent
-    with_items:
-    - master
-    - .config_managed
-
-  # with_fileglob doesn't work correctly due to a few issues.
-  # Could change this to fileglob when it gets fixed.
-  - name: find all files in /etc/origin/node so we can remove them
-    find:
-      path: /etc/origin/node/
-    register: find_results
-
-  - name: Remove everything except the resolv.conf required for node
-    file:
-      path: "{{ item.path }}"
-      state: absent
-    when:
-    - "'resolv.conf' not in item.path"
-    - "'node-dnsmasq.conf' not in item.path"
-    with_items: "{{ find_results.files }}"


### PR DESCRIPTION
Remove tasks associated with cleaning up RPM generated files
in the 3.0.2 version of the installer.  These files are no longer
generated and result in unnecessary skipped tasks.