### PR TITLE
[release-3.11] Remove runhour and runminute from curator config sample

### DIFF
--- a/roles/openshift_logging_curator/files/curator.yml
+++ b/roles/openshift_logging_curator/files/curator.yml
@@ -4,8 +4,6 @@
 #.defaults:
 #  delete:
 #    days: 30
-#  runhour: 0
-#  runminute: 0
 
 # to keep ops logs for a different duration:
 #.operations:


### PR DESCRIPTION
-  Related BZ: [Remove runhour and runminute from logging-curator configmap](https://bugzilla.redhat.com/show_bug.cgi?id=1655450)

- Version: only `v3.11`

- Description:
  Refer [Compatibility with OpenShift 3.7
](https://github.com/openshift/origin-aggregated-logging/tree/master/curator#compatibility-with-openshift-37)
~~~
In earlier releases admins could control the timezone and time when curator runs from the curator config. This configuration has been moved to openshift-ansible. The timezone is not currently configurable, instead the timezone of OpenShift master node is used.
~~~
  The `Curator` is controlled by `CronJob` as of `v3.11`, the `runhour` and `runminute` are useless any more. Remove them from `logging-curator` ConfigMap.