### PR TITLE
remove dash causing syntax error in kibana install role

### DIFF
--- a/roles/openshift_logging_kibana/tasks/main.yaml
+++ b/roles/openshift_logging_kibana/tasks/main.yaml
@@ -59,7 +59,7 @@
     - openshift_logging_kibana_image_pull_secret == ''
 
 - name: Create Kibana service account auth delegator clusterrolebinding
-- oc_adm_policy_user:
+  oc_adm_policy_user:
     state: present
     namespace: "{{ openshift_logging_namespace }}"
     resource_kind: cluster-role


### PR DESCRIPTION
A recent PR into the openshift_logging_kibana role included a syntax error which breaks the openshift-ansible install. This PR simply removes the dash, allowing the playbook to proceed. 

Referenced in issue: https://github.com/openshift/openshift-ansible/issues/11382