### PR TITLE
Ensure default StorageClass reclaimPolicy is set to nil instead of emptystring when reclaim_policy undefined

### DIFF
--- a/roles/openshift_default_storage_class/tasks/main.yml
+++ b/roles/openshift_default_storage_class/tasks/main.yml
@@ -7,7 +7,7 @@
     parameters: "{{ openshift_storageclass_parameters }}"
     provisioner: "{{ openshift_storageclass_provisioner }}"
     mount_options: "{{ openshift_storageclass_mount_options }}"
-    reclaim_policy: "{{ openshift_storageclass_reclaim_policy | default(None) }}"
+    reclaim_policy: "{{ openshift_storageclass_reclaim_policy | default(omit, True) }}"
   run_once: true
 
 - when: openshift_cloudprovider_kind == 'azure'


### PR DESCRIPTION
Attempt to fix https://github.com/openshift/openshift-ansible/issues/9340 again.

Thank you Clayton for finding https://github.com/ansible/ansible/issues/44503. ~I've added to the integration to ensure that `reclaim_policy: "{{ undefined_variable | default(omit, True) }}"` results in `storageClass.reclaimPolicy` being nil then defaulted by openshift to Delete. I am still figuring out how to test this with ansible locally but the integration test will suffice in the meantime~ I tested it locally and it works as expected.