### PR TITLE
[3.10] Add minor upgrade path

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/v3_10/upgrade_control_plane_minor.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_10/upgrade_control_plane_minor.yml
@@ -1,0 +1,16 @@
+---
+#
+# Control Plane Upgrade Playbook
+#
+# Upgrades masters and Docker (only on standalone etcd hosts)
+#
+# This upgrade does not include:
+# - node service running on masters
+# - docker running on masters
+# - node service running on dedicated nodes
+#
+# You can run the upgrade_nodes.yml playbook after this to upgrade these components separately.
+#
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_10/upgrade_control_plane_minor.yml
+
+- import_playbook: ../../../../openshift-master/private/restart.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_10/upgrade_minor.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_10/upgrade_minor.yml
@@ -1,0 +1,5 @@
+---
+#
+# Full Control Plane + Nodes Upgrade
+#
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_10/upgrade_minor.yml

--- a/playbooks/byo/openshift-cluster/upgrades/v3_10/upgrade_nodes_minor.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_10/upgrade_nodes_minor.yml
@@ -1,0 +1,7 @@
+---
+#
+# Node Upgrade Playbook
+#
+# Upgrades nodes only, but requires the control plane to have already been upgraded.
+#
+- import_playbook: ../../../../common/openshift-cluster/upgrades/v3_10/upgrade_nodes_minor.yml

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -95,6 +95,12 @@
           ('glusterfs' in groups and inventory_hostname in groups['glusterfs'])
           or ('glusterfs_registry' in groups and inventory_hostname in groups['glusterfs_registry'])
 
+- name: Upgrade SDN
+  hosts: oo_first_master
+  roles:
+  - role: openshift_sdn
+    when: openshift_use_openshift_sdn | default(True) | bool
+
 - name: Re-enable excluders
   hosts: oo_nodes_to_upgrade:!oo_masters_to_config
   tasks:

--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes_minor.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes_minor.yml
@@ -95,6 +95,12 @@
           ('glusterfs' in groups and inventory_hostname in groups['glusterfs'])
           or ('glusterfs_registry' in groups and inventory_hostname in groups['glusterfs_registry'])
 
+- name: Upgrade SDN
+  hosts: oo_first_master
+  roles:
+  - role: openshift_sdn
+    when: openshift_use_openshift_sdn | default(True) | bool
+
 - name: Re-enable excluders
   hosts: oo_nodes_to_upgrade:!oo_masters_to_config
   tasks:

--- a/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane_minor.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane_minor.yml
@@ -1,0 +1,130 @@
+---
+#
+# Control Plane Upgrade Playbook
+#
+# Upgrades masters and Docker (only on standalone etcd hosts)
+#
+# This upgrade does not include:
+# - node service running on masters
+# - docker running on masters
+# - node service running on dedicated nodes
+#
+# You can run the upgrade_nodes.yml playbook after this to upgrade these components separately.
+#
+- import_playbook: ../init.yml
+  vars:
+    l_upgrade_no_switch_firewall_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_init_fact_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config:oo_nodes_to_config"
+    l_base_packages_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+
+- name: Configure the upgrade target for the common upgrade tasks 3.10
+  hosts: oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config
+  tasks:
+  - set_fact:
+      openshift_upgrade_target: '3.10'
+      openshift_upgrade_min: '3.10'
+      openshift_release: '3.10'
+
+- import_playbook: ../pre/config.yml
+  # These vars a meant to exclude oo_nodes from plays that would otherwise include
+  # them by default.
+  vars:
+    l_openshift_version_set_hosts: "oo_etcd_to_config:oo_masters_to_config:!oo_first_master"
+    l_upgrade_repo_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_upgrade_no_proxy_hosts: "oo_masters_to_config"
+    l_upgrade_health_check_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_upgrade_verify_targets_hosts: "oo_masters_to_config"
+    l_upgrade_docker_target_hosts: "oo_masters_to_config:oo_etcd_to_config"
+    l_upgrade_excluder_hosts: "oo_masters_to_config"
+    openshift_protect_installed_version: False
+
+# Need to run sanity checks after version has been run.
+- import_playbook: ../../../../init/sanity_checks.yml
+  vars:
+    # oo_lb_to_config might not be present; Can't use !oo_nodes because masters are nodes.
+    l_sanity_check_hosts: "{{ groups['oo_etcd_to_config'] | union(groups['oo_masters_to_config']) | union(groups['oo_lb_to_config'] | default([]) ) }}"
+
+# Some change makes critical outage on current cluster.
+- name: Confirm upgrade will not make critical changes
+  hosts: oo_first_master
+  tasks:
+  - name: Confirm Reconcile Security Context Constraints will not change current SCCs
+    command: >
+      {{ openshift_client_binary }} adm policy --config={{ openshift.common.config_base }}/master/admin.kubeconfig reconcile-sccs --additive-only=true -o name
+    register: check_reconcile_scc_result
+    when: openshift_reconcile_sccs_reject_change | default(true) | bool
+    until: check_reconcile_scc_result.rc == 0
+    retries: 3
+
+  - fail:
+      msg: >
+        Changes to bootstrapped SCCs have been detected. Please review the changes by running
+        "{{ openshift_client_binary }} adm policy --config={{ openshift.common.config_base }}/master/admin.kubeconfig reconcile-sccs --additive-only=true"
+        After reviewing the changes please apply those changes by adding the '--confirm' flag.
+        Do not modify the default SCCs. Customizing the default SCCs will cause this check to fail when upgrading.
+        If you require non standard SCCs please refer to https://docs.openshift.org/latest/admin_guide/manage_scc.html
+    when:
+    - openshift_reconcile_sccs_reject_change | default(true) | bool
+    - check_reconcile_scc_result.stdout != '' or check_reconcile_scc_result.rc != 0
+
+- name: Flag pre-upgrade checks complete for hosts without errors
+  hosts: oo_masters_to_config:oo_etcd_to_config
+  tasks:
+  - set_fact:
+      pre_upgrade_complete: True
+
+- import_playbook: label_nodes.yml
+
+# To upgrade, we need masters to be capable of signing certificates
+- hosts: oo_masters
+  serial: 1
+  tasks:
+  - name: Enable core bootstrapping components
+    include_tasks: ../../../../openshift-master/private/tasks/enable_bootstrap.yml
+  - name: Place shim commands on the masters before we begin the upgrade
+    import_role:
+      name: openshift_control_plane
+      tasks_from: static_shim
+
+
+- name: Update master nodes
+  hosts: oo_masters
+  serial: 1
+  tasks:
+  - import_role:
+      name: openshift_node
+      tasks_from: upgrade_pre
+  - import_role:
+      name: openshift_node
+      tasks_from: upgrade
+  - import_role:
+      name: openshift_storage_glusterfs
+      tasks_from: check_cluster_health.yml
+    when: >
+          ('glusterfs' in groups and inventory_hostname in groups['glusterfs'])
+          or ('glusterfs_registry' in groups and inventory_hostname in groups['glusterfs_registry'])
+
+- import_playbook: ../upgrade_control_plane.yml
+  vars:
+    openshift_release: '3.10'
+
+- import_playbook: ../post_control_plane.yml
+
+- hosts: oo_masters
+  tasks:
+  - import_role:
+      name: openshift_web_console
+      tasks_from: remove_old_asset_config
+
+# This is a one time migration. No need to save it in the 3.11.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1565736
+- hosts: oo_first_master
+  tasks:
+  - import_role:
+      name: openshift_hosted
+      tasks_from: registry_service_account.yml
+    when: openshift_hosted_manage_registry | default(True) | bool
+  - import_role:
+      name: openshift_hosted
+      tasks_from: remove_legacy_env_variables.yml
+    when: openshift_hosted_manage_registry | default(True) | bool

--- a/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_minor.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_minor.yml
@@ -1,0 +1,7 @@
+---
+#
+# Full Control Plane + Nodes Upgrade
+#
+- import_playbook: upgrade_control_plane_minor.yml
+
+- import_playbook: upgrade_nodes_minor.yml

--- a/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_nodes_minor.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_nodes_minor.yml
@@ -1,0 +1,38 @@
+---
+#
+# Node Upgrade Playbook
+#
+# Upgrades nodes only, but requires the control plane to have already been upgraded.
+#
+- import_playbook: ../init.yml
+
+- name: Configure the upgrade target for the common upgrade tasks
+  hosts: oo_all_hosts
+  tasks:
+  - set_fact:
+      openshift_upgrade_target: '3.10'
+      openshift_upgrade_min: '3.10'
+      openshift_release: '3.10'
+
+- import_playbook: ../pre/config.yml
+  vars:
+    l_upgrade_repo_hosts: "oo_nodes_to_config"
+    l_upgrade_no_proxy_hosts: "oo_all_hosts"
+    l_upgrade_health_check_hosts: "oo_nodes_to_config"
+    l_upgrade_verify_targets_hosts: "oo_nodes_to_config"
+    l_upgrade_docker_target_hosts: "oo_nodes_to_config"
+    l_upgrade_excluder_hosts: "oo_nodes_to_config:!oo_masters_to_config"
+    l_upgrade_nodes_only: True
+
+# Need to run sanity checks after version has been run.
+- import_playbook: ../../../../init/sanity_checks.yml
+
+- name: Flag pre-upgrade checks complete for hosts without errors
+  hosts: oo_masters_to_config:oo_nodes_to_upgrade:oo_etcd_to_config
+  tasks:
+  - set_fact:
+      pre_upgrade_complete: True
+
+# Pre-upgrade completed
+
+- import_playbook: ../upgrade_nodes_minor.yml

--- a/roles/openshift_sdn/tasks/main.yml
+++ b/roles/openshift_sdn/tasks/main.yml
@@ -50,6 +50,24 @@
   shell: >
     {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig apply -f "{{ mktemp.stdout }}"
 
+- name: Wait for rollout
+  command: >
+    {{ openshift_client_binary }} rollout status ds/sdn --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift-sdn
+  changed_when: false
+  # Ignore errors so we can log troubleshooting info on failures.
+  ignore_errors: yes
+  register: sdn_rollout_status
+
+- when: sdn_rollout_status.rc != 0
+  block:
+    - name: Get pods in the openshift-sdn namespace
+      command: >
+        {{ openshift_client_binary }} get pods -o wide --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift-sdn
+      register: pods
+      ignore_errors: true
+    - debug:
+        msg: "{{ pods.stdout_lines }}"
+
 - name: Remove temp directory
   file:
     state: absent


### PR DESCRIPTION
This commit adds minor upgrade path for 3.10 releases to move sdn
pod updating into node portion.  This will reduce disruption to
clusters when upgrading just the control plane during 3.10 minor
upgrades.
