### PR TITLE
Add support for ak/orgid in OpenStack provision playbook

### DIFF
--- a/playbooks/openstack/openshift-cluster/provision.yml
+++ b/playbooks/openstack/openshift-cluster/provision.yml
@@ -54,8 +54,7 @@
       name: rhel_subscribe
     when:
     - ansible_distribution == "RedHat"
-    - rhsub_user is defined
-    - rhsub_pass is defined
+    - (rhsub_user is defined and rhsub_pass is defined) or (rhsub_ak is defined and rhsub_orgid is defined)
 
 - name: Show information about the deployed cluster
   import_playbook: cluster-info.yml


### PR DESCRIPTION
Related to #9579 

This will allow to specify ak/orgid or user/pass to register osp instances.