### PR TITLE
Add CI scripts in hack/

### DIFF
--- a/hack/ci-build-rpm.sh
+++ b/hack/ci-build-rpm.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# This script builds RPMs for Prow CI
+tito tag --offline --accept-auto-changelog --use-release '9999%{?dist}'
+tito build --output="_output/local/releases" --rpm --test --offline --quiet
+
+mkdir _output/local/releases/rpms
+mv _output/local/releases/noarch/* _output/local/releases/rpms
+createrepo _output/local/releases/rpms

--- a/hack/ci-build-unittests.sh
+++ b/hack/ci-build-unittests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This script installs tox dependencies in the test container
+yum install -y gcc libffi-devel python-devel openssl-devel python-pip
+pip install tox
+chmod uga+w /etc/passwd

--- a/hack/ci-run-unittests.sh
+++ b/hack/ci-run-unittests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# This script runs tox tests in test container
+echo "${USER:-default}:x:$(id -u):$(id -g):Default User:${HOME:-/tmp}:/sbin/nologin" >> /etc/passwd
+tox 2>&1 | tee /tmp/artifacts/output.log


### PR DESCRIPTION
Prow CI currently runs several commands before e2e tests. These commands 
should be placed in our repo

/cc @stevekuznetsov 