### PR TITLE
Relax version requirements

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -16,8 +16,9 @@ License:        ASL 2.0
 URL:            https://github.com/openshift/openshift-ansible
 Source0:        https://github.com/openshift/openshift-ansible/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
-
-Requires:      ansible >= 2.6
+# We expect most to run >= 2.6 but there are some module dependency conflicts
+# in openstack modules for 2.6 that are nearly impossible to resolve so tolerate 2.5.7
+Requires:      ansible >= 2.5.7
 Requires:      python2
 Requires:      python-six
 Requires:      tar

--- a/roles/lib_utils/callback_plugins/aa_version_requirement.py
+++ b/roles/lib_utils/callback_plugins/aa_version_requirement.py
@@ -31,7 +31,7 @@ else:
 
 
 # Set to minimum required Ansible version
-REQUIRED_VERSION = version.StrictVersion('2.6')
+REQUIRED_VERSION = version.StrictVersion('2.5.7')
 DESCRIPTION = "Supported versions: %s or newer" % REQUIRED_VERSION
 
 


### PR DESCRIPTION
OpenStack has compatibility issues with Ansible 2.6 OSP modules and in
those situations we need to be able to run Ansible 2.5.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1685606
/cc @vrutkovs 