### PR TITLE
Require ansible 2.6, allow ansible 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install base dependencies:
 
 Requirements:
 
-- Ansible >= 2.6.5, Ansible 2.7 is not yet supported and known to fail
+- Ansible >= 2.6, Ansible 2.7 is supported
 - Jinja >= 2.7
 - pyOpenSSL
 - python-lxml

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -10,7 +10,7 @@ COPY images/installer/origin-extra-root /
 # install ansible and deps
 RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
- && EPEL_PKGS="ansible-2.7.4 python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46" \
+ && EPEL_PKGS="ansible-2.7.8 python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
  && if [ "$(uname -m)" == "x86_64" ]; then yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm ; fi \

--- a/images/installer/origin-extra-root/etc/yum.repos.d/centos-ansible27.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/centos-ansible27.repo
@@ -1,6 +1,6 @@
 
-[centos-ansible26-testing]
-name=CentOS Ansible 2.6 testing repo
+[centos-ansible27-testing]
+name=CentOS Ansible 2.7 testing repo
 baseurl=https://cbs.centos.org/repos/configmanagement7-ansible-27-testing/x86_64/os/
 enabled=1
 gpgcheck=0

--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -17,7 +17,7 @@ URL:            https://github.com/openshift/openshift-ansible
 Source0:        https://github.com/openshift/openshift-ansible/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-Requires:      ansible >= 2.5.7
+Requires:      ansible >= 2.6
 Requires:      python2
 Requires:      python-six
 Requires:      tar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.6.5
+ansible==2.7.8
 boto==2.44.0
 click==6.7
 pyOpenSSL==17.5.0

--- a/roles/lib_utils/callback_plugins/aa_version_requirement.py
+++ b/roles/lib_utils/callback_plugins/aa_version_requirement.py
@@ -31,7 +31,7 @@ else:
 
 
 # Set to minimum required Ansible version
-REQUIRED_VERSION = version.StrictVersion('2.5.7')
+REQUIRED_VERSION = version.StrictVersion('2.6')
 DESCRIPTION = "Supported versions: %s or newer" % REQUIRED_VERSION
 
 


### PR DESCRIPTION
Update ansible version to changes in https://cbs.centos.org/repos/configmanagement7-ansible-27-testing/x86_64/os/Packages/
