### PR TITLE
[3.11] test/ci fixes

### DIFF
--- a/playbooks/openshift-node/private/network_manager.yml
+++ b/playbooks/openshift-node/private/network_manager.yml
@@ -3,12 +3,19 @@
   hosts: oo_all_hosts
   become: yes
   tasks:
+  - name: Detecting Operating System
+    shell: ls /run/ostree-booted
+    ignore_errors: yes
+    failed_when: false
+    register: ostree_output
+
   - name: install NetworkManager
     package:
       name: 'NetworkManager'
       state: present
     register: result
     until: result is succeeded
+    when: ostree_output.rc != 0
 
   - name: configure NetworkManager
     lineinfile:

--- a/test/ci/deprovision.yml
+++ b/test/ci/deprovision.yml
@@ -15,20 +15,31 @@
           tag-key: "kubernetes.io/cluster/{{ aws_cluster_id }}"
       register: ec2
 
-    - name: Stop VMs
+    - name: Terminate instances
       ec2:
         instance_ids: "{{ item.instance_id }}"
         region: "{{ aws_region }}"
-        state: stopped
+        state: absent
         wait: no
       with_items: "{{ ec2.instances }}"
-      ignore_errors: true
+      when: not aws_use_auto_terminator | default(true)
 
-    - name: Rename VMs
-      ec2_tag:
-        resource: "{{ item.instance_id }}"
-        region: "{{ aws_region }}"
-        tags:
-          Name: "{{ item.tags.Name }}-terminate"
-      when: "'-terminate' not in item.tags.Name"
-      with_items: "{{ ec2.instances }}"
+    - when: aws_use_auto_terminator | default(true)
+      block:
+        - name: Stop VMs
+          ec2:
+            instance_ids: "{{ item.instance_id }}"
+            region: "{{ aws_region }}"
+            state: stopped
+            wait: no
+          with_items: "{{ ec2.instances }}"
+          ignore_errors: true
+
+        - name: Rename VMs
+          ec2_tag:
+            resource: "{{ item.instance_id }}"
+            region: "{{ aws_region }}"
+            tags:
+              Name: "{{ item.tags.Name }}-terminate"
+          when: "'-terminate' not in item.tags.Name"
+          with_items: "{{ ec2.instances }}"

--- a/test/ci/launch.yml
+++ b/test/ci/launch.yml
@@ -76,5 +76,7 @@
     - wait_for_connection: {}
     - setup: {}
 
+
+- import_playbook: ../../playbooks/openshift-node/network_manager.yml
 - import_playbook: ../../playbooks/prerequisites.yml
 - import_playbook: ../../playbooks/deploy_cluster.yml

--- a/test/ci/vars.yml.sample
+++ b/test/ci/vars.yml.sample
@@ -7,6 +7,7 @@ vm_prefix: "ci_test"
 type: aws
 aws_user: "ec2-user"
 python: "/usr/bin/python"
+
 aws_key: "libra"
 aws_region: "us-east-1"
 aws_cluster_id: "ci"

--- a/test/ci/vars.yml.sample
+++ b/test/ci/vars.yml.sample
@@ -1,5 +1,8 @@
 ---
 vm_prefix: "ci_test"
+#aws_use_auto_terminator is set to True by default, as rh-dev account doesn't have permission
+# to terminate instances. These should be stopped and renamed to include 'terminate' instead
+#aws_use_auto_terminator: false
 
 type: aws
 aws_user: "ec2-user"


### PR DESCRIPTION
Cherrypick of test/ci fixes on release-3.11 branch

* #10065 - test ci: add an option to terminate VMs instead of stopping
* #10070 - test/ci: setup network manager before prerequisites 
* #10108 - Don't install NM on atomic systems