### PR TITLE
sync: tolerate all taints

### DIFF
--- a/roles/openshift_node_group/files/sync.yaml
+++ b/roles/openshift_node_group/files/sync.yaml
@@ -196,3 +196,6 @@ spec:
       - hostPath:
           path: /run/systemd/system
         name: run-systemd-system
+      # Sync daemonset should tolerate all taints to make sure it runs on all nodes
+      tolerations:
+      - operator: "Exists"

--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -38,7 +38,7 @@ spec:
       # It relies on an up to date node-config.yaml being present.
       - name: sdn
         image: " "
-        command: 
+        command:
         - /bin/bash
         - -c
         - |
@@ -204,3 +204,5 @@ spec:
       - name: host-var-lib-cni-networks-openshift-sdn
         hostPath:
           path: /var/lib/cni/networks/openshift-sdn
+      tolerations:
+      - operator: "Exists"


### PR DESCRIPTION
Some nodes may be tainted and disallow scheduling new pods. This should 
not apply to sync and SDN pods, as these should at least attempt to run on all 
nodes.

`Wait for sync pods task` lists all nodes and expects sync to run on all of those, including tainted nodes

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1635462
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1635804