### PR TITLE
Default install monitoring to false

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_components.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_components.yml
@@ -24,7 +24,7 @@
   when: openshift_enable_olm | default(false) | bool
 
 - import_playbook: ../../../openshift-monitoring/private/config.yml
-  when: openshift_cluster_monitoring_operator_install | default(true) | bool
+  when: openshift_cluster_monitoring_operator_install | default(False) | bool
 
 - import_playbook: ../../../openshift-monitor-availability/private/config.yml
   when: openshift_monitor_availability_install | default(false) | bool

--- a/playbooks/common/private/components.yml
+++ b/playbooks/common/private/components.yml
@@ -20,7 +20,7 @@
 - import_playbook: ../../openshift-hosted/private/config.yml
 
 - import_playbook: ../../openshift-monitoring/private/config.yml
-  when: openshift_cluster_monitoring_operator_install | default(true) | bool
+  when: openshift_cluster_monitoring_operator_install | default(False) | bool
 
 - import_playbook: ../../openshift-metering/private/config.yml
   when: openshift_metering_install | default(false) | bool

--- a/roles/openshift_cluster_monitoring_operator/tasks/main.yaml
+++ b/roles/openshift_cluster_monitoring_operator/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - include_tasks: install.yaml
-  when: openshift_cluster_monitoring_operator_install | default(true) | bool
+  when: openshift_cluster_monitoring_operator_install | default(False) | bool
 
 - include_tasks: remove.yaml
-  when: not openshift_cluster_monitoring_operator_install | default(true) | bool
+  when: not openshift_cluster_monitoring_operator_install | default(False) | bool


### PR DESCRIPTION
This commit changes monitoring to not install by default
because it is tech preview.