### PR TITLE
Set no_log for registry login

### DIFF
--- a/roles/container_runtime/tasks/registry_auth.yml
+++ b/roles/container_runtime/tasks/registry_auth.yml
@@ -17,6 +17,7 @@
   register: crt_oreg_auth_credentials_create
   retries: 3
   delay: 5
+  no_log: true
   until: crt_oreg_auth_credentials_create is succeeded
 
 - name: Create for any additional registries
@@ -35,6 +36,7 @@
   register: crt_addl_credentials_create
   retries: 3
   delay: 5
+  no_log: true
   until: crt_addl_credentials_create is succeeded
   with_items:
     "{{ openshift_additional_registry_credentials }}"


### PR DESCRIPTION
Without no_log enabled on the play, when logging into the registry (especially for
openshift-enterprise installations), you'll expose the registry login password on the
console. Hide it with no_log for safety.

Closes #10753