### PR TITLE
Include iscsi storage only on non-atomic host installs.

### DIFF
--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -80,6 +80,8 @@
 
 - name: iSCSI storage plugin configuration
   import_tasks: storage_plugins/iscsi.yml
-  when: "'iscsi' in osn_storage_plugin_deps"
+  when:
+    - "'iscsi' in osn_storage_plugin_deps"
+    - not openshift_is_atomic | bool
 
 ##### END Storage #####

--- a/roles/openshift_node/tasks/storage_plugins/iscsi.yml
+++ b/roles/openshift_node/tasks/storage_plugins/iscsi.yml
@@ -3,7 +3,6 @@
   package:
     name: "{{ pkg_list | join(',') }}"
     state: present
-  when: not openshift_is_atomic | bool
   register: result
   until: result is succeeded
   vars:
@@ -16,7 +15,6 @@
     name: "{{ item }}"
     state: started
     enabled: True
-  when: not openshift_is_atomic | bool
   with_items:
     - multipathd
     - rpcbind
@@ -29,7 +27,6 @@
     src: multipath.conf.j2
     backup: true
     force: no
-  when: not openshift_is_atomic | bool
 
 # check whether devices section is present
 - name: Check devices section present
@@ -82,4 +79,3 @@
 #enable multipath
 - name: Enable and start multipath
   command: "mpathconf --enable --with_multipathd y"
-  when: not openshift_is_atomic | bool


### PR DESCRIPTION
[Bug 1684742](https://bugzilla.redhat.com/show_bug.cgi?id=1684742)

We should not include the isci storage plugin playbooks when running on atomic host.

Prior to #11153 all tasks in iscsi.yml were marked with `when: not openshift_is_atomic | bool` but that PR introduced some tasks without the conditional which caused some failures.  This PR moves the conditional outside the playbook.