### PR TITLE
[devel-40] Add openshift_bootstrap_endpoint for scaleup.

### DIFF
--- a/playbooks/deploy_cluster_40.yml
+++ b/playbooks/deploy_cluster_40.yml
@@ -72,8 +72,6 @@
 
 - name: Start masters
   hosts: masters
-  vars:
-    openshift_bootstrap_endpoint: "https://{{ openshift_install_config['metadata']['name'] }}-api.{{ openshift_install_config['baseDomain'] }}:49500/config/master"
   tasks:
   - name: Wait for bootstrap endpoint to show up
     uri:
@@ -97,8 +95,6 @@
 
 - name: Start workers
   hosts: workers
-  vars:
-    openshift_bootstrap_endpoint: "https://{{ openshift_install_config['metadata']['name'] }}-api.{{ openshift_install_config['baseDomain'] }}:49500/config/worker"
   tasks:
   - name: Wait for bootstrap endpoint to show up
     uri:

--- a/playbooks/init/basic_facts.yml
+++ b/playbooks/init/basic_facts.yml
@@ -31,19 +31,32 @@
     - deployment_type is defined
 
 - name: Read in openshift-install
-  hosts: masters[0]
+  hosts: "{{ l_init_fact_hosts | default('nodes') }}"
   tasks:
   - slurp:
       src: "{{ openshift_install_config_path }}"
     register: openshift_install_config_reg
     delegate_to: localhost
-    run_once: True
-  - set_fact:
+    when: openshift_install_config_path is defined
+  - name: 'set openshift_install_config if path is defined'
+    set_fact:
       openshift_install_config: "{{ openshift_install_config_reg['content'] | b64decode | from_yaml }}"
+    when: openshift_install_config_path is defined
 
-# We might need to access these values on each host later.
-- name: set_fact openshift_install_config across all nodes
-  hosts: "{{ l_init_fact_hosts | default('nodes') }}"
+- name: Set worker openshift_bootstrap_endpoint if not already defined
+  hosts: "{{ l_init_fact_hosts | default('nodes') }}:!masters:!bootstrap"
   tasks:
   - set_fact:
-      openshift_install_config: "{{ hostvars[groups['masters'][0]].openshift_install_config }}"
+      openshift_bootstrap_endpoint: "https://{{ openshift_install_config['metadata']['name'] }}-api.{{ openshift_install_config['baseDomain'] }}:49500/config/worker"
+    when:
+    - openshift_install_config_path is defined
+    - openshift_bootstrap_endpoint is not defined
+
+- name: Set master openshift_bootstrap_endpoint if not already defined
+  hosts: "{{ l_init_fact_hosts | default('nodes') }}:&masters"
+  tasks:
+  - set_fact:
+      openshift_bootstrap_endpoint: "https://{{ openshift_install_config['metadata']['name'] }}-api.{{ openshift_install_config['baseDomain'] }}:49500/config/master"
+    when:
+    - openshift_install_config_path is defined
+    - openshift_bootstrap_endpoint is not defined

--- a/playbooks/openshift-node/scaleup.yml
+++ b/playbooks/openshift-node/scaleup.yml
@@ -22,8 +22,6 @@
 
 - name: install nodes
   hosts: new_workers
-  vars:
-    openshift_bootstrap_endpoint: "https://{{ openshift_install_config['metadata']['name'] }}-api.{{ openshift_install_config['baseDomain'] }}:49500/config/worker"
   roles:
   - role: container_runtime
   tasks:


### PR DESCRIPTION
Prior to this change, the install-config.yaml needed to be retained from
the original openshift-install of the cluster and passed to the scaleup
playbook via the openshift_install_config_path variable.

This change allows scaleup to work without the install-config.yaml by
passing the openshift_bootstrap_endpoint variable directly as part of the
inventory while maintaining backwards compatability.

Example Inventory:
```
[new_workers]
test-worker-rhel-0.tt.testing

[new_workers:vars]
ansible_ssh_user='cloud-user'
ansible_become=yes
openshift_deployment_type='origin'
openshift_bootstrap_endpoint='https://test-api.tt.testing:49500/config/worker'
```