### PR TITLE
WIP DONOTMERGE Test AWS provisioner

### DIFF
--- a/test/ci/launch.yml
+++ b/test/ci/launch.yml
@@ -78,15 +78,27 @@
     - name: Make sure hostname is set to public ansible host
       hostname:
         name: "{{ ansible_host }}"
+    - name: Detecting Operating System
+      shell: ls /run/ostree-booted
+      ignore_errors: yes
+      failed_when: false
+      register: ostree_output
     - name: Update all packages
       package:
         name: '*'
         state: latest
+      when: ostree_output.rc != 0
+      register: yum_update
+    - name: Update Atomic system
+      command: atomic host upgrade
+      when: ostree_output.rc == 0
+      register: ostree_update
     - name: Reboot machines
       shell: sleep 5 && systemctl reboot
       async: 1
       poll: 0
       ignore_errors: true
+      when: yum_update | changed or ostree_update | changed
     - name: Wait for connection
       wait_for_connection:
         connect_timeout: 20

--- a/test/ci/launch.yml
+++ b/test/ci/launch.yml
@@ -78,6 +78,21 @@
     - name: Make sure hostname is set to public ansible host
       hostname:
         name: "{{ ansible_host }}"
+    - name: Update all packages
+      package:
+        name: '*'
+        state: latest
+    - name: Reboot machines
+      shell: sleep 5 && systemctl reboot
+      async: 1
+      poll: 0
+      ignore_errors: true
+    - name: Wait for connection
+      wait_for_connection:
+        connect_timeout: 20
+        sleep: 5
+        delay: 5
+        timeout: 300
     - setup: {}
 
 - import_playbook: ../../playbooks/openshift-node/network_manager.yml

--- a/test/ci/launch.yml
+++ b/test/ci/launch.yml
@@ -75,10 +75,10 @@
   become: true
   tasks:
     - wait_for_connection: {}
-    - setup: {}
     - name: Make sure hostname is set to public ansible host
       hostname:
         name: "{{ ansible_host }}"
+    - setup: {}
 
 - import_playbook: ../../playbooks/openshift-node/network_manager.yml
 - import_playbook: ../../playbooks/prerequisites.yml


### PR DESCRIPTION
Current status:

* [x] aws misconfiguration - new namespaces are not created
* [x] https://github.com/openshift/release/pull/1440
* [x] https://github.com/openshift/release/pull/1448
* [x] https://github.com/openshift/release/pull/1496
* [x] CI is using a different key, not libra, so created instance cannot be ssh'ed to
* [x] CSR approval gets stuck
  CI's AWS security group didn't allow access to 10250, which caused `/healthz` checks to fail
* [x] SDN is broken on AWS CI account
  Registry service can be pinged by pod and service IP from infra node only.
  Security group was incorrectly setup
* [x] https://github.com/openshift/release/pull/1813