### PR TITLE
Fix gluster deploy checks

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
@@ -41,7 +41,7 @@
   vars:
     is_enterprise: "{{ openshift_deployment_type == 'openshift-enterprise' }}"
     version: "{{ (openshift_storage_glusterfs_image | regex_replace('^.*:(v?)(?P<version>.+$)', '\\g<version>')) }}"
-    is_legacy_ocs_version: "{{ version is version_compare('3.11.1', '<') }}"
+    is_legacy_ocs_version: "{{ version != 'latest' and version is version_compare('3.11.1', '<') }}"
     gluster_use_legacy_ocs: "{{ is_enterprise and is_legacy_ocs_version }}"
     host_dev_dir: "{{ '/dev' if gluster_use_legacy_ocs else '/mnt/host-dev' }}"
   when: (glusterfs_ds.results.results[0].status is not defined) or


### PR DESCRIPTION
By default, the version of the gluster image is `latest`, meaning
the use of the version_compare filter fails and causes a template error
which ends the playbook run. This simply adds one more check for the
string value.
