### PR TITLE
Enable openshift-aws-autoscaler

### DIFF
--- a/playbooks/openshift-cluster-autoscaler/config.yml
+++ b/playbooks/openshift-cluster-autoscaler/config.yml
@@ -5,5 +5,4 @@
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 
-
 - import_playbook: private/config.yml

--- a/playbooks/openshift-cluster-autoscaler/private/config.yml
+++ b/playbooks/openshift-cluster-autoscaler/private/config.yml
@@ -1,4 +1,17 @@
 ---
+- name: Setup master instances
+  hosts: localhost
+  tasks:
+  - block:
+    - import_role:
+        name: openshift_aws
+        tasks_from: setup_master_group.yml
+    - name: add a master to oo_first_master group
+      add_host:
+        groups: oo_first_master
+        hostname: "{{ groups['masters'][0] }}"
+    when: openshift_aws_clusterid is defined
+
 - name: Cluster Auto Scaler Install Checkpoint Start
   hosts: all
   gather_facts: false


### PR DESCRIPTION
Enable openshift-aws-autoscaler

Minimum req'd keys...
```
openshift_cluster_autoscaler_install: true
openshift_cluster_autoscaler_node_groups:
- name: "ccallegar2 compute group 1"
  min: "6"
  max: "10"
```