### PR TITLE
[release-3.11] Call version.yml before repos.yml to ensure openshift_version is set

### DIFF
--- a/roles/openshift_repos/meta/main.yml
+++ b/roles/openshift_repos/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  author: OpenShift Development <dev@lists.openshift.redhat.com>
+  description: Enable additional repositories
+  company: Red Hat, Inc.
+  license: license (Apache)
+  min_ansible_version: 2.2
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  - name: Fedora
+    versions:
+    - all
+  categories:
+  - openshift
+dependencies:
+- role: openshift_version

--- a/roles/openshift_repos/tasks/rhel_repos.yml
+++ b/roles/openshift_repos/tasks/rhel_repos.yml
@@ -26,7 +26,7 @@
   command: subscription-manager repos \
                --enable="rhel-7-server-rpms" \
                --enable="rhel-7-server-extras-rpms" \
-               --enable="rhel-7-server-ose-{{ ( openshift_version ).split('.')[0:2] | join('.') }}-rpms"
+               --enable="rhel-7-server-ose-{{ ( openshift_release ).split('.')[0:2] | join('.') }}-rpms"
   register: subscribe_repos
   until: subscribe_repos is succeeded
   when: repo_rhel.changed


### PR DESCRIPTION
repos.yml requires openshift_version to be set if RHEL repositories are to be enabled. Calling version.yml before repos.yml ensures openshift_version is set.