### PR TITLE
WIP Delete router service and DC when updating a router

### DIFF
--- a/roles/openshift_hosted/tasks/upgrade_routers.yml
+++ b/roles/openshift_hosted/tasks/upgrade_routers.yml
@@ -1,14 +1,22 @@
 ---
-- name: Update router image to current version
-  oc_edit:
-    kind: dc
+- name: Delete router service
+  oc_obj:
+    kind: svc
+    state: absent
     name: "{{ item['name'] }}"
     namespace: "{{ item['namespace'] }}"
-    content:
-      spec.template.spec.containers[0].image: "{{ l_osh_router_image }}"
   with_items: "{{ openshift_hosted_routers }}"
-  vars:
-    l_osh_router_image: "{{ openshift_hosted_router_registryurl | replace( '${component}', 'haproxy-router' ) |
-                            replace ( '${version}', openshift_image_tag ) }}"
   when:
   - openshift_hosted_routers | length > 0
+
+- name: Delete router deployment config
+  oc_obj:
+    kind: dc
+    state: absent
+    name: "{{ item['name'] }}"
+    namespace: "{{ item['namespace'] }}"
+  with_items: "{{ openshift_hosted_routers }}"
+  when:
+  - openshift_hosted_routers | length > 0
+
+- include_tasks: router.yml


### PR DESCRIPTION
This ensures the router DC is relevant, new permissions are set and secrets     
are updated during major upgrades.                                              
                                                                                
Note, that this would erase all custom configs applied to the router