### PR TITLE
[3.10] ensure atomic and skopeo are installed

### DIFF
--- a/roles/container_runtime/tasks/package_crio.yml
+++ b/roles/container_runtime/tasks/package_crio.yml
@@ -38,8 +38,10 @@
   until: result is succeeded
   vars:
     crio_pkgs:
-      - "cri-o"
-      - "cri-tools"
+      - cri-o
+      - cri-tools
+      - atomic
+      - skopeo
 
 - name: Remove CRI-O default configuration files
   file:

--- a/roles/container_runtime/tasks/package_docker.yml
+++ b/roles/container_runtime/tasks/package_docker.yml
@@ -22,14 +22,17 @@
 # Note: The curr_docker_version.stdout check can be removed when https://github.com/ansible/ansible/issues/33187 gets fixed.
 - name: Install Docker
   package:
-    name: "docker{{ '-' + docker_version if docker_version is defined else '' }}"
+    name: "{{ pkg_list | join(',') }}"
     state: present
   when:
   - not (openshift_is_atomic | bool)
-  - not (curr_docker_version is skipped)
-  - not (curr_docker_version.stdout != '')
   register: result
   until: result is succeeded
+  vars:
+    pkg_list:
+    - "docker{{ '-' + docker_version if docker_version is defined else '' }}"
+    - atomic
+    - skopeo
 
 - block:
   # Extend the default Docker service unit file when using iptables-services


### PR DESCRIPTION
This packages are required for various things such as
docker_image_availability health checks.