### PR TITLE
[release-3.11]FIX:1644741:Add new variables to specify storageclass to prometheus and alertmanager

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -665,10 +665,14 @@ debug_level=2
 # openshift_cluster_monitoring_operator_install=false
 #
 # Cluster monitoring configuration variables allow setting the amount of
-# storage requested through PersistentVolumeClaims.
+# storage and storageclass requested through PersistentVolumeClaims.
 #
 # openshift_cluster_monitoring_operator_prometheus_storage_capacity="50Gi"
 # openshift_cluster_monitoring_operator_alertmanager_storage_capacity="2Gi"
+#
+# openshift_cluster_monitoring_operator_prometheus_storage_class_name=""
+# openshift_cluster_monitoring_operator_alertmanager_storage_class_name=""
+
 
 # Logging deployment
 #


### PR DESCRIPTION
* Related `PR`: [Add the related description of specifying each storageclass](https://github.com/openshift/openshift-docs/pull/13001)

* Related `BZ`: [[DOCS] vxlan port iptables change should be udp not tcp](https://bugzilla.redhat.com/show_bug.cgi?id=1644741)

Add the new variables to example inventory for specifying the storageclass of `prometheus` and `alertmanager` instances in the `PersistentVolumeClaim`. 

There was a recommendation of the reviewer from the [Add the related description of specifying each storageclass](https://github.com/openshift/openshift-docs/pull/13001) `PR`. 