### PR TITLE
fix ca cert deploy for 3.10 addresses bz 1585978

### DIFF
--- a/playbooks/openshift-master/private/redeploy-openshift-ca.yml
+++ b/playbooks/openshift-master/private/redeploy-openshift-ca.yml
@@ -247,7 +247,7 @@
     - update ca trust
   - name: Update node client kubeconfig CA data
     kubeclient_ca:
-      client_path: "{{ openshift.common.config_base }}/node/system:node:{{ openshift.common.hostname }}.kubeconfig"
+      client_path: "{{ openshift.common.config_base }}/node/node.kubeconfig"
       ca_path: "{{ openshift.common.config_base }}/node/ca.crt"
   handlers:
   # Normally this handler would restart docker after updating ca


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1585978

```
TASK [Update node client kubeconfig CA data] ********************************************************************************************************************************
fatal: [ec2-34-207-246-134.compute-1.amazonaws.com]: FAILED! => {"changed": false, "failed": true, "msg": "[Errno 2] No such file or directory: '/etc/origin/node/system:node:ip-172-18-0-157.ec2.internal.kubeconfig'"}
fatal: [ec2-52-90-247-129.compute-1.amazonaws.com]: FAILED! => {"changed": false, "failed": true, "msg": "[Errno 2] No such file or directory: '/etc/origin/node/system:node:ip-172-18-11-10.ec2.internal.kubeconfig'"}
```