### PR TITLE
40 Install node package names based on openshift_release

### DIFF
--- a/roles/openshift_node40/tasks/install.yml
+++ b/roles/openshift_node40/tasks/install.yml
@@ -10,9 +10,6 @@
   delay: 1
   vars:
     l_node_packages:
-    #- "atomic-openshift-node{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
-    #- "atomic-openshift-clients{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
-    #- "atomic-openshift-hyperkube{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
-    - "origin-node{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
-    - "origin-clients{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
-    - "origin-hyperkube{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
+    - "{{ openshift_service_type }}-node{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
+    - "{{ openshift_service_type }}-clients{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
+    - "{{ openshift_service_type }}-hyperkube{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"


### PR DESCRIPTION
Previously, the packages to be installed were hard coded for origin. As
a result, there was no way of installing the openshift-enterprise
packages. This was a regression from 3.x behavior.

This patch uses the openshift_service_type variable to determine which
packages are to be installed based on the value of openshift_release.