### PR TITLE
Fix BZ1663306 when gluster nodes are SchedulingDisabled

### DIFF
--- a/roles/lib_utils/library/glusterfs_check_containerized.py
+++ b/roles/lib_utils/library/glusterfs_check_containerized.py
@@ -80,7 +80,7 @@ def get_valid_nodes(module, oc_exec, exclude_node):
         fields = line.split()
         if not fields:
             continue
-        if fields[0] != exclude_node and fields[1] == "Ready":
+        if fields[0] != exclude_node and "Ready" in fields[1].split(','):
             valid_nodes.append(fields[0])
     if not valid_nodes:
         fail(module,

--- a/roles/lib_utils/test/test_glusterfs_check_containerized.py
+++ b/roles/lib_utils/test/test_glusterfs_check_containerized.py
@@ -37,6 +37,13 @@ fedora2.openshift.io   NotReady     infra                  1d        v1.11.0+d4c
 fedora3.openshift.io   Invalid     infra                  1d        v1.11.0+d4cacc0
 """)
 
+NODE_LIST_STD_OUT_4 = ("""
+NAME                       STATUS    ROLES                  AGE       VERSION
+fedora1.openshift.io   Ready     infra,master   1d        v1.11.0+d4cacc0
+fedora2.openshift.io   NotReady     infra                  1d        v1.11.0+d4cacc0
+fedora3.openshift.io   Ready,SchedulingDisabled     compute                  1d        v1.11.0+d4cacc0
+""")
+
 POD_SELECT_STD_OUT = ("""NAME                                          READY     STATUS    RESTARTS   AGE       IP                NODE
 glusterblock-storage-provisioner-dc-1-ks5zt   1/1       Running   0          1d        10.130.0.5        fedora3.openshift.io
 glusterfs-storage-fzdn2                       1/1       Running   0          1d        192.168.124.175   fedora1.openshift.io
@@ -106,6 +113,10 @@ def test_get_valid_nodes():
         with pytest.raises(Exception) as err:
             valid_nodes = glusterfs_check_containerized.get_valid_nodes(module, oc_exec, exclude_node)
         assert 'Exception: Unable to find suitable node in get nodes output' in str(err)
+
+        call_mock.return_value = NODE_LIST_STD_OUT_4
+        valid_nodes = glusterfs_check_containerized.get_valid_nodes(module, oc_exec, exclude_node)
+        assert valid_nodes == ['fedora3.openshift.io']
 
 
 def test_select_pod():


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1663306.

Problem:
When gluster nodes have other statuses than only Ready (such as SchedulingDisabled), the cluster health check fails. (ansible task: Check GlusterFS for cluster health)