### PR TITLE
No blank between words in error messages.

### DIFF
--- a/roles/lib_utils/action_plugins/sanity_checks.py
+++ b/roles/lib_utils/action_plugins/sanity_checks.py
@@ -444,9 +444,9 @@ class ActionModule(ActionBase):
     def check_for_oreg_password(self, hostvars, host, odt):
         """Ensure oreg_password is defined when using registry.redhat.io"""
         reg_to_check = 'registry.redhat.io'
-        err_msg = ("oreg_auth_user and oreg_auth_password must be provided when"
+        err_msg = ("oreg_auth_user and oreg_auth_password must be provided when "
                    "deploying openshift-enterprise")
-        err_msg2 = ("oreg_auth_user and oreg_auth_password must be provided when using"
+        err_msg2 = ("oreg_auth_user and oreg_auth_password must be provided when using "
                     "{}".format(reg_to_check))
 
         oreg_password = self.template_var(hostvars, host, 'oreg_auth_password')


### PR DESCRIPTION

Current error messages are as follows during sanity checking.
As you can see, no blank in partial error message phase. 

>      Message:  last_checked_host: master.ocp311.host.local, last_checked_var: oreg_url;oreg_auth_user and oreg_auth_password must be provided whendeploying openshift-enterprise

`whendeploying openshift-enterprise` -> `when deploying openshift-enterprise`

>      Message:  last_checked_host: master.ocp311.host.local, last_checked_var: oreg_url;oreg_auth_user and oreg_auth_password must be provided when usingregistry.redhat.io

`usingregistry.redhat.io` -> `using registry.redhat.io`