### PR TITLE
cert expiry: cert subject can contain unicode

### DIFF
--- a/roles/lib_utils/library/openshift_cert_expiry.py
+++ b/roles/lib_utils/library/openshift_cert_expiry.py
@@ -289,7 +289,7 @@ A tuple of the form:
         if isinstance(name, bytes) or isinstance(value, bytes):
             name = name.decode('utf-8')
             value = value.decode('utf-8')
-        cert_subjects.append('{}:{}'.format(name, value))
+        cert_subjects.append(u'{}:{}'.format(name, value))
 
     # To read SANs from a cert we must read the subjectAltName
     # extension from the X509 Object. What makes this more difficult
@@ -307,7 +307,7 @@ A tuple of the form:
         # to the list of existing names
         cert_subjects.extend(str(san).split(', '))
 
-    cert_subject = ', '.join(cert_subjects)
+    cert_subject = u', '.join(cert_subjects)
     ######################################################################
 
     # Grab the expiration date


### PR DESCRIPTION
Correctly convert certificate subject to unicode in case certificate has unicode chars

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1669439