### PR TITLE
[release-3.11] Add kuryr support for network policies

### DIFF
--- a/playbooks/openstack/README.md
+++ b/playbooks/openstack/README.md
@@ -71,8 +71,10 @@ The OpenStack environment must satisfy these requirements:
 * The keypair for SSH must be available in OpenStack
 * You must have a`keystonerc` file that lets you talk to the OpenStack services
 * In order to install an OpenShift cluster and deploy services, we recommend
-that you have a minimum of 30 security groups, 200 security group rules, and 200
-ports available in your quota.
+that you have a minimum of 30 security groups, 200 security group rules, and
+200 ports available in your quota. If kuryr is enabled, and specially if
+network policies are used, we recommend to further increase those quotas to
+at least 100 security groups, 500 security group rules, and 500 ports.
 
 It is also strongly recommended that you configure an external Neutron network
 with a floating IP address pool.

--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -762,6 +762,23 @@ openshift_kuryr_sg_driver: namespace
 ```
 
 
+### Network Policies
+
+By default, kuryr is configured with the default isolation policy where pods
+isolation is statically defined. Kuryr also permits to enable more advanced
+and dynamic isolation policies by implementing network policies through
+security groups. To enable it you need to uncomment the following on the
+all.yml inventory file:
+
+```yaml
+openshift_kuryr_subnet_driver: namespace
+openshift_kuryr_sg_driver: policy
+```
+
+Note enabling the namespace subnet driver is required to enabled network
+policy isolation
+
+
 ### Kuryr Controller and CNI healthchecks probes
 
 By default kuryr controller and cni pods are deployed with readiness and
@@ -1118,7 +1135,7 @@ Modify the all.yml file and add the following variables:
 ```
 openshift_openstack_master_group_name: node-config-master-crio
 openshift_openstack_infra_group_name: node-config-infra-crio
-openshift_openstack_compute_group_name: node-config-compute-crio  
+openshift_openstack_compute_group_name: node-config-compute-crio
 ```
 
 NOTE: Currently, OpenShift builds require docker.
@@ -1153,6 +1170,8 @@ openshift_use_crio: true
 
 ```
 openshift_openstack_master_group_name: node-config-master-crio
+openshift_openstack_infra_group_name: node-config-infra-crio
+openshift_openstack_compute_group_name: node-config-compute-crio
 ```
 
 ### Some nodes using cri-o, some others docker
@@ -1228,7 +1247,7 @@ After a successful installation, the containerRuntimeVersion field says the CR
 it uses:
 
 ```
-$ oc get nodes -o=custom-columns=NAME:.metadata.name,CR:.status.nodeInfo.containerRuntimeVersion --selector='node-role.kubernetes.io/compute=true'                                                                   
+$ oc get nodes -o=custom-columns=NAME:.metadata.name,CR:.status.nodeInfo.containerRuntimeVersion --selector='node-role.kubernetes.io/compute=true'
 NAME                                  CR
 app-node-0.shiftstack.automated.lan   cri-o://1.11.5
 app-node-1.shiftstack.automated.lan   docker://1.13.1

--- a/playbooks/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/openstack/sample-inventory/group_vars/all.yml
@@ -52,9 +52,15 @@ openshift_openstack_external_network_name: "public"
 # information
 # kuryr_openstack_public_subnet_id: uuid_of_my_fip_subnet
 
-# # Kuryr can use a different subnet per namespace
+# # Kuryr can use a different subnet per namespace by enabling:
 # openshift_kuryr_subnet_driver: namespace
-# openshift_kuryr_sg_driver: namespace
+
+# # Kuryr can use different security group driver to provide different
+# isolation policies. The two options available are namespace isolation and
+# network policies. and both of them require the subnet per namespace driver
+# to be enabled. To enable one or the other use the next, by setting it to
+# 'namespace' or 'policy'
+# openshift_kuryr_sg_driver: policy
 
 # If you VM images will name the ethernet device different than 'eth0',
 # override this

--- a/roles/kuryr/tasks/master.yaml
+++ b/roles/kuryr/tasks/master.yaml
@@ -49,6 +49,13 @@
     dest: "{{ manifests_tmpdir.stdout }}/kuryrnet.yaml"
   when: openshift_kuryr_subnet_driver|default("default") == 'namespace'
 
+- name: Create kuryrnetpolicy CRD manifest
+  become: yes
+  template:
+    src: kuryrnetpolicy.yaml.j2
+    dest: "{{ manifests_tmpdir.stdout }}/kuryrnetpolicy.yaml"
+  when: openshift_kuryr_sg_driver|default("default") == 'policy'
+
 - name: Apply OpenShift node's ImageStreamTag manifest
   oc_obj:
     state: present
@@ -109,3 +116,13 @@
     - "{{ manifests_tmpdir.stdout }}/kuryrnet.yaml"
   run_once: true
   when: openshift_kuryr_subnet_driver|default("default") == 'namespace'
+
+- name: Apply kuryrnetpolicy CRD manifest
+  oc_obj:
+    state: present
+    kind: CustomResourceDefinition
+    name: "kuryrnetpolicies"
+    files:
+    - "{{ manifests_tmpdir.stdout }}/kuryrnetpolicy.yaml"
+  run_once: true
+  when: openshift_kuryr_sg_driver|default("default") == 'policy'

--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -236,7 +236,11 @@ data:
     # The comma-separated handlers that should be registered for watching
     # in the pipeline. (list value)
 {% if openshift_kuryr_subnet_driver|default('default') == 'namespace' %}
+{% if openshift_kuryr_sg_driver|default('default') == 'policy' %}
+    enabled_handlers = vif,lb,lbaasspec,namespace,policy,pod_label
+{% else %}
     enabled_handlers = vif,lb,lbaasspec,namespace
+{% endif %}
 {% else %}
     enabled_handlers = vif,lb,lbaasspec
 {% endif %}

--- a/roles/kuryr/templates/kuryrnetpolicy.yaml.j2
+++ b/roles/kuryr/templates/kuryrnetpolicy.yaml.j2
@@ -1,0 +1,16 @@
+# More info about the template: https://docs.openstack.org/kuryr-kubernetes/latest/installation/containerized.html#generating-kuryr-resource-definitions-for-kubernetes
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kuryrnetpolicies.openstack.org
+spec:
+  group: openstack.org
+  version: v1
+  scope: Namespaced
+  names:
+    plural: kuryrnetpolicies
+    singular: kuryrnetpolicy
+    kind: KuryrNetPolicy
+    shortNames:
+      - knp

--- a/roles/openshift_openstack/library/os_netpolicy_sg_deletion.py
+++ b/roles/openshift_openstack/library/os_netpolicy_sg_deletion.py
@@ -19,7 +19,7 @@
 
 # pylint: disable=unused-wildcard-import,wildcard-import,unused-import,redefined-builtin
 
-''' os_namespace_resources_deletion '''
+''' os_netpolicy_sg_deletions '''
 import keystoneauth1
 
 from ansible.module_utils.basic import AnsibleModule
@@ -32,11 +32,10 @@ except ImportError:
 
 DOCUMENTATION = '''
 ---
-module: os_namespace_resources_deletion
-short_description: Delete network resources associated to the namespace
+module: os_netpolicy_sg_deletions
+short_description: Delete security group associated to the network policy
 description:
-    - Detach namespace's subnet from the router and delete the network and the
-      associated security groups
+    - Delete the security group associated to the network policy
 author:
     - "Luis Tomas Bolivar <ltomasbo@redhat.com>"
 '''
@@ -49,10 +48,7 @@ def main():
     ''' Main module function '''
     module = AnsibleModule(
         argument_spec=dict(
-            router_id=dict(default=False, type='str'),
-            subnet_id=dict(default=False, type='str'),
-            net_id=dict(default=False, type='str'),
-            sg_id=dict(default=None, type='str'),
+            sg_id=dict(default=False, type='str'),
         ),
         supports_check_mode=True,
     )
@@ -79,25 +75,12 @@ def main():
                              'API')
 
     try:
-        subnet_info = {"subnet_id": module.params['subnet_id'].encode('ascii')}
-        data = {'data': str(subnet_info).replace('\'', '\"')}
-        adapter.put('/routers/' + module.params['router_id'] + '/remove_router_interface', **data)
-    # pylint: disable=broad-except
-    except Exception:
-        module.fail_json(msg='Failed to detach subnet from the router')
-
-    try:
-        adapter.delete('/networks/' + module.params['net_id'])
-    # pylint: disable=broad-except
-    except Exception:
-        module.fail_json(msg='Failed to delete Neutron Network associated to the namespace')
-
-    try:
         if module.params.get('sg_id'):
             adapter.delete('/security-groups/' + module.params['sg_id'])
     # pylint: disable=broad-except
     except Exception:
-        module.fail_json(msg='Failed to delete Security groups associated to the namespace')
+        module.fail_json(msg='Failed to delete Security group associated to '
+                         'the network policy')
 
     module.exit_json(
         changed=True)

--- a/roles/openshift_openstack/tasks/unprovision.yml
+++ b/roles/openshift_openstack/tasks/unprovision.yml
@@ -19,6 +19,7 @@
     - not (item.metadata.name == "kubernetes")
     - openshift_use_kuryr | default(false) | bool
     - item.metadata.annotations is defined
+  ignore_errors: true
 
 - name: Remove trunk subports
   os_subports_deletion:
@@ -27,29 +28,59 @@
   when:
     - openshift_use_kuryr | default(false) | bool
 
+- name: Get kuryr net policies CRDs
+  delegate_to: "{{ groups.oo_first_master.0 }}"
+  oc_obj:
+    kind: kuryrnetpolicies
+    state: list
+    all_namespaces: true
+  register: knp_output
+  ignore_errors: true
+
+- name: Delete network policy security groups
+  os_netpolicy_sg_deletion:
+    sg_id: "{{ item.spec.securityGroupId }}"
+  with_items: "{{ knp_output.results.results[0]['items'] if 'results' in knp_output else []}}"
+  when:
+    - openshift_use_kuryr|default(false) == true
+    - openshift_kuryr_sg_driver|default("default") == 'policy'
+    - item.metadata.annotations is defined
+
 - name: Get kuryr net CRDs
   delegate_to: "{{ groups.oo_first_master.0 }}"
   oc_obj:
     kind: kuryrnets
     state: list
     all_namespaces: true
-  register: svc_output
+  register: knet_output
   ignore_errors: true
 
 # NOTE(ltomasbo) This only works for nested deployments.
 # Moreover the pods should not have FIPs attached
-- name: Delete namespaced resources
+- name: Delete namespaced resources with project isolation
   os_namespace_resources_deletion:
     router_id: "{{ item.spec.routerId }}"
     subnet_id: "{{ item.spec.subnetId }}"
     net_id: "{{ item.spec.netId }}"
     sg_id: "{{ item.spec.sgId }}"
-  with_items: "{{ svc_output.results.results[0]['items'] if 'results' in svc_output else [] }}"
+  with_items: "{{ knet_output.results.results[0]['items'] if 'results' in knet_output else [] }}"
   when:
     - openshift_use_kuryr|default(false) == true
     - openshift_kuryr_subnet_driver|default("default") == 'namespace'
-    - openshift_kuryr_sg_driver|default("default") == 'namespace'
     - item.metadata.annotations is defined
+    - item.spec.sgId is defined
+  ignore_errors: true
+- name: Delete namespaced resources without project isolation
+  os_namespace_resources_deletion:
+    router_id: "{{ item.spec.routerId }}"
+    subnet_id: "{{ item.spec.subnetId }}"
+    net_id: "{{ item.spec.netId }}"
+  with_items: "{{ knet_output.results.results[0]['items'] if 'results' in knet_output else [] }}"
+  when:
+    - openshift_use_kuryr|default(false) == true
+    - openshift_kuryr_subnet_driver|default("default") == 'namespace'
+    - item.metadata.annotations is defined
+  ignore_errors: true
 
 - name: Delete the Stack
   ignore_errors: False


### PR DESCRIPTION
It adds support to configure kuryr with the network policy handler
and the related drivers to provide fine grain isolation. It also
enables the support to configure network policy together with the
network per namespace feature -- but without enabling the namespace
isolation as the network policies will be the ones defining the
isolation between pods/projects.
