### PR TITLE
Add init facts step for html_and_json_timestamp.yaml

### DIFF
--- a/playbooks/openshift-checks/certificate_expiry/html_and_json_timestamp.yaml
+++ b/playbooks/openshift-checks/certificate_expiry/html_and_json_timestamp.yaml
@@ -1,6 +1,12 @@
 ---
 # Generate timestamped HTML and JSON reports in /var/lib/certcheck
 
+- name: Initialize facts
+  import_playbook: ../../init/main.yml
+  vars:
+    l_init_fact_hosts: nodes:masters:etcd
+    l_openshift_version_set_hosts: nodes:masters:etcd
+
 - name: Check cert expirys
   hosts: nodes:masters:etcd
   vars:


### PR DESCRIPTION
A supplement for https://github.com/openshift/openshift-ansible/pull/11033

Or else html_and_json_timestamp.yaml playbook would fail with the same error.

ansible-playbook openshift-ansible/playbooks/openshift-checks/certificate_expiry/html_and_json_timestamp.yaml

TASK [openshift_certificate_expiry : Ensure python dateutil library is present] *********************************************************************************************
fatal: [x.x.x.com]: FAILED! => {"msg": "The conditional check 'not openshift_is_atomic | bool' failed. The error was: error while evaluating conditional (not openshift_is_atomic | bool): 'openshift_is_atomic' is undefined\n\nThe error appears to have been in '/root/openshift-ansible/roles/openshift_certificate_expiry/tasks/main.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Ensure python dateutil library is present\n  ^ here\n"}
