### PR TITLE
Added capability to fix static addresses to openshift_ovirt provider vms

### DIFF
--- a/playbooks/ovirt/provisioning-vars.yaml.example
+++ b/playbooks/ovirt/provisioning-vars.yaml.example
@@ -79,4 +79,40 @@ node_vm:
       name: localvol_disk
       interface: virtio
   state: running
-...
+
+openshift_ovirt_vm_manifest:
+######################################
+# Single Node Static Ip addresses
+######################################
+- name: 'master'
+  count: 1
+  profile: 'master_vm'
+  nic_mode:
+      master0:
+        nic_ip_address: '192.168.123.165'
+        nic_netmask: '255.255.255.0'
+        nic_gateway: '192.168.123.1'
+        nic_on_boot: True
+#######################################
+# Multiple Node Static Ip addresses
+#######################################
+- name: 'node'
+  count: 2
+  profile: 'node_vm'
+  nic_mode:
+      node0:     # This must fit the same name as this kind of vms. (e.g) if the name is test, this must be test0
+          nic_ip_address: '192.168.123.166'
+          nic_netmask: '255.255.255.0'
+          nic_gateway: '192.168.123.1'
+          nic_on_boot: True
+      node1:
+        nic_ip_address: '192.168.123.168'
+        nic_netmask: '255.255.255.0'
+        nic_gateway: '192.168.123.1'
+        nic_on_boot: True
+################################################
+# Multiple/Single Node Dynamic Ip addresses
+################################################
+- name: 'lb'
+  count: 1
+  profile: 'node_vm'

--- a/roles/openshift_ovirt/README.md
+++ b/roles/openshift_ovirt/README.md
@@ -1,16 +1,13 @@
-OpenShift oVirt
-=============
+# OpenShift oVirt
 
 OpenShift Provisioned on Red Hat Virtualization and oVirt
 
-Role Tasks
-----------
+## Role Tasks
 
 * `build_vm_list.yml`: Creates a list of virtual machine definitions and
   affinity groups based on a simple manifest (below)
 
-Role Variables
---------------
+## Role Variables
 
 For documentation on virtual machine profile options, see the [oVirt Ansible VM-Infra Documentation](https://github.com/oVirt/ovirt-ansible-vm-infra)
 
@@ -18,6 +15,28 @@ For documentation on virtual machine profile options, see the [oVirt Ansible VM-
 |---------------------------|---------------|-----------------------------------------------------------------------------------------|
 | openshift_ovirt_vm_profile  | See below.    | Dictionary of dictionaries providing common VM parameters for virtual machine creation. |
 | openshift_ovirt_vm_manifest | See below.    | List of dictionaries specifying node base name, count, and which of the above profiles to apply. The default creates three master nodes, three infrastructure nodes, one application node, and a load balancer. |
+
+The `openshift_ovirt_vm_manifest` variable can contain following attributes
+
+| Name      | Type | Default value |                                                                                                                 |
+|-----------|------|---------------|-----------------------------------------------------------------------------------------------------------------|
+| nic_mode  | Dict | UNDEF         | If you define this variable means that the interface on the VM will have static address instead of dynamic one. |
+
+Below `nic_mode` we can find this other parameters
+
+| Name            |  Type  | Default value |                                          |
+|-----------------|--------|---------------|------------------------------------------|
+| nic_ip_address  | String | UNDEF         | Static ipaddress for vm interface.       | 
+| nic_netmask     | String | UNDEF         | Static Netmask for vm interface .        | 
+| nic_gateway     | String | UNDEF         | Static Gateway address for vm interface. | 
+| nic_on_boot     | Bool   | True          | The interface will be up on boot.        | 
+| nic_name        | String | 'eth0'        | The Interface name for the vm.           | 
+| dns_servers     | String | UNDEF         | The DNS set on the VM.                   | 
+
+
+## Examples
+
+- **openshift_ovirt_vm_profile**
 
 ```
 openshift_ovirt_vm_profile:
@@ -59,24 +78,113 @@ openshift_ovirt_vm_profile:
     state: running
 ```
 
+
+- **openshift_ovirt_vm_manifest**
 ```
 openshift_ovirt_vm_manifest:
+#######################################
+# Multiple Node Static Ip addresses
+#######################################
 - name: 'master'
   count: 3
   profile: 'master'
+  nic_mode:
+      # This must fit the same name as this kind of vms. (e.g) if the name is test, this must be test0
+      master0:
+        nic_ip_address: '192.168.123.160'
+        nic_netmask: '255.255.255.0'
+        nic_gateway: '192.168.123.1'
+        nic_on_boot: True
+        nic_name: 'eth0'
+        dns_servers: "192.168.1.100"
+      master1:
+        nic_ip_address: '192.168.123.161'
+        nic_netmask: '255.255.255.0'
+        nic_gateway: '192.168.123.1'
+        nic_on_boot: True
+        nic_name: 'nic0'
+        dns_servers: "192.168.1.100"
+      master2:
+        nic_ip_address: '192.168.123.162'
+        nic_netmask: '255.255.255.0'
+        nic_gateway: '192.168.123.1'
+        nic_on_boot: True
+        dns_servers: "192.168.1.100"
 - name: 'infra'
-  count: 3
+  count: 2
   profile: 'node'
+  nic_mode:
+      infra0:
+        nic_ip_address: '192.168.123.163'
+        nic_netmask: '255.255.255.0'
+        nic_gateway: '192.168.123.1'
+        nic_on_boot: True
+        dns_servers: "192.168.1.100"
+      infra1:
+        nic_ip_address: '192.168.123.164'
+        nic_netmask: '255.255.255.0'
+        nic_gateway: '192.168.123.1'
+        nic_on_boot: True
+        dns_servers: "192.168.1.100"
+
+################################################
+# Multiple/Single Node Dynamic Ip addresses
+################################################
 - name: 'compute'
-  count: 1
+  count: 2
   profile: 'node'
+
+######################################
+# Single Node Static Ip addresses
+######################################
 - name: 'lb'
   count: 1
-  profile: 'node'
+  profile: 'node_vm'
+  nic_mode:
+      lb0:
+        nic_ip_address: '192.168.123.170'
+        nic_netmask: '255.255.255.0'
+        nic_gateway: '192.168.123.1'
+        dns_servers: "192.168.1.100"
 ```
 
 Example Playbook
 ----------------
+
+```
+---
+- name: Deploy oVirt template and virtual machines
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  pre_tasks:
+    - name: Log in to oVirt
+      ovirt_auth:
+        url: "{{ engine_url }}"
+        username: "{{ engine_user }}"
+        password: "{{ engine_password }}"
+        ca_file: "{{ engine_cafile | default(omit) }}"
+        insecure: "{{ engine_insecure | default(true) }}"
+      tags:
+        - always
+    - name: Build virtual machine facts
+      import_role:
+        name: openshift_ovirt
+        tasks_from: build_vm_list.yml
+
+  roles:
+    - oVirt.image-template
+    - oVirt.vm-infra
+
+  post_tasks:
+    - name: Logout from oVirt
+      ovirt_auth:
+        state: absent
+        ovirt_auth: "{{ ovirt_auth }}"
+      tags:
+        - always
+```
 
 License
 -------

--- a/roles/openshift_ovirt/tasks/build_vm_list.yml
+++ b/roles/openshift_ovirt/tasks/build_vm_list.yml
@@ -17,6 +17,15 @@
       'cloud_init':
       {
       'host_name': '{{ item.name }}{{ iter }}.{{ openshift_ovirt_dns_zone }}',
+      {% if item.nic_mode is defined -%}
+      'nic_boot_protocol': 'static',
+      'nic_ip_address': '{{ item["nic_mode"][item["name"] + iter | string ]["nic_ip_address"] }}',
+      'nic_netmask': '{{ item["nic_mode"][item["name"] + iter | string ]["nic_netmask"] }}',
+      'nic_gateway': '{{ item["nic_mode"][item["name"] + iter | string ]["nic_gateway"] }}',
+      'nic_on_boot': {{ item["nic_mode"][item["name"] + iter | string ]["nic_on_boot"] | default(true) | bool }},
+      'nic_name': '{{ item["nic_mode"][item["name"] + iter | string ]["nic_name"] | default("eth0") }}',
+      'dns_servers': '{{ item["nic_mode"][item["name"] + iter | string ]["dns_servers"] }}',
+      {% endif -%}
       'authorized_ssh_keys': '{{ openshift_ovirt_ssh_key }}'
       },
       'profile':  {{ openshift_ovirt_vm_profile[ item.profile ] }} ,


### PR DESCRIPTION
This feature gives openshift_ovirt the capability to select static addresses on oVirt provider passing it using cloud-init as messenger.

- Definition as variables on manifest
```
######################################
# Single Node Static Ip addresses
######################################
- name: 'master'
  count: 1
  profile: 'master_vm'
  nic_mode:
      master0:
        nic_ip_address: '192.168.123.165'
        nic_netmask: '255.255.255.0'
        nic_gateway: '192.168.123.1'
        nic_on_boot: True
#######################################
# Multiple Node Static Ip addresses
#######################################
- name: 'node'
  count: 2
  profile: 'node_vm'
  nic_mode:
      # This must fit the same name as this kind of vms. (e.g) if the name is test, this must be test0
      node0:     
          nic_ip_address: '192.168.123.166'
          nic_netmask: '255.255.255.0'
          nic_gateway: '192.168.123.1'
          nic_on_boot: True
      node1:
        nic_ip_address: '192.168.123.168'
        nic_netmask: '255.255.255.0'
        nic_gateway: '192.168.123.1'
        nic_on_boot: True
################################################
# Multiple/Single Node Dynamic Ip addresses
################################################
- name: 'lb'
  count: 1
  profile: 'node_vm'
```