### PR TITLE
SDN check: Expand openshift_client_binary variable

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/sdn.py
+++ b/roles/openshift_health_checker/openshift_checks/sdn.py
@@ -60,6 +60,7 @@ class SDNCheck(OpenShiftCheck):
                                              ['/bin/docker', 'version'])
                 oc_executable = self.get_var('openshift_client_binary',
                                              default='/bin/oc')
+                oc_executable = self.template_var(oc_executable)
                 self.save_command_output('oc-version', [oc_executable,
                                                         'version'])
                 self.register_file('os-version', None,


### PR DESCRIPTION
Expand the `openshift_client_binary variable` in case it is a template.

This commit is a follow-up to https://github.com/openshift/openshift-ansible/pull/9688.

This commit fixes bug 1615705.

https://bugzilla.redhat.com/show_bug.cgi?id=1615705#c8

* `roles/openshift_health_checker/openshift_checks/sdn.py` (`SDNCheck.run`): Expand the `openshift_client_binary` variable using the `template_var` method.