### PR TITLE
Control plane static pods (apiserver, etcd, controller-manager) must be assigned highest priority class system-node-critical. 

### DIFF
--- a/roles/etcd/files/etcd.yaml
+++ b/roles/etcd/files/etcd.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   restartPolicy: Always
   hostNetwork: true
+  priorityClassName: system-node-critical
   containers:
   - name: etcd
     image: quay.io/coreos/etcd:v3.3

--- a/roles/openshift_control_plane/files/apiserver.yaml
+++ b/roles/openshift_control_plane/files/apiserver.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   restartPolicy: Always
   hostNetwork: true
+  priorityClassName: system-node-critical
   containers:
   - name: api
     image: docker.io/openshift/origin:v3.11.0

--- a/roles/openshift_control_plane/files/controller.yaml
+++ b/roles/openshift_control_plane/files/controller.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   restartPolicy: Always
   hostNetwork: true
+  priorityClassName: system-node-critical
   containers:
   - name: controllers
     image: docker.io/openshift/origin:v3.11.0


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1622439

The issue is happening as priority admission plugin incorrectly assigns system-cluster-critical to pods with critical pod annotations if no priority class is assigned. This PR now explicitly assigns  system-node-critical priority class to most critical pods like (apiserver, etcd, controller-manager).

On a related note, since the behavior with critical pod annotation is that any pod with critical pod annotation is never evicted by kubelet, so after upgrade to maintain the same behavior, if no priority class is class is assigned, only system-node-critical can provide this guarantee. I have sent a PR to upstream to address this: https://github.com/kubernetes/kubernetes/pull/67958 .

@sjenning @ravisantoshgudimetla @sdodson @michaelgugino 