### PR TITLE
Change namespace of testing bastion server to byoh-ssh-bastion.

### DIFF
--- a/test/aws/files/01_service.yml
+++ b/test/aws/files/01_service.yml
@@ -4,7 +4,7 @@ metadata:
   labels:
     run: ssh-bastion
   name: ssh-bastion
-  namespace: openshift-ssh-bastion
+  namespace: byoh-ssh-bastion
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"

--- a/test/aws/files/02_serviceaccount.yml
+++ b/test/aws/files/02_serviceaccount.yml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ssh-bastion
-  namespace: openshift-ssh-bastion
+  namespace: byoh-ssh-bastion

--- a/test/aws/files/03_role.yml
+++ b/test/aws/files/03_role.yml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ssh-bastion
-  namespace: openshift-ssh-bastion
+  namespace: byoh-ssh-bastion
 rules:
 - apiGroups:
   - security.openshift.io

--- a/test/aws/files/04_rolebinding.yml
+++ b/test/aws/files/04_rolebinding.yml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     openshift.io/description: Allows ssh-pod to run as root
   name: ssh-bastion
-  namespace: openshift-ssh-bastion
+  namespace: byoh-ssh-bastion
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -12,4 +12,4 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: system:serviceaccount:openshift-ssh-bastion:ssh-bastion
+  name: system:serviceaccount:byoh-ssh-bastion:ssh-bastion

--- a/test/aws/files/06_clusterrolebinding.yml
+++ b/test/aws/files/06_clusterrolebinding.yml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: system:serviceaccount:openshift-ssh-bastion:ssh-bastion
+  name: system:serviceaccount:byoh-ssh-bastion:ssh-bastion

--- a/test/aws/files/07_deployment.yml
+++ b/test/aws/files/07_deployment.yml
@@ -4,7 +4,7 @@ metadata:
   labels:
     run: ssh-bastion
   name: ssh-bastion
-  namespace: openshift-ssh-bastion
+  namespace: byoh-ssh-bastion
 spec:
   replicas: 1
   selector:

--- a/test/aws/ssh_bastion.yml
+++ b/test/aws/ssh_bastion.yml
@@ -3,7 +3,7 @@
   k8s:
     kubeconfig: "{{ kubeconfig_path }}"
     kind: Namespace
-    name: openshift-ssh-bastion
+    name: byoh-ssh-bastion
     state: present
 
 - name: Create ssh bastion keys secret
@@ -14,7 +14,7 @@
       kind: Secret
       metadata:
         name: ssh-host-keys
-        namespace: openshift-ssh-bastion
+        namespace: byoh-ssh-bastion
       data:
         ssh_host_rsa_key: "{{ lookup('file', '../../inventory/dynamic/injected/ssh-privatekey') | b64encode }}"
         sshd_config: "{{ lookup('file', 'files/sshd_config') | b64encode }}"
@@ -58,7 +58,7 @@
 - name: Wait for ssh bastion deployment to rollout
   k8s_facts:
     kubeconfig: "{{ kubeconfig_path }}"
-    namespace: openshift-ssh-bastion
+    namespace: byoh-ssh-bastion
     kind: Deployment
     name: ssh-bastion
   register: k8s_result
@@ -74,7 +74,7 @@
 - name: Get ssh bastion address
   k8s_facts:
     kubeconfig: "{{ kubeconfig_path }}"
-    namespace: openshift-ssh-bastion
+    namespace: byoh-ssh-bastion
     kind: Service
     name: ssh-bastion
   register: k8s_result


### PR DESCRIPTION
This changes the namespace of the CI testing ssh bastion from `openshift-ssh-bastion` to `byoh-ssh-bastion` (open to other suggestions).

PR #11400 is failing with:
```
fail [github.com/openshift/origin/test/extended/operators/images.go:87]: Mar 25 17:32:31.819: Pods found with invalid container images not present in release payload: openshift-ssh-bastion/ssh-bastion-86cc5c6fd7-zn2t9/ssh-bastion image=quay.io/eparis/ssh:latest
```
We should be able to fix that by moving the bastion host out of the openshift- or kube- namespaces:
https://github.com/openshift/origin/blob/master/test/extended/operators/images.go#L58