### PR TITLE
glusterfs: Force delete heketi pod and avoid waiting for unmount,

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
@@ -7,6 +7,7 @@
     name: "{{ item.name | default(omit) }}"
     selector: "{{ item.selector | default(omit) }}"
     state: absent
+    force: yes
   with_items:
   - kind: "template,route,service,dc,jobs,secret"
     selector: "deploy-heketi"


### PR DESCRIPTION
given that we will be deleting glusterfs pod as well.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>
