### PR TITLE
Port #10740 and #10981 to release-3.10

### DIFF
--- a/roles/calico_master/tasks/main.yml
+++ b/roles/calico_master/tasks/main.yml
@@ -1,8 +1,10 @@
 ---
+# kube_proxy_and_dns should be called only once, and run_once is not honored with import_role
+# using a when statement to control this
 - name: Calico | Run kube proxy
-  run_once: true
   import_role:
     name: kube_proxy_and_dns
+  when: "inventory_hostname == groups.oo_first_master.0"
 
 - include_tasks: certs.yml
 


### PR DESCRIPTION
The automated 3.10 cherry-picks failed for
https://github.com/openshift/openshift-ansible/pull/10740 and
https://github.com/openshift/openshift-ansible/pull/10981, because the
relevant file name changed from 'calico_master' to 'calico'.  Here we
make those changes manually.
