### PR TITLE
fixes #10248 - changing default variables

### DIFF
--- a/roles/openshift_grafana/defaults/main.yaml
+++ b/roles/openshift_grafana/defaults/main.yaml
@@ -6,9 +6,9 @@ openshift_grafana_proxy_image: "{{ l2_os_logging_proxy_image }}"
 openshift_grafana_state: present
 openshift_grafana_namespace: openshift-grafana
 openshift_grafana_pod_timeout: 300
-openshift_grafana_prometheus_namespace: "openshift-monitoring"
-openshift_grafana_prometheus_serviceaccount: "prometheus-k8s"
-openshift_grafana_prometheus_route: "prometheus-k8s"
+openshift_grafana_prometheus_namespace: "openshift-metrics"
+openshift_grafana_prometheus_serviceaccount: "prometheus"
+openshift_grafana_prometheus_route: "prometheus"
 openshift_grafana_serviceaccount_name: grafana
 openshift_grafana_serviceaccount_annotations: []
 l_openshift_grafana_serviceaccount_annotations:


### PR DESCRIPTION
This PR fix issue #10248 by changing the default variables `openshift_grafana_prometheus_namespace`, `openshift_grafana_prometheus_serviceaccount` and `openshift_grafana_prometheus_route` of the `roles/openshift_grafana` to be compatible with values used by OpenShift release 3.10.