### PR TITLE
Do not trigger sudo for local task

### DIFF
--- a/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
+++ b/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
@@ -178,6 +178,7 @@
   local_action: file path="/tmp/{{ inventory_hostname }}" state=absent
   changed_when: False
   when: etcd_server_certs_missing | bool
+  become: false
 
 - name: Validate permissions on certificate files
   file:


### PR DESCRIPTION
Running RPM cluster installation from workstation (not in a container) fails on "Delete temporary directory" task with error:
{"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

Since playbook is executed by local user and temporary files are created by the same user, there is no need to trigger sudo.
This error is limited to users with passwords to become sudoer.

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
