### PR TITLE
Check CVO status instead of particular operators

### DIFF
--- a/playbooks/deploy_cluster_40.yml
+++ b/playbooks/deploy_cluster_40.yml
@@ -131,42 +131,37 @@
   - name: Wait for core operators to appear and complete
     oc_obj:
       state: list
-      kind: ClusterOperator
-      name: "{{ item }}"
+      kind: ClusterVersion
+      name: version
       kubeconfig: /opt/openshift/auth/kubeconfig
-    register: operator
-    #Give each operator 5 mins to come up
-    retries: 60
+    register: cvo
+    #Give CVO 10 mins to come up
+    retries: 120
     delay: 5
     until:
-    - "'results' in operator"
-    - "'results' in operator.results"
-    - operator.results.results | length > 0
-    - "'status' in operator.results.results[0]"
-    - "'conditions' in operator.results.results[0]['status']"
-    - operator.results.results[0].status.conditions | selectattr('type', 'match', '^Available$') | map(attribute='status') | join | bool == True
-    - operator.results.results[0].status.conditions | selectattr('type', 'match', '^Progressing$') | map(attribute='status') | join | bool == False
-    - operator.results.results[0].status.conditions | selectattr('type', 'match', '^Failing$') | map(attribute='status') | join | bool == False
-    with_items:
-    - machine-config-operator
-    # Fails often with 'x of y nodes are not at revision n'
-    #- openshift-cluster-kube-apiserver-operator
-    # Failing with 'ConfigObservationFailing: configmap/cluster-config-v1.kube-system: no recognized cloud provider platform found' - https://github.com/openshift/cluster-kube-controller-manager-operator/issues/100
-    #- openshift-cluster-kube-controller-manager-operator
-    # Fails often with 'x of y nodes are not at revision n'
-    #- openshift-cluster-kube-scheduler-operator
-    #- openshift-cluster-openshift-apiserver-operator
-    - openshift-cluster-openshift-controller-manager-operator
-    - openshift-ingress-operator
+    - "'results' in cvo"
+    - "'results' in cvo.results"
+    - cvo.results.results | length > 0
+    - "'status' in cvo.results.results[0]"
+    - "'conditions' in cvo.results.results[0]['status']"
+    - cvo.results.results[0].status.conditions | selectattr('type', 'match', '^Available$') | map(attribute='status') | join | bool == True
+    - cvo.results.results[0].status.conditions | selectattr('type', 'match', '^Failing$') | map(attribute='status') | join | bool == False
+    - cvo.results.results[0].status.conditions | selectattr('type', 'match', '^Progressing$') | map(attribute='status') | join | bool == False
     ignore_errors: true
 
   - block:
-    - name: Output the operators status
+    - name: Output CVO status
+      oc_obj:
+        state: list
+        kind: ClusterVersion
+        name: version
+        kubeconfig: /opt/openshift/auth/kubeconfig
+    - name: Output operators status
       oc_obj:
         state: list
         kind: ClusterOperator
         selector: ""
         kubeconfig: /opt/openshift/auth/kubeconfig
     - fail:
-        msg: Required operators didn't complete the install
-    when: operator.failed
+        msg: CVO didn't complete the install
+    when: cvo.failed


### PR DESCRIPTION
Instead of checking the status of particular operators the playbook should check CVO progress.

 Some operators (e.g. -apiserver) might report failures while they are working fine - in that case it should be excluded from CVO. This change would wait for CVO report required statuses in 10 min, if it fails to do so - output CVO and every operator state
