### PR TITLE
Run the kube-proxy once per cluster for Calico

### DIFF
--- a/roles/calico_master/meta/main.yml
+++ b/roles/calico_master/meta/main.yml
@@ -15,4 +15,3 @@ galaxy_info:
 dependencies:
 - role: lib_utils
 - role: openshift_facts
-- role: kube_proxy_and_dns

--- a/roles/calico_master/tasks/main.yml
+++ b/roles/calico_master/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Calico | Run kube proxy
+  run_once: true
+  import_role:
+    name: kube_proxy_and_dns
+
 - include_tasks: certs.yml
 
 - name: Calico Master | oc adm policy add-scc-to-user privileged system:serviceaccount:kube-system:calico-node


### PR DESCRIPTION
Ensure that the kube_proxy_and_dns role dependency is run only once for Calico. This fixes errors that would occur in a multiple master scenario.

This is a forward port of https://github.com/openshift/openshift-ansible/pull/9871