### PR TITLE
Also set etcd_cert_config_dir for calico

### DIFF
--- a/roles/calico/tasks/certs.yml
+++ b/roles/calico/tasks/certs.yml
@@ -30,6 +30,7 @@
   vars:
     etcd_cert_prefix: calico-etcd-
     etcd_conf_dir: "{{ calico_etcd_cert_dir }}"
+    etcd_cert_config_dir: "{{ calico_etcd_cert_dir }}"
     etcd_ca_host: "{{ groups.oo_etcd_to_config.0 }}"
     etcd_cert_subdir: "calico-etcd-{{ openshift.common.hostname }}"
 


### PR DESCRIPTION
This was preventing initial cluster deployment from working as expected.

Additional fixes for https://bugzilla.redhat.com/show_bug.cgi?id=1644416
