### PR TITLE
Install python-docker-py instead of python-docker

### DIFF
--- a/playbooks/init/base_packages.yml
+++ b/playbooks/init/base_packages.yml
@@ -41,7 +41,7 @@
         - "{{ 'python3-PyYAML' if ansible_distribution == 'Fedora' else 'PyYAML' }}"
         - libsemanage-python
         - yum-utils
-        - "{{ 'python3-docker' if ansible_distribution == 'Fedora' else 'python-docker' }}"
+        - "{{ 'python3-docker' if ansible_distribution == 'Fedora' else 'python-docker-py' }}"
         pkg_list_non_fedora:
         - 'python-ipaddress'
         pkg_list_use_non_fedora: "{{ ansible_distribution != 'Fedora' | bool }}"


### PR DESCRIPTION
Package docker-python is obsoleted by python-docker-py package. Install python-docker-py package instead of python-docker.

[root@master-0 ~]# yum install python-docker
Loaded plugins: product-id, search-disabled-repos, subscription-manager
Package docker-python-1.4.0-115.el7.x86_64 is obsoleted by python-docker-py-1.10.6-4.el7.noarch which is already installed
Nothing to do
[root@master-0 ~]# oc version
oc v3.11.16
kubernetes v1.11.0+d4cacc0
features: Basic-Auth GSSAPI Kerberos SPNEGO

Server https://master.example.com:443
openshift v3.11.16
kubernetes v1.11.0+d4cacc0

Fixes #10440