### PR TITLE
[release 3.10] fix openstack facts when ec2 var is empty

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -306,13 +306,17 @@ def normalize_openstack_facts(metadata, facts):
 
     for f_var, h_var, ip_var in [('hostname', 'hostname', 'local-ipv4'),
                                  ('public_hostname', 'public-hostname', 'public-ipv4')]:
+        if metadata['ec2_compat'][ip_var] == []:
+            metadata_ip_var = ""
+        else:
+            metadata_ip_var = metadata['ec2_compat'][ip_var].split(',')[0]
         try:
-            if socket.gethostbyname(metadata['ec2_compat'][h_var]) == metadata['ec2_compat'][ip_var].split(',')[0]:
+            if socket.gethostbyname(metadata['ec2_compat'][h_var]) == metadata_ip_var:
                 facts['network'][f_var] = metadata['ec2_compat'][h_var]
             else:
-                facts['network'][f_var] = metadata['ec2_compat'][ip_var].split(',')[0]
+                facts['network'][f_var] = metadata_ip_var
         except socket.gaierror:
-            facts['network'][f_var] = metadata['ec2_compat'][ip_var].split(',')[0]
+            facts['network'][f_var] = metadata_ip_var
 
     return facts
 


### PR DESCRIPTION
The ec2 var is normally a string, but if empty will actually be an empty list, invalidating string operations.