### PR TITLE
Supply namespace when generating hawkular role binding

### DIFF
--- a/roles/openshift_metrics/tasks/generate_rolebindings.yaml
+++ b/roles/openshift_metrics/tasks/generate_rolebindings.yaml
@@ -12,6 +12,7 @@
     subjects:
     - kind: ServiceAccount
       name: hawkular
+      namespace: "{{openshift_metrics_project}}"
   changed_when: no
 
 - name: generate hawkular-metrics cluster role binding for the hawkular service account


### PR DESCRIPTION
Port of https://github.com/openshift/openshift-ansible/pull/10776 to 3.11