### PR TITLE
Add support for tls.insecureEdgeTerminationPolicy to oc_route

### DIFF
--- a/roles/lib_openshift/library/oc_route.py
+++ b/roles/lib_openshift/library/oc_route.py
@@ -1539,6 +1539,7 @@ class RouteConfig(object):
                  key=None,
                  host=None,
                  tls_termination=None,
+                 insecure_edge_termination_policy=None,
                  service_name=None,
                  wildcard_policy=None,
                  weight=None,
@@ -1550,6 +1551,7 @@ class RouteConfig(object):
         self.labels = labels
         self.host = host
         self.tls_termination = tls_termination
+        self.insecure_edge_termination_policy = insecure_edge_termination_policy
         self.destcacert = destcacert
         self.cacert = cacert
         self.cert = cert
@@ -1583,6 +1585,9 @@ class RouteConfig(object):
             self.data['spec']['tls'] = {}
 
             self.data['spec']['tls']['termination'] = self.tls_termination
+
+            if self.insecure_edge_termination_policy:
+                self.data['spec']['tls']['insecureEdgeTerminationPolicy'] = self.insecure_edge_termination_policy
 
             if self.tls_termination != 'passthrough':
                 self.data['spec']['tls']['key'] = self.key
@@ -1792,6 +1797,7 @@ class OCRoute(OpenShiftCLI):
                               files['key']['value'],
                               params['host'],
                               params['tls_termination'],
+                              params['insecure_edge_termination_policy'],
                               params['service_name'],
                               params['wildcard_policy'],
                               params['weight'],
@@ -1894,6 +1900,7 @@ def main():
             name=dict(default=None, required=True, type='str'),
             namespace=dict(default=None, required=True, type='str'),
             tls_termination=dict(default=None, type='str'),
+            insecure_edge_termination_policy=dict(default=None, type='str'),
             dest_cacert_path=dict(default=None, type='str'),
             cacert_path=dict(default=None, type='str'),
             cert_path=dict(default=None, type='str'),

--- a/roles/lib_openshift/src/ansible/oc_route.py
+++ b/roles/lib_openshift/src/ansible/oc_route.py
@@ -17,6 +17,7 @@ def main():
             name=dict(default=None, required=True, type='str'),
             namespace=dict(default=None, required=True, type='str'),
             tls_termination=dict(default=None, type='str'),
+            insecure_edge_termination_policy=dict(default=None, type='str'),
             dest_cacert_path=dict(default=None, type='str'),
             cacert_path=dict(default=None, type='str'),
             cert_path=dict(default=None, type='str'),

--- a/roles/lib_openshift/src/class/oc_route.py
+++ b/roles/lib_openshift/src/class/oc_route.py
@@ -128,6 +128,7 @@ class OCRoute(OpenShiftCLI):
                               files['key']['value'],
                               params['host'],
                               params['tls_termination'],
+                              params['insecure_edge_termination_policy'],
                               params['service_name'],
                               params['wildcard_policy'],
                               params['weight'],

--- a/roles/lib_openshift/src/lib/route.py
+++ b/roles/lib_openshift/src/lib/route.py
@@ -18,6 +18,7 @@ class RouteConfig(object):
                  key=None,
                  host=None,
                  tls_termination=None,
+                 insecure_edge_termination_policy=None,
                  service_name=None,
                  wildcard_policy=None,
                  weight=None,
@@ -29,6 +30,7 @@ class RouteConfig(object):
         self.labels = labels
         self.host = host
         self.tls_termination = tls_termination
+        self.insecure_edge_termination_policy = insecure_edge_termination_policy
         self.destcacert = destcacert
         self.cacert = cacert
         self.cert = cert
@@ -62,6 +64,9 @@ class RouteConfig(object):
             self.data['spec']['tls'] = {}
 
             self.data['spec']['tls']['termination'] = self.tls_termination
+
+            if self.insecure_edge_termination_policy:
+                self.data['spec']['tls']['insecureEdgeTerminationPolicy'] = self.insecure_edge_termination_policy
 
             if self.tls_termination != 'passthrough':
                 self.data['spec']['tls']['key'] = self.key


### PR DESCRIPTION
This patch allows to set a value to the `insecureEdgeTerminationPolicy` parameter when creating a route.