### PR TITLE
Configure a list of etcd cipher suites via `etcd_cipher_suites`

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -149,6 +149,8 @@ debug_level=2
 # etcd_debug=true
 # Set etcd log levels by package
 # etcd_log_package_levels="etcdserver=WARNING,security=DEBUG"
+# Comma-separated list of etcd cipher suites
+# etcd_cipher_suites="TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
 
 # Upgrade Hooks
 #

--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -112,3 +112,5 @@ etcd_ca_host: "{{ groups['oo_etcd_to_config'].0 }}"
 l_etcd_restart_command: "{{ l_etcd_static_pod | ternary('/usr/local/bin/master-restart etcd', 'systemctl restart etcd') }}"
 
 etcd_static_pod_location: "{{ openshift_control_plane_static_pod_location | default('/etc/origin/node/pods/') }}"
+
+etcd_cipher_suites: ""

--- a/roles/etcd/templates/etcd.conf.j2
+++ b/roles/etcd/templates/etcd.conf.j2
@@ -19,6 +19,9 @@ ETCD_LISTEN_CLIENT_URLS={{ etcd_listen_client_urls }}
 #ETCD_MAX_SNAPSHOTS=5
 #ETCD_MAX_WALS=5
 #ETCD_CORS=
+{% if etcd_cipher_suites is defined and etcd_cipher_suites %}
+ETCD_CIPHER_SUITES="{{ etcd_cipher_suites }}"
+{% endif %}
 
 
 #[cluster]


### PR DESCRIPTION
If `etcd_cipher_suites` etcd would use a specifed list of etcd_cipher_suites

Note, that this feature is available since etcd 3.2.22 so it cannot be backported to OCP 3.9

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1623646
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1595666
Replaces #9869