### PR TITLE
Uninstall: delete all cri-o containers.

### DIFF
--- a/playbooks/adhoc/uninstall_openshift.yml
+++ b/playbooks/adhoc/uninstall_openshift.yml
@@ -210,6 +210,11 @@
     failed_when: False
     with_items: "{{ exited_containers_to_delete.results }}"
 
+  - name: Delete all cri-o containers
+    shell: 'crictl ps --all -q | xargs crictl rm'
+    changed_when: False
+    failed_when: False
+
   - name: Remove k8s_ containters
     shell: docker ps -a -q -f name=k8s_ | xargs docker rm -f
     failed_when: False


### PR DESCRIPTION
Prior to this change, the cri-o containers remained active after
uninstall was ran, causing issues when attempting to re-install
openshift onto the cluster.

This change removes all cri-o containers from all cluster hosts when the
uninstall.yml playbook is executed.

https://bugzilla.redhat.com/show_bug.cgi?id=1642589