### PR TITLE
Enable monitoring of openshift-metering via cluster monitoring

### DIFF
--- a/roles/openshift_metering/defaults/main.yml
+++ b/roles/openshift_metering/defaults/main.yml
@@ -2,6 +2,8 @@
 openshift_metering_install: true
 openshift_metering_operator_image: ''
 
+openshift_metering_enable_monitoring: true
+
 openshift_metering_config: null
 
 # Configures AWS Access credentials on all pods which use it for communicating

--- a/roles/openshift_metering/files/monitoring/rbac/role.yaml
+++ b/roles/openshift_metering/files/monitoring/rbac/role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-metering
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/roles/openshift_metering/files/monitoring/rbac/rolebinding.yaml
+++ b/roles/openshift_metering/files/monitoring/rbac/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-metering
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/roles/openshift_metering/files/monitoring/service-monitors/presto-service-monitor.yaml
+++ b/roles/openshift_metering/files/monitoring/service-monitors/presto-service-monitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: metering-presto
+  namespace: openshift-monitoring
+  labels:
+    k8s-app: metering-presto
+spec:
+  jobLabel: k8s-app
+  endpoints:
+  - port: metrics
+    interval: 30s
+    scheme: "http"
+  selector:
+    matchLabels:
+      app: presto
+      metrics: "true"
+  namespaceSelector:
+    matchNames:
+    - openshift-metering

--- a/roles/openshift_metering/files/monitoring/service-monitors/reporting-operator-service-monitor.yaml
+++ b/roles/openshift_metering/files/monitoring/service-monitors/reporting-operator-service-monitor.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: metering-reporting-operator
+  namespace: openshift-monitoring
+  labels:
+    k8s-app: metering-reporting-operator
+spec:
+  jobLabel: k8s-app
+  endpoints:
+  - port: metrics
+    scheme: "https"
+    interval: 30s
+    tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+      serverName: reporting-operator-metrics.openshift-metering.svc
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  selector:
+    matchLabels:
+      app: reporting-operator
+      metrics: "true"
+  namespaceSelector:
+    matchNames:
+    - openshift-metering

--- a/roles/openshift_metering/tasks/monitoring-install.yml
+++ b/roles/openshift_metering/tasks/monitoring-install.yml
@@ -1,0 +1,28 @@
+---
+- name: Install Role and RoleBinding to allow cluster-monitoring to scrape Metering
+  oc_obj:
+    state: present
+    kind: "{{ obj.kind }}"
+    name: "{{ obj.metadata.name }}"
+    namespace: "{{ __openshift_metering_namespace }}"
+    content:
+      path: "/tmp/{{ obj.kind }}-{{ obj.metadata.name }}.yaml"
+      data: "{{ obj }}"
+  vars:
+    obj: "{{ lookup('file', item) | from_yaml }}"
+  with_fileglob:
+  - "files/monitoring/rbac/*.yaml"
+
+- name: Install Metering ServiceMonitors into openshift-monitoring namespace
+  oc_obj:
+    state: present
+    kind: "{{ obj.kind }}"
+    name: "{{ obj.metadata.name }}"
+    namespace: "openshift-monitoring"
+    content:
+      path: "/tmp/{{ obj.kind }}-{{ obj.metadata.name }}.yaml"
+      data: "{{ obj }}"
+  vars:
+    obj: "{{ lookup('file', item) | from_yaml }}"
+  with_fileglob:
+  - "files/monitoring/service-monitors/*.yaml"

--- a/roles/openshift_metering/tasks/monitoring-uninstall.yml
+++ b/roles/openshift_metering/tasks/monitoring-uninstall.yml
@@ -1,0 +1,11 @@
+---
+- name: Uninstall Metering ServiceMonitors from openshift-monitoring namespace
+  oc_obj:
+    state: absent
+    kind: "{{ obj.kind }}"
+    name: "{{ obj.metadata.name }}"
+    namespace: "openshift-monitoring"
+  vars:
+    obj: "{{ lookup('file', item) | from_yaml }}"
+  with_fileglob:
+  - "files/monitoring/service-monitors/*.yaml"

--- a/roles/openshift_metering/tasks/operator-install.yml
+++ b/roles/openshift_metering/tasks/operator-install.yml
@@ -193,3 +193,7 @@
     name: "{{ mktemp.stdout }}"
     state: absent
   changed_when: False
+
+- name: Install monitoring resources
+  import_tasks: monitoring-install.yml
+  when: openshift_metering_enable_monitoring | bool

--- a/roles/openshift_metering/tasks/operator-uninstall.yml
+++ b/roles/openshift_metering/tasks/operator-uninstall.yml
@@ -14,3 +14,6 @@
   oc_clusterrole:
     state: absent
     name: "openshift-metering-namespace-viewer-{{ __openshift_metering_namespace }}"
+
+- name: Uninstall monitoring resources
+  import_tasks: monitoring-uninstall.yml


### PR DESCRIPTION
Due to current limitations in the cluster-monitoring operator, we're having the openshift metering role/playbook handle configuring the cluster monitoring component to monitor metering.
Currently this requires prometheus to have access to a few resources in the openshift-metering namespace, and for a few ServiceMonitors to be created in the openshift-monitoring namespace, which is what is now done by default when installing metering with these changes.