### PR TITLE
Add playbook for upgrading cri-o and kubelet on nodes

### DIFF
--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -1,0 +1,70 @@
+---
+- name: Pre-upgrade checks
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - fail:
+      msg: >
+        Detected no workers in inventory. Please add hosts to the
+        workers host group to upgrade nodes
+    when: groups.workers | default([]) | length == 0
+
+- name: upgrade nodes
+  hosts: workers
+  serial: 1
+  tasks:
+  - block:
+    - debug:
+        msg: "Running openshift_node_pre_cordon_hook {{ openshift_node_pre_cordon_hook }}"
+    - include_tasks: "{{ openshift_node_pre_cordon_hook }}"
+    when: openshift_node_pre_cordon_hook is defined
+
+  - name: Cordon node prior to upgrade
+    command: >
+      oc adm cordon {{ item | lower }}
+      --config={{ openshift_kubeconfig_path }}
+    delegate_to: localhost
+    with_items: "{{ ansible_play_batch }}"
+
+  - name: Drain node prior to upgrade
+    command: >
+      oc adm drain {{ item | lower }}
+      --config={{ openshift_kubeconfig_path }}
+      --force --delete-local-data --ignore-daemonsets
+    delegate_to: localhost
+    with_items: "{{ ansible_play_batch }}"
+
+  # Run the openshift_node_pre_upgrade_hook if defined
+  - block:
+    - debug:
+        msg: "Running node openshift_node_pre_upgrade_hook {{ openshift_node_pre_upgrade_hook }}"
+    - include_tasks: "{{ openshift_node_pre_upgrade_hook }}"
+    when: openshift_node_pre_upgrade_hook is defined
+
+  # Upgrade Node
+  - import_role:
+      name: openshift_node
+    vars:
+      openshift_node_package_state: latest
+
+  # Run the openshift_node_pre_uncordon_hook if defined
+  - block:
+    - debug:
+        msg: "Running openshift_node_pre_uncordon_hook {{ openshift_node_pre_uncordon_hook }}"
+    - include_tasks: "{{ openshift_node_pre_uncordon_hook }}"
+    when: openshift_node_pre_uncordon_hook is defined
+
+  - name: Uncordon node after upgrade
+    command: >
+      oc adm uncordon {{ item | lower }}
+      --config={{ openshift_kubeconfig_path }}
+    delegate_to: localhost
+    with_items: "{{ ansible_play_batch }}"
+
+  # Run the openshift_node_post_upgrade_hook if defined
+  - block:
+    - debug:
+        msg: "Running node openshift_node_post_upgrade_hook {{ openshift_node_post_upgrade_hook }}"
+    - include_tasks: "{{ openshift_node_post_upgrade_hook }}"
+    when: openshift_node_post_upgrade_hook is defined

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -10,7 +10,13 @@ openshift_node_bootstrap_port: 22623
 openshift_node_bootstrap_server: "{{ openshift_node_kubeconfig.clusters.0.cluster.server.split(':')[0:-1] | join(':') }}:{{ openshift_node_bootstrap_port }}"
 openshift_node_bootstrap_endpoint: "{{ openshift_node_bootstrap_server }}/config/{{ openshift_node_machineconfigpool }}"
 
-openshift_node_install_packages:
+openshift_node_package_state: present
+openshift_node_packages:
+  - cri-o
+  - openshift-clients
+  - openshift-hyperkube
+
+openshift_node_support_packages:
   # Packages from redhat-coreos.git manifest-base.yaml
   - kernel
   - irqbalance

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -1,21 +1,17 @@
 ---
 - name: Install openshift support packages
   package:
-    name: "{{ openshift_node_install_packages | join(',') }}"
+    name: "{{ openshift_node_support_packages | join(',') }}"
     update_cache: true
   async: 3600
   poll: 30
 
 - name: Install openshift packages
   package:
-    name: "{{ l_node_packages | join(',') }}"
+    name: "{{ openshift_node_packages | join(',') }}"
+    state: "{{ openshift_node_package_state }}"
   async: 3600
   poll: 30
-  vars:
-    l_node_packages:
-    - cri-o
-    - openshift-clients
-    - openshift-hyperkube
 
 - name: Enable the CRI-O service
   systemd:


### PR DESCRIPTION
This change adds the ability to upgrade cri-o, openshift-kubelet, and openshift-clients on UPI RHEL7 nodes. It does so by re-applying the openshift_node role to the hosts where these packages now have a state of latest. It also contains four hooks that can be used by adding any of the following variables to the inventory.

openshift_node_pre_cordon_hook
openshift_node_pre_upgrade_hook
openshift_node_pre_uncordon_hook
openshift_node_post_upgrade_hook

https://jira.coreos.com/browse/BYOH-230