### PR TITLE
Fixes #8267

### DIFF
--- a/roles/lib_utils/library/openshift_cert_expiry.py
+++ b/roles/lib_utils/library/openshift_cert_expiry.py
@@ -10,6 +10,7 @@ import io
 import os
 import subprocess
 import yaml
+import dateutil.parser
 
 # pylint import-error disabled because pylint cannot find the package
 # when installed in a virtualenv
@@ -145,7 +146,7 @@ platforms missing the Python OpenSSL library.
                 # => 20190207181935Z
                 not_after_raw = l.partition(' : ')[-1]
                 # Last item: ('Not After', ' : ', 'Feb  7 18:19:35 2019 GMT')
-                not_after_parsed = datetime.datetime.strptime(not_after_raw, '%b %d %H:%M:%S %Y %Z')
+                not_after_parsed = dateutil.parser.parse(not_after_raw)
                 self.not_after = not_after_parsed.strftime('%Y%m%d%H%M%SZ')
 
             elif l.startswith('X509v3 Subject Alternative Name:'):

--- a/roles/openshift_certificate_expiry/tasks/main.yml
+++ b/roles/openshift_certificate_expiry/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Ensure python dateutil library is present
+  package:
+    name: "{{ 'python3-dateutil' if ansible_distribution == 'Fedora' else 'python-dateutil' }}"
+    state: present
+
 - name: Check cert expirys on host
   openshift_cert_expiry:
     warning_days: "{{ openshift_certificate_expiry_warning_days|int }}"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,3 +12,4 @@ coverage==4.3.4
 mock==2.0.0
 pytest==3.0.7
 pytest-cov==2.4.0
+python-dateutil==2.7.3


### PR DESCRIPTION
Using dateutil instead of datetime so we make a "best guess" for the date format instead of sticking to a specific regexp which doesn't match some locales.