### PR TITLE
3.10: migrate LDAP/RequestHeader/OpenID CA during upgrade

### DIFF
--- a/roles/lib_utils/filter_plugins/oo_filters.py
+++ b/roles/lib_utils/filter_plugins/oo_filters.py
@@ -708,6 +708,36 @@ def lib_utils_mutate_htpass_provider(idps):
     return idps
 
 
+def lib_utils_mutate_providers_with_ca(idps):
+    '''Updates identityProviders list to mutate CA path'''
+    providers = [
+        {
+            'kind': 'LDAPPasswordIdentityProvider',
+            'ca_field': 'ca',
+            'ca_postfix': 'ldap'
+        },
+        {
+            'kind': 'RequestHeaderIdentityProvider',
+            'ca_field': 'clientCA',
+            'ca_postfix': 'request_header'
+        },
+        {
+            'kind': 'OpenIDIdentityProvider',
+            'ca_field': 'ca',
+            'ca_postfix': 'openid'
+        }
+    ]
+    for idp in idps:
+        if 'provider' in idp:
+            idp_p = idp['provider']
+            for provider in providers:
+                if idp_p['kind'] == provider['kind']:
+                    if not idp_p.get('insecure'):
+                        idp_p[provider['ca_field']] = '/etc/origin/master/{0}_{1}_ca.crt'.format(
+                            idp['name'], provider['ca_postfix'])
+    return idps
+
+
 def lib_utils_oo_oreg_image(image_default, oreg_url):
     '''Converts default image string to utilize oreg_url, if defined.
        oreg_url should be passed in as string "None" if undefined.
@@ -766,6 +796,7 @@ class FilterModule(object):
             "map_to_pairs": map_to_pairs,
             "lib_utils_oo_etcd_host_urls": lib_utils_oo_etcd_host_urls,
             "lib_utils_mutate_htpass_provider": lib_utils_mutate_htpass_provider,
+            "lib_utils_mutate_providers_with_ca": lib_utils_mutate_providers_with_ca,
             "lib_utils_oo_oreg_image": lib_utils_oo_oreg_image,
             "oo_flatten": oo_flatten,
         }

--- a/roles/openshift_control_plane/tasks/create_ca_files.yml
+++ b/roles/openshift_control_plane/tasks/create_ca_files.yml
@@ -1,0 +1,33 @@
+---
+- name: Create the ldap ca file if needed
+  copy:
+    dest: "/etc/origin/master/{{ item.name }}_ldap_ca.crt"
+    content: "{{ openshift.master.ldap_ca }}"
+    mode: 0600
+    backup: yes
+  when:
+  - openshift.master.ldap_ca is defined
+  - item.kind == 'LDAPPasswordIdentityProvider'
+  with_items: "{{ openshift_master_identity_providers }}"
+
+- name: Create the openid ca file if needed
+  copy:
+    dest: "/etc/origin/master/{{ item.name }}_openid_ca.crt"
+    content: "{{ openshift.master.openid_ca }}"
+    mode: 0600
+    backup: yes
+  when:
+  - openshift.master.openid_ca is defined
+  - item.kind == 'OpenIDIdentityProvider'
+  with_items: "{{ openshift_master_identity_providers }}"
+
+- name: Create the request header ca file if needed
+  copy:
+    dest: "/etc/origin/master/{{ item.name }}_request_header_ca.crt"
+    content: "{{ openshift_master_request_header_ca }}"
+    mode: 0600
+    backup: yes
+  when:
+  - openshift_master_request_header_ca != l_osm_request_header_none
+  - item.kind == 'RequestHeaderIdentityProvider'
+  with_items: "{{ openshift_master_identity_providers }}"

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -59,39 +59,7 @@
     backup: true
 
 - import_tasks: htpass_provider.yml
-
-- name: Create the ldap ca file if needed
-  copy:
-    dest: "/etc/origin/master/{{ item.name }}_ldap_ca.crt"
-    content: "{{ openshift.master.ldap_ca }}"
-    mode: 0600
-    backup: yes
-  when:
-  - openshift.master.ldap_ca is defined
-  - item.kind == 'LDAPPasswordIdentityProvider'
-  with_items: "{{ openshift_master_identity_providers }}"
-
-- name: Create the openid ca file if needed
-  copy:
-    dest: "/etc/origin/master/{{ item.name }}_openid_ca.crt"
-    content: "{{ openshift.master.openid_ca }}"
-    mode: 0600
-    backup: yes
-  when:
-  - openshift.master.openid_ca is defined
-  - item.kind == 'OpenIDIdentityProvider'
-  with_items: "{{ openshift_master_identity_providers }}"
-
-- name: Create the request header ca file if needed
-  copy:
-    dest: "/etc/origin/master/{{ item.name }}_request_header_ca.crt"
-    content: "{{ openshift_master_request_header_ca }}"
-    mode: 0600
-    backup: yes
-  when:
-  - openshift_master_request_header_ca != l_osm_request_header_none
-  - item.kind == 'RequestHeaderIdentityProvider'
-  with_items: "{{ openshift_master_identity_providers }}"
+- import_tasks: create_ca_files.yml
 
 - name: Set fact of all etcd host IPs
   openshift_facts:

--- a/roles/openshift_control_plane/tasks/migrate_idproviders.yml
+++ b/roles/openshift_control_plane/tasks/migrate_idproviders.yml
@@ -16,3 +16,12 @@
   when:
   - openshift_master_existing_idproviders is defined
   - openshift_master_manage_htpasswd
+
+- name: modify providers which need CA to have set
+  yedit:
+    src: /etc/origin/master/master-config.yaml
+    edits:
+    - key: oauthConfig.identityProviders
+      value: "{{ openshift_master_existing_idproviders | lib_utils_mutate_providers_with_ca }}"
+  when:
+  - openshift_master_existing_idproviders is defined

--- a/roles/openshift_control_plane/tasks/upgrade.yml
+++ b/roles/openshift_control_plane/tasks/upgrade.yml
@@ -14,6 +14,7 @@
 - import_tasks: static_shim.yml
 
 - import_tasks: upgrade/upgrade_scheduler.yml
+- import_tasks: create_ca_files.yml
 
 # master_config_hook is passed in from upgrade play.
 - include_tasks: "upgrade/{{ master_config_hook }}"


### PR DESCRIPTION
3.9 to 3.10 upgrade doesn't set `ca` field for identity providers, as it is now required in 3.10.

This PR ensures CA is copied on master and `ca` field is set (unless `insecure` is specified) for three providers.

This doesn't need to be present in 3.11, as its a one time action during upgrade.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1639589