### PR TITLE
bug 1636248. Delete logging cluster service if clusterIP != None

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -290,6 +290,24 @@
       path: "{{ generated_certs_dir }}/passwd.yml"
 
 # services
+# bz1636248 - need to delete the service if it exists because clusterIP is immutable
+- name: Check to see if logging-{{ es_component }}-cluster service
+  oc_obj:
+    state: list
+    kind: service
+    name: "logging-{{ es_component }}-cluster"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+  register: logging_elasticsearch_cluster_service
+
+- name: Remove logging-{{ es_component }}-cluster service
+  oc_service:
+    state: absent
+    name: "logging-{{ es_component }}-cluster"
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+  when:
+  - logging_elasticsearch_cluster_service.results.returncode == 0
+  - logging_elasticsearch_cluster_service.results.results[0] | from_yaml | walk('spec.clusterIP', '') != 'None'
+
 - name: Set logging-{{ es_component }}-cluster service
   oc_service:
     state: present


### PR DESCRIPTION
This PR fixes:

https://bugzilla.redhat.com/show_bug.cgi?id=1636248

by deleting the logging cluster service if the clusterIP != None.  This is to ensure it is a headless service that is required for es to function properly