### PR TITLE
Add log persistency to ovs

### DIFF
--- a/roles/openshift_sdn/files/sdn-ovs.yaml
+++ b/roles/openshift_sdn/files/sdn-ovs.yaml
@@ -91,6 +91,8 @@ spec:
           readOnly: true
         - mountPath: /etc/openvswitch
           name: host-config-openvswitch
+        - mountPath: /var/log/openvswitch
+          name: log-openvswitch
         resources:
           requests:
             cpu: 100m
@@ -112,3 +114,6 @@ spec:
       - name: host-config-openvswitch
         hostPath:
           path: /etc/origin/openvswitch
+      - name: log-openvswitch
+        hostPath:
+          path: /var/log/openvswitch


### PR DESCRIPTION
This is useful for debugging the ovs containers when there is a problem and the pod is in CrashLoopBackoff or the logs are not retrievable for some reason directly from the pod.
