### PR TITLE
Fixing static pod initialization

### DIFF
--- a/roles/openshift_control_plane/files/apiserver.yaml
+++ b/roles/openshift_control_plane/files/apiserver.yaml
@@ -14,7 +14,7 @@ spec:
   containers:
   - name: api
     image: docker.io/openshift/origin:v3.10.0
-    command: ["/bin/bash", "-c"]
+    command: ["/bin/sh", "-c"]
     args:
     - |
       #!/bin/bash

--- a/roles/openshift_control_plane/files/controller.yaml
+++ b/roles/openshift_control_plane/files/controller.yaml
@@ -14,7 +14,7 @@ spec:
   containers:
   - name: controllers
     image: docker.io/openshift/origin:v3.10.0
-    command: ["/bin/bash", "-c"]
+    command: ["/bin/sh", "-c"]
     args:
     - |
       #!/bin/bash


### PR DESCRIPTION
This fixes an issue in which the startup of the master api and controller static pods were failing to start up due to incorrectly interpreting the given command.

Before:
```
[root@master01 ~]# docker logs 4e9c7da2b279
container_linux.go:247: starting container process caused "exec: \"#!/bin/bash\\nset -euo pipefail\\nif [[ -f /etc/origin/master/master.env ]]; then\\n  set -o allexport\\n  source /etc/origin/master/master.env\\nfi\\nexec openshift start master api --config=/etc/origin/master/master-config.yaml --loglevel=${DEBUG_LOGLEVEL:-2}\\n\": stat #!/bin/bash\nset -euo pipefail\nif [[ -f /etc/origin/master/master.env ]]; then\n  set -o allexport\n  source /etc/origin/master/master.env\nfi\nexec openshift start master api --config=/etc/origin/master/master-config.yaml --loglevel=${DEBUG_LOGLEVEL:-2}\n: no such file or directory"
```

After:
```
I1107 21:14:49.348295       1 plugins.go:84] Registered admission plugin "NamespaceLifecycle"
I1107 21:14:49.348393       1 plugins.go:84] Registered admission plugin "Initializers"
I1107 21:14:49.348399       1 plugins.go:84] Registered admission plugin "ValidatingAdmissionWebhook"
I1107 21:14:49.348404       1 plugins.go:84] Registered admission plugin "MutatingAdmissionWebhook"
I1107 21:14:49.348409       1 plugins.go:84] Registered admission plugin "AlwaysAdmit"
I1107 21:14:49.348414       1 plugins.go:84] Registered admission plugin "AlwaysPullImages"
I1107 21:14:49.348419       1 plugins.go:84] Registered admission plugin "LimitPodHardAntiAffinityTopology"
I1107 21:14:49.348424       1 plugins.go:84] Registered admission plugin "DefaultTolerationSeconds"
I1107 21:14:49.348429       1 plugins.go:84] Registered admission plugin "AlwaysDeny"
I1107 21:14:49.348435       1 plugins.go:84] Registered admission plugin "EventRateLimit"
I1107 21:14:49.348440       1 plugins.go:84] Registered admission plugin "DenyEscalatingExec"
I1107 21:14:49.348443       1 plugins.go:84] Registered admission plugin "DenyExecOnPrivileged"
I1107 21:14:49.348448       1 plugins.go:84] Registered admission plugin "ExtendedResourceToleration"
I1107 21:14:49.348453       1 plugins.go:84] Registered admission plugin "OwnerReferencesPermissionEnforcement"
I1107 21:14:49.348460       1 plugins.go:84] Registered admission plugin "ImagePolicyWebhook"
...
```

May address this issue:
https://github.com/openshift/openshift-ansible/issues/10247#issuecomment-425650770
