### PR TITLE
Removing the task which removes the docker files from the cluster when openshift_uninstall_docker is set true

### DIFF
--- a/playbooks/adhoc/uninstall_docker.yml
+++ b/playbooks/adhoc/uninstall_docker.yml
@@ -39,10 +39,3 @@
     shell: docker-storage-setup --reset
     failed_when: False
 
-  - name: rm -rf docker config files
-    shell: "rm {{ item }} -rf"
-    failed_when: False
-    with_items:
-    - /etc/docker*
-    - /etc/sysconfig/docker*
-    - /etc/systemd/system/docker*


### PR DESCRIPTION
Removing the task which removes the docker files from the cluster when openshift_uninstall_docker is set true

The docker storage setup reset task should work to reset the docker storage. hence removing the docker related files would not be required and hence I have removed that. 

Fixes #10305