### PR TITLE
[release-3.11]FIX:1655183:Add tasks to initialize a "openshift_is_atomic" fact.

### DIFF
--- a/roles/openshift_certificate_expiry/tasks/main.yml
+++ b/roles/openshift_certificate_expiry/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Detecting Operating System from ostree_booted
+  stat:
+    path: /run/ostree-booted
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
+  register: ostree_booted
+
+- name: initialize_facts set fact openshift_is_atomic
+  set_fact:
+    openshift_is_atomic: "{{ ostree_booted.stat.exists }}"
+
 - name: Ensure python dateutil library is present
   package:
     name: "{{ 'python3-dateutil' if ansible_distribution == 'Fedora' else 'python-dateutil' }}"


### PR DESCRIPTION
* Fix bugzilla: [Certificate expiry checks fail when `openshift_is_atomic` is undefine]](https://bugzilla.redhat.com/show_bug.cgi?id=1655183)

* Version: `v3.11`

* Description:
  Add tasks to initialize a `openshift_is_atoimic` fact for detecting `OS`, because this `role` will run without initializing `basic host facts` (playbooks/init/basic_facts.yml) from `playbooks/openshift-checks/certificate_expiry/easy-mode.yaml` playbooks, for that reason `openshift_is_atomic` is required to initialize in this `role`'s tasks.

e.g.> [playbooks/openshift-checks/certificate_expiry/easy-mode.yaml](https://github.com/openshift/openshift-ansible/blob/release-3.11/playbooks/openshift-checks/certificate_expiry/easy-mode.yaml#L9-L16) playbooks are not including initializing facts roles itself.
~~~
- name: Check cert expirys
  hosts: nodes:masters:etcd
  vars:
    openshift_certificate_expiry_save_json_results: yes
    openshift_certificate_expiry_generate_html_report: yes
    openshift_certificate_expiry_show_all: yes
  roles:
    - role: openshift_certificate_expiry
~~~

  Added tasks are same with original [playbooks/init/basic_facts.yml](https://github.com/openshift/openshift-ansible/blob/release-3.11/playbooks/init/basic_facts.yml#L19-L25) tasks.

