### PR TITLE
[3.11] Fix CentOS repo version

### DIFF
--- a/roles/openshift_repos/tasks/centos_repos.yml
+++ b/roles/openshift_repos/tasks/centos_repos.yml
@@ -10,15 +10,11 @@
     dest: "/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS"
   notify: refresh cache
 
-# openshift_version is formatted to a standard string in openshift_version role.
-# openshift_version is expected to be in format 'x.y.z...' here.
-# Here, we drop the '.' characters and try to match the correct repo template
-# for our corresponding openshift_version.
 - name: Configure correct origin release repository
   template:
     src: "{{ item }}"
     dest: "/etc/yum.repos.d/{{ (item | basename | splitext)[0] }}"
   with_first_found:
-    - "CentOS-OpenShift-Origin{{ ((openshift_version | default('')).split('.')[0:2] | join('')) }}.repo.j2"
+    - "CentOS-OpenShift-Origin{{ ((openshift_release | default('')).split('.')[0:2] | join('')) }}.repo.j2"
     - "CentOS-OpenShift-Origin.repo.j2"
   notify: refresh cache


### PR DESCRIPTION
openshift_version may be undefined by this point, we default
openshift_release in openshift_version role defaults now which
we pull in as meta depends.  This commit matches RHEL behavior.