### PR TITLE
set permissions on vsphere.conf file

### DIFF
--- a/roles/openshift_cloud_provider/tasks/vsphere.yml
+++ b/roles/openshift_cloud_provider/tasks/vsphere.yml
@@ -3,6 +3,9 @@
   template:
     dest: "{{ openshift.common.config_base }}/cloudprovider/vsphere.conf"
     src: vsphere.conf.j2
+    owner: root
+    group: root
+    mode: 0660
   when:
   - openshift_cloudprovider_vsphere_username is defined
   - openshift_cloudprovider_vsphere_password is defined


### PR DESCRIPTION
The vsphere.conf template task does not set owner, group, or mode. This will leave the file with world-readable permissions if root's umask is unchanged (0022). This is a security risk as vsphere.conf contains a vcenter user and password that can manipulate vcenter configuration.

This patch explicitly sets owner, group, and mode on the file, such that world-readable is not granted.
