### PR TITLE
Run openshift_version before configuring repositories

### DIFF
--- a/playbooks/init/main.yml
+++ b/playbooks/init/main.yml
@@ -22,6 +22,8 @@
 
 - import_playbook: basic_facts.yml
 
+- import_playbook: version.yml
+
 # NOTE: we must call init repos before installing base packages
 # because they may come from the repos.
 - import_playbook: repos.yml
@@ -31,8 +33,6 @@
   when: l_install_base_packages | default(False) | bool
 
 - import_playbook: cluster_facts.yml
-
-- import_playbook: version.yml
 
 - import_playbook: sanity_checks.yml
   when: not (skip_sanity_checks | default(False))


### PR DESCRIPTION
This fixes #10445.

Correct file is templated:

```
TASK [openshift_repos : Configure correct origin release repository] ***************************************************************************************************************************************************************************************************************************************************************************************************************************
Thursday 08 November 2018  15:43:08 +0100 (0:00:00.865)       0:00:36.746 ***** 
changed: [oc-dev.marbis.net] => (item=/opt/openshift/roles/openshift_repos/templates/CentOS-OpenShift-Origin310.repo.j2)

TASK [openshift_repos : debug] *****************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
Thursday 08 November 2018  15:43:09 +0100 (0:00:01.172)       0:00:37.918 ***** 
ok: [oc-dev.marbis.net] => {
    "msg": "CentOS-OpenShift-Origin310.repo.j2"
}
```

```
$ rm /etc/yum.repos.d/*Origin*
$ ansible-playbook playbooks/prerequisites.yml
[...]
$ ls /etc/yum.repos.d/*Origin*
/etc/yum.repos.d/CentOS-OpenShift-Origin310.repo
```

We might want to remove the wrongly deployed CentOS-OpenShift-Origin.repo for existing 3.10 installs, otherwise, they will pull 3.11 packages as soon as those are added to the SIG repo.