### PR TITLE
openshift_ovirt: add vms into inventory groups

### DIFF
--- a/roles/openshift_ovirt/README.md
+++ b/roles/openshift_ovirt/README.md
@@ -19,6 +19,7 @@ The generated inventory can be merged into and openshift inventory(see examples 
 - `build_vm_list.yml`: Creates a list of virtual machine definitions and
   affinity groups based on a simple manifest (below)
 - `create_vms.yaml`: consumes the output of the former task and create vms for the nodes of the cluster. It generates an inventory of nodes.
+- `inventory tasks` : tasks that will insert the oVirt VMs from former tasks into the inventory, so you don't need to specify it manually in the inventory.
 
 ## Role Variables
 
@@ -26,6 +27,7 @@ For documentation on virtual machine profile options, see the [oVirt Ansible VM-
 
 | Name                      | Default value |                                                                                         |
 |---------------------------|---------------|-----------------------------------------------------------------------------------------|
+| openshift_ovirt_all_in_one  | false    | When true, creates an all in one inventory entries from the first master vm |
 | openshift_ovirt_vm_profile  | See below.    | Dictionary of dictionaries providing common VM parameters for virtual machine creation. |
 | openshift_ovirt_vm_manifest | See below.    | List of dictionaries specifying node base name, count, and which of the above profiles to apply. The default creates three master nodes, three infrastructure nodes, one application node, and a load balancer. |
 
@@ -94,8 +96,20 @@ openshift_ovirt_vm_profile:
     state: running
 ```
 
-
 - **openshift_ovirt_vm_manifest**
+```
+openshift_ovirt_vm_manifest:
+- name: 'master'
+  count: 3
+- name: 'infra'
+  count: 2
+  profile: 'node'
+- name: 'compute'
+  count: 9
+  profile: 'node'
+
+
+- **openshift_ovirt_vm_manifest with static IPs**
 ```
 openshift_ovirt_vm_manifest:
 #######################################
@@ -169,7 +183,7 @@ openshift_ovirt_vm_manifest:
 
 ```
 ---
-- name: Deploy oVirt template and virtual machines
+- name: Deploy OKD on oVirt from zero to working state
   hosts: localhost
   connection: local
   gather_facts: false
@@ -185,8 +199,13 @@ openshift_ovirt_vm_manifest:
       tags:
         - always
 
-  roles:
-    - openshift_ovirt
+  tasks:
+    - import_role:
+        name: openshift_ovirt
+
+- import_playbook: /home/rgolan/src/openshift-ansible/playbooks/prerequisites.yml
+- import_playbook: /home/rgolan/src/openshift-ansible/playbooks/openshift-node/network_manager.yml
+- import_playbook: /home/rgolan/src/openshift-ansible/playbooks/deploy_cluster.yml
 
   post_tasks:
     - name: Logout from oVirt
@@ -196,8 +215,6 @@ openshift_ovirt_vm_manifest:
       tags:
         - always
 ```
-
-**Side Note:** Regarding the behaviour, of the iterations, If we have a `count: 1` in our vm definition, the name that you put in the proper field will be preserved, but if we have more than 1 a counter will be raised and the vm name will be `name + iteration` (EG) _node0_, _node1_, _node2_ in case of `count: 3`
 
 License
 -------

--- a/roles/openshift_ovirt/defaults/main.yml
+++ b/roles/openshift_ovirt/defaults/main.yml
@@ -3,8 +3,10 @@
 compatibility_version: 4.2
 data_center_name: Default
 wait_for_ip: true
+openshift_ovirt_data_store: data
 openshift_ovirt_cluster: Default
 template_name: openshift_node
+openshift_ovirt_all_in_one: false
 
 # User must provide those vars:
 openshift_ovirt_dns_zone:

--- a/roles/openshift_ovirt/tasks/build_vm_list.yml
+++ b/roles/openshift_ovirt/tasks/build_vm_list.yml
@@ -1,81 +1,19 @@
 ---
 # Creates a dictionary for use with oVirt.vm-infra role
 # https://github.com/oVirt/ovirt-ansible-vm-infra
-# Side note:
-# If we have a count: 1 in our vm definition, the name that you put in the proper field will be preserved
-# if we have more than 1 a counter will be raised and the vm name will be name + iteration (EG) node0, node1, node2
-# in case of count: 3
 - fail:
     msg: "The openshift_ovirt_dns_zone variable is required."
   when:
-  - openshift_ovirt_dns_zone is none
+    - openshift_ovirt_dns_zone is none
+
 - name: Create virtual machine list fact
   set_fact:
-    vms: >-
-      {{ vms|default([]) }} + [
-      {% for iter in range(item.count) -%}
-      {% if iter > 0 -%},{% endif -%}
-      {
-      {% if item.count == 1 -%}
-      'name': '{{ item.name }}.{{ openshift_ovirt_dns_zone }}',
-      {% elif item.count > 1 -%}
-      'name': '{{ item.name }}{{ iter }}.{{ openshift_ovirt_dns_zone }}',
-      {% endif -%}
-      {% if ovirt_admin | default(True) -%}
-      'tag': "openshift_{{ item.profile }}",
-      {% endif -%}
-      'description': '{{ item.description | default("") }}',
-      'cloud_init':
-      {
-      {% if item.count == 1 -%}
-      'host_name': '{{  (item.empty_hostname | default(True)) | ternary('', item.name + '.' + openshift_ovirt_dns_zone) }}',
-        {% if item.nic_mode is defined -%}
-      'nic_boot_protocol': 'static',
-      'nic_ip_address': '{{ item["nic_mode"][item["name"]]["nic_ip_address"] }}',
-      'nic_netmask': '{{ item["nic_mode"][item["name"]]["nic_netmask"] }}',
-      'nic_gateway': '{{ item["nic_mode"][item["name"]]["nic_gateway"] }}',
-      'nic_on_boot': {{ item["nic_mode"][item["name"]]["nic_on_boot"] | default(true) | bool }},
-      'nic_name': '{{ item["nic_mode"][item["name"]]["nic_name"] | default("eth0") }}',
-          {% if item["nic_mode"][item["name"]]["dns_servers"] is defined -%}
-      'dns_servers': '{{ item["nic_mode"][item["name"]]["dns_servers"] }}',
-      'dns_search': '{{ item["nic_mode"][item["name"]]["dns_search"] }}',
-          {% endif -%}
-        {% endif -%}
-        {% if item.dns_servers is defined -%}
-      'dns_servers': '{{ item["dns_servers"] }}',
-        {% endif -%}
-        {% if item.dns_search is defined -%}
-      'dns_search': '{{ item["dns_search"] }}',
-        {% endif -%}
-      {% elif item.count > 1 -%}
-      'host_name': '{{  (item.empty_hostname | default(True)) | ternary('', item.name + iter | string + '.' + openshift_ovirt_dns_zone) }}',
-        {% if item.nic_mode is defined -%}
-      'nic_boot_protocol': 'static',
-      'nic_ip_address': '{{ item["nic_mode"][item["name"] + iter | string ]["nic_ip_address"] }}',
-      'nic_netmask': '{{ item["nic_mode"][item["name"] + iter | string ]["nic_netmask"] }}',
-      'nic_gateway': '{{ item["nic_mode"][item["name"] + iter | string ]["nic_gateway"] }}',
-      'nic_on_boot': {{ item["nic_mode"][item["name"] + iter | string ]["nic_on_boot"] | default(true) | bool }},
-      'nic_name': '{{ item["nic_mode"][item["name"] + iter | string ]["nic_name"] | default("eth0") }}',
-          {% if item["nic_mode"][item["name"] + iter | string ]["dns_servers"] is defined -%}
-      'dns_servers': '{{ item["nic_mode"][item["name"] + iter | string ]["dns_servers"] }}',
-          {% endif -%}
-          {% if item["nic_mode"][item["name"] + iter | string ]["dns_search"] is defined -%}
-      'dns_search': '{{ item["nic_mode"][item["name"] + iter | string ]["dns_search"] }}',
-          {% endif -%}
-        {% endif -%}
-        {% if item.dns_servers is defined -%}
-      'dns_servers': '{{ item["dns_servers"] }}',
-        {% endif -%}
-        {% if item.dns_search is defined -%}
-      'dns_search': '{{ item["dns_search"] }}',
-        {% endif -%}
-      {% endif -%}
-      'authorized_ssh_keys': '{{ openshift_ovirt_ssh_key }}'
-      },
-      'profile':  {{ openshift_ovirt_vm_profile[ item.profile ] }} ,
-      }
-      {% endfor -%}
-      ]
+    vms: "{{ lookup('template', './vms.j2') }}"
+  tags:
+    - openshift_ovirt
+
+- name: Create affnity groups
+  set_fact:
     affinity_groups: >-
       {% if ovirt_admin | default(True) -%}
       {{ affinity_groups|default([]) }} + [
@@ -98,5 +36,5 @@
       {% endif -%}
   with_items: "{{ openshift_ovirt_vm_manifest }}"
   tags:
-  - openshift_ovirt
+    - openshift_ovirt
 ...

--- a/roles/openshift_ovirt/tasks/create_all_in_one_inventory_from_vms.yaml
+++ b/roles/openshift_ovirt/tasks/create_all_in_one_inventory_from_vms.yaml
@@ -1,0 +1,9 @@
+---
+- name: Add master Vms to the master inventory group
+  add_host:
+    hostname: '{{ [item.name, "0.", openshift_ovirt_dns_zone] | join }}'
+    groups: [masters, nodes, etcd]
+    openshift_node_group_name: node-config-all-in-one
+    openshift_schedulable: true
+  with_items: '{{ openshift_ovirt_vm_manifest }}'
+  when: openshift_ovirt_all_in_one and item.name == 'master'

--- a/roles/openshift_ovirt/tasks/create_inventory_from_vms.yaml
+++ b/roles/openshift_ovirt/tasks/create_inventory_from_vms.yaml
@@ -1,0 +1,42 @@
+---
+- name: Add master Vms to the master inventory group
+  add_host:
+    groups: masters
+    hostname: '{{ [item.name, item.count - 1, ".", openshift_ovirt_dns_zone] | join }}'
+    openshift_node_group_name: node-config-master
+    openshift_schedulable: true
+  with_items: "{{ openshift_ovirt_vm_manifest }}"
+  when: item.count > 0 and item.name == 'master'
+
+- name: Add compute Vms to the nodes inventory group
+  add_host:
+    groups: nodes
+    hostname: '{{ [item.name, item.count - 1, ".", openshift_ovirt_dns_zone] | join }}'
+    openshift_node_group_name: node-config-compute
+    openshift_schedulable: true
+  with_items: "{{ openshift_ovirt_vm_manifest }}"
+  when: item.count > 0 and item.name == 'compute'
+
+- name: Add infra Vms to the nodes inventory group
+  add_host:
+    groups: nodes
+    hostname: '{{ [item.name, item.count - 1, ".", openshift_ovirt_dns_zone] | join }}'
+    openshift_node_group_name: node-config-infra
+    openshift_schedulable: true
+  with_items: "{{ openshift_ovirt_vm_manifest }}"
+  when: item.count > 0 and item.name == 'infra'
+
+- name: Add etcd Vms to the etcd inventory group
+  add_host:
+    hostname: '{{ [item.name, item.count - 1, ".", openshift_ovirt_dns_zone] | join }}'
+    groups: 'etcd'
+  with_items: "{{ openshift_ovirt_vm_manifest }}"
+  when: item.count > 0 and item.name == 'etcd'
+
+- name: Add load balancers Vms to the lb inventory group
+  add_host:
+    groups: 'lb'
+    hostname: '{{ [item.name, item.count - 1, ".", openshift_ovirt_dns_zone] | join }}'
+  with_items: "{{ openshift_ovirt_vm_manifest }}"
+  when: item.count > 0 and item.name == 'lb'
+...

--- a/roles/openshift_ovirt/tasks/create_vms.yaml
+++ b/roles/openshift_ovirt/tasks/create_vms.yaml
@@ -4,7 +4,7 @@
 - fail:
     msg: "The vms fact is not set. Run build_vm_list task from this role"
   when:
-  - vms is none
+    - vms is none
 
 - name: check if the template already exists
   ovirt_templates_facts:
@@ -19,6 +19,7 @@
 
 - import_role:
     name: oVirt.vm-infra
+
 - name: print all created vms that are in the inventory
   debug:
     var: hostvars

--- a/roles/openshift_ovirt/tasks/main.yaml
+++ b/roles/openshift_ovirt/tasks/main.yaml
@@ -1,4 +1,10 @@
 ---
-- include_tasks: build_vm_list.yaml
+- include_tasks: build_vm_list.yml
 
 - include_tasks: create_vms.yaml
+
+- include_tasks: create_inventory_from_vms.yaml
+  when: not openshift_ovirt_all_in_one
+
+- include_tasks: create_all_in_one_inventory_from_vms.yaml
+  when: openshift_ovirt_all_in_one

--- a/roles/openshift_ovirt/tasks/vms.j2
+++ b/roles/openshift_ovirt/tasks/vms.j2
@@ -1,0 +1,44 @@
+[{% for item in openshift_ovirt_vm_manifest -%}
+  {% for iter in range(item.count) -%}
+    {
+      'name':         '{{ [item.name, iter, ".", openshift_ovirt_dns_zone] | join }}',
+      'host_name':    '{{ (item.empty_hostname | default(True)) | ternary('', [item.name, iter, ".", openshift_ovirt_dns_zone] | join) }}',
+      'description':  '{{ item.description | default('') }}',
+      'tag':          '{{ ["openshift_", item.profile] | join }}',
+      'profile':      {{ openshift_ovirt_vm_profile[ item.profile ] }},
+      {%- set cloud_init = {} -%}
+      {%- do cloud_init.update(
+        {
+          'nic_boot_protocol': 'static',
+          'nic_ip_address': item.nic_mode[item["name"] + iter | string ]["nic_ip_address"],
+          'nic_netmask':    item.nic_mode[item["name"] + iter | string ]["nic_netmask"],
+          'nic_gateway':    item.nic_mode[item["name"] + iter | string ]["nic_gateway"],
+          'nic_on_boot':    item.nic_mode[item["name"] + iter | string ]["nic_on_boot"] | default(true) | bool,
+          'nic_name':       item.nic_mode[item["name"] + iter | string ]["nic_name"] | default("eth0"),
+        }) if item.nic_mode is defined -%}
+      
+      {%- do cloud_init.update(
+        {
+          'dns_servers': item.nic_mode[item["name"] + iter | string ]["dns_servers"],
+        }
+      ) if item.nic_mode is defined and item.nic_mode[item["name"] + iter | string ]["dns_servers"] is defined -%}
+      {%- do cloud_init.update(
+        {
+          'dns_search': item.nic_mode[item["name"] + iter | string ]["dns_search"],
+        }
+      ) if item.nic_mode is defined and item.nic_mode[item["name"] + iter | string ]["dns_search"] is defined -%}
+      {%- do cloud_init.update(
+        {
+          'dns_servers': item["dns_servers"] 
+        }
+      ) if item.dns_servers is defined -%}
+      {%- do cloud_init.update(
+        {
+          'dns_search': item["dns_searc"] 
+        }
+      ) if item.dns_search is defined -%}
+      'cloud_init': {{ cloud_init | combine(openshift_ovirt_vm_profile[item.profile]["cloud_init"], recursive=True) }},
+      },
+  {% endfor -%}
+{% endfor -%}
+]


### PR DESCRIPTION
Motivation:
This role should be easy to consume and should be ready made to be
consumed with other playbooks to install a cluster without specifing an
explicit inventory of openshift nodes. The manifest should be the single
point where one specifies the nodes layout.

Modification:
2 new tasks added to create the inventory from the manifest -
create_inventory_from_vms.yaml and
create_all_in_one_inventory_from_vms.yaml. The latter will take the
first master and make it all-in-one, regardless of the count.

Result:
The role now supports all-in-one install by setting
openshift_ovirt_all_in_one=true.
To install the a cluster, just include the role, and the prerequisit and
install_cluster playbooks - see the examples in the
roles/openshift_ovirt/README.md