### PR TITLE
Don't re-deploy node system containers when deploying auth credentials

### DIFF
--- a/playbooks/openshift-node/private/registry_auth.yml
+++ b/playbooks/openshift-node/private/registry_auth.yml
@@ -7,13 +7,6 @@
   - import_role:
       name: openshift_node
       tasks_from: registry_auth.yml
-  # If there were previously no authenticated registries, the credential file
-  # won't be mounted in the system container;  Need to rerun this step to ensure
-  # additional mounts are provided.
-  - import_role:
-      name: openshift_node
-      tasks_from: node_system_container_install.yml
-    when: openshift_is_atomic
 
 # l_reg_auth_restart_hosts is passed in via imageconfig.yml to prevent
 # the nodes from restarting because the sync pod will be restarting them


### PR DESCRIPTION
This triggers a premature upgrade of node components to the next
release.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1628881
/cc @michaelgugino 