### PR TITLE
[release 3.11] Allow OpenStack persistent volumes to specify storage class

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -960,10 +960,13 @@ and then set the following in `inventory/group_vars/OSEv3.yml`:
 * `openshift_hosted_registry_storage_volume_size`: 10Gi
 
 For a volume *you created*, you must also specify its **UUID** (it must be
-the UUID, not the volume's name):
+the UUID, not the volume's name). If using the default storage class, you must specify
+that as well (for OpenStack it's `standard`):
 
 ```
 openshift_hosted_registry_storage_openstack_volumeID: e0ba2d73-d2f9-4514-a3b2-a0ced507fa05
+openshift_hosted_registry_storage_annotations:
+- 'volume.beta.kubernetes.io/storage-class: standard'
 ```
 
 If you want the volume *created automatically*, set the desired name instead:

--- a/roles/lib_utils/action_plugins/generate_pv_pvcs_list.py
+++ b/roles/lib_utils/action_plugins/generate_pv_pvcs_list.py
@@ -62,7 +62,7 @@ class ActionModule(ActionBase):
 
     def build_pv_openstack(self, varname=None):
         """Build pv dictionary for openstack storage type"""
-        volume, size, labels, _, access_modes = self.build_common(varname=varname)
+        volume, size, labels, annotations, access_modes = self.build_common(varname=varname)
         filesystem = self.get_templated(str(varname) + '_openstack_filesystem')
         volume_name = self.get_templated(str(varname) + '_volume_name')
         volume_id = self.get_templated(str(varname) + '_openstack_volumeID')
@@ -72,6 +72,7 @@ class ActionModule(ActionBase):
             name="{0}-volume".format(volume),
             capacity=size,
             labels=labels,
+            annotations=annotations,
             access_modes=access_modes,
             storage=dict(
                 cinder=dict(

--- a/roles/openshift_persistent_volumes/templates/persistent-volume.yml.j2
+++ b/roles/openshift_persistent_volumes/templates/persistent-volume.yml.j2
@@ -7,6 +7,12 @@ items:
   kind: PersistentVolume
   metadata:
     name: "{{ volume.name }}"
+{% if volume.annotations %}
+    annotations:
+{% for annotation in volume.annotations %}
+      {{ annotation }}
+{% endfor %}
+{% endif %}
 {% if volume.labels is defined and volume.labels is mapping %}
     labels:
 {% for key,value in volume.labels.items() %}


### PR DESCRIPTION
By default, a default storage class is applied. This prevents OpenStack persistent volumes from matching their persistent volume claims, as the default storage class applies to the PVC but not the PV. This PR provides a mechanism for a deployer to specify the storage class for their PVs.