### PR TITLE
[release-3.10] Add permissions for the Calico CNI plugin to access namespaces

### DIFF
--- a/roles/calico_master/templates/calicov3.yml.j2
+++ b/roles/calico_master/templates/calicov3.yml.j2
@@ -14,6 +14,7 @@ rules:
       - namespaces
       - networkpolicies
       - nodes
+      - serviceaccounts
     verbs:
       - watch
       - list
@@ -49,6 +50,7 @@ rules:
   - apiGroups: [""]
     resources:
       - pods
+      - namespaces
       - nodes
     verbs:
       - get


### PR DESCRIPTION
For Calico 3.3, the CNI plugin checks the namespaces. These changes give the CNI plugin and the controllers the appropriate permissions that they need to operate.

This is a cherry-pick of https://github.com/openshift/openshift-ansible/pull/10443 that had to be done manually because of the role refactor that was done for 3.11+