### PR TITLE
Fix volume recycler configuration on upgrade

### DIFF
--- a/roles/openshift_control_plane/tasks/upgrade.yml
+++ b/roles/openshift_control_plane/tasks/upgrade.yml
@@ -84,11 +84,11 @@
   yedit:
     src: "{{ openshift.common.config_base }}/master/master-config.yaml"
     key: "kubernetesMasterConfig.controllerArguments.pv-recycler-pod-template-filepath-nfs"
-    value: "/etc/origin/master/recycler_pod.yaml"
-    value_type: list
+    value:
+    - /etc/origin/master/recycler_pod.yaml
 - name: Update controller-manager to have hostpath recycler pod
   yedit:
     src: "{{ openshift.common.config_base }}/master/master-config.yaml"
     key: "kubernetesMasterConfig.controllerArguments.pv-recycler-pod-template-filepath-hostpath"
-    value: "/etc/origin/master/recycler_pod.yaml"
-    value_type: list
+    value:
+    - /etc/origin/master/recycler_pod.yaml


### PR DESCRIPTION
It was setting the value as "key: value" but master-config is expecting
a list of values.
```
  key:
  - value1
```

/cc @gnufied 