### PR TITLE
[release-3.10] Retry our etcd health check

### DIFF
--- a/roles/etcd/tasks/upgrade/upgrade_image.yml
+++ b/roles/etcd/tasks/upgrade/upgrade_image.yml
@@ -2,6 +2,10 @@
 # INPUT r_etcd_upgrade_version
 - name: Verify cluster is healthy pre-upgrade
   command: "{{ etcdctlv2 }} cluster-health"
+  register: cluster_health
+  retries: 30
+  delay: 6
+  until: cluster_health.rc == 0
 
 - name: Get current image
   shell: "grep 'ExecStart=' {{ etcd_service_file }} | awk '{print $NF}'"

--- a/roles/etcd/tasks/upgrade/upgrade_rpm.yml
+++ b/roles/etcd/tasks/upgrade/upgrade_rpm.yml
@@ -10,6 +10,11 @@
 
 - name: Verify cluster is healthy pre-upgrade
   command: "{{ etcdctlv2 }} cluster-health"
+  register: cluster_health
+  retries: 30
+  delay: 6
+  until: cluster_health.rc == 0
+
 
 - set_fact:
     l_etcd_target_package: "{{ 'etcd' if r_etcd_upgrade_version is not defined else 'etcd-'+r_etcd_upgrade_version+'*' }}"

--- a/roles/etcd/tasks/upgrade_static.yml
+++ b/roles/etcd/tasks/upgrade_static.yml
@@ -7,6 +7,10 @@
 
 - name: Verify cluster is healthy pre-upgrade
   command: "{{ etcdctlv2 }} cluster-health"
+  register: cluster_health
+  retries: 30
+  delay: 6
+  until: cluster_health.rc == 0
 
 - name: Check for old etcd service files
   stat:


### PR DESCRIPTION
This is a followup attempt to fix a bug. Originally dns was failing due
to problems with the sdn pod. Now it appears that etcd is just prone to
taking longer than expected to become healthy. Wait up to 3 minutes for
etcd to come back online

Backports #10008 