### PR TITLE
[release-3.11] Satellite image URL can be worked in example template image url replecement.

### DIFF
--- a/roles/openshift_examples/defaults/main.yml
+++ b/roles/openshift_examples/defaults/main.yml
@@ -22,6 +22,7 @@ cockpit_ui_base: "{{ examples_base }}/infrastructure-templates/enterprise"
 
 openshift_examples_import_command: "create"
 registry_host: "{{ openshift_examples_registryurl.split('/')[0] if '.' in openshift_examples_registryurl.split('/')[0] else '' }}"
+satellite_prefix: "{{ openshift_examples_registryurl.split('$')[0] if '.' in openshift_examples_registryurl.split('$')[0] else '' }}"
 
 openshift_hosted_images_dict:
   origin: 'docker.io/openshift/origin-${component}:${version}'

--- a/roles/openshift_examples/tasks/stream_secrets.yml
+++ b/roles/openshift_examples/tasks/stream_secrets.yml
@@ -31,4 +31,17 @@
 - name: Modify registry paths if registry_url is not registry.redhat.io
   shell: >
     find {{ examples_base }} -type f | xargs -n 1 sed -i 's|registry.redhat.io|{{ registry_host | quote }}|g'
-  when: registry_host != '' and openshift_examples_modify_imagestreams | default(False) | bool
+  when:
+    - openshift_examples_registryurl.split('/') | length > 2
+    - registry_host != ''
+    - openshift_examples_modify_imagestreams | default(False) | bool
+
+- name: Modify registry paths if registry_url is not registry.redhat.io and using Satellite
+  shell: >
+    find {{ examples_base }} -type f | xargs -n 1 sed -i -e 's|registry.redhat.io/\([^/]*\)/\(.*\)$|registry.redhat.io/\1_\2|g' \
+         -e 's|registry.redhat.io/\([^/]*\)$|{{ satellite_prefix | quote }}\1|g' \
+         -e 's/openshift3[-_]ose-//g'
+  when:
+    - openshift_examples_registryurl.split('/') | length == 2
+    - satellite_prefix != ''
+    - openshift_examples_modify_imagestreams | default(False) | bool


### PR DESCRIPTION
- Fix: [example template image url does not work on Satellite ](https://bugzilla.redhat.com/show_bug.cgi?id=1689848)

- Version: `v3.11`

- Description:
  If `<hostname>/<sub path>/<image name>` pattern is configured as `oreg_url`, then it's works as it used be. Additionally if` <hostname>/<image name>` pattern is  configured in `oreg_url`, then the `image url` of templates is replaced with the same  depth of `<hostname>/<image name>` pattern.

For instance,

`oreg_url.splt('/') > 2`:
~~~
oreg_url=test.example.com:5000/test/imagename

then the template is replaced with test.example.com:5000/<subpath>/imagename per templates.
~~~

`oreg_url.split('/') == 2`:
~~~
oreg_url=test.example.com:5000/imagename

then the template is replaced with test.example.com:5000/imagename per templates.
~~~

And the example image url is replaced with the following format. Satellite is using a specific context after  hostname for specifying identification of registry.
~~~
oreg_url=satellite.registry.com:5000/some-prefix-ose-${component}:${version}
...
# cat /usr/share/openshift/examples/xpaas-streams/sso72-image-stream.json | grep \"name\":
        "name": "sso72-image-stream",
                "name": "redhat-sso72-openshift",
                        "name": "1.0",
                            "name": "satellite.registry.com:5000/some-prefix-ose-sso72-openshift:1.0"
                        "name": "1.1",
                            "name": "satellite.registry.com:5000/some-prefix-ose-sso72-openshift:1.1"
                        "name": "1.2",
                            "name": "satellite.registry.com:5000/some-prefix-ose-sso72-openshift:1.2"
~~~

