### PR TITLE
Fix master paths check, while using Istio

### DIFF
--- a/roles/lib_utils/action_plugins/master_check_paths_in_config.py
+++ b/roles/lib_utils/action_plugins/master_check_paths_in_config.py
@@ -29,6 +29,7 @@ ITEMS_TO_POP = (
 MIGRATED_ITEMS = ", ".join([".".join(x) for x in ITEMS_TO_POP])
 
 ALLOWED_DIRS = (
+    '/dev/null',
     '/etc/origin/master/',
     '/var/lib/origin',
     '/etc/origin/cloudprovider',


### PR DESCRIPTION
Having recently deployed OKD 3.11 and the Istio Operator -- https://docs.openshift.com/container-platform/3.11/servicemesh-install/servicemesh-install.html

Everything went well, until I tried deploying something else, ... now I have the following error:

```
fatal: [XXX]: FAILED! => {"msg": "A string value that appears to be a file path located outside of\n/etc/origin/master/, /var/lib/origin, /etc/origin/cloudprovider, /etc/origin/kubelet-plugins, /usr/libexec/kubernetes/kubelet-plugins has been found in /etc/origin/master/master-config.yaml.\nIn 3.10 and newer, all files needed by the master must reside inside of\nthose directories or a subdirectory or it will not be readable by the\nmaster process. Please migrate all files needed by the master into\none of /etc/origin/master/, /var/lib/origin, /etc/origin/cloudprovider, /etc/origin/kubelet-plugins, /usr/libexec/kubernetes/kubelet-plugins or a subdirectory and update your master configs before\nproceeding. The string found was: /dev/null\n***********************\nNOTE: the following items do not need to be migrated, they will be migrated\nfor you: oauthConfig.identityProviders"}
```

As far as I understand, this has to do with the content of my `/etc/master/master-config.yaml`, which includes:

```
    MutatingAdmissionWebhook:
      configuration:
        kubeConfigFile: /dev/null
```

AFAIU, there's no reason to prevent `/dev/null` (nor `/dev/std*`, and others devs, ...) from being mentioned in master-config.