### PR TITLE
Only create OpenStack router if both router and subnet are undefined

### DIFF
--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -391,7 +391,7 @@ resources:
       gateway_ip: null
 {% endif %}
 
-{% if not openshift_openstack_router_name %}
+{% if not openshift_openstack_router_name and not openshift_openstack_node_subnet_name %}
   router:
     type: OS::Neutron::Router
     properties:


### PR DESCRIPTION
Right now a router is created if it's undefined; but it also should not be necessary in cases where the user has defined a subnet and doesn't need a router.