### PR TITLE
[3.11] Added liveness probes to apiserver template

### DIFF
--- a/roles/template_service_broker/files/apiserver-template.yaml
+++ b/roles/template_service_broker/files/apiserver-template.yaml
@@ -61,6 +61,21 @@ objects:
               path: /healthz
               port: 8443
               scheme: HTTPS
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
         nodeSelector: "${{NODE_SELECTOR}}"
         volumes:
         - name: serving-cert


### PR DESCRIPTION
* Version: `v3.11`, but it can be applied from `v3.7` to `v3.11`.

* Description: 
  Liveness Probe is added as same rules with existing Readiness Probes for self-healing enhancement,
  because if the readiness is failed by network crash, the `apiserver` pod will be removed from its `Server` only,  it can not self-healing.

* Related Information: 
   - BZ: [Network of DaemonSet Pods are not available after upgrade_nodes.yml](https://bugzilla.redhat.com/show_bug.cgi?id=1667283)
   - https://github.com/openshift/openshift-ansible/pull/11029 : The `PR` closing cause is not `Template Service Broker` issue, so I suggest the Template Service Broker `PR` again here.

