### PR TITLE
roles/openshift-prometheus: fix failing prometheus service discovery …

### DIFF
--- a/roles/openshift_prometheus/templates/prometheus.j2
+++ b/roles/openshift_prometheus/templates/prometheus.j2
@@ -140,6 +140,7 @@ spec:
         - -cookie-secret-file=/etc/proxy/secrets/session_secret
         - -openshift-ca=/etc/pki/tls/cert.pem
         - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        - -skip-auth-regex=^/metrics
         volumeMounts:
         - mountPath: /etc/tls/private
           name: alerts-tls
@@ -169,10 +170,6 @@ spec:
         volumeMounts:
         - mountPath: /alert-buffer
           name: alert-buffer-data
-        ports:
-        - containerPort: 9099
-          name: alert-buf
-
       - name: alertmanager
         args:
         - -config.file=/etc/alertmanager/alertmanager.yml
@@ -193,9 +190,6 @@ spec:
 {% if openshift_prometheus_alertmanager_cpu_limit is defined and openshift_prometheus_alertmanager_cpu_limit is not none %}
             cpu: "{{ openshift_prometheus_alertmanager_cpu_limit }}"
 {% endif %}
-        ports:
-        - containerPort: 9093
-          name: web
         volumeMounts:
         - mountPath: /etc/alertmanager
           name: alertmanager-config


### PR DESCRIPTION
…scrapes

- remove containerPort config from alertmanager and alertbuffer so that the prometheus
  kube discovery doesn't try to scrape them
- allow unauthenticated access to /metrics path so alert buffer can be scraped