### PR TITLE
Override of logging ES image pull secret

### DIFF
--- a/roles/openshift_logging_elasticsearch/defaults/main.yml
+++ b/roles/openshift_logging_elasticsearch/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 ### Common settings
-openshift_logging_elasticsearch_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"
+openshift_logging_elasticsearch_image_pull_secret: "{{ openshift_logging_image_pull_secret | default('') }}"
+
 openshift_logging_elasticsearch_namespace: logging
 
 

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -62,8 +62,8 @@
     state: present
     name: "aggregated-logging-elasticsearch"
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    image_pull_secrets: "{{ openshift_logging_image_pull_secret }}"
-  when: openshift_logging_image_pull_secret != ''
+    image_pull_secrets: "{{ openshift_logging_elasticsearch_image_pull_secret }}"
+  when: openshift_logging_elasticsearch_image_pull_secret != ''
 
 - name: Create ES service account
   oc_serviceaccount:
@@ -71,7 +71,7 @@
     name: "aggregated-logging-elasticsearch"
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
   when:
-  - openshift_logging_image_pull_secret == ''
+  - openshift_logging_elasticsearch_image_pull_secret == ''
 
 # rolebinding reader
 - name: Create rolebinding-reader role


### PR DESCRIPTION
The default variables of the `openshift_logging_elasticsearch` role
suggest that the image pull secret can be overridden only for
Elasticsearch. It actually was only possible to do so for all logging
components. This commit actually makes use of
`openshift_logging_elasticsearch_image_pull_secret` which by default gets
assigned the broader `openshift_hosted_logging_image_pull_secret` or
`openshift_logging_image_pull_secret` values.
