### PR TITLE
Add a playbook to remove etcd2 data

### DIFF
--- a/playbooks/openshift-etcd/private/remove-etcdv2-data.yml
+++ b/playbooks/openshift-etcd/private/remove-etcdv2-data.yml
@@ -1,6 +1,6 @@
 ---
 - name: Remove etcd v2 data
-  hosts: oo_etcd_to_config
+  hosts: oo_etcd_to_config[0]
   any_errors_fatal: true
   tasks:
   - import_role:

--- a/playbooks/openshift-etcd/private/remove-etcdv2-data.yml
+++ b/playbooks/openshift-etcd/private/remove-etcdv2-data.yml
@@ -1,0 +1,10 @@
+---
+- name: Remove etcd v2 data
+  hosts: oo_etcd_to_config
+  any_errors_fatal: true
+  tasks:
+  - import_role:
+      name: etcd
+      tasks_from: remove-etcd-v2-data.yml
+    vars:
+      etcd_peer: "{{ openshift.common.hostname }}"

--- a/playbooks/openshift-etcd/remove-etcdv2-data.yml
+++ b/playbooks/openshift-etcd/remove-etcdv2-data.yml
@@ -1,0 +1,8 @@
+---
+- import_playbook: ../init/main.yml
+  vars:
+    l_openshift_version_set_hosts: "all:!all"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) }}"
+
+- import_playbook: private/remove-etcdv2-data.yml

--- a/roles/etcd/tasks/remove-etcd-v2-data.yml
+++ b/roles/etcd/tasks/remove-etcd-v2-data.yml
@@ -1,12 +1,24 @@
+---
 - name: Verify cluster is healthy pre-upgrade
   command: "{{ etcdctlv2 }} cluster-health"
 
-- name: Remove etcdv2 kubernetes data
-  command: "{{ etcdctlv2 }} rm -r /kubernetes.io"
-  register: etcdv2_remove_k8s
-  failed_when: "'Key not found' not in etcdv2_remove_k8s.stderr"
+- name: Check migrated status
+  command: "{{ etcdctlv2 }} get /kubernetes.io"
+  register: etcdv2_migrated_status
+  failed_when: ('stdout' not in etcdv2_migrated_status)
 
-- name: Remove etcdv2 openshift data
-  command: "{{ etcdctlv2 }} rm -r /openshift.io"
-  register: etcdv2_remove_openshift
-  failed_when: "'Key not found' not in etcdv2_remove_openshift.stderr"
+- block:
+  - name: Remove etcdv2 kubernetes data
+    command: "{{ etcdctlv2 }} rm -r /kubernetes.io"
+    register: etcdv2_remove_k8s
+    failed_when: ('Key not found' not in etcdv2_remove_k8s.stderr)
+
+  - name: Remove etcdv2 openshift data
+    command: "{{ etcdctlv2 }} rm -r /openshift.io"
+    register: etcdv2_remove_openshift
+    failed_when: ('Key not found' not in etcdv2_remove_openshift.stderr)
+
+  - name: Set migrated mark
+    command: "{{ etcdctlv2 }} set /kubernetes.io migrated"
+
+  when: (etcdv2_migrated_status.stdout != 'migrated')

--- a/roles/etcd/tasks/remove-etcd-v2-data.yml
+++ b/roles/etcd/tasks/remove-etcd-v2-data.yml
@@ -1,0 +1,12 @@
+- name: Verify cluster is healthy pre-upgrade
+  command: "{{ etcdctlv2 }} cluster-health"
+
+- name: Remove etcdv2 kubernetes data
+  command: "{{ etcdctlv2 }} rm -r /kubernetes.io"
+  register: etcdv2_remove_k8s
+  failed_when: "'Key not found' not in etcdv2_remove_k8s.stderr"
+
+- name: Remove etcdv2 openshift data
+  command: "{{ etcdctlv2 }} rm -r /openshift.io"
+  register: etcdv2_remove_openshift
+  failed_when: "'Key not found' not in etcdv2_remove_openshift.stderr"


### PR DESCRIPTION
This PR adds a playbook to remove existing etcd2 data in case the cluster has been migrated from 1.5 times.

This also fixes several issues with `etcdctl2/etcdctl3` aliases on the host

TODO:
* [x] Run on first etcd host only?
* [x] Set `migrated` status
* [x] Different paths to `etcdctl` in quay.io / registry.access.redhat.com images? 
  Moved to https://github.com/openshift/openshift-ansible/pull/9904
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1514487