### PR TITLE
[devel-40] Rework bootstrap to setup workers during bootstrap

### DIFF
--- a/inventory/dynamic/gcp/group_vars/all/00_defaults.yml
+++ b/inventory/dynamic/gcp/group_vars/all/00_defaults.yml
@@ -21,7 +21,6 @@ openshift_master_cluster_public_hostname: "openshift-master.{{ public_hosted_zon
 openshift_master_default_subdomain: "{{ wildcard_zone }}"
 
 mcd_port: 49500
-mcd_endpoint: "https://{{ openshift_master_cluster_public_hostname }}:{{ mcd_port }}"
 
 # Cloud specific settings
 openshift_cloudprovider_kind: gce

--- a/playbooks/deploy_cluster_40.yml
+++ b/playbooks/deploy_cluster_40.yml
@@ -8,8 +8,8 @@
     l_repo_hosts: "nodes"
 
 # TODO(michaelgugino): break up the rest of this file into reusable chunks.
-- name: Install nodes
-  hosts: nodes
+- name: Install precondition packages on masters
+  hosts: bootstrap:masters
   roles:
   - role: container_runtime
   tasks:
@@ -40,7 +40,7 @@
       - progress.service
   - name: Wait for MCS endpoint to show up
     uri:
-      url: "{{ mcd_endpoint }}/config/master"
+      url: "https://{{ openshift_install_config['metadata']['name'] }}-api.{{ openshift_install_config['baseDomain'] }}:49500/config/master"
       validate_certs: false
     delay: 10
     retries: 60
@@ -95,21 +95,25 @@
       name: openshift_node40
       tasks_from: systemd.yml
 
-- name: Start workers
+- name: Setup workers
   hosts: workers
   vars:
     openshift_bootstrap_endpoint: "https://{{ openshift_install_config['metadata']['name'] }}-api.{{ openshift_install_config['baseDomain'] }}:49500/config/worker"
+  roles:
+  - role: container_runtime
   tasks:
-  - name: Wait for bootstrap endpoint to show up
-    uri:
-      url: "{{ openshift_bootstrap_endpoint }}"
-      validate_certs: false
-    delay: 10
-    retries: 60
-    register: result
-    until:
-    - "'status' in result"
-    - result.status == 200
+  - import_role:
+      name: container_runtime
+      tasks_from: docker_storage_setup_overlay.yml
+  - import_role:
+      name: container_runtime
+      tasks_from: extra_storage_setup.yml
+  - import_role:
+      name: container_runtime
+      tasks_from: package_crio.yml
+  - import_role:
+      name: openshift_node40
+      tasks_from: install.yml
   - import_role:
       name: openshift_node40
       tasks_from: config.yml
@@ -117,46 +121,17 @@
       name: openshift_node40
       tasks_from: systemd.yml
 
-- name: Wait for nodes to become ready
+- name: Wait for core operators to appear and complete
   hosts: bootstrap
   tasks:
-  - name: Wait for temporary control plane to show up
-    oc_obj:
-      state: list
-      kind: pod
-      namespace: kube-system
-      kubeconfig: /opt/openshift/auth/kubeconfig
-    register: control_plane_pods
-    retries: 60
-    delay: 10
-    until:
-    - "'results' in control_plane_pods and 'results' in control_plane_pods.results"
-    - control_plane_pods.results.results[0]['items'] | length > 0
-  - name: Wait for master nodes to show up
-    oc_obj:
-      state: list
-      kind: node
-      selector: "node-role.kubernetes.io/master"
-      kubeconfig: /opt/openshift/auth/kubeconfig
-    register: master_nodes
-    retries: 60
-    delay: 10
-    until:
-    - "'results' in master_nodes and 'results' in master_nodes.results"
-    - master_nodes.results.results[0]['items'] | length > 0
   - name: Wait for bootkube service to finish
     service_facts: {}
     #10 mins to complete temp plane
+    ignore_errors: true
+    register: bootstrap_status
     retries: 120
     delay: 5
     until: "'bootkube.service' not in ansible_facts.services"
-    ignore_errors: true
-  - name: Fetch kubeconfig for test container
-    fetch:
-      src: /opt/openshift/auth/kubeconfig
-      dest: /tmp/artifacts/installer/auth/kubeconfig
-      flat: yes
-
   - name: Wait for core operators to appear and complete
     oc_obj:
       state: list
@@ -177,7 +152,6 @@
     - cvo.results.results[0].status.conditions | selectattr('type', 'match', '^Failing$') | map(attribute='status') | join | bool == False
     - cvo.results.results[0].status.conditions | selectattr('type', 'match', '^Progressing$') | map(attribute='status') | join | bool == False
     ignore_errors: true
-
   - block:
     - name: Output CVO status
       oc_obj:
@@ -194,3 +168,8 @@
     - fail:
         msg: CVO didn't complete the install
     when: cvo.failed
+  - name: Fetch kubeconfig for test container
+    fetch:
+      src: /opt/openshift/auth/kubeconfig
+      dest: /tmp/artifacts/installer/auth/kubeconfig
+      flat: yes

--- a/roles/openshift_gcp/defaults/main.yml
+++ b/roles/openshift_gcp/defaults/main.yml
@@ -63,7 +63,6 @@ openshift_gcp_multizone: False
 
 provision_custom_repositories: []
 
-mcd_port: 49500
 openshift_gcp_kubernetes_api_port: 6443
 openshift_gcp_master_healthcheck_port: 8080
 


### PR DESCRIPTION
Rearrange tasks to setup workers when bootstrap service is running on bootstrap node.

This also removes traces of `mcd_endpoint` var