### PR TITLE
[WIP] Add limit to container storage for cri-o nodes

### DIFF
--- a/roles/container_runtime/tasks/package_crio.yml
+++ b/roles/container_runtime/tasks/package_crio.yml
@@ -87,6 +87,22 @@
     dest: "{{ containers_registries_conf_path }}"
     src: registries.conf.j2
 
+- name: Check if /etc/containers/storage.conf exists
+  stat:
+    path: /etc/containers/storage.conf
+    get_checksum: false
+    get_mime: false
+  register: storage_conf_check
+
+- name: Set storage size restriction
+  ini_file:
+    path: /etc/containers/storage.conf
+    section: storage.options
+    option: size
+    value: '"3G"'
+    backup: yes
+  when: storage_conf_check.stat.exists == True
+
 - name: Start the CRI-O service
   systemd:
     name: "cri-o"


### PR DESCRIPTION
Setting the max limit to 1G to ensure that container
storage is not fully consumed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1658386

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>
