### PR TITLE
Fix install of kube_proxy_and_dns, with Calico

### DIFF
--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: Calico | Run kube proxy
   import_role:
     name: kube_proxy_and_dns
-  when: "ansible_hostname == groups.oo_first_master.0"
+  when: "inventory_hostname == groups.oo_first_master.0"
 
 - include_tasks: certs.yml
 


### PR DESCRIPTION
See explanation at
https://github.com/openshift/openshift-ansible/pull/10815.

This change copies just the ansible_hostname -> inventory_hostname fix
from that PR, as I believe that's the only change needed to get
OpenShift 3.11 working again with Calico CNI.