### PR TITLE
Set gquota on slash filesystem

### DIFF
--- a/playbooks/openshift-node/private/clean_image.yml
+++ b/playbooks/openshift-node/private/clean_image.yml
@@ -17,6 +17,11 @@
 - name: Configure nodes
   hosts: oo_nodes_to_config
   tasks:
+  - name: Set gquota for slash filesystem
+    import_role:
+      name: openshift_aws
+      tasks_from: set_gquota_for_slashfs.yml
+    when: openshift_aws_ami_build_set_gquota_on_slashfs | default(false)
   - name: Remove any ansible facts created during AMI creation
     file:
       path: "/etc/ansible/facts.d/{{ item }}"

--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -32,6 +32,15 @@ openshift_aws_ami_name: openshift-gi
 openshift_aws_base_ami_name: ami_base
 openshift_aws_instance_type: m4.xlarge
 
+# atomic-openshift-node service requires gquota to be set on the filesystem
+# that hosts /var/lib/origin/openshift.local.volumes ( OCP emptydir ).  Often
+# is it not ideal or cost effective to deploy a vol for emptydir.  This pushes
+# emptydir up to the / filesystem.  Base ami often does not ship with gquota
+# enabled for /.
+# Set this bool true to enable gquota on / filesystem when using Red Hat Cloud
+# Access RHEL7 AMI or Amazon Market RHEL7 AMI.
+openshift_aws_ami_build_set_gquota_on_slashfs: False
+
 openshift_aws_launch_config_bootstrap_token: ''
 
 openshift_aws_users: []

--- a/roles/openshift_aws/tasks/set_gquota_for_slashfs.yml
+++ b/roles/openshift_aws/tasks/set_gquota_for_slashfs.yml
@@ -1,0 +1,40 @@
+---
+- name: fetch block device of slash filesystem
+  command: bash -c "/usr/bin/mount | grep 'on / ' | cut -d ' ' -f1"
+  register: slashfsdevice
+
+- name: fetch filesystem of slash block device
+  command: bash -c "blkid {{ slashfsdevice.stdout }} -s TYPE -o value"
+  register: slashfstype
+
+- name: fetch uuid of slash block device
+  command: bash -c "blkid {{ slashfsdevice.stdout }} -s UUID -o value"
+  register: slashfsuuid
+
+- name: ensure nonUUID based slash mount entry in /etc/fstab is removed
+  lineinfile:
+    path: /etc/fstab
+    regexp: '^(?!(UUID=))(.*?)(\s+)(\/)(\s+){{ slashfstype.stdout }}(.+?)$'
+    state: absent
+
+- name: ensure slash mount uses UUID device and gquota option in /etc/fstab
+  mount:
+    path: "/"
+    src: "UUID={{ slashfsuuid.stdout }}"
+    fstype: "{{ slashfstype.stdout }}"
+    opts: "defaults,gquota"
+    state: "present"
+  register: slashmount
+
+- name: set rootvol flags in grub conf
+  lineinfile:
+    line: 'GRUB_CMDLINE_LINUX="console=ttyS0,115200n8 console=tty0 net.ifnames=0 crashkernel=auto rootflags=gquota"'
+    path: /etc/default/grub
+    regexp: 'GRUB_CMDLINE_LINUX="console=ttyS0,115200n8 console=tty0 net.ifnames=0 crashkernel=auto"'
+    state: present
+  register: etcdefaultgrub
+  when: slashmount.changed
+
+- name: recreate grub2 config
+  command: grub2-mkconfig -o /boot/grub2/grub.cfg
+  when: etcdefaultgrub.changed


### PR DESCRIPTION
Better functionality for setting gquota on slash filesystem

Workflow ...
1) set bool true
2) fetch block device of slash filesystem via mount/grep
3) fetch filesystem of slash block device via blkid
4) fetch uuid of slash block device via blkid
5) ensure nonUUID based slash mount entry in /etc/fstab is removed
6) ensure slash mount uses UUID device and gquota option in /etc/fstab
7) set grub.conf value
8) rebuild grub config

Resolves Bugzilla [1619380](https://bugzilla.redhat.com/show_bug.cgi?id=1619380) & [1626045](https://bugzilla.redhat.com/show_bug.cgi?id=1626045)