### PR TITLE
README: ansible 2.7 is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install base dependencies:
 
 Requirements:
 
-- Ansible >= 2.6.2
+- Ansible >= 2.6.2, Ansible 2.7 is not yet supported and known to fail
 - Jinja >= 2.7
 - pyOpenSSL
 - python-lxml


### PR DESCRIPTION
Add a not that Ansible 2.7 is not yet supported - it skips etcd CA playbooks so API won't come up

Related to https://github.com/openshift/openshift-ansible/issues/10368