### PR TITLE
Added Capability to assign an empty hostname to the created VMs

### DIFF
--- a/roles/openshift_ovirt/README.md
+++ b/roles/openshift_ovirt/README.md
@@ -34,6 +34,7 @@ The `openshift_ovirt_vm_manifest` variable can contain following attributes
 | Name      | Type | Default value |                                                                                                                 |
 |-----------|------|---------------|-----------------------------------------------------------------------------------------------------------------|
 | nic_mode  | Dict | UNDEF         | If you define this variable means that the interface on the VM will have static address instead of dynamic one. |
+| empty_hostname  | Bool | True   | If True, the VM's Hostname will remain empty in cloud-init, and will relays the VM's hostname on DHCP name. |
 
 Below `nic_mode` we can find this other parameters
 
@@ -102,6 +103,7 @@ openshift_ovirt_vm_manifest:
 - name: 'master'
   count: 3
   profile: 'master'
+  empty_hostname: True
   nic_mode:
       # This must fit the same name as this kind of vms. (e.g) if the name is test, this must be test0
       master0:

--- a/roles/openshift_ovirt/tasks/build_vm_list.yml
+++ b/roles/openshift_ovirt/tasks/build_vm_list.yml
@@ -26,7 +26,7 @@
       'cloud_init':
       {
       {% if item.count == 1 -%}
-      'host_name': '{{ item.name }}.{{ openshift_ovirt_dns_zone }}',
+      'host_name': '{{  (item.empty_hostname | default(True)) | ternary('', item.name + '.' + openshift_ovirt_dns_zone) }}',
         {% if item.nic_mode is defined -%}
       'nic_boot_protocol': 'static',
       'nic_ip_address': '{{ item["nic_mode"][item["name"]]["nic_ip_address"] }}',
@@ -46,7 +46,7 @@
       'dns_search': '{{ item["dns_search"] }}',
         {% endif -%}
       {% elif item.count > 1 -%}
-      'host_name': '{{ item.name }}{{ iter }}.{{ openshift_ovirt_dns_zone }}',
+      'host_name': '{{  (item.empty_hostname | default(True)) | ternary('', item.name + iter | string + '.' + openshift_ovirt_dns_zone) }}',
         {% if item.nic_mode is defined -%}
       'nic_boot_protocol': 'static',
       'nic_ip_address': '{{ item["nic_mode"][item["name"] + iter | string ]["nic_ip_address"] }}',


### PR DESCRIPTION
This feature gives to **openshift_ovirt** role the capability to relies the hostname definition to DHCP.

The implementation is very simple, just let the `host_name` field on cloud-init empty to allow DHCP to manage it, it's needed to set a boolean `empty_hostname` to `True` to activate this feature.

Comming from already closed PR: https://github.com/openshift/openshift-ansible/pull/10597