### PR TITLE
[release-3.11] Run firewall task on upgrades

### DIFF
--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -104,4 +104,6 @@
   retries: 30
   until: node_upgrade_oc_csr_approve is succeeded
 
+- import_tasks: firewall.yml
+
 - import_tasks: journald.yml


### PR DESCRIPTION
When upgrading from 3.10 to 3.11, the firewall rules aren't updated which means that Prometheus can't scrape metrics from node_exporter (and possibly the routers too).

BZ reference: https://bugzilla.redhat.com/show_bug.cgi?id=1659441

@vrutkovs @sdodson I did the simplest thing I could think of but feel free to correct me if it isn't the right way.

cc @pgier too.