### PR TITLE
Revert haproxy log config to default

### DIFF
--- a/roles/openshift_loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/openshift_loadbalancer/templates/haproxy.cfg.j2
@@ -2,7 +2,7 @@
 #---------------------------------------------------------------------
 global
     maxconn     {{ openshift_loadbalancer_global_maxconn | default(20000) }}
-    log         /dev/log local0 info
+    log         127.0.0.1 local2
 {% if openshift_is_atomic | bool %}
     stats socket /var/lib/haproxy/run/haproxy.sock mode 600 level admin
 {% else %}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1651856
This was originally configured here in order to make sure that logging worked inside containerized installations of the load balancer however that's no longer a concern in 3.11 and 3.10.