### PR TITLE
Removing SystemKeepFree to use default value

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -118,7 +118,6 @@ journald_vars_to_replace:
 - { var: RateLimitInterval, val: 1s }
 - { var: RateLimitBurst, val: 10000 }
 - { var: SystemMaxUse, val: 8G }
-- { var: SystemKeepFree, val: 20% }
 - { var: SystemMaxFileSize, val: 10M }
 - { var: MaxRetentionSec, val: 1month }
 - { var: MaxFileSec, val: 1day }


### PR DESCRIPTION
Fix bz#1676565

Previous value:

- { var: SystemKeepFree, val: 20% }

was incorrect, journald doesnt accept percentages as input for config files as specified in https://bugzilla.redhat.com/show_bug.cgi?id=874631

This cause log disk filling up because of wrong default configuration settings in openshift-ansible.

default if not specified is 15% but when specifying a value it must be in absolute units. So I think we should just drop this value as it's not possible to specify a percentage via configuration and it's not possible to come up with a reasonable absolute value otherwise.