### PR TITLE
[3.10] Ensure atomic hosts prepull node image during pre-upgrade

### DIFF
--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -22,6 +22,7 @@ openshift_image_default: "{{ l_os_registry_url | regex_replace('${component}' | 
 openshift_cli_image: "{{ (system_images_registry == 'docker') | ternary(openshift_image_default, (openshift_image_default.split('/')|length==2) | ternary(system_images_registry + '/' + openshift_image_default, openshift_image_default)) }}"
 system_openshift_cli_image: "{{ (system_images_registry == 'docker') | ternary('docker:' + openshift_cli_image, openshift_cli_image) }}"
 osn_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'node') }}"
+osn_pod_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'pod') }}"
 osm_image: "{{ l_osm_registry_url | regex_replace('${component}' | regex_escape, 'control-plane') }}"
 
 repoquery_cmd: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --latest-limit 1 -d 0', 'repoquery --plugins') }}"

--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: reload systemd units
+  command: systemctl daemon-reload
+  when:
+  - (not skip_node_svc_handlers | default(False) | bool)
+
 - name: restart NetworkManager
   systemd:
     name: NetworkManager
@@ -11,10 +16,5 @@
   systemd:
     name: dnsmasq
     state: restarted
-  when:
-  - (not skip_node_svc_handlers | default(False) | bool)
-
-- name: reload systemd units
-  command: systemctl daemon-reload
   when:
   - (not skip_node_svc_handlers | default(False) | bool)

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -1,20 +1,4 @@
 ---
-- name: Check that node image is present
-  command: 'docker images -q "{{ osn_image }}"'
-  register: node_image
-
-# This task runs async to save time while the node is being configured
-- name: Pre-pull node image
-  docker_image:
-    name: "{{ osn_image }}"
-  environment:
-    NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
-  when: node_image.stdout_lines == []
-  # 10 minutes to pull the image
-  async: 600
-  poll: 0
-  register: image_prepull
-
 - name: Install the systemd units
   import_tasks: systemd_units.yml
 
@@ -57,15 +41,3 @@
 - name: include aws provider credentials
   import_tasks: aws.yml
   when: not (openshift_node_use_instance_profiles | default(False))
-
-- name: Check status of node image pre-pull
-  async_status:
-    jid: "{{ image_prepull.ansible_job_id }}"
-  register: job_result
-  until: job_result.finished
-  when:
-  - node_image.stdout_lines == []
-  - not openshift_is_atomic | bool
-  retries: 20
-  delay: 30
-  failed_when: false

--- a/roles/openshift_node/tasks/copy_image_to_ostree.yml
+++ b/roles/openshift_node/tasks/copy_image_to_ostree.yml
@@ -1,0 +1,9 @@
+---
+- name: Copy node container image to ostree storage
+  command: >
+    atomic pull --storage=ostree docker:{{ osn_image }}
+  register: pull_result
+  retries: 3
+  delay: 5
+  until: pull_result.rc == 0
+  changed_when: "'Pulling layer' in pull_result.stdout"

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -6,6 +6,9 @@
     - openshift_deployment_type == 'openshift-enterprise'
     - not openshift_use_crio | bool
 
+- name: Start node image prepull
+  import_tasks: prepull.yml
+
 - import_tasks: dnsmasq_install.yml
 - import_tasks: dnsmasq.yml
 
@@ -55,6 +58,11 @@
 - import_tasks: selinux_container_cgroup.yml
 
 - import_tasks: registry_auth.yml
+
+- import_tasks: prepull_check.yml
+
+- import_tasks: copy_image_to_ostree.yml
+  when: openshift_is_atomic | bool
 
 - name: include standard node config
   import_tasks: config.yml

--- a/roles/openshift_node/tasks/node_system_container.yml
+++ b/roles/openshift_node/tasks/node_system_container.yml
@@ -16,54 +16,7 @@
   - "/var/lib/kubelet"
   - "/opt/cni/bin"
 
-- name: Check status of node image pre-pull
-  async_status:
-    jid: "{{ image_prepull.ansible_job_id }}"
-  register: job_result
-  until: job_result.finished
-  when:
-  - node_image is defined
-  - node_image.stdout_lines == []
-  retries: 20
-  delay: 30
-  failed_when: false
-
-- name: Copy node container image to ostree storage
-  command: >
-    atomic pull --storage=ostree docker:{{ osn_image }}
-  register: pull_result
-  retries: 3
-  delay: 5
-  until: pull_result.rc == 0
-  changed_when: "'Pulling layer' in pull_result.stdout"
-
-- name: Install or Update node system container
-  oc_atomic_container:
-    name: "{{ openshift_service_type }}-node"
-    image: "{{ system_osn_image }}"
-    values:
-    - "DNS_DOMAIN={{ openshift.common.dns_domain }}"
-    - "DOCKER_SERVICE={{ openshift_docker_service_name }}.service"
-    - 'ADDTL_MOUNTS={{ l_node_syscon_add_mounts2 }}'
-    state: latest
-  vars:
-    # We need to evaluate some variables here to ensure
-    # l_bind_docker_reg_auth is evaluated after registry_auth.yml has been
-    # processed.
-
-    # Determine if we want to include auth credentials mount.
-    l_node_syscon_auth_mounts_l: "{{ l_bind_docker_reg_auth | ternary(openshift_node_syscon_auth_mounts_l,[]) }}"
-
-    # Join any user-provided mounts and auth_mounts into a combined list.
-    l_node_syscon_add_mounts_l: "{{ openshift_node_syscon_add_mounts_l | union(l_node_syscon_auth_mounts_l) }}"
-
-    # We must prepend a ',' here to ensure the value is inserted properly into an
-    # existing json list in the container's config.json
-    # lib_utils_oo_l_of_d_to_csv is a custom filter plugin in roles/lib_utils/oo_filters.py
-    l_node_syscon_add_mounts: ",{{ l_node_syscon_add_mounts_l | lib_utils_oo_l_of_d_to_csv }}"
-    # if we have just a ',' then both mount lists were empty, we don't want to add
-    # anything to config.json
-    l_node_syscon_add_mounts2: "{{ (l_node_syscon_add_mounts != ',') | bool | ternary(l_node_syscon_add_mounts,'') }}"
+- import_tasks: node_system_container_install.yml
 
 # TODO: network manager on RHEL is failing to execute 99-origin-dns.sh with signal 13, an immediate
 # restart seems to allow the job to configure. Only occurs with system containers.

--- a/roles/openshift_node/tasks/node_system_container_install.yml
+++ b/roles/openshift_node/tasks/node_system_container_install.yml
@@ -1,0 +1,28 @@
+---
+- name: Install or Update node system container
+  oc_atomic_container:
+    name: "{{ openshift_service_type }}-node"
+    image: "{{ system_osn_image }}"
+    values:
+    - "DNS_DOMAIN={{ openshift.common.dns_domain }}"
+    - "DOCKER_SERVICE={{ openshift_docker_service_name }}.service"
+    - 'ADDTL_MOUNTS={{ l_node_syscon_add_mounts2 }}'
+    state: latest
+  vars:
+    # We need to evaluate some variables here to ensure
+    # l_bind_docker_reg_auth is evaluated after registry_auth.yml has been
+    # processed.
+
+    # Determine if we want to include auth credentials mount.
+    l_node_syscon_auth_mounts_l: "{{ l_bind_docker_reg_auth | ternary(openshift_node_syscon_auth_mounts_l,[]) }}"
+
+    # Join any user-provided mounts and auth_mounts into a combined list.
+    l_node_syscon_add_mounts_l: "{{ openshift_node_syscon_add_mounts_l | union(l_node_syscon_auth_mounts_l) }}"
+
+    # We must prepend a ',' here to ensure the value is inserted properly into an
+    # existing json list in the container's config.json
+    # lib_utils_oo_l_of_d_to_csv is a custom filter plugin in roles/lib_utils/oo_filters.py
+    l_node_syscon_add_mounts: ",{{ l_node_syscon_add_mounts_l | lib_utils_oo_l_of_d_to_csv }}"
+    # if we have just a ',' then both mount lists were empty, we don't want to add
+    # anything to config.json
+    l_node_syscon_add_mounts2: "{{ (l_node_syscon_add_mounts != ',') | bool | ternary(l_node_syscon_add_mounts,'') }}"

--- a/roles/openshift_node/tasks/prepull.yml
+++ b/roles/openshift_node/tasks/prepull.yml
@@ -1,0 +1,32 @@
+---
+- name: Check that node image is present
+  command: "{{ openshift_container_cli }} images -q {{ osn_image }}"
+  register: node_image
+
+# This task runs async to save time while the node is being configured
+- name: Pre-pull node image
+  docker_image:
+    name: "{{ osn_image }}"
+  environment:
+    NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
+  when: node_image.stdout_lines == []
+  # 10 minutes to pull the image
+  async: 600
+  poll: 0
+  register: image_prepull
+
+- name: Check that pod image is present
+  command: "{{ openshift_container_cli }} images -q {{ osn_pod_image }}"
+  register: pod_image
+
+# This task runs async to save time while other downloads proceed
+- name: pre-pull pod image
+  docker_image:
+    name: "{{ osn_pod_image }}"
+  environment:
+    NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
+  when: pod_image.stdout_lines == []
+  # 10 minutes to pull the image
+  async: 600
+  poll: 0
+  register: pod_image_prepull

--- a/roles/openshift_node/tasks/prepull_check.yml
+++ b/roles/openshift_node/tasks/prepull_check.yml
@@ -1,0 +1,22 @@
+---
+- name: Check status of node image pre-pull
+  async_status:
+    jid: "{{ image_prepull.ansible_job_id }}"
+  register: job_result
+  until: job_result.finished
+  when:
+  - node_image.stdout_lines == []
+  - not openshift_is_atomic | bool
+  retries: 20
+  delay: 30
+  failed_when: false
+
+- name: Check status of node pod image pre-pull
+  async_status:
+    jid: "{{ pod_image_prepull.ansible_job_id }}"
+  register: job_result
+  until: job_result.finished
+  when: pod_image.stdout_lines == []
+  retries: 20
+  delay: 30
+  failed_when: false

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -17,6 +17,5 @@
   import_tasks: node_system_container.yml
   when: openshift_is_atomic | bool
 
-
 - import_tasks: config/configure-node-settings.yml
 - import_tasks: configure-proxy-settings.yml

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -4,7 +4,6 @@
 # - openshift_is_atomic
 # - node_config_hook
 # - openshift_pkg_version
-# - openshift_release
 
 # tasks file for openshift_node_upgrade
 
@@ -88,9 +87,11 @@
     msg: "Restarting dnsmasq"
   # changed_when: True required for debug tasks to trigger handlers.
   changed_when: True
-  notify: restart dnsmasq
+  notify:
+  - reload systemd units
+  - restart dnsmasq
 
-# Need to flush handlers here so dnsmasq is restarted.
+# Need to flush handlers here so dnsmasq is restarted and daemon-reload
 - meta: flush_handlers
 
 # Restart all services

--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -83,11 +83,3 @@
     line: pause_image = "{{ openshift_crio_pause_image }}"
     regexp: '^pause_image ='
   when: crio_conf.stat.exists == True
-
-# NOTE: This is needed to make sure we are using the correct set
-#       of systemd unit files. The RPMs lay down defaults but
-#       the install/upgrade may override them in /etc/systemd/system/.
-# NOTE: We don't use the systemd module as some versions of the module
-#       require a service to be part of the call.
-- name: Reload systemd units
-  command: systemctl daemon-reload

--- a/roles/openshift_node/tasks/upgrade_pre.yml
+++ b/roles/openshift_node/tasks/upgrade_pre.yml
@@ -7,6 +7,9 @@
 
 - import_tasks: registry_auth.yml
 
+# Prepull the node and pod image, it's used by lots of components
+- import_tasks: prepull.yml
+
 - name: update package meta data to speed install later.
   command: "{{ ansible_pkg_mgr }} makecache"
   register: result
@@ -47,3 +50,8 @@
 
 - import_tasks: upgrade/rpm_upgrade.yml
   when: not openshift_is_atomic | bool
+
+- import_tasks: prepull_check.yml
+
+- import_tasks: copy_image_to_ostree.yml
+  when: openshift_is_atomic | bool


### PR DESCRIPTION
Currently, atomic hosts do not prepull the node image
during pre-upgrade step.  This commit refactors image
prepulling to ensure it happens at the approriate times
for both install and upgrades and properly accounts for
atomic host.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1629558
(cherry picked from commit 783085afb0d011b53a44c0fbbaf7084b242f15e0)

Backports: https://github.com/openshift/openshift-ansible/pull/10125

Backport Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1631021