### PR TITLE
[3.11] Ensure proper task ordering atomic upgrades.

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -2,6 +2,13 @@
 - name: Install the systemd units
   import_tasks: systemd_units.yml
 
+- name: Install node system container
+  import_tasks: node_system_container.yml
+  when: openshift_is_atomic | bool
+
+- import_tasks: config/configure-node-settings.yml
+- import_tasks: configure-proxy-settings.yml
+
 - name: Configure Node Environment Variables
   lineinfile:
     dest: /etc/sysconfig/{{ openshift_service_type }}-node

--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -12,10 +12,3 @@
   when: not openshift_is_atomic | bool
   notify:
   - reload systemd units
-
-- name: Install node system container
-  import_tasks: node_system_container.yml
-  when: openshift_is_atomic | bool
-
-- import_tasks: config/configure-node-settings.yml
-- import_tasks: configure-proxy-settings.yml

--- a/roles/openshift_node/tasks/upgrade/restart.yml
+++ b/roles/openshift_node/tasks/upgrade/restart.yml
@@ -36,6 +36,15 @@
     state: started
   when: openshift_use_crio | bool
 
+# For atomic, container runtime needs to be operational before we can upgrade
+# node system container image.
+- name: Install node system container
+  import_tasks: ../node_system_container.yml
+  when: openshift_is_atomic | bool
+
+- import_tasks: ../config/configure-node-settings.yml
+- import_tasks: ../configure-proxy-settings.yml
+
 - name: Start node service
   service:
     name: "{{ openshift_service_type }}-node"


### PR DESCRIPTION
This commit ensures that atomic command to setup node
service is executed after we restart docker/crio.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1641245