### PR TITLE
kuryr: support new openshift sdn binary

### DIFF
--- a/roles/kuryr/templates/cni-daemonset.yaml.j2
+++ b/roles/kuryr/templates/cni-daemonset.yaml.j2
@@ -92,6 +92,9 @@ spec:
           oc config --config=/tmp/kubeconfig set-context "$( oc config --config=/tmp/kubeconfig current-context )" --user=sa
 
           # Launch the SkyDNS
+          if which openshift-sdn; then
+            exec openshift-sdn --enable=dns --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
+          fi
           exec openshift start network --enable=dns --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
 
         securityContext:


### PR DESCRIPTION
okd master deprecated openshift start network moving the functionality
into the openshift-sdn binary. This patch makes the kuryr cni daemonset
use the new binary when available.

Signed-off-by: Antoni Segura Puimedon <celebdor@gmail.com>

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
