### PR TITLE
Back port override of logging ES image pull secret to release v3.9

### DIFF
--- a/roles/openshift_logging_elasticsearch/defaults/main.yml
+++ b/roles/openshift_logging_elasticsearch/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 ### Common settings
+openshift_logging_elasticsearch_image: "{{ openshift_logging_elasticsearch_image_prefix }}logging-elasticsearch:{{ openshift_logging_elasticsearch_image_version }}"
 openshift_logging_elasticsearch_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default(openshift_logging_image_pull_secret) }}"
 
 openshift_logging_elasticsearch_namespace: logging

--- a/roles/openshift_logging_elasticsearch/defaults/main.yml
+++ b/roles/openshift_logging_elasticsearch/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 ### Common settings
-openshift_logging_elasticsearch_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default('') }}"
+openshift_logging_elasticsearch_image_pull_secret: "{{ openshift_hosted_logging_image_pull_secret | default(openshift_logging_image_pull_secret) }}"
+
 openshift_logging_elasticsearch_namespace: logging
 
 openshift_logging_elasticsearch_nodeselector: "{{ openshift_logging_es_nodeselector | default('') }}"

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -472,7 +472,7 @@
     component: "{{ es_component }}"
     logging_component: elasticsearch
     deploy_name: "{{ es_deploy_name }}"
-    image: "{{ openshift_logging_elasticsearch_image_prefix }}logging-elasticsearch:{{ openshift_logging_elasticsearch_image_version }}"
+    image: "{{ openshift_logging_elasticsearch_image }}"
     proxy_image: "{{ openshift_logging_elasticsearch_proxy_image_prefix }}oauth-proxy:{{ openshift_logging_elasticsearch_proxy_image_version }}"
     es_cpu_limit: "{{ openshift_logging_elasticsearch_cpu_limit | default('') }}"
     es_cpu_request: "{{ openshift_logging_elasticsearch_cpu_request | min_cpu(openshift_logging_elasticsearch_cpu_limit | default(none)) }}"

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -77,8 +77,8 @@
     state: present
     name: "aggregated-logging-elasticsearch"
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
-    image_pull_secrets: "{{ openshift_logging_image_pull_secret }}"
-  when: openshift_logging_image_pull_secret != ''
+    image_pull_secrets: "{{ openshift_logging_elasticsearch_image_pull_secret }}"
+  when: openshift_logging_elasticsearch_image_pull_secret != ''
 
 - name: Create ES service account
   oc_serviceaccount:
@@ -86,7 +86,7 @@
     name: "aggregated-logging-elasticsearch"
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
   when:
-  - openshift_logging_image_pull_secret == ''
+  - openshift_logging_elasticsearch_image_pull_secret == ''
 
 # rolebinding reader
 - name: Create rolebinding-reader role


### PR DESCRIPTION
This is a back port to `release-3.9` of the change made in #10946.