### PR TITLE
cluster-monitoring: Add port definition to cluster-monitoring-operator

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-deployment.j2
+++ b/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-deployment.j2
@@ -42,6 +42,9 @@ spec:
         - "-tags=kube-state-metrics={{ openshift_image_tag }}"
         - "-tags=kube-rbac-proxy={{ openshift_image_tag }}"
 {% endif %}
+        ports:
+        - containerPort: 8080
+          name: http
         resources:
           limits:
             cpu: 20m


### PR DESCRIPTION
This is necessary for the cluster-monitoring-operator service to actually select any pods.

cc @squat @s-urbaniak 