### PR TITLE
Start only the ovsdb so we can add the config safely

### DIFF
--- a/roles/openshift_sdn/files/sdn-ovs.yaml
+++ b/roles/openshift_sdn/files/sdn-ovs.yaml
@@ -63,16 +63,17 @@ spec:
               exit 0
           }
           trap quit SIGTERM
-          /usr/share/openvswitch/scripts/ovs-ctl start --system-id=random
+          /usr/share/openvswitch/scripts/ovs-ctl start --no-ovs-vswitchd --system-id=random
 
           # Restrict the number of pthreads ovs-vswitchd creates to reduce the
           # amount of RSS it uses on hosts with many cores
           # https://bugzilla.redhat.com/show_bug.cgi?id=1571379
           # https://bugzilla.redhat.com/show_bug.cgi?id=1572797
           if [[ `nproc` -gt 12 ]]; then
-              ovs-vsctl set Open_vSwitch . other_config:n-revalidator-threads=4
-              ovs-vsctl set Open_vSwitch . other_config:n-handler-threads=10
+              ovs-vsctl --no-wait set Open_vSwitch . other_config:n-revalidator-threads=4
+              ovs-vsctl --no-wait set Open_vSwitch . other_config:n-handler-threads=10
           fi
+          /usr/share/openvswitch/scripts/ovs-ctl start --no-ovsdb-server --system-id=random
           while true; do sleep 5; done
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
The existing code starts both the ovsdb and the ovsvswitchd and then
chances the database to limit the threads used.

Unfortunately, on very fast machines that have many cores, there is a
race between when the config change gets in to limit the threads used,
and when the threads get started.  If the config change loses the
race, then the threads aren't limited and the vswitchd becomes
unresponsive.

The fix is to start the db component, program it, then start the
vswitchd component.

Fixes bug 1633892 (https://bugzilla.redhat.com/show_bug.cgi?id=1633892)