### PR TITLE
test/ci: ensure AWS instances have public hostname

### DIFF
--- a/test/ci/launch.yml
+++ b/test/ci/launch.yml
@@ -75,7 +75,9 @@
   tasks:
     - wait_for_connection: {}
     - setup: {}
-
+    - name: Make sure hostname is set to public ansible host
+      hostname:
+        name: "{{ ansible_host }}"
 
 - import_playbook: ../../playbooks/openshift-node/network_manager.yml
 - import_playbook: ../../playbooks/prerequisites.yml


### PR DESCRIPTION
This hostname would be used to communicate to the cluster, so it has to
be reset from `ec2.internal` to `amazonaws.com`

On CI AWS cloudprovider is not enabled, so cluster uses internal hostnames and IPs to communicate. This breaks test container, as it requires a kubeconfig. During `oc login` to this cluster internal AWS IP would be used, so a test from GCP would fail.

This PR and `openshift_hostname_check=false` would ensure `setup` container would login to a newly provisioned cluster correctly