### PR TITLE
use ca defined in the inventory instead of a fixed filename

### DIFF
--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -159,7 +159,8 @@ class LDAPPasswordIdentityProvider(IdentityProviderBase):
             self._idp['attributes']['preferredUsername'] = pref_user
 
         if not self._idp['insecure']:
-            self._idp['ca'] = '/etc/origin/master/{}_ldap_ca.crt'.format(self.name)
+            if "/" not in self._idp['ca']:
+                self._idp['ca'] = '/etc/origin/master/{}'.format(self.ca)
 
     def validate(self):
         ''' validate this idp instance '''


### PR DESCRIPTION
In the current code a fixed filename is used for the ca when an LDAP identity provider is configured. The parameters configured in the inventory are not taken into account.

With this change, if secure ldap is configured, and only a filename is configured (without a path), use a default path for the ca file (/etc/origin/master). If a path is configured, use the configured path, not a predefined filename.

At the moment installing a 3.11 cluster fails because master pods cannot start, because the ca file that is configured is not found.