### PR TITLE
Avoid using aliases which are prone to discovery problems

### DIFF
--- a/roles/kube_proxy_and_dns/tasks/main.yml
+++ b/roles/kube_proxy_and_dns/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Ensure the service account can run privileged
   oc_adm_policy_user:
     namespace: "kube-proxy-and-dns"
-    resource_kind: scc
+    resource_kind: securitycontextconstraints.security.openshift.io
     resource_name: privileged
     state: present
     user: "system:serviceaccount:kube-proxy-and-dns:proxy"

--- a/roles/kube_proxy_and_dns/tasks/main.yml
+++ b/roles/kube_proxy_and_dns/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Ensure the service account can run privileged
   oc_adm_policy_user:
     namespace: "kube-proxy-and-dns"
-    resource_kind: securitycontextconstraints.security.openshift.io
+    resource_kind: scc
     resource_name: privileged
     state: present
     user: "system:serviceaccount:kube-proxy-and-dns:proxy"

--- a/roles/lib_openshift/library/oc_adm_policy_user.py
+++ b/roles/lib_openshift/library/oc_adm_policy_user.py
@@ -2012,11 +2012,11 @@ class PolicyUserConfig(OpenShiftCLIConfig):
     def get_kind(self):
         ''' return the kind we are working with '''
         if self.config_options['resource_kind']['value'] == 'role':
-            return 'rolebinding'
+            return 'rolebinding.rbac.authorization.k8s.io'
         elif self.config_options['resource_kind']['value'] == 'cluster-role':
-            return 'clusterrolebinding'
+            return 'clusterrolebinding.rbac.authorization.k8s.io'
         elif self.config_options['resource_kind']['value'] == 'scc':
-            return 'scc'
+            return 'scc.security.openshift.io'
 
         return None
 

--- a/roles/lib_openshift/src/class/oc_adm_policy_user.py
+++ b/roles/lib_openshift/src/class/oc_adm_policy_user.py
@@ -18,11 +18,11 @@ class PolicyUserConfig(OpenShiftCLIConfig):
     def get_kind(self):
         ''' return the kind we are working with '''
         if self.config_options['resource_kind']['value'] == 'role':
-            return 'rolebinding'
+            return 'rolebinding.rbac.authorization.k8s.io'
         elif self.config_options['resource_kind']['value'] == 'cluster-role':
-            return 'clusterrolebinding'
+            return 'clusterrolebinding.rbac.authorization.k8s.io'
         elif self.config_options['resource_kind']['value'] == 'scc':
-            return 'scc'
+            return 'scc.security.openshift.io'
 
         return None
 

--- a/roles/openshift_bootstrap_autoapprover/tasks/main.yml
+++ b/roles/openshift_bootstrap_autoapprover/tasks/main.yml
@@ -22,7 +22,7 @@
   command: >
     {{ openshift_client_binary }}
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-    delete -n openshift-infra istag node:v3.11 --ignore-not-found
+    delete -n openshift-infra imagestreamtags.image.openshift.io node:v3.11 --ignore-not-found
   register: l_os_istag_del
   # The istag might not be there, so we want to not fail in that case.
   failed_when:

--- a/roles/openshift_bootstrap_autoapprover/tasks/main.yml
+++ b/roles/openshift_bootstrap_autoapprover/tasks/main.yml
@@ -23,11 +23,6 @@
     {{ openshift_client_binary }}
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
     delete -n openshift-infra imagestreamtags.image.openshift.io node:v3.11 --ignore-not-found
-  register: l_os_istag_del
-  # The istag might not be there, so we want to not fail in that case.
-  failed_when:
-    - l_os_istag_del.rc != 0
-    - "'have a resource type' not in l_os_istag_del.stderr"
 
 - name: Apply the config
   command: >

--- a/roles/openshift_node_group/tasks/sync.yml
+++ b/roles/openshift_node_group/tasks/sync.yml
@@ -37,12 +37,7 @@
   command: >
     {{ openshift_client_binary }}
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-    delete -n openshift-node imagestreamtags.image.openshift.io node:v3.10 --ignore-not-found
-  register: l_os_istag_del
-  # The istag might not be there, so we want to not fail in that case.
-  failed_when:
-    - l_os_istag_del.rc != 0
-    - "'have a resource type' not in l_os_istag_del.stderr"
+    delete -n openshift-node imagestreamtags.image.openshift.io node:v3.11 --ignore-not-found
 
 - name: Remove existing pods if present
   oc_obj:

--- a/roles/openshift_node_group/tasks/sync.yml
+++ b/roles/openshift_node_group/tasks/sync.yml
@@ -27,7 +27,7 @@
 - name: Ensure the service account can run privileged
   oc_adm_policy_user:
     namespace: "openshift-node"
-    resource_kind: securitycontextconstraints.security.openshift.io
+    resource_kind: scc
     resource_name: privileged
     state: present
     user: "system:serviceaccount:openshift-node:sync"

--- a/roles/openshift_node_group/tasks/sync.yml
+++ b/roles/openshift_node_group/tasks/sync.yml
@@ -27,7 +27,7 @@
 - name: Ensure the service account can run privileged
   oc_adm_policy_user:
     namespace: "openshift-node"
-    resource_kind: scc
+    resource_kind: securitycontextconstraints.security.openshift.io
     resource_name: privileged
     state: present
     user: "system:serviceaccount:openshift-node:sync"
@@ -37,7 +37,7 @@
   command: >
     {{ openshift_client_binary }}
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-    delete -n openshift-node istag node:v3.11 --ignore-not-found
+    delete -n openshift-node imagestreamtags.image.openshift.io node:v3.10 --ignore-not-found
   register: l_os_istag_del
   # The istag might not be there, so we want to not fail in that case.
   failed_when:

--- a/roles/openshift_sdn/tasks/main.yml
+++ b/roles/openshift_sdn/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: Ensure the service account can run privileged
   oc_adm_policy_user:
     namespace: "openshift-sdn"
-    resource_kind: scc
+    resource_kind: securitycontextconstraints.security.openshift.io
     resource_name: privileged
     state: present
     user: "system:serviceaccount:openshift-sdn:sdn"
@@ -39,7 +39,7 @@
   command: >
     {{ openshift_client_binary }}
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-    delete -n openshift-sdn istag node:v3.11 --ignore-not-found
+    delete -n openshift-sdn imagestreamtags.image.openshift.io node:v3.11 --ignore-not-found
   register: l_os_istag_del
   # The istag might not be there, so we want to not fail in that case.
   failed_when:

--- a/roles/openshift_sdn/tasks/main.yml
+++ b/roles/openshift_sdn/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: Ensure the service account can run privileged
   oc_adm_policy_user:
     namespace: "openshift-sdn"
-    resource_kind: securitycontextconstraints.security.openshift.io
+    resource_kind: scc
     resource_name: privileged
     state: present
     user: "system:serviceaccount:openshift-sdn:sdn"

--- a/roles/openshift_sdn/tasks/main.yml
+++ b/roles/openshift_sdn/tasks/main.yml
@@ -40,12 +40,6 @@
     {{ openshift_client_binary }}
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
     delete -n openshift-sdn imagestreamtags.image.openshift.io node:v3.11 --ignore-not-found
-  register: l_os_istag_del
-  # The istag might not be there, so we want to not fail in that case.
-  failed_when:
-    - l_os_istag_del.rc != 0
-    - "'have a resource type' not in l_os_istag_del.stderr"
-
 
 - name: Apply the config
   shell: >


### PR DESCRIPTION
- Avoid relying on discovery which may be unreliable as services are
restarting.
- Don't tolerate absence of resource types, that's a fatal condition but should no longer happen due to the other change

Silent failure which triggers problems in the task immediately following
```
TASK [openshift_node_group : Remove the image stream tag] *******************************************************
task path: /usr/share/ansible/openshift-ansible/roles/openshift_node_group/tasks/sync.yml:36
changed: [example.com] => {
    "changed": true, 
    "cmd": "oc --config=/etc/origin/master/admin.kubeconfig apply -f /tmp/ansible-k0VkgI", 
    "rc": 1, 
    "start": "2019-03-07 09:39:36.159571", 
    "stderr": "error: the server doesn't have a resource type \"istag\"", 
    "stderr_lines": [
        "error: the server doesn't have a resource type \"istag\""
    ], 

```

Potential fix for https://bugzilla.redhat.com/show_bug.cgi?id=1686590