### PR TITLE
Ensure async etcd-image-pull job exists before checking status.

### DIFF
--- a/roles/openshift_control_plane/tasks/pre_pull_poll.yml
+++ b/roles/openshift_control_plane/tasks/pre_pull_poll.yml
@@ -16,3 +16,4 @@
   retries: 20
   delay: 30
   failed_when: false
+  when: etcd_prepull is defined


### PR DESCRIPTION
Fixes bug in #11108 

In a standalone etcd cluster, an upgrade would skip the openshift-etcd static pod task where the etcd image is pulled, so the status check task in the control plane is tripping on the undefined variable. We should only run the async status check if that `etcd_prepull` is defined, which indicates the async job has been run.