### PR TITLE
make sure `openshift_use_nsx` is always defined during 3.9 -> 3.10 upgrade

### DIFF
--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -43,7 +43,7 @@
   package:
     name: openvswitch
     state: absent
-  when: not (openshift_is_atomic | bool or openshift_use_nsx | bool)
+  when: not (openshift_is_atomic | bool or openshift_use_nsx | default(false) | bool)
 
 - name: Remove old service information
   file:
@@ -58,7 +58,7 @@
   file:
     path: /etc/systemd/system/openvswitch.service
     state: absent
-  when: not openshift_use_nsx | bool
+  when: not openshift_use_nsx | default(false) | bool
 
 - name: Move existing credentials and configuration into bootstrap configuration
   import_tasks: bootstrap_changes.yml

--- a/roles/openshift_node/tasks/upgrade/stop_services.yml
+++ b/roles/openshift_node/tasks/upgrade/stop_services.yml
@@ -11,7 +11,7 @@
   service:
     name: openvswitch
     state: stopped
-  when: not openshift_use_nsx | bool
+  when: not openshift_use_nsx | default(false) | bool
   failed_when: false
 
 - service:


### PR DESCRIPTION
This var was introduced in #10023 but didn't have default setting set