### PR TITLE
[3.10] Start node image prepull after CRIO is restarted

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -6,9 +6,6 @@
     - openshift_deployment_type == 'openshift-enterprise'
     - not openshift_use_crio | bool
 
-- name: Start node image prepull
-  import_tasks: prepull.yml
-
 - import_tasks: dnsmasq_install.yml
 - import_tasks: dnsmasq.yml
 
@@ -24,9 +21,6 @@
 # /etc/fstab and runs swapoff -a, if necessary.
 - name: Disable swap
   swapoff: {}
-
-- name: include node installer
-  import_tasks: install.yml
 
 - name: Restart cri-o
   systemd:
@@ -44,6 +38,12 @@
     name: NetworkManager
     enabled: yes
     state: restarted
+
+- name: Start node image prepull
+  import_tasks: prepull.yml
+
+- name: include node installer
+  import_tasks: install.yml
 
 # The atomic-openshift-node service will set this parameter on
 # startup, but if the network service is restarted this setting is


### PR DESCRIPTION
This ensures node prepull happens after CRIO is configured and the
service is not restarted between start and prepull check.

This is a cherrypick of #10642. It also fixed a swapoff task to use `openshift_disable_swap`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1639623