### PR TITLE
Remove configmap check during upgrades

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -16,13 +16,6 @@
       name: openshift_certificate_expiry
       tasks_from: main.yml
 
-- name: Ensure essential node configmaps are present
-  hosts: oo_first_master
-  tasks:
-  - import_role:
-      name: openshift_node_group
-      tasks_from: check_for_configs.yml
-
 - name: Ensure firewall is not switched during upgrade
   hosts: "{{ l_upgrade_no_switch_firewall_hosts | default('oo_all_hosts') }}"
   vars:


### PR DESCRIPTION
This check is no longer necessary once a cluster is running 3.10.
As new default node groups are added, the check would fail on upgrades
unnecessarily.