### PR TITLE
[release-3.11] Make same timezone with running hosts

### DIFF
--- a/roles/etcd/files/etcd.yaml
+++ b/roles/etcd/files/etcd.yaml
@@ -31,6 +31,8 @@ spec:
        readOnly: true
      - mountPath: /var/lib/etcd/
        name: master-data
+     - mountPath: /etc/localtime
+       name: host-localtime
     livenessProbe:
       exec:
       initialDelaySeconds: 45
@@ -41,3 +43,6 @@ spec:
   - name: master-data
     hostPath:
       path: /var/lib/etcd
+  - name: host-localtime
+    hostPath:
+      path: /etc/localtime

--- a/roles/openshift_control_plane/files/apiserver.yaml
+++ b/roles/openshift_control_plane/files/apiserver.yaml
@@ -36,6 +36,8 @@ spec:
        name: master-data
      - mountPath: /etc/pki
        name: master-pki
+     - mountPath: /etc/localtime
+       name: host-localtime
     livenessProbe:
       httpGet:
         scheme: HTTPS
@@ -63,3 +65,6 @@ spec:
   - name: master-pki
     hostPath:
       path: /etc/pki
+  - name: host-localtime
+    hostPath:
+      path: /etc/localtime

--- a/roles/openshift_control_plane/files/controller.yaml
+++ b/roles/openshift_control_plane/files/controller.yaml
@@ -39,6 +39,8 @@ spec:
        mountPropagation: "HostToContainer"
      - mountPath: /etc/pki
        name: master-pki
+     - mountPath: /etc/localtime
+       name: host-localtime
     livenessProbe:
       httpGet:
         scheme: HTTPS
@@ -62,3 +64,6 @@ spec:
   - name: master-pki
     hostPath:
       path: /etc/pki
+  - name: host-localtime
+    hostPath:
+      path: /etc/localtime


### PR DESCRIPTION
- Fix: [Master pods are not matched the timezone with worker nodes and its running host](https://bugzilla.redhat.com/show_bug.cgi?id=1674170)

- Version: `v3.11`

- Description: 
  Master `static pods` are always running with `UTC` `timezone`, it would be not same `timezone` with `worker nodes`. It causes potential issues of time dependent works, such as not matching log timestamp, `Service Serving certs` evaluation timing, `CronJob` triggering time and so on.
 