### PR TITLE
test/aws: wait for machinesets to be registered

### DIFF
--- a/test/aws/create_machineset.yml
+++ b/test/aws/create_machineset.yml
@@ -43,7 +43,7 @@
 - name: wait for machine to be created
   oc_obj:
     state: list
-    kind: machines
+    kind: machines.machine.openshift.io
     namespace: openshift-cluster-api
     selector: "sigs.k8s.io/cluster-api-machineset={{ machineset_name.result }}-centos"
     kubeconfig: "{{ kubeconfig_path }}"

--- a/test/aws/get_machinesets.yml
+++ b/test/aws/get_machinesets.yml
@@ -1,5 +1,5 @@
 ---
-- name: List existing workers
+- name: List existing worker nodes
   oc_obj:
     kubeconfig: "{{ kubeconfig_path }}"
     state: list
@@ -27,11 +27,19 @@
 - name: get existing worker machinesets
   oc_obj:
     state: list
-    kind: machinesets
+    kind: machinesets.machine.openshift.io
     namespace: openshift-cluster-api
     selector: ""
     kubeconfig: "{{ kubeconfig_path }}"
   register: machineset
+  until:
+  - machineset.results is defined
+  - machineset.results.returncode is defined
+  - machineset.results.results is defined
+  - machineset.results.returncode == 0
+  - machineset.results.results[0]['items'] | length > 0
+  retries: 36
+  delay: 5
 
 - set_fact:
     pre_scaleup_machineset_names: "{{ machineset.results.results[0]['items'] |map(attribute='metadata.name') | list }}"

--- a/test/aws/scaleup.yml
+++ b/test/aws/scaleup.yml
@@ -121,7 +121,7 @@
   - name: remove existing machinesets
     oc_obj:
       state: absent
-      kind: machinesets
+      kind: machinesets.machine.openshift.io
       namespace: openshift-cluster-api
       name: "{{ item }}"
       kubeconfig: "{{ kubeconfig_path }}"


### PR DESCRIPTION
Workers are being added later on during install, but MachineSet objects might not be created. This PR would ensure both workers and machinesets were created before doing the scaleup.

This also uses `machinesets.machine.openshift.io` instead of `machinesets` as it may return empty resultset currently

Fixes https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_openshift-ansible/11121/pull-ci-openshift-openshift-ansible-devel-40-e2e-aws-scaleup/109/build-log.txt: task fails as no new machinesets were created