### PR TITLE
Place openshift_kubelet_name_override file

### DIFF
--- a/roles/openshift_node/tasks/upgrade_pre.yml
+++ b/roles/openshift_node/tasks/upgrade_pre.yml
@@ -5,6 +5,12 @@
 - set_fact:
     skip_node_svc_handlers: True
 
+- name: Place openshift_kubelet_name_override file
+  template:
+    src: KUBELET_HOSTNAME_OVERRIDE.j2
+    dest: "/etc/sysconfig/KUBELET_HOSTNAME_OVERRIDE"
+  when: openshift_kubelet_name_override is defined
+
 - import_tasks: registry_auth.yml
 
 # Prepull the node and pod image, it's used by lots of components

--- a/roles/openshift_node/templates/KUBELET_HOSTNAME_OVERRIDE.j2
+++ b/roles/openshift_node/templates/KUBELET_HOSTNAME_OVERRIDE.j2
@@ -1,0 +1,1 @@
+{{ openshift_kubelet_name_override }}


### PR DESCRIPTION
This commit places kubelet_name_override file for 3.10
upgrades only.