### PR TITLE
[release-3.7] Allow openshift_install_examples to be false

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/post_control_plane.yml
@@ -94,11 +94,11 @@
   # not already exist. We could have potentially done a replace --force to
   # create and update in one step.
   - role: openshift_examples
-    when: openshift_install_examples | default(true,true) | bool
+    when: openshift_install_examples | default(true) | bool
   - openshift_hosted_templates
   # Update the existing templates
   - role: openshift_examples
-    when: openshift_install_examples | default(true,true) | bool
+    when: openshift_install_examples | default(true) | bool
     registry_url: "{{ openshift.master.registry_url }}"
     openshift_examples_import_command: replace
   - role: openshift_hosted_templates

--- a/playbooks/common/openshift-master/additional_config.yml
+++ b/playbooks/common/openshift-master/additional_config.yml
@@ -22,7 +22,7 @@
   - role: openshift_project_request_template
     when: openshift_project_request_template_manage
   - role: openshift_examples
-    when: openshift_install_examples | default(true, true) | bool
+    when: openshift_install_examples | default(true) | bool
     registry_url: "{{ openshift.master.registry_url }}"
   - role: openshift_hosted_templates
     registry_url: "{{ openshift.master.registry_url }}"


### PR DESCRIPTION
when using yaml or json, a false value is converted to true

Backports #6134

https://bugzilla.redhat.com/show_bug.cgi?id=1634685