### PR TITLE
Rename task name in role rhel_repos

### DIFF
--- a/roles/openshift_repos/tasks/rhel_repos.yml
+++ b/roles/openshift_repos/tasks/rhel_repos.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure RHEL rhui repositories are disabled
+- name: Discover enabled RHEL rhui repositories
   command: bash -c "yum -q --noplugins repolist | grep -v 'repo id' | grep 'rhui'"
   register: repo_rhui
   changed_when: "repo_rhui.rc != 1"


### PR DESCRIPTION
Task 1 in role rhel_repos is unclear as to what is occurring...  This patch renames the task according to it's function.