### PR TITLE
openshift_prometheus: cleanup unused variables

### DIFF
--- a/roles/lib_utils/action_plugins/sanity_checks.py
+++ b/roles/lib_utils/action_plugins/sanity_checks.py
@@ -55,10 +55,7 @@ RELEASE_REGEX = {'re': '(^v?\\d+(\\.\\d+(\\.\\d+)?)?$)',
 STORAGE_KIND_TUPLE = (
     'openshift_loggingops_storage_kind',
     'openshift_logging_storage_kind',
-    'openshift_metrics_storage_kind',
-    'openshift_prometheus_alertbuffer_storage_kind',
-    'openshift_prometheus_alertmanager_storage_kind',
-    'openshift_prometheus_storage_kind')
+    'openshift_metrics_storage_kind')
 
 IMAGE_POLICY_CONFIG_VAR = "openshift_master_image_policy_config"
 ALLOWED_REGISTRIES_VAR = "openshift_master_image_policy_allowed_registries_for_import"

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -131,27 +131,6 @@ openshift_metrics_storage_nfs_options: '*(rw,root_squash)'
 openshift_metrics_storage_access_modes:
   - 'ReadWriteOnce'
 
-openshift_prometheus_storage_volume_name: 'prometheus'
-openshift_prometheus_storage_volume_size: '10Gi'
-openshift_prometheus_storage_access_modes:
-  - 'ReadWriteOnce'
-openshift_prometheus_storage_create_pv: True
-openshift_prometheus_storage_create_pvc: False
-
-openshift_prometheus_alertmanager_storage_volume_name: 'prometheus-alertmanager'
-openshift_prometheus_alertmanager_storage_volume_size: '10Gi'
-openshift_prometheus_alertmanager_storage_access_modes:
-  - 'ReadWriteOnce'
-openshift_prometheus_alertmanager_storage_create_pv: True
-openshift_prometheus_alertmanager_storage_create_pvc: False
-
-openshift_prometheus_alertbuffer_storage_volume_name: 'prometheus-alertbuffer'
-openshift_prometheus_alertbuffer_storage_volume_size: '10Gi'
-openshift_prometheus_alertbuffer_storage_access_modes:
-  - 'ReadWriteOnce'
-openshift_prometheus_alertbuffer_storage_create_pv: True
-openshift_prometheus_alertbuffer_storage_create_pvc: False
-
 openshift_service_type_dict:
   origin: origin
   openshift-enterprise: atomic-openshift


### PR DESCRIPTION
Remove variables which are no longer used due to removal of deprecated
prometheus install.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1629716