### PR TITLE
Fix issue with cockpit package list

### DIFF
--- a/roles/cockpit/tasks/main.yml
+++ b/roles/cockpit/tasks/main.yml
@@ -12,7 +12,7 @@
     - cockpit-system
     - cockpit-bridge
     - cockpit-docker
-    - "{{ cockpit_plugins }}"
+    - "{{ cockpit_plugins | join(',') }}"
   when: not openshift_is_atomic | bool
   register: result
   until: result is succeeded


### PR DESCRIPTION
The package list contains an item which is a list by default.  The list
is converted to a comma separated string to conform to the pattern used
by the package command.