### PR TITLE
Revert "[release-3.10] Don't fetch provider openshift_facts if openshift_cloud_provider_kind is not set"

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1030,9 +1030,7 @@ class OpenShiftFacts(object):
         roles = local_facts.keys()
 
         defaults = self.get_defaults(roles)
-        provider_facts = {}
-        if 'cloudprovider' in local_facts and 'kind' in local_facts['cloudprovider']:
-            provider_facts = self.init_provider_facts()
+        provider_facts = self.init_provider_facts()
         facts = apply_provider_facts(defaults, provider_facts)
         facts = merge_facts(facts,
                             local_facts,


### PR DESCRIPTION
Reverts openshift/openshift-ansible#9956

PR to revert this in master - #9999