### PR TITLE
SDN check: Ignore errors from `oc version`

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/sdn.py
+++ b/roles/openshift_health_checker/openshift_checks/sdn.py
@@ -61,8 +61,11 @@ class SDNCheck(OpenShiftCheck):
                 oc_executable = self.get_var('openshift_client_binary',
                                              default='/bin/oc')
                 oc_executable = self.template_var(oc_executable)
-                self.save_command_output('oc-version', [oc_executable,
-                                                        'version'])
+                # The oc executable is not installed on containerized nodes, so
+                # use "2>&1" to capture any error output (such as "command not
+                # found"), and use "|| :" to ignore the exit code.
+                self.save_command_output('oc-version',
+                                         oc_executable + ' version 2>&1 || :')
                 self.register_file('os-version', None,
                                    '/etc/system-release-cpe')
             except OpenShiftCheckException as exc:


### PR DESCRIPTION
Ignore the exit code from executing `oc version`, and capture any error output.

On containerized nodes, the `oc` executable may not exist, in which case the check should not fail but should instead merely log the "command not found" error.

This commit is a follow-up to commit d2a8a34392f866b62a98eaddf8dd6fbe57d72ee6.

This commit fixes bug 1615705.

https://bugzilla.redhat.com/show_bug.cgi?id=1615705#c1

* `roles/openshift_health_checker/openshift_checks/sdn.py` (`SDNCheck.run`): Ignore exit code from `oc version` check and capture error output.