### PR TITLE
Ensure kuryr has its own namespace

### DIFF
--- a/roles/kuryr/defaults/main.yaml
+++ b/roles/kuryr/defaults/main.yaml
@@ -9,7 +9,7 @@ kuryr_openstack_user_domain_name: default
 kuryr_openstack_project_domain_name: default
 
 # Kuryr OpenShift namespace
-kuryr_namespace: openshift-infra
+kuryr_namespace: kuryr
 
 # Default pod-in-VM link interface
 kuryr_cni_link_interface: eth0

--- a/roles/kuryr/tasks/master.yaml
+++ b/roles/kuryr/tasks/master.yaml
@@ -1,4 +1,11 @@
 ---
+- name: Ensure project exists
+  oc_project:
+    name: "{{ kuryr_namespace }}"
+    state: present
+    node_selector:
+    - ""
+
 - name: Perform OpenShift ServiceAccount config
   include_tasks: serviceaccount.yaml
   run_once: true


### PR DESCRIPTION
Kuryr components require a namespace with node_selector = ""
This PR ensures a project is created with that node_selector for
the kuryr components