### PR TITLE
Uninstall no longer unmounts openshift.local.volumes

### DIFF
--- a/playbooks/adhoc/uninstall_openshift.yml
+++ b/playbooks/adhoc/uninstall_openshift.yml
@@ -185,7 +185,7 @@
     - openvswitch
     when: openshift_use_openshift_sdn | default(True) | bool
 
-  - shell: find /var/lib/origin/openshift.local.volumes -type d -exec umount {} \; 2>/dev/null || true
+  - shell: find /var/lib/origin/openshift.local.volumes/* -type d -exec umount {} \; 2>/dev/null || true
     changed_when: False
 
   - shell: docker rm -f "{{ item }}"-master "{{ item }}"-node
@@ -268,6 +268,8 @@
     with_subelements:
     - "{{ directories.results | default([]) }}"
     - files
+    # Ignore failure when openshift.local.volumes is mounted.
+    failed_when: false
 
   - shell: systemctl daemon-reload
     changed_when: False


### PR DESCRIPTION
Prior to this change, the uninstall playbook unmounted
/var/lib/origin/openshift.local.volumes. As a result, subsequent
installations would no longer use this mount when configured.

This change ensures this path is no longer unmounted while unmounting
all subdirectories as intended.

https://bugzilla.redhat.com/show_bug.cgi?id=1661916