### PR TITLE
Add openssh-clients dependency

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -32,6 +32,7 @@ Requires:      python-passlib
 Requires:      python2-crypto
 Requires:      patch
 Requires:      pyOpenSSL
+Requires:      openssh-clients
 
 %description
 Openshift and Atomic Enterprise Ansible


### PR DESCRIPTION
Previously, openshift-ansible depended on atomic-openshift-clients,
which depnded on git, which depended on openssh-clients. However in 3.10
and newer the dependency on git was removed from
atomic-openshift-clients resulting in openssh-clients no longer being
installed inside the container image.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1625779
Origin 3.10 change here https://github.com/openshift/origin/commit/99e9405018b29de20ea3874bbbe8d62c1cc8278d