### PR TITLE
[devel-40] Run package installs with async

### DIFF
--- a/playbooks/init/base_packages.yml
+++ b/playbooks/init/base_packages.yml
@@ -15,6 +15,8 @@
     package:
       name: ntp
       state: present
+    async: 3600
+    poll: 60
     when:
     - openshift_clock_enabled | default(True) | bool
     - chrony_installed.rc != 0
@@ -29,6 +31,8 @@
     package:
       name: "{{ pkg_list | join(',') }}"
       state: present
+    async: 3600
+    poll: 60
     vars:
       pkg_list_temp:
       - iproute

--- a/roles/container_runtime/tasks/crio_firewall.yml
+++ b/roles/container_runtime/tasks/crio_firewall.yml
@@ -5,6 +5,8 @@
     package:
       name: iptables-services
       state: present
+    async: 3600
+    poll: 60
 
   - name: Add iptables allow rules
     os_firewall_manage_iptables:

--- a/roles/container_runtime/tasks/package_crio.yml
+++ b/roles/container_runtime/tasks/package_crio.yml
@@ -31,6 +31,8 @@
     state: latest
   register: result
   until: result is succeeded
+  async: 3600
+  poll: 60
   vars:
     pkg_list:
       - cri-o

--- a/roles/openshift_node40/tasks/install.yml
+++ b/roles/openshift_node40/tasks/install.yml
@@ -8,6 +8,8 @@
   until: install_openshift.rc == 0
   retries: 3
   delay: 1
+  async: 3600
+  poll: 60
   vars:
     l_node_packages:
     - "{{ openshift_service_type }}-node{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"

--- a/roles/openshift_repos/tasks/main.yaml
+++ b/roles/openshift_repos/tasks/main.yaml
@@ -7,6 +7,8 @@
     state: present
   register: result
   until: result is succeeded
+  async: 3600
+  poll: 60
 
 - name: Remove openshift_additional.repo file
   file:

--- a/test/aws/scaleup.yml
+++ b/test/aws/scaleup.yml
@@ -67,6 +67,8 @@
     package:
       name: nfs-utils
       state: present
+    async: 3600
+    poll: 60
   - name: Wait for new nodes to be ready
     oc_obj:
       kubeconfig: "{{ kubeconfig_path }}"

--- a/test/gcp/build_image.yml
+++ b/test/gcp/build_image.yml
@@ -95,6 +95,8 @@
     package:
       name: NetworkManager-glib
       state: present
+    async: 3600
+    poll: 60
   - name: Set MTU
     nmcli:
       conn_name: "System eth0"
@@ -106,6 +108,8 @@
     package:
       name: "nfs-utils"
       state: present
+    async: 3600
+    poll: 60
 
 - name: Commit image
   hosts: localhost


### PR DESCRIPTION
`package` module would wait for packages to be installed in a single ssh connection. Due to ssh bastion this connection may not be restored again, so while yum pulls and installs packages it may timeout and never come back.

This PR would ensure we use async to check back if process has finished. Since `async: 0` is not used here there is no need to add `async_status` task