### PR TITLE
Use correct container CLI for docker or cri-o

### DIFF
--- a/playbooks/byo/calico/legacy_upgrade.yml
+++ b/playbooks/byo/calico/legacy_upgrade.yml
@@ -40,7 +40,7 @@
   gather_facts: no
   tasks:
   - name: Prepull Images
-    command: "docker pull {{ calico_node_image }}"
+    command: "{{ openshift_container_cli }} pull {{ calico_node_image }}"
 
 - name: Calico Upgrade | Initiate
   hosts: oo_first_master

--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_upgrade_targets.yml
@@ -11,8 +11,7 @@
   when: oreg_auth_user is defined
 
 - name: Verify containers are available for upgrade
-  command: >
-    docker pull {{ openshift_cli_image }}
+  command: "{{ openshift_container_cli }} pull {{ openshift_cli_image }}"
   register: pull_result
   changed_when: "'Downloaded newer image' in pull_result.stdout"
   when: openshift_is_containerized | bool

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -30,7 +30,7 @@
   when: calico_node_image is not defined
 
 - name: Prepull Images
-  command: "docker pull {{ calico_node_image }}"
+  command: "{{ openshift_container_cli }} pull {{ calico_node_image }}"
 
 - name: Apply node label
   delegate_to: "{{ groups.oo_first_master.0 }}"

--- a/roles/contiv/tasks/aci.yml
+++ b/roles/contiv/tasks/aci.yml
@@ -1,12 +1,11 @@
 ---
 - name: ACI | Check aci-gw container image
-  command: "docker inspect contiv/aci-gw"
-  register: docker_aci_inspect_result
-  ignore_errors: yes
+  command: "{{ openshift_container_cli }} images -q contiv/aci-gw"
+  register: docker_aci_image
 
 - name: ACI | Pull aci-gw container
-  command: "docker pull contiv/aci-gw"
-  when: "'No such image' in docker_aci_inspect_result.stderr"
+  command: "{{ openshift_container_cli }} pull contiv/aci-gw"
+  when: docker_aci_image.stdout_lines == []
 
 - name: ACI | Copy shell script used by aci-gw service
   template:

--- a/roles/etcd/tasks/static.yml
+++ b/roles/etcd/tasks/static.yml
@@ -3,7 +3,7 @@
 - import_tasks: set_facts.yml
 
 - name: Check that etcd image is present
-  command: 'docker images -q "{{ etcd_image }}"'
+  command: "{{ openshift_container_cli }} images -q {{ etcd_image }}"
   register: etcd_image_exists
 
 - name: Pre-pull etcd image

--- a/roles/openshift_control_plane/tasks/pre_pull.yml
+++ b/roles/openshift_control_plane/tasks/pre_pull.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check that origin image is present
-  command: 'docker images -q "{{ osm_image }}"'
+  command: "{{ openshift_container_cli }} images -q {{ osm_image }}"
   register: control_plane_image
 
 # This task runs async to save time while the master is being configured

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -45,6 +45,7 @@ openshift_use_crio_only: False
 openshift_crio_enable_docker_gc: True
 openshift_crio_var_sock: "unix:///var/run/crio/crio.sock"
 openshift_crio_pause_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'pod') }}"
+openshift_container_cli: "{{ openshift_use_crio | bool | ternary('crictl', 'docker') }}"
 
 # osm_default_subdomain is an old migrated fact, can probably be removed.
 osm_default_subdomain: "router.default.svc.cluster.local"

--- a/roles/openshift_node/tasks/prepull.yml
+++ b/roles/openshift_node/tasks/prepull.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check that node image is present
-  command: 'docker images -q "{{ osn_image }}"'
+  command: "{{ openshift_container_cli }} images -q {{ osn_image }}"
   register: node_image
 
 # This task runs async to save time while the node is being configured

--- a/roles/openshift_node/tasks/upgrade_pre.yml
+++ b/roles/openshift_node/tasks/upgrade_pre.yml
@@ -13,18 +13,6 @@
   until: result is succeeded
   when: not openshift_is_atomic | bool
 
-- name: Check Docker image count
-  shell: "docker images -aq | wc -l"
-  register: docker_image_count
-  when:
-  - l_docker_upgrade is defined
-  - l_docker_upgrade | bool
-
-- debug: var=docker_image_count.stdout
-  when:
-  - l_docker_upgrade is defined
-  - l_docker_upgrade | bool
-
 # Prepull the rpms for docker upgrade, but don't install
 - name: download docker upgrade rpm
   command: "{{ ansible_pkg_mgr }} install -y --downloadonly docker{{ '-' + docker_version }}"


### PR DESCRIPTION
Image management tasks updated to use openshift_container_cli which will
be defined as either 'crictl' when using cri-o runtime or 'docker' when
using docker.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1618969