### PR TITLE
[release-3.9] Removing openshift_disable_swap

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -21,7 +21,6 @@
 # /etc/fstab and runs swapoff -a, if necessary.
 - name: Disable swap
   swapoff: {}
-  when: openshift_disable_swap | default(true) | bool
 
 - name: include node installer
   import_tasks: install.yml

--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -32,7 +32,6 @@
 # /etc/fstab and runs swapoff -a, if necessary.
 - name: Disable swap
   swapoff: {}
-  when: openshift_disable_swap | default(true) | bool
 
 - name: Apply 3.6 dns config changes
   yedit:


### PR DESCRIPTION
This changes removes the undocumented option for allowing swap to remain
enabled on new installs and upgrades.

Related: 1588611