### PR TITLE
Change legacy node_exporter port to 9102

### DIFF
--- a/roles/openshift_prometheus/files/node-exporter-template.yaml
+++ b/roles/openshift_prometheus/files/node-exporter-template.yaml
@@ -37,9 +37,9 @@ objects:
     clusterIP: None
     ports:
     - name: scrape
-      port: 9101
+      port: 9100
       protocol: TCP
-      targetPort: 9101
+      targetPort: 9100
     selector:
       app: prometheus-node-exporter
 - apiVersion: extensions/v1beta1
@@ -67,9 +67,8 @@ objects:
           name: node-exporter
           args:
           - --no-collector.wifi
-          - --web.listen-address=:9101
           ports:
-          - containerPort: 9101
+          - containerPort: 9100
             name: scrape
           resources:
             requests:

--- a/roles/openshift_prometheus/files/node-exporter-template.yaml
+++ b/roles/openshift_prometheus/files/node-exporter-template.yaml
@@ -37,9 +37,9 @@ objects:
     clusterIP: None
     ports:
     - name: scrape
-      port: 9100
+      port: 9102
       protocol: TCP
-      targetPort: 9100
+      targetPort: 9102
     selector:
       app: prometheus-node-exporter
 - apiVersion: extensions/v1beta1
@@ -67,8 +67,9 @@ objects:
           name: node-exporter
           args:
           - --no-collector.wifi
+          - --web.listen-address=:9102
           ports:
-          - containerPort: 9100
+          - containerPort: 9102
             name: scrape
           resources:
             requests:

--- a/roles/openshift_prometheus/templates/prometheus.yml.j2
+++ b/roles/openshift_prometheus/templates/prometheus.yml.j2
@@ -232,7 +232,7 @@ scrape_configs:
       action: replace
       target_label: kubernetes_name
 
-# Scrape config for node-exporter, which is expected to be running on port 9101.
+# Scrape config for node-exporter, which is expected to be running on port 9100.
 - job_name: 'kubernetes-nodes-exporter'
 
   tls_config:
@@ -270,7 +270,7 @@ scrape_configs:
   relabel_configs:
   - source_labels: [__address__]
     regex: '(.*):10250'
-    replacement: '${1}:9101'
+    replacement: '${1}:9100'
     target_label: __address__
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
     target_label: __instance__

--- a/roles/openshift_prometheus/templates/prometheus.yml.j2
+++ b/roles/openshift_prometheus/templates/prometheus.yml.j2
@@ -232,7 +232,7 @@ scrape_configs:
       action: replace
       target_label: kubernetes_name
 
-# Scrape config for node-exporter, which is expected to be running on port 9100.
+# Scrape config for node-exporter, which is expected to be running on port 9102.
 - job_name: 'kubernetes-nodes-exporter'
 
   tls_config:
@@ -270,7 +270,7 @@ scrape_configs:
   relabel_configs:
   - source_labels: [__address__]
     regex: '(.*):10250'
-    replacement: '${1}:9100'
+    replacement: '${1}:9102'
     target_label: __address__
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
     target_label: __instance__


### PR DESCRIPTION
The previous change to use 9101 ran into another conflict.
For more info see: https://bugzilla.redhat.com/show_bug.cgi?id=1608288