### PR TITLE
Revert "Enable cinder predicate by default"

### DIFF
--- a/roles/lib_utils/lookup_plugins/openshift_master_facts_default_predicates.py
+++ b/roles/lib_utils/lookup_plugins/openshift_master_facts_default_predicates.py
@@ -70,7 +70,6 @@ class LookupModule(LookupBase):
                 {'name': 'MaxEBSVolumeCount'},
                 {'name': 'MaxGCEPDVolumeCount'},
                 {'name': 'MaxAzureDiskVolumeCount'},
-                {'name': 'MaxCinderVolumeCount'},
                 {'name': 'MatchInterPodAffinity'},
                 {'name': 'NoDiskConflict'},
                 {'name': 'GeneralPredicates'},

--- a/roles/lib_utils/test/openshift_master_facts_default_predicates_tests.py
+++ b/roles/lib_utils/test/openshift_master_facts_default_predicates_tests.py
@@ -37,7 +37,6 @@ DEFAULT_PREDICATES_3_9 = [
     {'name': 'MaxEBSVolumeCount'},
     {'name': 'MaxGCEPDVolumeCount'},
     {'name': 'MaxAzureDiskVolumeCount'},
-    {'name': 'MaxCinderVolumeCount'},
     {'name': 'MatchInterPodAffinity'},
     {'name': 'NoDiskConflict'},
     {'name': 'GeneralPredicates'},


### PR DESCRIPTION
Reverts openshift/openshift-ansible#11044

Need to wait for this to be available in the build and possibly make sure to assert a minimum version.