### PR TITLE
Openshift autoheal fails to pull images even if oreg_url is specified

### DIFF
--- a/playbooks/openshift-autoheal/private/config.yml
+++ b/playbooks/openshift-autoheal/private/config.yml
@@ -16,6 +16,7 @@
 - name: Auto-heal
   hosts: oo_first_master
   roles:
+  - role: openshift_facts
   - role: openshift_autoheal
 
 - name: Auto-heal Install Checkpoint End

--- a/roles/openshift_autoheal/defaults/main.yml
+++ b/roles/openshift_autoheal/defaults/main.yml
@@ -3,7 +3,7 @@
 #
 # Image name:
 
-openshift_autoheal_image: "{{ l_osm_registry_url | regex_replace('${component}' | regex_escape, 'autoheal') }}" 
+openshift_autoheal_image: "{{ l_osm_registry_url | regex_replace('${component}' | regex_escape, 'autoheal') }}"
 
 #
 # Content of the configuration file of the auto-heal service. Note that this is

--- a/roles/openshift_autoheal/defaults/main.yml
+++ b/roles/openshift_autoheal/defaults/main.yml
@@ -2,17 +2,8 @@
 
 #
 # Image name:
-#
-openshift_autoheal_image_dict:
-  origin:
-    prefix: "docker.io/openshift/"
-    version: v0.0.1
-  openshift-enterprise:
-    prefix: "registry.redhat.io/openshift3/ose-"
-    version: "{{ openshift_image_tag }}"
-openshift_autoheal_image_prefix: "{{ openshift_autoheal_image_dict[openshift_deployment_type]['prefix'] }}"
-openshift_autoheal_image_version: "{{ openshift_autoheal_image_dict[openshift_deployment_type]['version'] }}"
-openshift_autoheal_image: "{{ openshift_autoheal_image_prefix }}autoheal:{{ openshift_autoheal_image_version }}"
+
+openshift_autoheal_image: "{{ l_osm_registry_url | regex_replace('${component}' | regex_escape, 'autoheal') }}" 
 
 #
 # Content of the configuration file of the auto-heal service. Note that this is


### PR DESCRIPTION
openshift autoheal always pull images from registry.redhat.io for openshift-enterprise.

This happens even if oreg_url is specified and in disconnected installations.