### PR TITLE
Update kube-service-catalog apiserver ds arguments after scaling up etcd

### DIFF
--- a/playbooks/openshift-etcd/private/scaleup.yml
+++ b/playbooks/openshift-etcd/private/scaleup.yml
@@ -61,6 +61,17 @@
     delay: 30
     until: scaleup_health.rc == 0
 
+- name: Update Service Catalog API server with new etcd members
+  hosts: oo_first_master
+  tasks:
+  - import_role:
+      name: openshift_service_catalog
+      tasks_from: update_api_server.yml
+    when: 
+    - openshift_enable_service_catalog | default(true) | bool
+  vars:
+    first_master: "{{ groups.oo_first_master[0] }}"
+
 - name: Update master etcd client urls
   hosts: oo_masters_to_config
   serial: 1

--- a/playbooks/openshift-etcd/private/scaleup.yml
+++ b/playbooks/openshift-etcd/private/scaleup.yml
@@ -86,13 +86,13 @@
       name: openshift_master
       tasks_from: update_etcd_client_urls.yml
 
-- name: Update Service Catalog API server with new etcd members
+- name: Update Service Catalog apiserver daemonset with new etcd member url references
   hosts: oo_first_master
   tasks:
   - import_role:
       name: openshift_service_catalog
       tasks_from: update_api_server.yml
-    when: 
+    when:
     - openshift_enable_service_catalog | default(true) | bool
   vars:
     first_master: "{{ groups.oo_first_master[0] }}"

--- a/playbooks/openshift-etcd/private/scaleup.yml
+++ b/playbooks/openshift-etcd/private/scaleup.yml
@@ -61,17 +61,6 @@
     delay: 30
     until: scaleup_health.rc == 0
 
-- name: Update Service Catalog API server with new etcd members
-  hosts: oo_first_master
-  tasks:
-  - import_role:
-      name: openshift_service_catalog
-      tasks_from: update_api_server.yml
-    when: 
-    - openshift_enable_service_catalog | default(true) | bool
-  vars:
-    first_master: "{{ groups.oo_first_master[0] }}"
-
 - name: Update master etcd client urls
   hosts: oo_masters_to_config
   serial: 1
@@ -96,3 +85,14 @@
   - import_role:
       name: openshift_master
       tasks_from: update_etcd_client_urls.yml
+
+- name: Update Service Catalog API server with new etcd members
+  hosts: oo_first_master
+  tasks:
+  - import_role:
+      name: openshift_service_catalog
+      tasks_from: update_api_server.yml
+    when: 
+    - openshift_enable_service_catalog | default(true) | bool
+  vars:
+    first_master: "{{ groups.oo_first_master[0] }}"

--- a/roles/openshift_service_catalog/tasks/update_api_server.yml
+++ b/roles/openshift_service_catalog/tasks/update_api_server.yml
@@ -13,7 +13,7 @@
 - name: Set service_catalog image facts
   set_fact:
     openshift_service_catalog_image_prefix: "{{ openshift_service_catalog_image_prefix | default(__openshift_service_catalog_image_prefix) }}"
-    openshift_service_catalog_image_version: "{{ openshift_service_catalog_image_version | default(__openshift_service_catalog_image_version) }}"  
+    openshift_service_catalog_image_version: "{{ openshift_service_catalog_image_version | default(__openshift_service_catalog_image_version) }}"
 
 - set_fact:
     generated_certs_dir: "{{ openshift.common.config_base }}/service-catalog"
@@ -30,7 +30,7 @@
     get_mime: false
   register: etcd_ca_crt
   check_mode: no
-  
+
 - template:
     src: api_server.j2
     dest: "{{ mktemp.stdout }}/service_catalog_api_server.yml"
@@ -46,7 +46,7 @@
     etcd_cafile: "{{ '/etc/origin/master/master.etcd-ca.crt' if etcd_ca_crt.stat.exists else '/etc/origin/master/ca-bundle.crt' }}"
     node_selector: {'node-role.kubernetes.io/master': 'true'}
     ca_hash: "{{ apiserver_ca.content|hash('sha1') }}"
-    
+
 - name: Set Service Catalog API Server daemonset
   oc_obj:
     state: present
@@ -60,7 +60,7 @@
 
 # Delete current pods so that they get respawned with new ds args.
 - oc_obj:
-   kind: po
-   namespace: "kube-service-catalog"
-   state: absent
-   selector: "app=apiserver"
+    kind: po
+    namespace: "kube-service-catalog"
+    state: absent
+    selector: "app=apiserver"

--- a/roles/openshift_service_catalog/tasks/update_api_server.yml
+++ b/roles/openshift_service_catalog/tasks/update_api_server.yml
@@ -1,0 +1,66 @@
+---
+- name: Create temp directory for doing work in
+  command: mktemp -d /tmp/openshift-service-catalog-ansible-XXXXXX
+  register: mktemp
+  changed_when: False
+
+- name: Set default image variables based on openshift_deployment_type
+  include_vars: "{{ item }}"
+  with_first_found:
+  - "{{ openshift_deployment_type }}.yml"
+  - "default_images.yml"
+
+- name: Set service_catalog image facts
+  set_fact:
+    openshift_service_catalog_image_prefix: "{{ openshift_service_catalog_image_prefix | default(__openshift_service_catalog_image_prefix) }}"
+    openshift_service_catalog_image_version: "{{ openshift_service_catalog_image_version | default(__openshift_service_catalog_image_version) }}"  
+
+- set_fact:
+    generated_certs_dir: "{{ openshift.common.config_base }}/service-catalog"
+
+- slurp:
+    src: "{{ generated_certs_dir }}/ca.crt"
+  register: apiserver_ca
+
+- name: Checking for master.etcd-ca.crt
+  stat:
+    path: /etc/origin/master/master.etcd-ca.crt
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
+  register: etcd_ca_crt
+  check_mode: no
+  
+- template:
+    src: api_server.j2
+    dest: "{{ mktemp.stdout }}/service_catalog_api_server.yml"
+  vars:
+    image: ""
+    namespace: ""
+    cpu_limit: none
+    memory_limit: none
+    cpu_requests: none
+    memory_request: none
+    cors_allowed_origin: localhost
+    etcd_servers: "{{ openshift_master_etcd_urls | join(',') }}"
+    etcd_cafile: "{{ '/etc/origin/master/master.etcd-ca.crt' if etcd_ca_crt.stat.exists else '/etc/origin/master/ca-bundle.crt' }}"
+    node_selector: {'node-role.kubernetes.io/master': 'true'}
+    ca_hash: "{{ apiserver_ca.content|hash('sha1') }}"
+    
+- name: Set Service Catalog API Server daemonset
+  oc_obj:
+    state: present
+    namespace: "kube-service-catalog"
+    kind: daemonset
+    name: apiserver
+    force: true
+    files:
+    - "{{ mktemp.stdout }}/service_catalog_api_server.yml"
+    delete_after: yes
+
+# Delete current pods so that they get respawned with new ds args.
+- oc_obj:
+   kind: po
+   namespace: "kube-service-catalog"
+   state: absent
+   selector: "app=apiserver"


### PR DESCRIPTION
After running the etcd scaleup playbook, kube-service-catalog apiserver daemonset arguments are not updated with the new etcd urls.

Somehow related docs BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1636645