### PR TITLE
Fix console certs after master cert redeploy

### DIFF
--- a/playbooks/openshift-master/redeploy-certificates.yml
+++ b/playbooks/openshift-master/redeploy-certificates.yml
@@ -4,3 +4,6 @@
 - import_playbook: private/redeploy-certificates.yml
 
 - import_playbook: private/restart.yml
+
+- import_playbook: ../openshift-web-console/private/redeploy-certificates.yml
+  when: openshift_web_console_install | default(true) | bool

--- a/playbooks/openshift-web-console/redeploy-certificates.yml
+++ b/playbooks/openshift-web-console/redeploy-certificates.yml
@@ -1,0 +1,6 @@
+---
+- import_playbook: ../init/main.yml
+
+- import_playbook: private/redeploy-certificates.yml
+
+- import_playbook: private/restart.yml

--- a/playbooks/openshift-web-console/redeploy-certificates.yml
+++ b/playbooks/openshift-web-console/redeploy-certificates.yml
@@ -2,5 +2,3 @@
 - import_playbook: ../init/main.yml
 
 - import_playbook: private/redeploy-certificates.yml
-
-- import_playbook: private/restart.yml


### PR DESCRIPTION
Re-create web console certs and pods after master certs were deployed.
This PR also adds a dedicated playbook to redeploy web-console certs.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1667981