### PR TITLE
Reorder playbook imports

### DIFF
--- a/playbooks/init/main.yml
+++ b/playbooks/init/main.yml
@@ -22,6 +22,8 @@
 
 - import_playbook: basic_facts.yml
 
+- import_playbook: version.yml
+
 # NOTE: we must call init repos before installing base packages
 # because they may come from the repos.
 - import_playbook: repos.yml
@@ -31,8 +33,6 @@
   when: l_install_base_packages | default(False) | bool
 
 - import_playbook: cluster_facts.yml
-
-- import_playbook: version.yml
 
 - import_playbook: sanity_checks.yml
   when: not (skip_sanity_checks | default(False))


### PR DESCRIPTION
If ansible variables `rhsub_user` and `rhsub_pass` or `rhsub_ak` and `rhsub_orgid` (as described in `roles/rhel_subscribe/README.md`) are defined, the rhel_subscribe role is imported during the prerequisites playbook run. However, the order of playbooks in `playbooks/init/main.yml` is wrong which leads to an error because the variable `openshift_version` has not yet been determined.

This pull request fixes this by importing the version.yml playbook _before_ the repos.yml playbook.