### PR TITLE
Include namedcertificates in the list of expiration checks

### DIFF
--- a/roles/lib_utils/library/openshift_cert_expiry.py
+++ b/roles/lib_utils/library/openshift_cert_expiry.py
@@ -537,6 +537,11 @@ an OpenShift Container Platform cluster
             if proxyClient:
                 cert_meta['proxyClient'] = os.path.join(cfg_path, proxyClient)
 
+            namedCertificates = cfg.get('servingInfo', {}).get('namedCertificates', [])
+            for i in namedCertificates:
+                if 'certFile' in i:
+                    cert_meta['namedCertificates'] = os.path.join(cfg_path, i.get('certFile'))
+
         ######################################################################
         # Load the certificate and the CA, parse their expiration dates into
         # datetime objects so we can manipulate them later


### PR DESCRIPTION
Certificates included in the section ServingInfo > namedCertificates are not included in the list to check expiration