### PR TITLE
[release-3.11] Add race condition protection when creating projects

### DIFF
--- a/roles/lib_openshift/library/oc_project.py
+++ b/roles/lib_openshift/library/oc_project.py
@@ -1717,7 +1717,10 @@ class OCProject(OpenShiftCLI):
                 api_rval = oadm_project.create()
 
                 if api_rval['returncode'] != 0:
-                    return {'failed': True, 'msg': api_rval}
+                    # race condition if run on multiple masters, so check if project exists
+                    # before failing
+                    if not oadm_project.exists():
+                        return {'failed': True, 'msg': api_rval}
 
                 # return the created object
                 api_rval = oadm_project.get()

--- a/roles/lib_openshift/src/class/oc_project.py
+++ b/roles/lib_openshift/src/class/oc_project.py
@@ -157,7 +157,10 @@ class OCProject(OpenShiftCLI):
                 api_rval = oadm_project.create()
 
                 if api_rval['returncode'] != 0:
-                    return {'failed': True, 'msg': api_rval}
+                    # race condition if run on multiple masters, so check if project exists
+                    # before failing
+                    if not oadm_project.exists():
+                        return {'failed': True, 'msg': api_rval}
 
                 # return the created object
                 api_rval = oadm_project.get()


### PR DESCRIPTION
The oc_project module can fail on a task that calls for a project to be
'present' when the task is run on multiple masters, as all masters will
see that the project does not exist and try to create it simultaneously.