### PR TITLE
openshift_prometheus: ignore router endpoint in kube service config

### DIFF
--- a/roles/openshift_prometheus/templates/prometheus.yml.j2
+++ b/roles/openshift_prometheus/templates/prometheus.yml.j2
@@ -148,7 +148,7 @@ scrape_configs:
     # drop infrastructure components managed by other scrape targets
     - source_labels: [__meta_kubernetes_service_name]
       action: drop
-      regex: 'prometheus-node-exporter'
+      regex: 'router|prometheus-node-exporter'
     # only those that have requested scraping
     - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
       action: keep


### PR DESCRIPTION
The router endpoint is scraped using a separate configuration which requires
a bearer token.
See: https://bugzilla.redhat.com/show_bug.cgi?id=1644544