### PR TITLE
Fix documentation for oc - modules

### DIFF
--- a/roles/lib_openshift/library/oc_adm_csr.py
+++ b/roles/lib_openshift/library/oc_adm_csr.py
@@ -63,11 +63,13 @@ description:
 options:
   state:
     description:
-    - approve|deny|list Approve, deny, and list are the only supported states for certificates
+    - State controls the action that will be taken with resource
+    - approve - create the certificate
+    - deny - remove the certificate
+    - list - return the current representation of a certificate
     required: false
-    default: present
-    choices:
-    - present
+    default: approve
+    choices: ["approve", "deny", "list"]
     aliases: []
   kubeconfig:
     description:

--- a/roles/lib_openshift/library/oc_adm_policy_group.py
+++ b/roles/lib_openshift/library/oc_adm_policy_group.py
@@ -61,6 +61,13 @@ short_description: Module to manage openshift policy for groups
 description:
   - Manage openshift policy for groups.
 options:
+  state:
+    description:
+    - State controls the action that will be taken with resource
+    required: true
+    default: present
+    choices: ["present", "absent"]
+    aliases: []
   kubeconfig:
     description:
     - The path for the kubeconfig file to use for authentication
@@ -103,13 +110,6 @@ options:
     - The name of the policy
     required: true
     default: None
-    aliases: []
-  state:
-    description:
-    - Desired state of the policy
-    required: true
-    default: present
-    choices: ["present", "absent"]
     aliases: []
 author:
 - "Kenny Woodson <kwoodson@redhat.com>"

--- a/roles/lib_openshift/library/oc_adm_policy_user.py
+++ b/roles/lib_openshift/library/oc_adm_policy_user.py
@@ -61,6 +61,13 @@ short_description: Module to manage openshift policy for users
 description:
   - Manage openshift policy for users.
 options:
+  state:
+    description:
+    - State controls the action that will be taken with resource
+    required: true
+    default: present
+    choices: ["present", "absent"]
+    aliases: []
   kubeconfig:
     description:
     - The path for the kubeconfig file to use for authentication
@@ -109,13 +116,6 @@ options:
     - The name of the policy
     required: true
     default: None
-    aliases: []
-  state:
-    description:
-    - Desired state of the policy
-    required: true
-    default: present
-    choices: ["present", "absent"]
     aliases: []
 author:
 - "Kenny Woodson <kwoodson@redhat.com>"

--- a/roles/lib_openshift/library/oc_adm_registry.py
+++ b/roles/lib_openshift/library/oc_adm_registry.py
@@ -63,12 +63,13 @@ description:
 options:
   state:
     description:
-    - The desired action when managing openshift registry
+    - State controls the action that will be taken with resource
     - present - update or create the registry
     - absent - tear down the registry service and deploymentconfig
     - list - returns the current representiation of a registry
     required: false
     default: False
+    choices: ["present", 'absent', 'list']
     aliases: []
   kubeconfig:
     description:

--- a/roles/lib_openshift/library/oc_adm_router.py
+++ b/roles/lib_openshift/library/oc_adm_router.py
@@ -63,15 +63,13 @@ description:
 options:
   state:
     description:
-    - Whether to create or delete the router
+    - State controls the action that will be taken with resource
     - present - create the router
     - absent - remove the router
     - list - return the current representation of a router
     required: false
     default: present
-    choices:
-    - present
-    - absent
+    choices: ["present", "absent", "list"]
     aliases: []
   kubeconfig:
     description:

--- a/roles/lib_openshift/library/oc_clusterrole.py
+++ b/roles/lib_openshift/library/oc_clusterrole.py
@@ -63,7 +63,7 @@ description:
 options:
   state:
     description:
-    - Supported states, present, absent, list
+    - State controls the action that will be taken with resource
     - present - will ensure object is created or updated to the value specified
     - list - will return a clusterrole
     - absent - will remove a clusterrole

--- a/roles/lib_openshift/library/oc_configmap.py
+++ b/roles/lib_openshift/library/oc_configmap.py
@@ -63,7 +63,7 @@ description:
 options:
   state:
     description:
-    - Supported states, present, absent, list
+    - State controls the action that will be taken with resource
     - present - will ensure object is created or updated to the value specified
     - list - will return a configmap
     - absent - will remove the configmap

--- a/roles/lib_openshift/library/oc_env.py
+++ b/roles/lib_openshift/library/oc_env.py
@@ -63,7 +63,7 @@ description:
 options:
   state:
     description:
-    - Supported states, present, absent, list
+    - State controls the action that will be taken with resource
     - present - will ensure object is created or updated to the value specified
     - list - will return a list of environment variables
     - absent - will remove the environment varibale from the object

--- a/roles/lib_openshift/library/oc_group.py
+++ b/roles/lib_openshift/library/oc_group.py
@@ -63,7 +63,7 @@ description:
 options:
   state:
     description:
-    - Supported states, present, absent, list
+    - State controls the action that will be taken with resource
     - present - will ensure object is created or updated to the value specified
     - list - will return a group
     - absent - will remove the group

--- a/roles/lib_openshift/library/oc_image.py
+++ b/roles/lib_openshift/library/oc_image.py
@@ -57,15 +57,15 @@ from ansible.module_utils.basic import AnsibleModule
 DOCUMENTATION = '''
 ---
 module: oc_image
-short_description: Create, modify, and idempotently manage openshift labels.
+short_description: Create, modify, and idempotently manage openshift images.
 description:
-  - Modify openshift labels programmatically.
+  - Modify openshift images programmatically.
 options:
   state:
     description:
     - State controls the action that will be taken with resource
-    - 'present' will create.  Does _not_ support update.
-    - 'list' will read the labels
+    - present - will create the image. Does _not_ support update.
+    - list - will read the images
     default: present
     choices: ["present", "list"]
     aliases: []

--- a/roles/lib_openshift/library/oc_label.py
+++ b/roles/lib_openshift/library/oc_label.py
@@ -64,10 +64,10 @@ options:
   state:
     description:
     - State controls the action that will be taken with resource
-    - 'present' will create or update and object to the desired state
-    - 'absent' will ensure certain labels are removed
-    - 'list' will read the labels
-    - 'add' will insert labels to the already existing labels
+    - present - will create or update and object to the desired state
+    - absent - will ensure certain labels are removed
+    - list - will read the labels
+    - add - will insert labels to the already existing labels
     default: present
     choices: ["present", "absent", "list", "add"]
     aliases: []

--- a/roles/lib_openshift/library/oc_obj.py
+++ b/roles/lib_openshift/library/oc_obj.py
@@ -63,10 +63,11 @@ description:
 options:
   state:
     description:
+    - State controls the action that will be taken with resource
     - Currently present is only supported state.
     required: true
     default: present
-    choices: ["present", "absent", "list"]
+    choices: ["present"]
     aliases: []
   kubeconfig:
     description:

--- a/roles/lib_openshift/library/oc_process.py
+++ b/roles/lib_openshift/library/oc_process.py
@@ -64,10 +64,10 @@ options:
   state:
     description:
     - State has a few different meanings when it comes to process.
-    - state: present - This state runs an `oc process <template>`.  When used in
+    - present - This state runs an `oc process <template>`.  When used in
     - conjunction with 'create: True' the process will be piped to | oc create -f
-    - state: absent - will remove a template
-    - state: list - will perform an `oc get template <template_name>`
+    - absent - will remove a template
+    - list - will perform an `oc get template <template_name>`
     default: present
     choices: ["present", "absent", "list"]
     aliases: []

--- a/roles/lib_openshift/library/oc_project.py
+++ b/roles/lib_openshift/library/oc_project.py
@@ -63,7 +63,10 @@ description:
 options:
   state:
     description:
-    - If present, the project will be created if it doesn't exist or update if different. If absent, the project will be removed if present. If list, information about the project will be gathered and returned as part of the Ansible call results.
+    - State controls the action that will be taken with resource
+    - present - the project will be created if it doesn't exist or update if different.
+    - absent - the project will be removed if present.
+    - list -  information about the project will be gathered and returned as part of the Ansible call results.
     required: false
     default: present
     choices: ["present", "absent", "list"]

--- a/roles/lib_openshift/library/oc_pvc.py
+++ b/roles/lib_openshift/library/oc_pvc.py
@@ -63,7 +63,7 @@ description:
 options:
   state:
     description:
-    - Supported states, present, absent, list
+    - State controls the action that will be taken with resource
     - present - will ensure object is created or updated to the value specified
     - list - will return a pvc
     - absent - will remove a pvc

--- a/roles/lib_openshift/library/oc_route.py
+++ b/roles/lib_openshift/library/oc_route.py
@@ -63,7 +63,10 @@ description:
 options:
   state:
     description:
-    - State represents whether to create, modify, delete, or list
+    - State controls the action that will be taken with resource
+    - present - create the route
+    - absent - remove the route
+    - list - returns the current representiation of the route
     required: true
     default: present
     choices: ["present", "absent", "list"]

--- a/roles/lib_openshift/library/oc_secret.py
+++ b/roles/lib_openshift/library/oc_secret.py
@@ -63,7 +63,10 @@ description:
 options:
   state:
     description:
-    - If present, the secret will be created if it doesn't exist or updated if different. If absent, the secret will be removed if present. If list, information about the secret will be gathered and returned as part of the Ansible call results.
+    - State controls the action that will be taken with resource
+    - present - the secret will be created if it doesn't exist or updated if different.
+    - absent - the secret will be removed if present.
+    - list - information about the secret will be gathered and returned as part of the Ansible call results.
     required: false
     default: present
     choices: ["present", "absent", "list"]

--- a/roles/lib_openshift/library/oc_service.py
+++ b/roles/lib_openshift/library/oc_service.py
@@ -63,7 +63,10 @@ description:
 options:
   state:
     description:
-    - State represents whether to create, modify, delete, or list
+    - State controls the action that will be taken with resource
+    - present - create the service
+    - absent - remove the service
+    - list - return the current representation of a service
     required: False
     default: present
     choices: ["present", "absent", "list"]

--- a/roles/lib_openshift/library/oc_serviceaccount.py
+++ b/roles/lib_openshift/library/oc_serviceaccount.py
@@ -63,7 +63,10 @@ description:
 options:
   state:
     description:
-    - If present, the service account will be created if it doesn't exist or updated if different. If absent, the service account will be removed if present. If list, information about the service account will be gathered and returned as part of the Ansible call results.
+    - State controls the action that will be taken with resource
+    - present - the service account will be created if it doesn't exist or updated if different.
+    - absent - the service account will be removed if present
+    - list - information about the service account will be gathered and returned as part of the Ansible call results.
     required: false
     default: present
     choices: ["present", "absent", "list"]

--- a/roles/lib_openshift/library/oc_serviceaccount_secret.py
+++ b/roles/lib_openshift/library/oc_serviceaccount_secret.py
@@ -63,7 +63,10 @@ description:
 options:
   state:
     description:
-    - If present, the service account will be linked with the secret if it is not already. If absent, the service account will be unlinked from the secret if it is already linked. If list, information about the service account secrets will be gathered and returned as part of the Ansible call results.
+    - State controls the action that will be taken with resource
+    - present - the service account will be linked with the secret if it is not already.
+    - absent - the service account will be unlinked from the secret if it is already linked.
+    - list - gather and return information about the service account secrets.
     required: false
     default: present
     choices: ["present", "absent", "list"]

--- a/roles/lib_openshift/library/oc_storageclass.py
+++ b/roles/lib_openshift/library/oc_storageclass.py
@@ -63,7 +63,10 @@ description:
 options:
   state:
     description:
-    - State represents whether to create, modify, delete, or list
+    - State controls the action that will be taken with resource
+    - present - create the storageclass
+    - absent - remove the storageclass
+    - list - return the current representation of a storageclass
     required: False
     default: present
     choices: ["present", "absent", "list"]

--- a/roles/lib_openshift/library/oc_user.py
+++ b/roles/lib_openshift/library/oc_user.py
@@ -64,9 +64,9 @@ options:
   state:
     description:
     - State controls the action that will be taken with resource
-    - 'present' will create or update a user to the desired state
-    - 'absent' will ensure user is removed
-    - 'list' will read and return a list of users
+    - present - will create or update a user to the desired state
+    - absent - will ensure user is removed
+    - list - will read and return a list of users
     default: present
     choices: ["present", "absent", "list"]
     aliases: []

--- a/roles/lib_openshift/library/oc_version.py
+++ b/roles/lib_openshift/library/oc_version.py
@@ -63,6 +63,7 @@ description:
 options:
   state:
     description:
+    - State controls the action that will be taken with resource
     - Currently list is only supported state.
     required: true
     default: list

--- a/roles/lib_openshift/library/oc_volume.py
+++ b/roles/lib_openshift/library/oc_volume.py
@@ -64,9 +64,9 @@ options:
   state:
     description:
     - State controls the action that will be taken with resource
-    - 'present' will create or update and object to the desired state
-    - 'absent' will ensure volumes are removed
-    - 'list' will read the volumes
+    - present - create the volume
+    - absent - remove the volume
+    - list - return the current representation of a volume
     default: present
     choices: ["present", "absent", "list"]
     aliases: []

--- a/roles/lib_openshift/src/doc/clusterrole
+++ b/roles/lib_openshift/src/doc/clusterrole
@@ -10,7 +10,7 @@ description:
 options:
   state:
     description:
-    - Supported states, present, absent, list
+    - State controls the action that will be taken with resource
     - present - will ensure object is created or updated to the value specified
     - list - will return a clusterrole
     - absent - will remove a clusterrole

--- a/roles/lib_openshift/src/doc/configmap
+++ b/roles/lib_openshift/src/doc/configmap
@@ -10,7 +10,7 @@ description:
 options:
   state:
     description:
-    - Supported states, present, absent, list
+    - State controls the action that will be taken with resource
     - present - will ensure object is created or updated to the value specified
     - list - will return a configmap
     - absent - will remove the configmap

--- a/roles/lib_openshift/src/doc/csr
+++ b/roles/lib_openshift/src/doc/csr
@@ -10,11 +10,13 @@ description:
 options:
   state:
     description:
-    - approve|deny|list Approve, deny, and list are the only supported states for certificates
+    - State controls the action that will be taken with resource
+    - approve - create the certificate
+    - deny - remove the certificate
+    - list - return the current representation of a certificate
     required: false
-    default: present
-    choices:
-    - present
+    default: approve
+    choices: ["approve", "deny", "list"]
     aliases: []
   kubeconfig:
     description:

--- a/roles/lib_openshift/src/doc/env
+++ b/roles/lib_openshift/src/doc/env
@@ -10,7 +10,7 @@ description:
 options:
   state:
     description:
-    - Supported states, present, absent, list
+    - State controls the action that will be taken with resource
     - present - will ensure object is created or updated to the value specified
     - list - will return a list of environment variables
     - absent - will remove the environment varibale from the object

--- a/roles/lib_openshift/src/doc/group
+++ b/roles/lib_openshift/src/doc/group
@@ -10,7 +10,7 @@ description:
 options:
   state:
     description:
-    - Supported states, present, absent, list
+    - State controls the action that will be taken with resource
     - present - will ensure object is created or updated to the value specified
     - list - will return a group
     - absent - will remove the group

--- a/roles/lib_openshift/src/doc/image
+++ b/roles/lib_openshift/src/doc/image
@@ -4,15 +4,15 @@
 DOCUMENTATION = '''
 ---
 module: oc_image
-short_description: Create, modify, and idempotently manage openshift labels.
+short_description: Create, modify, and idempotently manage openshift images.
 description:
-  - Modify openshift labels programmatically.
+  - Modify openshift images programmatically.
 options:
   state:
     description:
     - State controls the action that will be taken with resource
-    - 'present' will create.  Does _not_ support update.
-    - 'list' will read the labels
+    - present - will create the image. Does _not_ support update.
+    - list - will read the images
     default: present
     choices: ["present", "list"]
     aliases: []

--- a/roles/lib_openshift/src/doc/label
+++ b/roles/lib_openshift/src/doc/label
@@ -11,10 +11,10 @@ options:
   state:
     description:
     - State controls the action that will be taken with resource
-    - 'present' will create or update and object to the desired state
-    - 'absent' will ensure certain labels are removed
-    - 'list' will read the labels
-    - 'add' will insert labels to the already existing labels
+    - present - will create or update and object to the desired state
+    - absent - will ensure certain labels are removed
+    - list - will read the labels
+    - add - will insert labels to the already existing labels
     default: present
     choices: ["present", "absent", "list", "add"]
     aliases: []

--- a/roles/lib_openshift/src/doc/obj
+++ b/roles/lib_openshift/src/doc/obj
@@ -10,10 +10,11 @@ description:
 options:
   state:
     description:
+    - State controls the action that will be taken with resource
     - Currently present is only supported state.
     required: true
     default: present
-    choices: ["present", "absent", "list"]
+    choices: ["present"]
     aliases: []
   kubeconfig:
     description:

--- a/roles/lib_openshift/src/doc/policy_group
+++ b/roles/lib_openshift/src/doc/policy_group
@@ -8,6 +8,13 @@ short_description: Module to manage openshift policy for groups
 description:
   - Manage openshift policy for groups.
 options:
+  state:
+    description:
+    - State controls the action that will be taken with resource
+    required: true
+    default: present
+    choices: ["present", "absent"]
+    aliases: []
   kubeconfig:
     description:
     - The path for the kubeconfig file to use for authentication
@@ -50,13 +57,6 @@ options:
     - The name of the policy
     required: true
     default: None
-    aliases: []
-  state:
-    description:
-    - Desired state of the policy
-    required: true
-    default: present
-    choices: ["present", "absent"]
     aliases: []
 author:
 - "Kenny Woodson <kwoodson@redhat.com>"

--- a/roles/lib_openshift/src/doc/policy_user
+++ b/roles/lib_openshift/src/doc/policy_user
@@ -8,6 +8,13 @@ short_description: Module to manage openshift policy for users
 description:
   - Manage openshift policy for users.
 options:
+  state:
+    description:
+    - State controls the action that will be taken with resource
+    required: true
+    default: present
+    choices: ["present", "absent"]
+    aliases: []
   kubeconfig:
     description:
     - The path for the kubeconfig file to use for authentication
@@ -56,13 +63,6 @@ options:
     - The name of the policy
     required: true
     default: None
-    aliases: []
-  state:
-    description:
-    - Desired state of the policy
-    required: true
-    default: present
-    choices: ["present", "absent"]
     aliases: []
 author:
 - "Kenny Woodson <kwoodson@redhat.com>"

--- a/roles/lib_openshift/src/doc/process
+++ b/roles/lib_openshift/src/doc/process
@@ -11,10 +11,10 @@ options:
   state:
     description:
     - State has a few different meanings when it comes to process.
-    - state: present - This state runs an `oc process <template>`.  When used in
+    - present - This state runs an `oc process <template>`.  When used in
     - conjunction with 'create: True' the process will be piped to | oc create -f
-    - state: absent - will remove a template
-    - state: list - will perform an `oc get template <template_name>`
+    - absent - will remove a template
+    - list - will perform an `oc get template <template_name>`
     default: present
     choices: ["present", "absent", "list"]
     aliases: []

--- a/roles/lib_openshift/src/doc/project
+++ b/roles/lib_openshift/src/doc/project
@@ -10,7 +10,10 @@ description:
 options:
   state:
     description:
-    - If present, the project will be created if it doesn't exist or update if different. If absent, the project will be removed if present. If list, information about the project will be gathered and returned as part of the Ansible call results.
+    - State controls the action that will be taken with resource
+    - present - the project will be created if it doesn't exist or update if different.
+    - absent - the project will be removed if present.
+    - list -  information about the project will be gathered and returned as part of the Ansible call results.
     required: false
     default: present
     choices: ["present", "absent", "list"]

--- a/roles/lib_openshift/src/doc/pvc
+++ b/roles/lib_openshift/src/doc/pvc
@@ -10,7 +10,7 @@ description:
 options:
   state:
     description:
-    - Supported states, present, absent, list
+    - State controls the action that will be taken with resource
     - present - will ensure object is created or updated to the value specified
     - list - will return a pvc
     - absent - will remove a pvc

--- a/roles/lib_openshift/src/doc/registry
+++ b/roles/lib_openshift/src/doc/registry
@@ -10,12 +10,13 @@ description:
 options:
   state:
     description:
-    - The desired action when managing openshift registry
+    - State controls the action that will be taken with resource
     - present - update or create the registry
     - absent - tear down the registry service and deploymentconfig
     - list - returns the current representiation of a registry
     required: false
     default: False
+    choices: ["present", 'absent', 'list']
     aliases: []
   kubeconfig:
     description:

--- a/roles/lib_openshift/src/doc/route
+++ b/roles/lib_openshift/src/doc/route
@@ -10,7 +10,10 @@ description:
 options:
   state:
     description:
-    - State represents whether to create, modify, delete, or list
+    - State controls the action that will be taken with resource
+    - present - create the route
+    - absent - remove the route
+    - list - returns the current representiation of the route
     required: true
     default: present
     choices: ["present", "absent", "list"]

--- a/roles/lib_openshift/src/doc/router
+++ b/roles/lib_openshift/src/doc/router
@@ -10,15 +10,13 @@ description:
 options:
   state:
     description:
-    - Whether to create or delete the router
+    - State controls the action that will be taken with resource
     - present - create the router
     - absent - remove the router
     - list - return the current representation of a router
     required: false
     default: present
-    choices:
-    - present
-    - absent
+    choices: ["present", "absent", "list"]
     aliases: []
   kubeconfig:
     description:

--- a/roles/lib_openshift/src/doc/secret
+++ b/roles/lib_openshift/src/doc/secret
@@ -10,7 +10,10 @@ description:
 options:
   state:
     description:
-    - If present, the secret will be created if it doesn't exist or updated if different. If absent, the secret will be removed if present. If list, information about the secret will be gathered and returned as part of the Ansible call results.
+    - State controls the action that will be taken with resource
+    - present - the secret will be created if it doesn't exist or updated if different.
+    - absent - the secret will be removed if present.
+    - list - information about the secret will be gathered and returned as part of the Ansible call results.
     required: false
     default: present
     choices: ["present", "absent", "list"]

--- a/roles/lib_openshift/src/doc/service
+++ b/roles/lib_openshift/src/doc/service
@@ -10,7 +10,10 @@ description:
 options:
   state:
     description:
-    - State represents whether to create, modify, delete, or list
+    - State controls the action that will be taken with resource
+    - present - create the service
+    - absent - remove the service
+    - list - return the current representation of a service
     required: False
     default: present
     choices: ["present", "absent", "list"]

--- a/roles/lib_openshift/src/doc/serviceaccount
+++ b/roles/lib_openshift/src/doc/serviceaccount
@@ -10,7 +10,10 @@ description:
 options:
   state:
     description:
-    - If present, the service account will be created if it doesn't exist or updated if different. If absent, the service account will be removed if present. If list, information about the service account will be gathered and returned as part of the Ansible call results.
+    - State controls the action that will be taken with resource
+    - present - the service account will be created if it doesn't exist or updated if different.
+    - absent - the service account will be removed if present
+    - list - information about the service account will be gathered and returned as part of the Ansible call results.
     required: false
     default: present
     choices: ["present", "absent", "list"]

--- a/roles/lib_openshift/src/doc/serviceaccount_secret
+++ b/roles/lib_openshift/src/doc/serviceaccount_secret
@@ -10,7 +10,10 @@ description:
 options:
   state:
     description:
-    - If present, the service account will be linked with the secret if it is not already. If absent, the service account will be unlinked from the secret if it is already linked. If list, information about the service account secrets will be gathered and returned as part of the Ansible call results.
+    - State controls the action that will be taken with resource
+    - present - the service account will be linked with the secret if it is not already.
+    - absent - the service account will be unlinked from the secret if it is already linked.
+    - list - gather and return information about the service account secrets.
     required: false
     default: present
     choices: ["present", "absent", "list"]

--- a/roles/lib_openshift/src/doc/storageclass
+++ b/roles/lib_openshift/src/doc/storageclass
@@ -10,7 +10,10 @@ description:
 options:
   state:
     description:
-    - State represents whether to create, modify, delete, or list
+    - State controls the action that will be taken with resource
+    - present - create the storageclass
+    - absent - remove the storageclass
+    - list - return the current representation of a storageclass
     required: False
     default: present
     choices: ["present", "absent", "list"]

--- a/roles/lib_openshift/src/doc/user
+++ b/roles/lib_openshift/src/doc/user
@@ -11,9 +11,9 @@ options:
   state:
     description:
     - State controls the action that will be taken with resource
-    - 'present' will create or update a user to the desired state
-    - 'absent' will ensure user is removed
-    - 'list' will read and return a list of users
+    - present - will create or update a user to the desired state
+    - absent - will ensure user is removed
+    - list - will read and return a list of users
     default: present
     choices: ["present", "absent", "list"]
     aliases: []

--- a/roles/lib_openshift/src/doc/version
+++ b/roles/lib_openshift/src/doc/version
@@ -10,6 +10,7 @@ description:
 options:
   state:
     description:
+    - State controls the action that will be taken with resource
     - Currently list is only supported state.
     required: true
     default: list

--- a/roles/lib_openshift/src/doc/volume
+++ b/roles/lib_openshift/src/doc/volume
@@ -11,9 +11,9 @@ options:
   state:
     description:
     - State controls the action that will be taken with resource
-    - 'present' will create or update and object to the desired state
-    - 'absent' will ensure volumes are removed
-    - 'list' will read the volumes
+    - present - create the volume
+    - absent - remove the volume
+    - list - return the current representation of a volume
     default: present
     choices: ["present", "absent", "list"]
     aliases: []


### PR DESCRIPTION
[Cant't find a real PR template]

This PR fixes the description of some oc-module so you can run `ansible-doc oc_*` for them.
Before you got an error:
```
ansible-doc oc_user
ERROR! module oc_user has a documentation error formatting or is missing documentation
```

This PR also removes one useless line from `oc_group` and a trailing whitespace.
