### PR TITLE
Ensure dns records are available when deleting the stack

### DIFF
--- a/playbooks/openstack/openshift-cluster/uninstall.yml
+++ b/playbooks/openstack/openshift-cluster/uninstall.yml
@@ -17,6 +17,17 @@
     - ansible_distribution == "RedHat"
     - (rhsub_user is defined and rhsub_pass is defined) or (rhsub_ak is defined and rhsub_orgid is defined)
 
+- name: Remove OpenStack resources
+  hosts: localhost
+  tasks:
+  - name: retrieve cluster name from the environment if present
+    set_fact:
+      openshift_openstack_stack_name: "{{ lookup('env', 'OPENSHIFT_CLUSTER') | ternary (lookup('env', 'OPENSHIFT_CLUSTER'), omit) }}"
+  - name: Remove OpenStack resources
+    import_role:
+      name: openshift_openstack
+      tasks_from: unprovision.yml
+
 - name: Clean DNS entries
   hosts: localhost
   ignore_errors: True
@@ -31,14 +42,3 @@
     when:
     - openshift_openstack_external_nsupdate_keys is defined
     - openshift_openstack_external_nsupdate_keys.private is defined or openshift_openstack_external_nsupdate_keys.public is defined
-
-- name: Remove OpenStack resources
-  hosts: localhost
-  tasks:
-  - name: retrieve cluster name from the environment if present
-    set_fact:
-      openshift_openstack_stack_name: "{{ lookup('env', 'OPENSHIFT_CLUSTER') | ternary (lookup('env', 'OPENSHIFT_CLUSTER'), omit) }}"
-  - name: Remove OpenStack resources
-    import_role:
-      name: openshift_openstack
-      tasks_from: unprovision.yml


### PR DESCRIPTION
In order to remove the openstack resources created by kuryr, the
dns record pointing to the OpenShift API is required so that those
resources can be retrieved -- information is stored on CRDs