### PR TITLE
Add proper liveness and readiness checks for Calico 3.2

### DIFF
--- a/roles/calico_master/tasks/main.yml
+++ b/roles/calico_master/tasks/main.yml
@@ -38,6 +38,10 @@
     node_version: "{{ calico_node_image | regex_replace('^.*node:v?(.*)$', '\\1') }}"
     cnx: "{{ calico_node_image | regex_replace('^.*/(.*)-node:.*$', '\\1') }}"
 
+- name: Calico Master | Set the correct liveness and readiness checks
+  set_fact:
+    calico_binary_checks: "{{ (node_version > '3.2.0' and cnx != 'cnx') or (node_version > '2.2.0' and cnx == 'cnx') | bool }}"
+
 - name: Calico Master | Write Calico v2
   template:
     dest: "{{ mktemp.stdout }}/calico.yml"

--- a/roles/calico_master/templates/calicov3.yml.j2
+++ b/roles/calico_master/templates/calicov3.yml.j2
@@ -339,13 +339,24 @@ spec:
             httpGet:
               path: /liveness
               port: 9099
+{% if calico_binary_checks %}
+              host: localhost
+{% endif %}
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
           readinessProbe:
+{% if calico_binary_checks %}
+            exec:
+              command:
+              - /bin/calico-node
+              - -bird-ready
+              - -felix-ready
+{% else %}
             httpGet:
               path: /readiness
               port: 9099
+{% endif %}
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules


### PR DESCRIPTION
In Calico 3.2, new readiness checks and some changes to the liveness checks were made. This PR will update the liveness and readiness checks if the appropriate version of Calico is being used.