### PR TITLE
Complete requirements for persistent storage azure backend

### DIFF
--- a/playbooks/azure/openshift-cluster/build_node_image.yml
+++ b/playbooks/azure/openshift-cluster/build_node_image.yml
@@ -64,6 +64,12 @@
 
 - hosts: nodes
   tasks:
+  - name: set seboolean for samba use
+    seboolean:
+      name: virt_use_samba
+      state: yes
+      persistent: yes
+
   - name: deconfigure yum repositories
     import_tasks: tasks/remove_yum.yml
 

--- a/playbooks/azure/openshift-cluster/tasks/create_blob_from_vm.yml
+++ b/playbooks/azure/openshift-cluster/tasks/create_blob_from_vm.yml
@@ -23,7 +23,7 @@
 - name: start copy
   command: >
     az storage blob copy start
-    --source-uri "{{ (sas.stdout | from_json).accessSas }}"
+    --source-uri "{{ (sas.stdout | from_json).properties.output.accessSAS }}"
     --account-name "{{ openshift_azure_storage_account }}"
     --account-key "{{ (keys.stdout | from_json)[0].value }}"
     --destination-container "{{ openshift_azure_container }}"

--- a/playbooks/azure/openshift-cluster/tasks/create_blob_from_vm.yml
+++ b/playbooks/azure/openshift-cluster/tasks/create_blob_from_vm.yml
@@ -23,7 +23,7 @@
 - name: start copy
   command: >
     az storage blob copy start
-    --source-uri "{{ (sas.stdout | from_json).properties.output.accessSAS }}"
+    --source-uri "{{ (sas.stdout | from_json).accessSas }}"
     --account-name "{{ openshift_azure_storage_account }}"
     --account-key "{{ (keys.stdout | from_json)[0].value }}"
     --destination-container "{{ openshift_azure_container }}"

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -68,6 +68,7 @@ default_r_openshift_node_image_prep_packages:
 - atomic
 - cifs-utils    # requested by Azure
 - samba-common  # requested by Azure
+- samba-client  # requested by Azure
 r_openshift_node_image_prep_packages: "{{ default_r_openshift_node_image_prep_packages | union(openshift_node_image_prep_packages | default([])) }}"
 
 r_openshift_node_os_firewall_deny: []


### PR DESCRIPTION
As per https://docs.openshift.com/container-platform/3.11/install_config/persistent_storage/persistent_storage_azure_file.html
One more package was required, adding that.
Also need to set a SELinux boolean so the containers can talk to Samba.
Plus a small fix for the process that creates an SA blob from the image. This one I am not so sure about, but it appears the API now returns a different structure when creating an export lease on azure drives.