### PR TITLE
Add support for secret encryption

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -372,6 +372,10 @@ debug_level=2
 # glusterfs plugin dependencies will be installed, if available.
 #osn_storage_plugin_deps=['ceph','glusterfs','iscsi']
 
+# Configure datastore layer encryption, the encryption key can be gererated
+# with the following command: 'head -c 32 /dev/urandom | base64'
+#openshift_encryption_config="{'kind': 'EncryptionConfig','apiVersion': 'v1','resources': [{'resources': ['secrets'],'providers': [{'aescbc': {'keys': [{'name': 'key1','secret': 'xxxxxxxx'}]}},{'identity': {}}]}]}"
+#
 # OpenShift Router Options
 #
 # An OpenShift router will be created during install if there are

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -66,6 +66,12 @@
     dest: "{{ openshift_master_scheduler_conf }}"
     backup: true
 
+- name: Generate encryption config
+  copy:
+    content: "{{ openshift_encryption_config }}"
+    dest: "{{ openshift_encryption_config_file }}"
+  when: openshift_encryption_config is defined
+
 - import_tasks: htpass_provider.yml
 
 - name: Create the ldap ca file if needed

--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -73,6 +73,10 @@ kubeletClientInfo:
 kubernetesMasterConfig:
   apiServerArguments:
     {{ openshift.master.api_server_args | default(None) | lib_utils_to_padded_yaml( level=2 ) }}
+{% if openshift_encryption_config is defined %}
+    experimental-encryption-provider-config:
+    - {{ openshift_encryption_config_file }}
+{% endif %}
     storage-backend:
     - etcd3
     storage-media-type:

--- a/roles/openshift_control_plane/vars/main.yml
+++ b/roles/openshift_control_plane/vars/main.yml
@@ -84,3 +84,4 @@ osm_older_priorities_no_zone:
 openshift_master_config_file: "/etc/origin/master/master-config.yaml"
 openshift_master_scheduler_conf: "/etc/origin/master/scheduler.json"
 openshift_master_session_secrets_file: "/etc/origin/master/session-secrets.yaml"
+openshift_encryption_config_file: "/etc/origin/master/encryption-config.yaml"


### PR DESCRIPTION
The goal of this PR is to support the activation of [datastore layer encryption](https://docs.openshift.com/container-platform/3.11/admin_guide/encrypting_data.html).