### PR TITLE
Extend OpenStack cloud provider's LBaaS configuration

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -295,6 +295,7 @@ debug_level=2
 #openshift_cloudprovider_openstack_tenant_name=tenant_name
 #openshift_cloudprovider_openstack_region=region
 #openshift_cloudprovider_openstack_lb_subnet_id=subnet_id
+#openshift_cloudprovider_openstack_lb_floating_network_id=floating_network_id
 #
 # Note: If you're getting a "BS API version autodetection failed" when provisioning cinder volumes you may need this setting
 #openshift_cloudprovider_openstack_blockstorage_version=v2

--- a/roles/openshift_cloud_provider/defaults/main.yml
+++ b/roles/openshift_cloud_provider/defaults/main.yml
@@ -5,3 +5,7 @@ openshift_gcp_network_name: "{{ openshift_gcp_prefix }}network"
 openshift_gcp_multizone: False
 openshift_openstack_ca_file_path: '/etc/origin/cloudprovider/openstack.crt'
 openshift_cloudprovider_openstack_blockstorage_ignore_volume_az: false
+# When 'true' and an Octaiva LBaaS V2 entry can not be found, the provider will
+# fall back and attempt to find a Neutron LBaaS V2 endpoint instead (which is
+# the behaviour when this is set to 'false')
+openshift_cloudprovider_openstack_use_octavia: true

--- a/roles/openshift_cloud_provider/templates/openstack.conf.j2
+++ b/roles/openshift_cloud_provider/templates/openstack.conf.j2
@@ -21,6 +21,10 @@ ca-file = {{ openshift_openstack_ca_file_path }}
 {% if openshift_cloudprovider_openstack_lb_subnet_id is defined %}
 [LoadBalancer]
 subnet-id = {{ openshift_cloudprovider_openstack_lb_subnet_id }}
+use-octavia = {{ openshift_cloudprovider_openstack_use_octavia }}
+{% if openshift_cloudprovider_openstack_lb_floating_network_id is defined %}
+floating-network-id = {{ openshift_cloudprovider_openstack_lb_floating_network_id }}
+{% endif %}
 {% endif %}
 [BlockStorage]
 ignore-volume-az = {{ openshift_cloudprovider_openstack_blockstorage_ignore_volume_az | bool | ternary('yes', 'no') }}


### PR DESCRIPTION
Currently the only setting related to LBaaS configuration on openstack.conf is `subnet-id`.

When attempting to configure OSP 13 as a cloud provider and use LBaaS to access LoadBalancer services from the outside, we had to additionally specify at least `use-octavia` and `floating-network-id` to make it work.

There are [other options](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer) that could be added as optional, but I beleive that at least these two should be there.