### PR TITLE
Remove docker excluder from image prep packages

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -45,10 +45,8 @@ openshift_node_syscon_add_mounts_l: []
 
 default_r_openshift_node_image_prep_packages:
 - "{{ openshift_service_type }}-node"
-- "{{ openshift_service_type }}-docker-excluder"
 - ansible
 - bash-completion
-- docker
 - dnsmasq
 - ntp
 - logrotate

--- a/roles/openshift_node/tasks/install_rpms.yml
+++ b/roles/openshift_node/tasks/install_rpms.yml
@@ -1,9 +1,8 @@
 ---
 - name: install needed rpm(s)
   package:
-    name: "{{ item }}"
+    name: "{{ r_openshift_node_image_prep_packages  | join(',') }}"
     state: present
-  with_items: "{{ r_openshift_node_image_prep_packages }}"
   register: result
   until: result is succeeded
   when: not (openshift_is_atomic | default(False) | bool)


### PR DESCRIPTION
Given the choice of container runtime, docker and the docker excluder
should not be installed by default.  Container runtime installation is
handled by the container_runtime role.

Updated the package installation task to perform the install in one
transaction for the package list.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1614609