### PR TITLE
fix error in cnx conditional regex

### DIFF
--- a/roles/calico_master/tasks/main.yml
+++ b/roles/calico_master/tasks/main.yml
@@ -36,7 +36,7 @@
 - name: Calico Master | Parse node version
   set_fact:
     node_version: "{{ calico_node_image | regex_replace('^.*node:v?(.*)$', '\\1') }}"
-    cnx: "{{ calico_node_image | regex_replace('[^-]*', '\\0') }}"
+    cnx: "{{ calico_node_image | regex_replace('^.*/(.*)-node:.*$', '\\1') }}"
 
 - name: Calico Master | Write Calico v2
   template:


### PR DESCRIPTION
Fix bug found in https://github.com/openshift/openshift-ansible/pull/9573. Now correctly gets the `cnx` value to be used in the conditional. 

Signed-off-by: derek mcquay <derekmcquay@gmail.com>