### PR TITLE
Add the dependencies needed for openshift_ovirt role

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -23,6 +23,7 @@ fact_caching_connection = $HOME/ansible/facts
 fact_caching_timeout = 600
 callback_whitelist = profile_tasks
 inventory_ignore_extensions = secrets.py, .pyc, .cfg, .crt, .ini
+jinja2_extensions = jinja2.ext.do
 # work around privilege escalation timeouts in ansible:
 timeout = 30
 

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -8,7 +8,9 @@ USER root
 COPY images/installer/origin-extra-root /
 
 # install ansible and deps
-RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch" \
+RUN REPO_PKGS="http://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm" \
+ && yum install -y --setopt=tsflags=nodocs $REPO_PKGS \
+ && INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch python-ovirt-engine-sdk4 ovirt-ansible-roles" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
  && EPEL_PKGS="ansible-2.7.4 python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46" \
  && yum install -y epel-release \


### PR DESCRIPTION
Adding the dependencies needed for the openshift_ovirt role to run.
Without those, users would have to somehow add them to the container, by either inheriting the container, or modify it - rather than having it working out-of-the-box.