### PR TITLE
Adding a possible allowed path for auditFilePath values

### DIFF
--- a/roles/lib_utils/action_plugins/master_check_paths_in_config.py
+++ b/roles/lib_utils/action_plugins/master_check_paths_in_config.py
@@ -32,6 +32,7 @@ ALLOWED_DIRS = (
     '/dev/null',
     '/etc/origin/master/',
     '/var/lib/origin',
+    '/var/log/origin',
     '/etc/origin/cloudprovider',
     '/etc/origin/kubelet-plugins',
     '/usr/libexec/kubernetes/kubelet-plugins',


### PR DESCRIPTION
In slack today there was a discussion around deploying a ne build with audit config enabled.

https://openshiftcommons.slack.com/archives/C0FNVPMNF/p1543615669006000

```
TASK [openshift_control_plane : Check for file paths outside of /etc/origin/mast
er in master's config] ***
fatal: [openshiftm1.example.com]: FAILED! => {
  "msg": "A string value that appears to be a file path located outside of
/etc/origin/master/, /var/lib/origin, /etc/origin/cloudprovider, /etc/origin/kubelet-plugins, /usr/libexec/kubernetes/kubelet-plugins has been found in /etc/origin/master/master-config.yaml.
In 3.10 and newer, all files needed by the master must reside inside of
those directories or a subdirectory or it will not be readable by the
master process. Please migrate all files needed by the master into
one of /etc/origin/master/, /var/lib/origin, /etc/origin/cloudprovider, /etc/origin/kubelet-plugins, /usr/libexec/kubernetes/kubelet-plugins or a subdirectory and update your master configs before
proceeding. The string found was: /var/log/openshift/api.log
***********************
NOTE: the following items do not need to be migrated, they will be migrated
for you: oauthConfig.identityProviders"}
```

Summary: even the docs for 3.10/11 submit that auditpath might goto /var/log/origin but this script ignores that option.  One of the doc examples referenced putting the logs into /var/lib/origin but that seems like a bad idea.

The reporting user used /var/log/openshift.. so maybe just /var/log should be allowed ? 

This is *one* path forward.  Whichever path is suggested should probably replace the /var/lib/ example in the docs.


Also please backport to 3.10 *and* 3.11