### PR TITLE
Juniper Contrail SDN patch

### DIFF
--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -184,6 +184,8 @@
     when: openshift_use_nuage | default(false) | bool
   - role: calico_master
     when: openshift_use_calico | default(false) | bool
+  - role: contrail_master
+    when: openshift_use_contrail | default(false) | bool
   tasks:
   - import_role:
       name: kuryr

--- a/playbooks/openshift-node/private/additional_config.yml
+++ b/playbooks/openshift-node/private/additional_config.yml
@@ -23,6 +23,10 @@
   - group_by:
       key: oo_nodes_use_{{ (openshift_use_kuryr | default(False)) | ternary('kuryr','nothing') }}
     changed_when: False
+  # Create group for contrail nodes
+  - group_by:
+      key: oo_nodes_use_{{ (openshift_use_contrail | default(False)) | ternary('contrail','nothing') }}
+    changed_when: False
 
 - import_playbook: etcd_client_config.yml
   vars:
@@ -67,3 +71,27 @@
       name: kuryr
       tasks_from: node
     when: openshift_use_kuryr | default(false) | bool
+
+- name: Additional node config
+  hosts: oo_nodes_use_contrail
+  roles:
+  - role: contrail_node
+    when: openshift_use_contrail | default(false) | bool
+
+- name: Install Contrail
+  hosts: oo_first_master
+  roles:
+  - role: contrail_controller
+    when: openshift_use_contrail | default(false) | bool
+
+- name: Configure Contrail ST
+  hosts: oo_nodes_use_contrail
+  roles:
+  - role: contrail_st
+    when: openshift_use_contrail | default(false) | bool
+
+- name: Install Contrail Customized Web Console
+  hosts: oo_first_master
+  roles:
+  - role: contrail_web_console
+    when: openshift_use_contrail | default(false) | bool

--- a/playbooks/openshift-node/private/manage_node.yml
+++ b/playbooks/openshift-node/private/manage_node.yml
@@ -11,3 +11,26 @@
   - name: Create group for deployment type
     group_by: key=oo_nodes_deployment_type_{{ openshift.common.deployment_type }}
     changed_when: False
+
+- name: wait for sometime for agent pod to come up
+  hosts: "{{ openshift_node_scale_up_group | default('oo_nodes_to_config') }}"
+  tasks:
+  - name: wait for 180 seconds
+    wait_for: timeout=180
+    when: openshift_use_contrail | default(false) | bool
+
+- name: wait for pod check script
+  hosts: oo_first_master
+  tasks:
+  - name: Check Pods script to Master Node
+    command: /tmp/wait_for_pod.sh
+    register: command_result
+    failed_when: "'ERROR' in command_result.stdout"
+    when: openshift_use_contrail | default(false) | bool
+
+- name: Restarting dnsmasq service
+  hosts: "{{ openshift_node_scale_up_group | default('oo_nodes_to_config') }}"
+  tasks:
+  - name: Restart dnsmasq
+    service: name="dnsmasq" state=restarted enabled=yes
+    when: openshift_use_contrail | default(false) | bool

--- a/roles/contrail_common/README.md
+++ b/roles/contrail_common/README.md
@@ -1,0 +1,51 @@
+# Contrail SDN
+
+[Contrail Networking](https://www.juniper.net/us/en/products-services/sdn/contrail/contrail-networking/), based on [TungstenFabric](https://tungstenfabric.io/) project, is a truly open, multi-cloud network virtualization and policy management platform. Contrail / TungstenFabric SDN stack is integrated with various orchestration systems such as Kubernetes, OpenShift, OpenStack and Mesos, and provides different isolation modes for virtual machines, containers/pods and bare metal workloads.
+
+## SUPPORTED ARCHITECTURE
+
+* Contrail SDN installed through OpenShift ansible supports both non-HA and  HA configurations.
+
+## CONTRAIL SOFTWARE COMPONENTS
+
+### Contrail Master (DaemonSets)
+
+- **Contrail Image Installer**: Downloads all contrail container images if not present.
+- **Contrail Controller Config**: The config daemonset consists of all config components
+  like contrail service monitor, schema transformer, api server etc which are running as
+  a docker container.
+- **Contrail Controller Control**: The contrail controller is installed by this daemonset.
+- **Contrail Controller WebUI**: WebUI components are deployed here. We use port 8143.
+- **Contrail Analytics**: All Contrail analytics components like the analytics collector,
+  topology, alarm-gen are installed by this daemonset.
+- **Contrail Analytics Database**: Contrail Analytics uses this container as its DB.
+- **Contrail Config DB Node Manager**: Node Manager for Config DB, Node manager containers are run
+  by all Contrail components to provide current status.
+- **Contrail Config DB**: DB used by the Contrail Controller Config component.
+- **Contrail DB Node Manager**: Node Manager of Analytics.
+- **Contrail Kubernetes Manager**: The interface between the Openshift API server and
+  Contrail Controller.
+
+Note:  These Contrail components are installed on the infra-node.
+
+### Nodes (DaemonSets)
+- **Contrail Agent**: As part of the agent pod we install the **vrouter kernel module** and the **contrail-cni**.
+
+### Contrail Ansible Roles
+
+* **Contrail common**: This role contains common functions which are required by other contrail roles
+* **Contrail controller**: Installs all contrail master components
+* **Contrail master**: Preps up the openshift master node
+* **Contrail node**: Installs cni binaries on all nodes
+* **Contrail st**: Preps the contrail schema transformer
+* **Contrail web console**: Installs contrail web console on infra nodes
+
+## INSTALLATION
+
+To install Contrail SDN with OpenShift Enterprise, follow this [install guide](https://github.com/Juniper/contrail-kubernetes-docs)
+
+Refer to this example [openshift 3.9 contrail installation](https://github.com/Juniper/contrail-kubernetes-docs/blob/master/install/openshift/3.9/standalone-openshift.md) for non-HA/HA deployments
+
+### CONTACT
+
+Pragash Vijayaragavan <pvijayaragav@juniper.net>

--- a/roles/contrail_common/tasks/determine_contrail_masters.yaml
+++ b/roles/contrail_common/tasks/determine_contrail_masters.yaml
@@ -1,0 +1,26 @@
+---
+- name: Set contrail_masters var
+  set_fact:
+    contrail_masters: ""
+
+- name: Set contrail_masters from contrail_control_data_interface
+  set_fact:
+    contrail_masters: "{{ contrail_control_data_interface }}"
+  when:
+    - contrail_control_data_interface is defined
+
+- name: Set contrail_masters from infra nodes
+  set_fact:
+    contrail_masters: "{{ contrail_masters }} {{ item }}"
+  when:
+    - contrail_control_data_interface is not defined
+    - hostvars[item]['openshift_node_labels'] is defined
+    - hostvars[item]['openshift_node_labels']['region'] is defined
+    - hostvars[item]['openshift_node_labels']['region'] == 'infra'
+  with_items: "{{ groups.nodes }}"
+
+- name: Set contrail_masters from masters group if not set before
+  set_fact:
+    contrail_masters: "{{ contrail_masters }} {{ item }}"
+  with_items: "{{ groups.masters }}"
+  when: contrail_masters.split() | length < 1

--- a/roles/contrail_common/tasks/hosts_to_ip.yaml
+++ b/roles/contrail_common/tasks/hosts_to_ip.yaml
@@ -1,0 +1,7 @@
+---
+- set_fact:
+    contrail_masters_ip: ""
+
+- set_fact:
+    contrail_masters_ip: "{{ contrail_masters_ip }} {{ hostvars[item]['ansible_default_ipv4']['address'] }}"
+  with_items: "{{ contrail_masters.split() }}"

--- a/roles/contrail_common/tasks/main.yml
+++ b/roles/contrail_common/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Determine contrail masters
+  include_tasks: determine_contrail_masters.yaml
+
+- name: Convert hostnames to ip
+  include_tasks: hosts_to_ip.yaml

--- a/roles/contrail_controller/README.md
+++ b/roles/contrail_controller/README.md
@@ -1,0 +1,51 @@
+# Contrail SDN
+
+[Contrail Networking](https://www.juniper.net/us/en/products-services/sdn/contrail/contrail-networking/), based on [TungstenFabric](https://tungstenfabric.io/) project, is a truly open, multi-cloud network virtualization and policy management platform. Contrail / TungstenFabric SDN stack is integrated with various orchestration systems such as Kubernetes, OpenShift, OpenStack and Mesos, and provides different isolation modes for virtual machines, containers/pods and bare metal workloads.
+
+## SUPPORTED ARCHITECTURE
+
+* Contrail SDN installed through OpenShift ansible supports both non-HA and  HA configurations.
+
+## CONTRAIL SOFTWARE COMPONENTS
+
+### Contrail Master (DaemonSets)
+
+- **Contrail Image Installer**: Downloads all contrail container images if not present.
+- **Contrail Controller Config**: The config daemonset consists of all config components
+  like contrail service monitor, schema transformer, api server etc which are running as
+  a docker container.
+- **Contrail Controller Control**: The contrail controller is installed by this daemonset.
+- **Contrail Controller WebUI**: WebUI components are deployed here. We use port 8143.
+- **Contrail Analytics**: All Contrail analytics components like the analytics collector,
+  topology, alarm-gen are installed by this daemonset.
+- **Contrail Analytics Database**: Contrail Analytics uses this container as its DB.
+- **Contrail Config DB Node Manager**: Node Manager for Config DB, Node manager containers are run
+  by all Contrail components to provide current status.
+- **Contrail Config DB**: DB used by the Contrail Controller Config component.
+- **Contrail DB Node Manager**: Node Manager of Analytics.
+- **Contrail Kubernetes Manager**: The interface between the Openshift API server and
+  Contrail Controller.
+
+Note:  These Contrail components are installed on the infra-node.
+
+### Nodes (DaemonSets)
+- **Contrail Agent**: As part of the agent pod we install the **vrouter kernel module** and the **contrail-cni**.
+
+### Contrail Ansible Roles
+
+* **Contrail common**: This role contains common functions which are required by other contrail roles
+* **Contrail controller**: Installs all contrail master components
+* **Contrail master**: Preps up the openshift master node
+* **Contrail node**: Installs cni binaries on all nodes
+* **Contrail st**: Preps the contrail schema transformer
+* **Contrail web console**: Installs contrail web console on infra nodes
+
+## INSTALLATION
+
+To install Contrail SDN with OpenShift Enterprise, follow this [install guide](https://github.com/Juniper/contrail-kubernetes-docs)
+
+Refer to this example [openshift 3.9 contrail installation](https://github.com/Juniper/contrail-kubernetes-docs/blob/master/install/openshift/3.9/standalone-openshift.md) for non-HA/HA deployments
+
+### CONTACT
+
+Pragash Vijayaragavan <pvijayaragav@juniper.net>

--- a/roles/contrail_controller/defaults/main.yml
+++ b/roles/contrail_controller/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+contrail_os_release: redhat7
+analyticsdb_min_diskgb: 50
+configdb_min_diskgb: 25
+aaa_mode: no-auth
+auth_mode: noauth
+CLOUD_ORCHESTRATOR: openshift
+LOG_LEVEL: SYS_NOTICE
+METADATA_PROXY_SECRET: contrail
+cloud_orchestrator: kubernetes
+metadata_proxy_secret: contrail
+log_level: SYS_NOTICE
+rabbitmq_node_port: 5672
+zookeeper_analytics_port: 2182
+zookeeper_port: 2181
+zookeeper_ports: 2888:3888
+zookeeper_analytics_ports: 4888:5888
+vrouter_gateway:
+kubernetes_api_secure_port: 8443
+nested_mode_contrail: false

--- a/roles/contrail_controller/tasks/main.yaml
+++ b/roles/contrail_controller/tasks/main.yaml
@@ -1,0 +1,7 @@
+---
+- name: Get contrail nodes and ips
+  include_role:
+    name: contrail_common
+
+- name: Creating the containers
+  include_tasks: os_contrail_master.yaml

--- a/roles/contrail_controller/tasks/os_contrail_master.yaml
+++ b/roles/contrail_controller/tasks/os_contrail_master.yaml
@@ -1,0 +1,221 @@
+---
+- name: Create the get IP file to convert hostname to ip
+  template:
+    src: getIp.j2
+    dest: /tmp/getIp.py
+    owner: root
+    mode: 0644
+  run_once: true
+
+- set_fact:
+    api_vip: "{{ groups.lb.0 | ipaddr }}"
+  when: groups.lb is defined
+
+- set_fact:
+    api_vip: "{{ openshift_master_cluster_public_hostname }}"
+  when: openshift_master_cluster_public_hostname is defined
+
+- set_fact:
+    api_vip: "{{ groups.masters.0 | ipaddr }}"
+  when: api_vip is not defined
+
+- name: validate api_vip hostname or ip
+  command: python /tmp/getIp.py {{ api_vip }}
+  register: api_vip_result
+
+- name: set api_vip
+  set_fact:
+    api_vip: "{{ api_vip_result.stdout }}"
+  when: api_vip_result is success
+
+- name: Create the agent template file
+  template:
+    src: contrail-image-downloader-5.j2
+    dest: /tmp/contrail-image-downloader.yaml
+    owner: root
+    mode: 0644
+  run_once: true
+  when:
+    - contrail_version is version('5.0', '>=')
+    - contrail_version is version('5.1', '<')
+
+- name: Create the agent template file
+  template:
+    src: contrail-agent-installer-5.j2
+    dest: /tmp/contrail-agent-installer.yaml
+    owner: root
+    mode: 0644
+  run_once: true
+  when:
+    - contrail_version is version('5.0', '>=')
+    - contrail_version is version('5.1', '<')
+
+- name: Create the contrail infrastructure template file
+  template:
+    src: contrail-infra-installer-5.j2
+    dest: /tmp/contrail-infra-installer.yaml
+    owner: root
+    mode: 0644
+  run_once: true
+  when:
+    - contrail_version is version('5.0', '>=')
+    - contrail_version is version('5.1', '<')
+
+- name: Create Contrail single YAML file for Contrail 4.0
+  template:
+    src: contrail-installer-4.j2
+    dest: /tmp/contrail-installer.yaml
+    owner: root
+    mode: 0644
+  run_once: true
+  when:
+    - contrail_version is version('5.0', '<')
+
+- name: Create Contrail single YAML file for Contrail 5.0
+  template:
+    src: contrail-controller-installer-5.j2
+    dest: /tmp/contrail-installer.yaml
+    owner: root
+    mode: 0644
+  run_once: true
+  when:
+    - contrail_version is version('5.0', '>=')
+    - contrail_version is version('5.1', '<')
+
+- name: Create Contrail single YAML file for Contrail 5.1
+  template:
+    src: contrail-installer-5.1.j2
+    dest: /tmp/contrail-installer.yaml
+    owner: root
+    mode: 0644
+  run_once: true
+  when:
+    - contrail_version is version('5.1', '>=')
+
+- name: Create Contrail single YAML file for Contrail nested mode
+  template:
+    src: contrail-nested.j2
+    dest: /tmp/contrail-installer.yaml
+    owner: root
+    mode: 0644
+  when:
+    - nested_mode_contrail == "true"
+
+- name: Copy the wait for POD script to master node
+  template:
+    src: wait_for_pod.j2
+    dest: /tmp/wait_for_pod.sh
+    owner: root
+    mode: 0777
+  run_once: true
+
+- name: Add Contrail service account to privileged scc
+  oc_adm_policy_user:
+    user: system:serviceaccount:kube-system:contrail
+    resource_kind: scc
+    resource_name: privileged
+    state: present
+  run_once: True
+
+- name: Add the daemonset-controller service account to privileged scc
+  oc_adm_policy_user:
+    user: system:serviceaccount:kube-system:daemon-set-controller
+    resource_kind: scc
+    resource_name: privileged
+    state: present
+  run_once: True
+
+- name: Label infra nodes with node-role.kubernetes.io/compute=true
+  command: "{{ openshift_client_binary }} label nodes --selector=region=infra node-role.kubernetes.io/compute=true --overwrite=true"
+  run_once: True
+
+- name: Label contrail master nodes with opencontrail.org/controller=true
+  command: "{{ openshift_client_binary }} label nodes {{ hostvars[item]['openshift_hostname'] }} opencontrail.org/controller=true --overwrite=true"
+  with_items: "{{ contrail_masters.split() }}"
+
+- name: Create Contrail registry secret
+  command: "{{ openshift_client_binary }} create secret docker-registry contrail-registry-secret --docker-server={{ contrail_registry }} --docker-username={{ contrail_registry_username }} --docker-password={{ contrail_registry_password }} --docker-email=contrail@helloworld.com -n kube-system"
+  run_once: True
+  when: contrail_registry_username is defined
+  ignore_errors: True
+
+- name: Starting the images download
+  command: "{{ openshift_client_binary }} create -f /tmp/contrail-image-downloader.yaml"
+  run_once: True
+  ignore_errors: True
+  when:
+    - contrail_version is version('5.0', '>=')
+    - contrail_version is version('5.1', '<')
+
+- name: sleep for 300 seconds and continue with play
+  wait_for: timeout=300
+  delegate_to: localhost
+
+- name: Check Pods script to Master Node
+  command: /tmp/wait_for_pod.sh
+  register: command_result
+  failed_when: "'ERROR' in command_result.stdout"
+  run_once: True
+
+- name: Starting the agent pod on required nodes
+  command: "{{ openshift_client_binary }} create -f /tmp/contrail-agent-installer.yaml"
+  run_once: True
+  ignore_errors: True
+  when:
+    - contrail_version is version('5.0', '>=')
+    - contrail_version is version('5.1', '<')
+
+- name: sleep for 180 seconds and continue with play
+  wait_for: timeout=180
+  delegate_to: localhost
+
+- name: Check Pods script to Master Node
+  command: /tmp/wait_for_pod.sh
+  register: command_result
+  failed_when: "'ERROR' in command_result.stdout"
+  run_once: True
+
+- name: Restart dnsmasq
+  service: name="dnsmasq" state=restarted enabled=yes
+  delegate_to: "{{ item }}"
+  with_items: "{{ contrail_masters.split() }}"
+  ignore_errors: True
+
+- name: Starting the infrastructure pods on required nodes
+  command: "{{ openshift_client_binary }} create -f /tmp/contrail-infra-installer.yaml"
+  run_once: True
+  ignore_errors: True
+  when:
+    - contrail_version is version('5.0', '>=')
+    - contrail_version is version('5.1', '<')
+
+- name: Check Pods script to Master Node
+  command: /tmp/wait_for_pod.sh
+  register: command_result
+  failed_when: "'ERROR' in command_result.stdout"
+  run_once: True
+
+- name: sleep for 180 seconds and continue with play
+  wait_for: timeout=180
+  delegate_to: localhost
+
+- name: Launch the Contrail installer
+  command: "{{ openshift_client_binary }} create -f /tmp/contrail-installer.yaml"
+  run_once: True
+  ignore_errors: True
+
+- name: sleep for 300 seconds and continue with play
+  wait_for: timeout=300
+  delegate_to: localhost
+
+- name: Check Pods script to Master Node
+  command: /tmp/wait_for_pod.sh
+  register: command_result
+  failed_when: "'ERROR' in command_result.stdout"
+  run_once: True
+
+- name: Patch restricted scc
+  command: >
+    "{{ openshift_client_binary }} patch scc restricted --patch='{ "runAsUser": { "type": "RunAsAny" } }'"
+  run_once: True
+  ignore_errors: True

--- a/roles/contrail_controller/templates/contrail-agent-installer-5.j2
+++ b/roles/contrail_controller/templates/contrail-agent-installer-5.j2
@@ -1,0 +1,232 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-env
+  namespace: kube-system
+data:
+  AAA_MODE: {{ aaa_mode }}
+  ANALYTICS_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ANALYTICSDB_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  AUTH_MODE: {{ auth_mode }}
+  CLOUD_ORCHESTRATOR: {{ cloud_orchestrator }}
+  CONFIG_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONFIGDB_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONTROL_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONTROLLER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  KAFKA_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  LOG_LEVEL: {{ log_level }}
+  METADATA_PROXY_SECRET: {{ metadata_proxy_secret }}
+  PHYSICAL_INTERFACE: {{ vrouter_physical_interface | default('') }}
+  RABBITMQ_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  RABBITMQ_NODE_PORT: "{{ rabbitmq_node_port }}"
+  REDIS_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  VROUTER_GATEWAY: {{ vrouter_gateway }}
+  WEBUI_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ZOOKEEPER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-nodemgr-config
+  namespace: kube-system
+data:
+  DOCKER_HOST: "unix://mnt/docker.sock"
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-agent
+  namespace: kube-system
+  labels:
+    app: contrail-agent
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-agent
+    spec:
+      #Disable affinity for single node setup
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/compute"
+                operator: In
+                values:
+                  - "true"
+      automountServiceAccountToken: false
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: agent-env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      - name: contrail-download-contrail-status-image
+        image: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-contrail-kubernetes-cni-init-image
+        image: "{{ contrail_registry }}/contrail-kubernetes-cni-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-contrail-vrouter-agent-image
+        image: "{{ contrail_registry }}/contrail-vrouter-agent:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-contrail-nodemgr-image
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-vrouter-kernel-init
+        image: "{{ contrail_registry }}/contrail-vrouter-kernel-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: agent-env
+        volumeMounts:
+        - mountPath: /usr/src
+          name: usr-src
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /etc/sysconfig/network-scripts
+          name: network-scripts
+        - mountPath: /host/bin
+          name: host-bin
+      - name: contrail-kubernetes-cni-init
+        image: "{{ contrail_registry }}/contrail-kubernetes-cni-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: agent-env
+        volumeMounts:
+        - mountPath: /var/lib/contrail
+          name: var-lib-contrail
+        - mountPath: /host/etc_cni
+          name: etc-cni
+        - mountPath: /host/opt_cni_bin
+          name: opt-cni-bin
+        - mountPath: /host/log_cni
+          name: var-log-contrail-cni
+        - mountPath: /var/log/contrail
+          name: agent-logs
+      containers:
+      - name: contrail-vrouter-agent
+        image: "{{ contrail_registry }}/contrail-vrouter-agent:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        # TODO: Priveleged mode is requied because w/o it the device /dev/net/tun
+        # is not present in the container. The mounting it into container
+        # doesnt help because of permissions are not enough syscalls,
+        # e.g. https://github.com/Juniper/contrail-controller/blob/master/src/vnsw/agent/contrail/linux/pkt0_interface.cc: 48.
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: agent-env
+        volumeMounts:
+        - mountPath: /dev
+          name: dev
+        - mountPath: /etc/sysconfig/network-scripts
+          name: network-scripts
+        - mountPath: /host/bin
+          name: host-bin
+        - mountPath: /var/log/contrail
+          name: agent-logs
+        - mountPath: /usr/src
+          name: usr-src
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /var/lib/contrail
+          name: var-lib-contrail
+        - mountPath: /var/crashes
+          name: var-crashes
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-agent-nodemgr
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: agent-env
+        - configMapRef:
+            name: agent-nodemgr-config
+        env:
+        - name: NODE_TYPE
+          value: vrouter
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: agent-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: network-scripts
+        hostPath:
+          path: /etc/sysconfig/network-scripts
+      - name: host-bin
+        hostPath:
+          path: /bin
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: var-lib-contrail
+        hostPath:
+          path: /var/lib/contrail
+      - name: var-crashes
+        hostPath:
+          path: /var/contrail/crashes
+      - name: etc-cni
+        hostPath:
+          path: /etc/cni
+      - name: opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: var-log-contrail-cni
+        hostPath:
+          path: /var/log/contrail/cni
+      - name: agent-logs
+        hostPath:
+          path: /var/log/contrail/agent
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---

--- a/roles/contrail_controller/templates/contrail-controller-installer-5.j2
+++ b/roles/contrail_controller/templates/contrail-controller-installer-5.j2
@@ -1,0 +1,692 @@
+# Configs section
+# Note: using ".." for ports, because in v1 there is a bug
+# which leads to an error
+# "..error unmarshaling JSON: json: cannot unmarshal number into Go value of type string.."
+# (https://github.com/kubernetes/kubernetes/issues/2763)
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contrail
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: v1
+metadata:
+  name: contrail
+  namespace: kube-system
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: v1
+kind: ClusterRoleBinding
+metadata:
+  name: contrail
+roleRef:
+  name: contrail
+subjects:
+- kind: SystemUser
+  name: kube-system:contrail
+- kind: ServiceAccount
+  name: contrail
+  namespace: kube-system
+userNames:
+  - system:serviceaccount:kube-system:contrail
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: contrail-kubernetes-token
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: contrail
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-manager-config
+  namespace: kube-system
+data:
+  KUBERNETES_API_SERVER: {{ kubernetes_api_server | default(api_vip | ipaddr) }}
+  KUBERNETES_API_SECURE_PORT: "{{ openshift_master_api_port | default(kubernetes_api_secure_port) }}"
+  K8S_TOKEN_FILE: "/tmp/serviceaccount/token"
+  KUBERNETES_CLUSTER_NAME: "{{ cluster_name | default('k8s') }}"
+  KUBERNETES_CLUSTER_PROJECT: "{{ cluster_project | default('{}') }}"
+  KUBERNETES_CLUSTER_NETWORK: "{{ cluster_network | default('{}') }}"
+  KUBERNETES_POD_SUBNETS: "{{ pod_subnets | default('10.32.0.0/12') }}"
+  KUBERNETES_IP_FABRIC_SUBNETS: "{{ ip_fabric_subnets | default('10.64.0.0/12') }}"
+  KUBERNETES_SERVICE_SUBNETS: "{{ service_subnets | default('10.96.0.0/12') }}"
+  KUBERNETES_IP_FABRIC_FORWARDING: "{{ ip_fabric_forwarding | default('false') }}"
+  KUBERNETES_IP_FABRIC_SNAT: "{{ ip_fabric_snat | default('false') }}"
+  KUBERNETES_PUBLIC_FIP_POOL: "{{ public_fip_pool | default('{}') }}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-config
+  namespace: kube-system
+data:
+  KUBERNETES_API_SERVER: {{ kubernetes_api_server | default(api_vip | ipaddr) }}
+  KUBERNETES_API_PORT: "{{ openshift_master_api_port | default(kubernetes_api_secure_port) }}"
+  K8S_TOKEN_FILE: "/tmp/serviceaccount/token"
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-analytics
+  namespace: kube-system
+  labels:
+    app: contrail-analytics
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-analytics
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-analytics-api
+        image: "{{ contrail_registry }}/contrail-analytics-api:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-analytics-collector
+        image: "{{ contrail_registry }}/contrail-analytics-collector:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-analytics-alarm-gen
+        image: "{{ contrail_registry }}/contrail-analytics-alarm-gen:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-analytics-query-engine
+        image: "{{ contrail_registry }}/contrail-analytics-query-engine:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-analytics-snmp-collector
+        image: "{{ contrail_registry }}/contrail-analytics-snmp-collector:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-analytics-topology
+        image: "{{ contrail_registry }}/contrail-analytics-topology:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-analytics-nodemgr
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        env:
+        - name: NODE_TYPE
+          value: analytics
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: analytics-logs
+        hostPath:
+          path: /var/log/contrail/analytics
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-controller-control
+  namespace: kube-system
+  labels:
+    app: contrail-controller-control
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-controller-control
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-controller-control
+        image: "{{ contrail_registry }}/contrail-controller-control-control:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: control-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-control-dns
+        image: "{{ contrail_registry }}/contrail-controller-control-dns:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /etc/contrail
+          name: dns-config
+        - mountPath: /var/log/contrail
+          name: control-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-control-named
+        image: "{{ contrail_registry }}/contrail-controller-control-named:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/contrail
+          name: dns-config
+        - mountPath: /var/log/contrail
+          name: control-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-control-nodemgr
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        - configMapRef:
+            name: nodemgr-config
+        env:
+        - name: NODE_TYPE
+          value: control
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: control-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: control-logs
+        hostPath:
+          path: /var/log/contrail/control
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: dns-config
+        emptyDir: {}
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-controller-config
+  namespace: kube-system
+  labels:
+    app: contrail-controller-config
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-controller-config
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-controller-config-api
+        image: "{{ contrail_registry }}/contrail-controller-config-api:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-config-devicemgr
+        image: "{{ contrail_registry }}/contrail-controller-config-devicemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-config-schema
+        image: "{{ contrail_registry }}/contrail-controller-config-schema:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-config-svcmonitor
+        image: "{{ contrail_registry }}/contrail-controller-config-svcmonitor:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-config-nodemgr
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        env:
+        - name: NODE_TYPE
+          value: config
+        - name: CASSANDRA_CQL_PORT
+          value: "9041"
+        - name: CASSANDRA_JMX_LOCAL_PORT
+          value: "7201"
+        - name: CONFIG_NODEMGR__DEFAULTS__minimum_diskG
+          value: "2"
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: config-logs
+        hostPath:
+          path: /var/log/contrail/config
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-controller-webui
+  namespace: kube-system
+  labels:
+    app: contrail-controller-webui
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-controller-webui
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-controller-webui-job
+        image: "{{ contrail_registry }}/contrail-controller-webui-job:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        - configMapRef:
+            name: kubernetes-config
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: webui-logs
+        - mountPath: /tmp/serviceaccount
+          name: ssl-secret-gen-token
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-webui-web
+        image: "{{ contrail_registry }}/contrail-controller-webui-web:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        - configMapRef:
+            name: kubernetes-config
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: webui-logs
+        - mountPath: /tmp/serviceaccount
+          name: ssl-secret-gen-token
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: webui-logs
+        hostPath:
+          path: /var/log/contrail/webui
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: ssl-secret-gen-token
+        secret:
+          secretName: contrail-kubernetes-token
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-kube-manager
+  namespace: kube-system
+  labels:
+    app: contrail-kube-manager
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-kube-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      automountServiceAccountToken: false
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-kube-manager
+        image: "{{ contrail_registry }}/contrail-kubernetes-kube-manager:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: kube-manager-config
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: kube-manager-logs
+        - mountPath: /tmp/serviceaccount
+          name: pod-secret
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: kube-manager-logs
+        hostPath:
+          path: /var/log/contrail/kube-manager
+      - name: pod-secret
+        secret:
+          secretName: contrail-kubernetes-token
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---

--- a/roles/contrail_controller/templates/contrail-image-downloader-5.j2
+++ b/roles/contrail_controller/templates/contrail-image-downloader-5.j2
@@ -1,0 +1,138 @@
+# Configs section
+# Note: using ".." for ports, because in v1 there is a bug
+# which leads to an error
+# "..error unmarshaling JSON: json: cannot unmarshal number into Go value of type string.."
+# (https://github.com/kubernetes/kubernetes/issues/2763)
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-image-installer
+  namespace: kube-system
+  labels:
+    app: contrail-image-download
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-image-download
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-download-contrail-status-image
+        image: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-redis-image
+        image: "redis:4.0.2"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-node-init-image
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-node-manager-image
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-external-cassandra-image
+        image: "{{ contrail_registry }}/contrail-external-cassandra:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-external-zookeeper-image
+        image: "{{ contrail_registry }}/contrail-external-zookeeper:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-external-rabbitmq-image
+        image: "{{ contrail_registry }}/contrail-external-rabbitmq:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-external-kafka-image
+        image: "{{ contrail_registry }}/contrail-external-kafka:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-analytics-api-image
+        image: "{{ contrail_registry }}/contrail-analytics-api:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-analytics-collector-image
+        image: "{{ contrail_registry }}/contrail-analytics-collector:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-analytics-alarm-gen-image
+        image: "{{ contrail_registry }}/contrail-analytics-alarm-gen:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-analytics-query-engine-image
+        image: "{{ contrail_registry }}/contrail-analytics-query-engine:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-analytics-snmp-collector-image
+        image: "{{ contrail_registry }}/contrail-analytics-snmp-collector:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-analytics-topology-image
+        image: "{{ contrail_registry }}/contrail-analytics-topology:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-control-image
+        image: "{{ contrail_registry }}/contrail-controller-control-control:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-control-dns-image
+        image: "{{ contrail_registry }}/contrail-controller-control-dns:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-control-named-image
+        image: "{{ contrail_registry }}/contrail-controller-control-named:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-config-image
+        image: "{{ contrail_registry }}/contrail-controller-config-api:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-config-devicemgr-image
+        image: "{{ contrail_registry }}/contrail-controller-config-devicemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-config-schema-image
+        image: "{{ contrail_registry }}/contrail-controller-config-schema:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-config-svc-monitor-image
+        image: "{{ contrail_registry }}/contrail-controller-config-svcmonitor:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-webui-job-image
+        image: "{{ contrail_registry }}/contrail-controller-webui-job:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-webui-web-image
+        image: "{{ contrail_registry }}/contrail-controller-webui-web:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-kube-manager-image
+        image: "{{ contrail_registry }}/contrail-kubernetes-kube-manager:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      containers:
+      - name: contrail-download-image
+        image: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["tailf","/dev/null"]
+        securityContext:
+          privileged: true
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}

--- a/roles/contrail_controller/templates/contrail-infra-installer-5.j2
+++ b/roles/contrail_controller/templates/contrail-infra-installer-5.j2
@@ -1,0 +1,654 @@
+# Configs section
+# Note: using ".." for ports, because in v1 there is a bug
+# which leads to an error
+# "..error unmarshaling JSON: json: cannot unmarshal number into Go value of type string.."
+# (https://github.com/kubernetes/kubernetes/issues/2763)
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: env
+  namespace: kube-system
+data:
+  AAA_MODE: {{ aaa_mode }}
+  ANALYTICS_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ANALYTICSDB_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  AUTH_MODE: {{ auth_mode }}
+  CLOUD_ORCHESTRATOR: {{ cloud_orchestrator }}
+  CONFIG_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONFIGDB_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONTROL_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONTROLLER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  KAFKA_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  LOG_LEVEL: {{ log_level }}
+  METADATA_PROXY_SECRET: {{ metadata_proxy_secret }}
+  PHYSICAL_INTERFACE: {{ vrouter_physical_interface | default('') }}
+  RABBITMQ_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  RABBITMQ_NODE_PORT: "{{ rabbitmq_node_port }}"
+  REDIS_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  VROUTER_GATEWAY: {{ vrouter_gateway }}
+  WEBUI_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ZOOKEEPER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configzookeeperenv
+  namespace: kube-system
+data:
+  ZOOKEEPER_PORT: "{{ zookeeper_port }}"
+  ZOOKEEPER_PORTS: "{{ zookeeper_ports }}"
+  ZOOKEEPER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: analyticszookeeperenv
+  namespace: kube-system
+data:
+  ZOOKEEPER_PORT: "{{ zookeeper_analytics_port }}"
+  ZOOKEEPER_PORTS: "{{ zookeeper_analytics_ports }}"
+  ZOOKEEPER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contrail-analyticsdb-config
+  namespace: kube-system
+data:
+  CASSANDRA_SEEDS: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CASSANDRA_CLUSTER_NAME: Contrail
+  CASSANDRA_START_RPC: "true"
+  CASSANDRA_LISTEN_ADDRESS: auto
+  CASSANDRA_PORT: "9160"
+  CASSANDRA_CQL_PORT: "9042"
+  CASSANDRA_SSL_STORAGE_PORT: "7001"
+  CASSANDRA_STORAGE_PORT: "7000"
+  CASSANDRA_JMX_LOCAL_PORT: "7200"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contrail-configdb-config
+  namespace: kube-system
+data:
+  CASSANDRA_SEEDS: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CASSANDRA_CLUSTER_NAME: ContrailConfigDB
+  CASSANDRA_START_RPC: "true"
+  CASSANDRA_LISTEN_ADDRESS: auto
+  CASSANDRA_PORT: "9161"
+  CASSANDRA_CQL_PORT: "9041"
+  CASSANDRA_SSL_STORAGE_PORT: "7011"
+  CASSANDRA_STORAGE_PORT: "7010"
+  CASSANDRA_JMX_LOCAL_PORT: "7201"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rabbitmq-config
+  namespace: kube-system
+data:
+  RABBITMQ_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  RABBITMQ_NODE_PORT: "{{ rabbitmq_node_port }}"
+  RABBITMQ_ERLANG_COOKIE: "47EFF3BB-4786-46E0-A5BB-58455B3C2CB4"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nodemgr-config
+  namespace: kube-system
+data:
+  DOCKER_HOST: "unix://mnt/docker.sock"
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: redis
+  namespace: kube-system
+  labels:
+    app: redis
+spec:
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      containers:
+      - name: redis
+        image: "redis:4.0.2"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /var/lib/redis
+          name: redis-data
+        - mountPath: /var/log/redis
+          name: redis-logs
+      volumes:
+      - name: redis-data
+        hostPath:
+          path: /var/lib/contrail/redis
+      - name: redis-logs
+        hostPath:
+          path: /var/log/contrail/redis
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-config-database-nodemgr
+  namespace: kube-system
+  labels:
+    app: contrail-config-database-nodemgr
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-config-database-nodemgr
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{contrail_registry}}/contrail-node-init:{{contrail_container_tag}}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{contrail_registry}}/contrail-status:{{contrail_container_tag}}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-config-database-nodemgr
+        image: "{{contrail_registry}}/contrail-nodemgr:{{contrail_container_tag}}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        - configMapRef:
+            name: contrail-configdb-config
+        env:
+        - name: NODE_TYPE
+          value: config-database
+        - name: CONFIG_DATABASE_NODEMGR__DEFAULTS__minimum_diskGB
+          value: "2"
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: configdb-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: configdb-logs
+        hostPath:
+          path: /var/log/contrail/configdb
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-configdb
+  namespace: kube-system
+  labels:
+    app: contrail-configdb
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-configdb
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      containers:
+      - name: contrail-configdb
+        image: "{{ contrail_registry }}/contrail-external-cassandra:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: config-database
+        envFrom:
+        - configMapRef:
+            name: contrail-configdb-config
+        volumeMounts:
+        - mountPath: /var/lib/cassandra
+          name: configdb-data
+        - mountPath: /var/log/cassandra
+          name: configdb-log
+      volumes:
+      - name: configdb-data
+        hostPath:
+          path: /var/lib/contrail/configdb
+      - name: configdb-log
+        hostPath:
+          path: /var/log/contrail/configdb
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: config-zookeeper
+  namespace: kube-system
+  labels:
+    app: config-zookeeper
+spec:
+  template:
+    metadata:
+      labels:
+        app: config-zookeeper
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      containers:
+      - name: config-zookeeper
+        image: "{{ contrail_registry }}/contrail-external-zookeeper:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: config-database
+        envFrom:
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/lib/zookeeper
+          name: zookeeper-data
+        - mountPath: /var/log/zookeeper
+          name: zookeeper-logs
+      volumes:
+      - name: zookeeper-data
+        hostPath:
+          path: /var/lib/contrail/config-zookeeper
+      - name: zookeeper-logs
+        hostPath:
+          path: /var/log/contrail/config-zookeeper
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: rabbitmq
+  namespace: kube-system
+  labels:
+    app: rabbitmq
+spec:
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      containers:
+      - name: rabbitmq
+        image: "{{ contrail_registry }}/contrail-external-rabbitmq:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: config-database
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: rabbitmq-config
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/lib/rabbitmq
+          name: rabbitmq-data
+        - mountPath: /var/log/rabbitmq
+          name: rabbitmq-logs
+      volumes:
+      - name: rabbitmq-data
+        hostPath:
+          path: /var/lib/contrail/rabbitmq
+      - name: rabbitmq-logs
+        hostPath:
+          path: /var/log/contrail/rabbitmq
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-database-nodemgr
+  namespace: kube-system
+  labels:
+    app: contrail-database-nodemgr
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-database-nodemgr
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{contrail_registry}}/contrail-node-init:{{contrail_container_tag}}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{contrail_registry}}/contrail-status:{{contrail_container_tag}}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-database-nodemgr
+        image: "{{contrail_registry}}/contrail-nodemgr:{{contrail_container_tag}}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        - configMapRef:
+            name: contrail-analyticsdb-config
+        env:
+        - name: NODE_TYPE
+          value: database
+        - name: DATABASE_NODEMGR__DEFAULTS__minimum_diskGB
+          value: "2"
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analyticsdb-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: analyticsdb-logs
+        hostPath:
+          path: /var/log/contrail/analyticsdb
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kafka
+  namespace: kube-system
+  labels:
+    app: kafka
+spec:
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-create-kafka-dir
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        command: ["mkdir","-pm","777","/host/var/lib/contrail/kafka-logs"]
+        imagePullPolicy: "IfNotPresent"
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+        - mountPath: /host/var/lib
+          name: host-var-lib
+      containers:
+      - name: kafka
+        image: "{{ contrail_registry }}/contrail-external-kafka:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: database
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /tmp/kafka-logs
+          name: kafka-logs
+      volumes:
+      - name: kafka-logs
+        hostPath:
+          path: /var/lib/contrail/kafka-logs
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: host-var-lib
+        hostPath:
+          path: /var/lib
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-analyticsdb
+  namespace: kube-system
+  labels:
+    app: contrail-analyticsdb
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-analyticsdb
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      containers:
+      - name: contrail-analyticsdb
+        image: "{{ contrail_registry }}/contrail-external-cassandra:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: database
+        envFrom:
+        - configMapRef:
+            name: contrail-analyticsdb-config
+        volumeMounts:
+        - mountPath: /var/lib/cassandra
+          name: analyticsdb-data
+        - mountPath: /var/log/cassandra
+          name: analyticsdb-log
+      volumes:
+      - name: analyticsdb-data
+        hostPath:
+          path: /var/lib/contrail/analyticsdb
+      - name: analyticsdb-log
+        hostPath:
+          path: /var/log/contrail/analyticsdb
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: analytics-zookeeper
+  namespace: kube-system
+  labels:
+    app: analytics-zookeeper
+spec:
+  template:
+    metadata:
+      labels:
+        app: analytics-zookeeper
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      containers:
+      - name: analytics-zookeeper
+        image: "{{ contrail_registry }}/contrail-external-zookeeper:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: database
+        envFrom:
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /data
+          name: analytics-zookeeper-data
+        - mountPath: /datalog
+          name: analytics-zookeeper-datalog
+        - mountPath: /var/log/zookeeper
+          name: zookeeper-logs
+      volumes:
+      - name: analytics-zookeeper-data
+        hostPath:
+          path: /var/lib/analytics_zookeeper_data
+      - name: analytics-zookeeper-datalog
+        hostPath:
+          path: /var/lib/analytics_zookeeper_datalog
+      - name: zookeeper-logs
+        hostPath:
+          path: /var/log/contrail/analytics
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---

--- a/roles/contrail_controller/templates/contrail-installer-4.j2
+++ b/roles/contrail_controller/templates/contrail-installer-4.j2
@@ -1,0 +1,340 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contrail-config
+  namespace: kube-system
+data:
+  global-config: |-
+    [GLOBAL]
+    cloud_orchestrator = openshift
+    sandesh_ssl_enable = False
+    enable_config_service = True
+    enable_control_service = True
+    enable_webui_service = True
+    introspect_ssl_enable = False
+    config_nodes = {{ groups.contrail_masters | ipaddr | join(',') }}
+    controller_nodes = {{ groups.contrail_masters | ipaddr | join(',') }}
+    analytics_nodes = {{ groups.contrail_masters | ipaddr | join(',') }}
+    analyticsdb_nodes = {{ groups.contrail_masters | ipaddr | join(',') }}
+    analyticsdb_minimum_diskgb = {{ analyticsdb_min_diskgb }}
+    configdb_minimum_diskgb = {{ configdb_min_diskgb }}
+    opscenter_ip = 1.1.1.1
+  agent-config: |-
+    [AGENT]
+    compile_vrouter_module = False
+    vrouter_physical_interface = {{ vrouter_physical_interface }}
+  kubemanager-config: |-
+    [KUBERNETES]
+    cluster_name = k8s-default
+    cluster_project = {}
+    cluster_network = {}
+    service_subnets = 10.96.0.0/12
+    pod_subnets = 10.32.0.0/12
+    api_server = {{ api_vip | ipaddr }}
+  kubernetes-agent-config: |-
+    [AGENT]
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-analyticsdb
+  namespace: kube-system
+  labels:
+    app: contrail-analyticsdb
+spec:
+  selector:
+    matchLabels:
+      app: contrail-analyticsdb
+  template:
+    metadata:
+      labels:
+        app: contrail-analyticsdb
+    spec:
+      nodeSelector: 
+        "opencontrail.org/controller": "true"
+      hostNetwork: true
+      containers:
+      - name: contrail-analyticsdb
+        image: "contrail-analyticsdb-{{ contrail_os_release }}:{{ contrail_version }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/contrailctl
+          name: contrail-config
+        - mountPath: /var/lib/cassandra
+          name: analyticsdb-data
+        - mountPath: /var/lib/zookeeper
+          name: zookeeper-analyticsdb-data
+      volumes:
+      - name: contrail-config
+        configMap:
+          name: contrail-config
+          items:
+          - key: global-config
+            path: analyticsdb.conf
+      - name: analyticsdb-data
+        hostPath:
+          path: /var/lib/analyticsdb 
+      - name: zookeeper-analyticsdb-data
+        hostPath:
+          path: /var/lib/analyticsdb_zookeeper_data
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-analytics
+  namespace: kube-system
+  labels:
+    app: contrail-analytics
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-analytics
+    spec:
+      nodeSelector:
+        "opencontrail.org/controller": "true"
+      hostNetwork: true
+      containers:
+      - name: contrail-analytics
+        image: "contrail-analytics-{{ contrail_os_release }}:{{ contrail_version }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/contrailctl
+          name: contrail-config
+      volumes:
+      - name: contrail-config
+        configMap:
+          name: contrail-config
+          items:
+          - key: global-config
+            path: analytics.conf
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-controller
+  namespace: kube-system
+  labels:
+    app: contrail-controller
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-controller
+    spec:
+      nodeSelector:
+        "opencontrail.org/controller": "true"
+      hostNetwork: true
+      containers:
+      - name: contrail-controller
+        image: "contrail-controller-{{ contrail_os_release }}:{{ contrail_version }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/contrailctl
+          name: contrail-config
+        - mountPath: /var/lib/cassandra
+          name: configdb-data
+        - mountPath: /var/lib/zookeeper
+          name: zookeeper-data
+      volumes:
+      - name: contrail-config
+        configMap:
+          name: contrail-config
+          items:
+          - key: global-config
+            path: controller.conf
+      - name: configdb-data
+        hostPath: 
+          path: /var/lib/configdb
+      - name: zookeeper-data
+        hostPath: 
+          path: /var/lib/config_zookeeper_data
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-kube-manager
+  namespace: kube-system
+  labels:
+    app: contrail-kube-manager
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-kube-manager
+    spec:
+      nodeSelector:
+        "opencontrail.org/controller": "true"
+      automountServiceAccountToken: false
+      hostNetwork: true
+      containers:
+      - name: contrail-kube-manager
+        image: "contrail-kube-manager-{{ contrail_os_release }}:{{ contrail_version }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /tmp/contrailctl
+          name: tmp-contrail-config
+        - mountPath: /tmp/serviceaccount
+          name: pod-secret
+      volumes:
+      - name: tmp-contrail-config
+        configMap:
+          name: contrail-config
+          items:
+          - key: global-config
+            path: global.conf
+          - key: kubemanager-config
+            path: kubemanager.conf
+      - name: pod-secret
+        secret:
+          secretName: contrail-kube-manager-token
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-agent
+  namespace: kube-system
+  labels:
+    app: contrail-agent
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-agent
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: DoesNotExist
+      automountServiceAccountToken: false
+      hostNetwork: true
+      initContainers:
+      - name: contrail-kubernetes-agent
+        image: "contrail-kubernetes-agent-{{ contrail_os_release }}:{{ contrail_version }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /tmp/contrailctl
+          name: tmp-contrail-config
+        - mountPath: /var/lib/contrail/
+          name: var-lib-contrail
+        - mountPath: /host/etc_cni
+          name: etc-cni
+        - mountPath: /host/opt_cni_bin
+          name: opt-cni-bin
+        - mountPath: /var/log/contrail/cni
+          name: var-log-contrail-cni
+      containers:
+      - name: contrail-agent
+        image: "contrail-agent-{{ contrail_os_release }}:{{ contrail_version }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /usr/src
+          name: usr-src
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /tmp/contrailctl
+          name: tmp-contrail-config
+        - mountPath: /var/lib/contrail/
+          name: var-lib-contrail
+        - mountPath: /host/etc_cni
+          name: etc-cni
+        - mountPath: /host/opt_cni_bin
+          name: opt-cni-bin
+        # This is a workaround just to make sure the directory is created on host
+        - mountPath: /var/log/contrail/cni
+          name: var-log-contrail-cni
+        - mountPath: /tmp/serviceaccount
+          name: pod-secret
+      volumes:
+      - name: tmp-contrail-config
+        configMap:
+          name: contrail-config
+          items:
+          - key: global-config
+            path: global.conf
+          - key: agent-config
+            path: agent.conf
+          - key: kubemanager-config
+            path: kubemanager.conf
+          - key: kubernetes-agent-config
+            path: kubernetesagent.conf
+      - name: pod-secret
+        secret:
+          secretName: contrail-kube-manager-token
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: usr-src-kernels
+        hostPath:
+          path: /usr/src/kernels
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: var-lib-contrail
+        hostPath:
+          path: /var/lib/contrail/
+      - name: etc-cni
+        hostPath:
+          path: /etc/cni
+      - name: opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: var-log-contrail-cni
+        hostPath:
+          path: /var/log/contrail/cni/
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contrail
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: v1
+metadata:
+  name: contrail
+  namespace: kube-system
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: v1
+kind: ClusterRoleBinding
+metadata:
+  name: contrail
+roleRef:
+  name: contrail
+subjects:
+- kind: SystemUser
+  name: kube-system:contrail
+- kind: ServiceAccount
+  name: contrail
+  namespace: kube-system
+userNames:
+  - system:serviceaccount:kube-system:contrail
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: contrail-kube-manager-token
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: contrail
+type: kubernetes.io/service-account-token

--- a/roles/contrail_controller/templates/contrail-installer-5.1.j2
+++ b/roles/contrail_controller/templates/contrail-installer-5.1.j2
@@ -1,0 +1,1416 @@
+# Configs section
+# Note: using ".." for ports, because in v1 there is a bug
+# which leads to an error
+# "..error unmarshaling JSON: json: cannot unmarshal number into Go value of type string.."
+# (https://github.com/kubernetes/kubernetes/issues/2763)
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: env
+  namespace: kube-system
+data:
+  AAA_MODE: {{ aaa_mode }}
+  ANALYTICS_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ANALYTICSDB_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  AUTH_MODE: {{ auth_mode }}
+  CLOUD_ORCHESTRATOR: {{ cloud_orchestrator }}
+  CONFIG_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONFIGDB_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONTROL_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONTROLLER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  KAFKA_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  LOG_LEVEL: {{ log_level }}
+  METADATA_PROXY_SECRET: {{ metadata_proxy_secret }}
+  PHYSICAL_INTERFACE: {{ vrouter_physical_interface | default('') }}
+  RABBITMQ_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  RABBITMQ_NODE_PORT: "{{ rabbitmq_node_port }}"
+  REDIS_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  VROUTER_GATEWAY: {{ vrouter_gateway }}
+  WEBUI_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ZOOKEEPER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configzookeeperenv
+  namespace: kube-system
+data:
+  ZOOKEEPER_PORT: "{{ zookeeper_port }}"
+  ZOOKEEPER_PORTS: "{{ zookeeper_ports }}"
+  ZOOKEEPER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: analyticszookeeperenv
+  namespace: kube-system
+data:
+  ZOOKEEPER_PORT: "{{ zookeeper_analytics_port }}"
+  ZOOKEEPER_PORTS: "{{ zookeeper_analytics_ports }}"
+  ZOOKEEPER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nodemgr-config
+  namespace: kube-system
+data:
+  DOCKER_HOST: "unix://mnt/docker.sock"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contrail-analyticsdb-config
+  namespace: kube-system
+data:
+  CASSANDRA_SEEDS: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CASSANDRA_CLUSTER_NAME: Contrail
+  CASSANDRA_START_RPC: "true"
+  CASSANDRA_LISTEN_ADDRESS: auto
+  CASSANDRA_PORT: "9160"
+  CASSANDRA_CQL_PORT: "9042"
+  CASSANDRA_SSL_STORAGE_PORT: "7001"
+  CASSANDRA_STORAGE_PORT: "7000"
+  CASSANDRA_JMX_LOCAL_PORT: "7200"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contrail-configdb-config
+  namespace: kube-system
+data:
+  CASSANDRA_SEEDS: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CASSANDRA_CLUSTER_NAME: ContrailConfigDB
+  CASSANDRA_START_RPC: "true"
+  CASSANDRA_LISTEN_ADDRESS: auto
+  CASSANDRA_PORT: "9161"
+  CASSANDRA_CQL_PORT: "9041"
+  CASSANDRA_SSL_STORAGE_PORT: "7011"
+  CASSANDRA_STORAGE_PORT: "7010"
+  CASSANDRA_JMX_LOCAL_PORT: "7201"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rabbitmq-config
+  namespace: kube-system
+data:
+  RABBITMQ_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  RABBITMQ_NODE_PORT: "{{ rabbitmq_node_port }}"
+  RABBITMQ_ERLANG_COOKIE: "47EFF3BB-4786-46E0-A5BB-58455B3C2CB4"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-manager-config
+  namespace: kube-system
+data:
+  KUBERNETES_API_SERVER: {{ kubernetes_api_server | default(api_vip | ipaddr) }}
+  KUBERNETES_API_SECURE_PORT: "{{ kubernetes_api_secure_port | default('8443') }}"
+  K8S_TOKEN_FILE: "/tmp/serviceaccount/token"
+  KUBERNETES_CLUSTER_NAME: "{{ cluster_name | default('k8s') }}"
+  KUBERNETES_CLUSTER_PROJECT: "{{ cluster_project | default('{}') }}"
+  KUBERNETES_CLUSTER_NETWORK: "{{ cluster_network | default('{}') }}"
+  KUBERNETES_POD_SUBNETS: "{{ pod_subnets | default('10.32.0.0/12') }}"
+  KUBERNETES_IP_FABRIC_SUBNETS: "{{ ip_fabric_subnets | default('10.64.0.0/12') }}"
+  KUBERNETES_SERVICE_SUBNETS: "{{ service_subnets | default('10.96.0.0/12') }}"
+  KUBERNETES_IP_FABRIC_FORWARDING: "{{ ip_fabric_forwarding | default('false') }}"
+  KUBERNETES_IP_FABRIC_SNAT: "{{ ip_fabric_snat | default('false') }}"
+  KUBERNETES_PUBLIC_FIP_POOL: "{{ public_fip_pool | default('{}') }}"
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: config-zookeeper
+  namespace: kube-system
+  labels:
+    app: config-zookeeper
+spec:
+  template:
+    metadata:
+      labels:
+        app: config-zookeeper
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      containers:
+      - name: config-zookeeper
+        image: "{{ contrail_registry }}/contrail-external-zookeeper:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: config-database
+        envFrom:
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/lib/zookeeper
+          name: zookeeper-data
+        - mountPath: /var/log/zookeeper
+          name: zookeeper-logs
+      volumes:
+      - name: zookeeper-data
+        hostPath:
+          path: /var/lib/contrail/config-zookeeper
+      - name: zookeeper-logs
+        hostPath:
+          path: /var/log/contrail/config-zookeeper
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: analytics-zookeeper
+  namespace: kube-system
+  labels:
+    app: analytics-zookeeper
+spec:
+  template:
+    metadata:
+      labels:
+        app: analytics-zookeeper
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      containers:
+      - name: analytics-zookeeper
+        image: "{{ contrail_registry }}/contrail-external-zookeeper:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: database
+        envFrom:
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /data
+          name: analytics-zookeeper-data
+        - mountPath: /datalog
+          name: analytics-zookeeper-datalog
+        - mountPath: /var/log/zookeeper
+          name: zookeeper-logs
+      volumes:
+      - name: analytics-zookeeper-data
+        hostPath:
+          path: /var/lib/analytics_zookeeper_data
+      - name: analytics-zookeeper-datalog
+        hostPath:
+          path: /var/lib/analytics_zookeeper_datalog
+      - name: zookeeper-logs
+        hostPath:
+          path: /var/log/contrail/analytics
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kafka
+  namespace: kube-system
+  labels:
+    app: kafka
+spec:
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      containers:
+      - name: kafka
+        image: "{{ contrail_registry }}/contrail-external-kafka:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: database
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /tmp/kafka-logs
+          name: kafka-logs
+      volumes:
+      - name: kafka-logs
+        hostPath:
+          path: /var/lib/contrail/kafka-logs
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-analyticsdb
+  namespace: kube-system
+  labels:
+    app: contrail-analyticsdb
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-analyticsdb
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      containers:
+      - name: contrail-analyticsdb
+        image: "{{ contrail_registry }}/contrail-external-cassandra:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: database
+        envFrom:
+        - configMapRef:
+            name: contrail-analyticsdb-config
+        volumeMounts:
+        - mountPath: /var/lib/cassandra
+          name: analyticsdb-data
+        - mountPath: /var/log/cassandra
+          name: analyticsdb-log
+      volumes:
+      - name: analyticsdb-data
+        hostPath:
+          path: /var/lib/contrail/analyticsdb
+      - name: analyticsdb-log
+        hostPath:
+          path: /var/log/contrail/analyticsdb
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-configdb
+  namespace: kube-system
+  labels:
+    app: contrail-configdb
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-configdb
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      containers:
+      - name: contrail-configdb
+        image: "{{ contrail_registry }}/contrail-external-cassandra:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: config-database
+        envFrom:
+        - configMapRef:
+            name: contrail-configdb-config
+        volumeMounts:
+        - mountPath: /var/lib/cassandra
+          name: configdb-data
+        - mountPath: /var/log/cassandra
+          name: configdb-log
+      volumes:
+      - name: configdb-data
+        hostPath:
+          path: /var/lib/contrail/configdb
+      - name: configdb-log
+        hostPath:
+          path: /var/log/contrail/configdb
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-database-nodemgr
+  namespace: kube-system
+  labels:
+    app: contrail-database-nodemgr
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-database-nodemgr
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{contrail_registry}}/contrail-node-init:{{contrail_container_tag}}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{contrail_registry}}/contrail-status:{{contrail_container_tag}}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-database-nodemgr
+        image: "{{contrail_registry}}/contrail-nodemgr:{{contrail_container_tag}}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        - configMapRef:
+            name: contrail-analyticsdb-config
+        env:
+        - name: NODE_TYPE
+          value: database
+        - name: DATABASE_NODEMGR__DEFAULTS__minimum_diskGB
+          value: "2"
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analyticsdb-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+      volumes:
+      - name: analyticsdb-logs
+        hostPath:
+          path: /var/log/contrail/analyticsdb
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-config-database-nodemgr
+  namespace: kube-system
+  labels:
+    app: contrail-config-database-nodemgr
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-config-database-nodemgr
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{contrail_registry}}/contrail-node-init:{{contrail_container_tag}}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{contrail_registry}}/contrail-status:{{contrail_container_tag}}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-config-database-nodemgr
+        image: "{{contrail_registry}}/contrail-nodemgr:{{contrail_container_tag}}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        - configMapRef:
+            name: contrail-configdb-config
+        env:
+        - name: NODE_TYPE
+          value: config-database
+        - name: CONFIG_DATABASE_NODEMGR__DEFAULTS__minimum_diskGB
+          value: "2"
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: configdb-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+      volumes:
+      - name: configdb-logs
+        hostPath:
+          path: /var/log/contrail/configdb
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-analytics
+  namespace: kube-system
+  labels:
+    app: contrail-analytics
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-analytics
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-analytics-api
+        image: "{{ contrail_registry }}/contrail-analytics-api:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+      - name: contrail-analytics-collector
+        image: "{{ contrail_registry }}/contrail-analytics-collector:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+      - name: contrail-analytics-alarm-gen
+        image: "{{ contrail_registry }}/contrail-analytics-alarm-gen:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+      - name: contrail-analytics-query-engine
+        image: "{{ contrail_registry }}/contrail-analytics-query-engine:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+      - name: contrail-analytics-snmp-collector
+        image: "{{ contrail_registry }}/contrail-analytics-snmp-collector:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+      - name: contrail-analytics-topology
+        image: "{{ contrail_registry }}/contrail-analytics-topology:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+      - name: contrail-analytics-nodemgr
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        env:
+        - name: NODE_TYPE
+          value: analytics
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+      volumes:
+      - name: analytics-logs
+        hostPath:
+          path: /var/log/contrail/analytics
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-controller-control
+  namespace: kube-system
+  labels:
+    app: contrail-controller-control
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-controller-control
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-controller-control
+        image: "{{ contrail_registry }}/contrail-controller-control-control:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: control-logs
+      - name: contrail-controller-control-dns
+        image: "{{ contrail_registry }}/contrail-controller-control-dns:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /etc/contrail
+          name: dns-config
+        - mountPath: /var/log/contrail
+          name: control-logs
+      - name: contrail-controller-control-named
+        image: "{{ contrail_registry }}/contrail-controller-control-named:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/contrail
+          name: dns-config
+        - mountPath: /var/log/contrail
+          name: control-logs
+      - name: contrail-controller-control-nodemgr
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        - configMapRef:
+            name: nodemgr-config
+        env:
+        - name: NODE_TYPE
+          value: control
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: control-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+      volumes:
+      - name: control-logs
+        hostPath:
+          path: /var/log/contrail/control
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: dns-config
+        emptyDir: {}
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-controller-config
+  namespace: kube-system
+  labels:
+    app: contrail-controller-config
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-controller-config
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-controller-config-api
+        image: "{{ contrail_registry }}/contrail-controller-config-api:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+      - name: contrail-controller-config-devicemgr
+        image: "{{ contrail_registry }}/contrail-controller-config-devicemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+      - name: contrail-controller-config-schema
+        image: "{{ contrail_registry }}/contrail-controller-config-schema:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+      - name: contrail-controller-config-svcmonitor
+        image: "{{ contrail_registry }}/contrail-controller-config-svcmonitor:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+      - name: contrail-controller-config-nodemgr
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        env:
+        - name: NODE_TYPE
+          value: config
+        - name: CASSANDRA_CQL_PORT
+          value: "9041"
+        - name: CASSANDRA_JMX_LOCAL_PORT
+          value: "7201"
+        - name: CONFIG_NODEMGR__DEFAULTS__minimum_diskG
+          value: "2"
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+      volumes:
+      - name: config-logs
+        hostPath:
+          path: /var/log/contrail/config
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-controller-webui
+  namespace: kube-system
+  labels:
+    app: contrail-controller-webui
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-controller-webui
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-controller-webui-job
+        image: "{{ contrail_registry }}/contrail-controller-webui-job:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: webui-logs
+      - name: contrail-controller-webui-web
+        image: "{{ contrail_registry }}/contrail-controller-webui-web:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: webui-logs
+      volumes:
+      - name: webui-logs
+        hostPath:
+          path: /var/log/contrail/webui
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: redis
+  namespace: kube-system
+  labels:
+    app: redis
+spec:
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      containers:
+      - name: redis
+        image: "redis:4.0.2"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /var/lib/redis
+          name: redis-data
+        - mountPath: /var/log/redis
+          name: redis-logs
+      volumes:
+      - name: redis-data
+        hostPath:
+          path: /var/lib/contrail/redis
+      - name: redis-logs
+        hostPath:
+          path: /var/log/contrail/redis
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: rabbitmq
+  namespace: kube-system
+  labels:
+    app: rabbitmq
+spec:
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      hostNetwork: true
+      containers:
+      - name: rabbitmq
+        image: "{{ contrail_registry }}/contrail-external-rabbitmq:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: config-database
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: rabbitmq-config
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/lib/rabbitmq
+          name: rabbitmq-data
+        - mountPath: /var/log/rabbitmq
+          name: rabbitmq-logs
+      volumes:
+      - name: rabbitmq-data
+        hostPath:
+          path: /var/lib/contrail/rabbitmq
+      - name: rabbitmq-logs
+        hostPath:
+          path: /var/log/contrail/rabbitmq
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-kube-manager
+  namespace: kube-system
+  labels:
+    app: contrail-kube-manager
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-kube-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "opencontrail.org/controller"
+                operator: Exists
+      automountServiceAccountToken: false
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-kube-manager
+        image: "{{ contrail_registry }}/contrail-kubernetes-kube-manager:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: kube-manager-config
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: kube-manager-logs
+        - mountPath: /tmp/serviceaccount
+          name: pod-secret
+      volumes:
+      - name: kube-manager-logs
+        hostPath:
+          path: /var/log/contrail/kube-manager
+      - name: pod-secret
+        secret:
+          secretName: contrail-kube-manager-token
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-agent
+  namespace: kube-system
+  labels:
+    app: contrail-agent
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-agent
+    spec:
+      #Disable affinity for single node setup
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/compute"
+                operator: In
+                values:
+                  - "true"
+      automountServiceAccountToken: false
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      - name: contrail-vrouter-kernel-init
+        image: "{{ contrail_registry }}/contrail-vrouter-kernel-init:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /usr/src
+          name: usr-src
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /etc/sysconfig/network-scripts
+          name: network-scripts
+        - mountPath: /host/bin
+          name: host-bin
+      - name: contrail-kubernetes-cni-init
+        image: "{{ contrail_registry }}/contrail-kubernetes-cni-init:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /var/lib/contrail
+          name: var-lib-contrail
+        - mountPath: /host/etc_cni
+          name: etc-cni
+        - mountPath: /host/opt_cni_bin
+          name: opt-cni-bin
+        - mountPath: /host/log_cni
+          name: var-log-contrail-cni
+        - mountPath: /var/log/contrail
+          name: agent-logs
+      containers:
+      - name: contrail-vrouter-agent
+        image: "{{ contrail_registry }}/contrail-vrouter-agent:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        # TODO: Priveleged mode is requied because w/o it the device /dev/net/tun
+        # is not present in the container. The mounting it into container
+        # doesnt help because of permissions are not enough syscalls,
+        # e.g. https://github.com/Juniper/contrail-controller/blob/master/src/vnsw/agent/contrail/linux/pkt0_interface.cc: 48.
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/clean-up.sh"]
+        volumeMounts:
+        - mountPath: /dev
+          name: dev
+        - mountPath: /etc/sysconfig/network-scripts
+          name: network-scripts
+        - mountPath: /host/bin
+          name: host-bin
+        - mountPath: /var/log/contrail
+          name: agent-logs
+        - mountPath: /usr/src
+          name: usr-src
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /var/lib/contrail
+          name: var-lib-contrail
+        - mountPath: /var/crashes
+          name: var-crashes
+        - mountPath: /tmp/serviceaccount
+          name: pod-secret
+      - name: contrail-agent-nodemgr
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        env:
+        - name: NODE_TYPE
+          value: vrouter
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: agent-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+      volumes:
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: network-scripts
+        hostPath:
+          path: /etc/sysconfig/network-scripts
+      - name: host-bin
+        hostPath:
+          path: /bin
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: pod-secret
+        secret:
+          secretName: contrail-kube-manager-token
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: var-lib-contrail
+        hostPath:
+          path: /var/lib/contrail
+      - name: var-crashes
+        hostPath:
+          path: /var/contrail/crashes
+      - name: etc-cni
+        hostPath:
+          path: /etc/cni
+      - name: opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: var-log-contrail-cni
+        hostPath:
+          path: /var/log/contrail/cni
+      - name: agent-logs
+        hostPath:
+          path: /var/log/contrail/agent
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contrail
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: v1
+metadata:
+  name: contrail
+  namespace: kube-system
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: v1
+kind: ClusterRoleBinding
+metadata:
+  name: contrail
+roleRef:
+  name: contrail
+subjects:
+- kind: SystemUser
+  name: kube-system:contrail
+- kind: ServiceAccount
+  name: contrail
+  namespace: kube-system
+userNames:
+  - system:serviceaccount:kube-system:contrail
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: contrail-kube-manager-token
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: contrail
+type: kubernetes.io/service-account-token

--- a/roles/contrail_controller/templates/contrail-nested.j2
+++ b/roles/contrail_controller/templates/contrail-nested.j2
@@ -1,0 +1,195 @@
+# Configs section
+# Note: using ".." for ports, because in v1 there is a bug
+# which leads to an error
+# "..error unmarshaling JSON: json: cannot unmarshal number into Go value of type string.."
+# (https://github.com/kubernetes/kubernetes/issues/2763)
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: env
+  namespace: kube-system
+data:
+  AUTH_MODE: {{ auth_mode }}
+  KEYSTONE_AUTH_HOST: {{ keystone_auth_host }}
+  KEYSTONE_AUTH_ADMIN_TENANT: "{{ keystone_auth_admin_tenant }}"
+  KEYSTONE_AUTH_ADMIN_USER: "{{ keystone_auth_admin_user }}"
+  KEYSTONE_AUTH_ADMIN_PASSWORD: "{{ keystone_auth_admin_password }}"
+  KEYSTONE_AUTH_ADMIN_PORT: "{{ keystone_auth_admin_port }}"
+  KEYSTONE_AUTH_URL_VERSION: "{{ keystone_auth_url_version }}"
+  CLOUD_ORCHESTRATOR: {{ cloud_orchestrator }}
+  CONTROLLER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONFIG_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONFIG_API_VIP: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  LOG_LEVEL: {{ log_level }}
+  RABBITMQ_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  RABBITMQ_NODE_PORT: "{{ rabbitmq_node_port }}"
+  ZOOKEEPER_SERVERS: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  KUBEMANAGER_NESTED_MODE: "1"
+  KUBERNETES_CLUSTER_NAME: "{{ cluster_name | default('k8s') }}"
+  KUBERNETES_CLUSTER_PROJECT: "{{ cluster_project | default('{}') }}"
+  KUBERNETES_CLUSTER_NETWORK: "{{ cluster_network }}"
+  KUBERNETES_POD_SUBNETS: "{{ pod_subnets | default('10.32.0.0/12') }}"
+  KUBERNETES_IP_FABRIC_SUBNETS: "{{ ip_fabric_subnets | default('10.64.0.0/12') }}"
+  KUBERNETES_SERVICE_SUBNETS: "{{ service_subnets | default('10.96.0.0/12') }}"
+  KUBERNETES_IP_FABRIC_FORWARDING: "{{ ip_fabric_forwarding | default('false') }}"
+  KUBERNETES_IP_FABRIC_SNAT: "{{ ip_fabric_snat | default('false') }}"
+  KUBERNETES_PUBLIC_FIP_POOL: "{{ public_fip_pool | default('{}') }}"
+  KUBERNESTES_NESTED_VROUTER_VIP: {{ k8s_nested_vrouter_vip }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-manager-config
+  namespace: kube-system
+data:
+  KUBERNETES_API_SERVER: {{ k8s_vip }}
+  KUBERNETES_API_SECURE_PORT: "{{ openshift_master_api_port | default(kubernetes_api_secure_port) }}"
+  K8S_TOKEN_FILE: "/tmp/serviceaccount/token"
+# Containers section
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-kube-manager
+  namespace: kube-system
+  labels:
+    app: contrail-kube-manager
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-kube-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/master"
+                operator: Exists
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      automountServiceAccountToken: false
+      hostNetwork: true
+      containers:
+      - name: contrail-kube-manager
+        image: "{{contrail_registry}}/contrail-kubernetes-kube-manager:{{contrail_container_tag}}"
+        imagePullPolicy: IfNotPresent
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: kube-manager-config
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: kube-manager-logs
+        - mountPath: /tmp/serviceaccount
+          name: pod-secret
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+      volumes:
+      - name: kube-manager-logs
+        hostPath:
+          path: /var/log/contrail/kube-manager
+      - name: pod-secret
+        secret:
+          secretName: contrail-kube-manager-token
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-kubernetes-cni-agent
+  namespace: kube-system
+  labels:
+    app: contrail-kubernetes-cni-agent
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-agent
+    spec:
+      #Disable affinity for single node setup
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.opencontrail.org/controller"
+                operator: NotIn
+                values:
+                - "true"
+      automountServiceAccountToken: false
+      hostNetwork: true
+      containers:
+      - name: contrail-kubernetes-cni-init
+        image: "{{contrail_registry}}/contrail-kubernetes-cni-init:{{contrail_container_tag}}"
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/etc_cni
+          name: etc-cni
+        - mountPath: /host/opt_cni_bin
+          name: opt-cni-bin
+        - mountPath: /var/lib/contrail
+          name: var-lib-contrail
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+      volumes:
+      - name: etc-cni
+        hostPath:
+          path: /etc/cni
+      - name: opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: var-lib-contrail
+        hostPath:
+          path: /var/lib/contrail
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: contrail-kube-manager
+  namespace: kube-system
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contrail-kube-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: contrail-kube-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: contrail-kube-manager
+subjects:
+- kind: ServiceAccount
+  name: contrail-kube-manager
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: contrail-kube-manager-token
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: contrail-kube-manager
+type: kubernetes.io/service-account-token

--- a/roles/contrail_controller/templates/getIp.j2
+++ b/roles/contrail_controller/templates/getIp.j2
@@ -1,0 +1,13 @@
+import sys
+import socket
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print >> sys.stderr, "Invalid Usage: No hostname provided as argument."
+        sys.exit(1)
+    try:
+       sys.stdout.write(socket.gethostbyname(sys.argv[1]))
+       sys.exit(0)
+    except Exception as e:
+        print >> sys.stderr, e
+        sys.exit(1)

--- a/roles/contrail_controller/templates/wait_for_pod.j2
+++ b/roles/contrail_controller/templates/wait_for_pod.j2
@@ -1,0 +1,55 @@
+#!/bin/bash 
+###
+### Borrowed from https://github.com/kubernetes/charts/blob/master/test/verify-release.sh
+### 
+
+NAMESPACE=kube-system
+
+# Ensure all pods in the namespace entered a Running state
+SUCCESS=0
+PODS_FOUND=0
+POD_RETRY_COUNT=0
+RETRY=100
+RETRY_DELAY=5
+while [ "$POD_RETRY_COUNT" -lt "$RETRY" ]; do
+  POD_RETRY_COUNT=$((POD_RETRY_COUNT+1))
+  POD_STATUS=`{{ openshift_client_binary }} get pods --no-headers --namespace $NAMESPACE`
+  if [ -z "$POD_STATUS" ];then
+    echo "INFO: No pods found for this release, retrying after sleep"
+    POD_RETRY_COUNT=$((POD_RETRY_COUNT+1))
+    sleep $RETRY_DELAY
+    continue
+  else
+    PODS_FOUND=1
+    sleep $RETRY_DELAY
+  fi
+
+  if ! echo "$POD_STATUS" | grep -v Running;then
+    echo "INFO: All pods entered the Running state"
+
+    CONTAINER_RETRY_COUNT=0
+    while [ "$CONTAINER_RETRY_COUNT" -lt "$RETRY" ]; do
+      UNREADY_CONTAINERS=`{{ openshift_client_binary }} get pods --namespace $NAMESPACE \
+        -o jsonpath="{.items[*].status.containerStatuses[?(@.ready!=true)].name}"`
+      if [ -n "$UNREADY_CONTAINERS" ];then
+        echo "INFO: Some containers are not yet ready; retrying after sleep"
+        CONTAINER_RETRY_COUNT=$((CONTAINER_RETRY_COUNT+1))
+  	sleep $RETRY_DELAY
+        continue
+      else
+        echo "INFO: All containers are ready"
+        exit 0
+      fi
+    done
+  fi
+done
+
+if [ "$PODS_FOUND" -eq 0 ];then
+  echo "WARN: No pods launched by this chart's default settings"
+  exit 0
+else
+  POD_FAILED=`{{ openshift_client_binary }} get pods --no-headers --namespace kube-system | grep -v Running | cut -d " " -f1`
+  echo "ERROR: Some containers failed to reach the ready state"
+  echo ERROR  POD $POD_FAILED is not ready
+  exit 1
+fi

--- a/roles/contrail_master/README.md
+++ b/roles/contrail_master/README.md
@@ -1,0 +1,51 @@
+# Contrail SDN
+
+[Contrail Networking](https://www.juniper.net/us/en/products-services/sdn/contrail/contrail-networking/), based on [TungstenFabric](https://tungstenfabric.io/) project, is a truly open, multi-cloud network virtualization and policy management platform. Contrail / TungstenFabric SDN stack is integrated with various orchestration systems such as Kubernetes, OpenShift, OpenStack and Mesos, and provides different isolation modes for virtual machines, containers/pods and bare metal workloads.
+
+## SUPPORTED ARCHITECTURE
+
+* Contrail SDN installed through OpenShift ansible supports both non-HA and  HA configurations.
+
+## CONTRAIL SOFTWARE COMPONENTS
+
+### Contrail Master (DaemonSets)
+
+- **Contrail Image Installer**: Downloads all contrail container images if not present.
+- **Contrail Controller Config**: The config daemonset consists of all config components
+  like contrail service monitor, schema transformer, api server etc which are running as
+  a docker container.
+- **Contrail Controller Control**: The contrail controller is installed by this daemonset.
+- **Contrail Controller WebUI**: WebUI components are deployed here. We use port 8143.
+- **Contrail Analytics**: All Contrail analytics components like the analytics collector,
+  topology, alarm-gen are installed by this daemonset.
+- **Contrail Analytics Database**: Contrail Analytics uses this container as its DB.
+- **Contrail Config DB Node Manager**: Node Manager for Config DB, Node manager containers are run
+  by all Contrail components to provide current status.
+- **Contrail Config DB**: DB used by the Contrail Controller Config component.
+- **Contrail DB Node Manager**: Node Manager of Analytics.
+- **Contrail Kubernetes Manager**: The interface between the Openshift API server and
+  Contrail Controller.
+
+Note:  These Contrail components are installed on the infra-node.
+
+### Nodes (DaemonSets)
+- **Contrail Agent**: As part of the agent pod we install the **vrouter kernel module** and the **contrail-cni**.
+
+### Contrail Ansible Roles
+
+* **Contrail common**: This role contains common functions which are required by other contrail roles
+* **Contrail controller**: Installs all contrail master components
+* **Contrail master**: Preps up the openshift master node
+* **Contrail node**: Installs cni binaries on all nodes
+* **Contrail st**: Preps the contrail schema transformer
+* **Contrail web console**: Installs contrail web console on infra nodes
+
+## INSTALLATION
+
+To install Contrail SDN with OpenShift Enterprise, follow this [install guide](https://github.com/Juniper/contrail-kubernetes-docs)
+
+Refer to this example [openshift 3.9 contrail installation](https://github.com/Juniper/contrail-kubernetes-docs/blob/master/install/openshift/3.9/standalone-openshift.md) for non-HA/HA deployments
+
+### CONTACT
+
+Pragash Vijayaragavan <pvijayaragav@juniper.net>

--- a/roles/contrail_master/meta/main.yml
+++ b/roles/contrail_master/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  author: Contrail
+  description: Contrail Networking
+  company: Juniper Networks, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 2.5
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+  - system

--- a/roles/contrail_master/tasks/main.yaml
+++ b/roles/contrail_master/tasks/main.yaml
@@ -1,0 +1,15 @@
+---
+- name: Get contrail nodes and ips
+  include_role:
+    name: contrail_common
+
+- block:
+  - name: Set master as ntp server
+    include_tasks: ntp.yml
+    when: ntpserver is not defined
+
+  - name: Set master as client to provided ntp server
+    include_role:
+      name: contrail_node
+      tasks_from: ntp.yml
+    when: ntpserver is defined

--- a/roles/contrail_master/tasks/ntp.yml
+++ b/roles/contrail_master/tasks/ntp.yml
@@ -1,0 +1,33 @@
+---
+- name: install ntp packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - ntp
+
+- name: open ntp port 123 on masters
+  command: iptables -I INPUT 4 -j ACCEPT -p udp --dport 123
+  when:
+  - not r_openshift_node_use_firewalld | default(false) | bool
+
+- name: stop ntp service
+  service: name="ntpd" state=stopped enabled=yes
+
+- name: set ntp server
+  template:
+    src: ntp.conf.j2
+    dest: /etc/ntp.conf
+
+- name: start ntp service
+  service: name="ntpd" state=started enabled=yes
+
+- name: set fact that this master is an ntp server
+  set_fact:
+    is_ntp_server: true
+
+- name: disable service chronyd
+  systemd:
+    name: chronyd
+    enabled: no
+  ignore_errors: yes

--- a/roles/contrail_master/templates/ntp.conf.j2
+++ b/roles/contrail_master/templates/ntp.conf.j2
@@ -1,0 +1,12 @@
+tinker panic 0
+
+disable monitor
+restrict default kod nomodify notrap nopeer noquery
+restrict -6 default kod nomodify notrap nopeer noquery
+restrict 127.0.0.1
+restrict -6 ::1
+
+server 127.127.1.0
+
+# Driftfile.
+driftfile /var/lib/ntp/drift

--- a/roles/contrail_node/README.md
+++ b/roles/contrail_node/README.md
@@ -1,0 +1,51 @@
+# Contrail SDN
+
+[Contrail Networking](https://www.juniper.net/us/en/products-services/sdn/contrail/contrail-networking/), based on [TungstenFabric](https://tungstenfabric.io/) project, is a truly open, multi-cloud network virtualization and policy management platform. Contrail / TungstenFabric SDN stack is integrated with various orchestration systems such as Kubernetes, OpenShift, OpenStack and Mesos, and provides different isolation modes for virtual machines, containers/pods and bare metal workloads.
+
+## SUPPORTED ARCHITECTURE
+
+* Contrail SDN installed through OpenShift ansible supports both non-HA and  HA configurations.
+
+## CONTRAIL SOFTWARE COMPONENTS
+
+### Contrail Master (DaemonSets)
+
+- **Contrail Image Installer**: Downloads all contrail container images if not present.
+- **Contrail Controller Config**: The config daemonset consists of all config components
+  like contrail service monitor, schema transformer, api server etc which are running as
+  a docker container.
+- **Contrail Controller Control**: The contrail controller is installed by this daemonset.
+- **Contrail Controller WebUI**: WebUI components are deployed here. We use port 8143.
+- **Contrail Analytics**: All Contrail analytics components like the analytics collector,
+  topology, alarm-gen are installed by this daemonset.
+- **Contrail Analytics Database**: Contrail Analytics uses this container as its DB.
+- **Contrail Config DB Node Manager**: Node Manager for Config DB, Node manager containers are run
+  by all Contrail components to provide current status.
+- **Contrail Config DB**: DB used by the Contrail Controller Config component.
+- **Contrail DB Node Manager**: Node Manager of Analytics.
+- **Contrail Kubernetes Manager**: The interface between the Openshift API server and
+  Contrail Controller.
+
+Note:  These Contrail components are installed on the infra-node.
+
+### Nodes (DaemonSets)
+- **Contrail Agent**: As part of the agent pod we install the **vrouter kernel module** and the **contrail-cni**.
+
+### Contrail Ansible Roles
+
+* **Contrail common**: This role contains common functions which are required by other contrail roles
+* **Contrail controller**: Installs all contrail master components
+* **Contrail master**: Preps up the openshift master node
+* **Contrail node**: Installs cni binaries on all nodes
+* **Contrail st**: Preps the contrail schema transformer
+* **Contrail web console**: Installs contrail web console on infra nodes
+
+## INSTALLATION
+
+To install Contrail SDN with OpenShift Enterprise, follow this [install guide](https://github.com/Juniper/contrail-kubernetes-docs)
+
+Refer to this example [openshift 3.9 contrail installation](https://github.com/Juniper/contrail-kubernetes-docs/blob/master/install/openshift/3.9/standalone-openshift.md) for non-HA/HA deployments
+
+### CONTACT
+
+Pragash Vijayaragavan <pvijayaragav@juniper.net>

--- a/roles/contrail_node/defaults/main.yml
+++ b/roles/contrail_node/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+contrail_os_release: redhat7
+cni_version: v0.5.2
+contrail_registry: docker.io/opencontrailnightly/

--- a/roles/contrail_node/meta/main.yml
+++ b/roles/contrail_node/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: Contrail
+  description: Contrail Networking
+  company: Juniper Networks, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 2.5
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+  - system
+dependencies:
+- role: lib_utils
+- role: openshift_facts

--- a/roles/contrail_node/tasks/bind_mounts.yaml
+++ b/roles/contrail_node/tasks/bind_mounts.yaml
@@ -1,0 +1,9 @@
+---
+- name: copy the bind mounts of contrail into openshift system config
+  lineinfile:
+    dest: /etc/sysconfig/{{ openshift_service_type }}-node
+    line: "{{ contrail_containerized_bind_mounts }}"
+    create: true
+
+- name: restart node
+  systemd: name={{ openshift_service_type }}-node daemon-reload=yes state=restarted

--- a/roles/contrail_node/tasks/main.yaml
+++ b/roles/contrail_node/tasks/main.yaml
@@ -1,0 +1,14 @@
+---
+- name: Get contrail nodes and ips
+  include_role:
+    name: contrail_common
+
+- name: Set ntp on nodes
+  include_tasks: ntp.yml
+
+- name: Configure all openshift nodes
+  include_tasks: node_config.yaml
+
+- name: Set bind mounts for containerized install
+  include_tasks: bind_mounts.yaml
+  when: openshift_is_containerized | bool

--- a/roles/contrail_node/tasks/node_config.yaml
+++ b/roles/contrail_node/tasks/node_config.yaml
@@ -1,0 +1,29 @@
+---
+- name: Set core dump pattern on node
+  command: echo "/var/crashes/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
+
+- name: Stat for loopback plugin
+  stat:
+    path: "/opt/cni/bin/loopback"
+  register: loopback
+
+- when:
+  - loopback.stat.exists == False
+
+  block:
+  - name: Ensure CNI bin path exists
+    file:
+      path: "/opt/cni/bin"
+      recurse: True
+      state: directory
+
+  - name: Download & extract loopback CNI binary
+    unarchive:
+      src: "https://github.com/containernetworking/cni/releases/download/{{ cni_version }}/cni-{{ cni_version }}.tgz"
+      dest: "/opt/cni/bin"
+      mode: a+x
+      remote_src: True
+    register: result
+    until: result is success
+    retries: 3
+    delay: 10

--- a/roles/contrail_node/tasks/ntp.yml
+++ b/roles/contrail_node/tasks/ntp.yml
@@ -1,0 +1,26 @@
+---
+- name: install ntp packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - ntp
+
+- name: stop ntp service
+  service: name="ntpd" state=stopped enabled=yes
+
+- name: set ntp conf file
+  template:
+    src: ntp.conf.j2
+    dest: /etc/ntp.conf
+  when:
+  - is_ntp_server is not defined
+
+- name: start ntp service
+  service: name="ntpd" state=started enabled=yes
+
+- name: disable service chronyd
+  systemd:
+    name: chronyd
+    enabled: no
+  ignore_errors: yes

--- a/roles/contrail_node/templates/ntp.conf.j2
+++ b/roles/contrail_node/templates/ntp.conf.j2
@@ -1,0 +1,18 @@
+tinker panic 0
+
+disable monitor
+restrict default kod nomodify notrap nopeer noquery
+restrict -6 default kod nomodify notrap nopeer noquery
+restrict 127.0.0.1
+restrict -6 ::1
+
+{% if ntpserver is not defined %}
+{% for master in groups.masters %}
+server {{ master | ipaddr }} iburst
+{% endfor %}
+{% else %}
+server {{ ntpserver | ipaddr }} iburst
+{% endif %}
+
+# Driftfile.
+driftfile /var/lib/ntp/drift

--- a/roles/contrail_node/vars/main.yaml
+++ b/roles/contrail_node/vars/main.yaml
@@ -1,0 +1,2 @@
+---
+contrail_containerized_bind_mounts: 'CONTRAIL_ADDTL_BIND_MOUNTS=-v /opt/cni/bin:/opt/cni/bin -v /etc/cni/net.d:/etc/cni/net.d -v /var/lib/contrail:/var/lib/contrail'

--- a/roles/contrail_st/README.md
+++ b/roles/contrail_st/README.md
@@ -1,0 +1,51 @@
+# Contrail SDN
+
+[Contrail Networking](https://www.juniper.net/us/en/products-services/sdn/contrail/contrail-networking/), based on [TungstenFabric](https://tungstenfabric.io/) project, is a truly open, multi-cloud network virtualization and policy management platform. Contrail / TungstenFabric SDN stack is integrated with various orchestration systems such as Kubernetes, OpenShift, OpenStack and Mesos, and provides different isolation modes for virtual machines, containers/pods and bare metal workloads.
+
+## SUPPORTED ARCHITECTURE
+
+* Contrail SDN installed through OpenShift ansible supports both non-HA and  HA configurations.
+
+## CONTRAIL SOFTWARE COMPONENTS
+
+### Contrail Master (DaemonSets)
+
+- **Contrail Image Installer**: Downloads all contrail container images if not present.
+- **Contrail Controller Config**: The config daemonset consists of all config components
+  like contrail service monitor, schema transformer, api server etc which are running as
+  a docker container.
+- **Contrail Controller Control**: The contrail controller is installed by this daemonset.
+- **Contrail Controller WebUI**: WebUI components are deployed here. We use port 8143.
+- **Contrail Analytics**: All Contrail analytics components like the analytics collector,
+  topology, alarm-gen are installed by this daemonset.
+- **Contrail Analytics Database**: Contrail Analytics uses this container as its DB.
+- **Contrail Config DB Node Manager**: Node Manager for Config DB, Node manager containers are run
+  by all Contrail components to provide current status.
+- **Contrail Config DB**: DB used by the Contrail Controller Config component.
+- **Contrail DB Node Manager**: Node Manager of Analytics.
+- **Contrail Kubernetes Manager**: The interface between the Openshift API server and
+  Contrail Controller.
+
+Note:  These Contrail components are installed on the infra-node.
+
+### Nodes (DaemonSets)
+- **Contrail Agent**: As part of the agent pod we install the **vrouter kernel module** and the **contrail-cni**.
+
+### Contrail Ansible Roles
+
+* **Contrail common**: This role contains common functions which are required by other contrail roles
+* **Contrail controller**: Installs all contrail master components
+* **Contrail master**: Preps up the openshift master node
+* **Contrail node**: Installs cni binaries on all nodes
+* **Contrail st**: Preps the contrail schema transformer
+* **Contrail web console**: Installs contrail web console on infra nodes
+
+## INSTALLATION
+
+To install Contrail SDN with OpenShift Enterprise, follow this [install guide](https://github.com/Juniper/contrail-kubernetes-docs)
+
+Refer to this example [openshift 3.9 contrail installation](https://github.com/Juniper/contrail-kubernetes-docs/blob/master/install/openshift/3.9/standalone-openshift.md) for non-HA/HA deployments
+
+### CONTACT
+
+Pragash Vijayaragavan <pvijayaragav@juniper.net>

--- a/roles/contrail_st/tasks/main.yaml
+++ b/roles/contrail_st/tasks/main.yaml
@@ -1,0 +1,3 @@
+---
+- name: Sanitize Schema Transformer process.
+  include_tasks: schema_transformer_sanity.yaml

--- a/roles/contrail_st/tasks/schema_transformer_sanity.yaml
+++ b/roles/contrail_st/tasks/schema_transformer_sanity.yaml
@@ -1,0 +1,41 @@
+---
+- name: Run contrail-status command to get status of contrail services.
+  command: /usr/bin/contrail-status
+  register: contrail_status_output
+  when:
+    - inventory_hostname in contrail_masters
+
+- set_fact:
+    schema_valid: true
+  when:
+    - inventory_hostname in contrail_masters
+
+- name: If Schema Transformer is not in active or backup state, mark it as being in invalid state.
+  set_fact:
+    schema_valid: false
+  when:
+    - inventory_hostname in contrail_masters
+    - '"schema: active" not in contrail_status_output.stdout'
+    - '"schema: backup" not in contrail_status_output.stdout'
+
+- when:
+    - inventory_hostname in contrail_masters
+    - not schema_valid
+
+    # Schema Transformer is invalid.
+    # We will attempt to resuscitate it by restarting its container.
+
+  block:
+    - name: Get docker container details of Schema Transformer
+      command: docker ps --filter "name=schema" -q
+      register: schema_docker_output
+      ignore_errors: yes
+
+    - name: Restart Schema Transformer container "{{ schema_docker_output.stdout }}"
+      command: docker restart "{{ schema_docker_output.stdout }}"
+      when: schema_docker_output.stdout != ""
+      ignore_errors: yes
+
+    - name: Wait for Schema Transformer to restart.
+      wait_for: timeout=10
+      when: schema_docker_output.stdout != ""

--- a/roles/contrail_web_console/README.md
+++ b/roles/contrail_web_console/README.md
@@ -1,0 +1,51 @@
+# Contrail SDN
+
+[Contrail Networking](https://www.juniper.net/us/en/products-services/sdn/contrail/contrail-networking/), based on [TungstenFabric](https://tungstenfabric.io/) project, is a truly open, multi-cloud network virtualization and policy management platform. Contrail / TungstenFabric SDN stack is integrated with various orchestration systems such as Kubernetes, OpenShift, OpenStack and Mesos, and provides different isolation modes for virtual machines, containers/pods and bare metal workloads.
+
+## SUPPORTED ARCHITECTURE
+
+* Contrail SDN installed through OpenShift ansible supports both non-HA and  HA configurations.
+
+## CONTRAIL SOFTWARE COMPONENTS
+
+### Contrail Master (DaemonSets)
+
+- **Contrail Image Installer**: Downloads all contrail container images if not present.
+- **Contrail Controller Config**: The config daemonset consists of all config components
+  like contrail service monitor, schema transformer, api server etc which are running as
+  a docker container.
+- **Contrail Controller Control**: The contrail controller is installed by this daemonset.
+- **Contrail Controller WebUI**: WebUI components are deployed here. We use port 8143.
+- **Contrail Analytics**: All Contrail analytics components like the analytics collector,
+  topology, alarm-gen are installed by this daemonset.
+- **Contrail Analytics Database**: Contrail Analytics uses this container as its DB.
+- **Contrail Config DB Node Manager**: Node Manager for Config DB, Node manager containers are run
+  by all Contrail components to provide current status.
+- **Contrail Config DB**: DB used by the Contrail Controller Config component.
+- **Contrail DB Node Manager**: Node Manager of Analytics.
+- **Contrail Kubernetes Manager**: The interface between the Openshift API server and
+  Contrail Controller.
+
+Note:  These Contrail components are installed on the infra-node.
+
+### Nodes (DaemonSets)
+- **Contrail Agent**: As part of the agent pod we install the **vrouter kernel module** and the **contrail-cni**.
+
+### Contrail Ansible Roles
+
+* **Contrail common**: This role contains common functions which are required by other contrail roles
+* **Contrail controller**: Installs all contrail master components
+* **Contrail master**: Preps up the openshift master node
+* **Contrail node**: Installs cni binaries on all nodes
+* **Contrail st**: Preps the contrail schema transformer
+* **Contrail web console**: Installs contrail web console on infra nodes
+
+## INSTALLATION
+
+To install Contrail SDN with OpenShift Enterprise, follow this [install guide](https://github.com/Juniper/contrail-kubernetes-docs)
+
+Refer to this example [openshift 3.9 contrail installation](https://github.com/Juniper/contrail-kubernetes-docs/blob/master/install/openshift/3.9/standalone-openshift.md) for non-HA/HA deployments
+
+### CONTACT
+
+Pragash Vijayaragavan <pvijayaragav@juniper.net>

--- a/roles/contrail_web_console/defaults/main.yml
+++ b/roles/contrail_web_console/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+openshift_web_console_contrail_nodeselector: {'region':'infra'}
+
+__console_template_file: "console-template.yaml"
+__console_config_file: "console-config.yaml"
+
+openshift_web_console_image_dict:
+  origin:
+    prefix: "docker.io/openshift/origin-"
+    version: "{{ openshift_image_tag }}"
+    image_name: "web-console"
+  openshift-enterprise:
+    prefix: "registry.access.redhat.com/openshift3/ose-"
+    version: "{{ openshift_image_tag }}"
+    image_name: "web-console"
+
+openshift_web_console_prefix: "{{ openshift_web_console_image_dict[openshift_deployment_type]['prefix'] }}"
+openshift_web_console_version: "{{ openshift_web_console_image_dict[openshift_deployment_type]['version'] }}"
+openshift_web_console_image_name: "{{ openshift_web_console_image_dict[openshift_deployment_type]['image_name'] }}"
+# Default the replica count to the number of masters.
+openshift_web_console_replica_count: "{{ groups.oo_masters_to_config | length }}"

--- a/roles/contrail_web_console/files/console-config.yaml
+++ b/roles/contrail_web_console/files/console-config.yaml
@@ -1,0 +1,24 @@
+apiVersion: webconsole.config.openshift.io/v1
+kind: WebConsoleConfiguration
+clusterInfo:
+  consolePublicURL: https://127.0.0.1:18443/console/
+  loggingPublicURL: ""
+  logoutPublicURL: ""
+  masterPublicURL: https://127.0.0.1:8443
+  metricsPublicURL: ""
+extensions:
+  scriptURLs: []
+  stylesheetURLs: []
+  properties: null
+features:
+  inactivityTimeoutMinutes: 0
+  clusterResourceOverridesEnabled: false
+servingInfo:
+  bindAddress: 0.0.0.0:18443
+  bindNetwork: tcp4
+  certFile: /var/serving-cert/tls.crt
+  clientCA: ""
+  keyFile: /var/serving-cert/tls.key
+  maxRequestsInFlight: 0
+  namedCertificates: null
+  requestTimeoutSeconds: 0

--- a/roles/contrail_web_console/files/console-template.yaml
+++ b/roles/contrail_web_console/files/console-template.yaml
@@ -1,0 +1,135 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: openshift-web-console
+  annotations:
+    openshift.io/display-name: OpenShift Web Console
+    description: The server for the OpenShift web console.
+    iconClass: icon-openshift
+    tags: openshift,infra
+    openshift.io/documentation-url: https://github.com/openshift/origin-web-console-server
+    openshift.io/support-url: https://access.redhat.com
+    openshift.io/provider-display-name: Red Hat, Inc.
+parameters:
+- name: IMAGE
+  value: openshift/origin-web-console:latest
+- name: NAMESPACE
+  # This namespace cannot be changed. Only `openshift-web-console` is supported.
+  value: openshift-web-console
+- name: LOGLEVEL
+  value: "0"
+- name: API_SERVER_CONFIG
+- name: NODE_SELECTOR
+  value: "{}"
+- name: REPLICA_COUNT
+  value: "1"
+objects:
+
+# to create the web console server
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  metadata:
+    namespace: ${NAMESPACE}
+    name: webconsole
+    labels:
+      app: openshift-web-console
+      webconsole: "true"
+  spec:
+    replicas: "${{REPLICA_COUNT}}"
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        name: webconsole
+        labels:
+          webconsole: "true"
+      spec:
+        hostNetwork: true
+        serviceAccountName: webconsole
+        containers:
+        - name: webconsole
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command:
+          - "/usr/bin/origin-web-console"
+          - "--audit-log-path=-"
+          - "-v=${LOGLEVEL}"
+          - "--config=/var/webconsole-config/webconsole-config.yaml"
+          ports:
+          - containerPort: 18443
+          volumeMounts:
+          - mountPath: /var/serving-cert
+            name: serving-cert
+          - mountPath: /var/webconsole-config
+            name: webconsole-config
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 18443
+              scheme: HTTPS
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -i
+                - -c
+                - |-
+                  if [[ ! -f /tmp/webconsole-config.hash ]]; then \
+                    md5sum /var/webconsole-config/webconsole-config.yaml > /tmp/webconsole-config.hash; \
+                  elif [[ $(md5sum /var/webconsole-config/webconsole-config.yaml) != $(cat /tmp/webconsole-config.hash) ]]; then \
+                    exit 1; \
+                  fi && curl -k -f https://0.0.0.0:18443/console/
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+        nodeSelector: "${{NODE_SELECTOR}}"
+        volumes:
+        - name: serving-cert
+          secret:
+            defaultMode: 400
+            secretName: webconsole-serving-cert
+        - name: webconsole-config
+          configMap:
+            defaultMode: 440
+            name: webconsole-config
+
+# to create the config for the web console
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    namespace: ${NAMESPACE}
+    name: webconsole-config
+    labels:
+      app: openshift-web-console
+  data:
+    webconsole-config.yaml: ${API_SERVER_CONFIG}
+
+# to be able to assign powers to the process
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    namespace: ${NAMESPACE}
+    name: webconsole
+    labels:
+      app: openshift-web-console
+
+# to be able to expose web console inside the cluster
+- apiVersion: v1
+  kind: Service
+  metadata:
+    namespace: ${NAMESPACE}
+    name: webconsole
+    labels:
+      app: openshift-web-console
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: webconsole-serving-cert
+      prometheus.io/scrape: "true"
+      prometheus.io/scheme: https
+  spec:
+    selector:
+      webconsole: "true"
+    ports:
+    - name: https
+      port: 443
+      targetPort: 18443

--- a/roles/contrail_web_console/tasks/main.yaml
+++ b/roles/contrail_web_console/tasks/main.yaml
@@ -1,0 +1,9 @@
+---
+- name: Get contrail nodes and ips
+  include_role:
+    name: contrail_common
+
+- name: Web Console install
+  include_tasks: web_console_install.yaml
+  when:
+    - openshift_web_console_contrail_install | default(false) | bool

--- a/roles/contrail_web_console/tasks/web_console_install.yaml
+++ b/roles/contrail_web_console/tasks/web_console_install.yaml
@@ -1,0 +1,199 @@
+---
+- name: Ensure openshift-web-console project exists
+  oc_project:
+    name: openshift-web-console
+    state: present
+    node_selector:
+    - ""
+  register: create_console_project
+
+- name: Make temp directory for web console templates
+  command: mktemp -d /tmp/console-ansible-XXXXXX
+  register: mktemp
+  changed_when: False
+
+- name: Copy admin client config
+  command: >
+    cp {{ openshift.common.config_base }}/master//admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
+  changed_when: false
+
+- name: Copy web console templates to temp directory
+  copy:
+    src: "{{ item }}"
+    dest: "{{ mktemp.stdout }}/{{ item }}"
+  with_items:
+  - "{{ __console_template_file }}"
+  - "{{ __console_config_file }}"
+
+# Check if an existing webconsole-config config map exists. If so, use those
+# contents so we don't overwrite changes.
+- name: Read the existing web console config map
+  oc_configmap:
+    namespace: openshift-web-console
+    name: webconsole-config
+    state: list
+  register: webconsole_config_map
+
+- set_fact:
+    existing_config_map_data: "{{ webconsole_config_map.results.results[0].data | default({}) }}"
+
+- name: Copy the existing web console config to temp directory
+  copy:
+    content: "{{ existing_config_map_data['webconsole-config.yaml'] }}"
+    dest: "{{ mktemp.stdout }}/{{ __console_config_file }}"
+  when: existing_config_map_data['webconsole-config.yaml'] is defined
+
+# Generate a new config when a config map is not defined.
+- when: existing_config_map_data['webconsole-config.yaml'] is not defined
+  block:
+  # Migrate the previous master-config.yaml asset config if it exists into the new
+  # web console config config map.
+  - name: Read existing assetConfig in master-config.yaml
+    slurp:
+      src: "{{ openshift.common.config_base }}/master/master-config.yaml"
+    register: master_config_output
+
+  - set_fact:
+      config_to_migrate: "{{ master_config_output.content | b64decode | from_yaml }}"
+
+  - set_fact:
+      cro_plugin_enabled: "{{ config_to_migrate.admissionConfig is defined and config_to_migrate.admissionConfig.pluginConfig is defined and config_to_migrate.admissionConfig.pluginConfig.ClusterResourceOverrides is defined }}"
+
+  # Update properties in the config template based on inventory vars when the
+  # asset config does not exist.
+  - name: Set web console config properties from inventory variables
+    yedit:
+      src: "{{ mktemp.stdout }}/{{ __console_config_file }}"
+      edits:
+      - key: clusterInfo#consolePublicURL
+        # Must have a trailing slash
+        value: "{{ openshift.master.public_console_url }}/"
+      - key: clusterInfo#masterPublicURL
+        value: "{{ openshift.master.public_api_url }}"
+      - key: clusterInfo#logoutPublicURL
+        value: "{{ openshift.master.logout_url | default('') }}"
+      - key: features#inactivityTimeoutMinutes
+        value: "{{ openshift_web_console_inactivity_timeout_minutes | default(0) }}"
+      - key: features#clusterResourceOverridesEnabled
+        value: "{{ openshift_web_console_cluster_resource_overrides_enabled | default(cro_plugin_enabled) }}"
+      - key: extensions#scriptURLs
+        value: "{{ openshift_web_console_extension_script_urls | default([]) }}"
+      - key: extensions#stylesheetURLs
+        value: "{{ openshift_web_console_extension_stylesheet_urls | default([]) }}"
+      - key: extensions#properties
+        value: "{{ openshift_web_console_extension_properties | default({}) }}"
+      separator: '#'
+      state: present
+    when: config_to_migrate.assetConfig is not defined
+
+  - name: Migrate assetConfig from master-config.yaml
+    yedit:
+      src: "{{ mktemp.stdout }}/{{ __console_config_file }}"
+      edits:
+      - key: clusterInfo#consolePublicURL
+        value: "{{ config_to_migrate.assetConfig.publicURL }}"
+      - key: clusterInfo#masterPublicURL
+        value: "{{ config_to_migrate.assetConfig.masterPublicURL }}"
+      - key: clusterInfo#logoutPublicURL
+        value: "{{ config_to_migrate.assetConfig.logoutURL | default('') }}"
+      - key: clusterInfo#metricsPublicURL
+        value: "{{ config_to_migrate.assetConfig.metricsPublicURL | default('') }}"
+      - key: clusterInfo#loggingPublicURL
+        value: "{{ config_to_migrate.assetConfig.loggingPublicURL | default('') }}"
+      - key: servingInfo#maxRequestsInFlight
+        value: "{{ config_to_migrate.assetConfig.servingInfo.maxRequestsInFlight | default(0) }}"
+      - key: servingInfo#requestTimeoutSeconds
+        value: "{{ config_to_migrate.assetConfig.servingInfo.requestTimeoutSeconds | default(0) }}"
+      - key: features#clusterResourceOverridesEnabled
+        value: "{{ openshift_web_console_cluster_resource_overrides_enabled | default(cro_plugin_enabled) }}"
+      separator: '#'
+      state: present
+    when: config_to_migrate.assetConfig is defined
+
+- slurp:
+    src: "{{ mktemp.stdout }}/{{ __console_config_file }}"
+  register: updated_console_config
+
+- name: Open hosts network previledges for webconsole
+  command: oc adm policy add-scc-to-user hostnetwork -z webconsole -n openshift-web-console
+  run_once: True
+  ignore_errors: True
+
+- name: Apply the web console template file
+  shell: >
+    {{ openshift_client_binary }} process -f "{{ mktemp.stdout }}/{{ __console_template_file }}"
+    --param API_SERVER_CONFIG="{{ updated_console_config['content'] | b64decode }}"
+    --param IMAGE="{{ openshift_web_console_prefix }}{{ openshift_web_console_image_name }}:{{ openshift_web_console_version }}"
+    --param NODE_SELECTOR={{ openshift_web_console_contrail_nodeselector | to_json | quote }}
+    --param REPLICA_COUNT="{{ openshift_web_console_replica_count }}"
+    --config={{ mktemp.stdout }}/admin.kubeconfig
+    | {{ openshift_client_binary }} apply --config={{ mktemp.stdout }}/admin.kubeconfig -f -
+
+# Wait to give the rollout time to start before verifying that the console is
+# running. Unfortunately, we can't check if the deployment revision changed
+# because it's possible applying the template did not result in any changes to
+# the pod template spec, which would skip a new revision.
+- name: Pause for the web console deployment to start
+  pause:
+    seconds: 30
+  # Skip if the project didn't exist since there was no previous deployment.
+  when: not create_console_project.changed
+
+- name: Verify that the web console is running
+  command: >
+    curl -k https://webconsole.openshift-web-console.svc/healthz
+  args:
+    # Disables the following warning:
+    # Consider using get_url or uri module rather than running curl
+    warn: no
+  register: console_health
+  until: console_health.stdout == 'ok'
+  retries: 60
+  delay: 1
+  changed_when: false
+  # Ignore errors so we can log troubleshooting info on failures.
+  ignore_errors: yes
+
+# Log the result of `oc status`, `oc get pods`, `oc get events`, and `oc logs deployment/webconsole` for troubleshooting failures.
+- when: console_health.stdout != 'ok'
+  block:
+  - name: Check status in the openshift-web-console namespace
+    command: >
+      {{ openshift_client_binary }} status --config={{ mktemp.stdout }}/admin.kubeconfig -n openshift-web-console
+    register: console_status
+    ignore_errors: true
+  - debug:
+      msg: "{{ console_status.stdout_lines }}"
+  - name: Get pods in the openshift-web-console namespace
+    command: >
+      {{ openshift_client_binary }} get pods --config={{ mktemp.stdout }}/admin.kubeconfig -n openshift-web-console -o wide
+    register: console_pods
+    ignore_errors: true
+  - debug:
+      msg: "{{ console_pods.stdout_lines }}"
+  - name: Get events in the openshift-web-console namespace
+    command: >
+      {{ openshift_client_binary }} get events --config={{ mktemp.stdout }}/admin.kubeconfig -n openshift-web-console
+    register: console_events
+    ignore_errors: true
+  - debug:
+      msg: "{{ console_events.stdout_lines }}"
+  - name: Get console pod logs
+    command: >
+      {{ openshift_client_binary }} logs deployment/webconsole --tail=50 --config={{ mktemp.stdout }}/admin.kubeconfig -n openshift-web-console
+    register: console_log
+    ignore_errors: true
+  - debug:
+      msg: "{{ console_log.stdout_lines }}"
+
+- name: Remove temp directory
+  file:
+    state: absent
+    name: "{{ mktemp.stdout }}"
+  changed_when: False
+
+# This health check is not reported currently because of dnsmasq issue
+#- name: Report console errors
+#  fail:
+#    msg: Console install failed.
+#  when: console_health.stdout != 'ok'

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -189,6 +189,168 @@ default_r_openshift_node_os_firewall_allow:
   cond: "{{ openshift_node_port_range is defined }}"
 - service: Prometheus monitoring
   port: 9000-10000/tcp
+- service: Contrail VRouter Agent Introspect
+  port: 8085/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail VRouter Agent Metadata Proxy
+  port: 8097/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail VRouter Agent Port IPC
+  port: 9091/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail VRouter Agent NodeMgr
+  port: 8102/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Redis Query Port
+  port: 6379/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config Database NodeMgr
+  port: 8112/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config Cassandra
+  port: 9041/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config Cassandra 2
+  port: 9161/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config Cassandra 3
+  port: 7010/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config Zookeeper 1
+  port: 2181/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config Zookeeper 2
+  port: 43391/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config Zookeeper 3
+  port: 2888/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config Zookeeper 4
+  port: 3888/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail RabbitMQ
+  port: 4369/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail RabbitMQ 2
+  port: 25672/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail RabbitMQ 3
+  port: 5672/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Controller Database NodeMgr
+  port: 8103/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Kafka
+  port: 9092/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Kafka 2
+  port: 33994/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics Cassandra 1
+  port: 9042/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics Cassandra 2
+  port: 9160/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics Cassandra 3
+  port: 7000/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics Zookeeper
+  port: 2182/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics Zookeeper 2
+  port: 40799/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics HTTP Opserver
+  port: 8090/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics Zookeeper 3
+  port: 4888/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics Zookeeper 4
+  port: 5888/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics Opserver
+  port: 8081/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics HTTP Collector
+  port: 8089/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytic Collector
+  port: 8086/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics Collector Structured Syslog
+  port: 3514/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics Query Engine
+  port: 8091/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics Snmp Collector
+  port: 5920/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics Port Topology
+  port: 5921/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics NodeMgr
+  port: 8104/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Analytics Alarm Generator
+  port: 5995/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Control XMPP
+  port: 5269/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Control Control
+  port: 8083/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Control DNS
+  port: 8092/udp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Control DNS XMPP
+  port: 8093/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Control NodeMgr
+  port: 8101/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Control BGP
+  port: 179/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config API server
+  port: 8082/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config HTTP API server
+  port: 8084/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config Schema Transformer
+  port: 8087/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config Service Monitor
+  port: 8088/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config Device Manager
+  port: 8096/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config NodeMgr
+  port: 8100/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Config API Backend
+  port: 9100/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail WebUI
+  port: 8143/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail WebUI 2
+  port: 8180/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail WebUI Console
+  port: 8080/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail KubeManager Introspect
+  port: 8108/tcp
+  condition: "{{ openshift_node_use_contrail }}"
+- service: Contrail Openshift WebConsole
+  port: 18443/tcp
+  condition: "{{ openshift_node_use_contrail }}"
 # Allow multiple port ranges to be added to the role
 r_openshift_node_os_firewall_allow: "{{ default_r_openshift_node_os_firewall_allow | union(openshift_node_open_ports | default([])) }}"
 
@@ -252,5 +414,8 @@ openshift_node_config_dir: "{{ openshift_node_config_dir_default }}"
 
 openshift_node_image_config_latest_default: "{{ openshift_image_config_latest | default(False) }}"
 openshift_node_image_config_latest: "{{ openshift_node_image_config_latest_default }}"
+
+openshift_node_use_contrail_default: "{{ openshift_use_contrail | default(False) }}"
+openshift_node_use_contrail: "{{ openshift_node_use_contrail_default }}"
 
 openshift_node_use_instance_profiles: False

--- a/roles/openshift_node/templates/openshift.docker.node.service
+++ b/roles/openshift_node/templates/openshift.docker.node.service
@@ -39,6 +39,7 @@ ExecStart=/usr/bin/docker run --name {{ openshift_service_type }}-node \
   -v /etc/origin/sdn:/etc/openshift-sdn -v /var/lib/cni:/var/lib/cni \
   -v /etc/systemd/system:/host-etc/systemd/system -v /var/log:/var/log \
   {% if openshift_use_nuage | default(false) -%} $NUAGE_ADDTL_BIND_MOUNTS {% endif -%} \
+  {% if openshift_use_contrail | default(false) -%} $CONTRAIL_ADDTL_BIND_MOUNTS {% endif -%} \
   -v /dev:/dev $DOCKER_ADDTL_BIND_MOUNTS -v /etc/pki:/etc/pki:ro \
   {% if l_bind_docker_reg_auth %} -v {{ oreg_auth_credentials_path }}:/root/.docker:ro{% endif %}\
   -v /var/lib/kubelet:/var/lib/kubelet\


### PR DESCRIPTION
** Contrail SDN **

[Contrail Networking](https://www.juniper.net/us/en/products-services/sdn/contrail/contrail-networking/),
based on [TungstenFabric](https://tungstenfabric.io/) project, is a truly open,
multi-cloud network virtualization and policy management platform.
Contrail / TungstenFabric SDN stack is integrated with various orchestration systems
such as Kubernetes, OpenShift, OpenStack and Mesos, and provides different isolation
modes for virtual machines, containers/pods and bare metal workloads.

** SUPPORTED ARCHITECTURE **

- Contrail SDN installed through OpenShift ansible supports both non-HA and
  HA configurations.

** CONTRAIL SOFTWARE COMPONENTS **

* Contrail components are installed on the infra-node.

* Contrail Master (DaemonSets)

- Contrail Image Installer: Downloads all contrail container images if not present.
- Contrail Controller Config: The config daemonset consists of all config components
  like contrail service monitor, schema transformer, api server etc which are running as
  a docker container.
- Contrail Controller Control: The contrail controller is installed by this daemonset.
- Contrail Controller WebUI: WebUI components are deployed here. We use port 8143.
- Contrail Analytics: All Contrail analytics components like the analytics collector,
  topology, alarm-gen are installed by this daemonset.
- Contrail Analytics Database: Contrail Analytics uses this container as its DB.
- Contrail Config DB Node Manager: Node Manager for Config DB, Node manager containers are run
  by all Contrail components to provide current status.
- Contrail Config DB: DB used by the Contrail Controller Config component.
- Contrail DB Node Manager: Node Manager of Analytics.
- Contrail Kubernetes Manager: The interface between the Openshift API server and
  Contrail Controller.

Note:  These Contrail components are installed on the infra-node.

* Nodes (DaemonSets)

- Contrail Agent: As part of out contrail-agent daemonset we install the **vrouter kernel module** and the
  **contrail-cni** on all nodes.

** INSTALLATION **

To install Contrail SDN with OpenShift Enterprise, follow this
Refer to this example [openshift 3.x contrail installation]
(https://github.com/Juniper/contrail-kubernetes-docs/blob/master/install/openshift/3.9/standalone-openshift.md)
for non-HA/HA deployments

** Openshift ansible code changes **

1. Added contrail roles to openshift roles.
2. Added openshift hooks to call contrail when contrail is chosen as sdn provider.
        - playbooks/openshift-master/private/config.yml
        - playbooks/openshift-node/private/additional_config.yml
3. Modified openshift-node docker service to support contrail.
        - Contrail containerized install requires mounting the cni binary directories
          and Contrail directories.
4. Modified the manage-node play in openshift-node to restart dnsmasq service
- After installing Contrail vrouter kernel module, a flap in the interface
  causes the dnsmasq service to stop working, hence a restart of the service is
  required. Issue may be seen only on RHEL systems and resolved in 3.10.
5. Opened contrail ports in the openshift-node role.
- Contrail ports are opened up through openshift node roles. All contrail components require
  specific ports to be opened for them to communicate with each other, like the 8143 port for
  webUI, 8085 the introspect port etc.

* Contrail Ansible Roles

- Contrail common: This role contains common functions which are required by other contrail roles
- Contrail controller: Installs all contrail master components
- Contrail master: Preps up the openshift master node
- Contrail node: Installs cni binaries on all nodes
- Contrail st: Preps the contrail schema transformer
- Contrail web console: Installs contrail web console on infra nodes

** CONTACT **
Pragash Vijayaragavan <pvijayaragav@juniper.net>

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
