### PR TITLE
[release-3.9] Override ovsdb-server systemd unit timeout when upgrading.

### DIFF
--- a/roles/openshift_node/tasks/upgrade/openvswitch.yml
+++ b/roles/openshift_node/tasks/upgrade/openvswitch.yml
@@ -1,0 +1,22 @@
+---
+- name: Create ovsdb-server systemd dropin folder
+  file:
+    path: /etc/systemd/system/ovsdb-server.service.d/
+    state: directory
+
+- name: Create ovsdb-server dropin config
+  ini_file:
+    path: /etc/systemd/system/ovsdb-server.service.d/timeout.conf
+    section: Service
+    option: TimeoutStartSec
+    value: 300
+  register: ovsdb_config_result
+
+- name: Reload systemd units for ovsdb config change
+  command: systemctl daemon-reload
+  when: ovsdb_config_result is changed
+
+- name: Start openvswitch service
+  service:
+    name: openvswitch
+    state: started

--- a/roles/openshift_node/tasks/upgrade/restart.yml
+++ b/roles/openshift_node/tasks/upgrade/restart.yml
@@ -38,12 +38,30 @@
     enabled: true
   when: openshift_use_crio | bool
 
+- name: Create ovsdb-server systemd dropin folder
+  file:
+    path: /etc/systemd/system/ovsdb-server.service.d/
+    state: directory
+  when: openshift_node_use_openshift_sdn | bool
+
+- name: Create ovsdb-server dropin config
+  ini_file:
+    path: /etc/systemd/system/ovsdb-server.service.d/timeout.conf
+    section: Service
+    option: TimeoutStartSec
+    value: 300
+  register: ovsdb_config_result
+  when: openshift_node_use_openshift_sdn | bool
+
+- name: Reload systemd units for ovsdb config change
+  command: systemctl daemon-reload
+  when: ovsdb_config_result | changed
+
 - name: Start openvswitch service
   service:
     name: openvswitch
     state: started
-  when:
-    - openshift_node_use_openshift_sdn | bool
+  when: openshift_node_use_openshift_sdn | bool
 
 - name: Start services
   service: name={{ item }} state=started

--- a/roles/openshift_node/tasks/upgrade/restart.yml
+++ b/roles/openshift_node/tasks/upgrade/restart.yml
@@ -38,29 +38,8 @@
     enabled: true
   when: openshift_use_crio | bool
 
-- name: Create ovsdb-server systemd dropin folder
-  file:
-    path: /etc/systemd/system/ovsdb-server.service.d/
-    state: directory
-  when: openshift_node_use_openshift_sdn | bool
-
-- name: Create ovsdb-server dropin config
-  ini_file:
-    path: /etc/systemd/system/ovsdb-server.service.d/timeout.conf
-    section: Service
-    option: TimeoutStartSec
-    value: 300
-  register: ovsdb_config_result
-  when: openshift_node_use_openshift_sdn | bool
-
-- name: Reload systemd units for ovsdb config change
-  command: systemctl daemon-reload
-  when: ovsdb_config_result | changed
-
-- name: Start openvswitch service
-  service:
-    name: openvswitch
-    state: started
+- name: Configure and start openvswitch systemd unit
+  include_tasks: openvswitch.yml
   when: openshift_node_use_openshift_sdn | bool
 
 - name: Start services


### PR DESCRIPTION
Fix:https://bugzilla.redhat.com/show_bug.cgi?id=1636234

Systemd is failing ovsdb-server on some upgrades. These tasks increase the systemd unit startup time for ovsdb-server to five minutes. Tested these tasks on rhel7 and saw TimeoutStartSec change from 1m30s to 5m when running ` systemctl show ovsdb-server.service`.