### PR TITLE
gluster: detect intent to deploy legacy OpenShift Container Storage

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
@@ -37,6 +37,13 @@
       NODE_LABELS: "{{ glusterfs_nodeselector }}"
       CLUSTER_NAME: "{{ glusterfs_name }}"
       GB_GLFS_LRU_COUNT: "{{ glusterfs_block_host_vol_max }}"
+      HOST_DEV_DIR: "{{ host_dev_dir }}"
+  vars:
+    is_enterprise: "{{ openshift_deployment_type == 'openshift-enterprise' }}"
+    version: "{{ (openshift_storage_glusterfs_image | regex_replace('^.*:(v?)(?P<version>.+$)', '\\g<version>')) }}"
+    is_legacy_ocs_version: "{{ version is version_compare('3.11.1', '<') }}"
+    gluster_use_legacy_ocs: "{{ is_enterprise and is_legacy_ocs_version }}"
+    host_dev_dir: "{{ '/dev' if gluster_use_legacy_ocs else '/mnt/host-dev' }}"
   when: (glusterfs_ds.results.results[0].status is not defined) or
         (glusterfs_ds.results.results[0].status.numberReady | default(0) < glusterfs_ds.results.results[0].status.desiredNumberScheduled | default(glusterfs_nodes | count))
 


### PR DESCRIPTION
Old versions of OpenShift Container Storage (OCS) do not have the needed
scripts to handle the HOST_DEV_DIR environmant variable. These versions
should (try to) use a normal /dev bind mount from the host into the
container.

This will not work in combination with CRI-O. Only OCS-3.11.1 and newer
have the HOST_DEV_DIR script.

Upstream Gluster containers do not have this problem, as the images have
been updated to contain the script. Hence there is a check for the
"openshift-enterprise" variant of deploying.

Bug: https://bugzilla.redhat.com/1668316
Bug: https://bugzilla.redhat.com/1668335
Bug: https://bugzilla.redhat.com/1667803