### PR TITLE
[release-3.11]Add tasks to run init playbooks for collecting "openshift_is_atomic" fact

### DIFF
--- a/playbooks/openshift-checks/certificate_expiry/default.yaml
+++ b/playbooks/openshift-checks/certificate_expiry/default.yaml
@@ -2,6 +2,12 @@
 # Default behavior, you will need to ensure you run ansible with the
 # -v option to see report results:
 
+- name: Initialize facts
+  import_playbook: ../../init/main.yml
+  vars:
+    l_init_fact_hosts: nodes:masters:etcd
+    l_openshift_version_set_hosts: nodes:masters:etcd
+
 - name: Check cert expirys
   hosts: nodes:masters:etcd
   become: yes

--- a/playbooks/openshift-checks/certificate_expiry/easy-mode.yaml
+++ b/playbooks/openshift-checks/certificate_expiry/easy-mode.yaml
@@ -6,6 +6,12 @@
 #
 # All certificates (healthy or not) are included in the results
 
+- name: Initialize facts
+  import_playbook: ../../init/main.yml
+  vars:
+    l_init_fact_hosts: nodes:masters:etcd
+    l_openshift_version_set_hosts: nodes:masters:etcd
+
 - name: Check cert expirys
   hosts: nodes:masters:etcd
   vars:

--- a/playbooks/openshift-checks/certificate_expiry/html_and_json_default_paths.yaml
+++ b/playbooks/openshift-checks/certificate_expiry/html_and_json_default_paths.yaml
@@ -1,6 +1,12 @@
 ---
 # Generate HTML and JSON artifacts in their default paths:
 
+- name: Initialize facts
+  import_playbook: ../../init/main.yml
+  vars:
+    l_init_fact_hosts: nodes:masters:etcd
+    l_openshift_version_set_hosts: nodes:masters:etcd
+
 - name: Check cert expirys
   hosts: nodes:masters:etcd
   vars:

--- a/playbooks/openshift-checks/certificate_expiry/longer-warning-period-json-results.yaml
+++ b/playbooks/openshift-checks/certificate_expiry/longer-warning-period-json-results.yaml
@@ -2,6 +2,12 @@
 # Change the expiration warning window to 1500 days (good for testing
 # the module out) and save the results as a JSON file:
 
+- name: Initialize facts
+  import_playbook: ../../init/main.yml
+  vars:
+    l_init_fact_hosts: nodes:masters:etcd
+    l_openshift_version_set_hosts: nodes:masters:etcd
+
 - name: Check cert expirys
   hosts: nodes:masters:etcd
   vars:

--- a/playbooks/openshift-checks/certificate_expiry/longer_warning_period.yaml
+++ b/playbooks/openshift-checks/certificate_expiry/longer_warning_period.yaml
@@ -2,6 +2,12 @@
 # Change the expiration warning window to 1500 days (good for testing
 # the module out):
 
+- name: Initialize facts
+  import_playbook: ../../init/main.yml
+  vars:
+    l_init_fact_hosts: nodes:masters:etcd
+    l_openshift_version_set_hosts: nodes:masters:etcd
+
 - name: Check cert expirys
   hosts: nodes:masters:etcd
   vars:


### PR DESCRIPTION
- Fix:
   - [Certificate expiry checks fail when `openshift_is_atomic` is undefined](https://bugzilla.redhat.com/show_bug.cgi?id=1655183)
   - [Running example other certificate expiration playbooks are failed due to missing "openshift_is_atomic"](https://bugzilla.redhat.com/show_bug.cgi?id=1667618)

- Version: `v3.11`

- Description:
   The following `playbooks` are always failed due to missing `openshift_is_atomic` fact, because initialing facts `playbooks` does not run before the main `playbooks`.
    - easy-mode.yaml
    - default.yaml
    - html_and_json_default_paths.yaml
    - longer_warning_period.yaml
    - longer-warning-period-json-results.yaml

  For fix, I added the following `initializing playbooks` before running `main playbooks`. And I've verified  to run ones without any errors.
  Refer https://github.com/openshift/openshift-ansible/pull/11017#issuecomment-455589650 
~~~
- name: Initialize facts
  import_playbook: ../../init/main.yml
  vars:
    l_init_fact_hosts: nodes:masters:etcd
    l_openshift_version_set_hosts: nodes:masters:etcd
~~~
  
