### PR TITLE
Erase docker during docker uninstall

### DIFF
--- a/playbooks/adhoc/uninstall_docker.yml
+++ b/playbooks/adhoc/uninstall_docker.yml
@@ -46,3 +46,6 @@
     - /etc/docker*
     - /etc/sysconfig/docker*
     - /etc/systemd/system/docker*
+
+  - name: Erase docker package
+    command: "yum -y erase docker"


### PR DESCRIPTION
This commit ensures docker is actually uninstalled and all
associated config files are cleaned up.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1635254