### PR TITLE
Setup kubeadmin password when openshift_kubeadmin_password is defined

### DIFF
--- a/playbooks/deploy_cluster_40.yml
+++ b/playbooks/deploy_cluster_40.yml
@@ -194,3 +194,23 @@
     - fail:
         msg: CVO didn't complete the install
     when: cvo.failed
+
+  - when: openshift_kubeadmin_password is defined
+    block:
+    - name: Delete existing kube-admin secret
+      oc_secret:
+        kubeconfig: /opt/openshift/auth/kubeconfig
+        name: kube-admin
+        namespace: default
+        state: absent
+      run_once: true
+
+    - name: Create kube-admin secret
+      oc_secret:
+        kubeconfig: /opt/openshift/auth/kubeconfig
+        name: kube-admin
+        namespace: default
+        state: present
+        contents:
+          - path: kubeadmin
+            data: "{{ openshift_kubeadmin_password }}"


### PR DESCRIPTION
Installer doesn't create kubeadmin password file in BYOR install, so kubeadmin secret needs to be removed. The auth system needs it happen within one hour of installation, so it needs to happen soon during the install.

This step is skipped if `openshift_kubeadmin_password` is not specified