### PR TITLE
Allow Ansible 2.5.7

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -17,7 +17,7 @@ URL:            https://github.com/openshift/openshift-ansible
 Source0:        https://github.com/openshift/openshift-ansible/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-Requires:      ansible >= 2.6.5
+Requires:      ansible >= 2.5.7
 Requires:      python2
 Requires:      python-six
 Requires:      tar

--- a/roles/lib_utils/callback_plugins/aa_version_requirement.py
+++ b/roles/lib_utils/callback_plugins/aa_version_requirement.py
@@ -29,7 +29,7 @@ else:
 
 
 # Set to minimum required Ansible version
-REQUIRED_VERSION = '2.6.5'
+REQUIRED_VERSION = '2.5.7'
 DESCRIPTION = "Supported versions: %s or newer" % REQUIRED_VERSION
 
 


### PR DESCRIPTION
This relaxes the Ansible version checking to allow 2.5.7.

While it is recommended to stick with 2.6, some of the packages are not
avaliable for systems running the current Long Term Support version of
OpenStack (Queens / OSP 13).

https://bugzilla.redhat.com/show_bug.cgi?id=1626538
https://bugzilla.redhat.com/show_bug.cgi?id=1635293