### PR TITLE
[release 3.11] Restart docker after openstack storage setup

### DIFF
--- a/roles/openshift_openstack/defaults/main.yml
+++ b/roles/openshift_openstack/defaults/main.yml
@@ -18,6 +18,7 @@ openshift_openstack_lbaasv2_provider: Octavia
 openshift_openstack_use_vm_load_balancer: false
 openshift_openstack_api_lb_listeners_timeout: 500000
 
+openshift_docker_service_name: "docker"
 
 # container-storage-setup
 openshift_openstack_container_storage_setup:

--- a/roles/openshift_openstack/tasks/container-storage-setup.yml
+++ b/roles/openshift_openstack/tasks/container-storage-setup.yml
@@ -35,3 +35,14 @@
   # TODO(shadower): Find out which CentOS version supports overlayfs2
   when:
     - ansible_distribution == "CentOS"
+
+- name: restart docker after storage configuration
+  become: yes
+  systemd:
+    name: "{{ openshift_docker_service_name }}"
+    state: restarted
+  register: l_docker_restart_docker_in_storage_setup_result
+  until: not (l_docker_restart_docker_in_storage_setup_result is failed)
+  retries: 3
+  delay: 30
+  when: not openshift_use_crio_only|default(None)


### PR DESCRIPTION
OpenStack storage setup happens after docker has started, meaning changes aren't picked up. This PR restarts docker after the storage setup.