### PR TITLE
[WIP][DONOT MERGE]systemd unit that clears the cni config  on boot

### DIFF
--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -5,6 +5,13 @@
     dest: /usr/local/bin/openshift-node
     mode: 0500
 
+- name: Install cni-cleanup service file
+  template:
+    dest: "/etc/systemd/system/cni-cleanup.service"
+    src: "cni-cleanup.j2"
+  notify:
+  - reload systemd units
+
 - name: Install Node service file
   template:
     dest: "/etc/systemd/system/{{ openshift_service_type }}-node.service"

--- a/roles/openshift_node/templates/cni-cleanup.j2
+++ b/roles/openshift_node/templates/cni-cleanup.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Cleanup of cni/net.d and ovs
+Before=atomic-openshift-node.service
+ConditionPathExists=/etc/cni/net.d
+ConditionPathExists=/etc/origin/openvswitch
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/rm -f /etc/cni/net.d/80-openshift-network.conf
+ExecStart=/usr/bin/rm -f /etc/origin/openvswitch/conf.db
+ExecStart=/usr/bin/ls -R /etc/cni
+ExecStart=/usr/bin/ls -R /etc/origin
+
+[Install]
+WantedBy=atomic-openshift-node.service
+WantedBy=multi-user.target


### PR DESCRIPTION
Networking is ready when the /etc/cni/net.d/80-openshift-network.conf
exists. When the host is rebooted or power cycled, this file is
still on the disk and the cluster immediately starts creating pods.
This change deletes the file before the cluster node is started.

templates/cni-cleanup.j2 is the unit file that dos the delete,
tasks/systemd_units.yml is the playbook that references it.

SDN-329 - Create a systemd unit that clears the cni configuration directory on boot
https://jira.coreos.com/browse/SDN-329

Part of solution to:
Bug 1654044 - OCP 3.11: pods end up in CrashLoopBackOff state after a rolling reboot of the node

Signed-off-by: Phil Cameron <pcameron@redhat.com>

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
