### PR TITLE
Change aws launch_config & asg name

### DIFF
--- a/roles/openshift_aws/tasks/scale_group.yml
+++ b/roles/openshift_aws/tasks/scale_group.yml
@@ -14,7 +14,7 @@
 - name: Create the scale group
   ec2_asg:
     name: "{{ l_node_group_name }}"
-    launch_config_name: "{{ openshift_aws_node_group.name }}-{{ openshift_aws_ami_map[openshift_aws_node_group.group] | default(openshift_aws_ami) }}-{{ l_epoch_time }}"
+    launch_config_name: "{{ openshift_aws_node_group.name }}-{{ openshift_aws_ami_map[openshift_aws_node_group.group] | default(openshift_aws_ami) }}-{{ l_deployment_serial }}"
     health_check_period: "{{ l_node_group_config[openshift_aws_node_group.group].health_check.period }}"
     health_check_type: "{{ l_node_group_config[openshift_aws_node_group.group].health_check.type }}"
     min_size: "{{ l_node_group_config[openshift_aws_node_group.group].min_size }}"


### PR DESCRIPTION
Change aws launch_config & asg name to contain deployment serial rather than epoch_time.

This makes lc & asg name immutable (no changes after repeated play runs)

Fixes Bugzilla [1620536](https://bugzilla.redhat.com/show_bug.cgi?id=1620536)