### PR TITLE
check for sync pod availability before node selector

### DIFF
--- a/roles/openshift_control_plane/tasks/ensure_nodes_matching_selector.yml
+++ b/roles/openshift_control_plane/tasks/ensure_nodes_matching_selector.yml
@@ -1,4 +1,23 @@
 ---
+- name: Ensure the sync pods are all available so that node labels are up to date
+  oc_obj:
+    state: list
+    kind: daemonset
+    name: sync
+    namespace: openshift-node
+  register: __status_of_sync_ds
+  until:
+    - __status_of_sync_ds.results is defined
+    - __status_of_sync_ds.results.results is defined
+    - __status_of_sync_ds.results.results | length > 0
+    - __status_of_sync_ds.results.results[0].status is defined
+    - __status_of_sync_ds.results.results[0].status.numberAvailable is defined
+    - __status_of_sync_ds.results.results[0].status.desiredNumberScheduled is defined
+    - __status_of_sync_ds.results.results[0].status.numberAvailable == __status_of_sync_ds.results.results[0].status.desiredNumberScheduled
+  retries: 60
+  delay: 30
+  failed_when: false
+
 - name: Retrieve list of schedulable nodes matching selector
   oc_obj:
     state: list

--- a/roles/openshift_node_group/tasks/sync.yml
+++ b/roles/openshift_node_group/tasks/sync.yml
@@ -53,22 +53,3 @@
     state: absent
     name: "{{ mktemp.stdout }}"
   changed_when: False
-
-- name: Wait for the sync daemonset to become ready and available
-  oc_obj:
-    state: list
-    kind: daemonset
-    name: sync
-    namespace: openshift-node
-  register: __status_of_sync_ds
-  until:
-    - __status_of_sync_ds.results is defined
-    - __status_of_sync_ds.results.results is defined
-    - __status_of_sync_ds.results.results | length > 0
-    - __status_of_sync_ds.results.results[0].status is defined
-    - __status_of_sync_ds.results.results[0].status.numberAvailable is defined
-    - __status_of_sync_ds.results.results[0].status.desiredNumberScheduled is defined
-    - __status_of_sync_ds.results.results[0].status.numberAvailable == __status_of_sync_ds.results.results[0].status.desiredNumberScheduled
-  retries: 60
-  delay: 30
-  failed_when: false


### PR DESCRIPTION
The sync pods need to be running on all nodes to ensure that labels are
up to date before checking for nodes matching a selector.  This change
moves the location of the sync pod check, because previously the sync
check would succeed before infra and compute nodes are added to the cluster.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1609019