### PR TITLE
Properly prefix certificate paths

### DIFF
--- a/roles/calico/tasks/certs.yml
+++ b/roles/calico/tasks/certs.yml
@@ -29,7 +29,7 @@
     tasks_from: server_certificates
   vars:
     etcd_cert_prefix: calico-etcd-
-    etcd_cert_config_dir: "{{ calico_etcd_cert_dir }}"
+    etcd_conf_dir: "{{ calico_etcd_cert_dir }}"
     etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
     etcd_cert_subdir: "calico-etcd-{{ openshift.common.hostname }}"
 

--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -25,20 +25,22 @@ etcdctl_dict:
 r_etcd_common_etcdctl_command: "{{ etcdctl_dict[r_etcd_common_etcd_runtime] }}"
 
 # etcd server vars
+# etcd_cert_prefix is to facilitate multiple etcd instances on one host
+# in one path
+etcd_cert_prefix: ''
 etcd_conf_dir: '/etc/etcd'
 etcd_conf_file: "{{ etcd_conf_dir }}/etcd.conf"
-etcd_ca_file: "{{ etcd_conf_dir }}/ca.crt"
-etcd_cert_file: "{{ etcd_conf_dir }}/server.crt"
+etcd_ca_file: "{{ etcd_conf_dir }}/{{ etcd_cert_prefix }}ca.crt"
+etcd_cert_file: "{{ etcd_conf_dir }}/{{ etcd_cert_prefix }}server.crt"
 etcd_cert_subdir: "etcd-{{ openshift.common.hostname }}"
-etcd_key_file: "{{ etcd_conf_dir }}/server.key"
-etcd_peer_ca_file: "{{ etcd_conf_dir }}/ca.crt"
-etcd_peer_cert_file: "{{ etcd_conf_dir }}/peer.crt"
-etcd_peer_key_file: "{{ etcd_conf_dir }}/peer.key"
+etcd_key_file: "{{ etcd_conf_dir }}/{{ etcd_cert_prefix }}server.key"
+etcd_peer_ca_file: "{{ etcd_conf_dir }}/{{ etcd_cert_prefix }}ca.crt"
+etcd_peer_cert_file: "{{ etcd_conf_dir }}/{{ etcd_cert_prefix }}peer.crt"
+etcd_peer_key_file: "{{ etcd_conf_dir }}/{{ etcd_cert_prefix }}peer.key"
 
 # etcd ca vars
 etcd_ca_dir: "{{ etcd_conf_dir}}/ca"
 etcd_generated_certs_dir: "{{ etcd_conf_dir }}/generated_certs"
-etcd_cert_prefix: ''
 etcd_cert_config_dir: "/etc/etcd"
 etcd_ca_cert: "{{ etcd_ca_dir }}/ca.crt"
 etcd_ca_key: "{{ etcd_ca_dir }}/ca.key"

--- a/roles/etcd/tasks/certificates/backup_server_certificates.yml
+++ b/roles/etcd/tasks/certificates/backup_server_certificates.yml
@@ -2,10 +2,10 @@
 - name: Backup etcd certificates
   command: >
     tar -czvf /etc/etcd/etcd-server-certificate-backup-{{ ansible_date_time.epoch }}.tgz
-    {{ etcd_conf_dir }}/ca.crt
-    {{ etcd_conf_dir }}/server.crt
-    {{ etcd_conf_dir }}/server.key
-    {{ etcd_conf_dir }}/peer.crt
-    {{ etcd_conf_dir }}/peer.key
+    {{ etcd_ca_file }}
+    {{ etcd_cert_file }}
+    {{ etcd_key_file }}
+    {{ etcd_peer_cert_file }}
+    {{ etcd_peer_key_file }}
   args:
     warn: no

--- a/roles/etcd/tasks/certificates/distribute_ca.yml
+++ b/roles/etcd/tasks/certificates/distribute_ca.yml
@@ -31,17 +31,17 @@
 
 - name: Read current etcd CA
   slurp:
-    src: "{{ etcd_conf_dir }}/ca.crt"
+    src: "{{ etcd_ca_file }}"
   register: g_current_etcd_ca_output
 
 - name: Read new etcd CA
   slurp:
-    src: "{{ etcd_ca_dir }}/ca.crt"
+    src: "{{ etcd_ca_cert }}"
   register: g_new_etcd_ca_output
 
 - copy:
     content: "{{ (g_new_etcd_ca_output.content|b64decode) + (g_current_etcd_ca_output.content|b64decode) }}"
-    dest: "{{ item }}/ca.crt"
+    dest: "{{ item }}"
   with_items:
-  - "{{ etcd_conf_dir }}"
-  - "{{ etcd_ca_dir }}"
+  - "{{ etcd_ca_file }}"
+  - "{{ etcd_ca_cert }}"

--- a/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
+++ b/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
@@ -15,9 +15,9 @@
     get_attributes: false
     get_mime: false
   with_items:
-  - "{{ etcd_cert_config_dir }}/{{ etcd_cert_prefix }}server.crt"
-  - "{{ etcd_cert_config_dir }}/{{ etcd_cert_prefix }}peer.crt"
-  - "{{ etcd_cert_config_dir }}/{{ etcd_cert_prefix }}ca.crt"
+  - "{{ etcd_cert_file }}"
+  - "{{ etcd_peer_cert_file }}"
+  - "{{ etcd_ca_file }}"
   register: g_etcd_server_cert_stat_result
   when: not etcd_certificates_redeploy | default(false) | bool
 
@@ -199,6 +199,7 @@
   - "{{ etcd_peer_cert_file }}"
   - "{{ etcd_peer_key_file }}"
 
+# this may not be right
 - name: Validate permissions on the config dir
   file:
     path: "{{ etcd_conf_dir }}"

--- a/roles/etcd/tasks/certificates/retrieve_ca_certificates.yml
+++ b/roles/etcd/tasks/certificates/retrieve_ca_certificates.yml
@@ -1,7 +1,7 @@
 ---
 - name: Retrieve etcd CA certificate
   fetch:
-    src: "{{ etcd_conf_dir }}/ca.crt"
+    src: "{{ etcd_ca_file }}"
     dest: "{{ etcd_sync_cert_dir }}/"
     flat: yes
     fail_on_missing: yes


### PR DESCRIPTION
When calico is installed and you're scaling up the master/node in order
to subsequently scale up etcd the cert permission checks were failing
because their paths weren't properly templated. This meant that we were
checking for openshift etcd files rather than calico etcd certificates. The
former do not exist until etcd has been scaled up.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1644416