### PR TITLE
[devel-40] deploy_cluster_40: bootkube service no longer removes itself

### DIFF
--- a/playbooks/deploy_cluster_40.yml
+++ b/playbooks/deploy_cluster_40.yml
@@ -149,8 +149,7 @@
     #10 mins to complete temp plane
     retries: 120
     delay: 5
-    until: "'bootkube.service' not in ansible_facts.services"
-    ignore_errors: true
+    until: ansible_facts.services['bootkube.service'].state == 'stopped'
   - name: Fetch kubeconfig for test container
     fetch:
       src: /opt/openshift/auth/kubeconfig


### PR DESCRIPTION
bootkube service now properly stops instead of removing itself