### PR TITLE
[release-3.11] openshift_node: use init_file to replace journald.conf settings

### DIFF
--- a/roles/openshift_node/tasks/journald.yml
+++ b/roles/openshift_node/tasks/journald.yml
@@ -13,14 +13,23 @@
     state: directory
 
 - name: Update journald setup
-  replace:
-    dest: /etc/systemd/journald.conf
-    regexp: '^(\#| )?{{ item.var }}=\s*.*?$'
-    replace: ' {{ item.var }}={{ item.val }}'
+  ini_file:
+    path: /etc/systemd/journald.conf
+    section: 'Journal'
+    option: "{{ item.var }}"
+    value: "{{ item.val }}"
+    no_extra_spaces: yes
     backup: yes
   with_items: "{{ journald_vars_to_replace | default([]) }}"
   when: journald_conf_file.stat.exists
   register: journald_update
+
+- name: Tag journald managed by Ansible
+  lineinfile:
+    path: /etc/systemd/journald.conf
+    line: '# Managed by OpenShift Ansible'
+    insertbefore: BOF
+  when: journald_update is changed
 
 # I need to restart journald immediatelly, otherwise it gets into way during
 # further steps in ansible


### PR DESCRIPTION
Prior to this change, modifications to journald.conf settings were inconsistent. The values would only be modified if the keys already existed in the targeted journald.conf file. Furthermore, several of the key/value pairs were not being set at all even though they were in the list of changes to be applied.

This change switches to using init_file module to make the desired changes more consistent. It also places a comment at the top of journald.conf stating it was modified by Openshift Ansible.