### PR TITLE
GlusterFS: add writable /sys/dev/block volume to allow lvcreate

### DIFF
--- a/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
+++ b/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
@@ -65,6 +65,8 @@ objects:
             mountPath: "/dev"
           - name: glusterfs-misc
             mountPath: "/var/lib/misc/glusterfsd"
+          - name: glusterfs-sys-dev-block
+            mountPath: "/sys/dev/block"
           - name: glusterfs-cgroup
             mountPath: "/sys/fs/cgroup"
             readOnly: true
@@ -126,6 +128,9 @@ objects:
         - name: glusterfs-misc
           hostPath:
             path: "/var/lib/misc/glusterfsd"
+        - name: glusterfs-sys-dev-block
+          hostPath:
+            path: "/sys/dev/block"
         - name: glusterfs-cgroup
           hostPath:
             path: "/sys/fs/cgroup"


### PR DESCRIPTION
lvcreate tries to change the read-ahead configuration for new LVs that
are created. In case /sys/dev/block is not writable, the following error
is recorded by the Heketi service that executes the lvcreate commands:

    /dev/mapper/vg_30435fabe0a2ee4a20dc4e7218ee3cf1-lvol0: open failed: No such file or directory

Running the exact same command on the host works, just inside a pod it
does not. Adding -vvv to the lvcreate command shows the actual error
just before the above message:

    /sys/dev/block/252:0/bdi/read_ahead_kb: open failed: Read-only file system

By adding a writable volume for /sys/dev/block, the lvcreate command
succeeds again.

This might be caused by newer versions of the LVM tools, or possibly
specific configurations in /etc/lvm/lvm.conf. The cause has not been
investigated (yet).