### PR TITLE
Remove 80-openshift-network.conf during uninstallation

### DIFF
--- a/playbooks/adhoc/uninstall_openshift.yml
+++ b/playbooks/adhoc/uninstall_openshift.yml
@@ -297,6 +297,7 @@
     file: path={{ item }} state=absent
     with_items:
     - /etc/systemd/system/openvswitch.service
+    - /etc/cni/net.d/80-openshift-network.conf
     when: openshift_use_openshift_sdn | default(True) | bool
 
   - name: Rebuild ca-trust


### PR DESCRIPTION
After the uninstallation `/etc/cni/net.d/80-openshift-network.conf` still exists. This patch changes to remove `/etc/cni/net.d/80-openshift-network.conf` during uninstallation.

```
PLAY RECAP ********************************************************************************************************************************************************************************************************
knakayam-ose311-all.example.com : ok=63   changed=18   unreachable=0    failed=0   

# ls /etc/cni/net.d/80-openshift-network.conf 
/etc/cni/net.d/80-openshift-network.conf
```
