### PR TITLE
[release-3.6] Update openshift_hosted_routers example to be in ini format

### DIFF
--- a/inventory/byo/hosts.origin.example
+++ b/inventory/byo/hosts.origin.example
@@ -367,45 +367,9 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # and is in the form of a list.  If no data is passed then a default router will be
 # created.  There are multiple combinations of router sharding.  The one described
 # below supports routers on separate nodes.
-#openshift_hosted_routers:
-#- name: router1
-#  stats_port: 1936
-#  ports:
-#  - 80:80
-#  - 443:443
-#  replicas: 1
-#  namespace: default
-#  serviceaccount: router
-#  selector: type=router1
-#  images: "openshift3/ose-${component}:${version}"
-#  edits: []
-#  certificate:
-#    certfile: /path/to/certificate/abc.crt
-#    keyfile: /path/to/certificate/abc.key
-#    cafile: /path/to/certificate/ca.crt
-#- name: router2
-#  stats_port: 1936
-#  ports:
-#  - 80:80
-#  - 443:443
-#  replicas: 1
-#  namespace: default
-#  serviceaccount: router
-#  selector: type=router2
-#  images: "openshift3/ose-${component}:${version}"
-#  certificate:
-#    certfile: /path/to/certificate/xyz.crt
-#    keyfile: /path/to/certificate/xyz.key
-#    cafile: /path/to/certificate/ca.crt
-#  edits:
-#  # ROUTE_LABELS sets the router to listen for routes
-#  # tagged with the provided values
-#  - key: spec.template.spec.containers[0].env
-#    value:
-#      name: ROUTE_LABELS
-#      value: "route=external"
-#    action: append
 #
+#openshift_hosted_routers=[{'name': 'router1', 'certificate': {'certfile': '/path/to/certificate/abc.crt', 'keyfile': '/path/to/certificate/abc.key', 'cafile': '/path/to/certificate/ca.crt'}, 'replicas': 1, 'serviceaccount': 'router', 'namespace': 'default', 'stats_port': 1936, 'edits': [], 'images': 'openshift3/ose-${component}:${version}', 'selector': 'type=router1', 'ports': ['80:80', '443:443']}, {'name': 'router2', 'certificate': {'certfile': '/path/to/certificate/xyz.crt', 'keyfile': '/path/to/certificate/xyz.key', 'cafile': '/path/to/certificate/ca.crt'}, 'replicas': 1, 'serviceaccount': 'router', 'namespace': 'default', 'stats_port': 1936, 'edits': [{'action': 'append', 'key': 'spec.template.spec.containers[0].env', 'value': {'name': 'ROUTE_LABELS', 'value': 'route=external'}}], 'images': 'openshift3/ose-${component}:${version}', 'selector': 'type=router2', 'ports': ['80:80', '443:443']}]
+
 # OpenShift Registry Console Options
 # Override the console image prefix for enterprise deployments, not used in origin
 # default is "registry.access.redhat.com/openshift3/" and the image appended is "registry-console"

--- a/inventory/byo/hosts.ose.example
+++ b/inventory/byo/hosts.ose.example
@@ -374,44 +374,8 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 # and is in the form of a list.  If no data is passed then a default router will be
 # created.  There are multiple combinations of router sharding.  The one described
 # below supports routers on separate nodes.
-#openshift_hosted_routers:
-#- name: router1
-#  stats_port: 1936
-#  ports:
-#  - 80:80
-#  - 443:443
-#  replicas: 1
-#  namespace: default
-#  serviceaccount: router
-#  selector: type=router1
-#  images: "openshift3/ose-${component}:${version}"
-#  edits: []
-#  certificate:
-#    certfile: /path/to/certificate/abc.crt
-#    keyfile: /path/to/certificate/abc.key
-#    cafile: /path/to/certificate/ca.crt
-#- name: router2
-#  stats_port: 1936
-#  ports:
-#  - 80:80
-#  - 443:443
-#  replicas: 1
-#  namespace: default
-#  serviceaccount: router
-#  selector: type=router2
-#  images: "openshift3/ose-${component}:${version}"
-#  certificate:
-#    certfile: /path/to/certificate/xyz.crt
-#    keyfile: /path/to/certificate/xyz.key
-#    cafile: /path/to/certificate/ca.crt
-#  edits:
-#  # ROUTE_LABELS sets the router to listen for routes
-#  # tagged with the provided values
-#  - key: spec.template.spec.containers[0].env
-#    value:
-#      name: ROUTE_LABELS
-#      value: "route=external"
-#    action: append
+#
+#openshift_hosted_routers=[{'name': 'router1', 'certificate': {'certfile': '/path/to/certificate/abc.crt', 'keyfile': '/path/to/certificate/abc.key', 'cafile': '/path/to/certificate/ca.crt'}, 'replicas': 1, 'serviceaccount': 'router', 'namespace': 'default', 'stats_port': 1936, 'edits': [], 'images': 'openshift3/ose-${component}:${version}', 'selector': 'type=router1', 'ports': ['80:80', '443:443']}, {'name': 'router2', 'certificate': {'certfile': '/path/to/certificate/xyz.crt', 'keyfile': '/path/to/certificate/xyz.key', 'cafile': '/path/to/certificate/ca.crt'}, 'replicas': 1, 'serviceaccount': 'router', 'namespace': 'default', 'stats_port': 1936, 'edits': [{'action': 'append', 'key': 'spec.template.spec.containers[0].env', 'value': {'name': 'ROUTE_LABELS', 'value': 'route=external'}}], 'images': 'openshift3/ose-${component}:${version}', 'selector': 'type=router2', 'ports': ['80:80', '443:443']}]
 
 # OpenShift Registry Console Options
 # Override the console image prefix:


### PR DESCRIPTION
Backports #5268
https://bugzilla.redhat.com/show_bug.cgi?id=1486808