### PR TITLE
Ensure skopeo is installed prior to upgrade to 3.11

### DIFF
--- a/playbooks/openshift-node/private/registry_auth.yml
+++ b/playbooks/openshift-node/private/registry_auth.yml
@@ -4,6 +4,16 @@
 - name: Update registry authentication credentials
   hosts: oo_nodes_to_config
   tasks:
+  - name: Install registry_auth dependencies
+    package:
+      name: "{{ pkg_list | join(',') }}"
+      state: present
+    register: result
+    until: result is succeeded
+    vars:
+      pkg_list:
+      - atomic
+      - skopeo
   - import_role:
       name: openshift_node
       tasks_from: registry_auth.yml


### PR DESCRIPTION
3.11 requires registry auth token to be present on nodes.
In order to validate credentials, skopeo needs to be installed.

In some cases, older clusters might not have skopeo installed
due to previous bug.

This commit ensures 3.11 upgrades will have skopeo installed
to validate credentials.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1639828