### PR TITLE
bug 1660956. Add container name to elasticsearch exec call

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/logging/elasticsearch.py
+++ b/roles/openshift_health_checker/openshift_checks/logging/elasticsearch.py
@@ -62,7 +62,9 @@ class Elasticsearch(LoggingCheck):
 
     @staticmethod
     def _build_es_curl_cmd(pod_name, url):
-        base = "exec {name} -- curl -s --cert {base}cert --key {base}key --cacert {base}ca -XGET '{url}'"
+        base = "exec {name} -c elasticsearch " \
+               "-- curl -s --cert {base}cert --key {base}key " \
+               "--cacert {base}ca -XGET '{url}'"
         return base.format(base="/etc/elasticsearch/secret/admin-", name=pod_name, url=url)
 
     def check_elasticsearch_masters(self, pods_by_name):


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1660956

Add the container name in the exec call