### PR TITLE
[release-3.10] Reload tuned service when node-config.yaml has changed.

### DIFF
--- a/roles/openshift_node_group/files/sync.yaml
+++ b/roles/openshift_node_group/files/sync.yaml
@@ -121,6 +121,7 @@ spec:
             md5sum /etc/origin/node/tmp/node-config.yaml > /tmp/.new
             if [[ "$( cat /tmp/.old )" != "$( cat /tmp/.new )" ]]; then
               mv /etc/origin/node/tmp/node-config.yaml /etc/origin/node/node-config.yaml
+              SYSTEMD_IGNORE_CHROOT=1 systemctl restart tuned || :
               echo "info: Configuration changed, restarting kubelet" 2>&1
               # TODO: kubelet doesn't relabel nodes, best effort for now
               # https://github.com/kubernetes/kubernetes/issues/59314
@@ -171,6 +172,12 @@ spec:
         - mountPath: /etc/sysconfig
           name: host-sysconfig-node
           readOnly: true
+        - mountPath: /var/run/dbus
+          name: var-run-dbus
+          readOnly: true
+        - mountPath: /run/systemd/system
+          name: run-systemd-system
+          readOnly: true
 
       volumes:
       # In bootstrap mode, the host config contains information not easily available
@@ -181,3 +188,9 @@ spec:
       - name: host-sysconfig-node
         hostPath:
           path: /etc/sysconfig
+      - name: var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: run-systemd-system
+        hostPath:
+          path: /run/systemd/system


### PR DESCRIPTION
One of the tasks of the openshift-ansible installer is to include the tuned
role and apply the correct per-node tuning.  The tuned role relies on the
"recommend" tuned daemon functionality, which queries node-config.yaml for
appropriate node labels and sets the correct tuned profile according to these
labels.  Unfortunately, with the introduction of the openshift-node/sync pods,
the node labelling information may be set by the sync pods after the installer
finished and therefore OpenShift nodes may run with incorrect tuned profiles.

This PR adds a functionality to restart the tuned daemon and as a result set
the correct tuned profile when node-config.yaml changes.

Backports: #10102

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1569917

/cc jmencak