### PR TITLE
[release-3.11] kibana, curator ops false; wait for es deploy

### DIFF
--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -237,6 +237,7 @@
     name: openshift_logging_kibana
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
+    openshift_logging_kibana_ops_deployment: false
     openshift_logging_kibana_namespace: "{{ openshift_logging_namespace }}"
     openshift_logging_kibana_master_url: "{{ openshift_logging_master_url }}"
     openshift_logging_kibana_master_public_url: "{{ openshift_logging_master_public_url }}"
@@ -278,6 +279,7 @@
     name: openshift_logging_curator
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
+    openshift_logging_curator_ops_deployment: false
     openshift_logging_curator_namespace: "{{ openshift_logging_namespace }}"
     openshift_logging_curator_es_host: "{{ openshift_logging_es_host }}"
     openshift_logging_curator_es_port: "{{ openshift_logging_es_port }}"

--- a/roles/openshift_logging_elasticsearch/tasks/restart_es_node.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/restart_es_node.yml
@@ -14,12 +14,23 @@
     - (_disable_output.stdout | from_json)['acknowledged'] | bool
   failed_when: false
 
+- name: "Check if there is a rollout in progress for {{ _es_node }}"
+  command: >
+    {{ openshift_client_binary }}
+    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    rollout status --watch=false dc/{{ _es_node }}
+    -n {{ openshift_logging_elasticsearch_namespace }}
+  register: _rollout_status
+  ignore_errors: True
+
 - name: "Rolling out new pod(s) for {{ _es_node }}"
   command: >
     {{ openshift_client_binary }}
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
     rollout latest {{ _es_node }}
     -n {{ openshift_logging_elasticsearch_namespace }}
+  when:
+    - _rollout_status.stdout.find('Waiting for rollout to finish') < 0
 
 - when: not _skip_healthcheck | bool
   name: "Waiting for {{ _es_node }} to finish scaling up"


### PR DESCRIPTION
When doing the non-ops deployments for kibana and curator,
force the `openshift_logging_xxx_ops_deployment: false`
Seems to be a problem only with ansible 2.7 - at least, I
could only reproduce the problem when using ansible 2.7.7 -
whatever ansible version, it seems like a good idea to
avoid polluting the global vars namespace with the wrong
values, and it also works with ansible 2.6

Before doing a deployment of elasticsearch, check to see
if there is a deployment already in progress.

(cherry picked from commit 516e302ff79e9b6d739daf65bfa75d5c14a3b603)