### PR TITLE
Ignore errors on node/pod image pre-pull

### DIFF
--- a/roles/contiv/tasks/aci.yml
+++ b/roles/contiv/tasks/aci.yml
@@ -1,11 +1,6 @@
 ---
-- name: ACI | Check aci-gw container image
-  command: "{{ openshift_container_cli }} images -q contiv/aci-gw"
-  register: docker_aci_image
-
 - name: ACI | Pull aci-gw container
   command: "{{ openshift_container_cli }} pull contiv/aci-gw"
-  when: docker_aci_image.stdout_lines == []
 
 - name: ACI | Copy shell script used by aci-gw service
   template:

--- a/roles/etcd/tasks/static.yml
+++ b/roles/etcd/tasks/static.yml
@@ -2,15 +2,10 @@
 # Set some facts to reference from hostvars
 - import_tasks: set_facts.yml
 
-- name: Check that etcd image is present
-  command: "{{ openshift_container_cli }} images -q {{ etcd_image }}"
-  register: etcd_image_exists
-
 - name: Pre-pull etcd image
   command: "{{ openshift_container_cli }} pull {{ etcd_image }}"
   environment:
     NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
-  when: etcd_image_exists.stdout_lines == []
   # 10 minutes to pull the image
   async: 600
   poll: 0

--- a/roles/openshift_control_plane/tasks/pre_pull.yml
+++ b/roles/openshift_control_plane/tasks/pre_pull.yml
@@ -1,14 +1,9 @@
 ---
-- name: Check that origin image is present
-  command: "{{ openshift_container_cli }} images -q {{ osm_image }}"
-  register: control_plane_image
-
 # This task runs async to save time while the master is being configured
 - name: Pre-pull Origin image (docker)
   command: "{{ openshift_container_cli }} pull {{ osm_image }}"
   environment:
     NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
-  when: control_plane_image.stdout_lines == []
   # 10 minutes to pull the image
   async: 600
   poll: 0

--- a/roles/openshift_control_plane/tasks/pre_pull_poll.yml
+++ b/roles/openshift_control_plane/tasks/pre_pull_poll.yml
@@ -4,7 +4,6 @@
     jid: "{{ image_prepull.ansible_job_id }}"
   register: job_result
   until: job_result.finished
-  when: control_plane_image.stdout_lines == []
   retries: 20
   delay: 30
   failed_when: false
@@ -14,10 +13,6 @@
     jid: "{{ etcd_prepull.ansible_job_id }}"
   register: job_result
   until: job_result.finished
-  when:
-  - etcd_image_exists is defined
-  - "'stdout_lines' in etcd_image_exists"
-  - etcd_image_exists.stdout_lines == []
   retries: 20
   delay: 30
   failed_when: false

--- a/roles/openshift_node/tasks/prepull.yml
+++ b/roles/openshift_node/tasks/prepull.yml
@@ -1,27 +1,17 @@
 ---
-- name: Check that node image is present
-  command: "{{ openshift_container_cli }} images -q {{ osn_image }}"
-  register: node_image
-
 # This task runs async to save time while the node is being configured
 - name: Pre-pull node image
   command: "{{ openshift_container_cli }} pull {{ osn_image }}"
-  when: node_image.stdout_lines == []
   # 10 minutes to pull the image
   async: 600
   poll: 0
   register: image_prepull
-
-- name: Check that pod image is present
-  command: "{{ openshift_container_cli }} images -q {{ osn_pod_image }}"
-  register: pod_image
 
 # This task runs async to save time while other downloads proceed
 - name: pre-pull pod image
   command: "{{ openshift_container_cli }} pull {{ osn_pod_image }}"
   environment:
     NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
-  when: pod_image.stdout_lines == []
   # 10 minutes to pull the image
   async: 600
   poll: 0

--- a/roles/openshift_node/tasks/prepull.yml
+++ b/roles/openshift_node/tasks/prepull.yml
@@ -6,6 +6,9 @@
   async: 600
   poll: 0
   register: image_prepull
+  # Pre-pull is not critical to upgrade.  When upgrading from 3.9, crictl may
+  # not be installed yet or may not match the installed crio version.
+  ignore_errors: true
 
 # This task runs async to save time while other downloads proceed
 - name: pre-pull pod image
@@ -16,3 +19,6 @@
   async: 600
   poll: 0
   register: pod_image_prepull
+  # Pre-pull is not critical to upgrade.  When upgrading from 3.9, crictl may
+  # not be installed yet or may not match the installed crio version.
+  ignore_errors: true

--- a/roles/openshift_node/tasks/prepull.yml
+++ b/roles/openshift_node/tasks/prepull.yml
@@ -5,10 +5,7 @@
 
 # This task runs async to save time while the node is being configured
 - name: Pre-pull node image
-  docker_image:
-    name: "{{ osn_image }}"
-  environment:
-    NO_PROXY: "{{ openshift.common.no_proxy | default('') }}"
+  command: "{{ openshift_container_cli }} pull {{ osn_image }}"
   when: node_image.stdout_lines == []
   # 10 minutes to pull the image
   async: 600

--- a/roles/openshift_node/tasks/prepull_check.yml
+++ b/roles/openshift_node/tasks/prepull_check.yml
@@ -5,7 +5,6 @@
   register: job_result
   until: job_result.finished
   when:
-  - node_image.stdout_lines == []
   - not openshift_is_atomic | bool
   retries: 20
   delay: 30
@@ -16,7 +15,6 @@
     jid: "{{ pod_image_prepull.ansible_job_id }}"
   register: job_result
   until: job_result.finished
-  when: pod_image.stdout_lines == []
   retries: 20
   delay: 30
   failed_when: false


### PR DESCRIPTION
The image pre-pull is not critical to the upgrade path.  When upgrading from 3.9, crictl may not be installed yet or may not match the installed crio version.

