### PR TITLE
remove unix prefix from crio path

### DIFF
--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -48,7 +48,7 @@ repoquery_installed: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --l
 openshift_use_crio: False
 openshift_use_crio_only: False
 openshift_crio_enable_docker_gc: False
-openshift_crio_var_sock: "unix:///var/run/crio/crio.sock"
+openshift_crio_var_sock: "/var/run/crio/crio.sock"
 openshift_crio_pause_image: "{{ l_os_registry_url | regex_replace('${component}' | regex_escape, 'pod') }}"
 openshift_container_cli: "{{ openshift_use_crio | bool | ternary('crictl', 'docker') }}"
 openshift_crio_docker_gc_node_selector:


### PR DESCRIPTION
Prefixing the runtime socket path with `unix://` causes this comparison in the kubelet to not behave in the expected way:

https://github.com/openshift/origin/blob/d036aec25521e662b52ac904c5c516415377f9db/vendor/k8s.io/kubernetes/pkg/kubelet/cadvisor/util.go#L77-L80

This results in the `stats/summary` endpoint not returning pod-level stats.

We need to pick this to 3.11 urgently https://github.com/openshift/openshift-ansible/pull/10178

xref https://bugzilla.redhat.com/show_bug.cgi?id=1631300

@nhr @derekwaynecarr @mrunalp @jsanda 