### PR TITLE
Increase number of retries in sync DS

### DIFF
--- a/roles/openshift_manage_node/tasks/config.yml
+++ b/roles/openshift_manage_node/tasks/config.yml
@@ -24,6 +24,6 @@
         | map(attribute='metadata.annotations') | map('list') | flatten
         | select('match', 'node.openshift.io/md5sum') | list | length ==
       node_status.results.results[0]['items'] | length
-  retries: 60
+  retries: 180
   delay: 10
   delegate_to: "{{ openshift_master_host }}"

--- a/roles/openshift_node_group/tasks/sync.yml
+++ b/roles/openshift_node_group/tasks/sync.yml
@@ -86,7 +86,7 @@
         | map(attribute='metadata.annotations') | map('list') | flatten
         | select('match', 'node.openshift.io/md5sum') | list | length ==
       node_status.results.results[0]['items'] | length
-  retries: 60
+  retries: 180
   delay: 10
 
 # Sync DS may have restarted masters


### PR DESCRIPTION
This would ensure sync DS annotation check passes on installs with slow 
nodes (or a large number of nodes)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1636914