### PR TITLE
Copy multipath.conf file only if target does not exists.

### DIFF
--- a/roles/openshift_node/tasks/storage_plugins/iscsi.yml
+++ b/roles/openshift_node/tasks/storage_plugins/iscsi.yml
@@ -22,7 +22,7 @@
     - rpcbind
     - iscsid
 
-# Copy conf file only if not exists
+# Copy the conf file only if not exists
 - name: Template multipath configuration
   template:
     dest: "/etc/multipath.conf"
@@ -30,6 +30,32 @@
     backup: true
     force: no
   when: not openshift_is_atomic | bool
+
+# If the conf file already exists, update it
+- name: "Add LIO-ORG in MultiPath configuration"
+  blockinfile:
+    path: /etc/multipath.conf
+    marker: "# <!-- {mark} ANSIBLE MANAGED BLOCK -->"
+    block: |
+      devices {
+          device {
+                    vendor "LIO-ORG"
+                    user_friendly_names "yes"
+                    path_grouping_policy "failover"
+                    path_selector "round-robin 0"
+                    failback immediate
+                    path_checker "tur"
+                    prio "alua"
+                    hardware_handler "1 alua"
+                    no_path_retry 120
+                    rr_weight "uniform"
+          }
+      }
+    owner: root
+    group: root
+    mode: 0600
+    backup: yes
+    state: present
 
 #enable multipath
 - name: Enable and start multipath

--- a/roles/openshift_node/tasks/storage_plugins/iscsi.yml
+++ b/roles/openshift_node/tasks/storage_plugins/iscsi.yml
@@ -35,7 +35,7 @@
 - name: "Add LIO-ORG in MultiPath configuration"
   blockinfile:
     path: /etc/multipath.conf
-    marker: "# <!-- {mark} ANSIBLE MANAGED BLOCK -->"
+    marker: "# <!-- {mark} ANSIBLE MANAGED BLOCK - LIO iSCSI device -->"
     block: |
       devices {
           device {

--- a/roles/openshift_node/tasks/storage_plugins/iscsi.yml
+++ b/roles/openshift_node/tasks/storage_plugins/iscsi.yml
@@ -24,14 +24,12 @@
 
 # Copy conf file only if not exists
 - name: Template multipath configuration
-  stat:
-    path: "/etc/multipath.conf"
-  register: st
   template:
     dest: "/etc/multipath.conf"
     src: multipath.conf.j2
     backup: true
-  when: not st.stat.exists and (not openshift_is_atomic | bool)
+    force: no
+  when: not openshift_is_atomic | bool
 
 #enable multipath
 - name: Enable and start multipath

--- a/roles/openshift_node/tasks/storage_plugins/iscsi.yml
+++ b/roles/openshift_node/tasks/storage_plugins/iscsi.yml
@@ -50,7 +50,7 @@
     mode: 0600
     backup: yes
     state: present
-    when: devices_multipath.rc == 1
+  when: devices_multipath.rc == 1
 
 # Update LIO section under devices section
 - name: "Add LIO-ORG in MultiPath configuration"

--- a/roles/openshift_node/tasks/storage_plugins/iscsi.yml
+++ b/roles/openshift_node/tasks/storage_plugins/iscsi.yml
@@ -40,6 +40,7 @@
       devices {
           device {
                     vendor "LIO-ORG"
+                    product "TCMU device"
                     user_friendly_names "yes"
                     path_grouping_policy "failover"
                     path_selector "round-robin 0"

--- a/roles/openshift_node/tasks/storage_plugins/iscsi.yml
+++ b/roles/openshift_node/tasks/storage_plugins/iscsi.yml
@@ -31,13 +31,34 @@
     force: no
   when: not openshift_is_atomic | bool
 
-# If the conf file already exists, update it
+# check whether devices section is present
+- name: Check devices section present
+  command: grep -e "^devices {" /etc/multipath.conf
+  register: devices_multipath
+  failed_when: false
+
+# Add empty devices section if not present
+- name: "Add devices section"
+  blockinfile:
+    path: /etc/multipath.conf
+    marker: "# <!-- {mark} ANSIBLE MANAGED BLOCK -->"
+    block: |
+      devices {
+      }
+    owner: root
+    group: root
+    mode: 0600
+    backup: yes
+    state: present
+    when: devices_multipath.rc == 1
+
+# Update LIO section under devices section
 - name: "Add LIO-ORG in MultiPath configuration"
   blockinfile:
     path: /etc/multipath.conf
+    insertafter: "devices {"
     marker: "# <!-- {mark} ANSIBLE MANAGED BLOCK - LIO iSCSI device -->"
     block: |
-      devices {
           device {
                     vendor "LIO-ORG"
                     product "TCMU device"
@@ -51,7 +72,6 @@
                     no_path_retry 120
                     rr_weight "uniform"
           }
-      }
     owner: root
     group: root
     mode: 0600

--- a/roles/openshift_node/tasks/storage_plugins/iscsi.yml
+++ b/roles/openshift_node/tasks/storage_plugins/iscsi.yml
@@ -22,12 +22,16 @@
     - rpcbind
     - iscsid
 
+# Copy conf file only if not exists
 - name: Template multipath configuration
+  stat:
+    path: "/etc/multipath.conf"
+  register: st
   template:
     dest: "/etc/multipath.conf"
     src: multipath.conf.j2
     backup: true
-  when: not openshift_is_atomic | bool
+  when: not st.stat.exists and (not openshift_is_atomic | bool)
 
 #enable multipath
 - name: Enable and start multipath

--- a/roles/openshift_node/templates/multipath.conf.j2
+++ b/roles/openshift_node/templates/multipath.conf.j2
@@ -1,20 +1,5 @@
 # LIO iSCSI
 # TODO: Add env variables for tweaking
-devices {
-        device {
-                vendor "LIO-ORG"
-                product "TCMU device"
-                user_friendly_names "yes" 
-                path_grouping_policy "failover"
-                path_selector "round-robin 0"
-                failback immediate
-                path_checker "tur"
-                prio "alua"
-                hardware_handler "1 alua"
-                no_path_retry 120
-                rr_weight "uniform"
-        }
-}
 defaults {
 	user_friendly_names yes
 	find_multipaths yes

--- a/roles/openshift_node/templates/multipath.conf.j2
+++ b/roles/openshift_node/templates/multipath.conf.j2
@@ -3,6 +3,7 @@
 devices {
         device {
                 vendor "LIO-ORG"
+                product "TCMU device"
                 user_friendly_names "yes" 
                 path_grouping_policy "failover"
                 path_selector "round-robin 0"

--- a/roles/openshift_node/templates/multipath.conf.j2
+++ b/roles/openshift_node/templates/multipath.conf.j2
@@ -1,5 +1,3 @@
-# LIO iSCSI
-# TODO: Add env variables for tweaking
 defaults {
 	user_friendly_names yes
 	find_multipaths yes


### PR DESCRIPTION
This is to avoid any overwriting of existing configuration.

If already present, append new device section(for LIO-ORG).

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>