### PR TITLE
multipath: add hardware_handler for LIO-ORG (gluster-block) config

### DIFF
--- a/roles/openshift_node/templates/multipath.conf.j2
+++ b/roles/openshift_node/templates/multipath.conf.j2
@@ -9,6 +9,7 @@ devices {
                 failback immediate
                 path_checker "tur"
                 prio "alua"
+                hardware_handler "1 alua"
                 no_path_retry 120
                 rr_weight "uniform"
         }


### PR DESCRIPTION
Not all Linux kernels configure the hardware_handler automatically (only
versions 4.3+ do that). It does not hurt to configure it always, newer
kernels ignore the setting, and it brings advantages for the older ones.

BUG: https://bugzilla.redhat.com/1669500
Signed-off-by: Niels de Vos <ndevos@redhat.com>
