### PR TITLE
[release-3.11] Mount /etc/pki into apiserver pod

### DIFF
--- a/roles/openshift_control_plane/files/apiserver.yaml
+++ b/roles/openshift_control_plane/files/apiserver.yaml
@@ -34,6 +34,8 @@ spec:
        name: master-cloud-provider
      - mountPath: /var/lib/origin/
        name: master-data
+     - mountPath: /etc/pki
+       name: master-pki
     livenessProbe:
       httpGet:
         scheme: HTTPS
@@ -58,3 +60,6 @@ spec:
   - name: master-data
     hostPath:
       path: /var/lib/origin
+  - name: master-pki
+    hostPath:
+      path: /etc/pki


### PR DESCRIPTION
This means that the apiserver will share a trust store with the host.
Backports #10471

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1641657