### PR TITLE
Add default node groups to support running cri-o runtime

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -119,7 +119,7 @@ debug_level=2
 # these variables are set to the defaults shown. You may override them here.
 # NOTE: You will still need to tag crio nodes with your given label(s)!
 # Enable docker garbage collection when using cri-o
-#openshift_crio_enable_docker_gc=True
+#openshift_crio_enable_docker_gc=False
 # Node Selectors to run the garbage collection
 #openshift_crio_docker_gc_node_selector={'runtime': 'cri-o'}
 

--- a/playbooks/openshift-hosted/private/install_docker_gc.yml
+++ b/playbooks/openshift-hosted/private/install_docker_gc.yml
@@ -8,5 +8,4 @@
   - import_role:
       name: openshift_docker_gc
     when:
-    - openshift_use_crio | bool
     - openshift_crio_enable_docker_gc | bool

--- a/playbooks/openshift-hosted/private/upgrade.yml
+++ b/playbooks/openshift-hosted/private/upgrade.yml
@@ -17,5 +17,4 @@
   - import_role:
       name: openshift_docker_gc
     when:
-    - openshift_use_crio | bool
     - openshift_crio_enable_docker_gc | bool

--- a/roles/openshift_docker_gc/defaults/main.yml
+++ b/roles/openshift_docker_gc/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-r_enable_docker_gc: "{{ openshift_crio_enable_docker_gc }}"
-r_docker_gc_node_selectors: "{{ openshift_crio_docker_gc_node_selector | default({'runtime': 'cri-o'}) }}"
-
 openshift_docker_gc_image_dict:
   origin: "origin"
   openshift-enterprise: "ose-control-plane"

--- a/roles/openshift_docker_gc/templates/dockergc-ds.yaml.j2
+++ b/roles/openshift_docker_gc/templates/dockergc-ds.yaml.j2
@@ -23,9 +23,9 @@ items:
         name: dockergc
       spec:
 {# Only set nodeSelector if the dict is not empty #}
-{% if r_docker_gc_node_selectors %}
+{% if openshift_crio_docker_gc_node_selector %}
         nodeSelector:
-{% for k,v in r_docker_gc_node_selectors.items() %}
+{% for k,v in openshift_crio_docker_gc_node_selector.items() %}
           {{ k }}: "{{ v }}"{% endfor %}{% endif %}
 
         serviceAccountName: dockergc

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -46,6 +46,8 @@ openshift_crio_enable_docker_gc: True
 openshift_crio_var_sock: "unix:///var/run/crio/crio.sock"
 openshift_crio_pause_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'pod') }}"
 openshift_container_cli: "{{ openshift_use_crio | bool | ternary('crictl', 'docker') }}"
+openshift_crio_docker_gc_node_selector:
+  runtime: 'cri-o'
 
 # osm_default_subdomain is an old migrated fact, can probably be removed.
 osm_default_subdomain: "router.default.svc.cluster.local"
@@ -147,20 +149,66 @@ openshift_node_groups:
     labels:
       - 'node-role.kubernetes.io/master=true'
     edits: []
+  - name: node-config-master-crio
+    labels:
+      - 'node-role.kubernetes.io/master=true'
+      - "{{ openshift_crio_docker_gc_node_selector | lib_utils_oo_dict_to_keqv_list | join(',') }}"
+    edits: "{{ openshift_node_group_edits_crio }}"
   - name: node-config-infra
     labels:
       - 'node-role.kubernetes.io/infra=true'
     edits: []
+  - name: node-config-infra-crio
+    labels:
+      - 'node-role.kubernetes.io/infra=true'
+      - "{{ openshift_crio_docker_gc_node_selector | lib_utils_oo_dict_to_keqv_list | join(',') }}"
+    edits: "{{ openshift_node_group_edits_crio }}"
   - name: node-config-compute
     labels:
       - 'node-role.kubernetes.io/compute=true'
     edits: []
+  - name: node-config-compute-crio
+    labels:
+      - 'node-role.kubernetes.io/compute=true'
+      - "{{ openshift_crio_docker_gc_node_selector | lib_utils_oo_dict_to_keqv_list | join(',') }}"
+    edits: "{{ openshift_node_group_edits_crio }}"
   - name: node-config-master-infra
     labels:
-      - 'node-role.kubernetes.io/infra=true,node-role.kubernetes.io/master=true'
+      - 'node-role.kubernetes.io/master=true'
+      - 'node-role.kubernetes.io/infra=true'
     edits: []
+  - name: node-config-master-infra-crio
+    labels:
+      - 'node-role.kubernetes.io/master=true'
+      - 'node-role.kubernetes.io/infra=true'
+      - "{{ openshift_crio_docker_gc_node_selector | lib_utils_oo_dict_to_keqv_list | join(',') }}"
+    edits: "{{ openshift_node_group_edits_crio }}"
   - name: node-config-all-in-one
     labels:
-      - 'node-role.kubernetes.io/infra=true,node-role.kubernetes.io/master=true,node-role.kubernetes.io/compute=true'
+      - 'node-role.kubernetes.io/master=true'
+      - 'node-role.kubernetes.io/infra=true'
+      - 'node-role.kubernetes.io/compute=true'
     edits: []
+  - name: node-config-all-in-one-crio
+    labels:
+      - 'node-role.kubernetes.io/master=true'
+      - 'node-role.kubernetes.io/infra=true'
+      - 'node-role.kubernetes.io/compute=true'
+      - "{{ openshift_crio_docker_gc_node_selector | lib_utils_oo_dict_to_keqv_list | join(',') }}"
+    edits: "{{ openshift_node_group_edits_crio }}"
+
+openshift_node_group_edits_crio:
+  - key: kubeletArguments.container-runtime
+    value:
+      - "remote"
+  - key: kubeletArguments.container-runtime-endpoint
+    value:
+      - "{{ openshift_crio_var_sock }}"
+  - key: kubeletArguments.image-service-endpoint
+    value:
+      - "{{ openshift_crio_var_sock }}"
+  - key: kubeletArguments.runtime-request-timeout
+    value:
+      - "10m"
+
 openshift_master_manage_htpasswd: True

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -42,7 +42,7 @@ repoquery_installed: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --l
 
 openshift_use_crio: False
 openshift_use_crio_only: False
-openshift_crio_enable_docker_gc: True
+openshift_crio_enable_docker_gc: False
 openshift_crio_var_sock: "unix:///var/run/crio/crio.sock"
 openshift_crio_pause_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'pod') }}"
 openshift_container_cli: "{{ openshift_use_crio | bool | ternary('crictl', 'docker') }}"


### PR DESCRIPTION
To facilitate using cri-o as the container-runtime for OpenShift, the
node-config must be updated with the correct endpoint settings.  The
openshift_node_groups defaults have been extended to include cri-o
variants for each of the existing default node groups.

To use the cri-o runtime for a group of compute nodes, the following
inventory variables should be used.

openshift_use_crio=True
openshift_node_group_name="node-config-compute-crio"

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1615884