### PR TITLE
Don't fetch provider openshift_facts if openshift_cloud_provider_kind is not set

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1055,7 +1055,9 @@ class OpenShiftFacts(object):
         roles = local_facts.keys()
 
         defaults = self.get_defaults(roles)
-        provider_facts = self.init_provider_facts()
+        provider_facts = {}
+        if 'cloudprovider' in local_facts and 'kind' in local_facts['cloudprovider']:
+            provider_facts = self.init_provider_facts()
         facts = apply_provider_facts(defaults, provider_facts)
         facts = merge_facts(facts,
                             local_facts,


### PR DESCRIPTION
If `openshift_cloud_provider_kind` is not set, Ansible should not try to fetch metadata from provider, based on BIOS name.

This would allow using cloud provider instances as bare-metal VMs

cc @jsafrane