### PR TITLE
openshift_console: remove OAuthClient when uninstalling

### DIFF
--- a/roles/openshift_console/tasks/remove.yml
+++ b/roles/openshift_console/tasks/remove.yml
@@ -4,4 +4,8 @@
     name: openshift-console
     state: absent
 
-# TODO: Remove OAuthClient
+- name: Remove openshift-console OAuth client
+  oc_obj:
+    kind: oauthclient
+    name: openshift-console
+    state: absent


### PR DESCRIPTION
The OAuthClient is created within openshift-console installation
(tasks/install.yml, files/console-template.yml).

With this patch, the client is deleted by removal task.