### PR TITLE
Encode the cert when loading it

### DIFF
--- a/roles/lib_utils/library/openshift_cert_expiry.py
+++ b/roles/lib_utils/library/openshift_cert_expiry.py
@@ -277,7 +277,7 @@ A tuple of the form:
     if HAS_OPENSSL:
         # No work-around required
         cert_loaded = OpenSSL.crypto.load_certificate(
-            OpenSSL.crypto.FILETYPE_PEM, _cert_string)
+            OpenSSL.crypto.FILETYPE_PEM, _cert_string.encode('utf-8'))
     else:
         # Missing library, work-around required. Run the 'openssl'
         # command on it to decode it


### PR DESCRIPTION
This resolves the error when trying to load certificates

"Shared connection to host.com closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_QruODS/ansible_module_openshift_cert_expiry.py\", line 876, in <module>\r\n    main()\r\n  File \"/tmp/ansible_QruODS/ansible_module_openshift_cert_expiry.py\", line 772, in main\r\n    issuer) = load_and_handle_cert(router_c, now, base64decode=True, ans_module=module)\r\n  File \"/tmp/ansible_QruODS/ansible_module_openshift_cert_expiry.py\", line 280, in load_and_handle_cert\r\n    OpenSSL.crypto.FILETYPE_PEM, _cert_string)\r\nUnicodeEncodeError: 'ascii' codec can't encode character u'\\u0151' in position 151033: ordinal not in range(128)\r\n"

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1686449