### PR TITLE
openshift_node: open the router stats port by default

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -143,6 +143,9 @@ default_r_openshift_node_os_firewall_allow:
   cond: "{{ openshift_node_port_range is defined }}"
 - service: Prometheus monitoring
   port: 9000-10000/tcp
+- service: Router stats port
+  port: 1936/tcp
+  cond: "{{ openshift_router_stats_port_enable | default(True) }}"
 # Allow multiple port ranges to be added to the role
 r_openshift_node_os_firewall_allow: "{{ default_r_openshift_node_os_firewall_allow | union(openshift_node_open_ports | default([])) }}"
 


### PR DESCRIPTION
This allows prometheus to scrape the router metrics.
https://bugzilla.redhat.com/show_bug.cgi?id=1552235

