### PR TITLE
Run ssh bastion in privileged mode

### DIFF
--- a/test/aws/files/03_role.yml
+++ b/test/aws/files/03_role.yml
@@ -11,4 +11,4 @@ rules:
   verbs:
   - use
   resourceNames:
-  - anyuid
+  - privileged

--- a/test/aws/files/07_deployment.yml
+++ b/test/aws/files/07_deployment.yml
@@ -20,6 +20,8 @@ spec:
       - image: quay.io/eparis/ssh:latest
         imagePullPolicy: Always
         name: ssh-bastion
+        securityContext:
+          privileged: true
         ports:
         - containerPort: 22
           name: ssh


### PR DESCRIPTION
This PR fixes bastion behaviour on RHEL8. Its not yet clear why, but ssh bastion has to have additional privileges to run on RHCOS8 nodes.

https://github.com/openshift/openshift-ansible/pull/11358 needs to be updated too