### PR TITLE
[release-3.11] Fix OpenShift SDN/OVS pod restart during upgrades

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/upgrade_nodes.yml
@@ -94,12 +94,6 @@
           ('glusterfs' in groups and inventory_hostname in groups['glusterfs'])
           or ('glusterfs_registry' in groups and inventory_hostname in groups['glusterfs_registry'])
 
-- name: Upgrade SDN
-  hosts: oo_first_master
-  roles:
-  - role: openshift_sdn
-    when: openshift_use_openshift_sdn | default(True) | bool
-
 - name: Re-enable excluders
   hosts: oo_nodes_to_upgrade:!oo_masters_to_config
   tasks:

--- a/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
@@ -68,6 +68,13 @@
     - openshift_reconcile_sccs_reject_change | default(true) | bool
     - check_reconcile_scc_result.stdout != '' or check_reconcile_scc_result.rc != 0
 
+- name: Change SDN/OVS DaemonSets to 'OnDelete' updateStrategy
+  hosts: masters[0]
+  tasks:
+  - import_role:
+      name: openshift_sdn
+      tasks_from: update_daemonsets.yml
+
 # TODO: need to verify settings about the bootstrap configs
 # 1. Does network policy match the master config
 

--- a/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
@@ -78,6 +78,13 @@
     # a default is set on the actual variable in the role, so no fancy logic is needed here
     when: openshift_metrics_server_install | default(true) | bool
 
+
+- name: Configure components that must be available prior to upgrade
+  hosts: oo_first_master
+  roles:
+  - role: openshift_sdn
+    when: openshift_use_openshift_sdn | default(True) | bool
+
 - import_playbook: ../upgrade_control_plane.yml
   vars:
     openshift_release: '3.11'

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -7,6 +7,20 @@
 
 # tasks file for openshift_node_upgrade
 
+# https://bugzilla.redhat.com/show_bug.cgi?id=1660880
+# Delete the SDN/OVS pods to allow any changes to the DaemonSets to be applied.
+- name: Delete OpenShift SDN/OVS pods prior to upgrade
+  shell: >
+    {{ openshift_client_binary }} get pods
+    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    --field-selector=spec.nodeName={{ l_kubelet_node_name | lower }}
+    -o json
+    -n openshift-sdn |
+    {{ openshift_client_binary }} delete
+    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    -f -
+  delegate_to: "{{ groups.oo_first_master.0 }}"
+
 - name: stop services for upgrade
   import_tasks: upgrade/stop_services.yml
 

--- a/roles/openshift_sdn/files/sdn-ovs.yaml
+++ b/roles/openshift_sdn/files/sdn-ovs.yaml
@@ -13,7 +13,7 @@ spec:
     matchLabels:
       app: ovs
   updateStrategy:
-    type: RollingUpdate
+    type: OnDelete
   template:
     metadata:
       labels:

--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -16,7 +16,7 @@ spec:
     matchLabels:
       app: sdn
   updateStrategy:
-    type: RollingUpdate
+    type: OnDelete
   template:
     metadata:
       labels:

--- a/roles/openshift_sdn/meta/main.yaml
+++ b/roles/openshift_sdn/meta/main.yaml
@@ -16,4 +16,5 @@ galaxy_info:
   - openshift
 dependencies:
 - role: lib_openshift
+- role: lib_utils
 - role: openshift_facts

--- a/roles/openshift_sdn/tasks/main.yml
+++ b/roles/openshift_sdn/tasks/main.yml
@@ -51,24 +51,6 @@
   shell: >
     {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig apply -f "{{ mktemp.stdout }}"
 
-- name: Wait for rollout
-  command: >
-    {{ openshift_client_binary }} rollout status ds/sdn --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift-sdn
-  changed_when: false
-  # Ignore errors so we can log troubleshooting info on failures.
-  ignore_errors: yes
-  register: sdn_rollout_status
-
-- when: sdn_rollout_status.rc != 0
-  block:
-    - name: Get pods in the openshift-sdn namespace
-      command: >
-        {{ openshift_client_binary }} get pods -o wide --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n openshift-sdn
-      register: pods
-      ignore_errors: true
-    - debug:
-        msg: "{{ pods.stdout_lines }}"
-
 - name: Remove temp directory
   file:
     state: absent

--- a/roles/openshift_sdn/tasks/update_daemonset.yml
+++ b/roles/openshift_sdn/tasks/update_daemonset.yml
@@ -1,0 +1,44 @@
+---
+
+- name: Retrieve openshift-sdn DaemonSet [{{ l_daemonset }}]
+  oc_obj:
+    namespace: "openshift-sdn"
+    kind: DaemonSet
+    name: "{{ l_daemonset }}"
+    state: list
+  register: ds_out
+  ignore_errors: true
+
+- when:
+    - ds_out is succeeded
+    - ds_out.results.results[0].spec.updateStrategy.type == 'RollingUpdate'
+  block:
+    - name: Create DaemonSet tempdir
+      command: mktemp -d
+      register: mktemp
+
+    - name: Create DaemonSet manifest
+      copy:
+        content: "{{ ds_out.results.results[0] }}"
+        dest: "{{ mktemp.stdout }}/tmp_ds.yaml"
+
+    - name: Update DaemonSet updateStrategy
+      yedit:
+        src: "{{ mktemp.stdout }}/tmp_ds.yaml"
+        key: 'spec.updateStrategy.type'
+        value: "OnDelete"
+
+    - name: Apply DaemonSet manifest
+      oc_obj:
+        namespace: "openshift-sdn"
+        kind: DaemonSet
+        name: "ovs"
+        state: present
+        files:
+          - "{{ mktemp.stdout }}/tmp_ds.yaml"
+
+    - name: Remove DaemonSet tempdir
+      file:
+        state: absent
+        name: "{{ mktemp.stdout }}"
+      changed_when: False

--- a/roles/openshift_sdn/tasks/update_daemonsets.yml
+++ b/roles/openshift_sdn/tasks/update_daemonsets.yml
@@ -1,0 +1,16 @@
+---
+
+# https://bugzilla.redhat.com/show_bug.cgi?id=1660880
+# Updates to DaemonSets using the 'RollingUpdate' updateStrategy could cause pod
+# restarts on all nodes in a cluster, which will result in network and application
+# outages as the rollout occurs. The tasks below change the updateStrategy to
+# 'OnDelete' which will only update pods on nodes when they are deleted.  The
+# openshift_node upgrade.yml task file incorporates an SDN/OVS pod delete task
+# to delete these pods when the node is unschedulable and drained.
+
+- include_tasks: update_daemonset.yml
+  vars:
+    l_daemonset: "{{ item }}"
+  with_items:
+  - sdn
+  - ovs


### PR DESCRIPTION
Fix OpenShift SDN/OVS pod restart during upgrades

When the OpenShift SDN/OVS DaemonSets were upgraded during control plane
upgrades with an updateStrategy of RollingUpdate, an upgrade of the pods
in the entire cluster was performed.  This caused unexpected network and
application outages on nodes.

This patch updates the following:
* Changed the updateStrategy for SDN/OVS pods to OnDelete in the template,
  affects new installs.
* Added control plane upgrade task to modify SDN/OVS daemonsets to use
  OnDelete updateStrategy
* Added node upgrade task to delete all SDN/OVS pods while nodes are drained

Network outages for nodes should only occur during the node upgrade when
nodes are drained.

Reverts #10910 
Forward ports #11050