### PR TITLE
Install NetworkManager on OpenStack

### DIFF
--- a/playbooks/openstack/openshift-cluster/install.yml
+++ b/playbooks/openstack/openshift-cluster/install.yml
@@ -24,6 +24,9 @@
       name: openshift_openstack
       tasks_from: node-configuration.yml
 
+- name: install NetworkManager
+  import_playbook: ../../openshift-node/private/network_manager.yml
+
 - name: run the cluster deploy
   import_playbook: ../../deploy_cluster.yml
 


### PR DESCRIPTION
The OpenStack role removed its NetworkManager install and config code in
favour of the existing openshift-node/network_manager code.

It doesn't get called automatically though, so this makes sure we do use
it during installation.