### PR TITLE
[3.11] split readiness from liveness probe

### DIFF
--- a/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
+++ b/roles/openshift_service_catalog/files/kubeservicecatalog_roles_bindings.yml
@@ -265,3 +265,29 @@ objects:
   - kind: ServiceAccount
     name: service-catalog-apiserver
     namespace: kube-service-catalog
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: servicecatalog.k8s.io:service-catalog-readiness
+  rules:
+  - nonResourceURLs:
+    - /healthz/ready
+    verbs:
+      - get
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: servicecatalog.k8s.io:service-catalog-readiness
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: servicecatalog.k8s.io:service-catalog-readiness
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:unauthenticated
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated

--- a/roles/openshift_service_catalog/templates/api_server.j2
+++ b/roles/openshift_service_catalog/templates/api_server.j2
@@ -70,7 +70,7 @@ spec:
         readinessProbe:
           httpGet:
             port: 6443
-            path: /healthz
+            path: /healthz/ready
             scheme: HTTPS
           failureThreshold: 1
           initialDelaySeconds: 30

--- a/roles/openshift_service_catalog/templates/controller_manager.j2
+++ b/roles/openshift_service_catalog/templates/controller_manager.j2
@@ -67,7 +67,7 @@ spec:
         readinessProbe:
           httpGet:
             port: 6443
-            path: /healthz
+            path: /healthz/ready
             scheme: HTTPS
           failureThreshold: 1
           initialDelaySeconds: 30


### PR DESCRIPTION
Split the readiness probe functionality from the liveness probe to avoid unnecessary pod restarts.

Accompanies openshift/service-catalog#43
and fixes https://bugzilla.redhat.com/show_bug.cgi?id=1664753