### PR TITLE
Fix Calico liveness and readiness checks to include Calico 3.2

### DIFF
--- a/roles/calico_master/tasks/main.yml
+++ b/roles/calico_master/tasks/main.yml
@@ -96,7 +96,7 @@
 
 - name: Calico Master | Set the correct liveness and readiness checks
   set_fact:
-    calico_binary_checks: "{{ (node_version > '3.2.0' and cnx != 'cnx') or (node_version > '2.2.0' and cnx == 'cnx') | bool }}"
+    calico_binary_checks: "{{ (node_version >= '3.2.0' and cnx != 'cnx') or (node_version >= '2.2.0' and cnx == 'cnx') | bool }}"
 
 - name: Calico Master | Write Calico v2
   template:


### PR DESCRIPTION
Fixes the regex for controlling what type of Calico liveness and readiness checks are used to include version 3.2.0.

This is a manual cherry-pick of https://github.com/openshift/openshift-ansible/pull/10449 since the cherry-picking won't work nicely because of the role swap we did between 3.10 and 3.11.