### PR TITLE
Fix ASG tagging

### DIFF
--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -245,7 +245,6 @@ openshift_aws_node_groups:
     host-type: node
     sub-host-type: compute
     runtime: docker
-
 - name: "{{ openshift_aws_clusterid }} infra group"
   group: infra
   node_group_config: node-config-infra

--- a/roles/openshift_aws/tasks/build_node_group.yml
+++ b/roles/openshift_aws/tasks/build_node_group.yml
@@ -67,6 +67,18 @@
   - openshift_aws_node_group_upgrade | default(False)
   - asgs.results|length == 2
 
+- set_fact:
+    l_instance_tags: "{{ openshift_aws_node_group_config_tags
+    | combine(openshift_aws_node_group.tags)
+    | combine({'deployment_serial': l_deployment_serial, 'ami': openshift_aws_ami_map[openshift_aws_node_group.group] | default(openshift_aws_ami)})
+    | combine({'openshift-node-group-config': openshift_aws_node_group.node_group_config | default('unset') }) }}"
+    l_node_group_name: "{{ openshift_aws_node_group.name }} {{ l_deployment_serial }}"
+
+- name: Set scale group instances autonaming
+  set_fact:
+    l_instance_tags: "{{ l_instance_tags | combine({'Name': l_node_group_name }) }}"
+  when: openshift_aws_autoname_scale_group_instances | default(false)
+
 - when:
   - openshift_aws_create_iam_role
   - asgs.results|length != 2

--- a/roles/openshift_aws/tasks/scale_group.yml
+++ b/roles/openshift_aws/tasks/scale_group.yml
@@ -1,16 +1,4 @@
 ---
-- name: set node group name
-  set_fact:
-    l_node_group_name: "{{ openshift_aws_node_group.name }} {{ l_deployment_serial }}"
-
-- set_fact:
-    l_openshift_aws_node_group_config_tags: "{{ openshift_aws_node_group_config_tags }}"
-
-- name: Set scale group instances autonaming
-  set_fact:
-    l_openshift_aws_node_group_config_tags: "{{ l_openshift_aws_node_group_config_tags | combine({'Name': l_node_group_name }) }}"
-  when: openshift_aws_autoname_scale_group_instances | default(false)
-
 - name: Create the scale group
   ec2_asg:
     name: "{{ l_node_group_name }}"
@@ -29,10 +17,7 @@
     replace_all_instances: "{{ omit if openshift_aws_node_group_replace_instances != []
                                     else (l_node_group_config[openshift_aws_node_group.group].replace_all_instances | default(omit)) }}"
     tags:
-    - "{{ l_openshift_aws_node_group_config_tags
-          | combine(openshift_aws_node_group.tags)
-          | combine({'deployment_serial': l_deployment_serial, 'ami': openshift_aws_ami_map[openshift_aws_node_group.group] | default(openshift_aws_ami)})
-          | combine({'openshift-node-group-config': openshift_aws_node_group.node_group_config | default('unset') }) }}"
+    - "{{ l_instance_tags }}"
 
 - name: append the asg name to the openshift_aws_created_asgs fact
   set_fact:


### PR DESCRIPTION
During the many refactors of the stand alone masters commit we missed adjusting the tagging for the infra/compute autoscale groups.  This commit fixes the tagging.

See Bugzilla [1623421](https://bugzilla.redhat.com/show_bug.cgi?id=1623421)

**Infra nodes are now tagged correctly which result in a correct user_data:**
```
# cat /var/lib/cloud/instances/i-08cf0ccf9986fb3f8/user-data.txt
#cloud-config

write_files:
- path: /root/openshift_bootstrap/openshift_settings.yaml
  owner: 'root:root'
  permissions: '0640'
  content: |
    openshift_node_config_name: node-config-infra
- path: /etc/origin/node/bootstrap.kubeconfig
  owner: 'root:root'
  permissions: '0640'
  encoding: b64
  content: blahblahblah

runcmd:
- [ ansible-playbook, /root/openshift_bootstrap/bootstrap.yml]
- [ systemctl, restart, systemd-hostnamed]
- [ systemctl, restart, NetworkManager]
- [ systemctl, enable, atomic-openshift-node]
- [ systemctl, start, atomic-openshift-node]
```

**Compute nodes are now tagged correctly which result in a correct user_data:**
```
# cat /var/lib/cloud/instances/i-03b857fbb0ce2e0e9/user-data.txt
#cloud-config

write_files:
- path: /root/openshift_bootstrap/openshift_settings.yaml
  owner: 'root:root'
  permissions: '0640'
  content: |
    openshift_node_config_name: node-config-compute
- path: /etc/origin/node/bootstrap.kubeconfig
  owner: 'root:root'
  permissions: '0640'
  encoding: b64
  content: 
blahblahblah

runcmd:
- [ ansible-playbook, /root/openshift_bootstrap/bootstrap.yml]
- [ systemctl, restart, systemd-hostnamed]
- [ systemctl, restart, NetworkManager]
- [ systemctl, enable, atomic-openshift-node]
- [ systemctl, start, atomic-openshift-node]
```
**Nodes are now autoregistered correctly:**
```
# oc get nodes
NAME                            STATUS    ROLES     AGE       VERSION
ip-172-31-48-114.ec2.internal   Ready     master    1h        v1.11.0+d4cacc0
ip-172-31-50-53.ec2.internal    Ready     compute   4m        v1.11.0+d4cacc0
ip-172-31-51-120.ec2.internal   Ready     master    1h        v1.11.0+d4cacc0
ip-172-31-51-217.ec2.internal   Ready     infra     4m        v1.11.0+d4cacc0
ip-172-31-58-56.ec2.internal    Ready     compute   4m        v1.11.0+d4cacc0
ip-172-31-61-207.ec2.internal   Ready     infra     4m        v1.11.0+d4cacc0
ip-172-31-62-122.ec2.internal   Ready     compute   4m        v1.11.0+d4cacc0
ip-172-31-62-60.ec2.internal    Ready     master    1h        v1.11.0+d4cacc0
```