### PR TITLE
[release-3.10] Fail on openshift_kubelet_name_override for new hosts.

### DIFF
--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -28,7 +28,7 @@
     openshift_facts:
       role: common
       local_facts:
-        hostname: "{{ (openshift_kubelet_name_override | default(None)) if l_openshift_upgrade_in_progress else None }}"
+        hostname: "{{ openshift_kubelet_name_override | default(None) }}"
         ip: "{{ openshift_ip | default(None) }}"
         public_hostname: "{{ openshift_public_hostname | default(None) }}"
         public_ip: "{{ openshift_public_ip | default(None) }}"
@@ -65,7 +65,7 @@
         bootstrapped: "{{ openshift_is_bootstrapped }}"
   - name: set_fact l_kubelet_node_name
     set_fact:
-      l_kubelet_node_name: "{{ openshift_kubelet_name_override if (openshift_kubelet_name_override is defined and l_openshift_upgrade_in_progress) else openshift.node.nodename }}"
+      l_kubelet_node_name: "{{ openshift_kubelet_name_override | default(openshift.node.nodename) }}"
 
   - when:
     # l_check_nodename is passed in during upgrades.

--- a/playbooks/prerequisites.yml
+++ b/playbooks/prerequisites.yml
@@ -1,5 +1,12 @@
 ---
 # l_scale_up_hosts may be passed in via various scaleup plays.
+- name: Fail openshift_kubelet_name_override for new hosts
+  hosts: "{{ l_scale_up_hosts | default('oo_nodes_to_config') }}"
+  tasks:
+  - name: Fail when openshift_kubelet_name_override is defined
+    fail:
+      msg: "openshift_kubelet_name_override Cannot be defined for new hosts"
+    when: openshift_kubelet_name_override is defined
 
 - import_playbook: init/main.yml
   vars:

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -200,4 +200,3 @@ openshift_node_group_edits_crio:
       - "10m"
 
 openshift_master_manage_htpasswd: True
-l_openshift_upgrade_in_progress: False


### PR DESCRIPTION
This commit changes logic for openshift_kubelet_name_override
to ensure existing hosts will still set the value as appropriate
and new hosts cannot set the value.

Backports #10395