### PR TITLE
Move cluster-cidr proxy argument to the node config

### DIFF
--- a/roles/openshift_node_group/templates/node-config.yaml.j2
+++ b/roles/openshift_node_group/templates/node-config.yaml.j2
@@ -73,6 +73,9 @@ servingInfo:
   bindAddress: 0.0.0.0:10250
   bindNetwork: tcp4
   clientCA: client-ca.crt
+proxyArguments:
+  cluster-cidr:
+    - {{ openshift_cluster_network_cidr }}
 volumeConfig:
   localQuota:
     perFSGroup: null


### PR DESCRIPTION
As per https://github.com/openshift/openshift-ansible/pull/8099, "connections to nodeports only succeed if the pod backing the nodeport service is running on the host being hit. So requests are not forwarded to other nodes if the pod is running there.

This PR resolves the issue by passing Cluster CIDR to kube-proxy, which implements the nececssary iptables rules."

This PR replicates those changes in the new location of the node config template.