### PR TITLE
Remove duplicated parameter CLUSTER_NAME

### DIFF
--- a/roles/openshift_storage_glusterfs/files/gluster-s3-template.yml
+++ b/roles/openshift_storage_glusterfs/files/gluster-s3-template.yml
@@ -107,10 +107,6 @@ parameters:
 - name: IMAGE_NAME
   displayName: glusterblock provisioner container image name
   required: True
-- name: CLUSTER_NAME
-  displayName: GlusterFS cluster name
-  description: A unique name to identify which heketi service manages this cluster, useful for running multiple heketi instances
-  value: storage
 - name: S3_ACCOUNT
   displayName: S3 Account Name
   description: S3 storage account which will provide storage on GlusterFS volumes


### PR DESCRIPTION
This patch remove a duplicated parameter CLUSTER_NAME from gluster-s3-template.yml and prevent error to find the correct pod name when you change the parameter glusterfs_name.
