### PR TITLE
CloudForm node_selector format 

### DIFF
--- a/roles/openshift_management/defaults/main.yml
+++ b/roles/openshift_management/defaults/main.yml
@@ -6,7 +6,7 @@ openshift_management_project_description: CloudForms Management Engine
 # Number of retries when waiting for the app to start (retried every 30 seconds)
 openshift_management_pod_rollout_retries: 30
 # Node selector for project:
-openshift_management_nodeselector: "{{ openshift_hosted_infra_selector | default(['node-role.kubernetes.io/infra=true'])}}"
+openshift_management_nodeselector: "{{ openshift_hosted_infra_selector | default(['node-role.kubernetes.io/infra=true']) | map_from_pairs }}"
 
 ######################################################################
 # BASE TEMPLATE AND DATABASE OPTIONS

--- a/roles/openshift_management/tasks/main.yml
+++ b/roles/openshift_management/tasks/main.yml
@@ -16,7 +16,7 @@
     state: present
     name: "{{ openshift_management_project }}"
     display_name: "{{ openshift_management_project_description }}"
-    node_selector: "{{ openshift_management_nodeselector }}"
+    node_selector: "{{ openshift_management_nodeselector | map_to_pairs }}"
 
 - name: Create and Authorize Management Accounts
   include_tasks: accounts.yml


### PR DESCRIPTION
Issue #10101

- Add 'map_from_pairs' to default nodeselector value ==> return value wil be ` 'a': 'b' `
- Add 'map_to_pairs' to the task ==> return value will be `'a=b'`

With this changes,
- we can use the default value( 'node-role.kubernetes.io/infra=true' )
- we can use `openshift_management_nodeselector: {'region': 'infra'}` like other nodeselector

**Note**
`openshift_hosted_infra_selector` style must to be `region=infra`

