### PR TITLE
Use SHA1 to generate hwpass for hawkular metrics

### DIFF
--- a/roles/openshift_metrics/defaults/main.yaml
+++ b/roles/openshift_metrics/defaults/main.yaml
@@ -71,3 +71,4 @@ openshift_metrics_heapster_allowed_users: system:master-proxy
 
 openshift_metrics_cassandra_enable_prometheus_endpoint: True
 openshift_metrics_hawkular_enable_prometheus_endpoint: True
+openshift_metrics_hawkular_htpasswd_encryption_algorithm: apr_md5_crypt

--- a/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
@@ -25,7 +25,7 @@
   become: false
 
 - name: generate htpasswd file for hawkular metrics
-  local_action: htpasswd path="{{ local_tmp.stdout }}/hawkular-metrics.htpasswd" name=hawkular password="{{ hawkular_metrics_pwd.content | b64decode }}"
+  local_action: htpasswd crypt_scheme={{ openshift_metrics_hawkular_htpasswd_encryption_algorithm }}  path="{{ local_tmp.stdout }}/hawkular-metrics.htpasswd" name=hawkular password="{{ hawkular_metrics_pwd.content | b64decode }}"
   become: false
 
 - name: copy local generated passwords to target


### PR DESCRIPTION

This fixes "Bug 1691678"

When FIPS is enabled, it does not allow to generate .htpasswd files with MD5. This leading to errors on environments that has FIPS enabled.

SHA1 is allowed by FIPS[1] and fortunately is supported by hawkular metrics openshift authenticator[2]

1)https://docs.oracle.com/cd/E53394_01/html/E54966/fips-refs.html
2)https://github.com/hawkular/hawkular-metrics/blob/0a4d74824223b93e946c41512ddce73e58c12722/containers/hawkular-openshift-security-filter/src/main/java/org/hawkular/openshift/auth/BasicAuthenticator.java#L125


@jmartisk Could you please review?

