### PR TITLE
Bug 1671315 - Kibana and Curator pods names are with ops

### DIFF
--- a/roles/openshift_logging/tasks/delete_logging.yaml
+++ b/roles/openshift_logging/tasks/delete_logging.yaml
@@ -129,7 +129,7 @@
     loop_var: project
 
 ## EventRouter
-- import_role:
+- include_role:
     name: openshift_logging_eventrouter
   when:
     not openshift_logging_install_eventrouter | default(false) | bool

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -233,7 +233,7 @@
 
 
 ## Kibana
-- import_role:
+- include_role:
     name: openshift_logging_kibana
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -246,7 +246,7 @@
     openshift_logging_kibana_es_port: "{{ openshift_logging_es_port }}"
 
 
-- import_role:
+- include_role:
     name: openshift_logging_kibana
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -275,7 +275,7 @@
 - include_tasks: annotate_ops_projects.yaml
 
 ## Curator
-- import_role:
+- include_role:
     name: openshift_logging_curator
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -286,7 +286,7 @@
     openshift_logging_curator_master_url: "{{ openshift_logging_master_url }}"
     openshift_logging_curator_image_pull_secret: "{{ openshift_logging_image_pull_secret }}"
 
-- import_role:
+- include_role:
     name: openshift_logging_curator
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -307,7 +307,7 @@
   - openshift_logging_use_ops | bool
 
 ## Mux
-- import_role:
+- include_role:
     name: openshift_logging_mux
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -320,7 +320,7 @@
 
 
 ## Fluentd
-- import_role:
+- include_role:
     name: openshift_logging_fluentd
   vars:
     generated_certs_dir: "{{openshift.common.config_base}}/logging"
@@ -331,7 +331,7 @@
 
 
 ## EventRouter
-- import_role:
+- include_role:
     name: openshift_logging_eventrouter
   when:
     openshift_logging_install_eventrouter | default(false) | bool

--- a/roles/openshift_logging_curator/tasks/main.yaml
+++ b/roles/openshift_logging_curator/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure that Logging Curator has nodes to run on
-  import_role:
+  include_role:
     name: openshift_control_plane
     tasks_from: ensure_nodes_matching_selector.yml
   vars:
@@ -103,7 +103,7 @@
     - "curator.yml"
 
 # Patch existing configuration, if present
-- import_role:
+- include_role:
     name: openshift_logging
     tasks_from: patch_configmap_files.yaml
   vars:

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure that ElasticSearch has nodes to run on
-  import_role:
+  include_role:
     name: openshift_control_plane
     tasks_from: ensure_nodes_matching_selector.yml
   vars:

--- a/roles/openshift_logging_eventrouter/tasks/install_eventrouter.yaml
+++ b/roles/openshift_logging_eventrouter/tasks/install_eventrouter.yaml
@@ -5,7 +5,7 @@
     that: openshift_logging_eventrouter_sink in __eventrouter_sinks
 
 - name: Ensure that Logging EventRouter has nodes to run on
-  import_role:
+  include_role:
     name: openshift_control_plane
     tasks_from: ensure_nodes_matching_selector.yml
   vars:

--- a/roles/openshift_logging_fluentd/tasks/main.yaml
+++ b/roles/openshift_logging_fluentd/tasks/main.yaml
@@ -102,7 +102,7 @@
     src: "secure-forward.conf"
     dest: "{{ tempdir }}/secure-forward.conf"
 
-- import_role:
+- include_role:
     name: openshift_logging
     tasks_from: patch_configmap_files.yaml
   vars:

--- a/roles/openshift_logging_kibana/tasks/main.yaml
+++ b/roles/openshift_logging_kibana/tasks/main.yaml
@@ -11,7 +11,7 @@
     msg: "Provided value for 'openshift_logging_kibana_session_timeout_seconds' is invalid. Only positive integers are allowed."
 
 - name: Ensure that Kibana has nodes to run on
-  import_role:
+  include_role:
     name: openshift_control_plane
     tasks_from: ensure_nodes_matching_selector.yml
   vars:

--- a/roles/openshift_logging_mux/tasks/main.yaml
+++ b/roles/openshift_logging_mux/tasks/main.yaml
@@ -12,7 +12,7 @@
   when: openshift_logging_mux_default_namespaces is defined
 
 - name: Ensure that Logging Mux has nodes to run on
-  import_role:
+  include_role:
     name: openshift_control_plane
     tasks_from: ensure_nodes_matching_selector.yml
   vars:
@@ -92,7 +92,7 @@
     dest: "{{mktemp.stdout}}/secure-forward-mux.conf"
   changed_when: no
 
-- import_role:
+- include_role:
     name: openshift_logging
     tasks_from: patch_configmap_files.yaml
   vars:


### PR DESCRIPTION
I basically changed all of the logging rules to use include_role
instead of import_role.  In my (albeit limited) testing of
the logging roles with ansible 2.6 and 2.7, logging seems to
work just fine, and it fixes all of the "-ops" naming
problems.  This allows the logging roles to work with both
ansible 2.6 and ansible 2.7.

The problem is that the import_role behavior changed between
ansible 2.6 and ansible 2.7:
https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.7.html?highlight=import_role#include-role-and-import-role-variable-exposure
import_role is changing global variables like
openshift_logging_kibana_hostname when the role is imported,
even if the role is conditionally imported and the condition
is false.