### PR TITLE
Create the namespace only in the first master

### DIFF
--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -1,8 +1,10 @@
 ---
+# kube_proxy_and_dns should be called only once, and run_once is not honored with import_role
+# using a when statement to control this
 - name: Calico | Run kube proxy
-  run_once: true
   import_role:
     name: kube_proxy_and_dns
+  when: "ansible_hostname == groups.oo_first_master.0"
 
 - include_tasks: certs.yml
 


### PR DESCRIPTION
Using delegate_to to avoid the namespace being created in all the masters, which will result in the playbook failing.