### PR TITLE
Fixed wrong path to role in node scaleup playbook

### DIFF
--- a/playbooks/openshift-node/scaleup.yml
+++ b/playbooks/openshift-node/scaleup.yml
@@ -39,6 +39,6 @@
 - name: Ensure master facts are set
   hosts: oo_masters_to_config
   roles:
-  - openshift_master_facts
+  - ../../roles/openshift_master_facts
 
 - import_playbook: private/config.yml


### PR DESCRIPTION
Providing a fix for #10766 by setting the correct path to the role for scaling up nodes in an existing cluster.