### PR TITLE
[release-3.11] Switch subjectAltName type to bytes when checking certs using pyOpenSSL.

### DIFF
--- a/roles/lib_utils/filter_plugins/oo_filters.py
+++ b/roles/lib_utils/filter_plugins/oo_filters.py
@@ -326,7 +326,7 @@ def lib_utils_oo_parse_named_certificates(certificates, named_certs_dir, interna
             cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, st_cert)
             certificate['names'].append(str(cert.get_subject().commonName.decode()))
             for i in range(cert.get_extension_count()):
-                if cert.get_extension(i).get_short_name() == 'subjectAltName':
+                if cert.get_extension(i).get_short_name() == b'subjectAltName':
                     for name in str(cert.get_extension(i)).split(', '):
                         if 'DNS:' in name:
                             certificate['names'].append(name.replace('DNS:', ''))
@@ -392,7 +392,7 @@ def lib_utils_oo_parse_certificate_san(certificate):
     try:
         lcert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, certificate)
         for i in range(lcert.get_extension_count()):
-            if lcert.get_extension(i).get_short_name() == 'subjectAltName':
+            if lcert.get_extension(i).get_short_name() == b'subjectAltName':
                 sanstr = str(lcert.get_extension(i))
                 sanstr = sanstr.replace('DNS:', '')
                 sanstr = sanstr.replace('IP Address:', '')


### PR DESCRIPTION
Switch 'subjectAltName' to b'subjectAltName' to match the return type of [get_short_name()](https://pyopenssl.org/en/stable/api/crypto.html?highlight=get_short_name#OpenSSL.crypto.X509Extension.get_short_name). Prior to this PR, this conditional would always evaluate as False. The SANs were never found and during upgrades this would cause new certs to be created.

Fixes bug [1656526](https://bugzilla.redhat.com/show_bug.cgi?id=1656526) and issue #10361