### PR TITLE
glusterfs: bind-mount /dev/mapper into the glusterfs-server container

### DIFF
--- a/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
+++ b/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
@@ -65,6 +65,8 @@ objects:
             mountPath: "/var/lib/glusterd"
           - name: glusterfs-dev-disk
             mountPath: "/dev/disk"
+          - name: glusterfs-dev-mapper
+            mountPath: "/dev/mapper"
           - name: glusterfs-misc
             mountPath: "/var/lib/misc/glusterfsd"
           - name: glusterfs-cgroup
@@ -125,6 +127,9 @@ objects:
         - name: glusterfs-dev-disk
           hostPath:
             path: "/dev/disk"
+        - name: glusterfs-dev-mapper
+          hostPath:
+            path: "/dev/mapper"
         - name: glusterfs-misc
           hostPath:
             path: "/var/lib/misc/glusterfsd"


### PR DESCRIPTION
Commit f9445033 removed the bind-mount for /dev as this will be setup by
the container runtime automatically. However it seems that /dev/mapper
is missing, prevending users to supply /dev/mapper/* device names to
Heketi. It also seems possible that not all(?) LVM devices are available
when a container starts.

This change adds /dev/mapper as an additional bind-mount. CRI-O does
prevent /dev to be bind-mounted, but subdirectories of /dev do not seem
to be an issue.

Updates: gluster/gluster-kubernetes#499