### PR TITLE
[libvirt] Set worker replicas to 1 for now

### DIFF
--- a/test/libvirt/install-config.yml.template
+++ b/test/libvirt/install-config.yml.template
@@ -4,7 +4,7 @@ machines:
 - name: master
   replicas: ${OCP_MASTERS}
 - name: worker
-  replicas: 0
+  replicas: 1
 metadata:
   name: ${OCP_CLUSTER_NAME}
 networking:


### PR DESCRIPTION
The installer rejects 0.

The machine controller likely fails indefinitely with this but we can sort that out later.