### PR TITLE
Update sync DS after control plane upgrade

### DIFF
--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -239,3 +239,10 @@
       tasks_from: config.yml
     vars:
       openshift_master_host: "{{ groups.oo_first_master.0 }}"
+
+- name: Update sync DS
+  hosts: oo_first_master
+  tasks:
+  - import_role:
+      name: openshift_node_group
+      tasks_from: sync.yml


### PR DESCRIPTION
This PR ensures a new imagestream is created and sync daemonset is updated 
during major upgrades

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1623843