### PR TITLE
openshift_node: install same packages as coreos

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -11,16 +11,79 @@ openshift_node_bootstrap_server: "{{ openshift_node_kubeconfig.clusters.0.cluste
 openshift_node_bootstrap_endpoint: "{{ openshift_node_bootstrap_server }}/config/{{ openshift_node_machineconfigpool }}"
 
 openshift_node_install_packages:
-  # Packages from old init/base_packages
-  - iproute
-  - dbus-python
-  - PyYAML
-  - libsemanage-python
-  - yum-utils
-  - python-docker-py
+  # Packages from redhat-coreos.git manifest-base.yaml
+  - kernel
+  - irqbalance
+  - microcode_ctl
+  - systemd
   - systemd-journal-gateway
-  - python-ipaddress
-  # Packages from old roles/container_runtime
-  - cri-o
-  - cri-tools
+  #- rpm-ostree
+  #- nss-altfiles
+  - selinux-policy-targeted
+  - setools-console
+  #- ignition
+  #- ignition-dracut
+  - dracut-network
+  - passwd
+  #- grub2
+  #- grub2-efi
+  #- ostree-grub2
+  #- efibootmgr
+  #- shim
+  - openssh-server
+  - openssh-clients
   - podman
+  - skopeo
+  - runc
+  - containernetworking-plugins
+  #- cri-o
+  - cri-tools
+  #- toolbox
+  - nfs-utils
+  - NetworkManager
+  - dnsmasq
+  - lvm2
+  - iscsi-initiator-utils
+  - sg3_utils
+  - device-mapper-multipath
+  - xfsprogs
+  - e2fsprogs
+  - mdadm
+  - cryptsetup
+  - chrony
+  #- coreos-metadata
+  - logrotate
+  - sssd
+  - shadow-utils
+  - sudo
+  - coreutils
+  - less
+  - tar
+  - xz
+  - gzip
+  - bzip2
+  - rsync
+  - tmux
+  - nmap-ncat
+  - net-tools
+  - bind-utils
+  - strace
+  - bash-completion
+  - vim-minimal
+  - nano
+  #- openshift-hyperkube
+  #- openshift-clients
+  #- pivot
+  #- subscription-manager-rhsm-certificates
+  #
+  # Packages from redhat-coreos.git maipo/manifest.yaml
+  #- redhat-release-coreos
+  - authconfig
+  - policycoreutils-python
+  - iptables-services
+  - bridge-utils
+  - biosdevname
+  - container-storage-setup
+  - cloud-utils-growpart
+  - ceph-common
+  - glusterfs-fuse

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -6,11 +6,6 @@
   async: 3600
   poll: 30
 
-- name: Enable the CRI-O service
-  systemd:
-    name: "cri-o"
-    enabled: yes
-
 - name: Install openshift packages
   package:
     name: "{{ l_node_packages | join(',') }}"
@@ -18,5 +13,11 @@
   poll: 30
   vars:
     l_node_packages:
+    - cri-o
     - openshift-clients
     - openshift-hyperkube
+
+- name: Enable the CRI-O service
+  systemd:
+    name: "cri-o"
+    enabled: yes


### PR DESCRIPTION
This change ensures the same packages are installed on a node as configured to be installed on RHCOS at the time of this PR. In order to assisting with auditing, all packages are listed; the unnecessary ones commented out.

https://jira.coreos.com/browse/BYOH-212