### PR TITLE
Fix openshift_additional_registry_credentials comparison

### DIFF
--- a/roles/container_runtime/tasks/registry_auth.yml
+++ b/roles/container_runtime/tasks/registry_auth.yml
@@ -31,7 +31,7 @@
     test_image: "{{ item.test_image | default('openshift3/ose-pod') }}"
     tls_verify: "{{ item.tls_verify | default(omit) }}"
   when:
-  - openshift_additional_registry_credentials is defined
+  - openshift_additional_registry_credentials != []
   register: crt_addl_credentials_create
   retries: 3
   delay: 5

--- a/roles/openshift_control_plane/tasks/registry_auth.yml
+++ b/roles/openshift_control_plane/tasks/registry_auth.yml
@@ -31,7 +31,7 @@
     test_image: "{{ item.test_image | default('openshift3/ose-pod') }}"
     tls_verify: "{{ item.tls_verify | default(omit) }}"
   when:
-  - openshift_additional_registry_credentials is defined
+  - openshift_additional_registry_credentials != []
   register: crt_addl_credentials_create
   retries: 3
   delay: 5

--- a/roles/openshift_examples/tasks/main.yml
+++ b/roles/openshift_examples/tasks/main.yml
@@ -69,7 +69,7 @@
       --docker-email=openshift@openshift.com --docker-password={{ item.password }}
       --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift
   when:
-    - openshift_additional_registry_credentials is defined
+    - openshift_additional_registry_credentials != []
   with_items:
     - "{{ openshift_additional_registry_credentials }}"
   register: oex_additional_creds

--- a/roles/openshift_node/tasks/registry_auth.yml
+++ b/roles/openshift_node/tasks/registry_auth.yml
@@ -42,7 +42,7 @@
     test_image: "{{ item.test_image | default('openshift3/ose-pod') }}"
     tls_verify: "{{ item.tls_verify | default(omit) }}"
   when:
-    - openshift_additional_registry_credentials is defined
+    - openshift_additional_registry_credentials != []
   register: node_additional_registry_creds
   retries: 3
   delay: 5
@@ -56,4 +56,4 @@
     l_bind_docker_reg_auth: True
   when:
     - openshift_is_atomic | bool
-    - oreg_auth_user is defined or openshift_additional_registry_credentials is defined or node_oreg_auth_credentials_stat.stat.exists
+    - oreg_auth_user is defined or openshift_additional_registry_credentials != [] or node_oreg_auth_credentials_stat.stat.exists

--- a/roles/openshift_node/tasks/registry_auth.yml
+++ b/roles/openshift_node/tasks/registry_auth.yml
@@ -56,4 +56,4 @@
     l_bind_docker_reg_auth: True
   when:
     - openshift_is_atomic | bool
-    - oreg_auth_user is defined or openshift_additional_registry_credentials != [] or node_oreg_auth_credentials_stat.stat.exists
+    - oreg_auth_user is defined or openshift_additional_registry_credentials != [] or ('stat' in node_oreg_auth_credentials_stat and node_oreg_auth_credentials_stat.stat.exists)


### PR DESCRIPTION
`openshift_additional_registry_credentials` is defined in openshift_facts 
roles, so comparison should be 'not empty'

Fixes Origin master / 3.11 install on Atomic - `/root/.docker` won't be created,
but system container would require this folder to be present, as `l_bind_docker_reg_auth` would be mistakenly set to true