### PR TITLE
[release-3.11] Do not include enterprise registry unless available in oreg_url

### DIFF
--- a/roles/container_runtime/tasks/common/pre.yml
+++ b/roles/container_runtime/tasks/common/pre.yml
@@ -8,5 +8,6 @@
   when:
     - openshift_deployment_type == 'openshift-enterprise'
     - openshift_docker_ent_reg != ''
+    - openshift_docker_ent_reg in oreg_url
     - openshift_docker_ent_reg not in l2_docker_additional_registries
     - not openshift_use_crio_only | bool


### PR DESCRIPTION
Fixes: [openshift_docker_blocked_registries is not blocking registries](https://bugzilla.redhat.com/show_bug.cgi?id=1689230)