### PR TITLE
Redeploy admin console certificates when master certs are updated

### DIFF
--- a/playbooks/openshift-console/redeploy-certificates.yml
+++ b/playbooks/openshift-console/redeploy-certificates.yml
@@ -1,0 +1,4 @@
+---
+- import_playbook: ../init/main.yml
+
+- import_playbook: private/redeploy-certificates.yml

--- a/playbooks/openshift-master/redeploy-certificates.yml
+++ b/playbooks/openshift-master/redeploy-certificates.yml
@@ -7,3 +7,6 @@
 
 - import_playbook: ../openshift-web-console/private/redeploy-certificates.yml
   when: openshift_web_console_install | default(true) | bool
+
+- import_playbook: ../openshift-console/private/redeploy-certificates.yml
+  when: openshift_console_install | default(true) | bool


### PR DESCRIPTION
This would ensure admin console certs are redeployed when master certs
are redeployed. A new playbook to redeploy admin console certs was
added as well.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1667063 (see comment #10)
