### PR TITLE
reducing /sys/fs/selinux/avc/cache_threshold to 8192 instead of 65535

### DIFF
--- a/roles/tuned/templates/openshift/tuned.conf
+++ b/roles/tuned/templates/openshift/tuned.conf
@@ -7,7 +7,7 @@ summary=Optimize systems running OpenShift (parent profile)
 include=${f:virt_check:{{ openshift_tuned_guest_profile }}:throughput-performance}
 
 [selinux]
-avc_cache_threshold=65536
+avc_cache_threshold=8192
 
 [net]
 nf_conntrack_hashsize=131072


### PR DESCRIPTION
Creating 500 pods  / node and testing various values 512,1024,2048,4096,8192,16384,32768,65535
it was noticed that for case when /sys/fs/selinux/avc/cache_threshold is lower than current 65535 will
result to similar number of entries for RECLAIMS, MISSES in /sys/fs/selinux/avc/cache_stats for case
when 500 pods / OCP node was created

This PR will reduce /sys/fs/selinux/avc/cache_threshold from current 65535 to 8192 based on this test

Signed-off-by: Elvir Kuric <elvirkuric@gmail.com>