### PR TITLE
Update centos_repos.yml

### DIFF
--- a/roles/openshift_repos/tasks/centos_repos.yml
+++ b/roles/openshift_repos/tasks/centos_repos.yml
@@ -19,6 +19,6 @@
     src: "{{ item }}"
     dest: "/etc/yum.repos.d/{{ (item | basename | splitext)[0] }}"
   with_first_found:
-    - "CentOS-OpenShift-Origin{{ ((openshift_version | default('')).split('.') | join(''))[0:2] }}.repo.j2"
+    - "CentOS-OpenShift-Origin{{ ((openshift_version | default('')).split('.') | join(''))[0:3] }}.repo.j2"
     - "CentOS-OpenShift-Origin.repo.j2"
   notify: refresh cache

--- a/roles/openshift_repos/tasks/centos_repos.yml
+++ b/roles/openshift_repos/tasks/centos_repos.yml
@@ -19,6 +19,6 @@
     src: "{{ item }}"
     dest: "/etc/yum.repos.d/{{ (item | basename | splitext)[0] }}"
   with_first_found:
-    - "CentOS-OpenShift-Origin{{ ((openshift_version | default('')).split('.') | join(''))[0:3] }}.repo.j2"
+    - "CentOS-OpenShift-Origin{{ ((openshift_version | default('')).split('.')[0:2] | join('')) }}.repo.j2"
     - "CentOS-OpenShift-Origin.repo.j2"
   notify: refresh cache


### PR DESCRIPTION
I wonder how it worked, because for 3.10 and 3.11 it generates `CentOS-OpenShift-Origin31.repo.j2` string.

Fixes: https://github.com/openshift/openshift-ansible/issues/10445