### PR TITLE
Revert ensure gquota set on slash filesystem

### DIFF
--- a/playbooks/aws/openshift-cluster/build_ami.yml
+++ b/playbooks/aws/openshift-cluster/build_ami.yml
@@ -39,7 +39,6 @@
 - import_playbook: ../../openshift-node/private/image_prep.yml
   vars:
     openshift_node_reboot_instance_before_cleanup: true
-    openshift_aws_ami_set_gquota_on_slash: true
 
 - import_playbook: seal_ami.yml
   vars:

--- a/playbooks/openshift-node/private/clean_image.yml
+++ b/playbooks/openshift-node/private/clean_image.yml
@@ -27,24 +27,3 @@
     file:
       state: absent
       path: "/var/lib/cloud/"
-  - when: openshift_aws_ami_set_gquota_on_slash | default(false)
-    block:
-    - name: fetch uuid of root vol
-      command: blkid /dev/xvda2 -s UUID -o value
-      register: rootvoluuid
-    - name: ensure gquota option for root vol in /etc/fstab
-      lineinfile:
-        line: "UUID={{ rootvoluuid.stdout }} /                       xfs     defaults,gquota 0 0"
-        path: /etc/fstab
-        regexp: "^UUID={{ rootvoluuid.stdout }}"
-        state: present
-    - name: set rootvol flags in grub conf
-      lineinfile:
-        line: 'GRUB_CMDLINE_LINUX="console=ttyS0,115200n8 console=tty0 net.ifnames=0 crashkernel=auto rootflags=gquota"'
-        path: /etc/default/grub
-        regexp: 'GRUB_CMDLINE_LINUX="console=ttyS0,115200n8 console=tty0 net.ifnames=0 crashkernel=auto"'
-        state: present
-      register: etcdefaultgrub
-    - name: recreate grub2 config
-      command: grub2-mkconfig -o /boot/grub2/grub.cfg
-      when: etcdefaultgrub.changed


### PR DESCRIPTION
Revert https://github.com/openshift/openshift-ansible/pull/9846 ensure gquota set on slash filesystem.

Hot fix to unblock Ops - Bugzilla [1626045](https://bugzilla.redhat.com/show_bug.cgi?id=1626045)
