### PR TITLE
[release-3.10] Increase number of retries in sync DS

### DIFF
--- a/roles/openshift_manage_node/tasks/config.yml
+++ b/roles/openshift_manage_node/tasks/config.yml
@@ -24,7 +24,7 @@
         | map(attribute='metadata.annotations') | list | oo_flatten
         | select('match', 'node.openshift.io/md5sum') | list | length ==
       node_status.results.results[0]['items'] | length
-  retries: 60
+  retries: 180
   delay: 10
   delegate_to: "{{ openshift_master_host }}"
   when: not skip_sync_annotations_check

--- a/roles/openshift_node_group/tasks/sync.yml
+++ b/roles/openshift_node_group/tasks/sync.yml
@@ -89,7 +89,7 @@
             | map(attribute='metadata.annotations') | list | oo_flatten
             | select('match', 'node.openshift.io/md5sum') | list | length ==
           node_status.results.results[0]['items'] | length
-      retries: 60
+      retries: 180
       delay: 10
 
     # Sync DS may have restarted masters


### PR DESCRIPTION
This would ensure sync DS annotation check passes on installs with slow
nodes (or a large number of nodes)

Cherrypick of #10353 on release-3.10 branch

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1609019