### PR TITLE
Calico: Add support for environment variable IP_AUTODETECTION_METHOD

### DIFF
--- a/roles/calico/defaults/main.yaml
+++ b/roles/calico/defaults/main.yaml
@@ -7,6 +7,7 @@ calico_node_image: "quay.io/calico/node:v3.5.0"
 calico_cni_image: "quay.io/calico/cni:v3.5.0"
 calicoctl_image: "quay.io/calico/ctl:v3.5.0"
 calico_upgrade_image: "quay.io/calico/upgrade:v1.0.5"
+calico_ip_autodetection_method: "first-found"
 use_calico_etcd: False
 
 # Configure the IP Pool(s) from which Pod IPs will be chosen.

--- a/roles/calico/templates/calico.yml.j2
+++ b/roles/calico/templates/calico.yml.j2
@@ -213,6 +213,8 @@ spec:
             # Auto-detect the BGP IP address.
             - name: IP
               value: ""
+            - name: IP_AUTODETECTION_METHOD
+              value: "{{ calico_ip_autodetection_method }}"
             - name: FELIX_HEALTHENABLED
               value: "true"
           securityContext:

--- a/roles/calico/templates/calicov3.yml.j2
+++ b/roles/calico/templates/calicov3.yml.j2
@@ -398,6 +398,8 @@ spec:
             # Auto-detect the BGP IP address.
             - name: IP
               value: "autodetect"
+            - name: IP_AUTODETECTION_METHOD
+              value: "{{ calico_ip_autodetection_method }}"
             - name: FELIX_HEALTHENABLED
               value: "true"
           securityContext:


### PR DESCRIPTION
We have hosts with two interfaces, one *external* and one *internal*.
The provisioning is done over the *external* interface and this must not be part of the Calico SDN.

That's why we configured the ansible inventory as follows:

```
[new_nodes]
node-3.external.tld openshift_hostname=node-3.internal.tld openshift_ip="10.1.2.3"
node-4.external.tld openshift_hostname=node-4.internal.tld openshift_ip="10.1.2.4"
```

If we run the `scaleup.yml` playbook then Calico's default detection method
picks the wrong interface and thus the wrong IP address for Calico's BGP peering.

With the proposed change it's possible to choose one of the other detection [methods](https://docs.projectcalico.org/v3.6/reference/node/configuration#ip-autodetection-methods).