### PR TITLE
spec: remove roles/openshift_examples/latest symlink

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -160,6 +160,13 @@ BuildArch:     noarch
 %files roles
 %{_datadir}/ansible/%{name}/roles
 
+%pretrans roles
+#RHBZ https://bugzilla.redhat.com/show_bug.cgi?id=1626048
+#roles/openshift_examples/latest used to be a symlink, now its a dir
+# workaround for RPM bug https://bugzilla.redhat.com/show_bug.cgi?id=975909
+if [ -d %{_datadir}/ansible/%{name}/roles/openshift_examples/files/examples ]; then
+  find %{_datadir}/ansible/%{name}/roles/openshift_examples/files/examples -name latest -type l -delete
+fi
 
 
 %changelog


### PR DESCRIPTION
This is required to update RPM from 3.10 to 3.11.

In 3.10 `roles/openshift_examples/files/examples/latest` was a symlink to latest folder. In #9806 this symlink was removed and `3.11` dir is renamed to `latest`
RHEL7's yum however can't replace symlinks with dirs - see https://bugzilla.redhat.com/show_bug.cgi?id=975909 - so the old symlink needs to removed in `%pretrans` script.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1626048

This doesn't need to be cherrypicked and should be removed in 3.12