### PR TITLE
added provisioner file path parameter to template

### DIFF
--- a/roles/openshift_provisioners/templates/efs.j2
+++ b/roles/openshift_provisioners/templates/efs.j2
@@ -11,7 +11,7 @@ spec:
     provisioners-infra: "{{name}}"
     name: "{{name}}"
   strategy:
-    type: Recreate 
+    type: Recreate
   template:
     metadata:
       name: "{{deploy_name}}"
@@ -48,7 +48,7 @@ spec:
               value: "{{openshift_provisioners_efs_name}}"
           volumeMounts:
             - name: pv-volume
-              mountPath: /persistentvolumes
+              mountPath: "{{openshift_provisioners_efs_path}}"
       securityContext:
         supplementalGroups:
           - {{openshift_provisioners_efs_supplementalgroup}}


### PR DESCRIPTION
The provisioners role provides a parameter for a file path on the remote EFS/NFS volume, but it is ignored, as the variable is not part of the jinja2 template during the playbook execution. This PR replaces the static, hardcoded template value with the variable provided in the CLI. 

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
