### PR TITLE
test/aws: create necessary security groups

### DIFF
--- a/test/ci/deprovision.yml
+++ b/test/ci/deprovision.yml
@@ -43,3 +43,12 @@
               Name: "{{ item.tags.Name }}-terminate"
           when: "'-terminate' not in item.tags.Name"
           with_items: "{{ ec2.instances }}"
+
+    - name: Delete security groups
+      group_id:
+        name: "{{ item.security_groups.0.group_id }}"
+        state: absent
+        vpc_id: "{{ aws_vpc_id }}"
+        region: "{{ aws_region }}"
+      with_items: "{{ ec2.instances }}"
+      when: not aws_use_auto_terminator | default(true)

--- a/test/ci/launch.yml
+++ b/test/ci/launch.yml
@@ -25,6 +25,28 @@
         aws_image: "{{ ami_facts.images[-1].image_id }}"
       when: aws_image is not defined
 
+    - name: Create AWS security group
+      ec2_group:
+        name: "{{ item.aws_security_group }}"
+        description: "Openshift Ansible SG for {{ vm_prefix }}"
+        vpc_id: "{{ aws_vpc_id }}"
+        region: "{{ aws_region }}"
+        rules:
+          - proto: all
+            cidr_ip: 0.0.0.0/0
+        rules_egress:
+          - proto: all
+            cidr_ip: 0.0.0.0/0
+        tags: "{{ aws_sg_tags }}"
+      with_items: "{{ aws_instances }}"
+      when: not aws_use_auto_terminator | default(true)
+      vars:
+        aws_sg_tags: |
+          {
+            "kubernetes.io/cluster/{{ aws_cluster_id }}": "true",
+            "expirationDate": "{{ item.aws_expiration_date | default(aws_expiration_date) }}"
+          }
+
     - name: Create EC2 instance
       ec2:
         region: "{{ aws_region }}"


### PR DESCRIPTION
Previously in `rh-dev` account there was one immutable group, but in new CI AWS account SGs are being garbage collected based on `expirationDate` tag. Recently the group we've been using got deleted, so this would ensure AWS test creates a security group for each instance - and removes it afterwards.

TODO:
* [x] Create a release PR to pass VPC ID and randomize SG name for each run
