### PR TITLE
Fixes #10415 maintains the name and host_name when vm count field are 1.

### DIFF
--- a/roles/openshift_ovirt/README.md
+++ b/roles/openshift_ovirt/README.md
@@ -141,7 +141,7 @@ openshift_ovirt_vm_manifest:
   count: 1
   profile: 'node_vm'
   nic_mode:
-      lb0:
+      lb:
         nic_ip_address: '192.168.123.170'
         nic_netmask: '255.255.255.0'
         nic_gateway: '192.168.123.1'
@@ -185,6 +185,8 @@ Example Playbook
       tags:
         - always
 ```
+
+**Side Note:** Regarding the behaviour, of the iterations, If we have a `count: 1` in our vm definition, the name that you put in the proper field will be preserved, but if we have more than 1 a counter will be raised and the vm name will be `name + iteration` (EG) _node0_, _node1_, _node2_ in case of `count: 3`
 
 License
 -------

--- a/roles/openshift_ovirt/tasks/build_vm_list.yml
+++ b/roles/openshift_ovirt/tasks/build_vm_list.yml
@@ -34,7 +34,16 @@
       'nic_gateway': '{{ item["nic_mode"][item["name"]]["nic_gateway"] }}',
       'nic_on_boot': {{ item["nic_mode"][item["name"]]["nic_on_boot"] | default(true) | bool }},
       'nic_name': '{{ item["nic_mode"][item["name"]]["nic_name"] | default("eth0") }}',
+          {% if item["nic_mode"][item["name"]]["dns_servers"] is defined -%}
       'dns_servers': '{{ item["nic_mode"][item["name"]]["dns_servers"] }}',
+      'dns_search': '{{ item["nic_mode"][item["name"]]["dns_search"] }}',
+          {% endif -%}
+        {% endif -%}
+        {% if item.dns_servers is defined -%}
+      'dns_servers': '{{ item["name"]["dns_servers"] }}',
+        {% endif -%}
+        {% if item.dns_search is defined -%}
+      'dns_search': '{{ item["name"]["dns_search"] }}',
         {% endif -%}
       {% elif item.count > 1 -%}
       'host_name': '{{ item.name }}{{ iter }}.{{ openshift_ovirt_dns_zone }}',
@@ -45,7 +54,18 @@
       'nic_gateway': '{{ item["nic_mode"][item["name"] + iter | string ]["nic_gateway"] }}',
       'nic_on_boot': {{ item["nic_mode"][item["name"] + iter | string ]["nic_on_boot"] | default(true) | bool }},
       'nic_name': '{{ item["nic_mode"][item["name"] + iter | string ]["nic_name"] | default("eth0") }}',
+          {% if item["nic_mode"][item["name"] + iter | string ]["dns_servers"] is defined -%}
       'dns_servers': '{{ item["nic_mode"][item["name"] + iter | string ]["dns_servers"] }}',
+          {% endif -%}
+          {% if item["nic_mode"][item["name"] + iter | string ]["dns_search"] is defined -%}
+      'dns_search': '{{ item["nic_mode"][item["name"] + iter | string ]["dns_search"] }}',
+          {% endif -%}
+        {% endif -%}
+        {% if item.dns_servers is defined -%}
+      'dns_servers': '{{ item["nic_mode"][item["name"] + iter | string ]["dns_servers"] }}',
+        {% endif -%}
+        {% if item.dns_search is defined -%}
+      'dns_search': '{{ item["nic_mode"][item["name"] + iter | string ]["dns_search"] }}',
         {% endif -%}
       {% endif -%}
       'authorized_ssh_keys': '{{ openshift_ovirt_ssh_key }}'

--- a/roles/openshift_ovirt/tasks/build_vm_list.yml
+++ b/roles/openshift_ovirt/tasks/build_vm_list.yml
@@ -40,10 +40,10 @@
           {% endif -%}
         {% endif -%}
         {% if item.dns_servers is defined -%}
-      'dns_servers': '{{ item["name"]["dns_servers"] }}',
+      'dns_servers': '{{ item["dns_servers"] }}',
         {% endif -%}
         {% if item.dns_search is defined -%}
-      'dns_search': '{{ item["name"]["dns_search"] }}',
+      'dns_search': '{{ item["dns_search"] }}',
         {% endif -%}
       {% elif item.count > 1 -%}
       'host_name': '{{ item.name }}{{ iter }}.{{ openshift_ovirt_dns_zone }}',
@@ -62,10 +62,10 @@
           {% endif -%}
         {% endif -%}
         {% if item.dns_servers is defined -%}
-      'dns_servers': '{{ item["nic_mode"][item["name"] + iter | string ]["dns_servers"] }}',
+      'dns_servers': '{{ item["dns_servers"] }}',
         {% endif -%}
         {% if item.dns_search is defined -%}
-      'dns_search': '{{ item["nic_mode"][item["name"] + iter | string ]["dns_search"] }}',
+      'dns_search': '{{ item["dns_search"] }}',
         {% endif -%}
       {% endif -%}
       'authorized_ssh_keys': '{{ openshift_ovirt_ssh_key }}'

--- a/roles/openshift_ovirt/tasks/build_vm_list.yml
+++ b/roles/openshift_ovirt/tasks/build_vm_list.yml
@@ -1,6 +1,10 @@
 ---
 # Creates a dictionary for use with oVirt.vm-infra role
 # https://github.com/oVirt/ovirt-ansible-vm-infra
+# Side note:
+# If we have a count: 1 in our vm definition, the name that you put in the proper field will be preserved
+# if we have more than 1 a counter will be raised and the vm name will be name + iteration (EG) node0, node1, node2
+# in case of count: 3
 - fail:
     msg: "The openshift_ovirt_dns_zone variable is required."
   when:
@@ -12,12 +16,29 @@
       {% for iter in range(item.count) -%}
       {% if iter > 0 -%},{% endif -%}
       {
+      {% if item.count == 1 -%}
+      'name': '{{ item.name }}.{{ openshift_ovirt_dns_zone }}',
+      {% elif item.count > 1 -%}
       'name': '{{ item.name }}{{ iter }}.{{ openshift_ovirt_dns_zone }}',
+      {% endif -%}
       'tag': 'openshift_{{ item.profile }}',
+      'description': '{{ item.description | default("") }}',
       'cloud_init':
       {
+      {% if item.count == 1 -%}
+      'host_name': '{{ item.name }}.{{ openshift_ovirt_dns_zone }}',
+        {% if item.nic_mode is defined -%}
+      'nic_boot_protocol': 'static',
+      'nic_ip_address': '{{ item["nic_mode"][item["name"]]["nic_ip_address"] }}',
+      'nic_netmask': '{{ item["nic_mode"][item["name"]]["nic_netmask"] }}',
+      'nic_gateway': '{{ item["nic_mode"][item["name"]]["nic_gateway"] }}',
+      'nic_on_boot': {{ item["nic_mode"][item["name"]]["nic_on_boot"] | default(true) | bool }},
+      'nic_name': '{{ item["nic_mode"][item["name"]]["nic_name"] | default("eth0") }}',
+      'dns_servers': '{{ item["nic_mode"][item["name"]]["dns_servers"] }}',
+        {% endif -%}
+      {% elif item.count > 1 -%}
       'host_name': '{{ item.name }}{{ iter }}.{{ openshift_ovirt_dns_zone }}',
-      {% if item.nic_mode is defined -%}
+        {% if item.nic_mode is defined -%}
       'nic_boot_protocol': 'static',
       'nic_ip_address': '{{ item["nic_mode"][item["name"] + iter | string ]["nic_ip_address"] }}',
       'nic_netmask': '{{ item["nic_mode"][item["name"] + iter | string ]["nic_netmask"] }}',
@@ -25,6 +46,7 @@
       'nic_on_boot': {{ item["nic_mode"][item["name"] + iter | string ]["nic_on_boot"] | default(true) | bool }},
       'nic_name': '{{ item["nic_mode"][item["name"] + iter | string ]["nic_name"] | default("eth0") }}',
       'dns_servers': '{{ item["nic_mode"][item["name"] + iter | string ]["dns_servers"] }}',
+        {% endif -%}
       {% endif -%}
       'authorized_ssh_keys': '{{ openshift_ovirt_ssh_key }}'
       },


### PR DESCRIPTION
Fixes #10415 bug.

This PR will maintain the **vm_name** on oVirt and **host_name** injected into cloud-init also and will match the IP on the node when the vm definition `count` field stays at 1 and gives support to use `xip.io` or `nip.io`:

```
openshift_ovirt_dns_zone: 'xip.io'
openshift_ovirt_vm_manifest:
- name: '10.29.138.1'
  count: 1
  profile: 'master_vm'
  nic_mode:
      10.29.138.1:
        nic_ip_address: '10.29.138.1'
        nic_netmask: '255.255.255.0'
        nic_gateway: '10.29.138.254'
        dns_servers: '10.29.138.10'
        dns_search: "{{ openshift_ovirt_dns_zone }}" 
- name: '10.29.138.2'
  count: 1
  profile: 'node_vm'
  nic_mode:
      10.29.138.2:
        nic_ip_address: '10.29.138.2'
        nic_netmask: '255.255.255.0'
        nic_gateway: '10.29.138.254'
        dns_servers: '10.29.138.10'
        dns_search: "{{ openshift_ovirt_dns_zone }}" 
- name: '10.29.138.3'
  count: 1
  profile: 'node_vm'
  nic_mode:
      10.29.138.3:
        nic_ip_address: '10.29.138.3'
        nic_netmask: '255.255.255.0'
        nic_gateway: '10.29.138.254'
        dns_servers: '10.29.138.10'
        dns_search: "{{ openshift_ovirt_dns_zone }}" 
- name: '10.29.138.4'
  count: 1
  profile: 'node_vm'
  nic_mode:
      10.29.138.4:
        nic_ip_address: '10.29.138.4'
        nic_netmask: '255.255.255.0'
        nic_gateway: '10.29.38.254'
        dns_servers: '10.29.138.10'
        dns_search: "{{ openshift_ovirt_dns_zone }}" 
```

In this example we could see that the VMS generated will be

- vm_name: 10.29.138.1.xip.io, host_name: 10.29.138.1.xip.io ip: 10.29.138.1
- vm_name: 10.29.138.2.xip.io, host_name: 10.29.138.2.xip.io ip: 10.29.138.2
- vm_name: 10.29.138.3.xip.io, host_name: 10.29.138.3.xip.io ip: 10.29.138.3
- vm_name: 10.29.138.4.xip.io, host_name: 10.29.138.4.xip.io ip: 10.29.138.4

If we work on counters that are 2 or more: (this could not work with `xip.io` or `nip.io`

```
openshift_ovirt_dns_zone: 'example.com'
openshift_ovirt_vm_manifest:
- name: 'master'
  count: 3
  profile: 'node_vm'
  nic_mode:
      master0:
        nic_ip_address: '10.29.138.4'
        nic_netmask: '255.255.255.0'
        nic_gateway: '10.29.38.254'
        dns_servers: '10.29.138.10'
        dns_search: "{{ openshift_ovirt_dns_zone }}"
      master1:
        nic_ip_address: '10.29.138.5'
        nic_netmask: '255.255.255.0'
        nic_gateway: '10.29.38.254'
        dns_servers: '10.29.138.10'
        dns_search: "{{ openshift_ovirt_dns_zone }}"
      master2:
        nic_ip_address: '10.29.138.6'
        nic_netmask: '255.255.255.0'
        nic_gateway: '10.29.38.254'
        dns_servers: '10.29.138.10'
        dns_search: "{{ openshift_ovirt_dns_zone }}" 
```

The vms generated will be:

- vm_name: master0.example.com, host_name: master0.example.com ip: 10.29.138.4
- vm_name: master1.example.com, host_name: master1.example.com ip: 10.29.138.5
- vm_name: master2.example.com, host_name: master2.example.com ip: 10.29.138.6
