### PR TITLE
Fix scale up gluster storage

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/heketi_pod_check.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_pod_check.yml
@@ -33,6 +33,8 @@
     heketi_pod_results_count: "{{ heketi_pod_results | count }}"
     heketi_pod_results_ready_count: "{{ heketi_pod_results | lib_utils_oo_collect(attribute='status.conditions') | lib_utils_oo_collect(attribute='status', filters={'type': 'Ready'}) | map('bool') | select | list | count }}"
 
+- import_tasks: heketi_get_key.yml
+
 - import_tasks: heketi_set_cli.yml
   vars:
     deploy_heketi_pod_results: "{{ deploy_heketi_pod_check.results.results[0]['items'] }}"


### PR DESCRIPTION
Fix a Gluster scale up problem that does not have the heketi admin key to make the change to the existing topology.

