### PR TITLE
Use new node labels for descheduler

### DIFF
--- a/roles/openshift_descheduler/defaults/main.yaml
+++ b/roles/openshift_descheduler/defaults/main.yaml
@@ -45,7 +45,7 @@ openshift_descheduler_strategy_low_node_utilization_dict:
 
 # descheduler cronjob setup
 openshift_descheduler_cronjob_name: descheduler-cronjob
-openshift_descheduler_cronjob_node_selector: {"type": "infra"}
+openshift_descheduler_cronjob_node_selector: {"node-role.kubernetes.io/infra": "true"}
 # by default (00:00) everyday
 openshift_descheduler_cronjob_schedule: "*/1 0 * * *"
 


### PR DESCRIPTION
type=infra should not work by default