### PR TITLE
Recovering missing features that disappear with PR 10805

### DIFF
--- a/roles/openshift_ovirt/README.md
+++ b/roles/openshift_ovirt/README.md
@@ -13,6 +13,8 @@ The generated inventory can be merged into and openshift inventory(see examples 
     + [Playbook](#playbook)
   * [License](#license)
 
+**Important note**: To make this role work you need to set this option on your _ansible.cfg_ file `jinja2_extensions = jinja2.ext.do`
+
 ## Role Tasks
 
 - `main.yaml`: The entrypoint to the role. It invokes the following tasks below.

--- a/roles/openshift_ovirt/tasks/vms.j2
+++ b/roles/openshift_ovirt/tasks/vms.j2
@@ -4,7 +4,9 @@
       'name':         '{{ [item.name, iter, ".", openshift_ovirt_dns_zone] | join }}',
       'host_name':    '{{ (item.empty_hostname | default(True)) | ternary('', [item.name, iter, ".", openshift_ovirt_dns_zone] | join) }}',
       'description':  '{{ item.description | default('') }}',
+      {%- if ovirt_admin | default(True) -%}
       'tag':          '{{ ["openshift_", item.profile] | join }}',
+      {%- endif -%}
       'profile':      {{ openshift_ovirt_vm_profile[ item.profile ] }},
       {%- set cloud_init = {} -%}
       {%- do cloud_init.update(
@@ -34,7 +36,7 @@
       ) if item.dns_servers is defined -%}
       {%- do cloud_init.update(
         {
-          'dns_search': item["dns_searc"] 
+          'dns_search': item["dns_search"] 
         }
       ) if item.dns_search is defined -%}
       'cloud_init': {{ cloud_init | combine(openshift_ovirt_vm_profile[item.profile]["cloud_init"], recursive=True) }},


### PR DESCRIPTION
Some features was not included on this PR: https://github.com/openshift/openshift-ansible/pull/10805 here we've back and also fixing a typo.

- `ovirt_admin` flag comes back
- Typo for dns_search fixed
- Added to documentation to activate the j2 extension