### PR TITLE
Fix Calico launch on multi-master cluster

### DIFF
--- a/roles/calico_master/tasks/main.yml
+++ b/roles/calico_master/tasks/main.yml
@@ -113,6 +113,7 @@
   when: (node_version | regex_search('^[0-9]\.[0-9]\.[0-9]') and node_version >= '3.0.0') or (node_version == 'master') or (cnx == "cnx" and node_version >= '2.0.0')
 
 - name: Calico Master | Launch Calico
+  run_once: true
   command: >
     {{ openshift_client_binary }} apply
     -f {{ mktemp.stdout }}/calico.yml


### PR DESCRIPTION
example error:
    [0;31m    Error from server (AlreadyExists): error when creating "/tmp/openshift-ansible-zAWzABP/calico.yml": clusterroles.authorization.openshift.io "calico-kube-controllers" already exists[0m
    [0;31m    Error from server (AlreadyExists): error when creating "/tmp/openshift-ansible-zAWzABP/calico.yml": clusterroles.authorization.openshift.io "calico-node" already exists[0m
    [0;31m    Error from server (AlreadyExists): error when creating "/tmp/openshift-ansible-zAWzABP/calico.yml": jobs.batch "complete-upgrade" already exists[0m
    [0;31m    Error from server (AlreadyExists): error when creating "/tmp/openshift-ansible-zAWzABP/calico.yml": serviceaccounts "calico-upgrade-job" already exists[0m
    [0;31m    Error from server (AlreadyExists): error when creating "/tmp/openshift-ansible-zAWzABP/calico.yml": serviceaccounts "calico-node" already exists[0m

