### PR TITLE
Expose container_runtime role to openshift_node

### DIFF
--- a/playbooks/openshift-node/private/configure_nodes.yml
+++ b/playbooks/openshift-node/private/configure_nodes.yml
@@ -15,6 +15,7 @@
   - role: openshift_node
   - role: tuned
   - role: nickhammond.logrotate
+  - role: container_runtime
   tasks:
   - import_role:
       name: openshift_storage_glusterfs


### PR DESCRIPTION
This allows openshift_node to access openshift_crio_pause_image
when doing an upgrade.

Signed-off-by: umohnani8 <umohnani@redhat.com>