### PR TITLE
[release-3.10] Use first_master_client_binary from hostvars[groups.oo_first_master.0]

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/cluster_health.yml
+++ b/roles/openshift_storage_glusterfs/tasks/cluster_health.yml
@@ -3,7 +3,7 @@
 # lib_utils/library/glusterfs_check_containerized.py
 - name: Check for GlusterFS cluster health
   glusterfs_check_containerized:
-    oc_bin: "{{ first_master_client_binary }}"
+    oc_bin: "{{ hostvars[groups.oo_first_master.0]['first_master_client_binary'] }}"
     oc_conf: "{{ openshift.common.config_base }}/master/admin.kubeconfig"
     oc_namespace: "{{ glusterfs_namespace }}"
     cluster_name: "{{ glusterfs_name }}"


### PR DESCRIPTION
Since first_master_client_binary is initialized in oo_first_master, it
should be collected from oo_first_master.0. This patch changes to use
first_master_client_binary from hostvars[groups.oo_first_master.0] on
GlusterFS cluster health task.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1625568