### PR TITLE
[release 3.11] Check if docker is running before attempting to restart it

### DIFF
--- a/roles/openshift_openstack/tasks/container-storage-setup.yml
+++ b/roles/openshift_openstack/tasks/container-storage-setup.yml
@@ -36,6 +36,11 @@
   when:
     - ansible_distribution == "CentOS"
 
+- name: Check if docker is running
+  command: systemctl status {{ openshift_docker_service_name }}
+  register: docker_running
+  ignore_errors: yes
+
 - name: restart docker after storage configuration
   become: yes
   systemd:
@@ -45,4 +50,6 @@
   until: not (l_docker_restart_docker_in_storage_setup_result is failed)
   retries: 3
   delay: 30
-  when: not openshift_use_crio_only|default(None)
+  when:
+    - not openshift_use_crio_only|default(None)
+    - docker_running.rc == 0


### PR DESCRIPTION
The docker restart added to the openstack storage task should only be run if docker is actually running.