### PR TITLE
bug 1627689. Peg logging-es-ops to appropriate configmap

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -435,6 +435,7 @@
     dest: "{{ tempdir }}/templates/logging-es-dc.yml"
   vars:
     es_cluster_name: "{{ es_component }}"
+    configmap_name: "{{ elasticsearch_name }}"
     component: "{{ es_component }}"
     logging_component: elasticsearch
     deploy_name: "{{ es_deploy_name }}"

--- a/roles/openshift_logging_elasticsearch/templates/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/es.j2
@@ -197,7 +197,7 @@ spec:
             secretName: logging-elasticsearch
         - name: elasticsearch-config
           configMap:
-            name: logging-elasticsearch
+            name: "{{configmap_name}}"
         - name: podinfo
           downwardAPI:
             items:


### PR DESCRIPTION
Fix https://bugzilla.redhat.com/show_bug.cgi?id=1627689

* Make the logging-es-ops cluster use the same named configmap