### PR TITLE
[release-3.7] Added liveness probes to apiserver template 

### DIFF
--- a/files/origin-components/apiserver-template.yaml
+++ b/files/origin-components/apiserver-template.yaml
@@ -61,6 +61,21 @@ objects:
               path: /healthz
               port: 8443
               scheme: HTTPS
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
         nodeSelector: "${{NODE_SELECTOR}}"
         volumes:
         - name: serving-cert


### PR DESCRIPTION
* Version: `v3.7`

* Description: 
  Liveness Probe is added as same rules with existing Readiness Probes for self-healing enhancement,
  because if the readiness is failed by network crash, the `apiserver` pod will be removed from its `Server` only,  it can not self-healing.

* Related Information:
   - BZ: [Network of DaemonSet Pods are not available after upgrade_nodes.yml](https://bugzilla.redhat.com/show_bug.cgi?id=1667283)
   - this `PR` is backport. Refer merged `PR` of `v3.11` here: https://github.com/openshift/openshift-ansible/pull/11101 

