### PR TITLE
Ensure we don't attempt to yum install on atomic

### DIFF
--- a/playbooks/openshift-node/private/registry_auth.yml
+++ b/playbooks/openshift-node/private/registry_auth.yml
@@ -10,6 +10,7 @@
       state: present
     register: result
     until: result is succeeded
+    when: not (openshift_is_atomic | bool)
     vars:
       pkg_list:
       - atomic


### PR DESCRIPTION
This commit ensures we don't attempt to install packages
on atomic during upgrades.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1641397