### PR TITLE
[3.11] ensure sync DS is updated before draining masters

### DIFF
--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -213,6 +213,13 @@
       msg: "Upgrade cannot continue. The following masters did not finish reconciling: {{ reconcile_failed | join(',') }}"
     when: reconcile_failed | length > 0
 
+- name: Update sync DS
+  hosts: oo_first_master
+  tasks:
+  - import_role:
+      name: openshift_node_group
+      tasks_from: sync.yml
+
 - name: Drain and upgrade master nodes
   hosts: oo_masters_to_config:&oo_nodes_to_upgrade
   # This var must be set with -e on invocation, as it is not a per-host inventory var
@@ -228,10 +235,3 @@
       tasks_from: config.yml
     vars:
       openshift_master_host: "{{ groups.oo_first_master.0 }}"
-
-- name: Update sync DS
-  hosts: oo_first_master
-  tasks:
-  - import_role:
-      name: openshift_node_group
-      tasks_from: sync.yml

--- a/roles/openshift_node_group/tasks/sync.yml
+++ b/roles/openshift_node_group/tasks/sync.yml
@@ -44,6 +44,14 @@
     - l_os_istag_del.rc != 0
     - "'have a resource type' not in l_os_istag_del.stderr"
 
+- name: Remove existing pods if present
+  oc_obj:
+    state: absent
+    kind: pods
+    name: sync
+    namespace: openshift-node
+  ignore_errors: true
+
 - name: Apply the config
   shell: >
     {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig apply -f {{ mktemp.stdout }}


### PR DESCRIPTION
This ensures new sync DS is applied before draining masters and updating them,
so that on 3.10 -> 3.11 upgrade node annotations are set

This includes https://github.com/openshift/openshift-ansible/pull/10076 to 
delete existing sync DS are removed and new template is applied

Fixes https://github.com/openshift/openshift-ansible/pull/10077