### PR TITLE
Dissalow custom CA paths for identity providers

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -208,7 +208,7 @@ debug_level=2
 #openshift_master_identity_providers=[{'name': 'allow_all', 'login': 'true', 'challenge': 'true', 'kind': 'AllowAllPasswordIdentityProvider'}]
 
 # LDAP auth
-#openshift_master_identity_providers=[{'name': 'my_ldap_provider', 'challenge': 'true', 'login': 'true', 'kind': 'LDAPPasswordIdentityProvider', 'attributes': {'id': ['dn'], 'email': ['mail'], 'name': ['cn'], 'preferredUsername': ['uid']}, 'bindDN': '', 'bindPassword': '', 'ca': 'my-ldap-ca.crt', 'insecure': 'false', 'url': 'ldap://ldap.example.com:389/ou=users,dc=example,dc=com?uid'}]
+#openshift_master_identity_providers=[{'name': 'my_ldap_provider', 'challenge': 'true', 'login': 'true', 'kind': 'LDAPPasswordIdentityProvider', 'attributes': {'id': ['dn'], 'email': ['mail'], 'name': ['cn'], 'preferredUsername': ['uid']}, 'bindDN': '', 'bindPassword': '', 'insecure': 'false', 'url': 'ldap://ldap.example.com:389/ou=users,dc=example,dc=com?uid'}]
 #
 # Configure LDAP CA certificate
 # Specify either the ASCII contents of the certificate or the path to
@@ -222,7 +222,7 @@ debug_level=2
 #openshift_master_ldap_ca_file=<path to local ca file to use>
 
 # OpenID auth
-#openshift_master_identity_providers=[{"name": "openid_auth", "login": "true", "challenge": "false", "kind": "OpenIDIdentityProvider", "client_id": "my_client_id", "client_secret": "my_client_secret", "claims": {"id": ["sub"], "preferredUsername": ["preferred_username"], "name": ["name"], "email": ["email"]}, "urls": {"authorize": "https://myidp.example.com/oauth2/authorize", "token": "https://myidp.example.com/oauth2/token"}, "ca": "my-openid-ca-bundle.crt"}]
+#openshift_master_identity_providers=[{"name": "openid_auth", "login": "true", "challenge": "false", "kind": "OpenIDIdentityProvider", "client_id": "my_client_id", "client_secret": "my_client_secret", "claims": {"id": ["sub"], "preferredUsername": ["preferred_username"], "name": ["name"], "email": ["email"]}, "urls": {"authorize": "https://myidp.example.com/oauth2/authorize", "token": "https://myidp.example.com/oauth2/token"}]
 #
 # Configure OpenID CA certificate
 # Specify either the ASCII contents of the certificate or the path to
@@ -236,7 +236,7 @@ debug_level=2
 #openshift_master_openid_ca_file=<path to local ca file to use>
 
 # Request header auth
-#openshift_master_identity_providers=[{"name": "my_request_header_provider", "challenge": "true", "login": "true", "kind": "RequestHeaderIdentityProvider", "challengeURL": "https://www.example.com/challenging-proxy/oauth/authorize?${query}", "loginURL": "https://www.example.com/login-proxy/oauth/authorize?${query}", "clientCA": "my-request-header-ca.crt", "clientCommonNames": ["my-auth-proxy"], "headers": ["X-Remote-User", "SSO-User"], "emailHeaders": ["X-Remote-User-Email"], "nameHeaders": ["X-Remote-User-Display-Name"], "preferredUsernameHeaders": ["X-Remote-User-Login"]}]
+#openshift_master_identity_providers=[{"name": "my_request_header_provider", "challenge": "true", "login": "true", "kind": "RequestHeaderIdentityProvider", "challengeURL": "https://www.example.com/challenging-proxy/oauth/authorize?${query}", "loginURL": "https://www.example.com/login-proxy/oauth/authorize?${query}", "clientCommonNames": ["my-auth-proxy"], "headers": ["X-Remote-User", "SSO-User"], "emailHeaders": ["X-Remote-User-Email"], "nameHeaders": ["X-Remote-User-Display-Name"], "preferredUsernameHeaders": ["X-Remote-User-Login"]}]
 #
 # Configure request header CA certificate
 # Specify either the ASCII contents of the certificate or the path to

--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -158,6 +158,8 @@ class LDAPPasswordIdentityProvider(IdentityProviderBase):
             pref_user = self._idp['attributes'].pop('preferred_username')
             self._idp['attributes']['preferredUsername'] = pref_user
 
+        self._idp['ca'] = '/etc/origin/master/ldap_ca.crt'
+
     def validate(self):
         ''' validate this idp instance '''
         if not isinstance(self.provider['attributes'], dict):
@@ -218,6 +220,7 @@ class RequestHeaderIdentityProvider(IdentityProviderBase):
                            ['emailHeaders', 'email_headers'],
                            ['nameHeaders', 'name_headers'],
                            ['preferredUsernameHeaders', 'preferred_username_headers']]
+        self._idp['clientCA'] = '/etc/origin/master/request_header_ca.crt'
 
     def validate(self):
         ''' validate this idp instance '''
@@ -357,6 +360,8 @@ class OpenIDIdentityProvider(IdentityProviderOauthBase):
             self._idp['extraScopes'] = self._idp.pop('extra_scopes')
         if 'extra_authorize_parameters' in self._idp:
             self._idp['extraAuthorizeParameters'] = self._idp.pop('extra_authorize_parameters')
+
+        self._idp['ca'] = '/etc/origin/master/openid_ca.crt'
 
     def validate(self):
         ''' validate this idp instance '''

--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -158,7 +158,7 @@ class LDAPPasswordIdentityProvider(IdentityProviderBase):
             pref_user = self._idp['attributes'].pop('preferred_username')
             self._idp['attributes']['preferredUsername'] = pref_user
 
-        self._idp['ca'] = '/etc/origin/master/ldap_ca.crt'
+        self._idp['ca'] = '/etc/origin/master/{}_ldap_ca.crt'.format(self._idp['name'])
 
     def validate(self):
         ''' validate this idp instance '''
@@ -220,7 +220,8 @@ class RequestHeaderIdentityProvider(IdentityProviderBase):
                            ['emailHeaders', 'email_headers'],
                            ['nameHeaders', 'name_headers'],
                            ['preferredUsernameHeaders', 'preferred_username_headers']]
-        self._idp['clientCA'] = '/etc/origin/master/request_header_ca.crt'
+        self._idp['clientCA'] = \
+            '/etc/origin/master/{}_request_header_ca.crt'.format(self._idp['name'])
 
     def validate(self):
         ''' validate this idp instance '''
@@ -361,7 +362,7 @@ class OpenIDIdentityProvider(IdentityProviderOauthBase):
         if 'extra_authorize_parameters' in self._idp:
             self._idp['extraAuthorizeParameters'] = self._idp.pop('extra_authorize_parameters')
 
-        self._idp['ca'] = '/etc/origin/master/openid_ca.crt'
+        self._idp['ca'] = '/etc/origin/master/{}_openid_ca.crt'.format(self._idp['name'])
 
     def validate(self):
         ''' validate this idp instance '''

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -78,7 +78,7 @@
 
 - name: Create the ldap ca file if needed
   copy:
-    dest: "{{ item.ca if 'ca' in item and '/' in item.ca else '/etc/origin/master/' ~ item.ca | default('ldap_ca.crt') }}"
+    dest: "/etc/origin/master/ldap_ca.crt"
     content: "{{ openshift.master.ldap_ca }}"
     mode: 0600
     backup: yes
@@ -89,26 +89,24 @@
 
 - name: Create the openid ca file if needed
   copy:
-    dest: "{{ item.ca if 'ca' in item and '/' in item.ca else '/etc/origin/master/' ~ item.ca | default('openid_ca.crt') }}"
+    dest: "/etc/origin/master/openid_ca.crt"
     content: "{{ openshift.master.openid_ca }}"
     mode: 0600
     backup: yes
   when:
   - openshift.master.openid_ca is defined
   - item.kind == 'OpenIDIdentityProvider'
-  - item.ca | default('') != ''
   with_items: "{{ openshift_master_identity_providers }}"
 
 - name: Create the request header ca file if needed
   copy:
-    dest: "{{ item.clientCA if 'clientCA' in item and '/' in item.clientCA else '/etc/origin/master/' ~ item.clientCA | default('request_header_ca.crt') }}"
+    dest: "/etc/origin/master/request_header_ca.crt"
     content: "{{ openshift_master_request_header_ca }}"
     mode: 0600
     backup: yes
   when:
   - openshift_master_request_header_ca != l_osm_request_header_none
   - item.kind == 'RequestHeaderIdentityProvider'
-  - item.clientCA | default('') != ''
   with_items: "{{ openshift_master_identity_providers }}"
 
 - name: Set fact of all etcd host IPs

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -78,7 +78,7 @@
 
 - name: Create the ldap ca file if needed
   copy:
-    dest: "/etc/origin/master/ldap_ca.crt"
+    dest: "/etc/origin/master/{{ item.name }}_ldap_ca.crt"
     content: "{{ openshift.master.ldap_ca }}"
     mode: 0600
     backup: yes
@@ -89,7 +89,7 @@
 
 - name: Create the openid ca file if needed
   copy:
-    dest: "/etc/origin/master/openid_ca.crt"
+    dest: "/etc/origin/master/{{ item.name }}_openid_ca.crt"
     content: "{{ openshift.master.openid_ca }}"
     mode: 0600
     backup: yes
@@ -100,7 +100,7 @@
 
 - name: Create the request header ca file if needed
   copy:
-    dest: "/etc/origin/master/request_header_ca.crt"
+    dest: "/etc/origin/master/{{ item.name }}_request_header_ca.crt"
     content: "{{ openshift_master_request_header_ca }}"
     mode: 0600
     backup: yes


### PR DESCRIPTION
This commit would ensure ldap auth provider won't rewrite any files
in the static pod and gets placed in /etc/origin/master/ldap_ca.crt.

Previously, before static pod deployment, 
openshift_master_identity_providers
param for LDAP auth could specify the file, which was copied on the
host and was used by API server, running on the host.

In 3.10+ this file needs to be mounted in the API server container
(along with the rest of configuration), so a custom path in `ca` section
could be left on the node. This file was copied unconditionally and
could rewrite any CA / config file.

This commit would always place contents from `openshift_master_ldap_ca`
(or file from `openshift_master_ldap_ca_file`) in
/etc/origin/master/ldap_ca.crt, which would be mounted in a static pod.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1614414, https://bugzilla.redhat.com/show_bug.cgi?id=1616262 and #9397 

Fixes #6191

TODO:
* [x] make sure `LDAPPasswordIdentityProvider` has `ca` autofilled with `ldap_ca` if `openshift_master_ldap_ca_file` is set
* [x] Fix other providers using CA