### PR TITLE
Update Calico RBAC

### DIFF
--- a/roles/calico_master/templates/calicov3.yml.j2
+++ b/roles/calico_master/templates/calicov3.yml.j2
@@ -54,6 +54,18 @@ rules:
       - nodes
     verbs:
       - get
+  - apiGroups: [""]
+    resources:
+      - endpoints
+      - services
+    verbs:
+      - watch
+      - list
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      - patch
 
 ---
 


### PR DESCRIPTION
Update the RBAC manifests for Calico in preparation for Calico 3.4. This is a manual cherry-pick of https://github.com/openshift/openshift-ansible/pull/10832 since the files were moved between 3.10 and 3.11.