### PR TITLE
images/installer/Dockerfile: Backport recent 3.11 fixes

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -10,7 +10,7 @@ COPY images/installer/origin-extra-root /
 # install ansible and deps
 RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
- && EPEL_PKGS="ansible-2.6.5 python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46" \
+ && EPEL_PKGS="ansible-2.7.4 python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
  && if [ "$(uname -m)" == "x86_64" ]; then yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm ; fi \

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -10,13 +10,13 @@ COPY images/installer/origin-extra-root /
 # install ansible and deps
 RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
- && EPEL_PKGS="ansible-2.6.5 python2-boto python2-boto3 python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46" \
+ && EPEL_PKGS="ansible-2.6.5 python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
  && if [ "$(uname -m)" == "x86_64" ]; then yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm ; fi \
  && yum install -y java-1.8.0-openjdk-headless \
  && rpm -V $INSTALL_PKGS $EPEL_PKGS $EPEL_TESTING_PKGS \
- && pip install 'apache-libcloud~=2.2.1' 'SecretStorage<3' 'ansible[azure]' \
+ && pip install 'apache-libcloud~=2.2.1' 'SecretStorage<3' 'ansible[azure]' 'boto3==1.4.6' \
  && yum clean all
 
 LABEL name="openshift/origin-ansible" \

--- a/images/installer/origin-extra-root/etc/yum.repos.d/centos-ansible27.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/centos-ansible27.repo
@@ -1,6 +1,6 @@
 
 [centos-ansible26-testing]
 name=CentOS Ansible 2.6 testing repo
-baseurl=https://cbs.centos.org/repos/configmanagement7-ansible-26-testing/x86_64/os/
+baseurl=https://cbs.centos.org/repos/configmanagement7-ansible-27-testing/x86_64/os/
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
This cherry-picks d14a58eb6ed46841daa9c9a526daa28603ec8243 and 6bf461a6566687b054cf61e9d98a1e059c6e26ec into master in an attempt to [address][1]:

```
Package python2-s3transfer is obsoleted by python-s3transfer, but obsoleting package does not provide for requirements
--> Finished Dependency Resolution
You could try using --skip-broken to work around the problem
Error: Package: python2-boto3-1.4.6-1.el7.noarch (epel)
          Requires: python2-s3transfer >= 0.1.10
          Available: python2-s3transfer-0.1.10-1.el7.noarch (epel)
              python2-s3transfer = 0.1.10-1.el7
You could try running: rpm -Va --nofiles --nodigest
error: build error: running 'INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch"  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS  && EPEL_PKGS="ansible-2.6.5 python2-boto python2-boto3 python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46"  && yum install -y epel-release  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS  && if [ "$(uname -m)" == "x86_64" ]; then yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm ; fi  && yum install -y java-1.8.0-openjdk-headless  && rpm -V $INSTALL_PKGS $EPEL_PKGS $EPEL_TESTING_PKGS  && pip install 'apache-libcloud~=2.2.1' 'SecretStorage<3' 'ansible[azure]'  && yum clean all' failed with exit code 1
2018/12/12 20:56:13 Ran for 8m35s
error: could not run steps: could not wait for build: the build ansible failed after 2m21s with reason DockerBuildFailed: Docker build strategy has failed.
```

CC @sdodson, @vrutkovs, @stevekuznetsov

[1]: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_openshift-ansible/10873/pull-ci-openshift-openshift-ansible-master-images/543/build-log.txt