### PR TITLE
Fail on openshift_hostname defined; add openshift_kubelet_name_override

### DIFF
--- a/images/installer/root/usr/local/bin/generate
+++ b/images/installer/root/usr/local/bin/generate
@@ -186,7 +186,7 @@ class Host:
         if self.public_ip_addr:
             info += "openshift_public_ip=" + self.public_ip_addr + " "
         if self.hostname:
-            info += "openshift_hostname=" + self.hostname + " "
+            info += "openshift_kubelet_name_override=" + self.hostname + " "
         if self.public_hostname:
             info += "openshift_public_hostname=" + self.public_hostname
 

--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -825,7 +825,7 @@ debug_level=2
 #logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
 # The OpenShift-Ansible installer will fail when it detects that the
-# value of openshift_hostname resolves to an IP address not bound to any local
+# value of openshift_kubelet_name_override resolves to an IP address not bound to any local
 # interfaces. This mis-configuration is problematic for any pod leveraging host
 # networking and liveness or readiness probes.
 # Setting this variable to false will override that check.

--- a/inventory/hosts.openstack
+++ b/inventory/hosts.openstack
@@ -24,7 +24,7 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 #openshift_pkg_version=-3.0.0.0
 
 [masters]
-jdetiber-master.usersys.redhat.com openshift_public_hostname="{{ inventory_hostname }}" openshift_hostname="{{ ansible_default_ipv4.address }}"
+jdetiber-master.usersys.redhat.com openshift_public_hostname="{{ inventory_hostname }}"
 
 [etcd]
 jdetiber-etcd.usersys.redhat.com
@@ -33,5 +33,5 @@ jdetiber-etcd.usersys.redhat.com
 #ose3-lb-ansible.test.example.com
 
 [nodes]
-jdetiber-master.usersys.redhat.com openshift_public_hostname="{{ inventory_hostname }}" openshift_hostname="{{ ansible_default_ipv4.address }}" openshift_node_group_name="node-config-master"
-jdetiber-node[1:2].usersys.redhat.com openshift_public_hostname="{{ inventory_hostname }}" openshift_hostname="{{ ansible_default_ipv4.address }}" openshift_node_group_name="node-config-compute"
+jdetiber-master.usersys.redhat.com openshift_public_hostname="{{ inventory_hostname }}" openshift_node_group_name="node-config-master"
+jdetiber-node[1:2].usersys.redhat.com openshift_public_hostname="{{ inventory_hostname }}" openshift_node_group_name="node-config-compute"

--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -28,7 +28,7 @@
     openshift_facts:
       role: common
       local_facts:
-        hostname: "{{ openshift_hostname | default(None) }}"
+        hostname: "{{ openshift_kubelet_name_override | default(None) }}"
         ip: "{{ openshift_ip | default(None) }}"
         public_hostname: "{{ openshift_public_hostname | default(None) }}"
         public_ip: "{{ openshift_public_ip | default(None) }}"

--- a/playbooks/init/validate_hostnames.yml
+++ b/playbooks/init/validate_hostnames.yml
@@ -10,19 +10,20 @@
     changed_when: false
     failed_when: false
 
-  - name: Validate openshift_hostname when defined
+  - name: Validate openshift_kubelet_name_override when defined
     fail:
       msg: >
         The hostname {{ openshift.common.hostname }} for {{ ansible_nodename }}
         doesn't resolve to an IP address owned by this host. Please set
-        openshift_hostname variable to a hostname that when resolved on the host
+        openshift_kubelet_name_override variable to a hostname that when resolved on the host
         in question resolves to an IP address matching an interface on this host.
         This will ensure proper functionality of OpenShift networking features.
-        Inventory setting: openshift_hostname={{ openshift_hostname | default ('undefined') }}
+        Inventory setting: openshift_kubelet_name_override={{ openshift_kubelet_name_override | default ('undefined') }}
         This check can be overridden by setting openshift_hostname_check=false in
         the inventory.
         See https://docs.okd.io/latest/install_config/install/advanced_install.html#configuring-host-variables
     when:
+    - openshift_kubelet_name_override is defined
     - lookupip.stdout != '127.0.0.1'
     - lookupip.stdout not in ansible_all_ipv4_addresses
     - openshift_hostname_check | default(true) | bool

--- a/playbooks/openstack/resources.py
+++ b/playbooks/openstack/resources.py
@@ -101,8 +101,8 @@ def _get_hostvars(server, docker_storage_mountpoints):
         # name at all, so using a hostname here would require an internal
         # DNS which would complicate the setup and potentially introduce
         # performance issues.
-        hostvars['openshift_hostname'] = server.metadata.get(
-            'openshift_hostname', private_v4)
+        hostvars['openshift_kubelet_name_override'] = server.metadata.get(
+            'openshift_kubelet_name_override', private_v4)
     hostvars['openshift_public_hostname'] = server.name
 
     if server.metadata['host-type'] == 'cns':

--- a/roles/lib_utils/action_plugins/sanity_checks.py
+++ b/roles/lib_utils/action_plugins/sanity_checks.py
@@ -64,6 +64,7 @@ IMAGE_POLICY_CONFIG_VAR = "openshift_master_image_policy_config"
 ALLOWED_REGISTRIES_VAR = "openshift_master_image_policy_allowed_registries_for_import"
 
 REMOVED_VARIABLES = (
+    ('openshift_hostname', 'Removed: See documentation'),
     # TODO(michaelgugino): Remove in 3.12
     ('oreg_auth_credentials_replace', 'Removed: Credentials are now always updated'),
     ('oreg_url_master', 'oreg_url'),
@@ -331,10 +332,10 @@ class ActionModule(ActionBase):
             raise errors.AnsibleModuleError(msg)
 
     def check_hostname_vars(self, hostvars, host):
-        """Checks to ensure openshift_hostname
+        """Checks to ensure openshift_kubelet_name_override
            and openshift_public_hostname
            conform to the proper length of 63 characters or less"""
-        for varname in ('openshift_public_hostname', 'openshift_hostname'):
+        for varname in ('openshift_public_hostname', 'openshift_kubelet_name_override'):
             var_value = self.template_var(hostvars, host, varname)
             if var_value and len(var_value) > 63:
                 msg = '{} must be 63 characters or less'.format(varname)

--- a/roles/openshift_openstack/tasks/node-configuration.yml
+++ b/roles/openshift_openstack/tasks/node-configuration.yml
@@ -1,6 +1,6 @@
 ---
 # NOTE(shadower): we need to do this because some of the install tasks seem to
-# ignore openshift_hostname and rely on the actual system's hostname
+# ignore openshift_kubelet_name_override and rely on the actual system's hostname
 - name: Update hostname to match the OpenStack name
   hostname:
     name: "{{ inventory_hostname }}"

--- a/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
@@ -245,7 +245,7 @@ resources:
         sub-host-type:    { get_param: subtype }
         openshift_node_group_name: { get_param: openshift_node_group_name }
 {% if openshift_openstack_dns_nameservers %}
-        openshift_hostname: { get_param: name }
+        openshift_kubelet_name_override: { get_param: name }
 {% endif %}
       scheduler_hints: { get_param: scheduler_hints }
 


### PR DESCRIPTION
Adding openshift_kubelet_name_override as a stand-in for
various places we will need to account for possible hostname
overrides.