### PR TITLE
Ensure master image is pre-pulled on upgrade

### DIFF
--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -71,10 +71,17 @@
 # Set openshift_master_facts separately. In order to reconcile
 # admission_config's, we currently must run openshift_master_facts and
 # then run openshift_facts.
-- name: Set OpenShift master facts
+- name: Set OpenShift master facts and image prepull
   hosts: oo_masters_to_config
   roles:
   - openshift_master_facts
+  tasks:
+  - import_role:
+      name: openshift_control_plane
+      tasks_from: pre_pull.yml
+  - import_role:
+      name: openshift_control_plane
+      tasks_from: pre_pull_poll.yml
 
 - name: configure vsphere svc account
   hosts: oo_first_master

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -10,21 +10,7 @@
   when:
   - openshift_master_oauth_grant_method not in openshift_master_valid_grant_methods
 
-- name: Check that origin image is present
-  command: 'docker images -q "{{ osm_image }}"'
-  register: control_plane_image
-
-# This task runs async to save time while the master is being configured
-- name: Pre-pull Origin image
-  docker_image:
-    name: "{{ osm_image }}"
-  environment:
-    NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
-  when: control_plane_image.stdout_lines == []
-  # 10 minutes to pull the image
-  async: 600
-  poll: 0
-  register: image_prepull
+- import_tasks: pre_pull.yml
 
 - name: Open up firewall ports
   import_tasks: firewall.yml
@@ -159,28 +145,7 @@
   # copy to this location to bypass initial bootstrap request
   - /etc/origin/node/node.kubeconfig
 
-- name: Check status of control plane image pre-pull
-  async_status:
-    jid: "{{ image_prepull.ansible_job_id }}"
-  register: job_result
-  until: job_result.finished
-  when: control_plane_image.stdout_lines == []
-  retries: 20
-  delay: 30
-  failed_when: false
-
-- name: Check status of etcd image pre-pull
-  async_status:
-    jid: "{{ etcd_prepull.ansible_job_id }}"
-  register: job_result
-  until: job_result.finished
-  when:
-  - etcd_image_exists is defined
-  - "'stdout_lines' in etcd_image_exists"
-  - etcd_image_exists.stdout_lines == []
-  retries: 20
-  delay: 30
-  failed_when: false
+- import_tasks: pre_pull_poll.yml
 
 - name: Start and enable self-hosting node
   systemd:

--- a/roles/openshift_control_plane/tasks/pre_pull.yml
+++ b/roles/openshift_control_plane/tasks/pre_pull.yml
@@ -1,0 +1,16 @@
+---
+- name: Check that origin image is present
+  command: 'docker images -q "{{ osm_image }}"'
+  register: control_plane_image
+
+# This task runs async to save time while the master is being configured
+- name: Pre-pull Origin image
+  docker_image:
+    name: "{{ osm_image }}"
+  environment:
+    NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
+  when: control_plane_image.stdout_lines == []
+  # 10 minutes to pull the image
+  async: 600
+  poll: 0
+  register: image_prepull

--- a/roles/openshift_control_plane/tasks/pre_pull_poll.yml
+++ b/roles/openshift_control_plane/tasks/pre_pull_poll.yml
@@ -1,0 +1,23 @@
+---
+- name: Check status of control plane image pre-pull
+  async_status:
+    jid: "{{ image_prepull.ansible_job_id }}"
+  register: job_result
+  until: job_result.finished
+  when: control_plane_image.stdout_lines == []
+  retries: 20
+  delay: 30
+  failed_when: false
+
+- name: Check status of etcd image pre-pull
+  async_status:
+    jid: "{{ etcd_prepull.ansible_job_id }}"
+  register: job_result
+  until: job_result.finished
+  when:
+  - etcd_image_exists is defined
+  - "'stdout_lines' in etcd_image_exists"
+  - etcd_image_exists.stdout_lines == []
+  retries: 20
+  delay: 30
+  failed_when: false


### PR DESCRIPTION
This commit ensures we pre-pull the openshift
control plane image during upgrades.  This ensures
that we don't fail on waiting for the api to come up
due to slow image pulling.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1622256