### PR TITLE
Update olm images to use openshift registry instead of quay

### DIFF
--- a/roles/olm/defaults/main.yaml
+++ b/roles/olm/defaults/main.yaml
@@ -1,3 +1,5 @@
 ---
 operator_lifecycle_manager_remove: false
 operator_lifecycle_manager_install: true
+olm_operator_image: "{{ l_osm_registry_url | regex_replace('${component}' | regex_escape, 'operator-lifecycle-manager') }}"
+olm_catalog_operator_image: "{{ l_osm_registry_url | regex_replace('${component}' | regex_escape, 'operator-lifecycle-manager') }}"

--- a/roles/olm/defaults/main.yaml
+++ b/roles/olm/defaults/main.yaml
@@ -1,5 +1,13 @@
 ---
 operator_lifecycle_manager_remove: false
 operator_lifecycle_manager_install: true
-olm_operator_image: "{{ l_osm_registry_url | regex_replace('${component}' | regex_escape, 'operator-lifecycle-manager') }}"
-olm_catalog_operator_image: "{{ l_osm_registry_url | regex_replace('${component}' | regex_escape, 'operator-lifecycle-manager') }}"
+
+olm_image_dict:
+  origin: 'quay.io/coreos/olm'
+  openshift-enterprise: "{{ l_osm_registry_url | regex_replace('${component}' | regex_escape, 'operator-lifecycle-manager') }}"
+catalog_image_dict:
+  origin: 'quay.io/coreos/catalog'
+  openshift-enterprise: "{{ l_osm_registry_url | regex_replace('${component}' | regex_escape, 'operator-lifecycle-manager') }}"
+
+olm_operator_image: "{{ olm_image_dict[openshift_deployment_type] }}"
+olm_catalog_operator_image: "{{ catalog_image_dict[openshift_deployment_type] }}"

--- a/roles/olm/files/aggregated-edit.clusterrole.yaml
+++ b/roles/olm/files/aggregated-edit.clusterrole.yaml
@@ -1,5 +1,3 @@
-##---
-# Source: olm/templates/20-aggregated-edit.clusterrole.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/roles/olm/files/aggregated-view.clusterrole.yaml
+++ b/roles/olm/files/aggregated-view.clusterrole.yaml
@@ -1,5 +1,3 @@
-##---
-# Source: olm/templates/21-aggregated-view.clusterrole.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/roles/olm/files/catalogsource.crd.yaml
+++ b/roles/olm/files/catalogsource.crd.yaml
@@ -1,5 +1,3 @@
-##---
-# Source: olm/templates/05-catalogsource.crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/roles/olm/files/clusterserviceversion.crd.yaml
+++ b/roles/olm/files/clusterserviceversion.crd.yaml
@@ -1,5 +1,3 @@
-##---
-# Source: olm/templates/03-clusterserviceversion.crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/roles/olm/files/installplan.crd.yaml
+++ b/roles/olm/files/installplan.crd.yaml
@@ -1,5 +1,3 @@
-##---
-# Source: olm/templates/06-installplan.crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/roles/olm/files/ocs.catalogsource.yaml
+++ b/roles/olm/files/ocs.catalogsource.yaml
@@ -1,8 +1,3 @@
-##---
-# Source: olm/templates/10-ocs.catalogsource.yaml
-
-#! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml
-#! parse-kind: CatalogSource
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:

--- a/roles/olm/files/ocs.configmap.yaml
+++ b/roles/olm/files/ocs.configmap.yaml
@@ -1,6 +1,3 @@
-##---
-# Source: olm/templates/08-ocs.configmap.yaml
-
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/roles/olm/files/olm-operator.rolebinding.yaml
+++ b/roles/olm/files/olm-operator.rolebinding.yaml
@@ -1,5 +1,3 @@
-##---
-# Source: olm/templates/02-alm-operator.rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/roles/olm/files/olm-operator.serviceaccount.yaml
+++ b/roles/olm/files/olm-operator.serviceaccount.yaml
@@ -1,5 +1,3 @@
-##---
-# Source: olm/templates/01-alm-operator.serviceaccount.yaml
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/roles/olm/files/subscription.crd.yaml
+++ b/roles/olm/files/subscription.crd.yaml
@@ -1,5 +1,3 @@
-##---
-# Source: olm/templates/07-subscription.crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/roles/olm/tasks/install.yaml
+++ b/roles/olm/tasks/install.yaml
@@ -17,6 +17,21 @@
     src: "{{ item }}"
     dest: "{{ mktemp.stdout }}"
   with_fileglob: files/*.yaml
+
+- name: Set olm-operator template
+  template:
+    src: olm-operator.deployment.j2
+    dest: "{{ mktemp.stdout  }}/olm-operator.deployment.yaml"
+  vars:
+    namespace: "{{ openshift_cluster_monitoring_operator_namespace }}"
+
+- name: Set catalog-operator template
+  template:
+    src: catalog-operator.deployment.j2
+    dest: "{{ mktemp.stdout  }}/catalog-operator.deployment.yaml"
+  vars:
+    namespace: "{{ openshift_cluster_monitoring_operator_namespace }}"
+
 - name: Apply olm-operator-serviceaccount ServiceAccount manifest
   oc_obj:
     state: present
@@ -24,7 +39,7 @@
     name: olm-operator-serviceaccount
     namespace: operator-lifecycle-manager
     files:
-      - "{{ mktemp.stdout }}/01-alm-operator.serviceaccount.yaml"
+      - "{{ mktemp.stdout }}/olm-operator.serviceaccount.yaml"
 
 - name: Apply olm-operator-binding-operator-lifecycle-manager ClusterRoleBinding manifest
   oc_obj:
@@ -33,7 +48,7 @@
     name: olm-operator-binding-operator-lifecycle-manager
     namespace: operator-lifecycle-manager
     files:
-      - "{{ mktemp.stdout }}/02-alm-operator.rolebinding.yaml"
+      - "{{ mktemp.stdout }}/olm-operator.rolebinding.yaml"
 
 - name: Apply clusterserviceversions.operators.coreos.com CustomResourceDefinition manifest
   oc_obj:
@@ -42,7 +57,7 @@
     name: clusterserviceversions.operators.coreos.com
     namespace: operator-lifecycle-manager
     files:
-      - "{{ mktemp.stdout }}/03-clusterserviceversion.crd.yaml"
+      - "{{ mktemp.stdout }}/clusterserviceversion.crd.yaml"
 
 - name: Apply catalogsources.operators.coreos.com CustomResourceDefinition manifest
   oc_obj:
@@ -51,7 +66,7 @@
     name: catalogsources.operators.coreos.com
     namespace: operator-lifecycle-manager
     files:
-      - "{{ mktemp.stdout }}/05-catalogsource.crd.yaml"
+      - "{{ mktemp.stdout }}/catalogsource.crd.yaml"
 
 - name: Apply installplans.operators.coreos.com CustomResourceDefinition manifest
   oc_obj:
@@ -60,7 +75,7 @@
     name: installplans.operators.coreos.com
     namespace: operator-lifecycle-manager
     files:
-      - "{{ mktemp.stdout }}/06-installplan.crd.yaml"
+      - "{{ mktemp.stdout }}/installplan.crd.yaml"
 
 - name: Apply subscriptions.operators.coreos.com CustomResourceDefinition manifest
   oc_obj:
@@ -69,7 +84,7 @@
     name: subscriptions.operators.coreos.com
     namespace: operator-lifecycle-manager
     files:
-      - "{{ mktemp.stdout }}/07-subscription.crd.yaml"
+      - "{{ mktemp.stdout }}/subscription.crd.yaml"
 
 - name: Apply ocs ConfigMap manifest
   oc_obj:
@@ -78,7 +93,7 @@
     name: ocs
     namespace: operator-lifecycle-manager
     files:
-      - "{{ mktemp.stdout }}/08-ocs.configmap.yaml"
+      - "{{ mktemp.stdout }}/ocs.configmap.yaml"
 
 - name: Apply ocs CatalogSource manifest
   oc_obj:
@@ -87,16 +102,16 @@
     name: ocs
     namespace: operator-lifecycle-manager
     files:
-      - "{{ mktemp.stdout }}/10-ocs.catalogsource.yaml"
+      - "{{ mktemp.stdout }}/ocs.catalogsource.yaml"
 
-- name: Apply alm-operator Deployment manifest
+- name: Apply olm-operator Deployment manifest
   oc_obj:
     state: present
     kind: Deployment
-    name: alm-operator
+    name: olm-operator
     namespace: operator-lifecycle-manager
     files:
-      - "{{ mktemp.stdout }}/12-alm-operator.deployment.yaml"
+      - "{{ mktemp.stdout }}/olm-operator.deployment.yaml"
 
 - name: Apply catalog-operator Deployment manifest
   oc_obj:
@@ -105,7 +120,7 @@
     name: catalog-operator
     namespace: operator-lifecycle-manager
     files:
-      - "{{ mktemp.stdout }}/13-catalog-operator.deployment.yaml"
+      - "{{ mktemp.stdout }}/catalog-operator.deployment.yaml"
 
 - name: Apply aggregate-olm-edit ClusterRole manifest
   oc_obj:
@@ -114,7 +129,7 @@
     name: aggregate-olm-edit
     namespace: operator-lifecycle-manager
     files:
-      - "{{ mktemp.stdout }}/20-aggregated-edit.clusterrole.yaml"
+      - "{{ mktemp.stdout }}/aggregated-edit.clusterrole.yaml"
 
 - name: Apply aggregate-olm-view ClusterRole manifest
   oc_obj:
@@ -123,4 +138,4 @@
     name: aggregate-olm-view
     namespace: operator-lifecycle-manager
     files:
-      - "{{ mktemp.stdout }}/21-aggregated-view.clusterrole.yaml"
+      - "{{ mktemp.stdout }}/aggregated-view.clusterrole.yaml"

--- a/roles/olm/tasks/main.yaml
+++ b/roles/olm/tasks/main.yaml
@@ -1,8 +1,0 @@
----
-# do any asserts here
-
-- include_tasks: install.yaml
-  when: operator_lifecycle_manager_install | bool
-
-- include_tasks: remove.yaml
-  when: operator_lifecycle_manager_remove | bool

--- a/roles/olm/tasks/remove_components.yaml
+++ b/roles/olm/tasks/remove_components.yaml
@@ -55,11 +55,11 @@
     name: ocs
     namespace: operator-lifecycle-manager
 
-- name: Remove alm-operator Deployment manifest
+- name: Remove olm-operator Deployment manifest
   oc_obj:
     state: absent
     kind: Deployment
-    name: alm-operator
+    name: olm-operator
     namespace: operator-lifecycle-manager
 
 - name: Remove catalog-operator Deployment manifest

--- a/roles/olm/templates/catalog-operator.deployment.j2
+++ b/roles/olm/templates/catalog-operator.deployment.j2
@@ -1,30 +1,33 @@
 ##---
-# Source: olm/templates/12-alm-operator.deployment.yaml
+# Source: olm/templates/13-catalog-operator.deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: alm-operator
+  name: catalog-operator
   namespace: operator-lifecycle-manager
   labels:
-    app: alm-operator
+    app: catalog-operator
 spec:
   strategy:
     type: RollingUpdate
   replicas: 1
   selector:
     matchLabels:
-      app: alm-operator
+      app: catalog-operator
   template:
     metadata:
       labels:
-        app: alm-operator
+        app: catalog-operator
     spec:
       serviceAccountName: olm-operator-serviceaccount
       containers:
-        - name: alm-operator
+        - name: catalog-operator
           command:
-          - /bin/olm
-          image: quay.io/coreos/olm@sha256:44b445850b3e612c062424c3727bb85048ec8e71407b39985786d29aa20f5c79
+          - /bin/catalog
+          - '-namespace'
+          - operator-lifecycle-manager
+          - '-debug'
+          image: {{ olm_catalog_operator_image }}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -36,12 +39,5 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
-          env:
-          - name: OPERATOR_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: OPERATOR_NAME
-            value: alm-operator
       imagePullSecrets:
         - name: coreos-pull-secret

--- a/roles/olm/templates/olm-operator.deployment.j2
+++ b/roles/olm/templates/olm-operator.deployment.j2
@@ -1,33 +1,30 @@
 ##---
-# Source: olm/templates/13-catalog-operator.deployment.yaml
+# Source: olm/templates/12-alm-operator.deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: catalog-operator
+  name: alm-operator
   namespace: operator-lifecycle-manager
   labels:
-    app: catalog-operator
+    app: alm-operator
 spec:
   strategy:
     type: RollingUpdate
   replicas: 1
   selector:
     matchLabels:
-      app: catalog-operator
+      app: alm-operator
   template:
     metadata:
       labels:
-        app: catalog-operator
+        app: alm-operator
     spec:
       serviceAccountName: olm-operator-serviceaccount
       containers:
-        - name: catalog-operator
+        - name: alm-operator
           command:
-          - /bin/catalog
-          - '-namespace'
-          - operator-lifecycle-manager
-          - '-debug'
-          image: quay.io/coreos/catalog@sha256:20886d49205aa8d8fd53f1c85fad6a501775226da25ef14f51258b7066e91064
+          - /bin/olm
+          image: {{ olm_operator_image }}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -39,5 +36,12 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
+          env:
+          - name: OPERATOR_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: OPERATOR_NAME
+            value: alm-operator
       imagePullSecrets:
         - name: coreos-pull-secret


### PR DESCRIPTION
this should be the second to last update for OLM - this is updating the images (want to find any problems with that) and there are some changes coming through to the catalog that we'll follow up with