### PR TITLE
Enable context selector on console upgrade

### DIFF
--- a/roles/openshift_console/tasks/install.yml
+++ b/roles/openshift_console/tasks/install.yml
@@ -45,7 +45,7 @@
 - set_fact:
     # Must have a trailing slash
     console_picker_developer_console_public_url: "{{ openshift.master.public_console_url }}/"
-  when: openshift_web_console_install | default(true) | bool
+  when: (openshift_web_console_enable_context_selector | default(true) | bool) and (openshift_web_console_install | default(true) | bool)
 
 - set_fact: console_cert={{ lookup('file', openshift_console_cert) }}
   when: openshift_console_cert is exists
@@ -70,8 +70,6 @@
       value: "{{ openshift_console_base_path | default('') }}"
     - key: clusterInfo#masterPublicURL
       value: "{{ openshift.master.public_api_url }}"
-    - key: clusterInfo#developerConsolePublicURL
-      value: "{{ console_picker_developer_console_public_url | default('') }}"
     - key: auth#oauthEndpointCAFile
       value: "{{ openshift_console_auth_ca_file }}"
     - key: auth#logoutRedirect
@@ -83,6 +81,16 @@
     separator: '#'
     state: present
   when: existing_config_map_data['console-config.yaml'] is not defined
+
+# Add the developer console URL to the console picker on upgrade, even if there is an existing config.
+- name: Add context selector URL
+  yedit:
+    src: "{{ mktemp.stdout }}/{{ __console_config_file }}"
+    edits:
+    - key: clusterInfo#developerConsolePublicURL
+      value: "{{ console_picker_developer_console_public_url | default('') }}"
+    separator: '#'
+    state: present
 
 - slurp:
     src: "{{ mktemp.stdout }}/{{ __console_config_file }}"

--- a/roles/openshift_web_console/tasks/install.yml
+++ b/roles/openshift_web_console/tasks/install.yml
@@ -43,6 +43,10 @@
     dest: "{{ mktemp.stdout }}/{{ __console_config_file }}"
   when: existing_config_map_data['webconsole-config.yaml'] is defined
 
+- set_fact:
+    console_picker_admin_console_public_url: "https://{{ openshift_console_hostname | default('console.{{openshift_master_default_subdomain}}') }}{{ openshift_console_base_path | default('/') }}"
+  when: (openshift_web_console_enable_context_selector | default(true) | bool) and (openshift_console_install | default(true) | bool)
+
 # Generate a new config when a config map is not defined.
 - when: existing_config_map_data['webconsole-config.yaml'] is not defined
   block:
@@ -59,10 +63,6 @@
   - set_fact:
       cro_plugin_enabled: "{{ config_to_migrate.admissionConfig is defined and config_to_migrate.admissionConfig.pluginConfig is defined and config_to_migrate.admissionConfig.pluginConfig.ClusterResourceOverrides is defined }}"
 
-  - set_fact:
-      console_picker_admin_console_public_url: "https://{{ openshift_console_hostname | default('console.{{openshift_master_default_subdomain}}') }}/"
-    when: openshift_console_install | default(true) | bool
-
   # Update properties in the config template based on inventory vars when the
   # asset config does not exist.
   - name: Set web console config properties from inventory variables
@@ -76,8 +76,6 @@
         value: "{{ openshift.master.public_api_url }}"
       - key: clusterInfo#logoutPublicURL
         value: "{{ openshift.master.logout_url | default('') }}"
-      - key: clusterInfo#adminConsolePublicURL
-        value: "{{ console_picker_admin_console_public_url | default('') }}"
       - key: features#inactivityTimeoutMinutes
         value: "{{ openshift_web_console_inactivity_timeout_minutes | default(0) }}"
       - key: features#clusterResourceOverridesEnabled
@@ -115,6 +113,16 @@
       separator: '#'
       state: present
     when: config_to_migrate.assetConfig is defined
+
+# Add the admin console URL to the console picker on upgrade, even if there is an existing config.
+- name: Add context selector URL
+  yedit:
+    src: "{{ mktemp.stdout }}/{{ __console_config_file }}"
+    edits:
+    - key: clusterInfo#adminConsolePublicURL
+      value: "{{ console_picker_admin_console_public_url | default('') }}"
+    separator: '#'
+    state: present
 
 - slurp:
     src: "{{ mktemp.stdout }}/{{ __console_config_file }}"


### PR DESCRIPTION
Make sure to add the context selector on 3.10 -> 3.11 upgrades, even if there is an existing web console config. This prevents the selector from showing up in one console and not the other. 

Add `openshift_web_console_enable_context_selector` to disable the selector if desired (enabled by default).

Include the base path in the admin console URL if set.

/assign @vrutkovs 