### PR TITLE
Refactoring OpenShift Service Catalog Install

### DIFF
--- a/.papr-master-ha.inventory
+++ b/.papr-master-ha.inventory
@@ -12,7 +12,7 @@ openshift_master_default_subdomain="{{ lookup('env', 'RHCI_ocp_master1_IP') }}.x
 openshift_check_min_host_disk_gb=1.5
 openshift_check_min_host_memory_gb=1.9
 openshift_portal_net=172.30.0.0/16
-openshift_enable_service_catalog=false
+openshift_service_catalog_install=false
 debug_level=4
 openshift_docker_options="--log-driver=journald"
 

--- a/.papr.all-in-one.inventory
+++ b/.papr.all-in-one.inventory
@@ -12,7 +12,7 @@ openshift_master_default_subdomain="{{ lookup('env', 'RHCI_ocp_master_IP') }}.xi
 openshift_check_min_host_disk_gb=1.5
 openshift_check_min_host_memory_gb=1.9
 openshift_portal_net=172.30.0.0/16
-openshift_enable_service_catalog=false
+openshift_service_catalog_install=false
 debug_level=4
 openshift_docker_options="--log-driver=journald"
 

--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -901,7 +901,7 @@ debug_level=2
 #openshift_buildoverrides_json='{"BuildOverrides":{"configuration":{"apiVersion":"v1","kind":"BuildDefaultsConfig","forcePull":"true"}}}'
 
 # Enable service catalog
-#openshift_enable_service_catalog=true
+#openshift_service_catalog_install=true
 
 # Enable template service broker (requires service catalog to be enabled, above)
 #template_service_broker_install=true

--- a/playbooks/cluster-operator/aws/components/openshift-service-catalog.yml
+++ b/playbooks/cluster-operator/aws/components/openshift-service-catalog.yml
@@ -22,4 +22,4 @@
 
 - name: Run openshift-service-catalog playbook
   import_playbook: ../../../openshift-service-catalog/private/config.yml
-  when: openshift_enable_service_catalog | default(true) | bool
+  when: openshift_service_catalog_install | default(true) | bool

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_components.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_components.yml
@@ -8,7 +8,7 @@
       name: openshift_service_catalog
       tasks_from: install.yml
     when:
-    - openshift_enable_service_catalog | default(true) | bool
+    - openshift_service_catalog_install | default(true) | bool
   - import_role:
       name: ansible_service_broker
       tasks_from: install.yml

--- a/playbooks/common/private/components.yml
+++ b/playbooks/common/private/components.yml
@@ -53,7 +53,7 @@
   when: openshift_monitor_availability_install | default(false) | bool
 
 - import_playbook: ../../openshift-service-catalog/private/config.yml
-  when: openshift_enable_service_catalog | default(true) | bool
+  when: openshift_service_catalog_install | default(true) | bool
 
 - import_playbook: ../../olm/private/config.yml
   when: openshift_enable_olm | default(false) | bool

--- a/playbooks/rhv/inventory.example
+++ b/playbooks/rhv/inventory.example
@@ -12,7 +12,7 @@ lb
 ansible_user=root
 openshift_deployment_type=origin
 #openshift_deployment_type=openshift-enterprise
-openshift_enable_service_catalog=False
+openshift_service_catalog_install=False
 
 # Hostnames
 load_balancer_hostname=lb0.{{openshift_rhv_dns_zone}}

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -161,3 +161,7 @@ openshift_node_groups:
       - 'node-role.kubernetes.io/infra=true,node-role.kubernetes.io/master=true,node-role.kubernetes.io/compute=true'
     edits: []
 openshift_master_manage_htpasswd: True
+
+
+#Backwards compatibility with old inventory files
+openshift_service_catalog_install: "{{ openshift_enable_service_catalog | default(openshift_service_catalog_install) }}"

--- a/roles/openshift_sanitize_inventory/tasks/main.yml
+++ b/roles/openshift_sanitize_inventory/tasks/main.yml
@@ -45,6 +45,15 @@
     - openshift_cloudprovider_kind is defined
     - openshift_cloudprovider_kind == 'aws'
 
+- name: Ensure openshift_service_catalog_remove and openshift_service_catalog_install are mutually exclusive
+  fail:
+    msg: >
+      Ensure that openshift_service_catalog_remove and openshift_service_catalog_install are mutually exclusive,
+      do not set both to true. openshift_service_catalog_install defaults to true.
+  when:
+    - openshift_service_catalog_remove | default(false) | bool
+    - openshift_service_catalog_install | default(true) | bool
+
 - name: Ensure ansible_service_broker_remove and ansible_service_broker_install are mutually exclusive
   fail:
     msg: >

--- a/roles/openshift_service_catalog/defaults/main.yml
+++ b/roles/openshift_service_catalog/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+openshift_service_catalog_install: true
 openshift_service_catalog_remove: false
 
 # Feature Gates

--- a/roles/openshift_service_catalog/tasks/main.yml
+++ b/roles/openshift_service_catalog/tasks/main.yml
@@ -2,7 +2,7 @@
 # do any asserts here
 
 - include_tasks: install.yml
-  when: not openshift_service_catalog_remove | default(false) | bool
+  when: openshift_service_catalog_install | default(true) | bool
 
 - include_tasks: remove.yml
   when: openshift_service_catalog_remove | default(false) | bool


### PR DESCRIPTION
Refactored OpenShift Service Catalog Install to be inline with other OpenShift Components (Ansible Broker and Template Service Broker) in regards of variable naming and install/remove flag.

@sdodson @vrutkovs 