### PR TITLE
Fix auditConfig.policyConfiguration in master_check_paths_in_config

### DIFF
--- a/roles/lib_utils/action_plugins/master_check_paths_in_config.py
+++ b/roles/lib_utils/action_plugins/master_check_paths_in_config.py
@@ -22,6 +22,7 @@ for you: {}"""
 
 
 ITEMS_TO_POP = (
+    ('auditConfig', 'policyConfiguration'),
     ('oauthConfig', 'identityProviders'),
 )
 # Create csv string of dot-separated dictionary keys:
@@ -45,12 +46,19 @@ def pop_migrated_fields(mastercfg):
     """Some fields do not need to be searched because they will be migrated
     for users automatically"""
     # Walk down the tree and pop the specific item we migrate / don't care about
-    for item in ITEMS_TO_POP:
-        field = mastercfg
-        for sub_field in item:
-            parent_field = field
-            field = field[sub_field]
-        parent_field.pop(item[len(item) - 1])
+    for field_path in ITEMS_TO_POP:
+        pop_migrated_field(mastercfg, field_path)
+
+
+def pop_migrated_field(mastercfg, field_path):
+    """Remove field at given path from config"""
+    field = mastercfg
+    for sub_field in field_path:
+        parent_field = field
+        if sub_field not in field:
+            return
+        field = field[sub_field]
+    parent_field.pop(field_path[-1])
 
 
 def do_item_check(val, strings_to_check):


### PR DESCRIPTION
Excludes auditConfig.policyConfiguration from master_check_paths_in_config to
prevent issues with nonResourceURLs in policyConfiguration.

Fixes #11004

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
