### PR TITLE
openshift_storage_nfs_lvm: fix with_sequence

### DIFF
--- a/roles/openshift_storage_nfs_lvm/tasks/nfs.yml
+++ b/roles/openshift_storage_nfs_lvm/tasks/nfs.yml
@@ -23,8 +23,5 @@
   lineinfile: dest=/etc/exports
               regexp="^{{ osnl_mount_dir }}/{{ item }} "
               line="{{ osnl_mount_dir }}/{{ item }} {{osnl_nfs_export_options}}"
-  with_sequence:
-    start: "{{osnl_volume_num_start}}"
-    count: "{{osnl_number_of_volumes}}"
-    format: "{{osnl_volume_prefix}}{{osnl_volume_size}}g%04d"
+  with_sequence: start={{osnl_volume_num_start}} count={{osnl_number_of_volumes}} format={{osnl_volume_prefix}}{{osnl_volume_size}}g%04d
   notify: restart nfs


### PR DESCRIPTION
This fixes the with_sequence parameters which doesn't work anymore in recent ansible versions. This change makes it in line with the format used in main.yml