### PR TITLE
[release-3.9] Re-apply tuned profile during upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -70,4 +70,11 @@
     when:
     - __shared_resource_viewer_protected | default(false)
 
+# Tuned profile are removed when removing tuned-profiles-atomic-openshift-node rpm
+# Need to be re apply
+- name: Re apply tuned profiles
+  hosts: oo_first_master
+  roles:
+  - tuned
+
 - import_playbook: upgrade_components.yml

--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -70,11 +70,4 @@
     when:
     - __shared_resource_viewer_protected | default(false)
 
-# Tuned profile are removed when removing tuned-profiles-atomic-openshift-node rpm
-# Need to be re apply
-- name: Re apply tuned profiles
-  hosts: oo_first_master
-  roles:
-  - tuned
-
 - import_playbook: upgrade_components.yml

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -86,6 +86,11 @@
     when: >
           ('glusterfs' in groups and inventory_hostname in groups['glusterfs'])
           or ('glusterfs_registry' in groups and inventory_hostname in groups['glusterfs_registry'])
+  
+  # Tuned profile are removed when removing tuned-profiles-atomic-openshift-node rpm
+  # Need to be re apply
+  - import_role:
+      name: tuned
 
 - name: Re-enable excluders
   hosts: oo_nodes_to_upgrade:!oo_masters_to_config
@@ -94,12 +99,4 @@
       name: openshift_excluder
     vars:
       r_openshift_excluder_action: enable
-
-# Tuned profile are removed when removing tuned-profiles-atomic-openshift-node rpm
-# Need to be re apply
-- name: Re-enable tuned profiles
-  hosts: oo_nodes_to_upgrade:!oo_masters_to_config
-  tasks:
-  - import_role:
-      name: tuned
 

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -86,7 +86,7 @@
     when: >
           ('glusterfs' in groups and inventory_hostname in groups['glusterfs'])
           or ('glusterfs_registry' in groups and inventory_hostname in groups['glusterfs_registry'])
-  
+
   # Tuned profile are removed when removing tuned-profiles-atomic-openshift-node rpm
   # Need to be re apply
   - import_role:
@@ -99,4 +99,3 @@
       name: openshift_excluder
     vars:
       r_openshift_excluder_action: enable
-

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -94,3 +94,12 @@
       name: openshift_excluder
     vars:
       r_openshift_excluder_action: enable
+
+# Tuned profile are removed when removing tuned-profiles-atomic-openshift-node rpm
+# Need to be re apply
+- name: Re-enable tuned profiles
+  hosts: oo_nodes_to_upgrade:!oo_masters_to_config
+  tasks:
+  - import_role:
+      name: tuned
+

--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -345,3 +345,5 @@
     vars:
       openshift_master_host: "{{ groups.oo_first_master.0 }}"
       openshift_manage_node_is_master: true
+  - import_role:
+      name: tuned


### PR DESCRIPTION
During upgrade from 3.7 to 3.9 tuned-profiles-atomic-openshift-node rpm is removed and all tuned profiles.
Tuned role is not applied during an upgrade but during a fresh install. So tuned profiles are missing after an upgrade

bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1626558