### PR TITLE
Accept pairs and maps for logging node selectors

### DIFF
--- a/roles/lib_utils/filter_plugins/oo_filters.py
+++ b/roles/lib_utils/filter_plugins/oo_filters.py
@@ -606,6 +606,10 @@ def map_from_pairs(source, delim="="):
     if source == '':
         return dict()
 
+    # Return early if if input already is a dictionary.
+    if isinstance(source, dict):
+        return source
+
     return dict(item.split(delim) for item in source.split(","))
 
 
@@ -615,6 +619,10 @@ def map_to_pairs(source, delim="="):
     # Some default selectors are empty strings.
     if source == {} or source == '':
         return str()
+
+    # Return early if if input already is a pairs string.
+    if isinstance(source, basestring):
+        return source
 
     return ','.join(["{}{}{}".format(key, delim, value) for key, value in iteritems(source)])
 

--- a/roles/openshift_logging_curator/tasks/main.yaml
+++ b/roles/openshift_logging_curator/tasks/main.yaml
@@ -88,7 +88,7 @@
     curator_cpu_limit: "{{ openshift_logging_curator_cpu_limit }}"
     curator_cpu_request: "{{ openshift_logging_curator_cpu_request | min_cpu(openshift_logging_curator_cpu_limit | default(none)) }}"
     curator_memory_limit: "{{ openshift_logging_curator_memory_limit }}"
-    curator_node_selector: "{{openshift_logging_curator_nodeselector | default({})}}"
+    curator_node_selector: "{{openshift_logging_curator_nodeselector | default({}) | map_from_pairs }}"
     cron_job_schedule: "{{ openshift_logging_curator_run_minute | default(0) }} {{ openshift_logging_curator_run_hour | default(0) }} * * *"
   check_mode: no
   changed_when: no

--- a/roles/openshift_logging_eventrouter/tasks/install_eventrouter.yaml
+++ b/roles/openshift_logging_eventrouter/tasks/install_eventrouter.yaml
@@ -34,7 +34,7 @@
     src: "eventrouter-template.j2"
     dest: "{{ tempdir }}/templates/eventrouter-template.yaml"
   vars:
-    node_selector: "{{ openshift_logging_eventrouter_nodeselector | default({}) }}"
+    node_selector: "{{ openshift_logging_eventrouter_nodeselector | default({}) | map_from_pairs }}"
     cpu_limit: "{{ openshift_logging_eventrouter_cpu_limit }}"
 
 - name: Create EventRouter template

--- a/roles/openshift_logging_kibana/tasks/main.yaml
+++ b/roles/openshift_logging_kibana/tasks/main.yaml
@@ -257,7 +257,7 @@
     kibana_proxy_cpu_request: "{{ openshift_logging_kibana_proxy_cpu_request | min_cpu(openshift_logging_kibana_proxy_cpu_limit | default(none)) }}"
     kibana_proxy_memory_limit: "{{ openshift_logging_kibana_proxy_memory_limit }}"
     kibana_replicas: "{{ openshift_logging_kibana_replicas | default (1) }}"
-    kibana_node_selector: "{{ openshift_logging_kibana_nodeselector | default({}) }}"
+    kibana_node_selector: "{{ openshift_logging_kibana_nodeselector | default({}) | map_from_pairs }}"
     kibana_env_vars: "{{ openshift_logging_kibana_env_vars | default({}) }}"
 
 - name: Set Kibana DC


### PR DESCRIPTION
We opted to set `openshift_logging_curator_nodeselector` and `openshift_logging_kibana_nodeselector` equal to `openshift_hosted_infra_selector`. This did not work at first as one is set as key value pairs and the others expect a dictionary.

This PR equals this by making the logging node selector variables to accept both a dictionary and a key value pairs string.