### PR TITLE
'dict object' has no attribute 'openshift_master_etcd_urls'

### DIFF
--- a/roles/calico_master/tasks/certs.yml
+++ b/roles/calico_master/tasks/certs.yml
@@ -16,7 +16,7 @@
     calico_etcd_ca_cert_file: "/etc/origin/master/master.etcd-ca.crt"
     calico_etcd_cert_file: "/etc/origin/master/master.etcd-client.crt"
     calico_etcd_key_file: "/etc/origin/master/master.etcd-client.key"
-    calico_etcd_endpoints: "{{ hostvars[groups.oo_first_master.0].openshift_master_etcd_urls | join(',') }}"
+    calico_etcd_endpoints: "{{ openshift_master_etcd_urls | join(',') }}"
 
 - name: Calico Node | Error if no certs set.
   fail:


### PR DESCRIPTION
Signed-off-by: jkaurredhat <jkaur@redhat.com>

When adding a new master using scaleup playbook wih calico it fails with below error 

TASK [calico_master : Calico Node | Set etcd cert location facts] ************************************************************************************************************************
[1;30mtask path: /usr/share/ansible/openshift-ansible/roles/calico_master/tasks/certs.yml:13[0m
[0;31mfatal: [host.example.com]: FAILED! => {[0m
[0;31m    "failed": true, [0m
[0;31m    "msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'openshift_master_etcd_urls'\n\nThe error appears to have been in '/usr/share/ansible/openshift-ansible/roles/calico_master/tasks/certs.yml': line 13, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Calico Node | Set etcd cert location facts\n  ^ here\n\nexception type: <class 'ansible.errors.AnsibleUndefinedVariable'>\nexception: 'dict object' has no attribute 'openshift_master_etcd_urls'"
