### PR TITLE
Avoid S3 deployment check

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
@@ -110,11 +110,9 @@
 - import_tasks: glusterblock_storageclass.yml
   when: glusterfs_block_storageclass
 
-- name: Check if gluster-s3 can't be deployed
-  set_fact:
-    glusterfs_s3_deploy: False
-  when:
-  - "glusterfs_s3_account is not defined or glusterfs_s3_user is not defined or glusterfs_s3_password is not defined"
-
 - import_tasks: gluster_s3_deploy.yml
-  when: glusterfs_s3_deploy
+  when:
+  - glusterfs_s3_deploy
+  - glusterfs_s3_account is defined
+  - glusterfs_s3_user is defined
+  - glusterfs_s3_password is defined

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
@@ -76,12 +76,6 @@
   - glusterfs_heketi_is_native
   - glusterfs_heketi_is_missing
 
-- name: Check if gluster-s3 can't be deployed
-  set_fact:
-    glusterfs_s3_deploy: False
-  when:
-  - "glusterfs_s3_account is not defined or glusterfs_s3_user is not defined or glusterfs_s3_password is not defined"
-
 - block:
   - name: Create heketi secret
     oc_secret:
@@ -108,14 +102,19 @@
       name: "glusterfs-{{ glusterfs_name }}"
       files:
       - "{{ mktemp.stdout }}/glusterfs-storageclass.yml"
-  when:
-  - glusterfs_storageclass or glusterfs_s3_deploy
+  when: glusterfs_storageclass
 
 - import_tasks: glusterblock_deploy.yml
   when: glusterfs_block_deploy
 
 - import_tasks: glusterblock_storageclass.yml
   when: glusterfs_block_storageclass
+
+- name: Check if gluster-s3 can't be deployed
+  set_fact:
+    glusterfs_s3_deploy: False
+  when:
+  - "glusterfs_s3_account is not defined or glusterfs_s3_user is not defined or glusterfs_s3_password is not defined"
 
 - import_tasks: gluster_s3_deploy.yml
   when: glusterfs_s3_deploy


### PR DESCRIPTION
- Checking whether s3 deployment is enabled
is not required for creating generic storage class
(as we create separate storage class for s3).

 - Group S3 tasks together.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>