### PR TITLE
[release-3.11] Remove hard coded gather_timeout in openshift_facts

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -1276,7 +1276,6 @@ def main():
     )
 
     module.params['gather_subset'] = ['hardware', 'network', 'virtual', 'facter']  # noqa: F405
-    module.params['gather_timeout'] = 10  # noqa: F405
     module.params['filter'] = '*'  # noqa: F405
 
     role = module.params['role']  # noqa: F405


### PR DESCRIPTION
Hard coded value prevents user configurable value in ansible.cfg from
being honored.

https://bugzilla.redhat.com/show_bug.cgi?id=1671302