### PR TITLE
Updating logging eventrouter image name to match ose naming pattern

### DIFF
--- a/roles/openshift_logging_defaults/defaults/main.yml
+++ b/roles/openshift_logging_defaults/defaults/main.yml
@@ -26,3 +26,4 @@ openshift_logging_fluentd_image: "{{ l_os_registry_url | regex_replace('${compon
 openshift_logging_kibana_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'logging-kibana5') }}"
 openshift_logging_kibana_proxy_image: "{{ l2_os_logging_proxy_image }}"
 openshift_logging_mux_image: "{{ openshift_logging_fluentd_image }}"
+openshift_logging_eventrouter_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'logging-eventrouter') }}"

--- a/roles/openshift_logging_eventrouter/defaults/main.yaml
+++ b/roles/openshift_logging_eventrouter/defaults/main.yaml
@@ -6,5 +6,3 @@ openshift_logging_eventrouter_cpu_limit: null
 openshift_logging_eventrouter_cpu_request: 100m
 openshift_logging_eventrouter_memory_limit: 128Mi
 openshift_logging_eventrouter_namespace: default
-
-openshift_logging_eventrouter_image: "{{ l_os_registry_url | regex_replace(l_openshift_logging_search | regex_escape, 'logging-eventrouter') }}"


### PR DESCRIPTION
This is required for 3.11 since the eventrouter image will have a `"ose-"` prefix for enterprise installations like our other components.