### PR TITLE
Only enable console TSB support when both SC and TSB are installed

### DIFF
--- a/playbooks/common/openshift-master/tasks/wire_aggregator.yml
+++ b/playbooks/common/openshift-master/tasks/wire_aggregator.yml
@@ -145,7 +145,7 @@
 # setup extension file for service console UI
 - lineinfile:
     dest: /etc/origin/master/openshift-ansible-catalog-console.js
-    line: "window.OPENSHIFT_CONSTANTS.TEMPLATE_SERVICE_BROKER_ENABLED={{ 'true' if (template_service_broker_install | default(True)) else 'false' }}"
+    line: "window.OPENSHIFT_CONSTANTS.TEMPLATE_SERVICE_BROKER_ENABLED={{ 'true' if (template_service_broker_install | default(True) and openshift_enable_service_catalog | default(True)) else 'false' }}"
     create: yes
 
 - name: Update master config


### PR DESCRIPTION
When you disable the service catalog by setting
penshift_enable_service_catalog=false that skips the service catalog
playbooks which includes both ASB and TSB so they don't get installed.

However the console configuration tasks happen separately and we were
enabling TSB support in the console whenever
template_service_broker_install was not set to false. If they had
disable service catalog but not TSB by setting those variables the
console was still being configured for TSB.

/cc @jpeeler @spadgett 