### PR TITLE
Log driver for JSON should be json-file

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -18,7 +18,7 @@ openshift_docker_ent_reg: 'registry.redhat.io'
 openshift_docker_options: False  # str
 openshift_docker_log_driver: False  # str
 openshift_docker_log_options_defaults:
-  json:
+  json-file:
   - "max-size=50m"
 openshift_docker_log_options: "{{ openshift_docker_log_options_defaults[openshift_docker_log_driver] | default([]) }}"
 


### PR DESCRIPTION
When setting the max size for logs, we were checking if
the log driver is set to "json", when in fact it would be
"json-file". This was causing the max size to not be set.

Signed-off-by: umohnani8 <umohnani@redhat.com>