### PR TITLE
Sync pod support volume-config - Fixes BZ1669555

### DIFF
--- a/roles/openshift_node_group/files/sync.yaml
+++ b/roles/openshift_node_group/files/sync.yaml
@@ -118,6 +118,9 @@ spec:
                   echo "nodeName: $KUBELET_HOSTNAME_OVERRIDE" >> /etc/origin/node/tmp/node-config.yaml
             fi
 
+            NODERESTART=0
+            VOLRESTART=0
+
             # detect whether the node-config.yaml has changed, and if so trigger a restart of the kubelet.
             if [[ ! -f /etc/origin/node/node-config.yaml ]]; then
               cat /dev/null > /tmp/.old
@@ -126,8 +129,25 @@ spec:
             md5sum /etc/origin/node/tmp/node-config.yaml > /tmp/.new
             if [[ "$( cat /tmp/.old )" != "$( cat /tmp/.new )" ]]; then
               mv /etc/origin/node/tmp/node-config.yaml /etc/origin/node/node-config.yaml
+              NODERESTART=1
+              echo "info: Node configuration changed, mark kubelet for restart" 2>&1
+            fi
+
+            # detect whether the volume-config.yaml has changed, and if so trigger a restart of the kubelet.
+            if [[ ! -f /etc/origin/node/volume-config.yaml ]]; then
+              cat /dev/null > /tmp/.vol-old
+            fi
+
+            md5sum /etc/origin/node/tmp/volume-config.yaml > /tmp/.vol-new
+            if [[ "$( cat /tmp/.vol-old )" != "$( cat /tmp/.vol-new )" ]]; then
+              mv /etc/origin/node/tmp/volume-config.yaml /etc/origin/node/volume-config.yaml
+              VOLRESTART=1
+              echo "info: Volume configuration changed, mark kublet for restart" 2>&1
+            fi
+
+            if [[ "$NODERESTART" -eq "1" || "$VOLRESTART" -eq "1" ]]; then
               SYSTEMD_IGNORE_CHROOT=1 systemctl restart tuned || :
-              echo "info: Configuration changed, restarting kubelet" 2>&1
+              echo "info: Configuration change mark detected, restarting kubelet" 2>&1
               # TODO: kubelet doesn't relabel nodes, best effort for now
               # https://github.com/kubernetes/kubernetes/issues/59314
               if args="$(openshift-node-config --config /etc/origin/node/node-config.yaml)"; then
@@ -157,7 +177,10 @@ spec:
             # annotate node with md5sum of the config
             oc annotate --config=/etc/origin/node/node.kubeconfig "node/${NODE_NAME}" \
               node.openshift.io/md5sum="$( cat /tmp/.new | cut -d' ' -f1 )" --overwrite
+            oc annotate --config=/etc/origin/node/node.kubeconfig "node/${NODE_NAME}" \
+              volume.openshift.io/md5sum="$( cat /tmp/.vol-new | cut -d' ' -f1 )" --overwrite
             cp -f /tmp/.new /tmp/.old
+            cp -f /tmp/.vol-new /tmp/.vol-old
             sleep 180 &
             wait $!
           done


### PR DESCRIPTION
PR #10343 broke the ability of the sync pod to manage volume-config.yaml. This makes is hard to set emptydir quotas. Currently reported in BZ1669555

This PR adds functionality to restore this capability. 