### PR TITLE
Allow registry log level tuning

### DIFF
--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -93,6 +93,7 @@ openshift_hosted_registry_serviceaccount: registry
 openshift_hosted_registry_volumes: []
 openshift_hosted_registry_env_vars: {}
 openshift_hosted_registry_clusterip: null
+openshift_hosted_registry_log_level: info
 
 # These edits are being specified only to prevent 'changed' on rerun
 openshift_hosted_registry_edits:

--- a/roles/openshift_hosted/templates/registry_config.j2
+++ b/roles/openshift_hosted/templates/registry_config.j2
@@ -1,6 +1,6 @@
 version: 0.1
 log:
-  level: debug
+  level: {{ openshift_hosted_registry_log_level }} 
 http:
   addr: :5000
 storage:


### PR DESCRIPTION
Set the default log level to info and allow for the variable to be defined.

Fixes #9820