### PR TITLE
Don't stop docker when openshift_use_crio_only

### DIFF
--- a/roles/openshift_node/tasks/upgrade/restart.yml
+++ b/roles/openshift_node/tasks/upgrade/restart.yml
@@ -29,6 +29,7 @@
   until: not (docker_start_result is failed)
   retries: 3
   delay: 30
+  when: not openshift_use_crio_only | bool
 
 - name: Restart cri-o
   service:

--- a/roles/openshift_node/tasks/upgrade/stop_services.yml
+++ b/roles/openshift_node/tasks/upgrade/stop_services.yml
@@ -15,9 +15,10 @@
   until: not (l_openshift_node_upgrade_docker_stop_result is failed)
   retries: 3
   delay: 30
-  when: >
-        inventory_hostname in groups['oo_masters_to_config']
-        or (l_docker_upgrade is defined and l_docker_upgrade | bool)
+  when:
+  - not openshift_use_crio_only | bool
+  - inventory_hostname in groups['oo_masters_to_config'] or (l_docker_upgrade is defined and l_docker_upgrade | bool)
+
 
 - name: Stop crio
   service:


### PR DESCRIPTION
We were trying to stop docker when only cri-o is installed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1685072