### PR TITLE
[release-3.10] update test/ci playbooks

### DIFF
--- a/test/ci/launch.yml
+++ b/test/ci/launch.yml
@@ -8,23 +8,6 @@
         - vars.yml
         - vars.yaml
 
-    - name: list available AMIs
-      ec2_ami_facts:
-        region: "{{ aws_region }}"
-        filters: "{{ aws_ami_tags }}"
-      register: ami_facts
-      when: aws_image is not defined
-
-    - name: determine which AMI to use
-      set_fact:
-        aws_image: "{{ ami_facts.images[-1].image_id }}"
-      when: aws_image is not defined
-
-    - name: determine which AMI to use
-      set_fact:
-        aws_image: "{{ ami_facts.images[-1].image_id }}"
-      when: aws_image is not defined
-
     - name: Create AWS security group
       ec2_group:
         name: "{{ item.aws_security_group }}"


### PR DESCRIPTION
Avoid using `ec2_ami_facts` - its not available in Ansible 2.4

This is required to unblock https://github.com/openshift/release/pull/2683, so that we could use `e2e-aws` instead of `/install`