### PR TITLE
Router namespace fix - cluster-reader is not assigned if namespace != 'default'

### DIFF
--- a/roles/openshift_hosted/tasks/router.yml
+++ b/roles/openshift_hosted/tasks/router.yml
@@ -61,22 +61,22 @@
 - name: Create the router service account(s)
   oc_serviceaccount:
     name: "{{ item.serviceaccount }}"
-    namespace: "{{ item.namespace }}"
+    namespace: "{{ item.namespace | default('default') }}"
     state: present
   with_items: "{{ openshift_hosted_routers }}"
 
 - name: Grant the router service account(s) access to the appropriate scc
   oc_adm_policy_user:
-    user: "system:serviceaccount:{{ item.namespace }}:{{ item.serviceaccount }}"
-    namespace: "{{ item.namespace }}"
+    user: "system:serviceaccount:{{ item.namespace | default('default') }}:{{ item.serviceaccount }}"
+    namespace: "{{ item.namespace | default('default') }}"
     resource_kind: scc
     resource_name: hostnetwork
   with_items: "{{ openshift_hosted_routers }}"
 
 - name: Set additional permissions for router service account
   oc_adm_policy_user:
-    user: "system:serviceaccount:{{ item.namespace }}:{{ item.serviceaccount }}"
-    namespace: "{{ item.namespace }}"
+    user: "system:serviceaccount:{{ item.namespace | default('default') }}:{{ item.serviceaccount }}"
+    namespace: "{{ item.namespace | default('default') }}"
     resource_kind: cluster-role
     resource_name: cluster-reader
   when: item.namespace == 'default'

--- a/roles/openshift_hosted/tasks/router.yml
+++ b/roles/openshift_hosted/tasks/router.yml
@@ -79,7 +79,6 @@
     namespace: "{{ item.namespace | default('default') }}"
     resource_kind: cluster-role
     resource_name: cluster-reader
-  when: item.namespace == 'default'
   with_items: "{{ openshift_hosted_routers }}"
 
 - name: Create OpenShift router


### PR DESCRIPTION
If namespace used for routers in the openshift_hosted_routers var is different than 'default', task for assigning cluster-reader role to the router service account is not executed.