### PR TITLE
Fixed "AnsibleUndefinedVariable" error for missing annotations

### DIFF
--- a/roles/openshift_persistent_volumes/templates/persistent-volume-claim.yml.j2
+++ b/roles/openshift_persistent_volumes/templates/persistent-volume-claim.yml.j2
@@ -7,7 +7,7 @@ items:
   kind: "PersistentVolumeClaim"
   metadata:
     name: "{{ claim.name }}"
-{% if claim.annotations %}
+{% if claim.annotations is defined %}
     annotations:
 {% for annotation in claim.annotations %}
         {{ annotation }}

--- a/roles/openshift_persistent_volumes/templates/persistent-volume.yml.j2
+++ b/roles/openshift_persistent_volumes/templates/persistent-volume.yml.j2
@@ -7,7 +7,7 @@ items:
   kind: PersistentVolume
   metadata:
     name: "{{ volume.name }}"
-{% if volume.annotations %}
+{% if volume.annotations is defined %}
     annotations:
 {% for annotation in volume.annotations %}
       {{ annotation }}


### PR DESCRIPTION
Fixed "AnsibleUndefinedVariable: 'dict object' has no attribute 'annotations'" error while running the openshift-hosted/config.yml playbook.

