### PR TITLE
GlusterFS: Keep logs on uninstall

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
@@ -127,13 +127,6 @@
   delegate_to: "{{ item }}"
   with_items: "{{ glusterfs_nodes | default([]) }}"
 
-- name: Delete Glusterfs logs
-  file:
-    path: /var/log/glusterfs
-    state: absent
-  delegate_to: "{{ item }}"
-  with_items: "{{ glusterfs_nodes | default([]) }}"
-
 # This recreates expected directory structures
 - name: Reinstall GlusterFS Server (external)
   command: "yum reinstall -y glusterfs*"


### PR DESCRIPTION
The glusterfs-fuse client needs /var/log/glusterfs present to operate
properly. IN addition, these could be useful for post-mortem RCA.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1639427

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>