### PR TITLE
glusterfs: bind-mount /dev/disk into the glusterfs-server container

### DIFF
--- a/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
+++ b/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
@@ -63,6 +63,8 @@ objects:
             mountPath: "/var/log/glusterfs"
           - name: glusterfs-config
             mountPath: "/var/lib/glusterd"
+          - name: glusterfs-dev-disk
+            mountPath: "/dev/disk"
           - name: glusterfs-misc
             mountPath: "/var/lib/misc/glusterfsd"
           - name: glusterfs-cgroup
@@ -120,6 +122,9 @@ objects:
         - name: glusterfs-config
           hostPath:
             path: "/var/lib/glusterd"
+        - name: glusterfs-dev-disk
+          hostPath:
+            path: "/dev/disk"
         - name: glusterfs-misc
           hostPath:
             path: "/var/lib/misc/glusterfsd"


### PR DESCRIPTION
Commit f9445033 removed the bind-mount for /dev as this will be setup by
the container runtime automatically. However it seems that /dev/disk is
missing, prevending users to supply /dev/disk/by-id/* device names to
Heketi.

This change adds /dev/disk as an additional bind-mount. CRI-O does
prevent /dev to be bind-mounted, but subdirectories of /dev do not seem
to be an issue.

Reported-by: Gal Ben Haim <gbenhaim@redhat.com>