### PR TITLE
[release-3.6] Remove v3.7 check for shared-resource-viewer in control plane upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_control_plane.yml
@@ -280,7 +280,7 @@
     - reconcile_jenkins_role_binding_result.rc == 0
     when: openshift.common.version_gte_3_4_or_1_4  | bool
 
-  - when: (openshift.common.version_gte_3_6 | bool) and (not openshift.common.version_gte_3_7 | bool)
+  - when: openshift.common.version_gte_3_6 | bool
     block:
     - name: Retrieve shared-resource-viewer
       oc_obj:


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1639196
 
This code is for upgrades to 3.6, so we don't need to be checking for v3.7. 