### PR TITLE
[3.10] Add ansible 2.4 repo

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -10,7 +10,7 @@ COPY images/installer/origin-extra-root /
 # install ansible and deps
 RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
- && EPEL_PKGS="ansible-2.6* python2-boto python2-boto3 python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli" \
+ && EPEL_PKGS="ansible-2.4.3.0* python2-boto python2-boto3 python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
  && if [ "$(uname -m)" == "x86_64" ]; then yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm ; fi \

--- a/images/installer/origin-extra-root/etc/yum.repos.d/centos-ansible24.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/centos-ansible24.repo
@@ -1,0 +1,6 @@
+
+[centos-ansible24-release]
+name=CentOS Ansible 2.4 release repo
+baseurl=https://cbs.centos.org/repos/configmanagement7-ansible-24-release/x86_64/os/
+enabled=1
+gpgcheck=0


### PR DESCRIPTION
Add -testing repo for 2.4 packages and switch Dockerfile to use it.

Note that this repo is empty for now, but should have the package appear there soon. CentOS tracking bug -  https://bugs.centos.org/view.php?id=15376

Cherry-pick of https://github.com/openshift/openshift-ansible/pull/10406 on 3.10 branch