### PR TITLE
[osa ]add subscription manager to rhel node rhel images

### DIFF
--- a/playbooks/azure/openshift-cluster/build_node_image.yml
+++ b/playbooks/azure/openshift-cluster/build_node_image.yml
@@ -31,9 +31,9 @@
       etcdctlv2: ETCD_CTL2_REPLACE
       openshift_use_crio: True
 
-  - name: add insights-client to package installs when on rhel
+  - name: add insights-client and subscription-manager to package installs when on rhel
     set_fact:
-      openshift_node_image_prep_packages: "{{ openshift_node_image_prep_packages | union(['insights-client']) }}"
+      openshift_node_image_prep_packages: "{{ openshift_node_image_prep_packages | union(['insights-client', 'subscription-manager']) }}"
     when: openshift_deployment_type == 'openshift-enterprise'
 
   - set_fact:


### PR DESCRIPTION
Add subscription manager to rhel node so certificates would be laid down for the registry.

/cc @kwoodson @vrutkovs @kargakis @jim-minter @charlesakalugwu 

Now on our rhel boxes this is a soft link and `redhat-uep` does not exit. 
```
/etc/docker/certs.d/registry.access.redhat.com/redhat-ca.crt -> /etc/rhsm/ca/redhat-uep.pem
```
I didn't tested it, as its a case of "It works on my laptop" because I had subscription manager installed and it had these certs. How they got propagated to the build - No Idea.