### PR TITLE
LDAP auth: don't set CA when 'insecure' is specified

### DIFF
--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -158,7 +158,8 @@ class LDAPPasswordIdentityProvider(IdentityProviderBase):
             pref_user = self._idp['attributes'].pop('preferred_username')
             self._idp['attributes']['preferredUsername'] = pref_user
 
-        self._idp['ca'] = '/etc/origin/master/{}_ldap_ca.crt'.format(self.name)
+        if not self._idp['insecure']:
+            self._idp['ca'] = '/etc/origin/master/{}_ldap_ca.crt'.format(self.name)
 
     def validate(self):
         ''' validate this idp instance '''


### PR DESCRIPTION
Backport of #9889 to release-3.10

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1627764