### PR TITLE
Ensure OSE vars are not overwritten at the dynamic inventory

### DIFF
--- a/playbooks/openstack/inventory.py
+++ b/playbooks/openstack/inventory.py
@@ -169,7 +169,7 @@ def build_inventory():
             stout.get('public_router_ip')
 
         try:
-            inventory['OSEv3']['vars'] = _get_kuryr_vars(cloud, stout)
+            inventory['OSEv3']['vars'].update(_get_kuryr_vars(cloud, stout))
         except KeyError:
             pass  # Not a kuryr deployment
     return inventory


### PR DESCRIPTION
This PR ensures OSE vars are not overwritten at the dynamic inventory
when kuryr is enabled.