### PR TITLE
ovs process gets killed when oom-killer is invoked

### DIFF
--- a/roles/openshift_sdn/files/sdn-ovs.yaml
+++ b/roles/openshift_sdn/files/sdn-ovs.yaml
@@ -94,11 +94,15 @@ spec:
           name: log-openvswitch
         resources:
           requests:
-            cpu: 100m
-            memory: 300Mi
-          limits:
             cpu: 200m
             memory: 400Mi
+        livenessProbe:
+          exec:
+            command:
+            - /usr/share/openvswitch/scripts/ovs-ctl
+            - status
+          initialDelaySeconds: 15
+          periodSeconds: 5
 
       volumes:
       - name: host-modules


### PR DESCRIPTION
Added liveness probe
removed limits:
increase requests:

git cherry-pick PR 11116 c632bfe5bab7d301332e6a143eb2a7d398a3ba6e
Increased requests:
            cpu: 200m
            memory: 400Mi

bug 1669311
https://bugzilla.redhat.com/show_bug.cgi?id=1669311

Signed-off-by: Phil Cameron <pcameron@redhat.com>

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
