### PR TITLE
Replace 'command chmod' with 'file mode=...'

### DIFF
--- a/playbooks/openshift-etcd/private/redeploy-ca.yml
+++ b/playbooks/openshift-etcd/private/redeploy-ca.yml
@@ -34,7 +34,7 @@
     changed_when: false
 
   - name: Chmod local temp directory for syncing certs
-    local_action: command chmod 777 "{{ g_etcd_mktemp.stdout }}"
+    local_action: file path="{{ g_etcd_mktemp.stdout }}" mode=0777
     changed_when: false
 
 - name: Distribute etcd CA to etcd hosts

--- a/playbooks/openshift-master/private/create_service_signer_cert.yml
+++ b/playbooks/openshift-master/private/create_service_signer_cert.yml
@@ -11,7 +11,7 @@
     when: not (hostvars[groups.oo_first_master.0].service_signer_cert_stat.stat.exists | bool)
 
   - name: Chmod local temp directory
-    local_action: command chmod 777 "{{ local_cert_sync_tmpdir.stdout }}"
+    local_action: file path="{{ local_cert_sync_tmpdir.stdout }}" mode=0777
     changed_when: false
     when: not (hostvars[groups.oo_first_master.0].service_signer_cert_stat.stat.exists | bool)
 

--- a/playbooks/openshift-master/private/redeploy-openshift-ca.yml
+++ b/playbooks/openshift-master/private/redeploy-openshift-ca.yml
@@ -132,7 +132,7 @@
     changed_when: false
 
   - name: Chmod local temp directory for syncing certs
-    local_action: command chmod 777 "{{ g_master_mktemp.stdout }}"
+    local_action: file path="{{ g_master_mktemp.stdout }}" mode=0777
     changed_when: false
 
 - name: Retrieve OpenShift CA

--- a/roles/openshift_examples/tasks/main.yml
+++ b/roles/openshift_examples/tasks/main.yml
@@ -17,7 +17,7 @@
   run_once: True
 
 - name: Chmod local temp dir for OpenShift examples copy
-  local_action: command chmod 777 "{{ copy_examples_mktemp.stdout }}"
+  local_action: file path="{{ copy_examples_mktemp.stdout }}" mode=0777
   run_once: True
 
 - name: Create tar of OpenShift examples
@@ -28,7 +28,7 @@
     warn: no
 
 - name: Chmod local temp dir for OpenShift examples copy
-  local_action: command chmod 744 "{{ copy_examples_mktemp.stdout }}/openshift-examples.tar"
+  local_action: file path="{{ copy_examples_mktemp.stdout }}/openshift-examples.tar" mode=0744
   run_once: True
 
 - name: Create the remote OpenShift examples directory

--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -137,7 +137,7 @@
   when: master_certs_missing | bool
 
 - name: Chmod local temp directory for syncing certs
-  local_action: command chmod 777 "{{ g_master_certs_mktemp.stdout }}"
+  local_action: file path="{{ g_master_certs_mktemp.stdout }}" mode=0777
   changed_when: False
   when: master_certs_missing | bool
 


### PR DESCRIPTION
Removes "[WARNING]: Consider using the file module with mode rather than 
running chmod" warning