### PR TITLE
Adding new kuryr handler to avoid races

### DIFF
--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -237,7 +237,7 @@ data:
     # in the pipeline. (list value)
 {% if openshift_kuryr_subnet_driver|default('default') == 'namespace' %}
 {% if openshift_kuryr_sg_driver|default('default') == 'policy' %}
-    enabled_handlers = vif,lb,lbaasspec,namespace,policy,pod_label
+    enabled_handlers = vif,lb,lbaasspec,namespace,policy,pod_label,kuryrnetpolicy
 {% else %}
     enabled_handlers = vif,lb,lbaasspec,namespace
 {% endif %}


### PR DESCRIPTION
When using network policies, kuryr requires this new handler to
avoid races when deleting a complete namespace as it deletes all
the objects inside, such as network policies or kuryrnetpolicy CRDs