### PR TITLE
Use tempfile module in place of command mktemp

### DIFF
--- a/roles/openshift_node40/tasks/config.yml
+++ b/roles/openshift_node40/tasks/config.yml
@@ -23,17 +23,17 @@
     persistent: yes
 
 - name: create temp directory
-  command: mktemp -d /tmp/openshift-ansible-XXXXXXX
-  register: mktemp
-  changed_when: False
+  tempfile:
+    state: directory
+  register: tempfile
 
 - name: Copy pull secret in the directory
   copy:
     src: "{{ pull_secret }}"
-    dest: "{{ mktemp.stdout }}/pull-secret.json"
+    dest: "{{ tempfile.path }}/pull-secret.json"
 
 - name: Pull release image
-  command: "podman pull --tls-verify={{ tls_verify }} --authfile {{ mktemp.stdout }}/pull-secret.json {{ openshift_release_image }}"
+  command: "podman pull --tls-verify={{ tls_verify }} --authfile {{ tempfile.path }}/pull-secret.json {{ openshift_release_image }}"
 
 - name: Get machine controller daemon image from release image
   command: "podman run --rm {{ openshift_release_image }} image machine-config-daemon"
@@ -54,7 +54,7 @@
 
 - block:
   - name: Pull MCD image
-    command: "podman pull --tls-verify={{ tls_verify }} --authfile {{ mktemp.stdout }}/pull-secret.json {{ release_image_mcd.stdout }}"
+    command: "podman pull --tls-verify={{ tls_verify }} --authfile {{ tempfile.path }}/pull-secret.json {{ release_image_mcd.stdout }}"
 
   - name: Apply ignition manifest
     command: "podman run {{ podman_mounts }} {{ podman_flags }} {{ mcd_command }}"


### PR DESCRIPTION
The tempfile module will use the default system tmp location to safely
create tmpdirs.  This avoids permissions issues when trying to write to
/tmp if not root.