### PR TITLE
Revert "[release-3.10] [release-3.11] Remove deprecated "openshift_logging_curator_run_timezone variable""

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -27,6 +27,7 @@ When `openshift_logging_install_logging` is set to `False` the `openshift_loggin
 - `openshift_logging_curator_default_days`: The default minimum age (in days) Curator uses for deleting log records. Defaults to '30'.
 - `openshift_logging_curator_run_hour`: The hour of the day that Curator will run at. Defaults to '0'.
 - `openshift_logging_curator_run_minute`: The minute of the hour that Curator will run at. Defaults to '0'.
+- `openshift_logging_curator_run_timezone`: The timezone that Curator uses for figuring out its run time. Defaults to 'UTC'.
 - `openshift_logging_curator_timeout`: The timeout for each Curator operation. Defaults to 300.
 - `openshift_logging_curator_script_log_level`: The script log level for Curator. Defaults to 'INFO'.
 - `openshift_logging_curator_log_level`: The log level for the Curator process. Defaults to 'ERROR'.

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -18,6 +18,7 @@ openshift_logging_es5_techpreview: False
 openshift_logging_curator_default_days: 30
 openshift_logging_curator_run_hour: 3
 openshift_logging_curator_run_minute: 30
+openshift_logging_curator_run_timezone: UTC
 openshift_logging_curator_timeout: 300
 openshift_logging_curator_script_log_level: INFO
 openshift_logging_curator_log_level: ERROR

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -307,6 +307,7 @@
     openshift_logging_curator_default_days: "{{ openshift_logging_curator_ops_default_days | default() }}"
     openshift_logging_curator_run_hour: "{{ openshift_logging_curator_ops_run_hour | default() }}"
     openshift_logging_curator_run_minute: "{{ openshift_logging_curator_ops_run_minute | default() }}"
+    openshift_logging_curator_run_timezone: "{{ openshift_logging_curator_ops_run_timezone | default() }}"
   when:
   - openshift_logging_use_ops | bool
 

--- a/roles/openshift_logging/tasks/set_defaults_from_current.yml
+++ b/roles/openshift_logging/tasks/set_defaults_from_current.yml
@@ -107,6 +107,7 @@
         __openshift_logging_curator_default_days: "{{ openshift_logging_facts['curator']['deploymentconfigs']['logging-curator']['containers']['curator']['env'] | entry_from_name_value_pair('CURATOR_DEFAULT_DAYS') }}"
         __openshift_logging_curator_run_hour: "{{ openshift_logging_facts['curator']['deploymentconfigs']['logging-curator']['containers']['curator']['env'] | entry_from_name_value_pair('CURATOR_RUN_HOUR') }}"
         __openshift_logging_curator_run_minute: "{{ openshift_logging_facts['curator']['deploymentconfigs']['logging-curator']['containers']['curator']['env'] | entry_from_name_value_pair('CURATOR_RUN_MINUTE') }}"
+        __openshift_logging_curator_run_timezone: "{{ openshift_logging_facts['curator']['deploymentconfigs']['logging-curator']['containers']['curator']['env'] | entry_from_name_value_pair('CURATOR_RUN_TIMEZONE') }}"
         __openshift_logging_curator_nodeselector: "{{ openshift_logging_facts['curator']['deploymentconfigs']['logging-curator']['nodeSelector'] | default('') | from_yaml }}"
 
     - conditional_set_fact:
@@ -231,6 +232,7 @@
       openshift_logging_curator_default_days: openshift_logging_curator_default_days | __openshift_logging_curator_default_days
       openshift_logging_curator_run_hour: openshift_logging_curator_run_hour | __openshift_logging_curator_run_hour
       openshift_logging_curator_run_minute: openshift_logging_curator_run_minute | __openshift_logging_curator_run_minute
+      openshift_logging_curator_run_timezone: openshift_logging_curator_run_timezone | __openshift_logging_curator_run_timezone
       openshift_logging_curator_cpu_limit: openshift_logging_curator_cpu_limit | __openshift_logging_curator_cpu_limit
       openshift_logging_curator_cpu_request: openshift_logging_curator_cpu_request | __openshift_logging_curator_cpu_request
       openshift_logging_curator_memory_limit: openshift_logging_curator_memory_limit | __openshift_logging_curator_memory_limit

--- a/roles/openshift_logging_curator/defaults/main.yml
+++ b/roles/openshift_logging_curator/defaults/main.yml
@@ -28,6 +28,7 @@ openshift_logging_curator_ops_deployment: false
 openshift_logging_curator_default_days: 30
 openshift_logging_curator_run_hour: 3
 openshift_logging_curator_run_minute: 30
+openshift_logging_curator_run_timezone: UTC
 openshift_logging_curator_script_log_level: INFO
 openshift_logging_curator_log_level: ERROR
 openshift_logging_curator_timeout: 300


### PR DESCRIPTION
We removed this config option in 3.11, but it is still present in 3.10.

Reverts openshift/openshift-ansible#11244

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1684460