### PR TITLE
Set etcd facts necessary for etcd scaleup

### DIFF
--- a/playbooks/openshift-etcd/private/scaleup.yml
+++ b/playbooks/openshift-etcd/private/scaleup.yml
@@ -1,5 +1,21 @@
 ---
 - name: Configure etcd
+  hosts: oo_etcd_to_config
+  any_errors_fatal: true
+  tasks:
+  - fail:
+      msg: >
+        etcd stand-alone hosts on atomic is no longer supported. Please
+        co-locate your etcd hosts with masters.
+    when:
+    - openshift_is_atomic | bool
+    - not inventory_hostname in groups['oo_masters']
+
+  - import_role:
+      name: etcd
+      tasks_from: set_facts.yml
+
+- name: Configure etcd
   hosts: oo_new_etcd_to_config
   serial: 1
   any_errors_fatal: true


### PR DESCRIPTION
hostvars such as etcd_ip are needed to add hosts to the cluster