### PR TITLE
Ensure connection local on local host play

### DIFF
--- a/playbooks/openshift-node/private/bootstrap.yml
+++ b/playbooks/openshift-node/private/bootstrap.yml
@@ -15,6 +15,7 @@
 
 - name: Only target nodes that have not yet been bootstrapped
   hosts: localhost
+  connection: local
   tasks:
   - add_host:
       name: "{{ item }}"


### PR DESCRIPTION
This commit ensures that connection is type local
for localhost plays.

This may be required for some inventories.