### PR TITLE
3.6 Add a playbook to remove etcd v2 data after migration

### DIFF
--- a/playbooks/byo/openshift-etcd/remove-etcdv2-data.yml
+++ b/playbooks/byo/openshift-etcd/remove-etcdv2-data.yml
@@ -1,0 +1,16 @@
+---
+- include: ../openshift-cluster/initialize_groups.yml
+  tags:
+  - always
+
+- include: ../../common/openshift-cluster/std_include.yml
+  tags:
+  - always
+
+- name: Remove etcd v2 data
+  hosts: oo_etcd_to_config[0]
+  any_errors_fatal: true
+  roles:
+    - role: etcd_remove_v2
+      etcd_peer: "{{ openshift.common.hostname }}"
+      r_etcd_common_etcd_runtime: "{{ openshift.common.etcd_runtime }}"

--- a/roles/etcd_remove_v2/defaults/main.yml
+++ b/roles/etcd_remove_v2/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+etcdctl_cmd: "{{ r_etcd_common_etcdctl_command }} --cert-file {{ etcd_peer_cert_file }} --key-file {{ etcd_peer_key_file }} --ca-file {{ etcd_peer_ca_file }} --endpoint https://{{ etcd_peer }}:{{ etcd_client_port }}"

--- a/roles/etcd_remove_v2/meta/main.yml
+++ b/roles/etcd_remove_v2/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: Vadim Rutkovsky
+  description: Remove etcd v2 data
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 2.1
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+  - system
+dependencies:
+- { role: etcd_common }
+- { role: lib_utils }

--- a/roles/etcd_remove_v2/tasks/main.yml
+++ b/roles/etcd_remove_v2/tasks/main.yml
@@ -1,0 +1,23 @@
+- name: Verify cluster is healthy pre-upgrade
+  command: "{{ etcdctl_cmd }} cluster-health"
+
+- name: Check migrated status
+  command: "{{ etcdctl_cmd }} get /kubernetes.io"
+  register: etcdv2_migrated_status
+  failed_when: "'stdout' not in etcdv2_migrated_status"
+
+- block:
+  - name: Remove etcdv2 kubernetes data
+    command: "{{ etcdctl_cmd }} rm -r /kubernetes.io"
+    register: etcdv2_remove_k8s
+    failed_when: "'Key not found' not in etcdv2_remove_k8s.stderr"
+
+  - name: Remove etcdv2 openshift data
+    command: "{{ etcdctl_cmd }} rm -r /openshift.io"
+    register: etcdv2_remove_openshift
+    failed_when: "'Key not found' not in etcdv2_remove_openshift.stderr"
+
+  - name: Set migrated mark
+    command: "{{ etcdctl_cmd }} set /kubernetes.io migrated"
+
+  when: "etcdv2_migrated_status.stdout != 'migrated'"


### PR DESCRIPTION
This would add a playbook to remove etcd v2 data after it has been migrated to v3

Cherry-pick of #9899