### PR TITLE
Add missing option in Openstack documentation and sample file.

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -735,6 +735,7 @@ openshift_node_groups:
   - name: node-config-master
     labels:
       - 'node-role.kubernetes.io/master=true'
+      - 'pod_vif=nested-vlan'
     edits: []
   - name: node-config-infra
     labels:

--- a/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -33,6 +33,7 @@ openshift_hosted_registry_wait: True
 #  - name: node-config-master
 #    labels:
 #      - 'node-role.kubernetes.io/master=true'
+#      - 'pod_vif=nested-vlan'
 #    edits: []
 #  - name: node-config-infra
 #    labels:


### PR DESCRIPTION
'pod_vif=nested-vlan' label was missing for master nodes in
openshift_node_groups section, both in documentation file
and in OSEv3 sample inventory file.