### PR TITLE
Correct the ose image name when installation

### DIFF
--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -23,7 +23,7 @@ openshift_additional_registry_credentials: []
 l_os_non_standard_reg_url: "{{ oreg_url | default(l_osm_registry_url_default) }}"
 
 l_docker_creds_image_dict:
-  openshift-enterprise: 'openshift3/ose'
+  openshift-enterprise: 'openshift3/ose-control-plane:${version}'
   origin: 'openshift/origin'
 l_docker_creds_test_image: "{{ l_docker_creds_image_dict[openshift_deployment_type] }}"
 


### PR DESCRIPTION
After 3.11.x, openshift-ansible should use openshift3/ose-control-plane, not openshift3/ose.

Signed-off-by: Phil Huang <phil.huang@redhat.com>

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
