### PR TITLE
[release-3.11] Correct service serving secret name in the annotation

### DIFF
--- a/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
@@ -64,14 +64,27 @@
     - ('OPENSHIFT_CERT_DATA' in router_env_vars)
     - ('OPENSHIFT_KEY_DATA' in router_env_vars)
 
+  - name: Delete existing router certificate secret
+    oc_secret:
+      kubeconfig: "{{ router_cert_redeploy_tempdir.stdout }}/admin.kubeconfig"
+      name: router-certs
+      namespace: default
+      state: absent
+    run_once: true
+    when:
+    - l_router_dc.rc == 0
+    - l_router_svc.rc == 0
+    - ('router-certs' in router_secrets)
+    - openshift_hosted_router_certificate is undefined
+
   # When the router service contains service signer annotations we
   # will delete the existing certificate secret and allow OpenShift to
   # replace the secret.
   - block:
-    - name: Delete existing router certificate secret
+    - name: Delete existing router metrics certificate secret
       oc_secret:
         kubeconfig: "{{ router_cert_redeploy_tempdir.stdout }}/admin.kubeconfig"
-        name: router-certs
+        name: router-metrics-tls
         namespace: default
         state: absent
       run_once: true
@@ -87,14 +100,13 @@
     - name: Add serving-cert-secret annotation to router service
       command: >
         {{ openshift_client_binary }} annotate service/router
-        service.alpha.openshift.io/serving-cert-secret-name=router-certs
+        service.alpha.openshift.io/serving-cert-secret-name=router-metrics-tls
         --config={{ router_cert_redeploy_tempdir.stdout }}/admin.kubeconfig
         -n default
     when:
     - l_router_dc.rc == 0
     - l_router_svc.rc == 0
-    - ('router-certs' in router_secrets)
-    - openshift_hosted_router_certificate is undefined
+    - ('router-metrics-tls' in router_secrets)
     - ('service.alpha.openshift.io/serving-cert-secret-name') in router_service_annotations
     - ('service.alpha.openshift.io/serving-cert-signed-by') in router_service_annotations
 


### PR DESCRIPTION
* Fix: ["redeploy-router-certificates.yml" makes changes to wrong "service serving certificate secrets" annotation](https://bugzilla.redhat.com/show_bug.cgi?id=1672011)

* Version: `v3.11`, and I've verified other version is also affected this, such as `v3.3` ~ `v3.10`.

* Description:
  When `redeploy-router-certificates.yml` playbooks run for redeploy router certificates, both `router-certs` and `router-metrics-tls` certificates `secret` should be redeploy, and the `router-certs` should be also regenerated as wildcard certificates, it's not `service serving certificates`. `router-metrics-tls` secret has been managed as `service serving certificates secret`. If `router-certs` created as `service serving certificates`, it's affected the services to access using `wildcard certificates`

`router-certs` will be created again from included `openshift_hosted/tasks/router.yml` tasks in the `roles`.


