### PR TITLE
Include bootstrapped nodes in the inventory during GCP cluster update

### DIFF
--- a/roles/openshift_gcp/tasks/setup_scale_group_facts.yml
+++ b/roles/openshift_gcp/tasks/setup_scale_group_facts.yml
@@ -4,7 +4,7 @@
     name: "{{ hostvars[item].gce_name }}"
     groups: nodes, new_nodes
     openshift_node_group_name: "{{ openshift_gcp_node_group_mapping['compute'] }}"
-  with_items: "{{ groups['tag_ocp-node'] | default([]) | difference(groups['tag_ocp-bootstrap'] | default([])) }}"
+  with_items: "{{ groups['tag_ocp-node'] | default([]) }}"
 
 - name: Add bootstrap node instances as nodes
   add_host:
@@ -24,7 +24,7 @@
     name: "{{ hostvars[item].gce_name }}"
     groups: nodes, new_nodes
     openshift_node_group_name: "{{ openshift_gcp_node_group_mapping['infra'] }}"
-  with_items: "{{ groups['tag_ocp-infra-node'] | default([]) | difference(groups['tag_ocp-bootstrap'] | default([])) }}"
+  with_items: "{{ groups['tag_ocp-infra-node'] | default([]) }}"
 
 - name: Add masters to requisite groups
   add_host:


### PR DESCRIPTION
Bootstrapped nodes should be included in the inventory for GCP upgrade 3.10 -> 3.11 to proceed