### PR TITLE
Replace deprecated ec2_ami_find module with ec2_ami_facts

### DIFF
--- a/roles/openshift_aws/tasks/build_node_group.yml
+++ b/roles/openshift_aws/tasks/build_node_group.yml
@@ -6,21 +6,21 @@
   - (openshift_aws_ami == '' and openshift_aws_node_group.group not in openshift_aws_ami_map) or (openshift_aws_node_group.group in openshift_aws_ami_map and openshift_aws_ami_map[openshift_aws_node_group.group] == '')
   block:
   - name: fetch recently created AMI
-    ec2_ami_find:
+    ec2_ami_facts:
       region: "{{ openshift_aws_region }}"
-      sort: creationDate
-      sort_order: descending
-      name: "{{ openshift_aws_ami_name }}*"
-      ami_tags: "{{ openshift_aws_ami_tags }}"
-      no_result_action: fail
+      filters: "{ 'name': '{{ openshift_aws_ami_name }}*',
+             {%- for key in openshift_aws_ami_tags -%}
+                 'tag:{{ key }}': '{{ openshift_aws_ami_tags[key] }}',
+             {%- endfor -%} }"
     register: amiout
+    failed_when: "amiout.images|length == 0"
 
   - name: Set the openshift_aws_ami
     set_fact:
-      openshift_aws_ami: "{{ amiout.results[0].ami_id }}"
+      openshift_aws_ami: "{{ ( amiout.images | sort(attribute='creation_date') | map(attribute='image_id') | reverse | list )[0] }}"
     when:
-    - "'results' in amiout"
-    - amiout.results|length > 0
+    - "'images' in amiout"
+    - amiout.images|length > 0
 
 # Need to set epoch time in one place to use for launch_config and scale_group
 - set_fact:

--- a/roles/openshift_aws/tasks/seal_ami.yml
+++ b/roles/openshift_aws/tasks/seal_ami.yml
@@ -13,17 +13,17 @@
 - when: openshift_aws_copy_base_ami_tags | default(False) | bool
   block:
   - name: fetch the ami used to create the instance
-    ec2_ami_find:
+    ec2_ami_facts:
       region: "{{ openshift_aws_region }}"
-      ami_id: "{{ instancesout.instances[0]['image_id'] }}"
+      image_ids: [ "{{ instancesout.instances[0]['image_id'] }}" ]
     register: original_ami_out
     retries: 20
     delay: 3
-    until: original_ami_out.results|length > 0
+    until: original_ami_out.images|length > 0
 
   - name: combine the tags of the original ami with newly created ami
     set_fact:
-      l_openshift_aws_ami_tags: "{{ original_ami_out.results[0]['tags'] | combine(openshift_aws_ami_tags) }}"
+      l_openshift_aws_ami_tags: "{{ original_ami_out.images[0]['tags'] | combine(openshift_aws_ami_tags) }}"
 
 - name: bundle ami
   ec2_ami:


### PR DESCRIPTION
Replace deprecated ec2_ami_find module with ec2_ami_facts - Bugzilla [1583817](https://bugzilla.redhat.com/show_bug.cgi?id=1583817)