### PR TITLE
Remove value rather than replacing it with an empty string

### DIFF
--- a/roles/openshift_control_plane/tasks/upgrade.yml
+++ b/roles/openshift_control_plane/tasks/upgrade.yml
@@ -78,8 +78,9 @@
   yedit:
     src: "{{ openshift.common.config_base }}/master/master-config.yaml"
     key: "kubernetesMasterConfig.apiServerArguments.runtime-config"
-    value: "{{ runtime_config.result | join(',') | regex_replace('(?:,)*apis/settings\\.k8s\\.io/v1alpha1=true','') }}"
-  when: runtime_config.result
+    value: "{{ r_c | difference(['apis/settings.k8s.io/v1alpha1=true']) }}"
+  vars:
+    r_c: "{{ runtime_config.result | default([]) }}"
 - name: Copy recyler pod to config directory
   template:
     src: "recycler_pod.yaml.j2"


### PR DESCRIPTION
The original intent was to remove the item from the list if it existed. As implemented however it replaced it with an empty string which causes master-config.yaml parsing errors.

Actual
`runtime-config: ''`
Expected
`runtime-config: []`

This needs to be backported to release-3.10 and release-3.11.
