### PR TITLE
[release-3.7] Add probes to DaemonSet pod templates for autohealing

### DIFF
--- a/files/origin-components/apiserver-template.yaml
+++ b/files/origin-components/apiserver-template.yaml
@@ -61,6 +61,21 @@ objects:
               path: /healthz
               port: 8443
               scheme: HTTPS
+            failureThreshold: 1
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
         nodeSelector: "${{NODE_SELECTOR}}"
         volumes:
         - name: serving-cert

--- a/roles/openshift_service_catalog/templates/api_server.j2
+++ b/roles/openshift_service_catalog/templates/api_server.j2
@@ -63,6 +63,26 @@ spec:
         - mountPath: /etc/origin/master
           name: etcd-host-cert
           readOnly: true
+        readinessProbe:
+          httpGet:
+            port: 6443
+            path: /healthz
+            scheme: HTTPS
+          failureThreshold: 1
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            port: 6443
+            path: /healthz
+            scheme: HTTPS
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       securityContext: {}

--- a/roles/openshift_service_catalog/templates/controller_manager.j2
+++ b/roles/openshift_service_catalog/templates/controller_manager.j2
@@ -51,6 +51,26 @@ spec:
         - mountPath: /var/run/kubernetes-service-catalog
           name: service-catalog-ssl
           readOnly: true
+        readinessProbe:
+          httpGet:
+            port: 6443
+            path: /healthz
+            scheme: HTTPS
+          failureThreshold: 1
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            port: 6443
+            path: /healthz
+            scheme: HTTPS
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       securityContext: {}


### PR DESCRIPTION
* Fix: [Network of DaemonSet Pods are not available after upgrade_nodes.yml](https://bugzilla.redhat.com/show_bug.cgi?id=1667283)

* Version: `v3.7`

* Description:
  Add probes config to DaemonSet pod templates for Service Catalog and Template Service Broker for enhancement of autohealing.
  In `Service Catalog` `apiserver` and `controller-manager` `DaemonSet` has configured the readiness/liveness Probes as of `v3.11`, it's a backport of that.
  e.g.> [apiserver template at v3.11](https://github.com/openshift/openshift-ansible/blob/release-3.11/roles/openshift_service_catalog/templates/api_server.j2#L70-L89)
           Same code is also configures at [controller-manager template in v3.11](https://github.com/openshift/openshift-ansible/blob/release-3.11/roles/openshift_service_catalog/templates/controller_manager.j2#L67-L86)
~~~
        readinessProbe:
          httpGet:
            port: 6443
            path: /healthz
            scheme: HTTPS
          failureThreshold: 1
          initialDelaySeconds: 30
          periodSeconds: 5
          successThreshold: 1
          timeoutSeconds: 5
        livenessProbe:
          httpGet:
            port: 6443
            path: /healthz
            scheme: HTTPS
          failureThreshold: 3
          initialDelaySeconds: 30
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 5
~~~

`Template Service Broker`'s `apiserver` pod has configured only readiness Probe  at the moment, it can be `orphan Pod` if some network crash is happen. So I added liveness Probe to the template for `autohealing`.