### PR TITLE
Check for node-config.yaml file when comparing config changes in sync pod. 

### DIFF
--- a/roles/openshift_node_group/files/sync.yaml
+++ b/roles/openshift_node_group/files/sync.yaml
@@ -119,6 +119,10 @@ spec:
             fi
 
             # detect whether the node-config.yaml has changed, and if so trigger a restart of the kubelet.
+            if [[ ! -f /etc/origin/node/node-config.yaml ]]; then
+              cat /dev/null > /tmp/.old
+            fi
+
             md5sum /etc/origin/node/tmp/node-config.yaml > /tmp/.new
             if [[ "$( cat /tmp/.old )" != "$( cat /tmp/.new )" ]]; then
               mv /etc/origin/node/tmp/node-config.yaml /etc/origin/node/node-config.yaml


### PR DESCRIPTION
If node-config.yaml does not exist, wipe contents of /tmp/.old. This will copy
the configuration file over if node-config.yaml was delete externally.

Fixes bug [https://bugzilla.redhat.com/show_bug.cgi?id=1639655](https://bugzilla.redhat.com/show_bug.cgi?id=1639655)