### PR TITLE
[release-3.10] sdn: upgrade SDN after all nodes are upgraded.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -95,6 +95,12 @@
           ('glusterfs' in groups and inventory_hostname in groups['glusterfs'])
           or ('glusterfs_registry' in groups and inventory_hostname in groups['glusterfs_registry'])
 
+- name: Upgrade SDN
+  hosts: oo_first_master
+  roles:
+  - role: openshift_sdn
+    when: openshift_use_openshift_sdn | default(True) | bool
+
 - name: Re-enable excluders
   hosts: oo_nodes_to_upgrade:!oo_masters_to_config
   tasks:

--- a/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
@@ -104,9 +104,6 @@
       tasks_from: sync
     vars:
       skip_sync_annotations_check: true
-  roles:
-  - role: openshift_sdn
-    when: openshift_use_openshift_sdn | default(True) | bool
 
 - name: Update master nodes
   hosts: oo_masters

--- a/roles/openshift_sdn/tasks/main.yml
+++ b/roles/openshift_sdn/tasks/main.yml
@@ -50,6 +50,24 @@
   shell: >
     {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig apply -f "{{ mktemp.stdout }}"
 
+- name: Wait for rollout
+  command: >
+    {{ openshift_client_binary }} rollout status ds/sdn --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift-sdn
+  changed_when: false
+  # Ignore errors so we can log troubleshooting info on failures.
+  ignore_errors: yes
+  register: sdn_rollout_status
+
+- when: sdn_rollout_status.rc != 0
+  block:
+    - name: Get pods in the openshift-sdn namespace
+      command: >
+        {{ openshift_client_binary }} get pods -o wide --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift-sdn
+      register: pods
+      ignore_errors: true
+    - debug:
+        msg: "{{ pods.stdout_lines }}"
+
 - name: Remove temp directory
   file:
     state: absent


### PR DESCRIPTION
Restarting OVS kills all pods on the node. So, while we can't do it as
part of the node drain-upgrade loop, we can at least do it when users
are expecting disruption.

Backports #10910

/cc @squeed 