### PR TITLE
Pass admin kubeconfig

### DIFF
--- a/roles/openshift_cloud_provider/tasks/vsphere-svc.yml
+++ b/roles/openshift_cloud_provider/tasks/vsphere-svc.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check to see if the vsphere cluster role already exists
-  command: "{{ openshift_client_binary}}  get clusterrole"
+  command: "{{ openshift_client_binary}} --config={{ openshift.common.config_base }}/master/admin.kubeconfig get clusterrole"
   register: cluster_role
 
 - block:
@@ -13,7 +13,7 @@
 
   - name: Create vsphere-svc on cluster
     run_once: true
-    command: "{{ openshift_client_binary}} create -f /tmp/vsphere-svc.yml"
+    command: "{{ openshift_client_binary}} --config={{ openshift.common.config_base }}/master/admin.kubeconfig create -f /tmp/vsphere-svc.yml"
 
   - name: Remove vsphere-svc file
     run_once: true

--- a/roles/openshift_control_plane/tasks/check_master_api_is_ready.yml
+++ b/roles/openshift_control_plane/tasks/check_master_api_is_ready.yml
@@ -1,7 +1,7 @@
 ---
 - name: Wait for APIs to become available
   command: >
-    {{ openshift_client_binary }} get --raw /apis/{{ item }}/v1
+    {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig get --raw /apis/{{ item }}/v1
   register: openshift_apis
   until: openshift_apis.rc == 0
   with_items: "{{ l_core_api_list }}"
@@ -27,7 +27,7 @@
 
 - name: Check for apiservices/v1beta1.metrics.k8s.io registration
   command: >
-    {{ openshift_client_binary }} get apiservices/v1beta1.metrics.k8s.io
+    {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig get apiservices/v1beta1.metrics.k8s.io
   register: metrics_service_registration
   failed_when: metrics_service_registration.rc != 0 and 'NotFound' not in metrics_service_registration.stderr
   retries: 30
@@ -36,7 +36,7 @@
 
 - name: Wait for /apis/metrics.k8s.io/v1beta1 when registered
   command: >
-    {{ openshift_client_binary }} get --raw /apis/metrics.k8s.io/v1beta1
+    {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig get --raw /apis/metrics.k8s.io/v1beta1
   register: metrics_api
   until: metrics_api is succeeded
   retries: 30
@@ -45,7 +45,7 @@
 
 - name: Check for apiservices/v1beta1.servicecatalog.k8s.io registration
   command: >
-    {{ openshift_client_binary }} get apiservices/v1beta1.servicecatalog.k8s.io
+    {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig get apiservices/v1beta1.servicecatalog.k8s.io
   register: servicecatalog_service_registration
   failed_when: servicecatalog_service_registration.rc != 0 and 'NotFound' not in servicecatalog_service_registration.stderr
   retries: 30
@@ -55,7 +55,7 @@
 
 - name: Wait for /apis/servicecatalog.k8s.io/v1beta1 when registered
   command: >
-    {{ openshift_client_binary }} get --raw /apis/servicecatalog.k8s.io/v1beta1
+    {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig get --raw /apis/servicecatalog.k8s.io/v1beta1
   register: servicecatalog_api
   until: servicecatalog_api is succeeded
   retries: 30

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -54,7 +54,8 @@
 
 - name: Create the policy file if it does not already exist
   command: >
-    {{ openshift_client_binary }} adm create-bootstrap-policy-file
+    {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      adm create-bootstrap-policy-file
       --filename={{ openshift_master_policy }}
   args:
     creates: "{{ openshift_master_policy }}"


### PR DESCRIPTION
There were several places where we were relying on ~/.kube/config which could've been updated by the admin either with different credentials or non standard namespaces.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1631597