### PR TITLE
Add check_mode: false to container storage validation

### DIFF
--- a/roles/openshift_openstack/tasks/container-storage-setup.yml
+++ b/roles/openshift_openstack/tasks/container-storage-setup.yml
@@ -40,6 +40,7 @@
   command: systemctl status {{ openshift_docker_service_name }}
   register: docker_running
   ignore_errors: yes
+  check_mode: false  # aka run_always: true, makes sure next task doesn't unduly fail in check mode
 
 - name: restart docker after storage configuration
   become: yes


### PR DESCRIPTION
Adding check_mode: false to a command just reading information allows it
to run also in check mode (ansible-playbook --check) and makes sure that
registered variables are available in following tasks, which don't fail
anymore because the variable isn't defined.

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
