### PR TITLE
[3.11] Start node image prepull after CRIO is restarted

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -6,9 +6,6 @@
     - openshift_deployment_type == 'openshift-enterprise'
     - not openshift_use_crio | bool
 
-- name: Start node image prepull
-  import_tasks: prepull.yml
-
 - import_tasks: dnsmasq_install.yml
 - import_tasks: dnsmasq.yml
 
@@ -31,6 +28,9 @@
     name: NetworkManager
     enabled: yes
     state: restarted
+
+- name: Start node image prepull
+  import_tasks: prepull.yml
 
 - name: include node installer
   import_tasks: install.yml


### PR DESCRIPTION
This ensures node prepull happens after CRIO is configured and the 
service is not restarted between start and prepull check

Cherry-pick of #10641 on 3.11 branch