### PR TITLE
Install cifs-utils and samba required by Azure

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -66,6 +66,8 @@ default_r_openshift_node_image_prep_packages:
 - iscsi-initiator-utils
 - ceph-common
 - atomic
+- cifs-utils    # requested by Azure
+- samba-common  # requested by Azure
 r_openshift_node_image_prep_packages: "{{ default_r_openshift_node_image_prep_packages | union(openshift_node_image_prep_packages | default([])) }}"
 
 r_openshift_node_os_firewall_deny: []


### PR DESCRIPTION
Openshift node deployed on Azure requries both `cifs-utils` and `samba` rpms installed.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1624311