### PR TITLE
[openstack] Add configuration note for all-in-one and DNS

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -532,6 +532,11 @@ this new group to it.
 Note that the "all in one" node must be the "master". openshift-ansible
 expects at least one node in the `masters` Ansible group.
 
+Also keep in mind that if you don't use [LBaaS](#load-balancer-as-a-service)
+with an all-in-one setup the DNS wildcard record for the apps domain will not be
+added, because there are no dedicated infra nodes, so you will have to add it
+manually. See
+[Custom DNS Records Configuration](#custom-dns-records-configuration).
 
 ## Building Node Images
 


### PR DESCRIPTION
The fixes from #8607 allow the all-in-one use case, but when deploying an all-in-one with the Openstack playbooks without LBaaS the DNS wildcard record is not created by the playbooks because there are no dedicated infrastructure nodes. 

This PR adds a note to the configuration section for all-in-one in the openstack playbooks doc that explains it.
