### PR TITLE
GlusterFS: Recreate config directories for external uninstall

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
@@ -106,26 +106,29 @@
   when:
   - not glusterfs_is_native | bool
 
-- name: Delete GlusterFS config
+- name: Delete GlusterFS directories
   file:
-    path: /var/lib/glusterd
+    path: "{{ item[1] }}"
     state: absent
-  delegate_to: "{{ item }}"
-  with_items: "{{ glusterfs_nodes | default([]) }}"
+  delegate_to: "{{ item[0] }}"
+  with_nested:
+  - "{{ glusterfs_nodes | default([]) }}"
+  - /var/lib/glusterd
+    /etc/glusterfs
+    /var/lib/heketi
 
-- name: Delete additional GlusterFS config
+- name: Restore GlusterFS directories (external)
   file:
-    path: /etc/glusterfs
-    state: absent
-  delegate_to: "{{ item }}"
-  with_items: "{{ glusterfs_nodes | default([]) }}"
-
-- name: Delete Heketi config
-  file:
-    path: /var/lib/heketi
-    state: absent
-  delegate_to: "{{ item }}"
-  with_items: "{{ glusterfs_nodes | default([]) }}"
+    path: "{{ item[1] }}"
+    state: directory
+  delegate_to: "{{ item[0] }}"
+  with_nested:
+  - "{{ glusterfs_nodes | default([]) }}"
+  - /var/lib/glusterd
+    /etc/glusterfs
+    /var/lib/heketi
+  when:
+  - not glusterfs_is_native | bool
 
 # This recreates expected directory structures
 - name: Reinstall GlusterFS Server (external)


### PR DESCRIPTION
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1651311

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>