### PR TITLE
Extend Openstack cloud provider LB parameters

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -295,6 +295,7 @@ debug_level=2
 #openshift_cloudprovider_openstack_tenant_name=tenant_name
 #openshift_cloudprovider_openstack_region=region
 #openshift_cloudprovider_openstack_lb_subnet_id=subnet_id
+#openshift_cloudprovider_openstack_lb_floating_network_id=floating_network_id
 #
 # Note: If you're getting a "BS API version autodetection failed" when provisioning cinder volumes you may need this setting
 #openshift_cloudprovider_openstack_blockstorage_version=v2

--- a/roles/openshift_cloud_provider/defaults/main.yml
+++ b/roles/openshift_cloud_provider/defaults/main.yml
@@ -5,3 +5,6 @@ openshift_gcp_network_name: "{{ openshift_gcp_prefix }}network"
 openshift_gcp_multizone: False
 openshift_openstack_ca_file_path: '/etc/origin/cloudprovider/openstack.crt'
 openshift_cloudprovider_openstack_blockstorage_ignore_volume_az: false
+# In case Neutron LBaaS V2 endpoint should be used change this variable
+# to false
+openshift_cloudprovider_openstack_use_octavia: true

--- a/roles/openshift_cloud_provider/templates/openstack.conf.j2
+++ b/roles/openshift_cloud_provider/templates/openstack.conf.j2
@@ -18,9 +18,15 @@ region = {{ openshift_cloudprovider_openstack_region }}
 {% if openshift_cloudprovider_openstack_ca_file is defined %}
 ca-file = {{ openshift_openstack_ca_file_path }}
 {% endif %}
-{% if openshift_cloudprovider_openstack_lb_subnet_id is defined %}
+{% if (openshift_cloudprovider_openstack_lb_subnet_id is defined) or (openshift_cloudprovider_openstack_lb_floating_network_id is defined) %}
 [LoadBalancer]
+use-octavia = {{ openshift_cloudprovider_openstack_use_octavia }}
+{% if openshift_cloudprovider_openstack_lb_subnet_id is defined %}
 subnet-id = {{ openshift_cloudprovider_openstack_lb_subnet_id }}
+{% endif %}
+{% if openshift_cloudprovider_openstack_lb_floating_network_id is defined %}
+floating-network-id = {{ openshift_cloudprovider_openstack_lb_floating_network_id }}
+{% endif %}
 {% endif %}
 [BlockStorage]
 ignore-volume-az = {{ openshift_cloudprovider_openstack_blockstorage_ignore_volume_az | bool | ternary('yes', 'no') }}


### PR DESCRIPTION
This commit enables control of the following
parameters in  Openstack cloud provider Loadbalancer:

**Use Octavia:**  which OpenStack LBaaS endpoint
(Octavia or Neutron LBaaS) should be used.

**Floating IP network:** the network ID in which floating IPs
will be allocated from. If not specified, the first network
that marked as external will be used.

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
