### PR TITLE
crio: Don't use file locking

### DIFF
--- a/roles/container_runtime/templates/crio.conf.j2
+++ b/roles/container_runtime/templates/crio.conf.j2
@@ -37,7 +37,7 @@ stream_port = "10010"
 
 # file_locking is whether file-based locking will be used instead of
 # in-memory locking
-file_locking = true
+file_locking = false
 
 # The "crio.runtime" table contains settings pertaining to the OCI
 # runtime used and options for how to set up and manage the OCI runtime.


### PR DESCRIPTION
We don't need file locking for cri-o.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>