### PR TITLE
Fix Bug 1648832 - Hostname is configured as local-ipv4 in OpenStack 

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -337,12 +337,12 @@ def normalize_openstack_facts(metadata, facts):
     for f_var, h_var, ip_var in [('hostname', 'hostname', 'local-ipv4'),
                                  ('public_hostname', 'public-hostname', 'public-ipv4')]:
         try:
-            if socket.gethostbyname(metadata['ec2_compat'][h_var]) == metadata['ec2_compat'][ip_var]:
+            if socket.gethostbyname(metadata['ec2_compat'][h_var]) == metadata['ec2_compat'][ip_var].split(',')[0]:
                 facts['network'][f_var] = metadata['ec2_compat'][h_var]
             else:
-                facts['network'][f_var] = metadata['ec2_compat'][ip_var]
+                facts['network'][f_var] = metadata['ec2_compat'][ip_var].split(',')[0]
         except socket.gaierror:
-            facts['network'][f_var] = metadata['ec2_compat'][ip_var]
+            facts['network'][f_var] = metadata['ec2_compat'][ip_var].split(',')[0]
 
     return facts
 


### PR DESCRIPTION
Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1648832

The `ip_var` would have `local-ipv4` of `ec_compat`, so it can be `10.0.1.1,10.0.2.2` as `hostname`(`f_var`).
So we should split the string as `IP address` before assigning as `hostname`.

For example.
~~~
            facts['network'][f_var] = metadata['ec2_compat'][ip_var]
~~~
