### PR TITLE
Fix etcd scaleup on standalone hosts

### DIFF
--- a/playbooks/openshift-etcd/private/scaleup.yml
+++ b/playbooks/openshift-etcd/private/scaleup.yml
@@ -1,5 +1,5 @@
 ---
-- name: Configure etcd
+- name: Check for etcd stand-alone hosts on atomic
   hosts: oo_etcd_to_config
   any_errors_fatal: true
   tasks:
@@ -11,6 +11,9 @@
     - openshift_is_atomic | bool
     - not inventory_hostname in groups['oo_masters']
 
+- name: Set etcd facts for all hosts
+  hosts: oo_etcd_to_config:oo_new_etcd_to_config
+  tasks:
   - import_role:
       name: etcd
       tasks_from: set_facts.yml

--- a/roles/etcd/tasks/add_new_member.yml
+++ b/roles/etcd/tasks/add_new_member.yml
@@ -3,11 +3,8 @@
 - import_tasks: set_facts.yml
 
 - name: Add new etcd members to cluster
-  command: "{{ etcdctlv2 }} member add {{ etcd_hostname }} {{ etcd_peer_url_scheme }}://{{ etcd_ip }}:{{ etcd_peer_port }}"
+  command: "{{ hostvars[etcd_ca_host].etcdctlv2 }} member add {{ etcd_hostname }} {{ etcd_peer_url_scheme }}://{{ etcd_ip }}:{{ etcd_peer_port }}"
   delegate_to: "{{ etcd_ca_host }}"
-  failed_when:
-  - etcd_add_check.rc == 1
-  - ("peerURL exists" not in etcd_add_check.stderr)
   register: etcd_add_check
   retries: 3
   delay: 10

--- a/roles/etcd/tasks/set_facts.yml
+++ b/roles/etcd/tasks/set_facts.yml
@@ -3,3 +3,4 @@
   set_fact:
     etcd_ip: "{{ etcd_ip }}"
     etcd_hostname: "{{ etcd_hostname }}"
+    etcdctlv2: "{{ etcdctlv2 }}"


### PR DESCRIPTION
* Updated detection of running on standalone or as static pods
* Set value of etcdctlv2 for all hosts to ensure proper usage
* Use proper etcdctlv2 for adding new etcd members