### PR TITLE
Annotate nodes with md5sum of the applied config after sync DS has updated configs

### DIFF
--- a/roles/openshift_node_group/files/sync.yaml
+++ b/roles/openshift_node_group/files/sync.yaml
@@ -141,6 +141,9 @@ spec:
                 continue
               fi
             fi
+            # annotate node with md5sum of the config
+            oc annotate --config=/etc/origin/node/node.kubeconfig "node/${NODE_NAME}" \
+              node.openshift.io/md5sum="$( cat /tmp/.new | cut -d' ' -f1 )" --overwrite
             cp -f /tmp/.new /tmp/.old
             sleep 180 &
             wait $!

--- a/roles/openshift_node_group/tasks/sync.yml
+++ b/roles/openshift_node_group/tasks/sync.yml
@@ -70,5 +70,36 @@
     - __status_of_sync_ds.results.results[0].status.desiredNumberScheduled is defined
     - __status_of_sync_ds.results.results[0].status.numberAvailable == __status_of_sync_ds.results.results[0].status.desiredNumberScheduled
   retries: 60
-  delay: 30
-  failed_when: false
+  delay: 10
+
+- name: Wait for sync DS to set annotations on all nodes
+  oc_obj:
+    state: list
+    kind: node
+    selector: ""
+  register: node_status
+  until:
+    - node_status.results is defined
+    - node_status.results.results is defined
+    - node_status.results.results | length > 0
+    - node_status.results.results[0]['items']
+     | map(attribute='metadata.annotations') | map('list') | flatten
+     | select('match', '[\"node.openshift.io/md5sum\"]') | list | length == node_status.results.results | length
+  retries: 60
+  delay: 10
+
+# Sync DS may have restarted masters
+- name: Verify api server is available
+  command: >
+    curl --silent --tlsv1.2
+    --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+    {{ openshift.master.api_url }}/healthz/ready
+  args:
+    # Disables the following warning:
+    # Consider using get_url or uri module rather than running curl
+    warn: no
+  register: api_available_output
+  until: api_available_output.stdout == 'ok'
+  retries: 120
+  delay: 1
+  changed_when: false


### PR DESCRIPTION
Currently node config is stored in configmaps, which are monitored by sync daemonset. Once the configmap is updated sync daemonset would apply new labels or edits to the config and restart the node.

This process is async, so openshift-ansible can't currently know if the node is about to be restarted or has been restarted. This is critical for single master installs, where control plane pods can go down at any point due to sync DS.

This PR updates sync container - it now annotates the node with md5sum of the applied config. The annotation could be used by ansible playbooks to detect that sync has completed restarts. After sync pods have been started the playbook would ensure the annotation has been set for all nodes, verify API server is running and proceed.

@smarterclayton please advice on correct approach and annotation name

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1609019
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1628208