### PR TITLE
Fix sanity-check removed vars

### DIFF
--- a/roles/lib_utils/action_plugins/sanity_checks.py
+++ b/roles/lib_utils/action_plugins/sanity_checks.py
@@ -152,7 +152,7 @@ def check_for_removed_vars(hostvars, host):
     """Fails if removed variables are found"""
     found_removed = []
     for item in REMOVED_VARIABLES:
-        if item in hostvars[host]:
+        if item[0] in hostvars[host]:
             found_removed.append(item)
 
     if found_removed:

--- a/roles/lib_utils/test/sanity_check_test.py
+++ b/roles/lib_utils/test/sanity_check_test.py
@@ -7,6 +7,7 @@ from ansible.template import Templar
 from ansible import errors
 
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir, "action_plugins"))
+import sanity_checks  # noqa: E402
 from sanity_checks import ActionModule  # noqa: E402
 
 
@@ -108,3 +109,19 @@ class FakeTask(object):
         self.action = action
         self.args = args
         self.async = 0
+
+
+def test_removed_vars():
+    host1d = {'somevar': 'someval', 'openshift_hostname': '1'}
+    hostvars = {'host1': host1d}
+    host = "host1"
+    with pytest.raises(errors.AnsibleModuleError):
+        sanity_checks.check_for_removed_vars(hostvars, host)
+
+
+def main():
+    test_removed_vars()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Current implementation doesn't work as we attempt to locate
a tuple in a dictionary (hostvars) instead of item[0]
from said tuple.