### PR TITLE
[release-3.10]  Fix etcd scaleup on standalone hosts

### DIFF
--- a/playbooks/openshift-etcd/private/scaleup.yml
+++ b/playbooks/openshift-etcd/private/scaleup.yml
@@ -1,5 +1,5 @@
 ---
-- name: Configure etcd
+- name: Check for etcd stand-alone hosts on atomic
   hosts: oo_etcd_to_config
   any_errors_fatal: true
   tasks:
@@ -11,6 +11,9 @@
     - openshift_is_atomic | bool
     - not inventory_hostname in groups['oo_masters']
 
+- name: Set etcd facts for all hosts
+  hosts: oo_etcd_to_config:oo_new_etcd_to_config
+  tasks:
   - import_role:
       name: etcd
       tasks_from: set_facts.yml

--- a/playbooks/openshift-etcd/private/scaleup.yml
+++ b/playbooks/openshift-etcd/private/scaleup.yml
@@ -11,12 +11,12 @@
     - openshift_is_atomic | bool
     - not inventory_hostname in groups['oo_masters']
 
-- name: Set etcd facts for all hosts
-  hosts: oo_etcd_to_config:oo_new_etcd_to_config
+- name: Set etcdctlv2 for etcd ca host
+  hosts: oo_etcd_to_config[0]
   tasks:
   - import_role:
       name: etcd
-      tasks_from: set_facts.yml
+      tasks_from: set_etcdctlv2.yml
 
 - name: Configure etcd
   hosts: oo_new_etcd_to_config

--- a/playbooks/openshift-etcd/private/upgrade_backup.yml
+++ b/playbooks/openshift-etcd/private/upgrade_backup.yml
@@ -8,7 +8,6 @@
     vars:
       r_etcd_common_backup_tag: "{{ etcd_backup_tag }}"
       r_etcd_common_backup_sufix_name: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
-      r_etcd_common_skip_command_shim: true
 
 - name: Gate on etcd backup
   hosts: localhost

--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -2,11 +2,9 @@
 r_etcd_common_backup_tag: ''
 r_etcd_common_backup_sufix_name: ''
 
-l_etcd_bootstrapped: '{{ openshift.node.bootstrapped }}'
-
 # TODO(michaelgugino): Remove these in 3.11
 l_is_etcd_system_container: "{{ (openshift_use_etcd_system_container | default(openshift_use_system_containers | default(false)) | bool) }}"
-l_etcd_static_pod: "{{ not (r_etcd_common_skip_command_shim is defined and r_etcd_common_skip_command_shim) or l_etcd_bootstrapped }}"
+l_etcd_static_pod: "{{ openshift.node.bootstrapped }}"
 
 # runc, docker, static pod, host
 r_etcd_common_etcd_runtime: "{{ 'runc' if l_is_etcd_system_container else ('static_pod' if l_etcd_static_pod else ('docker' if openshift_is_containerized else 'host')) }}"

--- a/roles/etcd/tasks/add_new_member.yml
+++ b/roles/etcd/tasks/add_new_member.yml
@@ -3,11 +3,8 @@
 - import_tasks: set_facts.yml
 
 - name: Add new etcd members to cluster
-  command: "{{ etcdctlv2 }} member add {{ etcd_hostname }} {{ etcd_peer_url_scheme }}://{{ etcd_ip }}:{{ etcd_peer_port }}"
+  command: "{{ hostvars[etcd_ca_host].etcdctlv2 }} member add {{ etcd_hostname }} {{ etcd_peer_url_scheme }}://{{ etcd_ip }}:{{ etcd_peer_port }}"
   delegate_to: "{{ etcd_ca_host }}"
-  failed_when:
-  - etcd_add_check.rc == 1
-  - ("peerURL exists" not in etcd_add_check.stderr)
   register: etcd_add_check
   retries: 3
   delay: 10

--- a/roles/etcd/tasks/set_etcdctlv2.yml
+++ b/roles/etcd/tasks/set_etcdctlv2.yml
@@ -1,0 +1,4 @@
+---
+- name: Set fact etcdctlv2
+  set_fact:
+    etcdctlv2: "{{ etcdctlv2 }}"

--- a/roles/etcd/tasks/set_facts.yml
+++ b/roles/etcd/tasks/set_facts.yml
@@ -3,3 +3,4 @@
   set_fact:
     etcd_ip: "{{ etcd_ip }}"
     etcd_hostname: "{{ etcd_hostname }}"
+    etcdctlv2: "{{ etcdctlv2 }}"

--- a/roles/etcd/tasks/set_facts.yml
+++ b/roles/etcd/tasks/set_facts.yml
@@ -3,4 +3,3 @@
   set_fact:
     etcd_ip: "{{ etcd_ip }}"
     etcd_hostname: "{{ etcd_hostname }}"
-    etcdctlv2: "{{ etcdctlv2 }}"

--- a/roles/installer_checkpoint/callback_plugins/installer_checkpoint.py
+++ b/roles/installer_checkpoint/callback_plugins/installer_checkpoint.py
@@ -19,6 +19,10 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_stats(self, stats):
 
+        # Return if there are no custom stats to process
+        if stats.custom == {}:
+            return
+
         phases = stats.custom['_run']
 
         # Find the longest phase title


### PR DESCRIPTION
* Updated detection of running on standalone or as static pods
* Set value of etcdctlv2 for all hosts to ensure proper usage
* Use proper etcdctlv2 for adding new etcd members

https://bugzilla.redhat.com/show_bug.cgi?id=1578482