### PR TITLE
Remove leading spaces at openstack heat template

### DIFF
--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -580,7 +580,7 @@ resources:
           params:
             cluster_id: {{ openshift_openstack_full_dns_domain }}
       rules: {{ openshift_openstack_infra_secgroup_rules|to_json }}
-  {% if openshift_openstack_num_cns > 0 %}
+{% if openshift_openstack_num_cns > 0 %}
   cns-secgrp:
     type: OS::Neutron::SecurityGroup
     properties:


### PR DESCRIPTION
Hi everyone, 

with the leading spaces the resulting structure is getting wrong, the cns-secgrp is too far engaged.

Thanks & Regards
Robert