### PR TITLE
Fix sync pod restarts Kubelet without any configuration change

### DIFF
--- a/roles/openshift_node_group/files/sync.yaml
+++ b/roles/openshift_node_group/files/sync.yaml
@@ -60,7 +60,7 @@ spec:
 
           # track the current state of the config
           if [[ -f /etc/origin/node/node-config.yaml ]]; then
-            md5sum /etc/origin/node/node-config.yaml > /tmp/.old
+            md5sum /etc/origin/node/node-config.yaml | cut -d " " -f 1 > /tmp/.old
           else
             touch /tmp/.old
           fi
@@ -123,7 +123,7 @@ spec:
               cat /dev/null > /tmp/.old
             fi
 
-            md5sum /etc/origin/node/tmp/node-config.yaml > /tmp/.new
+            md5sum /etc/origin/node/tmp/node-config.yaml | cut -d " " -f 1 > /tmp/.new
             if [[ "$( cat /tmp/.old )" != "$( cat /tmp/.new )" ]]; then
               mv /etc/origin/node/tmp/node-config.yaml /etc/origin/node/node-config.yaml
               SYSTEMD_IGNORE_CHROOT=1 systemctl restart tuned || :

--- a/roles/openshift_node_group/files/sync.yaml
+++ b/roles/openshift_node_group/files/sync.yaml
@@ -155,8 +155,13 @@ spec:
               fi
             fi
             # annotate node with md5sum of the config
-            oc annotate --config=/etc/origin/node/node.kubeconfig "node/${NODE_NAME}" \
-              node.openshift.io/md5sum="$( cat /tmp/.new | cut -d' ' -f1 )" --overwrite
+            echo "info: Applying node annotation" 2>&1
+            if ! oc annotate --config=/etc/origin/node/node.kubeconfig "node/${NODE_NAME}" node.openshift.io/md5sum="$( cat /tmp/.new | cut -d' ' -f1 )" --overwrite; then
+              echo "error: Unable to annotate node, will retry in 10" 2>&1
+              sleep 10 &
+              wait $!
+              continue
+            fi
             cp -f /tmp/.new /tmp/.old
             sleep 180 &
             wait $!


### PR DESCRIPTION
Implemented error handling for the annotation with oc and changed md5sum call to only output the checksum.

Fixes #11007

NOTICE
Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.