### PR TITLE
Change the example docker_version for 3.9 and higher

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -129,7 +129,7 @@ debug_level=2
 
 # Specify exact version of Docker to configure or upgrade to.
 # Downgrades are not supported and will error out. Be careful when upgrading docker from < 1.10 to > 1.10.
-# docker_version="1.12.1"
+# docker_version="1.13.1"
 
 # Specify whether to run Docker daemon with SELinux enabled in containers. Default is True.
 # Uncomment below to disable; for example if your kernel does not support the


### PR DESCRIPTION
Docker 1.13.1 is supported by OpenShift 3.9. For 3.10 and
higher a Docker version of 1.13 is required and 1.12.1 an invalid
value.

NOTICE
======

Master branch is closed! A major refactor is ongoing in devel-40.
Changes for 3.x should be made directly to the latest release branch they're
relevant to and backported from there.
