### PR TITLE
Bug 1651632 - Force console rollout every time the playbook runs

### DIFF
--- a/roles/openshift_console/files/console-template.yaml
+++ b/roles/openshift_console/files/console-template.yaml
@@ -34,6 +34,9 @@ parameters:
 - name: OAUTH_SECRET
   generate: expression
   from: "[a-zA-Z0-9]{32}"
+- name: FORCE_ROLLOUT_ANNOTATION_VALUE
+  generate: expression
+  from: "[a-zA-Z0-9]{7}"
 objects:
 
 # to create the web console server
@@ -56,6 +59,8 @@ objects:
     replicas: "${{REPLICA_COUNT}}"
     template:
       metadata:
+        annotations:
+          installer-triggered-rollout: ${FORCE_ROLLOUT_ANNOTATION_VALUE}
         labels:
           app: openshift-console
           component: ui


### PR DESCRIPTION
This makes sure the console pods pick up the changes to the OAuth shared
secret to prevent errors logging in.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1651632

/assign @sdodson @vrutkovs 
