### PR TITLE
Update node config template for crio

### DIFF
--- a/roles/openshift_node_group/tasks/bootstrap.yml
+++ b/roles/openshift_node_group/tasks/bootstrap.yml
@@ -4,3 +4,10 @@
     src: node-config.yaml.j2
     dest: "/etc/origin/node/bootstrap-node-config.yaml"
     mode: 0600
+
+- name: Update bootstrap-node-config.yaml to use crio
+  yedit:
+    content:
+    src: "/etc/origin/node/bootstrap-node-config.yaml"
+    edits: "{{ openshift_node_group_edits_crio }}"
+  when: openshift_use_crio | bool

--- a/roles/openshift_node_group/templates/node-config.yaml.j2
+++ b/roles/openshift_node_group/templates/node-config.yaml.j2
@@ -24,16 +24,6 @@ kubeletArguments:
   volume-plugin-dir:
   - "/etc/origin/kubelet-plugins/volume/exec"
 {% endif %}
-{% if openshift_use_crio | bool %}
-  container-runtime:
-  - remote
-  container-runtime-endpoint:
-  - {{ openshift_crio_var_sock }}
-  image-service-endpoint:
-  - {{ openshift_crio_var_sock }}
-  runtime-request-timeout:
-  - 10m
-{% endif %}
   pod-manifest-path:
   - /etc/origin/node/pods
   bootstrap-kubeconfig:


### PR DESCRIPTION
Removes crio config from template which was causing all configmaps to
get crio settings if the first master had openshift_use_crio=True.

Updates bootstrap-node-config for crio settings directly.

https://bugzilla.redhat.com/show_bug.cgi?id=1647516