### PR TITLE
[release-3.7] Override ovsdb-server systemd unit timeout when upgrading. 

### DIFF
--- a/roles/openshift_node_upgrade/tasks/openvswitch.yml
+++ b/roles/openshift_node_upgrade/tasks/openvswitch.yml
@@ -1,0 +1,22 @@
+---
+- name: Create ovsdb-server systemd dropin folder
+  file:
+    path: /etc/systemd/system/ovsdb-server.service.d/
+    state: directory
+
+- name: Create ovsdb-server dropin config
+  ini_file:
+    path: /etc/systemd/system/ovsdb-server.service.d/timeout.conf
+    section: Service
+    option: TimeoutStartSec
+    value: 300
+  register: ovsdb_config_result
+
+- name: Reload systemd units for ovsdb config change
+  command: systemctl daemon-reload
+  when: ovsdb_config_result is changed
+
+- name: Start openvswitch service
+  service:
+    name: openvswitch
+    state: started

--- a/roles/openshift_node_upgrade/tasks/restart.yml
+++ b/roles/openshift_node_upgrade/tasks/restart.yml
@@ -26,12 +26,9 @@
   openshift_facts:
     role: docker
 
-- name: Start openvswitch service
-  service:
-    name: openvswitch
-    state: started
-  when:
-    - openshift_use_openshift_sdn | default(true) | bool
+- name: Configure and start openvswitch systemd unit
+  include: openvswitch.yml
+  when: openshift_use_openshift_sdn | default(true) | bool
 
 - name: Start services
   service: name={{ item }} state=started


### PR DESCRIPTION
This fixes the same problem for 3.7 as #10324 does for 3.9. 

Between the two versions, openvswitch is started in different plays:
3.7: roles/openshift_node_upgrade/tasks/restart.yml
3.9: roles/openshift_node/tasks/upgrade/restart.yml

So I don't think we can cherrypick this into release-3.7.
EDIT: Also, they use slightly different variable names, which has been fixed in 3.9 pr.

Cloned bz for v3.9: https://bugzilla.redhat.com/show_bug.cgi?id=1636234