### PR TITLE
Fixes idempotency on update of service in oc_service

### DIFF
--- a/roles/lib_openshift/library/oc_service.py
+++ b/roles/lib_openshift/library/oc_service.py
@@ -1804,7 +1804,7 @@ class OCService(OpenShiftCLI):
 
     def needs_update(self):
         ''' verify an update is needed '''
-        skip = ['clusterIP', 'portalIP']
+        skip = ['clusterIP', 'portalIP', 'sessionAffinityConfig']
         return not Utils.check_def_equal(self.user_svc.yaml_dict, self.service.yaml_dict, skip_keys=skip, debug=True)
 
     # pylint: disable=too-many-return-statements,too-many-branches

--- a/roles/lib_openshift/src/class/oc_service.py
+++ b/roles/lib_openshift/src/class/oc_service.py
@@ -84,7 +84,7 @@ class OCService(OpenShiftCLI):
 
     def needs_update(self):
         ''' verify an update is needed '''
-        skip = ['clusterIP', 'portalIP']
+        skip = ['clusterIP', 'portalIP', 'sessionAffinityConfig']
         return not Utils.check_def_equal(self.user_svc.yaml_dict, self.service.yaml_dict, skip_keys=skip, debug=True)
 
     # pylint: disable=too-many-return-statements,too-many-branches


### PR DESCRIPTION
After initial registry service creation, oc_service fails due to:

```
TASK [openshift_hosted : create the default registry service]
fatal: [master1.openshift]: FAILED! => {"changed": false,
"module_stderr": "", "module_stdout": "keys are not equal in dict
{'selector', 'ports', 'type', 'sessionAffinity'}
{'ports', 'type', 'selector', 'sessionAffinityConfig', 'sessionAffinity'}
```

Adds sessionAffinityConfig to the list of keys to skip.

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
