### PR TITLE
[3.10] Node problem detector always pull images from registry.redhat.io for openshift-enterprise

### DIFF
--- a/roles/openshift_node_problem_detector/defaults/main.yaml
+++ b/roles/openshift_node_problem_detector/defaults/main.yaml
@@ -5,17 +5,7 @@ openshift_node_problem_detector_tmp_location: /tmp
 openshift_node_problem_detector_delete_tempfiles: True
 
 # node-problem-detector image setup
-openshift_node_problem_detector_image_dict:
-  origin:
-    prefix: "docker.io/openshift/"
-    version: "{{ openshift_image_tag }}"
-  openshift-enterprise:
-    prefix: "registry.access.redhat.com/openshift3/ose-"
-    version: "{{ openshift_image_tag }}"
-
-openshift_node_problem_detector_image_prefix: "{{ openshift_node_problem_detector_image_dict[openshift_deployment_type]['prefix'] }}"
-openshift_node_problem_detector_image_version: "{{ openshift_node_problem_detector_image_dict[openshift_deployment_type]['version'] }}"
-
+openshift_node_problem_detector_image: "{{ l_osm_registry_url | regex_replace('${component}' | regex_escape, 'node-problem-detector') }}"
 
 # node_problem_detector daemonset setup
 openshift_node_problem_detector_daemonset_name: node-problem-detector

--- a/roles/openshift_node_problem_detector/templates/node-problem-detector-daemonset.yaml.j2
+++ b/roles/openshift_node_problem_detector/templates/node-problem-detector-daemonset.yaml.j2
@@ -21,7 +21,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: {{ openshift_node_problem_detector_image_prefix }}node-problem-detector:{{ openshift_node_problem_detector_image_version }}
+        image: {{ openshift_node_problem_detector_image }}
         imagePullPolicy: {{ openshift_node_problem_detector_image_pull_policy }}
         name: {{ openshift_node_problem_detector_daemonset_name }}
         resources: {}


### PR DESCRIPTION
This is a cherry-pick PR, xref #10260

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1670390