### PR TITLE
Release 3.11 vsphere network public network

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -321,7 +321,7 @@ debug_level=2
 #openshift_cloudprovider_vsphere_datacenter=datacenter
 #openshift_cloudprovider_vsphere_datastore=datastore
 #openshift_cloudprovider_vsphere_folder=optional_folder_name
-
+#openshift_cloudprovider_vsphere_network="public network portgroup"
 
 # Project Configuration
 #osm_project_request_message=''

--- a/roles/openshift_cloud_provider/templates/vsphere.conf.j2
+++ b/roles/openshift_cloud_provider/templates/vsphere.conf.j2
@@ -11,5 +11,9 @@ working-dir = /{{ openshift_cloudprovider_vsphere_datacenter }}/vm/{{ openshift_
 {% else %}
 working-dir = /{{ openshift_cloudprovider_vsphere_datacenter }}/vm/
 {% endif %}
+
 [Disk]
 scsicontrollertype = pvscsi
+
+[Network]
+public-network = "{{ openshift_cloudprovider_vsphere_network  | default('VM Network')}}"


### PR DESCRIPTION
1. Add inventory option for openshift_cloudprovider_vsphere_network in example
2. Add public-network section for vsphere jinja template and default to "VM Network".
