### PR TITLE
Fix ansible version checking

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -215,7 +215,7 @@ ignore-mixin-members=yes
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
 # Ignoring ansible.constants to suppress `no-member` warnings
-ignored-modules=ansible.constants
+ignored-modules=ansible.constants,distutils
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work

--- a/roles/lib_utils/callback_plugins/aa_version_requirement.py
+++ b/roles/lib_utils/callback_plugins/aa_version_requirement.py
@@ -7,6 +7,8 @@ The plugin is named with leading `aa_` to ensure this plugin is loaded
 first (alphanumerically) by Ansible.
 """
 import sys
+from distutils import version
+
 from ansible import __version__
 
 if __version__ < '2.0':
@@ -29,13 +31,15 @@ else:
 
 
 # Set to minimum required Ansible version
-REQUIRED_VERSION = '2.5.7'
+REQUIRED_VERSION = version.StrictVersion('2.5.7')
 DESCRIPTION = "Supported versions: %s or newer" % REQUIRED_VERSION
 
 
-def version_requirement(version):
+def version_requirement(ver):
     """Test for minimum required version"""
-    return version >= REQUIRED_VERSION
+    if not isinstance(ver, version.StrictVersion):
+        ver = version.StrictVersion(ver)
+    return ver >= REQUIRED_VERSION
 
 
 class CallbackModule(CallbackBase):


### PR DESCRIPTION
Before this patch, the version check was performed with strings, so
2.10.4 would be considered smaller than 2.8.4

For #10483 

Signed-off-by: Antoni Segura Puimedon <celebdor@gmail.com>