### PR TITLE
[release-3.9] Configure Ansible service broker secrets

### DIFF
--- a/roles/ansible_service_broker/defaults/main.yml
+++ b/roles/ansible_service_broker/defaults/main.yml
@@ -20,3 +20,9 @@ ansible_service_broker_image_pull_policy: Always
 ansible_service_broker_sandbox_role: edit
 ansible_service_broker_auto_escalate: false
 ansible_service_broker_local_registry_whitelist: []
+# Secrets to be mounted for APBs. Format:
+# - title: Database credentials
+#   secret: db_creds
+#   apb_name: dh-rhscl-postgresql-apb
+# https://github.com/openshift/ansible-service-broker/blob/master/docs/config.md#secrets-configuration
+ansible_service_broker_secrets: []

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -394,6 +394,7 @@
               auth:
                 - type: basic
                   enabled: false
+            secrets: {{ ansible_service_broker_secrets | to_json }}
 
 - oc_secret:
     name: asb-registry-auth


### PR DESCRIPTION
Make the secrets to be mounted by Ansible playbook bundles configurable.
The ASB can be configured to mount secrets for running APBs [1].

[1] https://github.com/openshift/ansible-service-broker/blob/master/docs/config.md#secrets-configuration