### PR TITLE
openstack: fix loadbalancer vm heat stack deployment

### DIFF
--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -727,10 +727,12 @@ resources:
 {% if openshift_openstack_provider_network_name %}
           net:         {{ openshift_openstack_provider_network_name }}
           net_name:         {{ openshift_openstack_provider_network_name }}
-{% elif openshift_openstack_node_network_id|default(false) %}
+{% else %}
+{% if openshift_openstack_node_network_id|default(false) %}
           net:         {{ openshift_openstack_node_network_id }}
 {% else %}
           net:         { get_resource: net }
+{% endif %}
 {% if openshift_openstack_node_subnet_name %}
           subnet:      {{ openshift_openstack_node_subnet_name }}
 {% else %}
@@ -745,6 +747,11 @@ resources:
               template: openshift-ansible-cluster_id-net
               params:
                 cluster_id: {{ openshift_openstack_full_dns_domain }}
+{% if openshift_use_flannel|default(False)|bool %}
+          attach_data_net: true
+          data_net:    { get_resource: data_net }
+          data_subnet: { get_resource: data_subnet }
+{% endif %}
 {% endif %}
           secgrp:
             - { get_resource: lb-secgrp }


### PR DESCRIPTION
#### Description

Provisioning Openshift on Openstack fails if loadbalancer VM is used because the heat
stack part for the loadbalancer VM is not generated correctly.

##### Version
OKD: 3.11
openshift-ansible: release-3.11 branch
ansible 2.5.9

##### Steps To Reproduce

1. Set `openshift_openstack_use_vm_load_balancer: true` in vars file.
2. Run playbook `ansible-playbook playbooks/openstack/openshift-cluster/provision.yml`

##### Exception

Playbook execution fails during dry-run.

```bash
TASK [openshift_openstack : Dry-run the stack (create)] *************************************************************************************************************************************************************
Tuesday 05 February 2019  12:21:50 +0100 (0:00:02.563)       0:01:14.756 ******
fatal: [localhost]: FAILED! => {
    "changed": true,
    "cmd": [
        "openstack",
        "stack",
        "create",
        "--dry-run",
        "-t",
        "/var/folders/p3/nbhnkd4d02jfjgfdsw05xhph0000gp/T/openshift-ansiblev8KN_i/stack.yaml",
        "openshift-cluster"
    ],
    "delta": "0:00:03.315222",
    "end": "2019-02-05 12:21:53.713830",
    "rc": 1,
    "start": "2019-02-05 12:21:50.398608"
}

STDERR:

ERROR: resources.loadbalancer<nested_stack>.resources.0<file:///var/folders/p3/nbhnkd4d02jfjgfdsw05xhph0000gp/T/openshift-ansiblev8KN_i/server.yaml>.outputs.private_ip.value.get_attr: : The Referenced Attribute (server addresses) is incorrect.

MSG:

non-zero return code
```
