### PR TITLE
WIP: Update README for OpenShift developers to setup GCP clusters.

### DIFF
--- a/inventory/dynamic/gcp/host_vars/localhost.yml
+++ b/inventory/dynamic/gcp/host_vars/localhost.yml
@@ -1,0 +1,2 @@
+---
+ansible_become: no

--- a/test/gcp/README.md
+++ b/test/gcp/README.md
@@ -1,0 +1,62 @@
+# OpenShift 4.0 on GCP - Not Supported
+This is for internal development purposes only and is not supported by Red Hat. Don't use this.
+
+# Initial Setup 
+
+## Requirements
+
+[OpenShift Installer](https://github.com/openshift/installer)
+
+[Ansible 2.7](https://docs.ansible.com/ansible/2.5/installation_guide/intro_installation.html) 
+```
+pip install -U apache-libcloud~=2.2.1
+pip install google-auth
+yum install -y google-cloud-sdk python2-crypto
+```
+## Credentials
+Place the following files in the root of OpenShift-Ansible with the given filename:
+
+* GCP service account key: `gce.json`
+* OpenShift pull secret: `try.openshift.com.json`
+
+## files_dir
+Point to the above credentials and any assets you will generate:
+```
+# Execute this from the root dir
+echo files_dir: $PWD > inventory/dynamic/gcp/group_vars/all/00_default_files_dir.yml
+```
+
+## Prepare Inventory Variables
+You can use the example files for GCP:
+```
+cp test/gcp/examples/group_vars/* inventory/dynamic/gcp/group_vars/all/
+```
+You will also need to change the `remote_user` value in `inventory/dynamic/gcp/ansible.cfg` from `cloud-user` to your GCP username.
+
+
+# Environment Variables
+During each session, make sure you have the following environment variables and are authenticated to GCP:
+```
+export ANSIBLE_CONFIG="inventory/dynamic/gcp/ansible.cfg"
+export INSTANCE_PREFIX=$(whoami)
+```
+
+```
+gcloud auth activate-service-account --quiet --key-file="gce.json"
+```
+You can confirm login with: `gcloud compute --project "openshift-gce-devel" instances list`.
+
+
+# Install Steps
+Now you are ready to start the installation process. All of these commands should be executed from the root directory of OpenShift-Ansible.
+
+
+To be safe, first remove any assets that may have been generated in a previous run. Then generate the install-config as an intermediate step
+to generating the ignition configs, after which you will be ready to run the playbooks.
+```
+rm .openshift_install_state.json *.ign
+./test/gcp/create-install-config.sh 
+openshift-install create ignition-configs
+ansible-playbook -vvv test/gcp/launch.yml
+```
+Keep in mind that the certs contained in the ignition-configs are valid for 30 minutes.

--- a/test/gcp/create-install-config.sh
+++ b/test/gcp/create-install-config.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# This script generates an install-config.yml asset to be consumed by openshift-install
+# for setting up a BYOH environment on GCP. This is intended for development purposes only
+# and is absolutely unsupported for any purpose.
+#
+# This script should be run from the root directory of OpenShift-Ansible.
+
+
+OCP_CLUSTER_NAME=$(whoami)
+OCP_PULL_SECRET=$(cat try.openshift.com.json)
+OCP_SSH_PUB_KEY=$(cat ~/.ssh/id_rsa.pub)
+
+cat > install-config.yaml <<EOF
+baseDomain: origin-gce.dev.openshift.com
+clusterID: $(uuidgen --random)
+machines:
+- name: master
+  platform: {}
+  replicas: 3
+- name: worker
+  platform: {}
+  replicas: 3
+metadata:
+  name: ${OCP_CLUSTER_NAME}
+networking:
+  clusterNetworks:
+  - cidr:             10.128.0.0/14
+    hostSubnetLength: 9
+  serviceCIDR: 172.30.0.0/16
+  type:        OpenshiftSDN
+platform:
+  none: {}
+pullSecret: |
+  ${OCP_PULL_SECRET}
+sshKey: |
+  ${OCP_SSH_PUB_KEY}
+EOF
+
+cp install-config.yaml install-config.ansible.yaml

--- a/test/gcp/examples/group_vars/vars-origin.yml
+++ b/test/gcp/examples/group_vars/vars-origin.yml
@@ -1,0 +1,59 @@
+---
+deployment_type: origin
+ansible_pkg_mgr: yum
+inventory_ip_type: external
+
+os_firewall_enabled: false
+
+openshift_gcp_prefix: "{{ lookup('env', 'INSTANCE_PREFIX') | mandatory }}-"
+
+openshift_gcp_region: us-east1
+openshift_gcp_zone: us-east1-c
+
+openshift_gcp_network_name: "{{ openshift_gcp_prefix }}network"
+
+openshift_gcp_iam_service_account_keyfile: "{{ files_dir }}/gce.json"
+
+openshift_gcp_ssh_private_key: "{{ files_dir + '/ssh-privatekey' }}"
+
+openshift_gcp_infra_network_instance_group: ig-i
+
+# Instructs the launch job to build an AMI prior to cluster provisioning and then use that image
+openshift_gcp_build_image: true
+openshift_gcp_image: '{{ openshift_gcp_prefix }}images'
+
+openshift_gcp_base_image: 'centos-7'
+openshift_gcp_root_image: 'centos-7'
+
+
+# Additional settings for GCE from defaults
+
+ansible_become: yes
+
+# External API settings
+console_port: 8443
+internal_console_port: 8443
+openshift_master_api_port: "8443"
+openshift_master_console_port: "8443"
+openshift_master_default_subdomain: "{{ wildcard_zone }}"
+
+mcd_port: 49500
+
+# Cloud specific settings
+openshift_cloudprovider_kind: gce
+openshift_hosted_registry_storage_provider: gcs
+openshift_additional_repos: [
+  {"name": "origin-pr", "baseurl": "https://rpms.svc.ci.openshift.org/openshift-origin-v4.0/", "enabled": 1, "gpgcheck": 0},
+  {"name": "origin-pr-dependencies", "baseurl": "http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/", "enabled": 1, "gpgcheck": 0}
+]
+
+openshift_bootstrap_ignition_file: "{{ files_dir }}/bootstrap.ign"
+openshift_gcp_master_healthcheck_port: 8080
+
+openshift_master_cluster_public_hostname: "{{ openshift_gcp_prefix }}api.{{ public_hosted_zone }}"
+openshift_master_cluster_hostname: "{{ openshift_gcp_prefix }}api.{{ public_hosted_zone }}"
+wildcard_zone: "apps.{{ lookup('env', 'INSTANCE_PREFIX') | mandatory }}.{{ public_hosted_zone }}"
+openshift_master_public_api_url: "https://{{ openshift_gcp_prefix }}api.{{ public_hosted_zone }}"
+openshift_master_public_console_hostname: "console.{{ wildcard_zone }}"
+
+openshift_install_config_path: "{{ files_dir }}/install-config.ansible.yaml"

--- a/test/gcp/examples/group_vars/vars.yml
+++ b/test/gcp/examples/group_vars/vars.yml
@@ -1,0 +1,28 @@
+---
+openshift_gcp_infra_network_instance_group: ig-n
+openshift_gcp_node_group_config:
+  - name: bootstrap
+    suffix: b
+    tags: ocp-bootstrap
+    machine_type: n1-standard-2
+    boot_disk_size: 150
+    scale: 1
+    wait_for_stable: true
+  - name: master
+    suffix: m
+    tags: ocp-master
+    machine_type: n1-standard-2
+    boot_disk_size: 150
+    scale: 3
+    wait_for_stable: true
+  - name: node
+    suffix: n
+    tags: ocp-worker
+    machine_type: n1-standard-2
+    boot_disk_size: 150
+    scale: 3
+    wait_for_stable: true
+
+openshift_gcp_project: openshift-gce-devel
+public_hosted_zone: origin-gce.dev.openshift.com
+dns_managed_zone: origin-gce


### PR DESCRIPTION
This is the first stab at creating simplified instructions for OpenShift developers to launch BYOH clusters on GCP. 

[Vadim's instructions ](https://mojo.redhat.com/people/vrutkovs/blog/2018/10/31/openshift-40-on-centos-machines-in-gcp-sneak-peek) were my starting point. 

Also I overwrote much of the root README. I'm not sure how much of it we should keep or if this should perhaps live somewhere else. 

TODO:
- [ ] Add link to [containerized instructions](https://github.com/vrutkovs/openshift-40-centos)
- [ ] Automatically set files_dir to be the repo root
- [x] Move inventory files from hastebin into repo, if possible (do they contain sensitive data?). Can we move them into test directory? Clean them up.
- [ ] Remove need for host_vars/localhost/ by adding nodes to a group (nodes) which does not include localhost
- [ ] improve the image building step
- [ ] add step for kubeconfig, show how to execute oc commands
- [ ] can we do anything about the cloud-user in the inventory/dynamic/gcp/ansible.cfg
