### PR TITLE
sync: remove existing pods if any present

### DIFF
--- a/roles/openshift_node_group/tasks/sync.yml
+++ b/roles/openshift_node_group/tasks/sync.yml
@@ -44,6 +44,14 @@
     - l_os_istag_del.rc != 0
     - "'have a resource type' not in l_os_istag_del.stderr"
 
+- name: Remove existing pods if present
+  oc_obj:
+    state: absent
+    kind: pods
+    name: sync
+    namespace: openshift-node
+  ignore_errors: true
+
 - name: Apply the config
   shell: >
     {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig apply -f {{ mktemp.stdout }}


### PR DESCRIPTION
This ensures a new sync DS is rolled out when template is updated, which is 
required for minor upgrades