### PR TITLE
Backup node-config and atomic-openshift services.

### DIFF
--- a/roles/openshift_control_plane/tasks/upgrade.yml
+++ b/roles/openshift_control_plane/tasks/upgrade.yml
@@ -142,6 +142,16 @@
     state: absent
   when: not openshift_is_atomic | bool
 
+- name: Backup atomic-openshift systemd services
+  copy:
+    src: "{{ item }}"
+    dest: "{{ item | regex_replace('[.]', '-') }}.bak-{{ ansible_date_time.iso8601_basic_short }}"
+    remote_src: yes
+  with_items:
+  - /etc/systemd/system/atomic-openshift-master.service
+  - /etc/systemd/system/atomic-openshift-node.service
+  failed_when: false
+
 - name: Remove old service information
   file:
     path: "{{ item }}"

--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -1,4 +1,14 @@
 ---
+- name: Backup node config and atomic-openshift service
+  copy:
+    src: "{{ item }}"
+    dest: "{{ item | regex_replace('[.]', '-') }}.bak-{{ ansible_date_time.iso8601_basic_short }}"
+    remote_src: yes
+  with_items:
+  - "{{ openshift.common.config_base }}/node/node-config.yaml"
+  - /etc/systemd/system/atomic-openshift-node.service
+  failed_when: false
+
 - name: Update oreg value
   yedit:
     src: "{{ openshift.common.config_base }}/node/node-config.yaml"


### PR DESCRIPTION
[Bug 1609191](https://bugzilla.redhat.com/show_bug.cgi?id=1609191)

Make a copy of the node-config.yaml for potential downgrade.

The bz says to make copies of: `/etc/systemd/system/atomic-openshift-*.service`

The docs mention several other files that should be backed up, but I did not include them in this pr. Would be happy to add them: https://docs.openshift.com/container-platform/3.10/upgrading/automated_upgrades.html#preparing-for-an-automated-upgrade