### PR TITLE
Fix validation of values in image_policy_allowed_registries_for_import

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -495,9 +495,11 @@ def set_nodename(facts):
 
 def make_allowed_registries(registry_list):
     """ turns a list of wildcard registries to allowedRegistriesForImport json setting """
+    if False in [isinstance(reg, string_types) for reg in registry_list]:
+        raise Exception("image_policy_allowed_registries_for_import is not a list of strings: '%s'" % registry_list)
     return {
         "allowedRegistriesForImport": [
-            {'domainName': reg} if isinstance(reg, str) else reg for reg in registry_list
+            {'domainName': reg} for reg in registry_list
         ]
     }
 


### PR DESCRIPTION
`image_policy_allowed_registries_for_import` should be validated before `image_policy_config` is being constructed. Error should be raised when its not a list of strings instead of inserting values as is.

This would pass when
`openshift_master_image_policy_allowed_registries_for_import=["docker.io", "*.docker.io", "*.redhat.com", "gcr.io", "quay.io", "registry.centos.org", "registry.redhat.io", "*.amazonaws.com"]`
and throw exception in 'Set master facts' when
`openshift_master_image_policy_allowed_registries_for_import=["docker.io", {"foo": "bar"}]` is set.

openshift_checks would verify that openshift_master_image_policy_allowed_registries_for_import is a valid list

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1670473