### PR TITLE
Logging playbook fails due to missing kubeconfig

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/get_es_version.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/get_es_version.yml
@@ -17,7 +17,7 @@
 
 - name: "Getting ES version for logging-es cluster"
   command: >
-    {{ openshift_client_binary }} exec {{ available_pod }} -c elasticsearch -n {{ openshift_logging_elasticsearch_namespace }} -- {{ __es_local_curl }} -XGET 'https://localhost:9200/'
+    {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig exec {{ available_pod }} -c elasticsearch -n {{ openshift_logging_elasticsearch_namespace }} -- {{ __es_local_curl }} -XGET 'https://localhost:9200/'
   register: _curl_output
   when: available_pod is defined
 


### PR DESCRIPTION
logging playbook fails due to missing kubeconfig.

This is corrected in 3.10

https://github.com/openshift/openshift-ansible/blob/release-3.10/roles/openshift_logging_elasticsearch/tasks/get_es_version.yml