### PR TITLE
Only upgrade ASB and TSB when they are installed

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_components.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_components.yml
@@ -13,12 +13,12 @@
       name: ansible_service_broker
       tasks_from: install.yml
     when:
-    - openshift_enable_service_catalog | default(true) | bool
+    - ansible_service_broker_install | default(true) | bool
   - import_role:
       name: template_service_broker
       tasks_from: upgrade.yml
     when:
-    - openshift_enable_service_catalog | default(true) | bool
+    - template_service_broker_install | default(true) | bool
 
 - import_playbook: ../../../olm/private/config.yml
   when: openshift_enable_olm | default(false) | bool


### PR DESCRIPTION
There are dedicated inventory vars to control whether SC, ASB or TSB should be deployed. However during the upgrade process, for all 3 components the variable for the SC is queried.

This has 2 undesired side effects for setups where ASB and TSB are not deployed:
1. The ASB is always deployed during upgrade, no matter what
2. The TSB upgrade role fails because at one point it waits for the TSB (which is not deployed) to become ready