### PR TITLE
docker_creds: rename image_name to test_image

### DIFF
--- a/roles/container_runtime/tasks/registry_auth.yml
+++ b/roles/container_runtime/tasks/registry_auth.yml
@@ -11,7 +11,7 @@
     # Test that we can actually connect with provided info
     test_login: "{{ oreg_test_login | default(True) }}"
     proxy_vars: "{{ l_docker_creds_proxy_vars }}"
-    image_name: "{{ l_docker_creds_image_name }}"
+    test_image: "{{ l_docker_creds_test_image }}"
   when:
   - oreg_auth_user is defined
   register: crt_oreg_auth_credentials_create
@@ -28,7 +28,7 @@
     # Test that we can actually connect with provided info
     test_login: "{{ item.test_login | default(omit) }}"
     proxy_vars: "{{ l_docker_creds_proxy_vars }}"
-    image_name: "{{ item.image_name | default('openshift3/ose-pod') }}"
+    test_image: "{{ item.test_image | default('openshift3/ose-pod') }}"
     tls_verify: "{{ item.tls_verify | default(omit) }}"
   when:
   - openshift_additional_registry_credentials is defined

--- a/roles/lib_utils/library/docker_creds.py
+++ b/roles/lib_utils/library/docker_creds.py
@@ -132,14 +132,14 @@ def load_config_file(module, dest):
 
 
 # pylint: disable=too-many-arguments
-def gen_skopeo_cmd(registry, username, password, proxy_vars, image_name, tls_verify):
+def gen_skopeo_cmd(registry, username, password, proxy_vars, test_image, tls_verify):
     '''Generate skopeo command to run'''
     skopeo_temp = ("{proxy_vars} timeout 10 skopeo inspect"
-                   " {creds} docker://{registry}/{image_name}")
+                   " {creds} docker://{registry}/{test_image}")
     # this will quote the entire creds argument to account for special chars.
     creds = pipes.quote('--creds={}:{}'.format(username, password))
     skopeo_args = {'proxy_vars': proxy_vars, 'creds': creds,
-                   'registry': registry, 'image_name': image_name,
+                   'registry': registry, 'test_image': test_image,
                    'tls_verify': tls_verify}
     return skopeo_temp.format(**skopeo_args).strip()
 
@@ -200,7 +200,7 @@ def run_module():
         password=dict(type='str', required=True, no_log=True),
         test_login=dict(type='bool', required=False, default=True),
         proxy_vars=dict(type='str', required=False, default=''),
-        image_name=dict(type='str', required=True),
+        test_image=dict(type='str', required=True),
         tls_verify=dict(type='bool', required=False, default=True)
     )
 
@@ -216,7 +216,7 @@ def run_module():
     password = module.params['password']
     test_login = module.params['test_login']
     proxy_vars = module.params['proxy_vars']
-    image_name = module.params['image_name']
+    test_image = module.params['test_image']
     tls_verify = module.params['tls_verify']
 
     if not check_dest_dir_exists(module, dest):
@@ -230,7 +230,7 @@ def run_module():
     # Test the credentials
     if test_login:
         skopeo_command = gen_skopeo_cmd(registry, username, password,
-                                        proxy_vars, image_name, tls_verify)
+                                        proxy_vars, test_image, tls_verify)
         validate_registry_login(module, skopeo_command)
 
     # base64 encode our username:password string

--- a/roles/openshift_control_plane/tasks/registry_auth.yml
+++ b/roles/openshift_control_plane/tasks/registry_auth.yml
@@ -11,7 +11,7 @@
     # Test that we can actually connect with provided info
     test_login: "{{ oreg_test_login | default(True) }}"
     proxy_vars: "{{ l_docker_creds_proxy_vars }}"
-    image_name: "{{ l_docker_creds_image_name }}"
+    test_image: "{{ l_docker_creds_test_image }}"
   when:
   - oreg_auth_user is defined
   register: master_oreg_auth_credentials_create
@@ -28,7 +28,7 @@
     # Test that we can actually connect with provided info
     test_login: "{{ item.test_login | default(omit) }}"
     proxy_vars: "{{ l_docker_creds_proxy_vars }}"
-    image_name: "{{ item.image_name | default('openshift3/ose-pod') }}"
+    test_image: "{{ item.test_image | default('openshift3/ose-pod') }}"
     tls_verify: "{{ item.tls_verify | default(omit) }}"
   when:
   - openshift_additional_registry_credentials is defined

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -25,7 +25,7 @@ l_os_non_standard_reg_url: "{{ oreg_url | default(l_osm_registry_url_default) }}
 l_docker_creds_image_dict:
   openshift-enterprise: 'openshift3/ose'
   origin: 'openshift/origin'
-l_docker_creds_image_name: "{{ l_docker_creds_image_dict[openshift_deployment_type] }}"
+l_docker_creds_test_image: "{{ l_docker_creds_image_dict[openshift_deployment_type] }}"
 
 l_docker_creds_http_proxy: "{{ 'HTTP_PROXY=' ~ openshift.common.http_proxy if openshift.common.http_proxy is defined and openshift.common.http_proxy != '' else ''}}"
 l_docker_creds_https_proxy: "{{ 'HTTPS_PROXY=' ~ openshift.common.https_proxy if openshift.common.https_proxy is defined and openshift.common.https_proxy != '' else ''}}"

--- a/roles/openshift_node/tasks/registry_auth.yml
+++ b/roles/openshift_node/tasks/registry_auth.yml
@@ -22,7 +22,7 @@
     # Test that we can actually connect with provided info
     test_login: "{{ oreg_test_login | default(True) }}"
     proxy_vars: "{{ l_docker_creds_proxy_vars }}"
-    image_name: "{{ l_docker_creds_image_name }}"
+    test_image: "{{ l_docker_creds_test_image }}"
   when:
     - oreg_auth_user is defined
   register: node_oreg_auth_credentials_create
@@ -39,7 +39,7 @@
     # Test that we can actually connect with provided info
     test_login: "{{ item.test_login | default(omit) }}"
     proxy_vars: "{{ l_docker_creds_proxy_vars }}"
-    image_name: "{{ item.image_name | default('openshift3/ose-pod') }}"
+    test_image: "{{ item.test_image | default('openshift3/ose-pod') }}"
     tls_verify: "{{ item.tls_verify | default(omit) }}"
   when:
     - openshift_additional_registry_credentials is defined


### PR DESCRIPTION
Folks testing the changes felt that this more accurately described the
purpose of this parameter. Since this was never documented anywhere
go ahead and change it now.

/cc @michaelgugino 