### PR TITLE
Remove glusterfs packages while uninstalling

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
@@ -170,3 +170,6 @@
   with_items: "{{ glusterfs_nodes | default([]) }}"
   failed_when: False
   when: glusterfs_wipe
+  
+ - name: Erase glusterfs packages
+   command: "yum -y erase glusterfs-fuse glusterfs glusterfs-client-xlators glusterfs-libs" 

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
@@ -170,6 +170,6 @@
   with_items: "{{ glusterfs_nodes | default([]) }}"
   failed_when: False
   when: glusterfs_wipe
-  
- - name: Erase glusterfs packages
-   command: "yum -y erase glusterfs-fuse glusterfs glusterfs-client-xlators glusterfs-libs" 
+
+- name: Erase glusterfs packages
+  command: "yum -y erase glusterfs-fuse glusterfs glusterfs-client-xlators glusterfs-libs"


### PR DESCRIPTION
Remove glusterfs client packages while uninstalling glusterfs. We wipe out the entire storage and delete few directories. However, we don't remove the glusterfs packages. Hence, after uninstalling the glusterfs using the playbooks and rerunning the installation playbook again fails. 

This is because the installer skips the glusterfs-fuse package installation since the packages are already installed on the nodes. However, installer fails to create the log files since the parent directories are removed which are provided by glusterfs package. 

This is the error installer throws:
~~~
    "msg": "Error mounting /tmp/openshift-glusterfs-registry-nn90GP: ERROR: failed to create logfile \"/var/log/glusterfs/tmp-openshift-glusterfs-registry-nn90GP.log\" (No s
uch file or directory)\nERROR: failed to open logfile /var/log/glusterfs/tmp-openshift-glusterfs-registry-nn90GP.log\nMount failed. Please check the log file for more detail
~~~
This fails because /var/log/glusterfs directory is not present. This directory is created by glusterfs package.
~~~
[root@localhost ~]# rpm -qf /var/log/glusterfs/
glusterfs-3.12.2-18.el7.x86_64
~~~
During installation, this is the task which installs glusterfs-fuse package.
~~~
- name: Install GlusterFS storage plugin dependencies
  package:
    name: glusterfs-fuse
    state: present
  register: result
until: result is succeeded
~~~
The other packages are installed as a dependency of glusterfs-fuse and glusterfs package.
~~~
[root@localhost ~]# rpm -q glusterfs-fuse --requires
config(glusterfs-fuse) = 3.12.2-18.el7
glusterfs(x86-64) = 3.12.2-18.el7
glusterfs-client-xlators(x86-64) = 3.12.2-18.el7
[root@localhost ~]# rpm -q glusterfs --requires
glusterfs-libs(x86-64) = 3.12.2-18.el7
~~~
the uninstall playbook followed by a install play


Removing the glusterfs packages and then running the install playbook works as expected. It installs the glusterfs* packages and creates all the necessary files and directories.

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
