### PR TITLE
Enable safe use of aws asg and autoscaler

### DIFF
--- a/roles/openshift_aws/tasks/build_node_group.yml
+++ b/roles/openshift_aws/tasks/build_node_group.yml
@@ -82,6 +82,40 @@
   delay: 3
   when: openshift_aws_create_iam_role
 
+- set_fact:
+    l_desired_capacity: "{{ l_node_group_config[openshift_aws_node_group.group].desired_size }}"
+  when:
+  - "openshift_cluster_autoscaler_install is not defined"
+  - "asgs.results | length == 0"
+
+- set_fact:
+    l_desired_capacity: "{{ asgs.results[0].desired_capacity if asgs.results[0].desired_capacity >= l_node_group_config[openshift_aws_node_group.group].desired_size
+                                                             else l_node_group_config[openshift_aws_node_group.group].desired_size }}"
+  when:
+  - "openshift_cluster_autoscaler_install is not defined"
+  - "asgs.results | length == 1"
+
+- set_fact:
+    l_desired_capacity: "{{ l_loop.min }}"
+  when:
+  - "openshift_cluster_autoscaler_install and openshift_cluster_autoscaler_node_groups is defined"
+  - "l_loop.name == l_node_group_name"
+  - "asgs.results | length == 0"
+  loop: "{{ openshift_cluster_autoscaler_node_groups }}"
+  loop_control:
+    loop_var: l_loop
+
+- set_fact:
+    l_desired_capacity: "{{ asgs.results[0].desired_capacity if asgs.results[0].desired_capacity >= ( l_loop.min | int )
+                                                             else l_loop.min }}"
+  when:
+  - "openshift_cluster_autoscaler_install and openshift_cluster_autoscaler_node_groups is defined"
+  - "l_loop.name == l_node_group_name"
+  - "asgs.results | length == 1"
+  loop: "{{ openshift_cluster_autoscaler_node_groups }}"
+  loop_control:
+    loop_var: l_loop
+
 - name: Set scale group instances autonaming
   set_fact:
     l_instance_tags: "{{ l_instance_tags | combine({'Name': l_node_group_name }) }}"

--- a/roles/openshift_aws/tasks/scale_group.yml
+++ b/roles/openshift_aws/tasks/scale_group.yml
@@ -7,7 +7,7 @@
     health_check_type: "{{ l_node_group_config[openshift_aws_node_group.group].health_check.type }}"
     min_size: "{{ l_node_group_config[openshift_aws_node_group.group].min_size }}"
     max_size: "{{ l_node_group_config[openshift_aws_node_group.group].max_size }}"
-    desired_capacity: "{{ l_node_group_config[openshift_aws_node_group.group].desired_size }}"
+    desired_capacity: "{{ l_desired_capacity }}"
     region: "{{ openshift_aws_region }}"
     termination_policies: "{{ l_node_group_config[openshift_aws_node_group.group].termination_policy if 'termination_policy' in  l_node_group_config[openshift_aws_node_group.group] else omit }}"
     load_balancers: "{{ l_node_group_config[openshift_aws_node_group.group].elbs if 'elbs' in l_node_group_config[openshift_aws_node_group.group] else omit }}"


### PR DESCRIPTION
Enable safe use of aws asg and autoscaler and resolves Bugzilla [1630025](https://bugzilla.redhat.com/show_bug.cgi?id=1630025)

The following behavior will now be displayed....
### NO AUTOSCALER
1) Initial deployment... asg desired capacity will use openshift_aws_node_group_config['blah'].desired_size
2) Subsequent runs... if asg exists and if existing asg desired capacity is > than openshift_aws_node_group_config['blah'].desired_size then existing asg desired capacity will be applied to 'Create the scale group'.desired_capacity else openshift_aws_node_group_config['blah'].desired_size is used.

### AUTOSCALER
1) Initial deployment... asg desired capacity will use openshift_cluster_autoscaler_node_groups['blah'].min
2) Subsequent runs... if asg exists and if existing asg desired capacity is > than openshift_cluster_autoscaler_node_groups['blah'].min then existing asg desired capacity will be applied to 'Create the scale group'.desired_capacity else openshift_cluster_autoscaler_node_groups['blah'].min is used.