### PR TITLE
[3.9] Remove unnecessary passlib check

### DIFF
--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -1,14 +1,4 @@
 ---
-- local_action: shell python -c 'import passlib' 2>/dev/null || echo not installed
-  register: passlib_result
-  become: false
-
-- name: Check that python-passlib is available on the control host
-  assert:
-    that:
-      - "'not installed' not in passlib_result.stdout"
-    msg: "python-passlib rpm must be installed on control host"
-
 - name: Set default image variables based on openshift_deployment_type
   include_vars: "{{ item }}"
   with_first_found:


### PR DESCRIPTION
python-passlib is an RPM dependency of openshift-ansible so it's safe to assume that supported installations would have python-passlib on the control host. Though they may not if operating from a github checkout.

Backports #9209
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1654887