### PR TITLE
Added ovirt_admin variable to avoid use admin rights on RHV platform

### DIFF
--- a/roles/openshift_ovirt/README.md
+++ b/roles/openshift_ovirt/README.md
@@ -35,6 +35,7 @@ The `openshift_ovirt_vm_manifest` variable can contain following attributes
 |-----------|------|---------------|-----------------------------------------------------------------------------------------------------------------|
 | nic_mode  | Dict | UNDEF         | If you define this variable means that the interface on the VM will have static address instead of dynamic one. |
 | empty_hostname  | Bool | True   | If True, the VM's Hostname will remain empty in cloud-init, and will relays the VM's hostname on DHCP name. |
+| ovirt_admin  | Bool | True   | If False, the role will not try to add tags to the created vms and also avoid to get into affinity groups. This way the role could be executed without admin rights |
 
 Below `nic_mode` we can find this other parameters
 

--- a/roles/openshift_ovirt/tasks/build_vm_list.yml
+++ b/roles/openshift_ovirt/tasks/build_vm_list.yml
@@ -21,7 +21,9 @@
       {% elif item.count > 1 -%}
       'name': '{{ item.name }}{{ iter }}.{{ openshift_ovirt_dns_zone }}',
       {% endif -%}
-      'tag': 'openshift_{{ item.profile }}',
+      {% if ovirt_admin | default(True) -%}
+      'tag': "openshift_{{ item.profile }}",
+      {% endif -%}
       'description': '{{ item.description | default("") }}',
       'cloud_init':
       {
@@ -75,21 +77,25 @@
       {% endfor -%}
       ]
     affinity_groups: >-
+      {% if ovirt_admin | default(True) -%}
       {{ affinity_groups|default([]) }} + [
-      {% if item.count > 1 -%}
-      {
+        {% if item.count > 1 -%}
+        {
       'name': '{{ item.name }}_ag',
       'cluster': '{{ openshift_ovirt_cluster }}',
       'vm_enforcing': 'false',
       'vm_rule': 'negative',
       'vms': [
-      {% for iter in range(item.count) -%}
+        {% for iter in range(item.count) -%}
       '{{ item.name }}{{ iter }}.{{ openshift_ovirt_dns_zone }}',
-      {% endfor -%}
+        {% endfor -%}
       ]
-      }
+        }
+        {% endif -%}
+      ]
+      {% else -%}
+      []
       {% endif -%}
-      ]
   with_items: "{{ openshift_ovirt_vm_manifest }}"
   tags:
   - openshift_ovirt


### PR DESCRIPTION
This feature adds the capability to deploy VMs without admin rights.

Let the VM tags and affinity groups empty if `ovirt_admin` is set to `False`
