### PR TITLE
add default(false) to openshift_autoheal_deploy

### DIFF
--- a/roles/openshift_autoheal/tasks/main.yml
+++ b/roles/openshift_autoheal/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include_tasks: install.yml
-  when: openshift_autoheal_deploy | bool
+  when: openshift_autoheal_deploy | default(false) | bool
 
 - include_tasks: uninstall.yml
-  when: not openshift_autoheal_deploy | bool
+  when: not openshift_autoheal_deploy |  default(false) | bool


### PR DESCRIPTION
Add `default(false)`  to openshift_autoheal_deploy 
per https://github.com/openshift/openshift-ansible/tree/master/roles/openshift_autoheal#installation
> openshift_autoheal_deploy: true - install/update. false - uninstall. Defaults to false.

