### PR TITLE
Run MCD task asynchronously

### DIFF
--- a/roles/openshift_node40/tasks/config.yml
+++ b/roles/openshift_node40/tasks/config.yml
@@ -63,11 +63,19 @@
       podman_mounts: "-v /:/rootfs -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd"
       mcd_command: "start --node-name {{ ansible_hostname }} --once-from {{ ign_file }}"
     # MCD reboots the machine, run the task but do not wait for completion
-    async: 60
+    register: manifest_apply
+    async: 900  # 15 minutes
     poll: 0
 
   # Wait for the host to come back
   - wait_for_connection: {}
+
+  # If the job fails, the async job status will find rc != 1 and will fail here
+  # When the job is successful, Ansible does not update this job status due to
+  # the host rebooting
+  - name: Check manifest apply status
+    async_status:
+      jid: "{{ manifest_apply.ansible_job_id }}"
 
   rescue:
   - fail:

--- a/roles/openshift_node40/tasks/config.yml
+++ b/roles/openshift_node40/tasks/config.yml
@@ -62,13 +62,13 @@
       podman_flags: "--privileged --rm -ti {{ release_image_mcd.stdout }}"
       podman_mounts: "-v /:/rootfs -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd"
       mcd_command: "start --node-name {{ ansible_hostname }} --once-from {{ ign_file }}"
-    # MCD reboots the machine
-    ignore_unreachable: true
-  # Wait for the host to come back and reset 'unreachable' status
+    # MCD reboots the machine, run the task but do not wait for completion
+    async: 60
+    poll: 0
+
+  # Wait for the host to come back
   - wait_for_connection: {}
-  # Clear unreachable status
-  - name: clear any host unreachable error messages.
-    meta: clear_host_errors
+
   rescue:
   - fail:
-      msg: "Ignition apply failed, {{ mcd_apply.stdout }}"
+      msg: "Ignition apply failed"


### PR DESCRIPTION
This will run the MCD command and not wait for a return.  The task does return that the command was started.

Alternative to #11237 