### PR TITLE
Include dedicated etcd in upgrade if they are nodes

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
@@ -42,8 +42,8 @@
       groups: oo_nodes_to_upgrade
       ansible_ssh_user: "{{ g_ssh_user | default(omit) }}"
       ansible_become: "{{ g_sudo | default(omit) }}"
-    when: item not in dedicated_etcds
+    when: item not in not_nodes
     vars:
-      dedicated_etcds: "{{ groups['oo_etcd_to_config'] | difference(groups['oo_masters']) }}"
+      not_nodes: "{{ groups['oo_etcd_to_config'] | difference( groups['oo_masters'] | union(groups['oo_nodes_to_config']) ) }}"
     with_items: "{{ groups['temp_nodes_to_upgrade'] | default(groups['oo_nodes_to_config']) }}"
     changed_when: False

--- a/playbooks/common/openshift-cluster/upgrades/pre/config.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/config.yml
@@ -72,8 +72,8 @@
   tasks:
   - import_tasks: verify_upgrade_targets.yml
     vars:
-      dedicated_etcds: "{{ groups['oo_etcd_to_config'] | difference(groups['oo_masters']) }}"
-    when: inventory_hostname not in dedicated_etcds
+      not_nodes: "{{ groups['oo_etcd_to_config'] | difference( groups['oo_masters'] | union(groups['oo_nodes_to_config']) ) }}"
+    when: inventory_hostname not in not_nodes
 
 - name: Verify docker upgrade targets
   hosts: "{{ l_upgrade_docker_target_hosts }}"


### PR DESCRIPTION
Dedicated etcd hosts should only be excluded from upgrades if they are
both not masters nor nodes.

https://bugzilla.redhat.com/show_bug.cgi?id=1668317
