### PR TITLE
Remove docker package when uninstalling the cluster with "openshift_uninstall_docker=True" variable

### DIFF
--- a/playbooks/adhoc/uninstall_docker.yml
+++ b/playbooks/adhoc/uninstall_docker.yml
@@ -39,6 +39,11 @@
     shell: docker-storage-setup --reset
     failed_when: False
 
+  - name: Remove Docker
+    package:
+      name: docker
+      state: absent
+
   - name: rm -rf docker config files
     shell: "rm {{ item }} -rf"
     failed_when: False


### PR DESCRIPTION
Executing 

ansible-playbook -e "openshift_uninstall_docker=True" -i inventories/openshift/openshift.yml /usr/share/ansible/openshift-ansible/playbooks/adhoc/uninstall.yml

Removes all the docker files, however, doesn't remove the docker package.

https://bugzilla.redhat.com/show_bug.cgi?id=1635254