### PR TITLE
sdn: upgrade SDN after all nodes are upgraded.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -87,6 +87,12 @@
           ('glusterfs' in groups and inventory_hostname in groups['glusterfs'])
           or ('glusterfs_registry' in groups and inventory_hostname in groups['glusterfs_registry'])
 
+- name: Upgrade SDN
+  hosts: oo_first_master
+  roles:
+  - role: openshift_sdn
+    when: openshift_use_openshift_sdn | default(True) | bool
+
 - name: Re-enable excluders
   hosts: oo_nodes_to_upgrade:!oo_masters_to_config
   tasks:

--- a/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
@@ -78,13 +78,6 @@
     # a default is set on the actual variable in the role, so no fancy logic is needed here
     when: openshift_metrics_server_install | default(true) | bool
 
-
-- name: Configure components that must be available prior to upgrade
-  hosts: oo_first_master
-  roles:
-  - role: openshift_sdn
-    when: openshift_use_openshift_sdn | default(True) | bool
-
 - import_playbook: ../upgrade_control_plane.yml
   vars:
     openshift_release: '3.11'

--- a/roles/openshift_sdn/tasks/main.yml
+++ b/roles/openshift_sdn/tasks/main.yml
@@ -51,6 +51,24 @@
   shell: >
     {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig apply -f "{{ mktemp.stdout }}"
 
+- name: Wait for rollout
+  command: >
+    {{ openshift_client_binary }} rollout status ds/sdn --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift-sdn
+  changed_when: false
+  # Ignore errors so we can log troubleshooting info on failures.
+  ignore_errors: yes
+  register: sdn_rollout_status
+
+- when: sdn_rollout_status.rc != 0
+  block:
+    - name: Get pods in the openshift-sdn namespace
+      command: >
+        {{ openshift_client_binary }} get pods -o wide --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift-sdn
+      register: pods
+      ignore_errors: true
+    - debug:
+        msg: "{{ pods.stdout_lines }}"
+
 - name: Remove temp directory
   file:
     state: absent


### PR DESCRIPTION
Restarting OVS kills all pods on the node. So, while we can't do it as part of the node drain-upgrade loop, we can at least do it when users are expecting disruption.

