### PR TITLE
olm: add openshift_facts dependency

### DIFF
--- a/roles/olm/meta/main.yaml
+++ b/roles/olm/meta/main.yaml
@@ -14,3 +14,4 @@ galaxy_info:
 dependencies:
 - role: lib_utils
 - role: lib_openshift
+- role: openshift_facts


### PR DESCRIPTION
Fixes l_osm_registry_url undefined error

/cc @ecordell 