### PR TITLE
[release-3.7] Ensure master facts are set during node scale-up

### DIFF
--- a/playbooks/byo/openshift-node/scaleup.yml
+++ b/playbooks/byo/openshift-node/scaleup.yml
@@ -16,4 +16,9 @@
 
 - include: ../../common/openshift-cluster/std_include.yml
 
+- name: Ensure master facts are set
+  hosts: oo_masters_to_config
+  roles:
+  - openshift_master_facts
+
 - include: ../../common/openshift-node/config.yml


### PR DESCRIPTION
If the cached facts file (openshift.facts) on masters is missing or
does not contain the 'master' section, the necessary master facts will
not be created during the fact initialization in std_include.yml.

This commit adds a step to ensure all master facts are set prior to
performing node scaleup.

Bug: 1627736