### PR TITLE
Add support for multiple cluster networks

### DIFF
--- a/roles/openshift_control_plane/templates/master.env.j2
+++ b/roles/openshift_control_plane/templates/master.env.j2
@@ -12,7 +12,7 @@ HTTP_PROXY={{ openshift.common.http_proxy | default('') }}
 HTTPS_PROXY={{ openshift.common.https_proxy | default('')}}
 {% endif %}
 {% if 'no_proxy' in openshift.common %}
-NO_PROXY={{ openshift.common.no_proxy | default('') }},{{ openshift.common.portal_net }},{{ openshift_cluster_network_cidr }}
+NO_PROXY={{ openshift.common.no_proxy | default('') }},{{ openshift.common.portal_net }},{{ [openshift_cluster_network_cidr] | union(openshift_cluster_networks | map(attribute='cidr') | list) | join(',') }}
 {% endif %}
 
 {% if openshift_master_debug_level is defined %}

--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -127,6 +127,12 @@ networkConfig:
   clusterNetworks:
   - cidr: {{ openshift_cluster_network_cidr }}
     hostSubnetLength: {{ openshift_host_subnet_length }}
+{% for cluster_network in openshift_cluster_networks %}
+{%   if cluster_network.cidr != openshift_cluster_network_cidr %}
+  - cidr: {{ cluster_network.cidr }}
+    hostSubnetLength: {{ cluster_network.host_subnet_length }}
+{%   endif %}
+{% endfor %}
 {% if r_openshift_master_use_openshift_sdn or r_openshift_master_use_nuage or r_openshift_master_use_contiv or r_openshift_master_use_kuryr or r_openshift_master_sdn_network_plugin_name == 'cni' %}
   networkPluginName: {{ r_openshift_master_sdn_network_plugin_name_default }}
 {% endif %}

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -60,6 +60,7 @@ openshift_master_default_subdomain: "{{ osm_default_subdomain }}"
 
 openshift_portal_net: "{{ openshift_master_portal_net | default(None) }}"
 openshift_cluster_network_cidr: "{{ osm_cluster_network_cidr | default('10.128.0.0/14') }}"
+openshift_cluster_networks: "{{ osm_cluster_networks | default([]) }}"
 openshift_host_subnet_length: "{{ osm_host_subnet_length | default('9') }}"
 
 openshift_hosted_etcd_storage_nfs_directory: '/exports'

--- a/roles/openshift_node/tasks/configure-proxy-settings.yml
+++ b/roles/openshift_node/tasks/configure-proxy-settings.yml
@@ -16,5 +16,5 @@
   - regex: '^HTTPS_PROXY='
     line: "HTTPS_PROXY={{ openshift.common.https_proxy | default('') }}"
   - regex: '^NO_PROXY='
-    line: "NO_PROXY={{ openshift.common.no_proxy | default([]) }},{{ openshift.common.portal_net }},{{ openshift_cluster_network_cidr }}"
+    line: "NO_PROXY={{ openshift.common.no_proxy | default([]) }},{{ openshift.common.portal_net }},{{ [openshift_cluster_network_cidr] | union(openshift_cluster_networks | map(attribute='cidr') | list) | join(',') }}"
   when: ('http_proxy' in openshift.common and openshift.common.http_proxy != '')


### PR DESCRIPTION
Introduces variable `osm_cluster_networks` to support having multiple cluster networks as documented at https://docs.openshift.com/container-platform/3.10/install_config/configuring_sdn.html#configuring-the-pod-network-on-masters

Example as could be used in ansible group_vars:

```
osm_cluster_networks:
- cidr: 172.64.0.0/16
  host_subnet_length: 8
- cidr: 172.65.0.0/16
  host_subnet_length: 8
```

Or the ugly way, directly inserted into hosts file:
```
osm_cluster_networks=[{'cidr': '172.64.0.0/16', 'host_subnet_length': 8}, {'cidr': '100.65.0.0/16', 'host_subnet_length': 8}]
```