### PR TITLE
Add ssh retries to ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -35,6 +35,7 @@ unparsed_is_failed=true
 
 # Additional ssh options for OpenShift Ansible
 [ssh_connection]
+retries = 15
 pipelining = True
 ssh_args = -o ControlMaster=auto -o ControlPersist=600s
 timeout = 10


### PR DESCRIPTION
Bringing the change made for CI to the project ansible.cfg to support running scaleup directly.
Ref: https://github.com/openshift/openshift-ansible/pull/11203/commits/4a125183a50aa61d3fb2869b00ce3c40ff801eb7