### PR TITLE
devel-4.0: several fixes

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -16,7 +16,7 @@ RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl 
  && if [ "$(uname -m)" == "x86_64" ]; then yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm ; fi \
  && yum install -y java-1.8.0-openjdk-headless \
  && rpm -V $INSTALL_PKGS $EPEL_PKGS $EPEL_TESTING_PKGS \
- && pip install 'apache-libcloud~=2.2.1' 'SecretStorage<3' 'ansible[azure] google-auth' \
+ && pip install 'apache-libcloud~=2.2.1' 'SecretStorage<3' 'ansible[azure]' 'google-auth' \
  && yum clean all
 
 LABEL name="openshift/origin-ansible" \

--- a/roles/container_runtime/tasks/crio_firewall.yml
+++ b/roles/container_runtime/tasks/crio_firewall.yml
@@ -1,6 +1,11 @@
 ---
 - when: r_crio_firewall_enabled | bool and not r_crio_use_firewalld | bool
   block:
+  - name: Make sure iptables-services is installed
+    package:
+      name: iptables-services
+      state: present
+
   - name: Add iptables allow rules
     os_firewall_manage_iptables:
       name: "{{ item.service }}"

--- a/roles/openshift_gcp/defaults/main.yml
+++ b/roles/openshift_gcp/defaults/main.yml
@@ -64,6 +64,8 @@ openshift_gcp_multizone: False
 provision_custom_repositories: []
 
 mcd_port: 49500
+openshift_gcp_kubernetes_api_port: 6443
+openshift_gcp_master_healthcheck_port: 8080
 
 openshift_gcp_firewall_rules:
   - rule: icmp

--- a/test/gcp/install.yml
+++ b/test/gcp/install.yml
@@ -143,3 +143,8 @@
     delay: 5
     until: ansible_facts.services['bootkube.service'].state == 'stopped'
     ignore_errors: true
+  - name: Fetch kubeconfig for test container
+    fetch:
+      src: /opt/tectonic/auth/kubeconfig
+      dest: /tmp/artifacts/installer/auth/kubeconfig
+      flat: yes


### PR DESCRIPTION
* Fix syntax in Dockerfile
* Set default values for new vars in `openshift_gcp` role
* Install iptables-services when setting up CRI-O firewall
* Copy auth kubeconfig from bootstrap node so that test container would use it