### PR TITLE
Update RBAC for Calico

### DIFF
--- a/roles/calico/templates/calicov3.yml.j2
+++ b/roles/calico/templates/calicov3.yml.j2
@@ -54,6 +54,18 @@ rules:
       - nodes
     verbs:
       - get
+  - apiGroups: [""]
+    resources:
+      - endpoints
+      - services
+    verbs:
+      - watch
+      - list
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      - patch
 
 ---
 


### PR DESCRIPTION
Update the RBAC manifests for Calico in preparation for Calico 3.4.