### PR TITLE
sdn: respect DEBUG_LOGLEVEL as written out by the "Configure Node settings" task

### DIFF
--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -81,9 +81,13 @@ spec:
           rm -Rf /etc/cni/net.d/80-openshift-network.conf
           cp -Rf /opt/cni/bin/* /host/opt/cni/bin/
 
+          # Load DEBUG_LOGLEVEL
           if [[ -f /etc/sysconfig/origin-node ]]; then
             set -o allexport
             source /etc/sysconfig/origin-node
+          elif [[ -f /etc/sysconfig/atomic-openshift-node ]]; then
+            set -o allexport
+            source /etc/sysconfig/atomic-openshift-node
           fi
 
           # use either the bootstrapped node kubeconfig or the static configuration


### PR DESCRIPTION
origin-node is only written for certain products; let's also read OSE products.

@danwinship @pecameron @weliang1 @sdodson 