### PR TITLE
fix(loadbalancer): haproxy should check for /healthz

### DIFF
--- a/roles/lib_utils/filter_plugins/oo_filters.py
+++ b/roles/lib_utils/filter_plugins/oo_filters.py
@@ -501,7 +501,7 @@ def lib_utils_oo_loadbalancer_backends(
     """TODO: Document me."""
     loadbalancer_backends = [{'name': 'atomic-openshift-api',
                               'mode': 'http',
-                              'custom_options':['http-check expect string ok'],
+                              'custom_options': ['http-check expect string ok'],
                               'options': ['ssl-hello-chk', 'httpchk GET /healthz HTTP/1.0'],
                               'balance': 'source',
                               'servers': haproxy_backend_masters_https(servers_hostvars, api_port)}]
@@ -509,7 +509,7 @@ def lib_utils_oo_loadbalancer_backends(
         # pylint: disable=line-too-long
         loadbalancer_backends.append({'name': 'nuage-monitor',
                                       'mode': 'tcp',
-                                      'custom_options':[],
+                                      'custom_options': [],
                                       'options': ['tcplog'],
                                       'balance': 'source',
                                       'servers': haproxy_backend_masters_tcp(servers_hostvars, nuage_rest_port)})

--- a/roles/lib_utils/filter_plugins/oo_filters.py
+++ b/roles/lib_utils/filter_plugins/oo_filters.py
@@ -502,7 +502,7 @@ def lib_utils_oo_loadbalancer_backends(
     loadbalancer_backends = [{'name': 'atomic-openshift-api',
                               'mode': 'http',
                               'custom_options':['http-check expect string ok'],
-                              'options': ['ssl-hello-chk','httpchk GET /healthz HTTP/1.0'],
+                              'options': ['ssl-hello-chk', 'httpchk GET /healthz HTTP/1.0'],
                               'balance': 'source',
                               'servers': haproxy_backend_masters_https(servers_hostvars, api_port)}]
     if bool(strtobool(str(use_nuage))) and nuage_rest_port is not None:

--- a/roles/openshift_loadbalancer/README.md
+++ b/roles/openshift_loadbalancer/README.md
@@ -52,19 +52,23 @@ Example Playbook
       default_backend: atomic-openshift-api
     openshift_loadbalancer_backends:
     - name: atomic-openshift-api
-      mode: tcp
-      option: tcplog
+      mode: http
+      custom_options:
+      - http-check expect string ok
+      options:
+      - ssl-hello-chk
+      - httpchk GET /healthz HTTP/1.0
       balance: source
       servers:
       - name: master1
         address: "192.168.122.221:8443"
-	opts: check
+	opts: check ssl verify none
       - name: master2
         address: "192.168.122.222:8443"
-	opts: check
+	opts: check ssl verify none
       - name: master3
         address: "192.168.122.223:8443"
-	opts: check
+	opts: check ssl verify none
     openshift_image_tag: v3.6.153
 ```
 

--- a/roles/openshift_loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/openshift_loadbalancer/templates/haproxy.cfg.j2
@@ -76,6 +76,11 @@ backend {{ backend.name }}
     option {{ option }}
 {% endfor %}
 {% endif %}
+{% if 'custom_options' in backend %}
+{% for custom in backend.custom_options %}
+    {{ custom }}
+{% endfor %}
+{% endif %}
 {% for server in backend.servers %}
     server      {{ server.name }} {{ server.address }} {{ server.opts }}
 {% endfor %}


### PR DESCRIPTION
Querying OpenShift API, HAProxy should ensure their /healthz endpoint returns with ok.

I've seen the master API service still listening for queries while being unavailable.
When a TCP loadbalancer does not check for service /healthz, active sessions may not failover, eventually leading to remaining masters re-scheduling deployments from nodes that would have stopped reporting, while new sessions could still be sent to a faulty master.

Here's a proposal reconfiguring the haproxy master-api balancers configuration, generating an `/etc/haproxy/haproxy.cfg` configuration that would look like:

```
[...]
frontend  atomic-openshift-api
    bind *:8443
    default_backend atomic-openshift-api
    mode tcp
    option tcplog

backend atomic-openshift-api
    balance source
    mode http
    option ssl-hello-chk
    option httpchk GET /healthz HTTP/1.0
    http-check expect string ok
    server      master0 10.42.253.10:8443 check ssl verify none
    server      master1 10.42.253.11:8443 check ssl verify none
    server      master2 10.42.253.12:8443 check ssl verify none
```