### PR TITLE
Release 3.11 Gluster installation missing defaults

### DIFF
--- a/roles/openshift_node/tasks/glusterfs.yml
+++ b/roles/openshift_node/tasks/glusterfs.yml
@@ -3,7 +3,7 @@
   package:
     name: glusterfs-fuse
     state: present
-  when: not openshift_is_atomic | bool
+  when: not openshift_is_atomic | default(False) | bool
   register: result
   until: result is succeeded
 

--- a/roles/openshift_storage_glusterfs/tasks/kernel_modules.yml
+++ b/roles/openshift_storage_glusterfs/tasks/kernel_modules.yml
@@ -9,7 +9,7 @@
   shell: "dnf install kernel-modules-$(uname -r) -y"
   when:
   - ansible_distribution == "Fedora"
-  - not (openshift_is_atomic | bool)
+  - not (openshift_is_atomic | default(False) | bool)
 
 - name: load kernel modules
   systemd:


### PR DESCRIPTION
PR moved from `3.10`: ([link](https://github.com/openshift/openshift-ansible/pull/10648) to original PR)
==============

When running the playbook to install Gluster (`/openshift-ansible/playbooks/openshift-glusterfs/config.yml`), tasks:

`openshift-ansible/roles/openshift_node/tasks/glusterfs.yml`
and
`openshift-ansible/roles/openshift_storage_glusterfs/tasks/kernel_modules.yml`

get run and they require the variable `openshift_is_atomic`.

This variable is set by `openshift-ansible/playbooks/init/basic_facts.yml` which gets run for:

`hosts: oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_nfs_to_config`

Seeing as worker and infra nodes are not in these host groups, you get the following error:

```
FAILED! => {"failed": true, "msg": "The conditional check 'not openshift_is_atomic | bool' failed. The error was: error while evaluating conditional (not openshift_is_atomic | bool): 'openshift_is_atomic' is undefined\n\nThe error appears to have been in '/usr/share/ansible/openshift-ansible/roles/openshift_node/tasks/glusterfs.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Install GlusterFS storage plugin dependencies\n  ^ here\n"}```