### PR TITLE
fix haproxy start in containerized install

### DIFF
--- a/roles/openshift_loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/openshift_loadbalancer/templates/haproxy.cfg.j2
@@ -3,9 +3,6 @@
 global
     maxconn     {{ openshift_loadbalancer_global_maxconn | default(20000) }}
     log         /dev/log local0 info
-{% if openshift_is_containerized | bool %}
-    stats socket /var/lib/haproxy/run/haproxy.sock mode 600 level admin
-{% else %}
     chroot      /var/lib/haproxy
     pidfile     /var/run/haproxy.pid
     user        haproxy
@@ -14,7 +11,6 @@ global
 
     # turn on stats unix socket
     stats socket /var/lib/haproxy/stats
-{% endif %}
 
 #---------------------------------------------------------------------
 # common defaults that all the 'listen' and 'backend' sections will


### PR DESCRIPTION
This commit remove oldest haproxy config when it was containerized (before openshift 3.10)
Issue: #9785 