### PR TITLE
Clear dnsmasq config via dbus after skydns exits

### DIFF
--- a/roles/kube_proxy_and_dns/files/kube-proxy-and-dns.yaml
+++ b/roles/kube_proxy_and_dns/files/kube-proxy-and-dns.yaml
@@ -36,7 +36,7 @@ spec:
       # It relies on an up to date node-config.yaml being present.
       - name: proxy-and-dns
         image: " "
-        command: 
+        command:
         - /bin/bash
         - -c
         - |
@@ -80,7 +80,8 @@ spec:
           oc config --config=/tmp/kubeconfig set-credentials sa "--token=$( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"
           oc config --config=/tmp/kubeconfig set-context "$( oc config --config=/tmp/kubeconfig current-context )" --user=sa
           # Launch the kube-proxy and DNS process
-          exec openshift start network --disable=plugins --enable=proxy,dns --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
+          openshift start network --disable=plugins --enable=proxy,dns --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2} || \
+            dbus-send --system --dest=uk.org.thekelleys.dnsmasq /uk/org/thekelleys/dnsmasq uk.org.thekelleys.SetDomainServers array:string:
 
         securityContext:
           runAsUser: 0

--- a/roles/kuryr/templates/cni-daemonset.yaml.j2
+++ b/roles/kuryr/templates/cni-daemonset.yaml.j2
@@ -92,7 +92,8 @@ spec:
           oc config --config=/tmp/kubeconfig set-context "$( oc config --config=/tmp/kubeconfig current-context )" --user=sa
 
           # Launch the SkyDNS
-          exec openshift start network --enable=dns --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
+          openshift start network --disable=plugins --enable=proxy,dns --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2} || \
+            dbus-send --system --dest=uk.org.thekelleys.dnsmasq /uk/org/thekelleys/dnsmasq uk.org.thekelleys.SetDomainServers array:string:
 
         securityContext:
           privileged: true

--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -38,7 +38,7 @@ spec:
       # It relies on an up to date node-config.yaml being present.
       - name: sdn
         image: " "
-        command: 
+        command:
         - /bin/bash
         - -c
         - |
@@ -102,7 +102,8 @@ spec:
           oc config --config=/tmp/kubeconfig set-credentials sa "--token=$( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"
           oc config --config=/tmp/kubeconfig set-context "$( oc config --config=/tmp/kubeconfig current-context )" --user=sa
           # Launch the network process
-          exec openshift start network --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
+          openshift start network --disable=plugins --enable=proxy,dns --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2} || \
+            dbus-send --system --dest=uk.org.thekelleys.dnsmasq /uk/org/thekelleys/dnsmasq uk.org.thekelleys.SetDomainServers array:string:
 
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
If we don't clear dnsmasq configuration when skydns exits then requests
will pile up and eventually dnsmasq will hit its max queries limit and
start failing requests including things like looking up the name for
etcd which then creates a deadlock scenario where the API fails to start
and because the API has failed the sdn pods fail to start.

Possible fix for https://bugzilla.redhat.com/show_bug.cgi?id=1624448
https://bugzilla.redhat.com/show_bug.cgi?id=1623145

/cc @dcbw @ironcladlou 