### PR TITLE
python-docker is obsoleted by python-docker-py

### DIFF
--- a/playbooks/init/base_packages.yml
+++ b/playbooks/init/base_packages.yml
@@ -41,7 +41,7 @@
         - "{{ 'python3-PyYAML' if ansible_distribution == 'Fedora' else 'PyYAML' }}"
         - libsemanage-python
         - yum-utils
-        - "{{ 'python3-docker' if ansible_distribution == 'Fedora' else 'python-docker' }}"
+        - "{{ 'python3-docker' if ansible_distribution == 'Fedora' else 'python-docker-py' }}"
         pkg_list_non_fedora:
         - 'python-ipaddress'
         pkg_list_use_non_fedora: "{{ ansible_distribution != 'Fedora' | bool }}"


### PR DESCRIPTION
python-docker is obsoleted by python-docker-py.

This still works on x86:
```
yum install python-docker
Loaded plugins: product-id, search-disabled-repos, subscription-manager
ocp311                                                   | 1.2 kB     00:00     
rhel-7-server-ansible-2.6-rpms                           | 4.0 kB     00:00     
rhel-7-server-extras-rpms                                | 3.4 kB     00:00     
rhel-7-server-rpms                                       | 3.5 kB     00:00     
Package docker-python-1.4.0-115.el7.x86_64 is obsoleted by 1:python-docker-py-1.10.6-7.el7.noarch which is already installed
Nothing to do

```

Unfortunately,  ppc64le systems can't handle this:

```
yum repolist
Loaded plugins: product-id, search-disabled-repos, subscription-manager
repo id                                                                repo name                                                                                status
rhel-7-for-power-le-extras-rpms/ppc64le                                Red Hat Enterprise Linux 7 for IBM Power LE - Extras (RPMs)                                 479
rhel-7-for-power-le-optional-rpms/7Server/ppc64le                      Red Hat Enterprise Linux 7 for IBM Power LE - Optional (RPMs)                            13,820
rhel-7-for-power-le-rpms/7Server/ppc64le                               Red Hat Enterprise Linux 7 for IBM Power LE (RPMs)                                       17,085
rhel-7-server-ansible-2.6-for-power-le-rpms/ppc64le                    Red Hat Ansible Engine 2.6 for RHEL 7 Server for IBM Power LE (RPMs)                         14
rhel-7-server-for-power-le-rhscl-rpms/7Server/ppc64le                  Red Hat Software Collections (for RHEL 7 Server for IBM Power LE) RPMs                    2,260
repolist: 33,658
[root@node2 yum.repos.d]# yum install python-docker
Loaded plugins: product-id, search-disabled-repos, subscription-manager
No package python-docker available.
Error: Nothing to do
```