### PR TITLE
[3.10] Ensure raw_hostname used as openshift.node.nodename

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -485,10 +485,7 @@ def set_nodename(facts):
         # elif 'cloudprovider' in facts and facts['cloudprovider']['kind'] == 'openstack':
         #     facts['node']['nodename'] = facts['provider']['metadata']['hostname'].replace('.novalocal', '')
         else:
-            if 'bootstrapped' in facts['node'] and facts['node']['bootstrapped']:
-                facts['node']['nodename'] = facts['common']['raw_hostname'].lower()
-            else:
-                facts['node']['nodename'] = facts['common']['hostname'].lower()
+            facts['node']['nodename'] = facts['common']['raw_hostname'].lower()
     return facts
 
 


### PR DESCRIPTION
This commit backports logic that fixes hostname problems
from 3.11.