### PR TITLE
Add new RPM with test playbooks and dockerfile to use in CI

### DIFF
--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -1,0 +1,41 @@
+FROM centos:7
+
+MAINTAINER OpenShift Team <dev@lists.openshift.redhat.com>
+
+USER root
+
+LABEL name="openshift/origin-ansible" \
+      summary="OpenShift's installation and configuration tool" \
+      description="A containerized openshift-ansible image to use in CI - includes necessary packages to test clusters on AWS/GCP/Azure" \
+      url="https://github.com/openshift/openshift-ansible" \
+      io.k8s.display-name="openshift-ansible" \
+      io.k8s.description="A containerized openshift-ansible image to use in CI - includes necessary packages to test clusters on AWS/GCP/Azure" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="openshift,install,upgrade,ansible" \
+      atomic.run="once"
+
+ENV USER_UID=1001 \
+    HOME=/opt/app-root/src \
+    WORK_DIR=/usr/share/ansible/openshift-ansible \
+    OPTS="-v"
+
+# Add image scripts and files for running as a system container
+COPY images/installer/root /
+# Add origin repo for including the oc client
+COPY images/installer/origin-extra-root /
+# Install openshift-ansible RPMs
+RUN yum install -y epel-release && \
+    rm -rf /etc/yum.repos.d/centos-openshift-origin.repo && \
+    yum-config-manager --enable built > /dev/null && \
+    INSTALL_PKGS="openssh google-cloud-sdk azure-cli" \
+    yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS openshift-ansible-test && \
+    yum clean all
+
+RUN /usr/local/bin/user_setup \
+ && rm /usr/local/bin/usage.ocp
+
+USER ${USER_UID}
+
+WORKDIR ${WORK_DIR}
+ENTRYPOINT [ "/usr/local/bin/entrypoint" ]
+CMD [ "/usr/local/bin/run" ]

--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -66,6 +66,7 @@ cp inventory/hosts.* inventory/README.md docs/example-inventories/
 
 # openshift-ansible-playbooks install
 cp -rp playbooks %{buildroot}%{_datadir}/ansible/%{name}/
+cp -rp test %{buildroot}%{_datadir}/ansible/%{name}/
 # remove contiv plabooks
 rm -rf %{buildroot}%{_datadir}/ansible/%{name}/playbooks/adhoc/contiv
 
@@ -168,6 +169,22 @@ if [ -d %{_datadir}/ansible/%{name}/roles/openshift_examples/files/examples ]; t
   find %{_datadir}/ansible/%{name}/roles/openshift_examples/files/examples -name latest -type l -delete
 fi
 
+# ----------------------------------------------------------------------------------
+# openshift-ansible-tests subpackage
+# ----------------------------------------------------------------------------------
+%package test
+Summary:       Openshift and Atomic Enterprise Ansible Test Playbooks
+Requires:      %{name} = %{version}-%{release}
+Requires:      %{name}-roles = %{version}-%{release}
+Requires:      %{name}-playbooks = %{version}-%{release}
+Requires:      python-boto3
+BuildArch:     noarch
+
+%description test
+%{summary}.
+
+%files test
+%{_datadir}/ansible/%{name}/test
 
 %changelog
 * Fri Sep 21 2018 AOS Automation Release Team <aos-team-art@redhat.com> 4.0.0-0.3.0


### PR DESCRIPTION
This PR would create a new Dockerfile.ci to be used on prow CI.
It would re-use RPMs built from spec files and avoid using pip and requirements.txt

After a few changes to /release repo, the namespace would start a new service,
serving RPMs via a web server. Base image would include the repo with a 
path to that repo in `built` repo and put it in /etc/yum.repos.d and use it 
as a base container to build ansible image.

Fixes #10188

Current state:
* [x] `test/ci` files need to be included there, otherwise AWS tests fail:
```
cp: cannot create regular file 'test/ci/vars.yaml': Permission denied
```
Fixed by creating a new `openshift-ansible-test` RPM

* [x] GCP test fails: `/usr/local/bin/entrypoint-provider: line 52: ssh-keygen: command not found `
