### PR TITLE
Increase etcd quota to 8GB.

### DIFF
--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -104,8 +104,8 @@ r_etcd_os_firewall_allow:
 - service: etcd peering
   port: "{{ etcd_peer_port }}/tcp"
 
-# set the backend quota to 4GB by default
-etcd_quota_backend_bytes: 4294967296
+# set the backend quota to 8GB by default
+etcd_quota_backend_bytes: 8589934592
 
 openshift_docker_service_name: "docker"
 


### PR DESCRIPTION
- large scale clusters (e.g. 80+ compute nodes) can hit
  the 4GB hard quota in real life and this can cause an
  outage
