### PR TITLE
glusterfs: add probe script for liveness and readiness checks

### DIFF
--- a/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
+++ b/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
@@ -38,6 +38,8 @@ objects:
           image: ${IMAGE_NAME}
           imagePullPolicy: IfNotPresent
           env:
+          - name: GLUSTER_BLOCKD_STATUS_PROBE_ENABLE
+            value: "${GLUSTER_BLOCKD_STATUS_PROBE_ENABLE}"
           - name: GB_GLFS_LRU_COUNT
             value: "${GB_GLFS_LRU_COUNT}"
           - name: TCMU_LOGDIR
@@ -86,7 +88,7 @@ objects:
               command:
               - "/bin/bash"
               - "-c"
-              - systemctl status glusterd.service
+              - "if command -v /usr/local/bin/status-probe.sh; then /usr/local/bin/status-probe.sh readiness; else systemctl status glusterd.service; fi"
             periodSeconds: 25
             successThreshold: 1
             failureThreshold: 50
@@ -97,7 +99,7 @@ objects:
               command:
               - "/bin/bash"
               - "-c"
-              - systemctl status glusterd.service
+              - "if command -v /usr/local/bin/status-probe.sh; then /usr/local/bin/status-probe.sh liveness; else systemctl status glusterd.service; fi"
             periodSeconds: 25
             successThreshold: 1
             failureThreshold: 50
@@ -147,6 +149,11 @@ parameters:
   displayName: Daemonset Node Labels
   description: Labels which define the daemonset node selector. Must contain at least one label of the format \'glusterfs=<CLUSTER_NAME>-host\'
   value: '{ "glusterfs": "storage-host" }'
+- name: GLUSTER_BLOCKD_STATUS_PROBE_ENABLE
+  displayName: Enable readiness/liveness probe for gluster-blockd
+  description: Setting the value to "1" enables the readiness/liveness probe for gluster-blockd.
+  value: "1"
+  required: false
 - name: IMAGE_NAME
   displayName: GlusterFS container image name
   required: True


### PR DESCRIPTION
This probe script is available in new containers only and thus
the fallback if statement. In addition, we provide an env var
that allows the user to disable the check for gluster-blockd.

Resolves [BZ#1635672](https://bugzilla.redhat.com/show_bug.cgi?id=1635672)

Signed-off-by: John Mulligan <jmulligan@redhat.com>