### PR TITLE
Ensure dnsmasq is restarted during upgrades

### DIFF
--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -65,6 +65,16 @@
 - import_tasks: dnsmasq_install.yml
 - import_tasks: dnsmasq.yml
 
+- name: ensure dnsmasq is always restarted
+  debug:
+    msg: "Restarting dnsmasq"
+  # changed_when: True required for debug tasks to trigger handlers.
+  changed_when: True
+  notify: restart dnsmasq
+
+# Need to flush handlers here so dnsmasq is restarted.
+- meta: flush_handlers
+
 # Restart all services
 - import_tasks: upgrade/restart.yml
 
@@ -80,5 +90,3 @@
   until: node_upgrade_oc_csr_approve is succeeded
 
 - import_tasks: journald.yml
-
-- meta: flush_handlers


### PR DESCRIPTION
Currently, upgrades are failing because sdn pod
does not notify dnsmasq to update dns server list.

This commit ensures dnsmasq is restarted before docker
is restarted so static pods get valid networking.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1629700