### PR TITLE
Make cloud-user SSH key maintenance more reliable

### DIFF
--- a/roles/openshift_gcp/templates/provision_ssh.j2.sh
+++ b/roles/openshift_gcp/templates/provision_ssh.j2.sh
@@ -23,7 +23,7 @@ if [[ -n "{{ openshift_gcp_ssh_private_key }}" ]]; then
         pub_key=$(cut -d ' ' -f 2 <  "${pub_file}")
     fi
     key_tmp_file='/tmp/ocp-gce-keys'
-    if ! gcloud --project "{{ openshift_gcp_project }}" compute project-info describe | grep -q "$pub_key"; then
+    if ! gcloud --project "{{ openshift_gcp_project }}" compute project-info describe | grep "$pub_key" | grep -q cloud-user; then
         if gcloud --project "{{ openshift_gcp_project }}" compute project-info describe | grep -q ssh-rsa; then
             gcloud --project "{{ openshift_gcp_project }}" compute project-info describe | grep ssh-rsa | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/value: //' > "$key_tmp_file"
         fi


### PR DESCRIPTION
Check GCP project metadata for cloud-user's SSH key more specifically. Before,
the key for cloud-user would only be updated if the key's contents were present
anywhere in the metadata value; sometimes, the key was present for the 'default'
user, but missing from cloud-user, causing the script to skip re-adding the key
for cloud-user, making the instances inaccessible to ansible.

/cc @smarterclayton 