### PR TITLE
Fix etcdctl aliases on etcd hosts

### DIFF
--- a/roles/etcd/templates/etcdctl.sh.j2
+++ b/roles/etcd/templates/etcdctl.sh.j2
@@ -3,19 +3,20 @@
 # command flags are different between the two. Should work on stand
 # alone etcd hosts and master + etcd hosts too because we use the peer keys.
 etcdctl2() {
- cmd="/usr/bin/etcdctl --cert-file {{ etcd_peer_cert_file }} --key-file {{ etcd_peer_key_file }} --ca-file {{ etcd_peer_ca_file }} -C https://`hostname`:2379 ${@}"
+
+ cmd="ETCDCTL_API=2 etcdctl --cert-file {{ etcd_peer_cert_file }} --key-file {{ etcd_peer_key_file }} --ca-file {{ etcd_peer_ca_file }} -C https://`hostname`:2379 ${@}"
  if [[ -f /usr/local/bin/master-exec ]]; then
-   /usr/local/bin/master-exec etcd etcd /bin/bash -c "$cmd"
+   /usr/local/bin/master-exec etcd etcd /bin/sh -c "$cmd"
  else
-   /bin/bash -c "$cmd"
+   /bin/sh -c "$cmd"
  fi
 }
 
 etcdctl3() {
- cmd="ETCDCTL_API=3 /usr/bin/etcdctl --cert {{ etcd_peer_cert_file }} --key {{ etcd_peer_key_file }} --cacert {{ etcd_peer_ca_file }} --endpoints https://`hostname`:2379 ${@}"
+ cmd="ETCDCTL_API=3 etcdctl --cert {{ etcd_peer_cert_file }} --key {{ etcd_peer_key_file }} --cacert {{ etcd_peer_ca_file }} --endpoints https://`hostname`:2379 ${@}"
  if [[ -f /usr/local/bin/master-exec ]]; then
-   /usr/local/bin/master-exec etcd etcd /bin/bash -c "$cmd"
+   /usr/local/bin/master-exec etcd etcd /bin/sh -c "$cmd"
  else
-   /bin/bash -c "$cmd"
+   /bin/sh -c "$cmd"
  fi
 }


### PR DESCRIPTION
* use sh as etcd static pods don't have bash
* don't set direct etcdctl path for static pods

quay.io image is using /usr/local/bin/etcdctl and official redhat image
has this binary in /usr/bin/

* explicitely set ETCDCTL_API