### PR TITLE
Increase delay time for get credntials

### DIFF
--- a/roles/openshift_node/tasks/registry_auth.yml
+++ b/roles/openshift_node/tasks/registry_auth.yml
@@ -27,7 +27,7 @@
     - oreg_auth_user is defined
   register: node_oreg_auth_credentials_create
   retries: 3
-  delay: 5
+  delay: 20
   until: node_oreg_auth_credentials_create is succeeded
 
 - name: Create credentials for any additional registries
@@ -45,7 +45,7 @@
     - openshift_additional_registry_credentials != []
   register: node_additional_registry_creds
   retries: 3
-  delay: 5
+  delay: 20
   until: node_additional_registry_creds is succeeded
   with_items:
     "{{ openshift_additional_registry_credentials }}"


### PR DESCRIPTION
Due to the default delay time is too short, it may cause the system doesn't have engough time to get the credentials.

The solution is better to increase delay time from 5s to 20s.

Signed-off-by: Phil Huang <phil.huang@redhat.com>

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
