### PR TITLE
_idp['name'] not availabe

### DIFF
--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -158,7 +158,7 @@ class LDAPPasswordIdentityProvider(IdentityProviderBase):
             pref_user = self._idp['attributes'].pop('preferred_username')
             self._idp['attributes']['preferredUsername'] = pref_user
 
-        self._idp['ca'] = '/etc/origin/master/{}_ldap_ca.crt'.format(self._idp['name'])
+        self._idp['ca'] = '/etc/origin/master/{}_ldap_ca.crt'.format(self.name)
 
     def validate(self):
         ''' validate this idp instance '''


### PR DESCRIPTION
The key 'name' is popped from the _idp dictionary in line 54.

    self.name = self._idp.pop('name')

Therefore it is not accessible in line 161.