### PR TITLE
Setup correct permissions for etcd config dir, fixes #10289

### DIFF
--- a/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
+++ b/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
@@ -145,6 +145,8 @@
   unarchive:
     src: "/tmp/{{ inventory_hostname }}/{{ etcd_generated_certs_dir }}/{{ etcd_cert_subdir }}.tgz"
     dest: "{{ etcd_cert_config_dir }}"
+    owner: etcd
+    group: etcd
   when: etcd_server_certs_missing | bool
 
 - name: Create a tarball of the etcd ca certs


### PR DESCRIPTION
See #10289

Putting this into `master` branch. Will need to backport that to `release-3.11` and `release-3.10` too.

After changing this and rerunning `redeploy_certificates` my cluster is back again.