### PR TITLE
[3.11] Dockerfile: install ansible 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install base dependencies:
 
 Requirements:
 
-- Ansible >= 2.6.2, Ansible 2.7 is not yet supported and known to fail
+- Ansible >= 2.6.5, Ansible 2.7 is not yet supported and known to fail
 - Jinja >= 2.7
 - pyOpenSSL
 - python-lxml

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -10,11 +10,9 @@ COPY images/installer/origin-extra-root /
 # install ansible and deps
 RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
- && EPEL_PKGS="python2-boto python2-boto3 python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli" \
- && EPEL_TESTING_PKGS="ansible-2.6.5" \
+ && EPEL_PKGS="ansible-2.6.5 python2-boto python2-boto3 python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
- && yum install -y --setopt=tsflags=nodocs --enablerepo=epel-testing $EPEL_TESTING_PKGS \
  && if [ "$(uname -m)" == "x86_64" ]; then yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm ; fi \
  && yum install -y java-1.8.0-openjdk-headless \
  && rpm -V $INSTALL_PKGS $EPEL_PKGS $EPEL_TESTING_PKGS \

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -11,7 +11,7 @@ COPY images/installer/origin-extra-root /
 RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
  && EPEL_PKGS="python2-boto python2-boto3 python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli" \
- && EPEL_TESTING_PKGS="ansible" \
+ && EPEL_TESTING_PKGS="ansible-2.6.5" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
  && yum install -y --setopt=tsflags=nodocs --enablerepo=epel-testing $EPEL_TESTING_PKGS \

--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -17,7 +17,7 @@ URL:            https://github.com/openshift/openshift-ansible
 Source0:        https://github.com/openshift/openshift-ansible/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-Requires:      ansible >= 2.6.2
+Requires:      ansible >= 2.6.5
 Requires:      python2
 Requires:      python-six
 Requires:      tar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.6.2
+ansible==2.6.5
 boto==2.44.0
 click==6.7
 pyOpenSSL==17.5.0

--- a/roles/lib_utils/callback_plugins/aa_version_requirement.py
+++ b/roles/lib_utils/callback_plugins/aa_version_requirement.py
@@ -29,7 +29,7 @@ else:
 
 
 # Set to minimum required Ansible version
-REQUIRED_VERSION = '2.6.2'
+REQUIRED_VERSION = '2.6.5'
 DESCRIPTION = "Supported versions: %s or newer" % REQUIRED_VERSION
 
 


### PR DESCRIPTION
ansible 2.7 has landed in EPEL Testing and broke additional repo setup
among other things.
This also changes other requirements to match ansible 2.6.5

This is a cherrypick of https://github.com/openshift/openshift-ansible/pull/10377, needs to be 
submitted manually to make sure `gcp-major-upgrade` passes on master branch