### PR TITLE
Add permissions for the Calico CNI plugin to access namespaces

### DIFF
--- a/roles/calico/templates/calicov3.yml.j2
+++ b/roles/calico/templates/calicov3.yml.j2
@@ -14,6 +14,7 @@ rules:
       - namespaces
       - networkpolicies
       - nodes
+      - serviceaccounts
     verbs:
       - watch
       - list
@@ -49,6 +50,7 @@ rules:
   - apiGroups: [""]
     resources:
       - pods
+      - namespaces
       - nodes
     verbs:
       - get


### PR DESCRIPTION
For Calico 3.3, the CNI plugin checks the namespaces. These changes give the CNI plugin and the controllers the appropriate permissions that they need to operate.