### PR TITLE
Fix idp configuration when using a insecure LTPA provisioner

### DIFF
--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -158,7 +158,8 @@ class LDAPPasswordIdentityProvider(IdentityProviderBase):
             pref_user = self._idp['attributes'].pop('preferred_username')
             self._idp['attributes']['preferredUsername'] = pref_user
 
-        self._idp['ca'] = '/etc/origin/master/{}_ldap_ca.crt'.format(idp['name'])
+        if not self._idp['insecure']:
+            self._idp['ca'] = '/etc/origin/master/{}_ldap_ca.crt'.format(idp['name'])
 
     def validate(self):
         ''' validate this idp instance '''


### PR DESCRIPTION
Fix idp configuration when using a insecure LTPA provisioner and script set a 'ca' properties, causing the following error from "master-logs api api":

W0903 15:04:04.809008       1 start_master.go:270] Warning: oauthConfig.identityProvider[0].provider.insecure: Invalid value: true: validating passwords over an insecure connection could allow them to be intercepted, master start will continue.
Invalid MasterConfig /etc/origin/master/master-config.yaml
  oauthConfig.identityProvider[0].provider.ca: Invalid value: "/etc/origin/master/myldapprovisioner_ldap_ca.crt": Cannot specify a ca with insecure=true