### PR TITLE
update references to outdated variable openshift_monitoring_deploy

### DIFF
--- a/playbooks/openshift-metering/README.md
+++ b/playbooks/openshift-metering/README.md
@@ -5,10 +5,12 @@ See the role for more information.
 
 ## Prequisites:
 
-This playbook requires Openshift Monitoring to be installed, to install it set this variable:
+This playbook requires Openshift Cluster Monitoring, which is installed by default.
+If Openshift Cluster Monitoring is not installed, check that the variable
+openshift\_cluster\_monitoring\_operator\_install is set to true.
 
 ```yaml
-openshift_monitoring_deploy: true
+openshift_cluster_monitoring_operator_install: true
 ```
 
 ## Installation

--- a/test/ci/inventory/group_vars/OSEv3/vars.yml
+++ b/test/ci/inventory/group_vars/OSEv3/vars.yml
@@ -16,7 +16,7 @@ template_service_broker_install: false
 ansible_service_broker_install: false
 openshift_enable_service_catalog: false
 osm_use_cockpit: false
-openshift_monitoring_deploy: false
+openshift_cluster_monitoring_operator_install: false
 openshift_metering_install: false
 openshift_metrics_server_install: false
 openshift_monitor_availability_install: false


### PR DESCRIPTION
openshift_monitoring_deploy was changed to openshift_cluster_monitoring_operator_install
See also: https://github.com/openshift/openshift-ansible/commit/64f19cf21cff615bf48a2e8af200121bb794304d