### PR TITLE
Add failed_when to 'Remove the image stream tag' tasks

### DIFF
--- a/roles/openshift_bootstrap_autoapprover/tasks/main.yml
+++ b/roles/openshift_bootstrap_autoapprover/tasks/main.yml
@@ -20,8 +20,14 @@
 # TODO: temporary until we fix apply for image stream tags
 - name: Remove the image stream tag
   command: >
-    {{ openshift_client_binary }} delete -n openshift-infra istag node:v3.10 --ignore-not-found
+    {{ openshift_client_binary }}
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    delete -n openshift-infra istag node:v3.10 --ignore-not-found
+  register: l_os_istag_del
+  # The istag might not be there, so we want to not fail in that case.
+  failed_when:
+    - l_os_istag_del.rc != 0
+    - "'have a resource type' not in l_os_istag_del.stderr"
 
 - name: Apply the config
   command: >

--- a/roles/openshift_node_group/tasks/sync.yml
+++ b/roles/openshift_node_group/tasks/sync.yml
@@ -34,8 +34,15 @@
 
 # TODO: temporary until we fix apply for image stream tags
 - name: Remove the image stream tag
-  shell: >
-    {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig delete -n openshift-node istag node:v3.10 --ignore-not-found
+  command: >
+    {{ openshift_client_binary }}
+    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    delete -n openshift-node istag node:v3.10 --ignore-not-found
+  register: l_os_istag_del
+  # The istag might not be there, so we want to not fail in that case.
+  failed_when:
+    - l_os_istag_del.rc != 0
+    - "'have a resource type' not in l_os_istag_del.stderr"
 
 - name: Apply the config
   shell: >

--- a/roles/openshift_sdn/tasks/main.yml
+++ b/roles/openshift_sdn/tasks/main.yml
@@ -36,8 +36,15 @@
 
 # TODO: temporary until we fix apply for image stream tags
 - name: Remove the image stream tag
-  shell: >
-    {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig delete -n openshift-sdn istag node:v3.10 --ignore-not-found
+  command: >
+    {{ openshift_client_binary }}
+    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    delete -n openshift-sdn istag node:v3.10 --ignore-not-found
+  register: l_os_istag_del
+  # The istag might not be there, so we want to not fail in that case.
+  failed_when:
+    - l_os_istag_del.rc != 0
+    - "'have a resource type' not in l_os_istag_del.stderr"
 
 - name: Apply the config
   shell: >


### PR DESCRIPTION
This commit adds appropriate failed_when condition to certain
tasks which attempt to remove istag resources that may have
already been deleted in a previous run.  This allows upgrades
to be more idempotent in case of a correctable failure.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1622255
(cherry picked from commit 5a53502f67f0e15b5e82de7ccf0a2400a6d349b7)

Backports: https://github.com/openshift/openshift-ansible/pull/9780