### PR TITLE
Update crictl.yaml config to resolve deprecation warnings

### DIFF
--- a/roles/container_runtime/tasks/package_crio.yml
+++ b/roles/container_runtime/tasks/package_crio.yml
@@ -61,7 +61,7 @@
   yedit:
     src: /etc/crictl.yaml
     key: runtime-endpoint
-    value: "{{ openshift_crio_var_sock }}"
+    value: "unix://{{ openshift_crio_var_sock }}"
 
 - name: Ensure CNI configuration directory exists
   file:

--- a/roles/container_runtime/templates/crio.conf.j2
+++ b/roles/container_runtime/templates/crio.conf.j2
@@ -27,7 +27,7 @@ storage_option = [
 [crio.api]
 
 # listen is the path to the AF_LOCAL socket on which crio will listen.
-listen = "/var/run/crio/crio.sock"
+listen = "{{ openshift_crio_var_sock }}"
 
 # stream_address is the IP address on which the stream server will listen
 stream_address = ""

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -45,7 +45,7 @@
   yedit:
     src: /etc/crictl.yaml
     key: runtime-endpoint
-    value: "{{ openshift_crio_var_sock }}"
+    value: "unix://{{ openshift_crio_var_sock }}"
   when:
   - openshift_use_crio | default(False) | bool
 


### PR DESCRIPTION
When using crictl at the cli and in openshift logs.

W0726 19:42:01.399525    6438 util_unix.go:75] Using
"/var/run/crio/crio.sock" as endpoint is deprecated, please consider
using full url format "unix:///var/run/crio/crio.sock".