### PR TITLE
cluster-monitoring: Fix regex_replace to remove image tag

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/defaults/main.yml
+++ b/roles/openshift_cluster_monitoring_operator/defaults/main.yml
@@ -21,16 +21,16 @@ l_openshift_cluster_monitoring_image_dicts:
     kube_rbac_proxy: quay.io/coreos/kube-rbac-proxy
     oauth_proxy: openshift/oauth-proxy
   openshift-enterprise:
-    prometheus_operator: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('${component}' | regex_escape, 'prometheus-operator') | regex_replace(':[^:]*$' | regex_escape, '') }}"
-    prometheus: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('ose-${component}' | regex_escape, 'prometheus') | regex_replace(':[^:]*$' | regex_escape, '')  }}"
-    alertmanager: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('ose-${component}' | regex_escape, 'prometheus-alertmanager') | regex_replace(':[^:]*$' | regex_escape, '')  }}"
-    node_exporter: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('ose-${component}' | regex_escape, 'prometheus-node-exporter') | regex_replace(':[^:]*$' | regex_escape, '')  }}"
-    prometheus_config_reloader: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('${component}' | regex_escape, 'prometheus-config-reloader') | regex_replace(':[^:]*$' | regex_escape, '')  }}"
-    configmap_reloader: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('${component}' | regex_escape, 'configmap-reloader') | regex_replace(':[^:]*$' | regex_escape, '')  }}"
-    grafana: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('ose-${component}' | regex_escape, 'grafana') | regex_replace(':[^:]*$' | regex_escape, '')  }}"
-    kube_state_metrics: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('${component}' | regex_escape, 'kube-state-metrics') | regex_replace(':[^:]*$' | regex_escape, '')  }}"
-    kube_rbac_proxy: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('${component}' | regex_escape, 'kube-rbac-proxy') | regex_replace(':[^:]*$' | regex_escape, '')  }}"
-    oauth_proxy: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('ose-${component}' | regex_escape, 'oauth-proxy') | regex_replace(':[^:]*$' | regex_escape, '')  }}"
+    prometheus_operator: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('${component}' | regex_escape, 'prometheus-operator') | regex_replace(':[^:]*$', '') }}"
+    prometheus: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('ose-${component}' | regex_escape, 'prometheus') | regex_replace(':[^:]*$', '') }}"
+    alertmanager: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('ose-${component}' | regex_escape, 'prometheus-alertmanager') | regex_replace(':[^:]*$', '') }}"
+    node_exporter: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('ose-${component}' | regex_escape, 'prometheus-node-exporter') | regex_replace(':[^:]*$', '') }}"
+    prometheus_config_reloader: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('${component}' | regex_escape, 'prometheus-config-reloader') | regex_replace(':[^:]*$', '') }}"
+    configmap_reloader: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('${component}' | regex_escape, 'configmap-reloader') | regex_replace(':[^:]*$', '') }}"
+    grafana: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('ose-${component}' | regex_escape, 'grafana') | regex_replace(':[^:]*$', '') }}"
+    kube_state_metrics: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('${component}' | regex_escape, 'kube-state-metrics') | regex_replace(':[^:]*$', '') }}"
+    kube_rbac_proxy: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('${component}' | regex_escape, 'kube-rbac-proxy') | regex_replace(':[^:]*$', '') }}"
+    oauth_proxy: "{{ l_openshift_cluster_monitoring_non_standard_reg_url | regex_replace('ose-${component}' | regex_escape, 'oauth-proxy') | regex_replace(':[^:]*$', '') }}"
 
 openshift_cluster_monitoring_operator_prometheus_operator_repo: "{{l_openshift_cluster_monitoring_image_dicts[openshift_deployment_type]['prometheus_operator']}}"
 openshift_cluster_monitoring_operator_prometheus_repo: "{{l_openshift_cluster_monitoring_image_dicts[openshift_deployment_type]['prometheus']}}"


### PR DESCRIPTION
cc @sdodson @sjenning @vrutkovs 

Tested this with the following:

```
- name: local-ansible-test
  hosts: 127.0.0.1
  connection: local
  tasks:
  - debug:
      msg: "{{ 'registry.reg-aws.openshift.com/openshift3/ose-${component}:v3.11' | regex_replace('${component}' | regex_escape, 'prometheus-operator') | regex_replace(':[^:]*$', '') }}"
  - debug:
      msg: "{{ 'registry.reg-aws.openshift.com/openshift3/ose-${component}:${version}' | regex_replace('${component}' | regex_escape, 'prometheus-operator') | regex_replace(':[^:]*$', '') }}"
```

This should now finally be the solution to https://github.com/openshift/openshift-ansible/issues/9987