### PR TITLE
Add evars file to override vars in CI. 

### DIFF
--- a/test/evars/vars.yml
+++ b/test/evars/vars.yml
@@ -1,0 +1,5 @@
+---
+openshift_node_labels:
+  region: infra
+  zone: default
+  node-role.kubernetes.io/infra: "true"


### PR DESCRIPTION
This creates a file which would be consumed as evars by CI. The approach is taken from this PR from logging:
https://github.com/openshift/origin-aggregated-logging/pull/1530

Currently 3.9 CI is broken because 3.9 requires infra nodes, but 3.10+ will fail sanity checks if there are infra nodes. CI shares the same inventory file for all versions. 

Here's a link to the PR which removed the node labels from CI. These are the values now in the vars.yml.
https://github.com/openshift/aos-cd-jobs/pull/1688