### PR TITLE
DO NOT MERGE - Debugging sdn flake

### DIFF
--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -103,9 +103,9 @@ spec:
           oc config --config=/tmp/kubeconfig set-context "$( oc config --config=/tmp/kubeconfig current-context )" --user=sa
           # Launch the network process
           if which openshift-sdn; then
-            exec openshift-sdn --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
+            exec openshift-sdn --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=6
           fi
-          exec openshift start network --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
+          exec openshift start network --config=/etc/origin/node/node-config.yaml --kubeconfig=/tmp/kubeconfig --loglevel=6
 
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
Setting SDN to loglevel=6 to try and recreate a no route to host
error in an router test.