### PR TITLE
Don't reset os_firewall_use_firewalld if iptables is inactive during upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -42,4 +42,4 @@
     set_fact:
       os_firewall_use_firewalld: false
     when:
-    - iptables_service.status.ActiveState != 'active'
+    - iptables_service.status.ActiveState == 'active'


### PR DESCRIPTION
Incorrect clause was added, this var should be reset only if iptables is 
active

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1623155