### PR TITLE
[release-3.7] Walk the node_output for undefined

### DIFF
--- a/playbooks/common/openshift-node/restart.yml
+++ b/playbooks/common/openshift-node/restart.yml
@@ -63,7 +63,15 @@
     register: node_output
     delegate_to: "{{ groups.oo_first_master.0 }}"
     when: inventory_hostname in groups.oo_nodes_to_config
-    until: node_output.results.returncode == 0 and node_output.results.results[0].status.conditions | selectattr('type', 'match', '^Ready$') | map(attribute='status') | join | bool == True
+    until:
+  - node_output.results is defined
+  - node_output.results.returncode is defined
+  - node_output.results.returncode == 0
+  - node_output.results.results is defined
+  - node_output.results.results | length > 0
+  - node_output.results.results[0].status is defined
+  - node_output.results.results[0].status.conditions is defined
+  - node_output.results.results[0].status.conditions | selectattr('type', 'match', '^Ready$') | map(attribute='status') | join | bool == True
     # Give the node two minutes to come back online.
     retries: 24
     delay: 5

--- a/roles/openshift_node_upgrade/tasks/main.yml
+++ b/roles/openshift_node_upgrade/tasks/main.yml
@@ -189,7 +189,15 @@
     name: "{{ openshift.common.hostname | lower }}"
   register: node_output
   delegate_to: "{{ groups.oo_first_master.0 }}"
-  until: node_output.results.returncode == 0 and node_output.results.results[0].status.conditions | selectattr('type', 'match', '^Ready$') | map(attribute='status') | join | bool == True
+  until:
+  - node_output.results is defined
+  - node_output.results.returncode is defined
+  - node_output.results.returncode == 0
+  - node_output.results.results is defined
+  - node_output.results.results | length > 0
+  - node_output.results.results[0].status is defined
+  - node_output.results.results[0].status.conditions is defined
+  - node_output.results.results[0].status.conditions | selectattr('type', 'match', '^Ready$') | map(attribute='status') | join | bool == True
   # Give the node two minutes to come back online.
   retries: 24
   delay: 5


### PR DESCRIPTION
TASK [openshift_node_upgrade : Wait for node to be ready]
**********************
fatal: [ocp-infra1]: FAILED! => {"failed": true, "msg": "The
conditional check 'node_output.results.returncode == 0 and
node_output.results.results[0].status.conditions | selectattr('type',
'match', '^Ready$') | map(attribute='status') | join | bool == True'
failed. The error was: error while evaluating conditional
(node_output.results.returncode == 0 and
node_output.results.results[0].status.conditions | selectattr('type',
'match', '^Ready$') | map(attribute='status') | join | bool == True):
'dict object' has no attribute 'status'"}

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1643271
Backports #8674 and #9563, or #10529 
Fixes #9942