### PR TITLE
Added support for route labelling to oc_label

### DIFF
--- a/roles/lib_openshift/library/oc_label.py
+++ b/roles/lib_openshift/library/oc_label.py
@@ -91,6 +91,7 @@ options:
     - node
     - pod
     - namespace
+    - route
     aliases: []
   labels:
     description:
@@ -142,6 +143,16 @@ EXAMPLES = '''
         value: master
       - key: environment
         value: production
+
+- name: Add a single label to a route
+  oc_label:
+    name: docker-registry
+    state: add
+    kind: route
+    labels:
+      - key: router
+        value: public
+
 '''
 
 # -*- -*- -*- End included fragment: doc/label -*- -*- -*-
@@ -1786,7 +1797,7 @@ def main():
                        choices=['present', 'absent', 'list', 'add']),
             debug=dict(default=False, type='bool'),
             kind=dict(default='node', type='str',
-                      choices=['node', 'pod', 'namespace']),
+                      choices=['node', 'pod', 'namespace', 'route']),
             name=dict(default=None, type='str'),
             namespace=dict(default=None, type='str'),
             labels=dict(default=None, type='list'),

--- a/roles/lib_openshift/src/ansible/oc_label.py
+++ b/roles/lib_openshift/src/ansible/oc_label.py
@@ -11,7 +11,7 @@ def main():
                        choices=['present', 'absent', 'list', 'add']),
             debug=dict(default=False, type='bool'),
             kind=dict(default='node', type='str',
-                      choices=['node', 'pod', 'namespace']),
+                      choices=['node', 'pod', 'namespace', 'route']),
             name=dict(default=None, type='str'),
             namespace=dict(default=None, type='str'),
             labels=dict(default=None, type='list'),

--- a/roles/lib_openshift/src/doc/label
+++ b/roles/lib_openshift/src/doc/label
@@ -38,6 +38,7 @@ options:
     - node
     - pod
     - namespace
+    - route
     aliases: []
   labels:
     description:
@@ -89,4 +90,14 @@ EXAMPLES = '''
         value: master
       - key: environment
         value: production
+
+- name: Add a single label to a route
+  oc_label:
+    name: docker-registry
+    state: add
+    kind: route
+    labels:
+      - key: router
+        value: public
+
 '''


### PR DESCRIPTION
Added the support to oc_label to be able to label route objects.

As the backend is implemented with the `oc label` command, and that command supports route labelling the changes are minimal.

The use case is to automate the route labelling in openshift as explained in Openshift's [routes documentation](https://docs.openshift.com/container-platform/3.9/architecture/networking/routes.html#router-sharding)