### PR TITLE
[WIP] s3: Use the same heketi URL as glusterfs SC

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/gluster_s3_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/gluster_s3_deploy.yml
@@ -23,14 +23,6 @@
   - glusterfs_heketi_is_native
   - glusterfs_heketi_url is not defined
 
-- name: Determine StorageClass heketi URL
-  set_fact:
-    glusterfs_heketi_url: "{{ heketi_endpoints.results.results[0]['subsets'][0]['addresses'][0]['ip'] }}"
-    glusterfs_heketi_port: "{{ heketi_endpoints.results.results[0]['subsets'][0]['ports'][0]['port'] }}"
-  when:
-  - glusterfs_heketi_is_native
-  - glusterfs_heketi_url is not defined
-
 - name: Generate GlusterFS StorageClass for S3 file
   template:
     src: "gluster-s3-storageclass.yml.j2"

--- a/roles/openshift_storage_glusterfs/templates/gluster-s3-storageclass.yml.j2
+++ b/roles/openshift_storage_glusterfs/templates/gluster-s3-storageclass.yml.j2
@@ -5,7 +5,7 @@ metadata:
   name: glusterfs-{{ glusterfs_name }}-s3
 provisioner: kubernetes.io/glusterfs
 parameters:
-  resturl: "http://{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}"
+  resturl: "http://{% if glusterfs_heketi_is_native %}heketi-{{ glusterfs_name }}.{{ glusterfs_namespace }}.svc:8080{% else %}{{ glusterfs_heketi_url }}:{{ glusterfs_heketi_port }}{% endif %}"
   restuser: "admin"
 {% if glusterfs_heketi_admin_key is defined %}
   secretNamespace: "{{ glusterfs_namespace }}"


### PR DESCRIPTION
Use the same heketi URL in gluster-s3 storage class as in glusterfs-(block).

For customer, provisioning failed when heketi's endpoint was configured. When replaced with the following, the pvc provisioned successfully.

        oc get -o json sc glusterfs-storage-s3 | \
            oc patch -o json --type=json --local -f - -p '[{
              "op": "add",
              "path": "/parameters/resturl",
              "value": "http://heketi-storage.app-storage.svc:8080"
            }]' | oc replace --force -f -

The PROXY was in the way, but all the proxy settings looked good (`/etc/sysconfig/atomic-openshift-node` contained the right CIDR in `NO_PROXY`.

Nevertheless, I find no harm in all the storage classes having the same heketi URL.

**Untested**.

Please let me know what you think.