### PR TITLE
disable autoupdate for waagent on azure

### DIFF
--- a/playbooks/azure/openshift-cluster/build_node_image.yml
+++ b/playbooks/azure/openshift-cluster/build_node_image.yml
@@ -79,7 +79,8 @@
       regexp: "{{ item.regexp }}"
       line: "{{ item.line }}"
     with_items:
-    - { regexp: '^ResourceDisk\.Format=', line: 'ResourceDisk.Format=n' }
+    - { regexp: 'ResourceDisk\.Format=', line: 'ResourceDisk.Format=n' }
+    - { regexp: 'AutoUpdate\.Enabled=', line: 'AutoUpdate.Enabled=n' }
 
   - name: persist oreg_url
     copy:


### PR DESCRIPTION
should save us a bit more than a minute on create and scale, and a bit more than a minute per vm on upgrade.