### PR TITLE
Unify cluster-monitoring install variables

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -637,6 +637,17 @@ debug_level=2
 #openshift_persistentlocalstorage_path=/mnt/local-storage
 #openshift_persistentlocalstorage_provisionner_image=quay.io/external_storage/local-volume-provisioner:v1.0.1
 
+# Cluster monitoring
+#
+# Cluster monitoring is enabled by default, disable it by setting
+# openshift_cluster_monitoring_operator_install=false
+#
+# Cluster monitoring configuration variables allow setting the amount of
+# storage requested through PersistentVolumeClaims.
+#
+# openshift_cluster_monitoring_operator_prometheus_storage_capacity="50Gi"
+# openshift_cluster_monitoring_operator_alertmanager_storage_capacity="2Gi"
+
 # Logging deployment
 #
 # Currently logging deployment is disabled by default, enable it by setting this

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_components.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_components.yml
@@ -21,7 +21,7 @@
     - openshift_enable_service_catalog | default(true) | bool
 
 - import_playbook: ../../../openshift-monitoring/private/config.yml
-  when: openshift_monitoring_deploy | default(false) | bool
+  when: openshift_cluster_monitoring_operator_install | default(true) | bool
 
 - import_playbook: ../../../openshift-monitor-availability/private/config.yml
   when: openshift_monitor_availability_install | default(false) | bool

--- a/playbooks/common/private/components.yml
+++ b/playbooks/common/private/components.yml
@@ -20,7 +20,7 @@
 - import_playbook: ../../openshift-hosted/private/config.yml
 
 - import_playbook: ../../openshift-monitoring/private/config.yml
-  when: openshift_monitoring_deploy | default(false) | bool
+  when: openshift_cluster_monitoring_operator_install | default(true) | bool
 
 - import_playbook: ../../openshift-metering/private/config.yml
   when: openshift_metering_install | default(false) | bool


### PR DESCRIPTION
Closes https://bugzilla.redhat.com/show_bug.cgi?id=1619505

Cluster monitoring is intended to be installed by default starting with 3.11, this PR unifies the previously two variables to control installing cluster-monitoring to one called `openshift_cluster_monitoring_operator_install`, and sets it by default to `true`.

Let me know if this is the idiomatic way to do it.

cc @sdodson @vrutkovs @smarterclayton 