### PR TITLE
Update sync daemonset annotation checks

### DIFF
--- a/roles/openshift_manage_node/tasks/config.yml
+++ b/roles/openshift_manage_node/tasks/config.yml
@@ -9,3 +9,21 @@
   until: node_schedulable is succeeded
   when: "'nodename' in openshift.node"
   delegate_to: "{{ openshift_master_host }}"
+
+- name: Wait for sync DS to set annotations on all nodes
+  oc_obj:
+    state: list
+    kind: node
+    selector: ""
+  register: node_status
+  until:
+    - node_status.results is defined
+    - node_status.results.results is defined
+    - node_status.results.results | length > 0
+    - node_status.results.results[0]['items']
+        | map(attribute='metadata.annotations') | map('list') | flatten
+        | select('match', '[\"node.openshift.io/md5sum\"]') | list | length ==
+      node_status.results.results[0]['items'] | length
+  retries: 60
+  delay: 10
+  delegate_to: "{{ openshift_master_host }}"

--- a/roles/openshift_node_group/tasks/sync.yml
+++ b/roles/openshift_node_group/tasks/sync.yml
@@ -72,7 +72,7 @@
   retries: 60
   delay: 10
 
-- name: Wait for sync DS to set annotations on all nodes
+- name: Wait for sync DS to set annotations on master nodes
   oc_obj:
     state: list
     kind: node
@@ -83,8 +83,9 @@
     - node_status.results.results is defined
     - node_status.results.results | length > 0
     - node_status.results.results[0]['items']
-     | map(attribute='metadata.annotations') | map('list') | flatten
-     | select('match', '[\"node.openshift.io/md5sum\"]') | list | length == node_status.results.results | length
+        | map(attribute='metadata.annotations') | map('list') | flatten
+        | select('match', '[\"node.openshift.io/md5sum\"]') | list | length ==
+      node_status.results.results[0]['items'] | length
   retries: 60
   delay: 10
 


### PR DESCRIPTION
* Use correct variable when checkin for expected number of master nodes
* Check that sync annotations were set on all nodes after schedulability is set

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1628485