### PR TITLE
Fixing incorrect indentation for cns-secgrp in heat template

### DIFF
--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -579,7 +579,7 @@ resources:
           params:
             cluster_id: {{ openshift_openstack_full_dns_domain }}
       rules: {{ openshift_openstack_infra_secgroup_rules|to_json }}
-  {% if openshift_openstack_num_cns > 0 %}
+{% if openshift_openstack_num_cns > 0 %}
   cns-secgrp:
     type: OS::Neutron::SecurityGroup
     properties:
@@ -594,7 +594,7 @@ resources:
           params:
             cluster_id: {{ openshift_openstack_full_dns_domain }}
       rules: {{ openshift_openstack_cns_secgroup_rules|to_json }}
-  {% endif %}
+{% endif %}
 {% endif %}
 
   lb-secgrp:


### PR DESCRIPTION
The jinja template creates the wrong indentation for the `cns-secgrp` definition in the heat template. Although the core readabilty is better the way it is, it just doesn't generate the correct template and OSP heat will error out. This PR fixes this indentation to make it possible to use the heat template to create OCS (f.k.a. CNS) nodes.