### PR TITLE
Use openshift_openstack_ephemeral_volumes for root volume too

### DIFF
--- a/roles/openshift_openstack/defaults/main.yml
+++ b/roles/openshift_openstack/defaults/main.yml
@@ -105,6 +105,15 @@ openshift_openstack_cns_volume_size: "{{ openshift_openstack_docker_volume_size 
 openshift_openstack_node_volume_size: "{{ openshift_openstack_docker_volume_size }}"
 openshift_openstack_etcd_volume_size: 2
 openshift_openstack_lb_volume_size: 5
+
+openshift_openstack_root_volume_size: 60
+openshift_openstack_master_root_volume_size: "{{ openshift_openstack_root_volume_size }}"
+openshift_openstack_infra_root_volume_size: "{{ openshift_openstack_root_volume_size }}"
+openshift_openstack_cns_root_volume_size: "{{ openshift_openstack_root_volume_size }}"
+openshift_openstack_node_root_volume_size: "{{ openshift_openstack_root_volume_size }}"
+openshift_openstack_etcd_root_volume_size: "{{ openshift_openstack_root_volume_size }}"
+openshift_openstack_lb_root_volume_size: "{{ openshift_openstack_root_volume_size }}"
+
 openshift_openstack_ephemeral_volumes: false
 openshift_openstack_master_group_name: node-config-master
 openshift_openstack_infra_group_name: node-config-infra

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -680,6 +680,7 @@ resources:
           attach_float_net: false
 {% endif %}
           volume_size: {{ openshift_openstack_etcd_volume_size }}
+          root_volume_size: {{ openshift_openstack_etcd_root_volume_size }}
 {% if not openshift_openstack_provider_network_name and not openshift_openstack_node_subnet_name  %}
     depends_on:
       - interface
@@ -763,6 +764,7 @@ resources:
           attach_float_net: false
 {% endif %}
           volume_size: {{ openshift_openstack_lb_volume_size }}
+          root_volume_size: {{ openshift_openstack_lb_root_volume_size }}
 {% if not openshift_openstack_provider_network_name and not openshift_openstack_node_subnet_name  %}
     depends_on:
       - interface
@@ -854,6 +856,7 @@ resources:
           attach_float_net: false
 {% endif %}
           volume_size: {{ openshift_openstack_master_volume_size }}
+          root_volume_size: {{ openshift_openstack_master_root_volume_size }}
 {% if openshift_openstack_master_server_group_policies|length > 0 %}
           scheduler_hints:
             group: { get_resource: master_server_group }
@@ -937,6 +940,7 @@ resources:
           attach_float_net: false
 {% endif %}
           volume_size: {{ openshift_openstack_node_volume_size }}
+          root_volume_size: {{ openshift_openstack_node_root_volume_size }}
 {% if not openshift_openstack_provider_network_name and not openshift_openstack_node_subnet_name  %}
     depends_on:
       - interface
@@ -1024,6 +1028,7 @@ resources:
           attach_float_net: false
 {% endif %}
           volume_size: {{ openshift_openstack_infra_volume_size }}
+          root_volume_size: {{ openshift_openstack_infra_root_volume_size }}
 {% if openshift_openstack_infra_server_group_policies|length > 0 %}
           scheduler_hints:
             group: { get_resource: infra_server_group }
@@ -1106,6 +1111,7 @@ resources:
           floating_network: {{ openshift_openstack_external_network_name }}
 {% endif %}
           volume_size: {{ openshift_openstack_cns_volume_size }}
+          root_volume_size: {{ openshift_openstack_cns_root_volume_size }}
 {% if not openshift_openstack_provider_network_name and not openshift_openstack_node_subnet_name  %}
     depends_on:
       - interface

--- a/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack_server.yaml.j2
@@ -159,6 +159,14 @@ parameters:
       - range: { min: 1, max: 1024 }
         description: must be between 1 and 1024 Gb.
 
+  root_volume_size:
+    type: number
+    description: Size of the root volume to be created.
+    default: 1
+    constraints:
+      - range: { min: 1, max: 1024 }
+        description: must be between 1 and 1024 Gb.
+
   openshift_node_group_name:
     type: string
     default: ''
@@ -248,6 +256,18 @@ resources:
         openshift_kubelet_name_override: { get_param: name }
 {% endif %}
       scheduler_hints: { get_param: scheduler_hints }
+{% if not openshift_openstack_ephemeral_volumes|default(false)|bool %}
+      block_device_mapping:
+        - device_name: vda
+          volume_id: { get_resource: root_volume }
+          delete_on_termination: true
+
+  root_volume:
+    type: OS::Cinder::Volume
+    properties:
+      size: {get_param: root_volume_size}
+      image: {get_param: image}
+{% endif %}
 
 {% if use_trunk_ports|default(false)|bool %}
   trunk_port:


### PR DESCRIPTION
Hi everyone,

add the possibility to switch between ephemeral and cinder volume for the root disk with  the option ```openshift_openstack_ephemeral_volumes``` too.

Get the opportunity with option ```openshift_openstack_root_volume_size:``` to decide how big should be the root disk. Or for different size for every kind of machine typ, similar to ```openshift_openstack_volume_size```.  

I don't how the ephemeral disk decide how big they should be.

If you have any queries, please do not hesitate to contact me!

Thanks & regards
Robert