### PR TITLE
Introducing retry in 'load heketi topology'

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/heketi_load.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_load.yml
@@ -15,4 +15,6 @@
 - name: Load heketi topology
   command: "{{ glusterfs_heketi_client }} topology load --json={{ mktemp.stdout }}/topology.json 2>&1"
   register: topology_load
-  failed_when: "topology_load.rc != 0 or 'Unable' in topology_load.stdout"
+  until: "'Unable' not in topology_load.stdout and topology_load.rc == 0"
+  retries: 4
+  delay: 6


### PR DESCRIPTION
Since gluster deployment is happening async, one could run into a situation where gluster/heketi ist not ready to accept the topology. As a result the playbook run fails with the following error message:

```
2018-12-25 16:17:08,140 p=*** u=*** |  TASK [openshift_storage_glusterfs : Generate topology file] ******************************************************************
2018-12-25 16:17:09,675 p=*** u=*** |  changed: [master.okd.local.tld]
2018-12-25 16:17:09,701 p=*** u=*** |  TASK [openshift_storage_glusterfs : Place heketi topology on heketi Pod] *****************************************************
2018-12-25 16:17:10,595 p=*** u=*** |  changed: [master.okd.local.tld]
2018-12-25 16:17:10,621 p=*** u=*** |  TASK [openshift_storage_glusterfs : Load heketi topology] ********************************************************************
2018-12-25 16:17:16,929 p=*** u=*** |  fatal: [master.okd.local.tld]: FAILED! => {"changed": true, "cmd": ["oc", "--config=/tmp/openshift-glusterfs-ansible-izlzGn/admin.kubeconfig", "rsh", "--namespace=glusterfs", "deploy-heketi-storage-1-zkfsw", "heketi-cli", "-s", "http://localhost:8080", "--user", "admin", "--secret", "eEdg61Rt4NEeimSkka+/LsZZwBgQkSNK7lAXWmiKhIQ=", "topology", "load", "--json=/tmp/openshift-glusterfs-ansible-izlzGn/topology.json", "2>&1"], "delta": "0:00:05.638639", "end": "2018-12-25 15:17:04.467134", "failed_when_result": true, "rc": 0, "start": "2018-12-25 15:16:58.828495", "stderr": "", "stderr_lines": [], "stdout": "Creating cluster ... ID: 9f1a2bb182314f4d0e8be343d875509a\r\n\tAllowing file volumes on cluster.\r\n\tAllowing block volumes on cluster.\r\n\tCreating node node1.okd.local.tld ... ID: 8feafb5c2630ebe4bc9060b563fd35b3\r\n\t\tAdding device /dev/sdb ... OK\r\n\t\tAdding device /dev/sdc ... OK\r\n\tCreating node node2.okd.local.tld ... ID: d1ea99c72a33f335d5e38cd76845086b\r\n\t\tAdding device /dev/sdb ... OK\r\n\t\tAdding device /dev/sdc ... OK\r\n\tCreating node node3.okd.local.tld ... Unable to create node: peer probe: failed: Probe returned with Transport endpoint is not connected", "stdout_lines": ["Creating cluster ... ID: 9f1a2bb182314f4d0e8be343d875509a", "\tAllowing file volumes on cluster.", "\tAllowing block volumes on cluster.", "\tCreating node node1.okd.local.tld ... ID: 8feafb5c2630ebe4bc9060b563fd35b3", "\t\tAdding device /dev/sdb ... OK", "\t\tAdding device /dev/sdc ... OK", "\tCreating node node2.okd.local.tld ... ID: d1ea99c72a33f335d5e38cd76845086b", "\t\tAdding device /dev/sdb ... OK", "\t\tAdding device /dev/sdc ... OK", "\tCreating node node3.okd.local.tld ... Unable to create node: peer probe: failed: Probe returned with Transport endpoint is not connected"]}
2018-12-25 16:17:16,933 p=*** u=*** |    to retry, use: --limit @/Users/USERNAME/openshift-ansible/playbooks/deploy_cluster.retry

2018-12-25 16:17:16,933 p=*** u=*** |  PLAY RECAP *******************************************************************************************************************
2018-12-25 16:17:16,933 p=*** u=*** |  localhost                  : ok=12   changed=0    unreachable=0    failed=0
2018-12-25 16:17:16,933 p=*** u=*** |  master.okd.local.tld   : ok=507  changed=232  unreachable=0    failed=1
2018-12-25 16:17:16,933 p=*** u=*** |  node1.okd.local.tld    : ok=123  changed=63   unreachable=0    failed=0
2018-12-25 16:17:16,933 p=*** u=*** |  node2.okd.local.tld    : ok=123  changed=64   unreachable=0    failed=0
2018-12-25 16:17:16,933 p=*** u=*** |  node3.okd.local.tld    : ok=123  changed=63   unreachable=0    failed=0
2018-12-25 16:17:16,934 p=*** u=*** |  INSTALLER STATUS *************************************************************************************************************
2018-12-25 16:17:16,938 p=*** u=*** |  Initialization              : Complete (0:00:29)
2018-12-25 16:17:16,938 p=*** u=*** |  Health Check                : Complete (0:00:37)
2018-12-25 16:17:16,938 p=*** u=*** |  Node Bootstrap Preparation  : Complete (0:15:15)
2018-12-25 16:17:16,938 p=*** u=*** |  etcd Install                : Complete (0:01:18)
2018-12-25 16:17:16,938 p=*** u=*** |  Master Install              : Complete (0:05:37)
2018-12-25 16:17:16,938 p=*** u=*** |  Master Additional Install   : Complete (0:00:51)
2018-12-25 16:17:16,938 p=*** u=*** |  Node Join                   : Complete (0:01:34)
2018-12-25 16:17:16,939 p=*** u=*** |  GlusterFS Install           : In Progress (0:03:29)
2018-12-25 16:17:16,939 p=*** u=*** |    This phase can be restarted by running: playbooks/openshift-glusterfs/new_install.yml
2018-12-25 16:17:16,939 p=*** u=*** |  Failure summary:


  1. master.okd.local.tld
     Configure GlusterFS
     Load heketi topology
     Failed without returning a message.
```

The heketi server log shows an `500 - Internal Server Error` (in this example, for node3):
```
[heketi] INFO 2018/12/25 15:16:59 Adding node node1.okd.local.tld
[negroni] Completed 202 Accepted in 86.723354ms
[asynchttp] INFO 2018/12/25 15:16:59 asynchttp.go:288: Started job 4f85a02a8d0952e48eca4c73862a1e4e
[negroni] Started GET /queue/4f85a02a8d0952e48eca4c73862a1e4e
[negroni] Completed 200 OK in 241.533µs
[heketi] INFO 2018/12/25 15:16:59 Added node 8feafb5c2630ebe4bc9060b563fd35b3
...
[heketi] INFO 2018/12/25 15:17:01 Adding node node2.okd.local.tld
[negroni] Completed 202 Accepted in 78.417259ms
[asynchttp] INFO 2018/12/25 15:17:01 asynchttp.go:288: Started job 78a4f845488248d1abf11791966b34c3
[cmdexec] INFO 2018/12/25 15:17:01 Probing: node1.okd.local.tld -> 10.222.111.22
[negroni] Started GET /queue/78a4f845488248d1abf11791966b34c3
[negroni] Completed 200 OK in 98.611µs
[kubeexec] DEBUG 2018/12/25 15:17:01 /src/github.com/heketi/heketi/executors/kubeexec/kubeexec.go:246: Host: node1.okd.local.tld Pod: glusterfs-storage-lcwrl Command: gluster peer probe 10.222.111.22
Result: peer probe: success.
[cmdexec] INFO 2018/12/25 15:17:01 Setting snapshot limit
[negroni] Started GET /queue/78a4f845488248d1abf11791966b34c3
[negroni] Completed 200 OK in 213.734µs
[kubeexec] DEBUG 2018/12/25 15:17:01 /src/github.com/heketi/heketi/executors/kubeexec/kubeexec.go:246: Host: node1.okd.local.tld Pod: glusterfs-storage-lcwrl Command: gluster --mode=script snapshot config snap-max-hard-limit 14
Result: snapshot config: snap-max-hard-limit for System set successfully
[heketi] INFO 2018/12/25 15:17:01 Added node d1ea99c72a33f335d5e38cd76845086b
...
[heketi] INFO 2018/12/25 15:17:04 Adding node node3.okd.local.tld
[negroni] Completed 202 Accepted in 76.454021ms
[asynchttp] INFO 2018/12/25 15:17:04 asynchttp.go:288: Started job c52950103a12fab10b37a50f0422641f
[cmdexec] INFO 2018/12/25 15:17:04 Probing: node1.okd.local.tld -> 10.222.111.23
[negroni] Started GET /queue/c52950103a12fab10b37a50f0422641f
[negroni] Completed 200 OK in 104.543µs
[kubeexec] ERROR 2018/12/25 15:17:04 /src/github.com/heketi/heketi/executors/kubeexec/kubeexec.go:242: Failed to run command [gluster peer probe 10.222.111.23] on glusterfs-storage-lcwrl: Err[command terminated with exit code 1]: Stdout []: Stderr [peer probe: failed: Probe returned with Transport endpoint is not connected]
[asynchttp] INFO 2018/12/25 15:17:04 asynchttp.go:292: Completed job c52950103a12fab10b37a50f0422641f in 123.390093ms
[negroni] Started GET /queue/c52950103a12fab10b37a50f0422641f
[negroni] Completed 500 Internal Server Error in 246.234µs
```

FYI:
`node1` matches `10.222.111.21`
`node2` matches `10.222.111.22`
`node3` matches `10.222.111.23`

Node3 cant be probed. Presumably, because gluster is not ready yet on that node.
After adding the proposed fix, a playbook run behaves as follows:
```
2018-12-13 01:05:13,329 p=*** u=*** |  TASK [openshift_storage_glusterfs : Generate topology file] ***********************************************************************************************
2018-12-13 01:05:15,003 p=*** u=*** |  changed: [master.okd.local.tld]
2018-12-13 01:05:15,070 p=*** u=*** |  TASK [openshift_storage_glusterfs : Place heketi topology on heketi Pod] **********************************************************************************
2018-12-13 01:05:15,703 p=*** u=*** |  changed: [master.okd.local.tld]
2018-12-13 01:05:15,764 p=*** u=*** |  TASK [openshift_storage_glusterfs : Load heketi topology] *************************************************************************************************
2018-12-13 01:05:19,671 p=*** u=*** |  FAILED - RETRYING: Load heketi topology (4 retries left).
2018-12-13 01:05:29,294 p=*** u=*** |  FAILED - RETRYING: Load heketi topology (3 retries left).
2018-12-13 01:05:38,551 p=*** u=*** |  changed: [master.okd.local.tld]
```

After two attepts, loading the topology is successful and therefore the playbook run is successful.
