### PR TITLE
Fix for BZ 1679746 - where VM LB is used

### DIFF
--- a/playbooks/openstack/openshift-cluster/install.yml
+++ b/playbooks/openstack/openshift-cluster/install.yml
@@ -18,7 +18,7 @@
 
 - name: Prepare the Nodes in the cluster for installation
   any_errors_fatal: true
-  hosts: oo_all_hosts
+  hosts: "{{ l_etcd_scale_up_crt_hosts | default(l_scale_up_hosts) | default('oo_nodes_to_config') }}"
   become: yes
   gather_facts: yes
   tasks:


### PR DESCRIPTION
Ensures LB VM is not targeted for docker restart operation

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
