### PR TITLE
Fix output of insecure registries in /etc/containers/registries.conf

### DIFF
--- a/roles/container_runtime/templates/registries.conf.j2
+++ b/roles/container_runtime/templates/registries.conf.j2
@@ -10,13 +10,13 @@
 # and 'registries.block'.
 
 [registries.search]
-registries = [{{ l_additional_crio_registries|default("") }}]
+registries = {{ l_crio_registries | to_json }}
 
 
 # If you need to access insecure registries, add the registry's fully-qualified name.
 # An insecure registry is one that does not have a valid SSL certificate or only does HTTP.
 [registries.insecure]
-registries = [{{ l_insecure_crio_registries|default("") }}]
+registries = {{ l2_docker_insecure_registries | to_json }}
 
 
 # If you need to block pull access from a registry, uncomment the section below


### PR DESCRIPTION
Was ending up with "" inside the list of insecure registry, which
was causing issues with docker start up. This ensures that "" doesn't
end up in the list.

Fixes BZ1654064
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>
