### PR TITLE
make upgrade of asb/tsb not just depending on srv catalog

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_components.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_components.yml
@@ -14,8 +14,10 @@
       tasks_from: install.yml
     when:
     - openshift_enable_service_catalog | default(true) | bool
+    - ansible_service_broker_install | default(true) | bool
   - import_role:
       name: template_service_broker
       tasks_from: upgrade.yml
     when:
     - openshift_enable_service_catalog | default(true) | bool
+    - template_service_broker_install | default(true) | bool


### PR DESCRIPTION
during upgrading from 3.9 (old) to 3.9 (recent) the upgrade failed
this will reflect inventory settings for correct upgade