### PR TITLE
Ensure openshift_upgrade_nodes_label works

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
@@ -31,7 +31,7 @@
       with_items: " {{ groups['oo_nodes_to_config'] }}"
       when:
       - hostvars[item].openshift is defined
-      - hostvars[item].openshift.common.hostname | lower in nodes_to_upgrade.results.results[0]['items'] | map(attribute='metadata.name') | list
+      - hostvars[item].openshift.node.nodename | lower in nodes_to_upgrade.results.results[0]['items'] | map(attribute='metadata.name') | list
       changed_when: false
 
   # Build up the oo_nodes_to_upgrade group, use the list filtered by label if


### PR DESCRIPTION
Currently, there is a potential mismatch between nodenames and
the variable we compare the output of oc get nodes to.

We should utilize openshift.node.nodename instead.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1649074