### PR TITLE
Added enviroment values for easier heketi-cli usage

### DIFF
--- a/roles/openshift_storage_glusterfs/files/heketi-template.yml
+++ b/roles/openshift_storage_glusterfs/files/heketi-template.yml
@@ -71,6 +71,10 @@ objects:
             value: ${HEKETI_USER_KEY}
           - name: HEKETI_ADMIN_KEY
             value: ${HEKETI_ADMIN_KEY}
+          - name: HEKETI_CLI_USER
+            value: 'admin'
+          - name: HEKETI_CLI_KEY
+            value: ${HEKETI_ADMIN_KEY}
           - name: HEKETI_EXECUTOR
             value: ${HEKETI_EXECUTOR}
           - name: HEKETI_FSTAB


### PR DESCRIPTION
Added HEKETI_CLI_USER and HEKETI_CLI_KEY environment values to the Deployment Config for easier use inside the `heketi-storage` Pod, i.e.:
```sh
$ heketi-cli topology info
```
instead of:
```sh
$ heketi-cli --user admin --secret $HEKETI_ADMIN_KEY topology info
```
 
