### PR TITLE
test/ci: remove SG using `ec2_group`

### DIFF
--- a/test/ci/deprovision.yml
+++ b/test/ci/deprovision.yml
@@ -45,10 +45,9 @@
           with_items: "{{ ec2.instances }}"
 
     - name: Delete security groups
-      group_id:
-        name: "{{ item.security_groups.0.group_id }}"
+      ec2_group:
+        group_id: "{{ item.security_groups.0.group_id }}"
         state: absent
-        vpc_id: "{{ aws_vpc_id }}"
         region: "{{ aws_region }}"
       with_items: "{{ ec2.instances }}"
       when: not aws_use_auto_terminator | default(true)

--- a/test/ci/deprovision.yml
+++ b/test/ci/deprovision.yml
@@ -20,7 +20,7 @@
         instance_ids: "{{ item.instance_id }}"
         region: "{{ aws_region }}"
         state: absent
-        wait: no
+        wait: yes
       with_items: "{{ ec2.instances }}"
 
     - when: aws_use_auto_terminator | default(true)

--- a/test/ci/deprovision.yml
+++ b/test/ci/deprovision.yml
@@ -22,19 +22,9 @@
         state: absent
         wait: no
       with_items: "{{ ec2.instances }}"
-      when: not aws_use_auto_terminator | default(true)
 
     - when: aws_use_auto_terminator | default(true)
       block:
-        - name: Stop VMs
-          ec2:
-            instance_ids: "{{ item.instance_id }}"
-            region: "{{ aws_region }}"
-            state: stopped
-            wait: no
-          with_items: "{{ ec2.instances }}"
-          ignore_errors: true
-
         - name: Rename VMs
           ec2_tag:
             resource: "{{ item.instance_id }}"

--- a/test/ci/launch.yml
+++ b/test/ci/launch.yml
@@ -60,6 +60,7 @@
         assign_public_ip: yes
         instance_tags: "{{ aws_instance_tags }}"
         volumes: "{{ item.aws_volumes | default(omit) }}"
+        instance_initiated_shutdown_behavior: "{{ (aws_use_auto_terminator | default(true)) | ternary('stop', 'terminate') }}"
       register: ec2
       with_items: "{{ aws_instances }}"
       vars:


### PR DESCRIPTION
Fixes error in deprovision in e2e-aws test:
```
ERROR! no action detected in task. This often indicates a misspelled module name, or incorrect module path.

The error appears to have been in '/usr/share/ansible/openshift-ansible/test/ci/deprovision.yml': line 47, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


    - name: Delete security groups
      ^ here
```

This also ensures SG is being deleted after instances are terminated