### PR TITLE
Added validation to avoid upload template always

### DIFF
--- a/playbooks/ovirt/openshift-cluster/ovirt-vm-infra.yml
+++ b/playbooks/ovirt/openshift-cluster/ovirt-vm-infra.yml
@@ -20,7 +20,7 @@
         tasks_from: build_vm_list.yml
 
   roles:
-    - oVirt.image-template
+    - { role: oVirt.image-template, when: qcow_url is defined }
     - oVirt.vm-infra
 
   post_tasks:

--- a/playbooks/ovirt/provisioning-vars.yaml.example
+++ b/playbooks/ovirt/provisioning-vars.yaml.example
@@ -20,6 +20,7 @@ openshift_ovirt_ssh_key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
 # Template Creation
 # https://github.com/oVirt/ovirt-ansible-image-template
 ##########################
+# If you comment the 'qcow_url' variable the template upload role will not be loaded  
 qcow_url:                       # https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2c
 image_path: "{{ lookup('env', 'HOME') }}/Downloads/{{ template_name }}.qcow2"
 template_name:                  # rhel75


### PR DESCRIPTION
Added a validation when `ovirt-vm-infra.yml` tries to load the **oVirt.image-template** role, if `qcow_url` are `undefined` this role will not be executed. Simple but very useful.