### PR TITLE
Fix version checker, Require 2.7.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Install base dependencies:
 
 Requirements:
 
-- Ansible >= 2.7.7
+- Ansible >= 2.7.8
 - Jinja >= 2.7
 - pyOpenSSL
 - python-lxml

--- a/images/installer/origin-extra-root/etc/yum.repos.d/centos-ansible27.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/centos-ansible27.repo
@@ -1,6 +1,6 @@
 
-[centos-ansible26-testing]
-name=CentOS Ansible 2.6 testing repo
+[centos-ansible27-testing]
+name=CentOS Ansible 2.7 testing repo
 baseurl=https://cbs.centos.org/repos/configmanagement7-ansible-27-testing/x86_64/os/
 enabled=1
 gpgcheck=0

--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -17,7 +17,7 @@ URL:            https://github.com/openshift/openshift-ansible
 Source0:        https://github.com/openshift/openshift-ansible/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-Requires:      ansible >= 2.7.7
+Requires:      ansible >= 2.7.8
 Requires:      python2
 Requires:      python-six
 Requires:      tar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.7.7
+ansible==2.7.8
 boto==2.44.0
 click==6.7
 pyOpenSSL==17.5.0

--- a/roles/lib_utils/callback_plugins/aa_version_requirement.py
+++ b/roles/lib_utils/callback_plugins/aa_version_requirement.py
@@ -21,7 +21,7 @@ def display(*args, **kwargs):
 
 
 # Set to minimum required Ansible version
-REQUIRED_VERSION = parse_version('2.7.8')
+REQUIRED_VERSION = '2.7.8'
 DESCRIPTION = "Supported versions: %s or newer" % REQUIRED_VERSION
 
 
@@ -40,7 +40,7 @@ class CallbackModule(CallbackBase):
         """
         super(CallbackModule, self).__init__()
 
-        if not parse_version(__version__) >= REQUIRED_VERSION:
+        if not parse_version(__version__) >= parse_version(REQUIRED_VERSION):
             display(
                 'FATAL: Current Ansible version (%s) is not supported. %s'
                 % (__version__, DESCRIPTION), color='red')

--- a/roles/lib_utils/callback_plugins/aa_version_requirement.py
+++ b/roles/lib_utils/callback_plugins/aa_version_requirement.py
@@ -7,39 +7,22 @@ The plugin is named with leading `aa_` to ensure this plugin is loaded
 first (alphanumerically) by Ansible.
 """
 import sys
-from distutils import version
+from pkg_resources import parse_version
 
 from ansible import __version__
+from ansible.plugins.callback import CallbackBase
+from ansible.utils.display import Display
 
-if __version__ < '2.0':
-    # pylint: disable=import-error,no-name-in-module
-    # Disabled because pylint warns when Ansible v2 is installed
-    from ansible.callbacks import display as pre2_display
-    CallbackBase = object
 
-    def display(*args, **kwargs):
-        """Set up display function for pre Ansible v2"""
-        pre2_display(*args, **kwargs)
-else:
-    from ansible.plugins.callback import CallbackBase
-    from ansible.utils.display import Display
-
-    def display(*args, **kwargs):
-        """Set up display function for Ansible v2"""
-        display_instance = Display()
-        display_instance.display(*args, **kwargs)
+def display(*args, **kwargs):
+    """Set up display function for Ansible v2"""
+    display_instance = Display()
+    display_instance.display(*args, **kwargs)
 
 
 # Set to minimum required Ansible version
-REQUIRED_VERSION = version.StrictVersion('2.7.7')
+REQUIRED_VERSION = parse_version('2.7.8')
 DESCRIPTION = "Supported versions: %s or newer" % REQUIRED_VERSION
-
-
-def version_requirement(ver):
-    """Test for minimum required version"""
-    if not isinstance(ver, version.StrictVersion):
-        ver = version.StrictVersion(ver)
-    return ver >= REQUIRED_VERSION
 
 
 class CallbackModule(CallbackBase):
@@ -57,7 +40,7 @@ class CallbackModule(CallbackBase):
         """
         super(CallbackModule, self).__init__()
 
-        if not version_requirement(__version__):
+        if not parse_version(__version__) >= REQUIRED_VERSION:
             display(
                 'FATAL: Current Ansible version (%s) is not supported. %s'
                 % (__version__, DESCRIPTION), color='red')


### PR DESCRIPTION
* Fix version requirement plugin to allow Ansible development versions (2.8.0.dev0)
* Standardize all version refs to 2.7.8
