### PR TITLE
GlusterFS uninstall: Only unlabel configured nodes

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
@@ -42,13 +42,13 @@
   - kind: storageclass
     name: "glusterfs-{{ glusterfs_name }}"
 
-- name: Unlabel any existing GlusterFS nodes
+- name: Unlabel GlusterFS nodes
   oc_label:
     name: "{{ hostvars[item].openshift.node.nodename }}"
     kind: node
     state: absent
     labels: "{{ glusterfs_nodeselector | lib_utils_oo_dict_to_list_of_dict }}"
-  with_items: "{{ groups.oo_nodes_to_config }}"
+  with_items: "{{ glusterfs_nodes }}"
   when: "'openshift' in hostvars[item]"
 
 - name: Delete deploy resources


### PR DESCRIPTION
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1634835

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>