### PR TITLE
Protect from dangerous etcd_image changes

### DIFF
--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -12,7 +12,8 @@ r_etcd_default_version: "3.2.22"
 # This filter attempts to combine oreg_url host with project/component from etcd_image_dict.
 # "oreg.example.com/openshift3/ose-${component}:${version}"
 # becomes "oreg.example.com/rhel7/etcd:{{ r_etcd_upgrade_version | default(r_etcd_default_version) }}"
-osm_etcd_image: "{{ etcd_image_dict[openshift_deployment_type] | lib_utils_oo_oreg_image((oreg_url | default('None'))) }}"
+l_default_osm_etcd_image: "{{ etcd_image_dict[openshift_deployment_type] | lib_utils_oo_oreg_image((oreg_url | default('None'))) }}"
+osm_etcd_image: "{{ l_default_osm_etcd_image }}"
 etcd_image_dict:
   origin: "quay.io/coreos/etcd:v{{ r_etcd_upgrade_version | default(r_etcd_default_version) }}"
   openshift-enterprise: "registry.redhat.io/rhel7/etcd:{{ r_etcd_upgrade_version | default(r_etcd_default_version) }}"

--- a/roles/etcd/tasks/static.yml
+++ b/roles/etcd/tasks/static.yml
@@ -2,6 +2,18 @@
 # Set some facts to reference from hostvars
 - import_tasks: set_facts.yml
 
+- name: Warn if osm_etcd_image is redefined
+  debug:
+    msg: "WARNING Overriding `osm_etcd_image` is not recommended. It may result in running an incorrect etcd version for this version of OpenShift. Please use `oreg_url` if you need to pull etcd from another location"
+  when:
+  - etcd_image != l_default_osm_etcd_image
+
+- name: Ensure etcd version has a version tag
+  fail:
+    msg: "etcd image '{{ etcd_image }}' doesn't contain explicit tag, so it will pull latest etcd image. It may not be compatible with this version of OpenShift. Please use `oreg_url` if you need to pull etcd from another location"
+  when:
+  - etcd_image.split(":") | length < 2
+
 - name: Pre-pull etcd image
   command: "{{ openshift_container_cli }} pull {{ etcd_image }}"
   environment:


### PR DESCRIPTION
If `osm_etcd_image` is overridden or resulting `etcd_image`  doesn't contain a tag, OpenShift will use `:latest` tag. This might break clusters, as latest available version is 3.3 and its not compatible 3.x.

This PR would introduce several changes:
* a warning is issued if either `etcd_image` or `osm_etcd_image` have been reset - `oreg_url` should be used instead
  `l_osm_etcd_image` would contain the expected etcd image
* playbook would stop if resulting `etcd_image` doesn't contain a tag explicitely - as Docker would automatically substitute it with `:latest`.

Marking it as WIP as it has not yet been tested

/cc @smarterclayton 