### PR TITLE
unmount just before removing

### DIFF
--- a/roles/container_runtime/tasks/common/setup_docker_symlink.yml
+++ b/roles/container_runtime/tasks/common/setup_docker_symlink.yml
@@ -11,11 +11,6 @@
       failed_when:
         - results.rc != 0
 
-    - name: ensure the unmount of top level mount point
-      mount:
-        path: "{{ docker_default_storage_path }}"
-        state: unmounted
-
     - name: "Set the selinux context on {{ docker_alt_storage_path }}"
       command: "semanage fcontext -a -e {{ docker_default_storage_path }} {{ docker_alt_storage_path }}"
       environment:
@@ -27,6 +22,11 @@
 
     - name: "restorecon the {{ docker_alt_storage_path }}"
       command: "restorecon -r {{ docker_alt_storage_path }}"
+
+    - name: ensure the unmount of top level mount point
+      mount:
+        path: "{{ docker_default_storage_path }}"
+        state: unmounted
 
     - name: Remove the old docker location
       file:


### PR DESCRIPTION
The current code calls umount /var/lib/docker/containers, then
immediately uses /var/lib/docker/containers for an selinux
operation, then attempts to remove the directory.  The removal
will sometimes fail with a "filesystem busy" error, I think because
doing the selinux operation after unmounting somehow causes it
to be busy.  Doing the unmount after all of the operations, and
just before doing the removal, seems to fix this condition.