### PR TITLE
[3.10] Backport setup_scale_group_facts changes from master

### DIFF
--- a/inventory/dynamic/gcp/group_vars/all/00_defaults.yml
+++ b/inventory/dynamic/gcp/group_vars/all/00_defaults.yml
@@ -36,8 +36,7 @@ osm_cluster_network_cidr: 172.16.0.0/16
 osm_host_subnet_length: 9
 openshift_portal_net: 172.30.0.0/16
 
-# masters and infra are the same in CI
 openshift_gcp_node_group_mapping:
   masters: 'node-config-master'
-  infra: 'node-config-master'
-  compute: 'node-config-compute'
+  infra: 'node-config-node'
+  compute: 'node-config-node'

--- a/playbooks/gcp/openshift-cluster/install.yml
+++ b/playbooks/gcp/openshift-cluster/install.yml
@@ -25,7 +25,7 @@
 - name: install components
   import_playbook: ../../common/private/components.yml
 
-- hosts: primary_master
+- hosts: oo_first_master
   gather_facts: no
   tasks:
   - name: Retrieve cluster configuration

--- a/roles/openshift_gcp/tasks/setup_scale_group_facts.yml
+++ b/roles/openshift_gcp/tasks/setup_scale_group_facts.yml
@@ -10,27 +10,12 @@
     openshift_node_group_name: "{{ openshift_gcp_node_group_mapping['compute'] }}"
   with_items: "{{ groups['tag_ocp-node'] | default([]) | difference(bootstrapped_nodes) }}"
 
-- name: Add bootstrap node instances
-  add_host:
-    name: "{{ hostvars[item].gce_name }}"
-    groups: bootstrap_nodes
-    openshift_is_bootstrapped: True
-    openshift_node_group_name: "{{ openshift_gcp_node_group_mapping['compute'] }}"
-  with_items: "{{ groups['tag_ocp-node'] | default([]) | intersect(groups['tag_ocp-bootstrap'] | default([])) }}"
-
 - name: Add bootstrap node instances as nodes
   add_host:
     name: "{{ item }}"
     groups: nodes, new_nodes
-    openshift_is_bootstrapped: True
   with_items: "{{ groups['tag_ocp-bootstrap'] | default([]) }}"
   when: all_nodes | default(False)
-
-- name: Add a master to the primary masters group
-  add_host:
-    name: "{{ hostvars[item].gce_name }}"
-    groups: primary_master
-  with_items: "{{ groups['tag_ocp-master'].0 }}"
 
 - name: Add non-bootstrapping master node instances to node group
   add_host:


### PR DESCRIPTION
This should fix 3.9 -> 3.10 upgrade on GCP

TODO:
* [x] Router tests fail, `role=infra` nodes were not found