### PR TITLE
[release-3.11]FIX:Bug 1614176:Add openshift_sdn_vxlan_port to change the vxlanPort

### DIFF
--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -140,6 +140,9 @@ networkConfig:
 {% if openshift_master_ingress_ip_network_cidr is defined %}
   ingressIPNetworkCIDR: {{ openshift_master_ingress_ip_network_cidr }}
 {% endif %}
+{% if openshift_sdn_vxlan_port != '4789' %}
+  vxlanPort: {{ openshift_sdn_vxlan_port }}
+{% endif %}
 oauthConfig:
 {% if openshift_master_oauth_always_show_provider_selection is defined %}
   alwaysShowProviderSelection: {{ openshift_master_oauth_always_show_provider_selection }}

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -139,6 +139,7 @@ openshift_service_type: "{{ openshift_service_type_dict[openshift_deployment_typ
 openshift_master_api_port: "8443"
 openshift_ca_host: "{{ groups.oo_first_master.0 }}"
 openshift_use_openshift_sdn: true
+openshift_sdn_vxlan_port: "4789"
 os_sdn_network_plugin_name: "redhat/openshift-ovs-subnet"
 
 openshift_node_groups:

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -79,7 +79,7 @@ default_r_openshift_node_os_firewall_allow:
 - service: https
   port: 443/tcp
 - service: OpenShift OVS sdn
-  port: 4789/udp
+  port: "{{ openshift_sdn_vxlan_port | default('4789') }}/udp"
   cond: openshift_use_openshift_sdn | bool
 - service: Calico BGP Port
   port: 179/tcp


### PR DESCRIPTION
* Fix: [[RFE] Allow vxlan port to be configurable in openshift-ansible when setup OCP cluster](https://bugzilla.redhat.com/show_bug.cgi?id=1614176)
* Version: `v3.11`
* Description: 
  Add the variable which can specify the `vxlanPort` when the `OCP` install initially. `vxlanPort` change feature is already supported as of `v3.11`([CONFIGURABLE VXLAN PORT](https://docs.openshift.com/container-platform/3.11/release_notes/ocp_3_11_release_notes.html#ocp-311-configurable-vxlan-port)), so it's just aspect of adding option to initial installation.
  Refer the above `BZ` for more details.
