### PR TITLE
Enable cinder predicate by default

### DIFF
--- a/roles/lib_utils/lookup_plugins/openshift_master_facts_default_predicates.py
+++ b/roles/lib_utils/lookup_plugins/openshift_master_facts_default_predicates.py
@@ -70,6 +70,7 @@ class LookupModule(LookupBase):
                 {'name': 'MaxEBSVolumeCount'},
                 {'name': 'MaxGCEPDVolumeCount'},
                 {'name': 'MaxAzureDiskVolumeCount'},
+                {'name': 'MaxCinderVolumeCount'},
                 {'name': 'MatchInterPodAffinity'},
                 {'name': 'NoDiskConflict'},
                 {'name': 'GeneralPredicates'},

--- a/roles/lib_utils/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/lib_utils/test/openshift_master_facts_default_predicates_tests.py
@@ -37,6 +37,7 @@ DEFAULT_PREDICATES_3_9 = [
     {'name': 'MaxEBSVolumeCount'},
     {'name': 'MaxGCEPDVolumeCount'},
     {'name': 'MaxAzureDiskVolumeCount'},
+    {'name': 'MaxCinderVolumeCount'},
     {'name': 'MatchInterPodAffinity'},
     {'name': 'NoDiskConflict'},
     {'name': 'GeneralPredicates'},


### PR DESCRIPTION
Enable Max Volume Cinder predicate by default - fixes https://bugzilla.redhat.com/show_bug.cgi?id=1659442