### PR TITLE
OSA 3.11 repos enable 

### DIFF
--- a/playbooks/azure/openshift-cluster/build_node_image.yml
+++ b/playbooks/azure/openshift-cluster/build_node_image.yml
@@ -24,7 +24,12 @@
       openshift_node_image_prep_packages:
       - strace
       - tcpdump
+      - skopeo
+      - crio
       etcd_ip: ETCD_IP_REPLACE
+      etcd_hostname: ETCD_HOSTNAME_REPLACE
+      etcdctlv2: ETCD_CTL2_REPLACE
+      openshift_use_crio: True
 
   - name: add insights-client to package installs when on rhel
     set_fact:
@@ -45,7 +50,7 @@
     import_tasks: tasks/yum_certs.yml
 
   - name: update rpms
-    import_role:
+    include_role:
       name: os_update_latest
     vars:
       os_update_latest_reboot: True

--- a/playbooks/azure/openshift-cluster/group_vars/all/yum_repos.yml
+++ b/playbooks/azure/openshift-cluster/group_vars/all/yum_repos.yml
@@ -40,9 +40,9 @@ azure_node_repos:
     sslclientkey: /var/lib/yum/client-key.pem
     enabled: yes
 
-  # TODO: Replace me post GA with https://mirror.openshift.com/libra/rhui-rhel-server-7-ose-4.0/
-  - name: rhel-server-7-ose-4.0
-    baseurl: https://mirror.openshift.com/enterprise/all/4.0/latest/x86_64/os
+  # TODO: Replace me post GA with https://mirror.openshift.com/libra/rhui-rhel-server-7-ose-3.11/
+  - name: rhel-server-7-ose-3.11
+    baseurl: https://mirror.openshift.com/enterprise/all/3.11/latest/x86_64/os
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
     # TODO: Remove me post GA
     gpgcheck: false

--- a/playbooks/azure/openshift-cluster/group_vars/all/yum_repos.yml
+++ b/playbooks/azure/openshift-cluster/group_vars/all/yum_repos.yml
@@ -33,8 +33,8 @@ azure_node_repos:
     sslclientkey: /var/lib/yum/client-key.pem
     enabled: yes
 
-  - name: rhel-7-server-ansible-2.4-rpms
-    baseurl: https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.4-rpms/
+  - name: rhel-7-server-ansible-2.6-rpms
+    baseurl: https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
     sslclientcert: /var/lib/yum/client-cert.pem
     sslclientkey: /var/lib/yum/client-key.pem

--- a/playbooks/azure/openshift-cluster/tasks/yum_certs.yml
+++ b/playbooks/azure/openshift-cluster/tasks/yum_certs.yml
@@ -13,7 +13,7 @@
   when: ansible_distribution == "RedHat"
 
 - name: add yum repositories
-  import_role:
+  include_role:
     name: openshift_repos
   vars:
     r_openshift_repos_has_run: True


### PR DESCRIPTION
We gonna use 3.11 repos currently.
Ansible 2.6+ behaves little bit different 
```
import_role:
versus
include_role:
````


/cc kargakis kwoodson jim-minter 

