### PR TITLE
Set AWS_CA_BUNDLE via openshift_cloudprovider_aws_ca_bundle

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -285,6 +285,10 @@ debug_level=2
 # Note: IAM profiles may be used instead of storing API credentials on disk.
 #openshift_cloudprovider_aws_access_key=aws_access_key_id
 #openshift_cloudprovider_aws_secret_key=aws_secret_access_key
+# If a custom CA is required for your AWS endpoint, this is copied to
+# /etc/origin/{master,node}/aws_ca_bundle.crt and configured via the envvar
+# AWS_CA_BUNDLE for master and node.
+#openshift_cloudprovider_aws_ca_bundle=/path/to/aws_ca_bundle.crt
 #
 # Openstack
 #openshift_cloudprovider_kind=openstack

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -84,6 +84,12 @@
 
 - import_tasks: htpass_provider.yml
 
+- name: Create AWS Custom CA if specified
+  copy:
+    dest: "/etc/origin/master/aws_ca_bundle.crt"
+    src: "{{ openshift_cloudprovider_aws_ca_bundle }}"
+  when: openshift_cloudprovider_aws_ca_bundle is defined
+
 - name: Create the ldap ca file if needed
   copy:
     dest: "/etc/origin/master/{{ item.name }}_ldap_ca.crt"

--- a/roles/openshift_control_plane/templates/master.env.j2
+++ b/roles/openshift_control_plane/templates/master.env.j2
@@ -2,6 +2,9 @@
 AWS_ACCESS_KEY_ID={{ openshift_cloudprovider_aws_access_key }}
 AWS_SECRET_ACCESS_KEY={{ openshift_cloudprovider_aws_secret_key }}
 {% endif %}
+{% if openshift_cloudprovider_aws_ca_bundle is defined %}
+AWS_CA_BUNDLE=/etc/origin/master/aws_ca_bundle.crt
+{% endif %}
 
 # Proxy configuration
 # See https://docs.openshift.com/container-platform/latest/install_config/http_proxies.html#configuring-hosts-for-proxies-using-ansible

--- a/roles/openshift_node/tasks/aws.yml
+++ b/roles/openshift_node/tasks/aws.yml
@@ -17,3 +17,18 @@
     - openshift_cloudprovider_kind == 'aws'
     - openshift_cloudprovider_aws_access_key is defined
     - openshift_cloudprovider_aws_secret_key is defined
+
+# not certain if it's safe to set this to an empty value so only set it when
+# specified
+- when: openshift_cloudprovider_aws_ca_bundle is defined
+  block:
+    - name: Copy aws_ca_bundle
+      copy:
+        dest: /etc/origin/node/aws_ca_bundle.crt
+        src: "{{ openshift_cloudprovider_aws_ca_bundle }}"
+    - name: Configure AWS_CA_BUNDLE if specified
+      lineinfile:
+        dest: /etc/sysconfig/{{ openshift_service_type }}-node
+        regexp: "^AWS_CA_BUNDLE"
+        line: "AWS_CA_BUNDLE=/etc/origin/node/aws_ca_bundle.crt"
+        create: true


### PR DESCRIPTION
Copies the local file to /etc/origin/{master,node}/aws_ca_bundle.crt
as appropriate.