### PR TITLE
[3.11] Atomic upgrade: ensure /etc/origin/kubelet-plugins exists

### DIFF
--- a/roles/openshift_control_plane/tasks/static.yml
+++ b/roles/openshift_control_plane/tasks/static.yml
@@ -45,6 +45,13 @@
     - key: spec.containers[0].readinessProbe.httpGet.port
       value: "{{ openshift_master_api_port }}"
 
+- name: ensure kubelet plugins dir exists
+  file:
+    path: "/etc/origin/kubelet-plugins"
+    state: directory
+    mode: "0755"
+  when: openshift_is_atomic | bool
+
 - name: Update controller-manager static pod on atomic host
   yedit:
     src: "{{ mktemp.stdout }}/controller.yaml"


### PR DESCRIPTION
Upgrade playbook changes path to `/etc/origin/kubelet-plugins` on Atomic systems, but doesn't verify this folder exists.

This happened on my cluster during 3.9 -> 3.10 upgrade