### PR TITLE
add docker_storage_setup_options since docker_storage_driver is ignored

### DIFF
--- a/playbooks/container-runtime/private/setup_storage.yml
+++ b/playbooks/container-runtime/private/setup_storage.yml
@@ -13,7 +13,7 @@
         name: container_runtime
         tasks_from: docker_storage_setup_overlay.yml
       when:
-        - container_runtime_docker_storage_type|default('') == "overlay2"
+        - docker_storage_setup_options.storage_driver is defined
     - import_role:
         name: container_runtime
         tasks_from: extra_storage_setup.yml

--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -51,7 +51,6 @@ docker_storage_size: 40G
 docker_storage_setup_options:
   vg: docker_vg
   data_size: 99%VG
-  storage_driver: overlay2
   root_lv_name: docker-root-lv
   root_lv_size: 100%FREE
   root_lv_mount_path: "{{ docker_storage_path }}"

--- a/roles/container_runtime/tasks/docker_storage_setup_overlay.yml
+++ b/roles/container_runtime/tasks/docker_storage_setup_overlay.yml
@@ -7,4 +7,4 @@
     group: root
     mode: 0664
   when:
-  - container_runtime_docker_storage_type == 'overlay2'
+    - docker_storage_setup_options.storage_driver is defined


### PR DESCRIPTION
#### Description

Parameter docker_storage_driver in inventory is ignored
In inventory docker_storage_driver=what_ever_you_want has no effect

Use the following parameter in inventory instead to allow storage driver parameter
```
docker_storage_setup_options={'storage_driver': 'overlay2'}
```

##### Additional Information

* Issue #10654 
* Red Hat Enterprise Linux Server release 7.6 (Maipo)
* Your inventory file (especially any non-standard configuration parameters)
* The following bugzilla has been opened [1648398](https://bugzilla.redhat.com/show_bug.cgi?id=1648398)
