### PR TITLE
[release-3.10] glusterfs: revert changes to /dev bind-mounts

### DIFF
--- a/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
+++ b/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
@@ -61,10 +61,8 @@ objects:
             mountPath: "/var/log/glusterfs"
           - name: glusterfs-config
             mountPath: "/var/lib/glusterd"
-          - name: glusterfs-dev-disk
-            mountPath: "/dev/disk"
-          - name: glusterfs-dev-mapper
-            mountPath: "/dev/mapper"
+          - name: glusterfs-dev
+            mountPath: "/dev"
           - name: glusterfs-misc
             mountPath: "/var/lib/misc/glusterfsd"
           - name: glusterfs-cgroup
@@ -122,12 +120,9 @@ objects:
         - name: glusterfs-config
           hostPath:
             path: "/var/lib/glusterd"
-        - name: glusterfs-dev-disk
+        - name: glusterfs-dev
           hostPath:
-            path: "/dev/disk"
-        - name: glusterfs-dev-mapper
-          hostPath:
-            path: "/dev/mapper"
+            path: "/dev"
         - name: glusterfs-misc
           hostPath:
             path: "/var/lib/misc/glusterfsd"


### PR DESCRIPTION
OpenShift-3.10 is not expected to support Gluster in CRI-O environments.
Only new versions of the Gluster containers make it possible to run on
CRI-O.

Several changes have been backported that now break deploying Gluster on
OpenShift-3.10. The following changes need to be reverted:

4b67e93a7 glusterfs: bind-mount /dev/mapper into the glusterfs-server container
d47656ee1 glusterfs: bind-mount /dev/disk into the glusterfs-server container
413508cf3 deploy: no need to have volumes for /dev in privileged containers

With this change, /dev becomes a 'normal' bind-mount again, and all
Gluster functionality regarding dynamic device creation and hot-plugging
of disks works again.