### PR TITLE
test/ci: set expirationDate flag for CI namespace garbage collector

### DIFF
--- a/test/ci/launch.yml
+++ b/test/ci/launch.yml
@@ -47,6 +47,7 @@
             "Name": "{{ item.name }}",
             "ansible-groups": "{{ item.ansible_groups | join(',') }}",
             "ansible-node-group": "{{ item.node_group }}",
+            "expirationDate": "{{ item.aws_expiration_date | default(aws_expiration_date) }}"
           }
 
     - name: Add machine to inventory

--- a/test/ci/vars.yml.sample
+++ b/test/ci/vars.yml.sample
@@ -14,6 +14,8 @@ aws_cluster_id: "ci"
 # us-east-1d
 aws_subnet: "subnet-cf57c596"
 
+aws_expiration_date: "{{ lookup('pipe','date -d \"4 hours\" --iso=minutes --utc') }}"
+
 aws_ami_tags:
   "tag:operating_system": "rhel"
   "tag:image_stage": "base"
@@ -40,3 +42,5 @@ aws_instances:
   # - device_name: /dev/sdb
   #   volume_size: 50
   #   delete_on_termination: yes
+  #Set expiration date for instances on CI namespace
+  #aws_expiration_date: "{{ lookup('pipe','date -d \"4 hours\" --iso=minutes --utc') }}"


### PR DESCRIPTION
CI namespace uses a different garbage collector, which reads `expirationDate` tag.