### PR TITLE
[release-3.11] Remove openshift_disable_swap for new install

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -44,7 +44,6 @@
 # /etc/fstab and runs swapoff -a, if necessary.
 - name: Disable swap
   swapoff: {}
-  when: openshift_disable_swap | default(true) | bool
 
 # The atomic-openshift-node service will set this parameter on
 # startup, but if the network service is restarted this setting is


### PR DESCRIPTION
This changes removes the undocumented option for allowing swap to remain
enabled on new installs.

Bug 1623333