### PR TITLE
[release-3.11] Remove hostname override from OpenStack inventory

### DIFF
--- a/playbooks/openstack/resources.py
+++ b/playbooks/openstack/resources.py
@@ -93,13 +93,6 @@ def _get_hostvars(server, docker_storage_mountpoints):
         hostvars['private_v4'] = server.private_v4
         hostvars['openshift_ip'] = server.private_v4
 
-        # NOTE(shadower): Yes, we set both hostname and IP to the private
-        # IP address for each node. OpenStack doesn't resolve nodes by
-        # name at all, so using a hostname here would require an internal
-        # DNS which would complicate the setup and potentially introduce
-        # performance issues.
-        hostvars['openshift_kubelet_name_override'] = server.metadata.get(
-            'openshift_kubelet_name_override', server.private_v4)
     hostvars['openshift_public_hostname'] = server.name
 
     if server.metadata['host-type'] == 'cns':


### PR DESCRIPTION
The pull request #10395 enabled failures for any new deployments that
use `openshift_kubelet_name_override`.

We were using this for certain non-DNS deployments, but have since
switched to always requiring internal DNS of some sorts just like all
the other cloud providers.

So the variable is no longer necessary and indeed breaks OpenStack-based
cloud deployments.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1641085