### PR TITLE
[openstack] openshift_version seems required

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -568,7 +568,7 @@ the `build_image` playbook.
 If you don't want to be setting the build variables in your inventory, you can
 pass them to ansible-playbook directly:
 
-    ansible-playbook -i inventory openshift-ansible/playbooks/openstack/openshift-cluster/build_image.yml -e openshift_openstack_build_base_image=CentOS-7-x86_64-GenericCloud-1805 -e openshift_openstack_build_network_cidr=192.168.42.0/24
+    ansible-playbook -i inventory openshift-ansible/playbooks/openstack/openshift-cluster/build_image.yml -e openshift_openstack_build_base_image=CentOS-7-x86_64-GenericCloud-1805 -e openshift_openstack_build_network_cidr=192.168.42.0/24 -e 'openshift_version="3.10"'
 
 
 ## Kuryr Networking Configuration
@@ -898,7 +898,7 @@ If you want the volume *created automatically*, set the desired name instead:
 openshift_hosted_registry_storage_volume_name: registry
 ```
 
-The volume will be formatted automaticaly and it will be mounted to one of the
+The volume will be formatted automatically and it will be mounted to one of the
 infra nodes when the registry pod gets started.
 
 ## Swift or Ceph Rados GW Backed Registry Configuration


### PR DESCRIPTION
Without the openshift_version variable:

```
TASK [openshift_repos : Enable RHEL repositories] ********************************************************************************************************************************************************************************************
Tuesday 11 September 2018  08:36:39 -0400 (0:00:35.236)       0:05:35.990 *****
fatal: [10.19.115.122]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'openshift_version' is undefined\n\nThe error appears to have been in '/home/cloud-user/git/openshift-ansible/roles/openshi
ft_repos/tasks/rhel_repos.yml': line 25, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Enable RHEL repositories\n  ^ here\n"}
        to retry, use: --limit @/home/cloud-user/git/openshift-ansible/playbooks/openstack/openshift-cluster/build_image.retry
```

The 'openshift_release’ ansible variable is in the OSEv3.yml file which I’m not sure if it is used… forcing it with:

```
ansible-playbook --user openshift -i inventory ~/git/openshift-ansible/playbooks/openstack/openshift-cluster/build_image.yml -e 'openshift_release=v3.10'
```

It fails…

```
TASK [openshift_sanitize_inventory : Abort when openshift_release is invalid] ****************************************************************************************************************************************************************
Tuesday 11 September 2018  08:52:41 -0400 (0:00:00.155)       0:02:55.288 *****
fatal: [10.19.115.119]: FAILED! => {"changed": false, "msg": "openshift_release is \"v3.10\" which is not a valid version string.\nPlease set openshift_release to a version string and ensure that the value is quoted, ex: openshift_release
=\"3.4\"."}
```

So, this worked:

```
ansible-playbook --user openshift -i inventory ~/git/openshift-ansible/playbooks/openstack/openshift-cluster/build_image.yml -e 'openshift_version=”3.10”’
```