### PR TITLE
Calico Upgrade Playbook Fix when default node-selector used

### DIFF
--- a/playbooks/byo/calico/legacy_upgrade.yml
+++ b/playbooks/byo/calico/legacy_upgrade.yml
@@ -71,6 +71,12 @@
       resource_name: privileged
       state: present
 
+  - name: Set default selector for kube-system
+    command: >
+      {{ openshift_client_binary }}
+      --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      annotate  ns kube-system openshift.io/node-selector="" --overwrite
+    
   - name: Apply Calico manifest
     command: >
       {{ openshift_client_binary }} apply


### PR DESCRIPTION
The Calico Upgrade Playbook in OpenShift 3.9 fails when a default node-selector is configured.

The Calico Upgrade Playbook cant schedule `calico-node` pods on nodes that are missing the default node-selector label due to the missing label on e.g. OpenShift Master Nodes.  But the `calico-node` pods have to run on each node of the OpenShift cluster. 

This PR overwrites the openshift.io/node-selector="" annotation in the `kube-system` namespace that `calico-node` pods can be scheduled on all OpenShift Nodes.