### PR TITLE
[release-3.10] Set owner 'etcd' of certs when upgrading from 3.9 to 3.10.

### DIFF
--- a/playbooks/openshift-etcd/private/upgrade_main.yml
+++ b/playbooks/openshift-etcd/private/upgrade_main.yml
@@ -14,23 +14,23 @@
       src: /etc/etcd/server.crt
     register: etcd_serving_cert
   - set_fact:
-      __etcd_cert_lacks_hostname: "{{ (openshift.common.hostname not in (etcd_serving_cert.content | b64decode | lib_utils_oo_parse_certificate_san)) | bool }}"
+      etcd_cert_lacks_hostname: "{{ (openshift.common.hostname not in (etcd_serving_cert.content | b64decode | lib_utils_oo_parse_certificate_san)) | bool }}"
 
 # Redeploy etcd certificates when hostnames were missing from etcd
 # serving certificate SANs.
 - import_playbook: redeploy-certificates.yml
   when:
-  - true in hostvars | lib_utils_oo_select_keys(groups['oo_etcd_to_config']) | lib_utils_oo_collect('__etcd_cert_lacks_hostname') | default([false])
+  - true in hostvars | lib_utils_oo_select_keys(groups['oo_etcd_to_config']) | lib_utils_oo_collect('etcd_cert_lacks_hostname') | default([false])
 
 - import_playbook: restart.yml
   vars:
     g_etcd_certificates_expired: "{{ ('expired' in (hostvars | lib_utils_oo_select_keys(groups['etcd']) | lib_utils_oo_collect('check_results.check_results.etcd') | lib_utils_oo_collect('health'))) | bool }}"
   when:
-  - true in hostvars | lib_utils_oo_select_keys(groups['oo_etcd_to_config']) | lib_utils_oo_collect('__etcd_cert_lacks_hostname') | default([false])
+  - true in hostvars | lib_utils_oo_select_keys(groups['oo_etcd_to_config']) | lib_utils_oo_collect('etcd_cert_lacks_hostname') | default([false])
 
 - import_playbook: ../../openshift-master/private/restart.yml
   when:
-  - true in hostvars | lib_utils_oo_select_keys(groups['oo_etcd_to_config']) | lib_utils_oo_collect('__etcd_cert_lacks_hostname') | default([false])
+  - true in hostvars | lib_utils_oo_select_keys(groups['oo_etcd_to_config']) | lib_utils_oo_collect('etcd_cert_lacks_hostname') | default([false])
 
 # For 1.4/3.4 we want to upgrade everyone to etcd-3.0. etcd docs say to
 # upgrade from 2.0.x to 2.1.x to 2.2.x to 2.3.x to 3.0.x. While this is a tedius

--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -122,3 +122,5 @@ l_etcd_restart_command: "{{ l_etcd_restart_is_pod | ternary('/usr/local/bin/mast
 etcd_static_pod_location: "{{ openshift_control_plane_static_pod_location | default('/etc/origin/node/pods/') }}"
 
 etcd_cipher_suites: ""
+
+etcd_cert_lacks_hostname: False

--- a/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
+++ b/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
@@ -184,6 +184,8 @@
   file:
     path: "{{ item }}"
     mode: 0600
+    owner: "{{ 'etcd' if etcd_cert_lacks_hostname | bool else omit }}"
+    group: "{{ 'etcd' if etcd_cert_lacks_hostname | bool else omit }}"
   when: etcd_url_scheme == 'https'
   with_items:
   - "{{ etcd_ca_file }}"
@@ -194,6 +196,8 @@
   file:
     path: "{{ item }}"
     mode: 0600
+    owner: "{{ 'etcd' if etcd_cert_lacks_hostname | bool else omit }}"
+    group: "{{ 'etcd' if etcd_cert_lacks_hostname | bool else omit }}"
   when: etcd_peer_url_scheme == 'https'
   with_items:
   - "{{ etcd_peer_ca_file }}"
@@ -205,4 +209,6 @@
   file:
     path: "{{ etcd_conf_dir }}"
     state: directory
+    owner: "{{ 'etcd' if etcd_cert_lacks_hostname | bool else omit }}"
+    group: "{{ 'etcd' if etcd_cert_lacks_hostname | bool else omit }}"
     mode: 0700


### PR DESCRIPTION
Change the owner of etcd certs to 'etcd' if we are redeploying certs as part of a 3.9 to 3.10 upgrade. With these permissions, both the 3.9 systemd unit and the 3.10 static pod (run as root) have permission to read the files.

Fixes [bug 1656526](https://bugzilla.redhat.com/show_bug.cgi?id=1656526) and issue #10361