### PR TITLE
Handle audit log path in /var/log/origin

### DIFF
--- a/roles/lib_utils/action_plugins/master_check_paths_in_config.py
+++ b/roles/lib_utils/action_plugins/master_check_paths_in_config.py
@@ -35,6 +35,7 @@ ALLOWED_DIRS = (
     '/etc/origin/cloudprovider',
     '/etc/origin/kubelet-plugins',
     '/usr/libexec/kubernetes/kubelet-plugins',
+    '/var/log/origin',
 )
 
 ALLOWED_DIRS_STRING = ', '.join(ALLOWED_DIRS)

--- a/roles/lib_utils/test/test_master_check_paths_in_config.py
+++ b/roles/lib_utils/test/test_master_check_paths_in_config.py
@@ -24,6 +24,8 @@ def loaded_config():
         'oauthConfig':
         {'identityProviders':
             ['1', '2', '/this/will/fail']},
+        'auditConfig':
+        {'auditFilePath': "/var/log/origin/audit-ocp.log"},
         'fake_top_item':
         {'fake_item':
             {'fake_item2':

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -52,6 +52,16 @@
     mode: '0750'
   when: not openshift_is_atomic | bool
 
+- name: Create openshift audit log directory
+  file:
+    state: directory
+    path: "/var/log/origin"
+    mode: 0700
+  when:
+  - openshift.master.audit_config is defined
+  - openshift.master.audit_config.auditFilePath is defined
+  - '"/var/log/origin" in openshift.master.audit_config.auditFilePath'
+
 - name: Create the policy file if it does not already exist
   command: >
     {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig

--- a/roles/openshift_control_plane/tasks/static.yml
+++ b/roles/openshift_control_plane/tasks/static.yml
@@ -62,6 +62,33 @@
       value: "/etc/origin/kubelet-plugins"
   when: openshift_is_atomic | bool
 
+- name: Add audit volume to master static pod (api)
+  yedit:
+    src: "{{ mktemp.stdout }}/apiserver.yaml"
+    append: true
+    key: spec.volumes
+    value:
+      name: audit-logs
+      hostPath:
+        path: "/var/log/origin"
+  when:
+  - openshift.master.audit_config is defined
+  - openshift.master.audit_config.auditFilePath is defined
+  - '"/var/log/origin" in openshift.master.audit_config.auditFilePath'
+
+- name: Add audit volumeMounts to master static pod (api)
+  yedit:
+    src: "{{ mktemp.stdout }}/apiserver.yaml"
+    append: true
+    key: spec.containers[0].volumeMounts
+    value:
+      mountPath: "/var/log/origin"
+      name: audit-logs
+  when:
+  - openshift.master.audit_config is defined
+  - openshift.master.audit_config.auditFilePath is defined
+  - '"/var/log/origin" in openshift.master.audit_config.auditFilePath'
+
 - name: ensure pod location exists
   file:
     path: "{{ openshift_control_plane_static_pod_location }}"


### PR DESCRIPTION
This commit is intended to make the installer able to handle OpenShift audit log paths different from (/etc/origin/master, /var/lib/origin, /etc/origin/cloudprovider), which in most of cases are not appropriate since those directories are not usually used as log store.

The code included create a new directory /var/log/origin if auditFilePath is defined within this directory, and adds it as a hostPath in the apiserver static pod definition. custom module master_check_paths_in_config has been also properly tuned to allow this directories to be defined in the master-config.yaml

If accepted, this change should be properly documented.

More info: #10717

