### PR TITLE
Fix auditConfig.policyConfiguration in master_check_paths_in_config

### DIFF
--- a/roles/lib_utils/action_plugins/master_check_paths_in_config.py
+++ b/roles/lib_utils/action_plugins/master_check_paths_in_config.py
@@ -22,6 +22,7 @@ for you: {}"""
 
 
 ITEMS_TO_POP = (
+    ('auditConfig', 'policyConfiguration'),
     ('oauthConfig', 'identityProviders'),
 )
 # Create csv string of dot-separated dictionary keys:


### PR DESCRIPTION
Excludes auditConfig.policyConfiguration from master_check_paths_in_config to
prevent issues with nonResourceURLs in policyConfiguration.

Fixes #11004

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
