### PR TITLE
Enable IAM roles for EC2s in AWS

### DIFF
--- a/playbooks/aws/openshift-cluster/prerequisites.yml
+++ b/playbooks/aws/openshift-cluster/prerequisites.yml
@@ -4,3 +4,5 @@
 - import_playbook: provision_ssh_keypair.yml
 
 - import_playbook: provision_sec_group.yml
+
+- import_playbook: provision_iam_role.yml

--- a/playbooks/aws/openshift-cluster/provision_iam_role.yml
+++ b/playbooks/aws/openshift-cluster/provision_iam_role.yml
@@ -1,0 +1,10 @@
+---
+- name: Create iam role
+  hosts: localhost
+  connection: local
+  tasks:
+  - name: create iam role
+    include_role:
+      name: openshift_aws
+      tasks_from: iam_role.yml
+    when: openshift_aws_create_iam_role | default(true) | bool

--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -19,7 +19,6 @@ openshift_aws_iam_cert_name: "{{ openshift_aws_clusterid }}-master-external"
 openshift_aws_iam_cert_path: ''
 openshift_aws_iam_cert_key_path: ''
 
-openshift_aws_iam_role_name: "openshift_node_describe_instances_{{ openshift_aws_clusterid }}"
 openshift_aws_iam_role_policy_json: "{{ lookup('file', 'describeinstances.json') }}"
 openshift_aws_iam_role_policy_name: "describe_instances_{{ openshift_aws_clusterid }}"
 
@@ -276,9 +275,7 @@ openshift_aws_master_instance_config:
   health_check: "{{ openshift_aws_scale_group_health_check }}"
   exact_count: "{{ openshift_aws_master_group_desired_size | default(3) }}"
   termination_policy: "{{ openshift_aws_node_group_termination_policy }}"
-  iam_role: "{{ openshift_aws_iam_master_role_name | default(openshift_aws_iam_role_name) }}"
-  policy_name: "{{ openshift_aws_iam_master_role_policy_name | default(openshift_aws_iam_role_policy_name) }}"
-  policy_json: "{{ openshift_aws_iam_master_role_policy_json | default(openshift_aws_iam_role_policy_json) }}"
+  iam_role: "{{ openshift_aws_launch_config_iam_roles['master'].name }}"
   elbs: "{{ openshift_aws_elb_dict | json_query('master.[*][0][*].name') }}"
   groups:
   - "{{ openshift_aws_clusterid }}"  # default sg
@@ -296,9 +293,7 @@ openshift_aws_node_group_config:
     desired_size: "{{ openshift_aws_compute_group_desired_size | default(3) }}"
     termination_policy: "{{ openshift_aws_node_group_termination_policy }}"
     replace_all_instances: "{{ openshift_aws_node_group_replace_all_instances }}"
-    iam_role: "{{ openshift_aws_iam_node_role_name | default(openshift_aws_iam_role_name) }}"
-    policy_name: "{{ openshift_aws_iam_node_role_policy_name | default(openshift_aws_iam_role_policy_name) }}"
-    policy_json: "{{ openshift_aws_iam_node_role_policy_json | default(openshift_aws_iam_role_policy_json) }}"
+    iam_role: "{{ openshift_aws_launch_config_iam_roles['compute'].name }}"
   # The 'infra' key is always required here.
   infra:
     instance_type: "{{ openshift_aws_infra_group_instance_type | default(openshift_aws_instance_type) }}"
@@ -309,9 +304,7 @@ openshift_aws_node_group_config:
     desired_size: "{{ openshift_aws_infra_group_desired_size | default(2) }}"
     termination_policy: "{{ openshift_aws_node_group_termination_policy }}"
     replace_all_instances: "{{ openshift_aws_node_group_replace_all_instances }}"
-    iam_role: "{{ openshift_aws_iam_node_role_name | default(openshift_aws_iam_role_name) }}"
-    policy_name: "{{ openshift_aws_iam_node_role_policy_name | default(openshift_aws_iam_role_policy_name) }}"
-    policy_json: "{{ openshift_aws_iam_node_role_policy_json | default(openshift_aws_iam_role_policy_json) }}"
+    iam_role: "{{ openshift_aws_launch_config_iam_roles['infra'].name }}"
     elbs: "{{ openshift_aws_elb_dict | json_query('infra.[*][0][*].name') }}"
 
 # build_instance_tags is a custom filter in role lib_utils
@@ -332,6 +325,20 @@ openshift_aws_launch_config_security_groups:
   - "{{ openshift_aws_clusterid }}"  # default sg
   - "{{ openshift_aws_clusterid }}_infra"  # node type sg
   - "{{ openshift_aws_clusterid }}_infra_k8s"  # node type sg k8s
+
+openshift_aws_launch_config_iam_roles:
+  master:
+    name: "{{ openshift_aws_iam_master_role_name | default(openshift_aws_clusterid ~ '-iam_master') }}"
+    policy_name: "{{ openshift_aws_iam_master_role_policy_name | default(openshift_aws_iam_role_policy_name) }}"
+    policy_json: "{{ openshift_aws_iam_master_role_policy_json | default(openshift_aws_iam_role_policy_json) }}"
+  compute:
+    name: "{{ openshift_aws_iam_compute_role_name | default(openshift_aws_clusterid ~ '-iam_compute') }}"
+    policy_name: "{{ openshift_aws_iam_node_role_policy_name | default(openshift_aws_iam_role_policy_name) }}"
+    policy_json: "{{ openshift_aws_iam_node_role_policy_json | default(openshift_aws_iam_role_policy_json) }}"
+  infra:
+    name: "{{ openshift_aws_iam_infra_role_name | default(openshift_aws_clusterid ~ '-iam_infra') }}"
+    policy_name: "{{ openshift_aws_iam_node_role_policy_name | default(openshift_aws_iam_role_policy_name) }}"
+    policy_json: "{{ openshift_aws_iam_node_role_policy_json | default(openshift_aws_iam_role_policy_json) }}"
 
 openshift_aws_security_groups_tags: "{{ openshift_aws_kube_tags }}"
 

--- a/roles/openshift_aws/tasks/build_node_group.yml
+++ b/roles/openshift_aws/tasks/build_node_group.yml
@@ -74,15 +74,18 @@
     | combine({'openshift-node-group-config': openshift_aws_node_group.node_group_config | default('unset') }) }}"
     l_node_group_name: "{{ openshift_aws_node_group.name }} {{ l_deployment_serial }}"
 
+- name: fetch the iam role
+  iam_role_facts:
+    name: "{{ openshift_aws_launch_config_iam_roles[openshift_aws_node_group.group].name }}"
+  register: l_profilename
+  retries: 3
+  delay: 3
+  when: openshift_aws_create_iam_role
+
 - name: Set scale group instances autonaming
   set_fact:
     l_instance_tags: "{{ l_instance_tags | combine({'Name': l_node_group_name }) }}"
   when: openshift_aws_autoname_scale_group_instances | default(false)
-
-- when:
-  - openshift_aws_create_iam_role
-  - asgs.results|length != 2
-  include_tasks: iam_role.yml
 
 - when:
   - openshift_aws_create_launch_config

--- a/roles/openshift_aws/tasks/iam_role.yml
+++ b/roles/openshift_aws/tasks/iam_role.yml
@@ -13,10 +13,14 @@
 #####
 - name: Create an iam role
   iam_role:
-    name: "{{ l_node_group_config[openshift_aws_node_group.group].iam_role }}"
+    name: "{{ openshift_aws_launch_config_iam_roles[l_item].name }}"
     assume_role_policy_document: "{{ lookup('file','trustpolicy.json') }}"
     state: "{{ openshift_aws_iam_role_state | default('present') }}"
-  when: l_node_group_config[openshift_aws_node_group.group].iam_role is defined
+  loop: "{{ openshift_aws_launch_config_iam_roles | list }}"
+  loop_control:
+    loop_var: l_item
+  retries: 3
+  delay: 3
 
 #####
 # The second part of this task file is linking the role to a policy
@@ -27,8 +31,13 @@
 - name: create an iam policy
   iam_policy:
     iam_type: role
-    iam_name: "{{ l_node_group_config[openshift_aws_node_group.group].iam_role }}"
-    policy_json: "{{ l_node_group_config[openshift_aws_node_group.group].policy_json }}"
-    policy_name: "{{ l_node_group_config[openshift_aws_node_group.group].policy_name }}"
+    iam_name: "{{ openshift_aws_launch_config_iam_roles[l_item].name }}"
+    policy_json: "{{ openshift_aws_launch_config_iam_roles[l_item].policy_json }}"
+    policy_name: "{{ openshift_aws_launch_config_iam_roles[l_item].policy_name }}"
     state: "{{ openshift_aws_iam_role_state | default('present') }}"
-  when: "'iam_role' in l_node_group_config[openshift_aws_node_group.group]"
+  register: l_iam_create_policy_out
+  loop: "{{ openshift_aws_launch_config_iam_roles | list }}"
+  loop_control:
+    loop_var: l_item
+  retries: 3
+  delay: 3

--- a/roles/openshift_aws/tasks/launch_config.yml
+++ b/roles/openshift_aws/tasks/launch_config.yml
@@ -21,10 +21,10 @@
     image_id: "{{ openshift_aws_ami_map[openshift_aws_node_group.group] | default(openshift_aws_ami) }}"
     instance_type: "{{ l_node_group_config[openshift_aws_node_group.group].instance_type }}"
     security_groups: "{{ openshift_aws_launch_config_security_group_id  | default(ec2sgs.security_groups | map(attribute='group_id')| list) }}"
-    instance_profile_name: "{{ l_node_group_config[openshift_aws_node_group.group].iam_role if l_node_group_config[openshift_aws_node_group.group].iam_role is defined and
-                                                                           l_node_group_config[openshift_aws_node_group.group].iam_role != '' and
-                                                                           openshift_aws_create_iam_role
-                                                                        else omit }}"
+    instance_profile_name: "{{ l_profilename.iam_roles[0].role_name if openshift_aws_create_iam_role and
+                                                                      l_node_group_config[openshift_aws_node_group.group].iam_role is defined and
+                                                                      l_node_group_config[openshift_aws_node_group.group].iam_role != ''
+                                                                    else omit }}"
     user_data: "{{ lookup('template', 'user_data.j2') }}"
     key_name: "{{ openshift_aws_ssh_key_name }}"
     ebs_optimized: False

--- a/roles/openshift_aws/tasks/provision_ec2.yml
+++ b/roles/openshift_aws/tasks/provision_ec2.yml
@@ -18,6 +18,10 @@
     volumes: "{{ openshift_aws_master_instance_config.volumes }}"
     vpc_subnet_id: "{{ l_loop }}"
     wait: yes
+    instance_profile_name: "{{ l_profilename.iam_roles[0].role_name if openshift_aws_create_iam_role and
+                                                                      openshift_aws_master_instance_config.iam_role is defined and
+                                                                      openshift_aws_master_instance_config.iam_role != ''
+                                                                    else omit }}"
   loop: "{{ l_subnetout_results | list }}"
   loop_control:
     loop_var: l_loop

--- a/roles/openshift_aws/tasks/provision_ec2_facts.yml
+++ b/roles/openshift_aws/tasks/provision_ec2_facts.yml
@@ -85,3 +85,11 @@
       vpc-id: "{{ vpcout.vpcs[0].id }}"
     region: "{{ openshift_aws_region }}"
   register: ec2sgs
+
+- name: fetch the iam role
+  iam_role_facts:
+    name: "{{ openshift_aws_launch_config_iam_roles['master'].name }}"
+  register: l_profilename
+  retries: 3
+  delay: 3
+  when: openshift_aws_create_iam_role


### PR DESCRIPTION
Enable IAM roles for EC2s in AWS.  Iam roles are now created during prerequisites play.  Build_node_group moved away iam role creation to iam role query.  Ec2 and Auto Scale Group instance_profile keys updated to suit.


- Set ```openshift_aws_create_iam_role: True```
- Update ```openshift_aws_master_instance_config```, ```openshift_aws_node_group_config```, ```openshift_aws_launch_config_iam_roles``` as needed.
- Execute the following plays...
```
ansible-playbook -i hosts openshift-cluster/prerequisites.yml -e @provisioning_vars.yml
ansible-playbook -i hosts openshift-cluster/provision_install.yml -e @provisioning_vars.yml
```