### PR TITLE
[release-3.10] Wait for aggregated API availability

### DIFF
--- a/roles/openshift_control_plane/tasks/check_master_api_is_ready.yml
+++ b/roles/openshift_control_plane/tasks/check_master_api_is_ready.yml
@@ -49,7 +49,7 @@
   failed_when: servicecatalog_service_registration.rc != 0 and 'NotFound' not in servicecatalog_service_registration.stderr
   retries: 30
   delay: 5
-  until: metrics_service_registration is succeeded
+  until: servicecatalog_service_registration is succeeded
 
 
 - name: Wait for /apis/servicecatalog.k8s.io/v1beta1 when registered

--- a/roles/openshift_control_plane/tasks/check_master_api_is_ready.yml
+++ b/roles/openshift_control_plane/tasks/check_master_api_is_ready.yml
@@ -23,3 +23,33 @@
       API did not become available. Verbose curl output and API logs
       have been collected above to assist with debugging.
   when: openshift_apis is failed
+
+- name: Check for apiservices/v1beta1.metrics.k8s.io registration
+  command: >
+    {{ openshift_client_binary }} get apiservices/v1beta1.metrics.k8s.io
+  register: metrics_service_registration
+  failed_when: metrics_service_registration.rc != 0 and 'NotFound' not in metrics_service_registration.stderr
+
+- name: Wait for /apis/metrics.k8s.io/v1beta1 when registered
+  command: >
+    {{ openshift_client_binary }} get --raw /apis/metrics.k8s.io/v1beta1
+  register: metrics_api
+  until: metrics_api.rc == 0
+  retries: 30
+  delay: 5
+  when: metrics_service_registration.rc == 0
+
+- name: Check for apiservices/v1beta1.servicecatalog.k8s.io registration
+  command: >
+    {{ openshift_client_binary }} get apiservices/v1beta1.servicecatalog.k8s.io
+  register: servicecatalog_service_registration
+  failed_when: servicecatalog_service_registration.rc != 0 and 'NotFound' not in servicecatalog_service_registration.stderr
+
+- name: Wait for /apis/servicecatalog.k8s.io/v1beta1 when registered
+  command: >
+    {{ openshift_client_binary }} get --raw /apis/servicecatalog.k8s.io/v1beta1
+  register: servicecatalog_api
+  until: servicecatalog_api.rc == 0
+  retries: 30
+  delay: 5
+  when: servicecatalog_service_registration.rc == 0

--- a/roles/openshift_control_plane/tasks/check_master_api_is_ready.yml
+++ b/roles/openshift_control_plane/tasks/check_master_api_is_ready.yml
@@ -29,12 +29,15 @@
     {{ openshift_client_binary }} get apiservices/v1beta1.metrics.k8s.io
   register: metrics_service_registration
   failed_when: metrics_service_registration.rc != 0 and 'NotFound' not in metrics_service_registration.stderr
+  retries: 30
+  delay: 5
+  until: metrics_service_registration is succeeded
 
 - name: Wait for /apis/metrics.k8s.io/v1beta1 when registered
   command: >
     {{ openshift_client_binary }} get --raw /apis/metrics.k8s.io/v1beta1
   register: metrics_api
-  until: metrics_api.rc == 0
+  until: metrics_api is succeeded
   retries: 30
   delay: 5
   when: metrics_service_registration.rc == 0
@@ -44,12 +47,16 @@
     {{ openshift_client_binary }} get apiservices/v1beta1.servicecatalog.k8s.io
   register: servicecatalog_service_registration
   failed_when: servicecatalog_service_registration.rc != 0 and 'NotFound' not in servicecatalog_service_registration.stderr
+  retries: 30
+  delay: 5
+  until: metrics_service_registration is succeeded
+
 
 - name: Wait for /apis/servicecatalog.k8s.io/v1beta1 when registered
   command: >
     {{ openshift_client_binary }} get --raw /apis/servicecatalog.k8s.io/v1beta1
   register: servicecatalog_api
-  until: servicecatalog_api.rc == 0
+  until: servicecatalog_api is succeeded
   retries: 30
   delay: 5
   when: servicecatalog_service_registration.rc == 0


### PR DESCRIPTION
It's not safe to continue the upgrade when any aggregated APIs are unavailable. This adds a 30 * 5s retry waiting for API availability to avoid problems.

Backports #10012 #10090 #10498
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1624493