### PR TITLE
Fix Upgrade of Components during OpenShift Upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_components.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_components.yml
@@ -13,12 +13,12 @@
       name: ansible_service_broker
       tasks_from: install.yml
     when:
-    - openshift_enable_service_catalog | default(true) | bool
+    - ansible_service_broker_install | default(true) | bool
   - import_role:
       name: template_service_broker
       tasks_from: upgrade.yml
     when:
-    - openshift_enable_service_catalog | default(true) | bool
+    - template_service_broker_install | default(true) | bool
 
 - import_playbook: ../../../openshift-monitoring/private/config.yml
   when: openshift_monitoring_deploy | default(false) | bool


### PR DESCRIPTION
Currently OpenShift Upgrades from 3.7 to 3.x fail when the Template Service Broker or Ansible Service Broker werent installed in the initial setup caused by a wrong check in the OpenShift Upgrade Playbook. 

This PR replaces the wrong variables that were checked.

@vrutkovs @sdodson 
