### PR TITLE
Logs are already being shipped to journald

### DIFF
--- a/playbooks/azure/openshift-cluster/files/waagent.service
+++ b/playbooks/azure/openshift-cluster/files/waagent.service
@@ -5,3 +5,6 @@ After=network-online.target docker.service
 
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf
+
+[Service]
+SyslogIdentifier=waagent


### PR DESCRIPTION
This is just to correctly identify the unit in the journald logs via
`journalctl -u waagent`