### PR TITLE
Teardown: remove security using cluster ID tag

### DIFF
--- a/test/ci/deprovision.yml
+++ b/test/ci/deprovision.yml
@@ -23,21 +23,28 @@
         wait: yes
       with_items: "{{ ec2.instances }}"
 
-    - when: aws_use_auto_terminator | default(true)
-      block:
-        - name: Rename VMs
-          ec2_tag:
-            resource: "{{ item.instance_id }}"
-            region: "{{ aws_region }}"
-            tags:
-              Name: "{{ item.tags.Name }}-terminate"
-          when: "'-terminate' not in item.tags.Name"
-          with_items: "{{ ec2.instances }}"
-
-    - name: Delete security groups
-      ec2_group:
-        group_id: "{{ item.security_groups.0.group_id }}"
-        state: absent
+    - name: Rename VMs
+      ec2_tag:
+        resource: "{{ item.instance_id }}"
         region: "{{ aws_region }}"
+        tags:
+          Name: "{{ item.tags.Name }}-terminate"
       with_items: "{{ ec2.instances }}"
-      when: not aws_use_auto_terminator | default(true)
+      when:
+        - aws_use_auto_terminator | default(true)
+        - "'-terminate' not in item.tags.Name"
+
+    - when: not aws_use_auto_terminator | default(true)
+      block:
+        - name: Find security groups
+          ec2_group_facts:
+            region: "{{ aws_region }}"
+            filters:
+              tag-key: "kubernetes.io/cluster/{{ aws_cluster_id }}"
+          register: ec2_groups
+        - name: Delete security groups
+          ec2_group:
+            name: "{{ item.group_id }}"
+            state: absent
+            region: "{{ aws_region }}"
+          with_items: "{{ ec2_groups.security_groups }}"


### PR DESCRIPTION
Fixes teardown error:
```
ERROR! no action detected in task. This often indicates a misspelled module name, or incorrect module path.

The error appears to have been in '/usr/share/ansible/openshift-ansible/test/ci/deprovision.yml': line 47, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


    - name: Delete security groups
      ^ here
```