### PR TITLE
Allow specification of openshift_additional_registry_credentials

### DIFF
--- a/roles/container_runtime/tasks/registry_auth.yml
+++ b/roles/container_runtime/tasks/registry_auth.yml
@@ -2,7 +2,7 @@
 # docker_creds is a custom module from lib_utils
 # 'docker login' requires a docker.service running on the local host, this is an
 # alternative implementation that operates directly on config.json
-- name: Create credentials for docker cli registry auth (alternative)
+- name: Create credentials for oreg_url
   docker_creds:
     path: "{{ docker_cli_auth_config_path }}"
     registry: "{{ oreg_host }}"
@@ -18,3 +18,23 @@
   retries: 3
   delay: 5
   until: crt_oreg_auth_credentials_create is succeeded
+
+- name: Create for any additional registries
+  docker_creds:
+    path: "{{ docker_cli_auth_config_path }}"
+    registry: "{{ item.host }}"
+    username: "{{ item.user | default('openshift') }}"
+    password: "{{ item.password }}"
+    # Test that we can actually connect with provided info
+    test_login: "{{ item.test_login | default(omit) }}"
+    proxy_vars: "{{ l_docker_creds_proxy_vars }}"
+    image_name: "{{ item.image_name | default('openshift3/ose-pod') }}"
+    tls_verify: "{{ item.tls_verify | default(omit) }}"
+  when:
+  - openshift_additional_registry_credentials is defined
+  register: crt_addl_credentials_create
+  retries: 3
+  delay: 5
+  until: crt_addl_credentials_create is succeeded
+  with_items:
+    "{{ openshift_additional_registry_credentials }}"

--- a/roles/lib_utils/library/docker_creds.py
+++ b/roles/lib_utils/library/docker_creds.py
@@ -196,7 +196,7 @@ def run_module():
         registry=dict(type='str', required=True),
         username=dict(type='str', required=True),
         password=dict(type='str', required=True, no_log=True),
-        test_login=dict(type='str', required=False, default=True),
+        test_login=dict(type='bool', required=False, default=True),
         proxy_vars=dict(type='str', required=False, default=''),
         image_name=dict(type='str', required=True),
     )

--- a/roles/lib_utils/library/docker_creds.py
+++ b/roles/lib_utils/library/docker_creds.py
@@ -131,14 +131,16 @@ def load_config_file(module, dest):
         return {}
 
 
-def gen_skopeo_cmd(registry, username, password, proxy_vars, image_name):
+# pylint: disable=too-many-arguments
+def gen_skopeo_cmd(registry, username, password, proxy_vars, image_name, tls_verify):
     '''Generate skopeo command to run'''
     skopeo_temp = ("{proxy_vars} timeout 10 skopeo inspect"
                    " {creds} docker://{registry}/{image_name}")
     # this will quote the entire creds argument to account for special chars.
     creds = pipes.quote('--creds={}:{}'.format(username, password))
     skopeo_args = {'proxy_vars': proxy_vars, 'creds': creds,
-                   'registry': registry, 'image_name': image_name}
+                   'registry': registry, 'image_name': image_name,
+                   'tls_verify': tls_verify}
     return skopeo_temp.format(**skopeo_args).strip()
 
 
@@ -199,6 +201,7 @@ def run_module():
         test_login=dict(type='bool', required=False, default=True),
         proxy_vars=dict(type='str', required=False, default=''),
         image_name=dict(type='str', required=True),
+        tls_verify=dict(type='bool', required=False, default=True)
     )
 
     module = AnsibleModule(
@@ -214,6 +217,7 @@ def run_module():
     test_login = module.params['test_login']
     proxy_vars = module.params['proxy_vars']
     image_name = module.params['image_name']
+    tls_verify = module.params['tls_verify']
 
     if not check_dest_dir_exists(module, dest):
         create_dest_dir(module, dest)
@@ -226,7 +230,7 @@ def run_module():
     # Test the credentials
     if test_login:
         skopeo_command = gen_skopeo_cmd(registry, username, password,
-                                        proxy_vars, image_name)
+                                        proxy_vars, image_name, tls_verify)
         validate_registry_login(module, skopeo_command)
 
     # base64 encode our username:password string

--- a/roles/openshift_control_plane/tasks/registry_auth.yml
+++ b/roles/openshift_control_plane/tasks/registry_auth.yml
@@ -2,7 +2,7 @@
 # docker_creds is a custom module from lib_utils
 # 'docker login' requires a docker.service running on the local host, this is an
 # alternative implementation that operates directly on config.json
-- name: Create credentials for registry auth (alternative)
+- name: Create credentials for oreg_url
   docker_creds:
     path: "{{ oreg_auth_credentials_path }}"
     registry: "{{ oreg_host }}"
@@ -18,3 +18,23 @@
   retries: 3
   delay: 5
   until: master_oreg_auth_credentials_create is succeeded
+
+- name: Create credentials for any additional registries
+  docker_creds:
+    path: "{{ oreg_auth_credentials_path }}"
+    registry: "{{ item.host }}"
+    username: "{{ item.user | default('openshift') }}"
+    password: "{{ item.password }}"
+    # Test that we can actually connect with provided info
+    test_login: "{{ item.test_login | default(omit) }}"
+    proxy_vars: "{{ l_docker_creds_proxy_vars }}"
+    image_name: "{{ item.image_name | default('openshift3/ose-pod') }}"
+    tls_verify: "{{ item.tls_verify | default(omit) }}"
+  when:
+  - openshift_additional_registry_credentials is defined
+  register: crt_addl_credentials_create
+  retries: 3
+  delay: 5
+  until: crt_addl_credentials_create is succeeded
+  with_items:
+    "{{ openshift_additional_registry_credentials }}"

--- a/roles/openshift_examples/tasks/main.yml
+++ b/roles/openshift_examples/tasks/main.yml
@@ -49,17 +49,31 @@
 ######################################################################
 # Begin image streams
 
-- name: Create imagestream import secret
+- name: Create imagestream import secret for oreg_url
   command: >
-    {{ openshift_client_binary }} create secret docker-registry imagestreamsecret --docker-server={{ registry_host }} --docker-username={{ oreg_auth_user }} --docker-email=openshift@openshift.com --docker-password={{ oreg_auth_password }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift
+    {{ openshift_client_binary }} create secret docker-registry imagestreamsecret
+    --docker-server={{ registry_host }} --docker-username={{ oreg_auth_user }}
+    --docker-email=openshift@openshift.com --docker-password={{ oreg_auth_password }}
+    --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift
   when:
     - openshift_examples_load_rhel | bool
     - oreg_auth_password is defined
-  with_items:
-    - "{{ rhel_image_streams }}"
   register: oex_imagestream_import_secret
   failed_when: "'already exists' not in oex_imagestream_import_secret.stderr and oex_imagestream_import_secret.rc != 0"
   changed_when: false
+
+- name: Create imagestream import secrets for any additional registries
+  command: >
+      {{ openshift_client_binary }} create secret docker-registry imagestreamsecret
+      --docker-server={{ item.host }} --docker-username={{ item.user }}
+      --docker-email=openshift@openshift.com --docker-password={{ item.password }}
+      --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift
+  when:
+    - openshift_additional_registry_credentials is defined
+  with_items:
+    - "{{ openshift_additional_registry_credentials }}"
+  register: oex_additional_creds
+  failed_when: "'already exists' not in oex_additional_creds.stderr and oex_additional_creds.rc != 0"
 
 - name: Modify registry paths if registry_url is not registry.redhat.io
   shell: >

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -15,6 +15,10 @@ l_oreg_host_temp: "{{ oreg_url | default(l_osm_registry_url_default) }}"
 # oreg_url is defined by user input.
 oreg_host: "{{ l_oreg_host_temp.split('/')[0] }}"
 
+# Used to define a list of registry credentials
+# ex openshift_additional_registry_credentials=[{'host':'registry.redhat.io','user':'bob','password':'redhat'},{'host':'registry.connect.redhat.com','user':'alice','password':'redhat','test_login':False}]
+openshift_additional_registry_credentials: []
+
 # this variable does not replace ${version} with openshift_image_tag
 l_os_non_standard_reg_url: "{{ oreg_url | default(l_osm_registry_url_default) }}"
 

--- a/roles/openshift_node/tasks/registry_auth.yml
+++ b/roles/openshift_node/tasks/registry_auth.yml
@@ -30,13 +30,30 @@
   delay: 5
   until: node_oreg_auth_credentials_create is succeeded
 
+- name: Create credentials for any additional registries
+  docker_creds:
+    path: "{{ oreg_auth_credentials_path }}"
+    registry: "{{ item.host }}"
+    username: "{{ item.user | default('openshift') }}"
+    password: "{{ item.password }}"
+    # Test that we can actually connect with provided info
+    test_login: "{{ item.test_login | default(omit) }}"
+    proxy_vars: "{{ l_docker_creds_proxy_vars }}"
+    image_name: "{{ item.image_name | default('openshift3/ose-pod') }}"
+    tls_verify: "{{ item.tls_verify | default(omit) }}"
+  when:
+    - openshift_additional_registry_credentials is defined
+  register: node_additional_registry_creds
+  retries: 3
+  delay: 5
+  until: node_additional_registry_creds is succeeded
+  with_items:
+    "{{ openshift_additional_registry_credentials }}"
+
 # Container images may need the registry credentials
 - name: Setup ro mount of /root/.docker for containerized hosts
   set_fact:
     l_bind_docker_reg_auth: True
   when:
     - openshift_is_atomic | bool
-    - oreg_auth_user is defined
-    - >
-        (node_oreg_auth_credentials_stat.stat.exists
-        or node_oreg_auth_credentials_create.changed) | bool
+    - oreg_auth_user is defined or openshift_additional_registry_credentials is defined or node_oreg_auth_credentials_stat.stat.exists


### PR DESCRIPTION
- Corrects docker_creds test_login type
- Adds tls_verify option to docker_creds
- Adds openshift_additional_registry_credentials with the ability to specify host, user, password, test_login, image_name, and tls_verify parameters

Should be in the form of
openshift_additional_registry_credentials=[{'host':'registry.example.com','user':'bob','password':'pass1','test_login':'False'},{'host':'registry2.example.com','password':'pass2','tls_verify':'False','image_name':'openshift3/ose-pod'}]

If the user is not specified it will default to 'openshift', this can be used in situations where a token is all that's required for a given host but skopeo requires a username.

Care should be taken to ensure that you do not specify conficting
credentials with those set via oreg_url, oreg_auth_password,
oreg_auth_user.

In the future we should clean this up to de-dupe these
two sets of credentials and eliminate the duplicated tasks.