### PR TITLE
[3.10] Set l_openshift_upgrade_in_progress during upgrades

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -8,6 +8,8 @@
 - import_playbook: ../../../init/basic_facts.yml
 - import_playbook: ../../../init/base_packages.yml
 - import_playbook: ../../../init/cluster_facts.yml
+  vars:
+    l_openshift_upgrade_in_progress: True
 
 - name: Ensure essential node configmaps are present
   hosts: oo_first_master


### PR DESCRIPTION
This commit sets l_openshift_upgrade_in_progress during
upgrades to enable hostname override logic during 3.10 upgrades.

Depends-on: https://github.com/openshift/openshift-ansible/pull/10392