### PR TITLE
Reset avc_cache_threshold to 512 as higher values cause performance issues

### DIFF
--- a/roles/tuned/templates/openshift/tuned.conf
+++ b/roles/tuned/templates/openshift/tuned.conf
@@ -7,7 +7,7 @@ summary=Optimize systems running OpenShift (parent profile)
 include=${f:virt_check:{{ openshift_tuned_guest_profile }}:throughput-performance}
 
 [selinux]
-avc_cache_threshold=65536
+avc_cache_threshold=4096
 
 [net]
 nf_conntrack_hashsize=131072


### PR DESCRIPTION
Reset avc_cache_threshold to 512 which is the default in RHEL7.
Higher values cause performance problems and any improvement is marginal for most workloads.
Rationale: https://github.com/SELinuxProject/selinux-kernel/issues/34#issuecomment-376544588
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1548428