### PR TITLE
Add newlines when concatenating router certificate

### DIFF
--- a/roles/lib_openshift/library/oc_adm_router.py
+++ b/roles/lib_openshift/library/oc_adm_router.py
@@ -2891,11 +2891,11 @@ class Router(OpenShiftCLI):
 
             router_pem = '/tmp/router.pem'
             with open(router_pem, 'w') as rfd:
-                rfd.write(open(self.config.config_options['cert_file']['value']).read())
-                rfd.write(open(self.config.config_options['key_file']['value']).read())
+                rfd.write(open(self.config.config_options['cert_file']['value']).read() + "\n")
+                rfd.write(open(self.config.config_options['key_file']['value']).read() + "\n")
                 if self.config.config_options['cacert_file']['value'] and \
                    os.path.exists(self.config.config_options['cacert_file']['value']):
-                    rfd.write(open(self.config.config_options['cacert_file']['value']).read())
+                    rfd.write(open(self.config.config_options['cacert_file']['value']).read() + "\n")
 
             atexit.register(Utils.cleanup, [router_pem])
 

--- a/roles/lib_openshift/src/class/oc_adm_router.py
+++ b/roles/lib_openshift/src/class/oc_adm_router.py
@@ -218,11 +218,11 @@ class Router(OpenShiftCLI):
 
             router_pem = '/tmp/router.pem'
             with open(router_pem, 'w') as rfd:
-                rfd.write(open(self.config.config_options['cert_file']['value']).read())
-                rfd.write(open(self.config.config_options['key_file']['value']).read())
+                rfd.write(open(self.config.config_options['cert_file']['value']).read() + "\n")
+                rfd.write(open(self.config.config_options['key_file']['value']).read() + "\n")
                 if self.config.config_options['cacert_file']['value'] and \
                    os.path.exists(self.config.config_options['cacert_file']['value']):
-                    rfd.write(open(self.config.config_options['cacert_file']['value']).read())
+                    rfd.write(open(self.config.config_options['cacert_file']['value']).read() + "\n")
 
             atexit.register(Utils.cleanup, [router_pem])
 


### PR DESCRIPTION
Insert new lines between cert, key, and cacert in case the inputs don't have a new line to start with. Extra new lines are harmless but the lack of a new line is fatal.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1668970