### PR TITLE
ssh bastion: use TCP NLB and require ops-mirror.pem

### DIFF
--- a/test/aws/files/01_service.yml
+++ b/test/aws/files/01_service.yml
@@ -5,6 +5,9 @@ metadata:
     run: ssh-bastion
   name: ssh-bastion
   namespace: openshift-ssh-bastion
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 spec:
   externalTrafficPolicy: Local
   ports:

--- a/test/aws/scaleup.yml
+++ b/test/aws/scaleup.yml
@@ -41,7 +41,6 @@
       owner: root
       group: root
       mode: 0644
-    ignore_errors: true
 
 - import_playbook: ../../playbooks/openshift-node/scaleup.yml
 


### PR DESCRIPTION
Create TCP-based NLB for ssh-bastion to speed up SSH.

This PR also requires AWS secret to have ops-mirror.pem file, otherwise if its not present yum install would timeout without any valid error message

This cuts scaleup time from 40+ mins to ~15 minutes