### PR TITLE
[Release-3.7] Configure API aggregation in serial

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_7/upgrade_control_plane.yml
@@ -131,6 +131,7 @@
 # names are changed
 - name: Configure API aggregation on masters
   hosts: oo_masters_to_config
+  serial: 1
   tasks:
   - include: ../../../openshift-master/tasks/wire_aggregator.yml
 


### PR DESCRIPTION
Previously, the API aggregation changes made during an upgrade were
performed in parallel. This caused unexpected service impact when the
entire control-plane was started at the same time.

This change forces the API aggregation to happen in series of 1. As a
result, clusters with a multiple node controle-plane will not experience
the same service impact.

https://bugzilla.redhat.com/show_bug.cgi?id=1677639