### PR TITLE
Mount /etc/pki into controller pod

### DIFF
--- a/roles/openshift_control_plane/files/controller.yaml
+++ b/roles/openshift_control_plane/files/controller.yaml
@@ -37,6 +37,8 @@ spec:
      - mountPath: /usr/libexec/kubernetes/kubelet-plugins
        name: kubelet-plugins
        mountPropagation: "HostToContainer"
+     - mountPath: /etc/pki
+       name: master-pki
     livenessProbe:
       httpGet:
         scheme: HTTPS
@@ -57,3 +59,6 @@ spec:
   - name: kubelet-plugins
     hostPath:
       path: /usr/libexec/kubernetes/kubelet-plugins
+  - name: master-pki
+    hostPath:
+      path: /etc/pki


### PR DESCRIPTION
This means that the controller will share a trust store with the host.