### PR TITLE
Revert "Don't fetch provider openshift_facts if openshift_cloud_provider_kind is not set"

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1055,9 +1055,7 @@ class OpenShiftFacts(object):
         roles = local_facts.keys()
 
         defaults = self.get_defaults(roles)
-        provider_facts = {}
-        if 'cloudprovider' in local_facts and 'kind' in local_facts['cloudprovider']:
-            provider_facts = self.init_provider_facts()
+        provider_facts = self.init_provider_facts()
         facts = apply_provider_facts(defaults, provider_facts)
         facts = merge_facts(facts,
                             local_facts,


### PR DESCRIPTION
Reverts openshift/openshift-ansible#9876

This PR would unbreak QE installs, I'll prepare a new PR to skip provider facts collection using a dedicated ansible var