### PR TITLE
Calico: Use hostIP as the BGP IP address

### DIFF
--- a/roles/calico/templates/calico.yml.j2
+++ b/roles/calico/templates/calico.yml.j2
@@ -210,9 +210,11 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_cert
-            # Auto-detect the BGP IP address.
+            # Use hostIP as the BGP IP address.
             - name: IP
-              value: ""
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
             - name: FELIX_HEALTHENABLED
               value: "true"
           securityContext:

--- a/roles/calico/templates/calicov3.yml.j2
+++ b/roles/calico/templates/calicov3.yml.j2
@@ -395,9 +395,11 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_cert
-            # Auto-detect the BGP IP address.
+            # Use hostIP as the BGP IP address.
             - name: IP
-              value: "autodetect"
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
             - name: FELIX_HEALTHENABLED
               value: "true"
           securityContext:


### PR DESCRIPTION
We have hosts with two interfaces, one *external* and one *internal*.
The provisioning is done over the *external* interface and this must not be part of the Calico SDN.

That's why we configured the ansible inventory as follows:

```
[new_nodes]
node-3.external.tld openshift_hostname=node-3.internal.tld openshift_ip="10.1.2.3"
node-4.external.tld openshift_hostname=node-4.internal.tld openshift_ip="10.1.2.4"
```

If we run the `scaleup.yml` playbook without the proposed change the auto-detect mechanism
picks the wrong interface and thus the wrong IP address for Calico's BGP peering.

Instead, the *internal* interface should be part of the Calico SDN and the *internal* IP addresses 10.1.2.X should be used for Calico's BGP peering.
