### PR TITLE
WIP [devel-40] collect facts after mco run to avoid hosts being unreachable

### DIFF
--- a/roles/openshift_node40/tasks/config.yml
+++ b/roles/openshift_node40/tasks/config.yml
@@ -66,6 +66,10 @@
     ignore_unreachable: true
   # Wait for the host to come back and reset 'unreachable' status
   - wait_for_connection: {}
+  # Collect facts from the node, this would cause the status to change to passing instead of
+  # unreachable
+  - setup:
+      gather_subset: min
   # Clear unreachable status
   - name: clear any host unreachable error messages.
     meta: clear_host_errors


### PR DESCRIPTION
Depends on https://github.com/openshift/openshift-ansible/pull/10958

Ansible would not stop after `ignore_unreachable: true` being set in MCO task and mark these hosts as potentially reachable after `meta: clear_host_errors`, but the last task would still be marked as unreachable. That would propagate to final node stats.

This PR ensures a task runs on scaled up nodes after clearing host errors. This should prevent from the host being marked as unreachable