### PR TITLE
Wait for ServiceMonitor CRD to be created should have configurable retries and delays

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -680,6 +680,10 @@ debug_level=2
 # openshift_cluster_monitoring_operator_prometheus_storage_class_name=""
 # openshift_cluster_monitoring_operator_alertmanager_storage_class_name=""
 
+# Update the time to wait for CRD to be creating by setting
+# openshift_cluster_monitoring_operator_crd_retries=30
+# openshift_cluster_monitoring_operator_crd_delay=30
+
 
 # Logging deployment
 #

--- a/roles/openshift_cluster_monitoring_operator/defaults/main.yml
+++ b/roles/openshift_cluster_monitoring_operator/defaults/main.yml
@@ -50,6 +50,9 @@ openshift_cluster_monitoring_operator_alertmanager_storage_enabled: false
 openshift_cluster_monitoring_operator_alertmanager_storage_class_name: ""
 openshift_cluster_monitoring_operator_alertmanager_storage_capacity: "2Gi"
 
+openshift_cluster_monitoring_operator_crd_retries: 30
+openshift_cluster_monitoring_operator_crd_delay: 30
+
 openshift_cluster_monitoring_operator_cluster_id: "{{ openshift_clusterid | default(openshift_master_cluster_public_hostname, true) | default(openshift_master_cluster_hostname, true) | default('openshift', true) }}"
 
 openshift_cluster_monitoring_operator_node_selector: "{{ openshift_hosted_infra_selector | default('node-role.kubernetes.io/infra=true') | map_from_pairs }}"

--- a/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
+++ b/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
@@ -116,8 +116,8 @@
   command: "{{ openshift_client_binary }} get crd servicemonitors.monitoring.coreos.com -n openshift-monitoring --config={{ mktemp.stdout }}/admin.kubeconfig"
   register: crd
   until: crd.rc == 0
-  delay: 30
-  retries: 30
+  delay: "{{ openshift_cluster_monitoring_operator_crd_delay }}"
+  retries: "{{ openshift_cluster_monitoring_operator_crd_retries }}"
 
 - name: Delete temp directory
   file:


### PR DESCRIPTION
ServiceMonitor CRD may not be created in 30 * 30 secs, due to slow image pulls or insufficient CPU

This PR adds two vars:
```
openshift_cluster_monitoring_operator_crd_retries: 30
openshift_cluster_monitoring_operator_crd_delay: 30
```
which set time to wait while CRD is being created


Fixes #10969