### PR TITLE
Add extensions to tasks_from: directives

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane.yml
@@ -95,10 +95,10 @@
   tasks:
   - import_role:
       name: openshift_node
-      tasks_from: upgrade_pre
+      tasks_from: upgrade_pre.yml
   - import_role:
       name: openshift_node
-      tasks_from: upgrade
+      tasks_from: upgrade.yml
   - import_role:
       name: openshift_storage_glusterfs
       tasks_from: check_cluster_health.yml
@@ -113,7 +113,7 @@
   tasks:
   - import_role:
       name: openshift_web_console
-      tasks_from: remove_old_asset_config
+      tasks_from: remove_old_asset_config.yml
 
 # This is a one time migration. No need to save it in the 3.11.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1565736

--- a/playbooks/openshift-metering/private/config.yml
+++ b/playbooks/openshift-metering/private/config.yml
@@ -19,7 +19,7 @@
   tasks:
   - include_role:
       name: openshift_metering
-      tasks_from: install
+      tasks_from: install.yml
 
 - name: Openshift Metering Install Checkpoint End
   hosts: all

--- a/playbooks/openshift-metering/private/uninstall.yml
+++ b/playbooks/openshift-metering/private/uninstall.yml
@@ -19,7 +19,7 @@
   tasks:
   - include_role:
       name: openshift_metering
-      tasks_from: uninstall
+      tasks_from: uninstall.yml
 
 - name: Openshift Metering Uninstall Checkpoint End
   hosts: all


### PR DESCRIPTION
Improve code supportability and maintainability by using extensions on
tasks_from: directives.  This makes it much easier to find all instances
where a file is included.