### PR TITLE
[BZ 1620236] metrics clean up fails

### DIFF
--- a/playbooks/openshift-metrics/private/config.yml
+++ b/playbooks/openshift-metrics/private/config.yml
@@ -25,7 +25,9 @@
     import_role:
       name: openshift_metrics
       tasks_from: update_master_config.yaml
-    when: not openshift.common.version_gte_3_9
+    when:
+      - not openshift.common.version_gte_3_9
+      - openshift_metrics_install_metrics | bool
 
 - name: Metrics Install Checkpoint End
   hosts: all

--- a/playbooks/openshift-metrics/private/config.yml
+++ b/playbooks/openshift-metrics/private/config.yml
@@ -25,9 +25,7 @@
     import_role:
       name: openshift_metrics
       tasks_from: update_master_config.yaml
-    when:
-      - not openshift.common.version_gte_3_9
-      - openshift_metrics_install_metrics | bool
+    when: not openshift.common.version_gte_3_9 and (openshift_metrics_install_metrics | bool)
 
 - name: Metrics Install Checkpoint End
   hosts: all


### PR DESCRIPTION
Do not set up non-first master configs when uninstalling metrics. This is for [BZ 1620236](https://bugzilla.redhat.com/show_bug.cgi?id=1620236).