### PR TITLE
Add network-project-id value for kubernetes config for GCP

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -305,6 +305,10 @@ debug_level=2
 # defined.
 # openshift_gcp_project is the project-id
 #openshift_gcp_project=
+# openshift_gcp_network_project is the project-id where the network-id lives defaults to openshift_gcp_project
+#openshift_gcp_network_project=
+# openshift_gcp_network_name is the network-id
+#openshift_gcp_network_name=
 # openshift_gcp_prefix is a unique string to identify each openshift cluster.
 #openshift_gcp_prefix=
 #openshift_gcp_multizone=False

--- a/roles/openshift_cloud_provider/tasks/gce.yml
+++ b/roles/openshift_cloud_provider/tasks/gce.yml
@@ -27,6 +27,7 @@
     value: "{{ item.value }}"
   with_items:
   - { key: 'project-id', value: '{{ openshift_gcp_project }}' }
+  - { key: 'network-project-id', value: '{{ openshift_gcp_network_project | default(openshift_gcp_project) }}' }
   - { key: 'network-name', value: '{{ openshift_gcp_network_name }}' }
   - { key: 'node-tags', value: '{{ openshift_gcp_prefix }}ocp' }
   - { key: 'node-instance-prefix', value: '{{ openshift_gcp_prefix }}' }

--- a/roles/openshift_gcp/defaults/main.yml
+++ b/roles/openshift_gcp/defaults/main.yml
@@ -14,6 +14,7 @@ openshift_gcp_region: us-central1
 openshift_gcp_zone: us-central1-a
 
 openshift_gcp_network_name: "{{ openshift_gcp_prefix }}network"
+openshift_gcp_network_project: ''
 
 openshift_gcp_iam_service_account: ''
 openshift_gcp_iam_service_account_keyfile: ''

--- a/roles/openshift_gcp/tasks/node_cloud_config.yml
+++ b/roles/openshift_gcp/tasks/node_cloud_config.yml
@@ -6,6 +6,7 @@
   ini_file: dest=/etc/origin/cloudprovider/gce.conf section=Global option={{ item.key }} value={{ item.value }} state=present create=yes
   with_items:
     - { key: 'project-id', value: '{{ openshift_gcp_project }}' }
+    - { key: 'network-project-id', value: '{{ openshift_gcp_network_project | default(openshift_gcp_project) }}' }
     - { key: 'network-name', value: '{{ openshift_gcp_network_name }}' }
     - { key: 'node-tags', value: '{{ openshift_gcp_prefix }}ocp' }
     - { key: 'node-instance-prefix', value: '{{ openshift_gcp_prefix }}' }


### PR DESCRIPTION
If the GCP network belongs to another GCP project, kubernetes needs to know the project-id.

Without this setting:
```
atomic-openshift-master-api[1256]: W1025 08:35:04.422245    1256 gce.go:446] Could not retrieve network "int-openshift"; err: googleapi: Error 404: The resource 'projects/nm-openshift/global/networks/int-openshift' was not found, notFound
```

If the GCP plugin fails on this early stage it will not be able to provision GCP persistent storage.

Documentation pull request: https://github.com/openshift/openshift-docs/pull/12846
