### PR TITLE
Prepull node image using openshift_container_cli

### DIFF
--- a/roles/openshift_node/tasks/prepull.yml
+++ b/roles/openshift_node/tasks/prepull.yml
@@ -5,10 +5,7 @@
 
 # This task runs async to save time while the node is being configured
 - name: Pre-pull node image
-  docker_image:
-    name: "{{ osn_image }}"
-  environment:
-    NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
+  command: "{{ openshift_container_cli }} pull {{ osn_image }}"
   when: node_image.stdout_lines == []
   # 10 minutes to pull the image
   async: 600


### PR DESCRIPTION
Additional fix for #10402 - prepull node image too, not just pod image

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1639201