### PR TITLE
Don't set reclaim policy to empty string

### DIFF
--- a/roles/openshift_default_storage_class/defaults/main.yml
+++ b/roles/openshift_default_storage_class/defaults/main.yml
@@ -41,4 +41,3 @@ openshift_storageclass_name: "{{ openshift_storageclass_defaults[openshift_cloud
 openshift_storageclass_provisioner: "{{ openshift_storageclass_defaults[openshift_cloudprovider_kind]['provisioner'] }}"
 openshift_storageclass_parameters: "{{ openshift_storageclass_defaults[openshift_cloudprovider_kind]['parameters'] }}"
 openshift_storageclass_mount_options: []
-openshift_storageclass_reclaim_policy: ""


### PR DESCRIPTION
fixes https://github.com/openshift/openshift-ansible/issues/9340

a lot of e2e tests rely on default storage class apparently and now 3.11 tests are failing
https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/18816/pull-ci-origin-e2e-gcp/2892/#sig-storage-dynamic-provisioning-block-volume-provisioning-featureblockvolume-should-create-and-delete-block-persistent-volumes-suiteopenshiftconformanceparallel-suitek8s