### PR TITLE
Install boto3 from pip and use python-docker-py and use python-docker-py

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -10,13 +10,13 @@ COPY images/installer/origin-extra-root /
 # install ansible and deps
 RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
- && EPEL_PKGS="ansible-2.6.5 python2-boto python2-boto3 python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46" \
+ && EPEL_PKGS="ansible-2.6.5 python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
  && if [ "$(uname -m)" == "x86_64" ]; then yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm ; fi \
  && yum install -y java-1.8.0-openjdk-headless \
  && rpm -V $INSTALL_PKGS $EPEL_PKGS $EPEL_TESTING_PKGS \
- && pip install 'apache-libcloud~=2.2.1' 'SecretStorage<3' 'ansible[azure]' \
+ && pip install 'apache-libcloud~=2.2.1' 'SecretStorage<3' 'ansible[azure]' 'boto3==1.4.6' \
  && yum clean all
 
 LABEL name="openshift/origin-ansible" \

--- a/playbooks/init/base_packages.yml
+++ b/playbooks/init/base_packages.yml
@@ -41,7 +41,7 @@
         - "{{ 'python3-PyYAML' if ansible_distribution == 'Fedora' else 'PyYAML' }}"
         - libsemanage-python
         - yum-utils
-        - "{{ 'python3-docker' if ansible_distribution == 'Fedora' else 'python-docker' }}"
+        - "{{ 'python3-docker' if ansible_distribution == 'Fedora' else 'python-docker-py' }}"
         pkg_list_non_fedora:
         - 'python-ipaddress'
         pkg_list_use_non_fedora: "{{ ansible_distribution != 'Fedora' | bool }}"


### PR DESCRIPTION
Due to https://bugs.centos.org/view.php?id=15516 / https://bugzilla.redhat.com/show_bug.cgi?id=1655730 we can't use 
python2-boto3

Included commit from #10459 to pass the tests