### PR TITLE
[release-3.11] Modify "lib_utils_oo_oreg_image" filter to work against Satellite url pattern

### DIFF
--- a/roles/lib_utils/filter_plugins/oo_filters.py
+++ b/roles/lib_utils/filter_plugins/oo_filters.py
@@ -658,7 +658,7 @@ def lib_utils_oo_oreg_image(image_default, oreg_url):
     oreg_parts = oreg_url.rsplit('/', 2)
     if len(oreg_parts) < 2:
         raise errors.AnsibleFilterError("oreg_url malformed: {}".format(oreg_url))
-    if not (len(oreg_parts) >= 3 and '.' in oreg_parts[0]):
+    if not (len(oreg_parts) >= 2 and '.' in oreg_parts[0]):
         # oreg_url does not include host information; we'll just return etcd default
         return image_default
 


### PR DESCRIPTION
- Fix: ["oreg_url" does not work on disconnected installation using Satellite](https://bugzilla.redhat.com/show_bug.cgi?id=1689796)

- Version: `v3.11`

- Description:
  Satellite usually use `<HOSTNAME>/<ORGANIZATION>-<PRODUCT>-<REPOSITORY>` `URL` pattern.
So `<hostname>`/`<image name>` pattern should be also valid to replace `oreg_url` when you install using Satellite.
Because if "registry.redhat.com/rhel7/etcd" image publish on the Satellite (register to Satellite as "rhel7/etcd" ),
then the URL will be changed to "satellite.example.com/--rhel7_etcd" format, and "/" is replaced with "_" on the Satellite.