### PR TITLE
Bug 1624493: If the node group objects already exist don't abort

### DIFF
--- a/roles/openshift_node_group/tasks/sync.yml
+++ b/roles/openshift_node_group/tasks/sync.yml
@@ -47,6 +47,15 @@
 - name: Apply the config
   shell: >
     {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig apply -f {{ mktemp.stdout }}
+  register: __config_apply
+  failed_when:
+    - "'already exists' not in __config_apply.stderr"
+    - __config_apply.rc != 0
+
+- name: Checking prexisting node configuration
+  debug:
+    msg: "WARNING: prexisting node configuration objects found"
+  when: "'already exists' in __config_apply.stderr"
 
 - name: Remove temp directory
   file:


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1624493