### PR TITLE
Start node image prepull after CRIO is restarted

### DIFF
--- a/roles/openshift_cli/tasks/main.yml
+++ b/roles/openshift_cli/tasks/main.yml
@@ -6,11 +6,15 @@
   register: result
   until: result is succeeded
 
-- block:
-  - name: Pull CLI Image
-    docker_image:
-      name: "{{ openshift_cli_image }}"
-    when: not openshift_use_crio_only | bool
+- name: Check that CLI image is present
+  command: "{{ openshift_container_cli }} images -q {{ openshift_cli_image }}"
+  register: cli_image
+
+- name: Pre-pull cli image
+  command: "{{ openshift_container_cli }} pull {{ openshift_cli_image }}"
+  environment:
+    NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
+  when: cli_image.stdout_lines == []
 
 - name: Install bash completion for oc tools
   package:

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -6,9 +6,6 @@
     - openshift_deployment_type == 'openshift-enterprise'
     - not openshift_use_crio | bool
 
-- name: Start node image prepull
-  import_tasks: prepull.yml
-
 - import_tasks: dnsmasq_install.yml
 - import_tasks: dnsmasq.yml
 
@@ -31,6 +28,9 @@
     name: NetworkManager
     enabled: yes
     state: restarted
+
+- name: Start node image prepull
+  import_tasks: prepull.yml
 
 - name: include node installer
   import_tasks: install.yml


### PR DESCRIPTION
This ensures node prepull happens after CRIO is configured and the 
service is not restarted between start and prepull check

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1647288