### PR TITLE
access the correct field from "az disk grant-access" response json

### DIFF
--- a/playbooks/azure/openshift-cluster/tasks/create_blob_from_vm.yml
+++ b/playbooks/azure/openshift-cluster/tasks/create_blob_from_vm.yml
@@ -23,7 +23,7 @@
 - name: start copy
   command: >
     az storage blob copy start
-    --source-uri "{{ (sas.stdout | from_json).properties.output.accessSAS }}"
+    --source-uri "{{ (sas.stdout | from_json).accessSas }}"
     --account-name "{{ openshift_azure_storage_account }}"
     --account-key "{{ (keys.stdout | from_json)[0].value }}"
     --destination-container "{{ openshift_azure_container }}"


### PR DESCRIPTION
closes https://github.com/openshift/openshift-azure/issues/591

in a follow-up PR, we'll pin the azure cli to `2.0.47` in the installer images for openshift-ansible

/cc @kwoodson @jim-minter 