### PR TITLE
WIP [3.11] GCP upgrade: don't exclude nodes with tag_ocp-bootstrap

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
@@ -116,16 +116,3 @@
   - import_role:
       name: openshift_web_console
       tasks_from: remove_old_asset_config.yml
-
-# This is a one time migration. No need to save it in the 3.11.
-# https://bugzilla.redhat.com/show_bug.cgi?id=1565736
-- hosts: oo_first_master
-  tasks:
-  - import_role:
-      name: openshift_hosted
-      tasks_from: registry_service_account.yml
-    when: openshift_hosted_manage_registry | default(True) | bool
-  - import_role:
-      name: openshift_hosted
-      tasks_from: remove_legacy_env_variables.yml
-    when: openshift_hosted_manage_registry | default(True) | bool

--- a/roles/openshift_gcp/tasks/setup_scale_group_facts.yml
+++ b/roles/openshift_gcp/tasks/setup_scale_group_facts.yml
@@ -4,7 +4,7 @@
     name: "{{ hostvars[item].gce_name }}"
     groups: nodes, new_nodes
     openshift_node_group_name: "{{ openshift_gcp_node_group_mapping['compute'] }}"
-  with_items: "{{ groups['tag_ocp-node'] | default([]) | difference(groups['tag_ocp-bootstrap'] | default([])) }}"
+  with_items: "{{ groups['tag_ocp-node'] | default([]) }}"
 
 - name: Add bootstrap node instances as nodes
   add_host:
@@ -24,7 +24,7 @@
     name: "{{ hostvars[item].gce_name }}"
     groups: nodes, new_nodes
     openshift_node_group_name: "{{ openshift_gcp_node_group_mapping['infra'] }}"
-  with_items: "{{ groups['tag_ocp-infra-node'] | default([]) | difference(groups['tag_ocp-bootstrap'] | default([])) }}"
+  with_items: "{{ groups['tag_ocp-infra-node'] | default([]) }}"
 
 - name: Add masters to requisite groups
   add_host:


### PR DESCRIPTION
Current status:

* [x] https://github.com/openshift/release/pull/1457
* [x] https://github.com/openshift/release/pull/1504
* [ ] ~~https://github.com/openshift/ci-operator/issues/147~~
* [ ] https://github.com/openshift/release/pull/1519