### PR TITLE
Glusterfs health check master binary fix

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/cluster_health.yml
+++ b/roles/openshift_storage_glusterfs/tasks/cluster_health.yml
@@ -3,7 +3,7 @@
 # lib_utils/library/glusterfs_check_containerized.py
 - name: Check for GlusterFS cluster health
   glusterfs_check_containerized:
-    oc_bin: "{{ first_master_client_binary }}"
+    oc_bin: "{{ hostvars[groups.oo_first_master.0]['first_master_client_binary'] }}"
     oc_conf: "{{ openshift.common.config_base }}/master/admin.kubeconfig"
     oc_namespace: "{{ glusterfs_namespace }}"
     cluster_name: "{{ glusterfs_name }}"


### PR DESCRIPTION
Currently, gluster health checks are executed via delegate_to
on first master, oc_bin is set to first_master_client_binary.

When this task is called during upgrades, it is executed once
per gluster node.  The facts for each node don't include
first_master_client_binary, that is only set on the first master.

This commit ensures we access the first_master_client_binary
via hostvars to always ensure we're getting the correct value.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1625568