### PR TITLE
[release-3.10] Remove openshift_disable_swap for new install

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -24,7 +24,6 @@
 # /etc/fstab and runs swapoff -a, if necessary.
 - name: Disable swap
   swapoff: {}
-  when: openshift_disable_swap | default(true) | bool
 
 - name: include node installer
   import_tasks: install.yml


### PR DESCRIPTION
This changes removes the undocumented option for allowing swap to remain
enabled on new installs.

Bug 1588611