### PR TITLE
Use first_master_client_binary from hostvars[groups.oo_first_master.0]

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/check_cluster_health.yml
+++ b/roles/openshift_storage_glusterfs/tasks/check_cluster_health.yml
@@ -3,7 +3,7 @@
 # lib_utils/library/glusterfs_check_containerized.py
 - name: Check for cluster health of glusterfs
   glusterfs_check_containerized:
-    oc_bin: "{{ first_master_client_binary }}"
+    oc_bin: "{{ hostvars[groups.oo_first_master.0]['first_master_client_binary'] }}"
     oc_conf: "{{ openshift.common.config_base }}/master/admin.kubeconfig"
     oc_namespace: "{{ openshift_storage_glusterfs_namespace }}"
     cluster_name: "{{ openshift_storage_glusterfs_name }}"
@@ -20,7 +20,7 @@
 
 - name: Check for cluster health of glusterfs (registry)
   glusterfs_check_containerized:
-    oc_bin: "{{ first_master_client_binary }}"
+    oc_bin: "{{ hostvars[groups.oo_first_master.0]['first_master_client_binary'] }}"
     oc_conf: "{{ openshift.common.config_base }}/master/admin.kubeconfig"
     oc_namespace: "{{ openshift_storage_glusterfs_registry_namespace }}"
     cluster_name: "{{ openshift_storage_glusterfs_registry_name }}"


### PR DESCRIPTION
Since first_master_client_binary is initialized in oo_first_master, it
should be collected from oo_first_master.0. This patch changes to use
first_master_client_binary from hostvars[groups.oo_first_master.0] on
GlusterFS cluster health task.

(cherry picked from commit b726ddaadcf1726be3ca7a95744d3b9f0c46db2b)

Backports: https://github.com/openshift/openshift-ansible/pull/9924
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1636018