### PR TITLE
Simplify match filter when looking for sync annotations

### DIFF
--- a/roles/openshift_manage_node/tasks/config.yml
+++ b/roles/openshift_manage_node/tasks/config.yml
@@ -22,7 +22,7 @@
     - node_status.results.results | length > 0
     - node_status.results.results[0]['items']
         | map(attribute='metadata.annotations') | map('list') | flatten
-        | select('match', '[\"node.openshift.io/md5sum\"]') | list | length ==
+        | select('match', 'node.openshift.io/md5sum') | list | length ==
       node_status.results.results[0]['items'] | length
   retries: 60
   delay: 10

--- a/roles/openshift_node_group/tasks/sync.yml
+++ b/roles/openshift_node_group/tasks/sync.yml
@@ -84,7 +84,7 @@
     - node_status.results.results | length > 0
     - node_status.results.results[0]['items']
         | map(attribute='metadata.annotations') | map('list') | flatten
-        | select('match', '[\"node.openshift.io/md5sum\"]') | list | length ==
+        | select('match', 'node.openshift.io/md5sum') | list | length ==
       node_status.results.results[0]['items'] | length
   retries: 60
   delay: 10


### PR DESCRIPTION
The filter uses the search string as a regex, so it may match other 
annotations (it would match `test: foo`) 

cc @jupierce 