### PR TITLE
Make tuned.conf syntax consistent

### DIFF
--- a/roles/tuned/templates/openshift/tuned.conf
+++ b/roles/tuned/templates/openshift/tuned.conf
@@ -13,7 +13,7 @@ avc_cache_threshold=8192
 nf_conntrack_hashsize=131072
 
 [sysctl]
-kernel.pid_max=>131072
+kernel.pid_max=131072
 net.netfilter.nf_conntrack_max=1048576
 fs.inotify.max_user_watches=65536
 net.ipv4.neigh.default.gc_thresh1=8192


### PR DESCRIPTION
Replace kernel.pid_max=>131072 with kernel.pid_max=131072

I found kernel.pid_max not being applied to every node, I suspect this might not work on some tuned versions.
As it is inconsistent and I haven't found a single reference to the => syntax in tuned.conf(5), I assume this is a typo that happens to work on some tuned versions.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653218