### PR TITLE
Updating clean up task to match become of creation task

### DIFF
--- a/roles/openshift_logging/tasks/main.yaml
+++ b/roles/openshift_logging/tasks/main.yaml
@@ -109,4 +109,3 @@
     state: absent
   tags: logging_cleanup
   changed_when: False
-  become: false


### PR DESCRIPTION
To address https://bugzilla.redhat.com/show_bug.cgi?id=1632273

We create the tempdir without `become: false` on the task but when we go to clean it up we have `become: false` on the task. This makes it more consistent.