### PR TITLE
[release-3.11] Correct regressions of Curator5 template file

### DIFF
--- a/roles/openshift_logging_curator/templates/curator-cj.j2
+++ b/roles/openshift_logging_curator/templates/curator-cj.j2
@@ -83,6 +83,15 @@ spec:
                   name: "CURATOR_DEFAULT_DAYS"
                   value: "{{openshift_logging_curator_default_days}}"
                 -
+                  name: "CURATOR_RUN_HOUR"
+                  value: "{{openshift_logging_curator_run_hour}}"
+                -
+                  name: "CURATOR_RUN_MINUTE"
+                  value: "{{openshift_logging_curator_run_minute}}"
+                -
+                  name: "CURATOR_RUN_TIMEZONE"
+                  value: "{{openshift_logging_curator_run_timezone}}"
+                -
                   name: "CURATOR_SCRIPT_LOG_LEVEL"
                   value: "{{openshift_logging_curator_script_log_level}}"
                 -


### PR DESCRIPTION
- Fix: ["openshift_logging_curator_run_timezone" is not implemented in CronJob template of Curator5 on v3.11](https://bugzilla.redhat.com/show_bug.cgi?id=1677454)

- Version: only `v3.11`

- Description:
  `Curator5` template is missing the following `env` variables which is implemented from `Curator2`.
~~~
            -
              name: "CURATOR_RUN_HOUR"
              value: "{{openshift_logging_curator_run_hour}}"
            -
              name: "CURATOR_RUN_MINUTE"
              value: "{{openshift_logging_curator_run_minute}}"
            -
              name: "CURATOR_RUN_TIMEZONE"
              value: "{{openshift_logging_curator_run_timezone}}"
~~~
* FYI
  I've also verified matching `ansible` variables are implemented and `Curator5` image is also aware of the env variables as follows.

-  `roles/openshift_logging_curator/defaults/main.yml` on `v3.11`
~~~
openshift_logging_curator_default_days: 30
openshift_logging_curator_run_hour: 3
openshift_logging_curator_run_minute: 30
openshift_logging_curator_run_timezone: UTC
openshift_logging_curator_script_log_level: INFO
openshift_logging_curator_log_level: ERROR
openshift_logging_curator_timeout: 300
~~~
- [Origin-Aggregated-Logging repo's codes here](https://github.com/openshift/origin-aggregated-logging/blob/release-3.11/curator/lib/oalconverter/parser.py#L30-L32)
~~~
        self.runhour = int(os.getenv('CURATOR_RUN_HOUR', 0))
        self.runminute = int(os.getenv('CURATOR_RUN_MINUTE', 0))
        self.timezone = str(os.getenv('CURATOR_RUN_TIMEZONE', 'UTC'))
~~~