### PR TITLE
Ensure sebool container_manage_cgroup on upgrade

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -55,14 +55,7 @@
     sysctl_file: "/etc/sysctl.d/99-openshift.conf"
     reload: yes
 
-# Required in some selinux policy versions see
-# https://bugzilla.redhat.com/show_bug.cgi?id=1587825
-# https://bugzilla.redhat.com/show_bug.cgi?id=1549765
-- name: Setting sebool container_manage_cgroup
-  seboolean:
-    name: container_manage_cgroup
-    state: yes
-    persistent: yes
+- import_tasks: selinux_container_cgroup.yml
 
 - import_tasks: registry_auth.yml
 

--- a/roles/openshift_node/tasks/selinux_container_cgroup.yml
+++ b/roles/openshift_node/tasks/selinux_container_cgroup.yml
@@ -1,0 +1,9 @@
+---
+# Required in some selinux policy versions see
+# https://bugzilla.redhat.com/show_bug.cgi?id=1587825
+# https://bugzilla.redhat.com/show_bug.cgi?id=1549765
+- name: Setting sebool container_manage_cgroup
+  seboolean:
+    name: container_manage_cgroup
+    state: yes
+    persistent: yes

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -45,6 +45,9 @@
   import_tasks: upgrade/rpm_upgrade_install.yml
   when: not openshift_is_atomic | bool
 
+# TODO(michaelgugino): Remove in 3.12
+- import_tasks: selinux_container_cgroup.yml
+
 - include_tasks: "{{ node_config_hook }}"
   when: node_config_hook is defined
 


### PR DESCRIPTION
Currently, new installs will properly set the
seboolean 'container_manage_cgroup' however, existing
installs (from prior to 3.9) will not have this boolean
enabled.  This creates drifts between existing and
new installs.

This commit ensures we enable this seboolean on existing
installs during upgrades.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1619672