### PR TITLE
Fix ansible groups to prevent unlabeling non-openshift nodes from inventory

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
@@ -22,7 +22,7 @@
     kind: node
     state: absent
     labels: "{{ glusterfs_nodeselector | oo_dict_to_list_of_dict }}"
-  with_items: "{{ groups.all }}"
+  with_items: "{{ groups.OSEv3 }}"
   when: "'openshift' in hostvars[item] and glusterfs_wipe"
 
 - name: Delete pre-existing GlusterFS config


### PR DESCRIPTION
Fix "Unlabel any existing GlusterFS nodes" - it must not try to unlabel any non-openshift nodes in inventory.
I have custom hosts(like zabbix host) which is not under OKD so there is no labels on them.