### PR TITLE
Extend logging-elasticsearch recreate param

### DIFF
--- a/roles/openshift_logging_elasticsearch/templates/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/es.j2
@@ -17,6 +17,8 @@ spec:
     logging-infra: "{{logging_component}}"
   strategy:
     type: Recreate
+    recreateParams:
+      timeoutSeconds: 1800
   triggers: []
   template:
     metadata:


### PR DESCRIPTION
This fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1655675 by extending the DC recreate param to avoid premature rollbacks