### PR TITLE
[release-3.9] Ensure master facts are set during node scale-up

### DIFF
--- a/playbooks/openshift-node/scaleup.yml
+++ b/playbooks/openshift-node/scaleup.yml
@@ -36,4 +36,9 @@
     l_openshift_version_set_hosts: "oo_nodes_to_config:!oo_first_master"
     l_openshift_version_check_hosts: "oo_nodes_to_config"
 
+- name: Ensure master facts are set
+  hosts: oo_masters_to_config
+  roles:
+  - openshift_master_facts
+
 - import_playbook: private/config.yml


### PR DESCRIPTION
If the cached facts file (openshift.facts) on masters is missing or
does not contain the 'master' section, the necessary master facts will
not be created during the fact initialization in std_include.yml.

This commit adds a step to ensure all master facts are set prior to
performing node scaleup.

Bug: 1630479

Forward-port of #10129.