### PR TITLE
Allow wiping GlusterFS devices at install time

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_common.yml
@@ -33,6 +33,9 @@
   - 'router'
   when: glusterfs_is_native or glusterfs_heketi_is_native
 
+- import_tasks: glusterfs_wipe.yml
+  when: glusterfs_wipe
+
 - import_tasks: glusterfs_deploy.yml
   when: glusterfs_is_native
 

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
@@ -142,31 +142,5 @@
   - not glusterfs_is_native | bool
   - not openshift_is_atomic | bool
 
-- name: Get GlusterFS storage devices state
-  command: "pvdisplay -C --noheadings -o pv_name,vg_name {% for device in hostvars[item].glusterfs_devices %}{{ device }} {% endfor %}"
-  register: devices_info
-  delegate_to: "{{ item }}"
-  with_items: "{{ glusterfs_nodes | default([]) }}"
-  failed_when: False
-  when: glusterfs_wipe
-
-  # Runs "lvremove -ff <vg>; vgremove -fy <vg>; pvremove -fy <pv>" for every device found to be a physical volume.
-- name: Clear GlusterFS storage device contents
-  shell: "{% for line in item.stdout_lines %}{% set fields = line.split() %}{% if fields | count > 1 %}lvremove -ff {{ fields[1] }}; vgchange -an {{ fields[1] }}; vgremove -fy {{ fields[1] }}; dmsetup remove {{ fields[1] }}; {% endif %}pvremove -fy {{ fields[0] }}; {% endfor %}"
-  delegate_to: "{{ item.item }}"
-  with_items: "{{ devices_info.results }}"
-  register: clear_devices
-  until:
-  - "'contains a filesystem in use' not in clear_devices.stderr"
-  delay: 1
-  retries: 30
-  when:
-  - glusterfs_wipe
-  - item.stdout_lines | count > 0
-
-- name: Wipe filesystem signatures from storage devices
-  command: "wipefs -a {% for device in hostvars[item].glusterfs_devices %}{{ device }} {% endfor %}"
-  delegate_to: "{{ item }}"
-  with_items: "{{ glusterfs_nodes | default([]) }}"
-  failed_when: False
+- import_tasks: glusterfs_wipe.yml
   when: glusterfs_wipe

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_wipe.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_wipe.yml
@@ -1,0 +1,25 @@
+---
+- name: Get GlusterFS storage devices state
+  command: "pvdisplay -C --noheadings -o pv_name,vg_name {% for device in hostvars[item].glusterfs_devices %}{{ device }} {% endfor %}"
+  register: devices_info
+  delegate_to: "{{ item }}"
+  with_items: "{{ glusterfs_nodes | default([]) }}"
+  failed_when: False
+
+  # Runs "lvremove -ff <vg>; vgremove -fy <vg>; pvremove -fy <pv>" for every device found to be a physical volume.
+- name: Clear GlusterFS storage device contents
+  shell: "{% for line in item.stdout_lines %}{% set fields = line.split() %}{% if fields | count > 1 %}lvremove -ff {{ fields[1] }}; vgchange -an {{ fields[1] }}; vgremove -fy {{ fields[1] }}; dmsetup remove {{ fields[1] }}; {% endif %}pvremove -fy {{ fields[0] }}; {% endfor %}"
+  delegate_to: "{{ item.item }}"
+  with_items: "{{ devices_info.results }}"
+  register: clear_devices
+  until:
+  - "'contains a filesystem in use' not in clear_devices.stderr"
+  delay: 1
+  retries: 30
+  when: item.stdout_lines | count > 0
+
+- name: Wipe filesystem signatures from storage devices
+  command: "wipefs -a {% for device in hostvars[item].glusterfs_devices %}{{ device }} {% endfor %}"
+  delegate_to: "{{ item }}"
+  with_items: "{{ glusterfs_nodes | default([]) }}"
+  failed_when: False


### PR DESCRIPTION
Extract glusterfs wipe into its own playbook and call it from the
install playbook as well.

This allows to redeploy OpenShift on the same nodes without the need to
call the uninstall playbook prior to it.

This is also more in line with the documentation  for the
`openshift_storage_glusterfs_wipe` variable that didn't mention wiping
GlusterFS storage devices only happened when specifically calling the
uninstall playbook.