### PR TITLE
[release 3.11] Service Catalog - wait for rollout of SC API Server & SC Controller Mgr

### DIFF
--- a/roles/openshift_service_catalog/tasks/start.yml
+++ b/roles/openshift_service_catalog/tasks/start.yml
@@ -1,6 +1,28 @@
 ---
-# TODO: abstract me into a relatively generic task
-- name: Verify that the catalog api server is running
+- name: Wait for API Server rollout success
+  command: >
+      {{ openshift_client_binary }} rollout status --config=/etc/origin/master/admin.kubeconfig -n kube-service-catalog ds/apiserver
+  changed_when: false
+  # Ignore errors so we can log troubleshooting info on failures.
+  ignore_errors: yes
+  register: apiserver_rollout_status
+  until: apiserver_rollout_status.rc == 0
+  retries: 5
+  delay: 10
+
+
+- name: Wait for Controller Manager rollout success
+  command: >
+      {{ openshift_client_binary }} rollout status --config=/etc/origin/master/admin.kubeconfig -n kube-service-catalog ds/controller-manager
+  changed_when: false
+  # Ignore errors so we can log troubleshooting info on failures.
+  ignore_errors: yes
+  register: controllermanager_rollout_status
+  until: controllermanager_rollout_status.rc == 0
+  retries: 5
+  delay: 10
+
+- name: Verify that the Catalog API Server is running
   command: >
     curl -k https://apiserver.kube-service-catalog.svc/healthz
   args:
@@ -16,7 +38,7 @@
   ignore_errors: yes
 
 # Log the result of `oc status`, `oc get pods`, `oc get events`, and `oc logs deployment/webconsole` for troubleshooting failures.
-- when: endpoint_health.stdout != 'ok'
+- when: (controllermanager_rollout_status.rc !=0 or apiserver_rollout_status.rc !=0 or endpoint_health.stdout != 'ok')
   block:
   - name: Check status in the kube-service-catalog namespace
     command: >
@@ -47,7 +69,7 @@
   - debug:
       msg: "{{ endpoint_log.stdout_lines }}"
 
-- when: endpoint_health.stdout != 'ok'
+- when: (controllermanager_rollout_status.rc !=0 or apiserver_rollout_status.rc !=0 or endpoint_health.stdout != 'ok')
   block:
   - name: Report errors
     fail:


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1648458

Wait for Service Catalog API Server and Controller Manager daemonset rollouts to finish before proceeding.

Fail the deployment if either rollout fails (in addition to if health check fails)