### PR TITLE
WIP [3.10] GCP upgrade: don't exclude nodes with tag_ocp-bootstrap

### DIFF
--- a/roles/openshift_gcp/tasks/setup_scale_group_facts.yml
+++ b/roles/openshift_gcp/tasks/setup_scale_group_facts.yml
@@ -4,7 +4,7 @@
     name: "{{ hostvars[item].gce_name }}"
     groups: nodes, new_nodes
     openshift_node_group_name: "{{ openshift_gcp_node_group_mapping['compute'] }}"
-  with_items: "{{ groups['tag_ocp-node'] | default([]) | difference(groups['tag_ocp-bootstrap'] | default([])) }}"
+  with_items: "{{ groups['tag_ocp-node'] | default([]) }}"
 
 - name: Add bootstrap node instances
   add_host:
@@ -39,7 +39,7 @@
     name: "{{ hostvars[item].gce_name }}"
     groups: nodes, new_nodes
     openshift_node_group_name: "{{ openshift_gcp_node_group_mapping['infra'] }}"
-  with_items: "{{ groups['tag_ocp-infra-node'] | default([]) | difference(groups['tag_ocp-bootstrap'] | default([])) }}"
+  with_items: "{{ groups['tag_ocp-infra-node'] | default([]) }}"
 
 - name: Add masters to requisite groups
   add_host:


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/openshift-ansible/pull/9929
on release-3.10 branch

Status:
* [x] https://github.com/openshift/release/pull/1453
* [x] https://github.com/openshift/release/pull/1483
* [x] https://github.com/openshift/release/pull/1504
* [ ] https://github.com/openshift/release/pull/1516
* [ ] playbooks/common/openshift-cluster/roles/openshift_version/tasks/first_master.yml rewrites `openshift_version`