### PR TITLE
Fix kuryr support for custom OpenStack network and subnet

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -476,7 +476,7 @@ $ ssh centos@172.24.4.10
 ### openshift-ansible Configuration
 
 In addition to the rest of openshift-ansible configuration, we will need to
-specify the node netwok, subnet and that we do not want any floating IP
+specify the node subnet, the routerand that we do not want any floating IP
 addresses.
 
 You must do this from inside the "bastion" host created in the previous step.
@@ -484,7 +484,7 @@ You must do this from inside the "bastion" host created in the previous step.
 Put the following to `inventory/group_vars/all.yml`:
 
 ```yaml
-openshift_openstack_node_network_name: openshift
+openshift_openstack_router_name: openshift-router
 openshift_openstack_node_subnet_name: openshift
 openshift_openstack_master_floating_ip: false
 openshift_openstack_infra_floating_ip: false

--- a/roles/openshift_openstack/defaults/main.yml
+++ b/roles/openshift_openstack/defaults/main.yml
@@ -76,7 +76,7 @@ openshift_openstack_lb_image: "{{ openshift_openstack_default_image_name }}"
 openshift_openstack_etcd_image: "{{ openshift_openstack_default_image_name }}"
 openshift_openstack_provider_network_name: null
 openshift_openstack_external_network_name: null
-openshift_openstack_node_network_name: null
+openshift_openstack_router_name: null
 openshift_openstack_node_subnet_name: null
 openshift_openstack_private_network: >-
   {% if openshift_openstack_provider_network_name | default(None) -%}

--- a/roles/openshift_openstack/tasks/check-prerequisites.yml
+++ b/roles/openshift_openstack/tasks/check-prerequisites.yml
@@ -75,6 +75,36 @@
     msg: "Network {{ openshift_openstack_external_network_name }} is not available"
   when: not openshift_openstack_provider_network_name|default(None)
 
+- name: Get subnet facts when using a custom subnet
+  os_subnets_facts:
+    name: "{{ openshift_openstack_node_subnet_name }}"
+  register: subnet_result
+  when: openshift_openstack_node_subnet_name is defined
+- name: Set custom network id
+  set_fact:
+    openshift_openstack_node_network_id: "{{ subnet_result.ansible_facts.openstack_subnets[0].network_id }}"
+  when: openshift_openstack_node_subnet_name is defined
+- name: Set custom subnet id
+  set_fact:
+    openshift_openstack_node_subnet_id: "{{ subnet_result.ansible_facts.openstack_subnets[0].id }}"
+  when: openshift_openstack_node_subnet_name is defined
+- name: Set custom subnet cidr
+  set_fact:
+    openshift_openstack_subnet_cidr: "{{ subnet_result.ansible_facts.openstack_subnets[0].cidr }}"
+  when: openshift_openstack_node_subnet_name is defined
+
+# TODO ltomasbo: there is no Ansible module for getting router facts
+- name: Get custom router id
+  command: >
+           python -c 'import shade; cloud = shade.openstack_cloud();
+           print cloud.get_router("{{ openshift_openstack_router_name }}").id'
+  register: router_info
+  when: openshift_openstack_router_name is defined
+- name: Set custom router id
+  set_fact:
+    openshift_openstack_router_id: "{{ router_info.stdout }}"
+  when: openshift_openstack_router_name is defined
+
 # Check keypair
 # TODO kpilatov: there is no Ansible module for getting OS keypairs
 #                (os_keypair is not suitable for this)

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -102,7 +102,11 @@ outputs:
 {% if openshift_use_kuryr|default(false)|bool %}
   vm_subnet:
     description: ID of the subnet the Pods will be on
+{% if not openshift_openstack_node_subnet_name %}
     value: { get_resource: subnet }
+{% else %}
+    value: {{ openshift_openstack_node_subnet_id }}
+{% endif %}
 
   pod_subnet:
     description: ID of the subnet the Pods will be on
@@ -114,7 +118,12 @@ outputs:
 
   pod_router:
     description: ID of the router where the pod subnet will be connected
+{% if not openshift_openstack_router_name %}
     value: { get_resource: router }
+{% else %}
+    value: {{ openshift_openstack_router_id }}
+{% endif %}
+
 
 {% if openshift_kuryr_subnet_driver|default('default') == 'namespace' %}
   pod_subnet_pool:
@@ -335,7 +344,7 @@ resources:
 
 {% endif %}
 
-{% if not openshift_openstack_node_network_name %}
+{% if not openshift_openstack_node_subnet_name %}
   net:
     type: OS::Neutron::Net
     properties:
@@ -382,6 +391,7 @@ resources:
       gateway_ip: null
 {% endif %}
 
+{% if not openshift_openstack_router_name %}
   router:
     type: OS::Neutron::Router
     properties:
@@ -393,7 +403,6 @@ resources:
       external_gateway_info:
         network: {{ openshift_openstack_external_network_name }}
 
-{% if not openshift_openstack_node_subnet_name %}
   interface:
     type: OS::Neutron::RouterInterface
     properties:
@@ -405,7 +414,11 @@ resources:
   pod_subnet_interface:
     type: OS::Neutron::RouterInterface
     properties:
+{% if not openshift_openstack_router_name %}
       router_id: { get_resource: router }
+{% else %}
+      router_id: {{ openshift_openstack_router_id }}
+{% endif %}
       subnet_id: { get_resource: pod_subnet }
 
   service_router_port:
@@ -424,7 +437,11 @@ resources:
   service_subnet_interface:
     type: OS::Neutron::RouterInterface
     properties:
+{% if not openshift_openstack_router_name %}
       router_id: { get_resource: router }
+{% else %}
+      router_id: {{ openshift_openstack_router_id }}
+{% endif %}
       port: { get_resource: service_router_port }
 {% endif %}
 
@@ -626,9 +643,8 @@ resources:
           net:         {{ openshift_openstack_provider_network_name }}
           net_name:         {{ openshift_openstack_provider_network_name }}
 {% else %}
-{% if openshift_openstack_node_network_name %}
-          net:         {{ openshift_openstack_node_network_name }}
-          net_name:    {{ openshift_openstack_node_network_name }}
+{% if openshift_openstack_node_network_id %}
+          net:         {{ openshift_openstack_node_network_id }}
 {% else %}
           net:         { get_resource: net }
 {% endif %}
@@ -711,8 +727,8 @@ resources:
 {% if openshift_openstack_provider_network_name %}
           net:         {{ openshift_openstack_provider_network_name }}
           net_name:         {{ openshift_openstack_provider_network_name }}
-{% elif openshift_openstack_node_network_name %}
-          net:         {{ openshift_openstack_node_network_name }}
+{% elif openshift_openstack_node_network_id %}
+          net:         {{ openshift_openstack_node_network_id }}
 {% else %}
           net:         { get_resource: net }
 {% if openshift_openstack_node_subnet_name %}
@@ -785,9 +801,8 @@ resources:
           net:         {{ openshift_openstack_provider_network_name }}
           net_name:         {{ openshift_openstack_provider_network_name }}
 {% else %}
-{% if openshift_openstack_node_network_name %}
-          net:         {{ openshift_openstack_node_network_name }}
-          net_name:    {{ openshift_openstack_node_network_name }}
+{% if openshift_openstack_node_network_id %}
+          net:         {{ openshift_openstack_node_network_id }}
 {% else %}
           net:         { get_resource: net }
 {% endif %}
@@ -880,9 +895,8 @@ resources:
           net:         {{ openshift_openstack_provider_network_name }}
           net_name:         {{ openshift_openstack_provider_network_name }}
 {% else %}
-{% if openshift_openstack_node_network_name %}
-          net:         {{ openshift_openstack_node_network_name }}
-          net_name:    {{ openshift_openstack_node_network_name }}
+{% if openshift_openstack_node_network_id %}
+          net:         {{ openshift_openstack_node_network_id }}
 {% else %}
           net:         { get_resource: net }
 {% endif %}
@@ -962,9 +976,8 @@ resources:
           net:         {{ openshift_openstack_provider_network_name }}
           net_name:         {{ openshift_openstack_provider_network_name }}
 {% else %}
-{% if openshift_openstack_node_network_name %}
-          net:         {{ openshift_openstack_node_network_name }}
-          net_name:    {{ openshift_openstack_node_network_name }}
+{% if openshift_openstack_node_network_id %}
+          net:         {{ openshift_openstack_node_network_id }}
 {% else %}
           net:         { get_resource: net }
 {% endif %}
@@ -1049,9 +1062,8 @@ resources:
           net:         {{ openshift_openstack_provider_network_name }}
           net_name:    {{ openshift_openstack_provider_network_name }}
 {% else %}
-{% if openshift_openstack_node_network_name %}
-          net:         {{ openshift_openstack_node_network_name }}
-          net_name:    {{ openshift_openstack_node_network_name }}
+{% if openshift_openstack_node_network_id %}
+          net:         {{ openshift_openstack_node_network_id }}
 {% else %}
           net:         { get_resource: net }
 {% endif %}


### PR DESCRIPTION
The addition of [1] didn't fully account for the changes needed when
deploying with kuryr. This PR ensures that kuryr can be deployed without
FIPS too.

In addition, it moves from requiring the custom network and subnet names used
to require the created subnet and router. Note the network can be obtain
from the subnet, and the router is needed for kuryr support.

[1] https://github.com/openshift/openshift-ansible/commit/22b6b19941517e8cae584e98ca7edc00aa426c3d#diff-aaccff40c391dc9989e2ca0acf56aca4