### PR TITLE
Ignore paths in `etcd-servers-overrides`

### DIFF
--- a/roles/lib_utils/action_plugins/master_check_paths_in_config.py
+++ b/roles/lib_utils/action_plugins/master_check_paths_in_config.py
@@ -24,6 +24,7 @@ for you: {}"""
 ITEMS_TO_POP = (
     ('auditConfig', 'policyConfiguration'),
     ('oauthConfig', 'identityProviders'),
+    ('kubernetesMasterConfig', 'apiServerArguments', 'etcd-servers-overrides')
 )
 # Create csv string of dot-separated dictionary keys:
 # eg: 'oathConfig.identityProviders, something.else.here'

--- a/roles/lib_utils/test/test_master_check_paths_in_config.py
+++ b/roles/lib_utils/test/test_master_check_paths_in_config.py
@@ -33,7 +33,15 @@ def loaded_config():
                     {"fake_item3":
                         ["some string 2",
                             {"fake_item4":
-                                {"some_key": "deeply_nested_string"}}]}]}}
+                                {"some_key": "deeply_nested_string"}}]}]}},
+        'kubernetesMasterConfig': {
+            'apiServerArguments': {
+                'etcd-servers-overrides': [
+                    '/events.k8s.io#https://master-0.example.com:3379',
+                    '/foo#bar'
+                ]
+            }
+        }
     }
     return data
 


### PR DESCRIPTION
`kubernetesMasterConfig.apiServerArguments.etcd-servers-overrides` may contain fake paths like `/events.k8s.io` (see https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) so it needs to be filtered from the path check.

To reproduce: set
```
osm_api_server_args:
  etcd-servers-overrides:
  - '/events.k8s.io#http://https://master-0.example.com:3379'
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1666491