### PR TITLE
Retrieve heketi secret before setting CLI command

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/update_topology.yml
+++ b/roles/openshift_storage_glusterfs/tasks/update_topology.yml
@@ -8,8 +8,8 @@
   block:
   - import_tasks: glusterfs_config_facts.yml
   - import_tasks: label_nodes.yml
-  - import_tasks: heketi_pod_check.yml
   - import_tasks: heketi_get_key.yml
+  - import_tasks: heketi_pod_check.yml
   - import_tasks: wait_for_pods.yml
   - import_tasks: heketi_load.yml
     when:
@@ -20,8 +20,8 @@
   block:
   - import_tasks: glusterfs_registry_facts.yml
   - import_tasks: label_nodes.yml
-  - import_tasks: heketi_pod_check.yml
   - import_tasks: heketi_get_key.yml
+  - import_tasks: heketi_pod_check.yml
   - import_tasks: wait_for_pods.yml
   - import_tasks: heketi_load.yml
     when:


### PR DESCRIPTION
Swap order for `heketi_get_key.yml` and `heketi_pod_check.yml` tasks
imports in `update_topology.yml` as the latter depends on the former
for cheking the status of heketi service.

This caused the "Verify heketi service" task to fail with invalid
signature error unless the heketi secret was set with
`openshift_storage_glusterfs_heketi_admin_key` or
`openshift_storage_glusterfs_registry_heketi_admin_key` ansible
variables.

Closes #9068
Related rhbz#1637105
Related rhbz#1645656
Related rhbz#1640382