### PR TITLE
Move openshift_crio_pause_image to openshift_facts

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -75,8 +75,6 @@ docker_http_proxy: "{{ openshift_http_proxy | default('') }}"
 docker_https_proxy: "{{ openshift.common.https_proxy | default('') }}"
 docker_no_proxy: "{{ openshift.common.no_proxy | default('') }}"
 
-openshift_crio_pause_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'pod') }}"
-
 l_required_docker_version: '1.13'
 
 l_insecure_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l2_docker_insecure_registries)) }}"

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -44,6 +44,7 @@ openshift_use_crio: False
 openshift_use_crio_only: False
 openshift_crio_enable_docker_gc: True
 openshift_crio_var_sock: "unix:///var/run/crio/crio.sock"
+openshift_crio_pause_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'pod') }}"
 
 # osm_default_subdomain is an old migrated fact, can probably be removed.
 osm_default_subdomain: "router.default.svc.cluster.local"


### PR DESCRIPTION
Moved openshift_crio_pause_image to openshift_facts defaults because the
variable is used outside of the container_runtime role. Specifically,
this caused a failure in
roles/openshift_node/tasks/upgrade/config_changes.yml L38.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1623760