### PR TITLE
Fix undefined l_nodeconfig_name variable

### DIFF
--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -82,7 +82,7 @@
     - name: Fail when nodeName is wrong
       fail:
         msg: >
-          nodeName mismatch from node's config; existing name in config: {{ l_nodeconfig_name }};
+          nodeName mismatch from node's config; existing name in config: {{ l_nodeconfig_nodename }};
           discovered nodename from openshift_facts: {{ l_kubelet_node_name }}
       vars:
         l_nodeconfig_yaml: "{{ node_config_slurp.content | b64decode| from_yaml }}"


### PR DESCRIPTION
The variable being printed in the fail message does not exist, and I assume it is supposed to represent the variable that is being checked in the "when" statements. My first upgrade run failed because this variable was not defined. After fixing the variable name, my upgrade failed at the expected time with the correct failure message.