### PR TITLE
openshift-sync: tolerate absence of KUBELET_HOSTNAME_OVERRIDE

### DIFF
--- a/roles/openshift_node_group/files/sync.yaml
+++ b/roles/openshift_node_group/files/sync.yaml
@@ -118,7 +118,7 @@ spec:
               continue
             fi
 
-            KUBELET_HOSTNAME_OVERRIDE=$(cat /etc/sysconfig/KUBELET_HOSTNAME_OVERRIDE) || :
+            KUBELET_HOSTNAME_OVERRIDE=$(cat /etc/sysconfig/KUBELET_HOSTNAME_OVERRIDE 2>/dev/null) || :
             if ! [[ -z "$KUBELET_HOSTNAME_OVERRIDE" ]]; then
                   #Patching node-config for hostname override
                   echo "nodeName: $KUBELET_HOSTNAME_OVERRIDE" >> /etc/origin/node/tmp/node-config.yaml


### PR DESCRIPTION
This file was only created during upgrades from 3.9 to 3.10 when a hostname override was provided. This will need to be backported to release-3.10 as well.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1657769