### PR TITLE
Handle audit log paths different from defaults

### DIFF
--- a/roles/lib_utils/action_plugins/master_check_paths_in_config.py
+++ b/roles/lib_utils/action_plugins/master_check_paths_in_config.py
@@ -23,6 +23,7 @@ for you: {}"""
 
 ITEMS_TO_POP = (
     ('oauthConfig', 'identityProviders'),
+    ('auditConfig', 'auditFilePath'),
 )
 # Create csv string of dot-separated dictionary keys:
 # eg: 'oathConfig.identityProviders, something.else.here'
@@ -48,8 +49,10 @@ def pop_migrated_fields(mastercfg):
         field = mastercfg
         for sub_field in item:
             parent_field = field
+            if sub_field not in field:
+                continue
             field = field[sub_field]
-        parent_field.pop(item[len(item) - 1])
+        parent_field.pop(item[len(item) - 1], None)
 
 
 def do_item_check(val, strings_to_check):

--- a/roles/lib_utils/test/test_master_check_paths_in_config.py
+++ b/roles/lib_utils/test/test_master_check_paths_in_config.py
@@ -24,6 +24,8 @@ def loaded_config():
         'oauthConfig':
         {'identityProviders':
             ['1', '2', '/this/will/fail']},
+        'auditConfig':
+        {'auditFilePath': "/var/log/audit-ocp.log"},
         'fake_top_item':
         {'fake_item':
             {'fake_item2':

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -44,6 +44,18 @@
     path: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
     mode: '0750'
 
+- name: Create openshift audit log directory
+  file:
+    state: directory
+    path: "{{ openshift.master.audit_config.auditFilePath | dirname }}"
+    mode: 0700
+  when:
+  - openshift.master.audit_config is defined
+  - openshift.master.audit_config.auditFilePath is defined
+  - not "/etc/origin/master" in openshift.master.audit_config.auditFilePath
+  - not "/var/lib/origin" in openshift.master.audit_config.auditFilePath
+  - not "/etc/origin/cloudprovider" in openshift.master.audit_config.auditFilePath
+
 - name: Create the policy file if it does not already exist
   command: >
     {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig

--- a/roles/openshift_control_plane/tasks/static.yml
+++ b/roles/openshift_control_plane/tasks/static.yml
@@ -45,6 +45,31 @@
     - key: spec.containers[0].readinessProbe.httpGet.port
       value: "{{ openshift_master_api_port }}"
 
+- name: Add audit volume to master static pod (api)
+  yedit:
+    src: "{{ mktemp.stdout }}/apiserver.yaml"
+    append: true
+    key: spec.volumes
+    value:
+      name: audit-logs
+      hostPath:
+        path: "{{ openshift.master.audit_config.auditFilePath | dirname }}"
+  when:
+  - openshift.master.audit_config is defined
+  - openshift.master.audit_config.auditFilePath is defined
+
+- name: Add audit volumeMounts to master static pod (api)
+  yedit:
+    src: "{{ mktemp.stdout }}/apiserver.yaml"
+    append: true
+    key: spec.containers[0].volumeMounts
+    value:
+      mountPath: "{{ openshift.master.audit_config.auditFilePath | dirname }}"
+      name: audit-logs
+  when:
+  - openshift.master.audit_config is defined
+  - openshift.master.audit_config.auditFilePath is defined
+
 - name: ensure pod location exists
   file:
     path: "{{ openshift_control_plane_static_pod_location }}"


### PR DESCRIPTION
This commit is intended to make the installer able to handle OpenShift log paths different from (/etc/origin/master, /var/lib/origin, /etc/origin/cloudprovider), which in most of cases are not appropiate since those directories are not usually used as log store.

The code included create new directory (if applies) and adds it as a hostPath in the apiserver static pod definition. The code of the custom module master_check_paths_in_config has been also properly tuned to allow this directories to be defined in the master-config.yaml
