### PR TITLE
[release-3.9] Allow to configure BlockStorage.ignore-volume-az for Openstack Cloud Provider

### DIFF
--- a/roles/openshift_cloud_provider/defaults/main.yml
+++ b/roles/openshift_cloud_provider/defaults/main.yml
@@ -3,3 +3,4 @@ openshift_gcp_project: ''
 openshift_gcp_prefix: ''
 openshift_gcp_network_name: "{{ openshift_gcp_prefix }}network"
 openshift_gcp_multizone: False
+openshift_cloudprovider_openstack_blockstorage_ignore_volume_az: false

--- a/roles/openshift_cloud_provider/templates/openstack.conf.j2
+++ b/roles/openshift_cloud_provider/templates/openstack.conf.j2
@@ -19,7 +19,8 @@ region = {{ openshift_cloudprovider_openstack_region }}
 [LoadBalancer]
 subnet-id = {{ openshift_cloudprovider_openstack_lb_subnet_id }}
 {% endif %}
-{% if openshift_cloudprovider_openstack_blockstorage_version is defined %}
 [BlockStorage]
+ignore-volume-az = {{ openshift_cloudprovider_openstack_blockstorage_ignore_volume_az | bool | ternary('yes', 'no') }}
+{% if openshift_cloudprovider_openstack_blockstorage_version is defined %}
 bs-version={{ openshift_cloudprovider_openstack_blockstorage_version }}
 {% endif %}


### PR DESCRIPTION
Allows to disable the Cinder volume labels as described in: https://docs.okd.io/latest/install_config/configuring_openstack.html#openstack-configuring-zone-labels directly with the Ansible playbook.

The default option is the same as it was before.