### PR TITLE
Removing run_once usage on include_tasks

### DIFF
--- a/roles/kuryr/tasks/master.yaml
+++ b/roles/kuryr/tasks/master.yaml
@@ -1,7 +1,6 @@
 ---
 - name: Perform OpenShift ServiceAccount config
   include_tasks: serviceaccount.yaml
-  run_once: true
 
 - name: Create kuryr manifests tempdir
   command: mktemp -d

--- a/roles/openshift_default_storage_class/tasks/main.yml
+++ b/roles/openshift_default_storage_class/tasks/main.yml
@@ -12,4 +12,3 @@
 
 - when: openshift_cloudprovider_kind == 'azure'
   include_tasks: azure.yml
-  run_once: true

--- a/roles/openshift_hosted/tasks/registry.yml
+++ b/roles/openshift_hosted/tasks/registry.yml
@@ -65,7 +65,6 @@
     clusterip: '{{ openshift_hosted_registry_clusterip | default(omit) }}'
 
 - include_tasks: secure.yml
-  run_once: true
   when:
   - not (openshift_docker_hosted_registry_insecure | default(False)) | bool
 


### PR DESCRIPTION
Previously, run_once (and several other options) were silently ignored on include_tasks
and effectively did nothing. As of 2.7/2.8 these invalid options will now raise errors,
so they must be removed.

This was tested against an install of 3.11 originally, so there may be others that were
added after that release.