### PR TITLE
Handle null values and multiple certs when checking namedCertificate expirys.

### DIFF
--- a/roles/lib_utils/library/openshift_cert_expiry.py
+++ b/roles/lib_utils/library/openshift_cert_expiry.py
@@ -560,9 +560,11 @@ an OpenShift Container Platform cluster
                 cert_meta['proxyClient'] = os.path.join(cfg_path, proxyClient)
 
             namedCertificates = cfg.get('servingInfo', {}).get('namedCertificates', [])
-            for i in namedCertificates:
-                if 'certFile' in i:
-                    cert_meta['namedCertificates'] = os.path.join(cfg_path, i.get('certFile'))
+            if namedCertificates:
+                for i, v in enumerate(namedCertificates):
+                    if 'certFile' in v:
+                        namedCertKey = 'namedCertificate-{}'.format(i)
+                        cert_meta[namedCertKey] = os.path.join(cfg_path, v.get('certFile'))
 
         ######################################################################
         # Load the certificate and the CA, parse their expiration dates into


### PR DESCRIPTION
We should check for null when running cert expiry checks, because the following is [valid for a node-config](https://docs.openshift.com/container-platform/3.11/install_config/master_node_configuration.html#node-configuration-files):
```
servingInfo:
  [...]
  namedCertificates: null
```

Also, the previous code would only process one namedCertificate, where there can be many.
