### PR TITLE
Don't install NM on atomic systems

### DIFF
--- a/playbooks/openshift-node/private/network_manager.yml
+++ b/playbooks/openshift-node/private/network_manager.yml
@@ -3,12 +3,19 @@
   hosts: oo_all_hosts
   become: yes
   tasks:
+  - name: Detecting Operating System
+    shell: ls /run/ostree-booted
+    ignore_errors: yes
+    failed_when: false
+    register: ostree_output
+
   - name: install NetworkManager
     package:
       name: 'NetworkManager'
       state: present
     register: result
     until: result is succeeded
+    when: ostree_output.rc != 0
 
   - name: configure NetworkManager
     lineinfile:


### PR DESCRIPTION
This playbook is used in custom AWS provisioner's launch.yml, but package check
should be skipped on Atomic systems