### PR TITLE
 [release-3.10] Set credentials and proper hostname when updating loopback kubeconfig

### DIFF
--- a/roles/openshift_control_plane/tasks/set_loopback_context.yml
+++ b/roles/openshift_control_plane/tasks/set_loopback_context.yml
@@ -17,6 +17,17 @@
   register: set_loopback_cluster
 
 - command: >
+    {{ openshift_client_binary }} config set-credentials
+    --client-certificate=/etc/origin/master/openshift-master.crt
+    --client-key=/etc/origin/master/openshift-master.key
+    --embed-certs=true
+    {{ openshift.master.loopback_user }}
+    --config={{ openshift_master_loopback_config }}
+  when:
+  - set_loopback_cluster is changed
+  register: l_set_loopback_credentials
+
+- command: >
     {{ openshift_client_binary }} config set-context
     --cluster={{ openshift.master.loopback_cluster_name }}
     --namespace=default --user={{ openshift.master.loopback_user }}

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -394,7 +394,7 @@ def set_url_facts_if_unset(facts):
                                                                    ports[prefix]))
 
         r_lhn = "{0}:{1}".format(hostname, ports['api']).replace('.', '-')
-        r_lhu = "system:openshift-master/{0}:{1}".format(api_hostname, ports['api']).replace('.', '-')
+        r_lhu = "system:openshift-master/{0}:{1}".format(hostname, ports['api']).replace('.', '-')
         facts['master'].setdefault('loopback_cluster_name', r_lhn)
         facts['master'].setdefault('loopback_context_name', "default/{0}/system:openshift-master".format(r_lhn))
         facts['master'].setdefault('loopback_user', r_lhu)


### PR DESCRIPTION
Make sure that the user we expect has proper credentials set.

When a cluster is installed the username in the loopback kubeconfig
is equal to hostname of that local master. This changes the variable
to equal a value of what would originally be set.

Backports #11169
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1675133