### PR TITLE
[3.10] split readiness from liveness probe

### DIFF
--- a/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
+++ b/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
@@ -259,3 +259,29 @@ objects:
   - kind: ServiceAccount
     name: service-catalog-apiserver
     namespace: kube-service-catalog
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: servicecatalog.k8s.io:service-catalog-readiness
+  rules:
+  - nonResourceURLs:
+    - /healthz/ready
+    verbs:
+      - get
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: servicecatalog.k8s.io:service-catalog-readiness
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: servicecatalog.k8s.io:service-catalog-readiness
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:unauthenticated
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated

--- a/roles/openshift_service_catalog/templates/api_server.j2
+++ b/roles/openshift_service_catalog/templates/api_server.j2
@@ -66,7 +66,7 @@ spec:
         readinessProbe:
           httpGet:
             port: 6443
-            path: /healthz
+            path: /healthz/ready
             scheme: HTTPS
           failureThreshold: 1
           initialDelaySeconds: 30

--- a/roles/openshift_service_catalog/templates/controller_manager.j2
+++ b/roles/openshift_service_catalog/templates/controller_manager.j2
@@ -63,7 +63,7 @@ spec:
         readinessProbe:
           httpGet:
             port: 6443
-            path: /healthz
+            path: /healthz/ready
             scheme: HTTPS
           failureThreshold: 1
           initialDelaySeconds: 30


### PR DESCRIPTION
Split the readiness probe functionality from the liveness probe to avoid unnecessary pod restarts.

Accompanies https://github.com/openshift/service-catalog/pull/42 
and fixes https://bugzilla.redhat.com/show_bug.cgi?id=1664799