### PR TITLE
test/ci: setup network manager before prerequisites

### DIFF
--- a/test/ci/launch.yml
+++ b/test/ci/launch.yml
@@ -76,5 +76,7 @@
     - wait_for_connection: {}
     - setup: {}
 
+
+- import_playbook: ../../playbooks/openshift-node/network_manager.yml
 - import_playbook: ../../playbooks/prerequisites.yml
 - import_playbook: ../../playbooks/deploy_cluster.yml

--- a/test/ci/vars.yml.sample
+++ b/test/ci/vars.yml.sample
@@ -4,6 +4,7 @@ vm_prefix: "ci_test"
 type: aws
 aws_user: "ec2-user"
 python: "/usr/bin/python"
+
 aws_key: "libra"
 aws_region: "us-east-1"
 aws_cluster_id: "ci"


### PR DESCRIPTION
Official CentOS AMI doesn't have NM setup by default, so it needs to run this 
playbook first