### PR TITLE
Clear the cni config  on boot

### DIFF
--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -5,6 +5,11 @@
     dest: /usr/local/bin/openshift-node
     mode: 0500
 
+- name: Install cni-cleanup file
+  template:
+    dest: "/usr/lib/tmpfiles.d/cleanup-cni.conf"
+    src: "cleanup-cni.j2"
+
 - name: Install Node service file
   template:
     dest: "/etc/systemd/system/{{ openshift_service_type }}-node.service"

--- a/roles/openshift_node/templates/cleanup-cni.j2
+++ b/roles/openshift_node/templates/cleanup-cni.j2
@@ -1,0 +1,2 @@
+r /etc/cni/net.d/80-openshift-network.conf
+r /etc/origin/openvswitch/conf.db

--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -46,7 +46,7 @@ spec:
           set -euo pipefail
 
           # if another process is listening on the cni-server socket, wait until it exits
-          trap 'kill $(jobs -p); exit 0' TERM
+          trap 'kill $(jobs -p); rm -Rf /etc/cni/net.d/80-openshift-network.conf ; exit 0' TERM
           retries=0
           while true; do
             if echo 'test' | socat - UNIX-CONNECT:/var/run/openshift-sdn/cni-server.sock >/dev/null; then
@@ -167,7 +167,11 @@ spec:
         #     path: /healthz
         #     port: 10256
         #     scheme: HTTP
+        # force node to be notready when sdn is gone.
         lifecycle:
+          preStop:
+            exec:
+              command: ["rm","-Rf","/etc/cni/net.d/80-openshift-network.conf", "/host/opt/cni/bin/openshift-sdn"]
 
       volumes:
       # In bootstrap mode, the host config contains information not easily available


### PR DESCRIPTION
Networking is ready when the /etc/cni/net.d/80-openshift-network.conf
exists. When the host is rebooted or power cycled, this file is
still on the disk and the cluster immediately starts creating pods.
This change deletes the file before the cluster node is started.

templates/cni-cleanup.j2 is the unit file that dos the delete,
tasks/systemd_units.yml is the playbook that references it.

SDN-329 - Create a systemd unit that clears the cni configuration directory on boot
https://jira.coreos.com/browse/SDN-329

Part of solution to:
Bug 1654044 - OCP 3.11: pods end up in CrashLoopBackOff state after a rolling reboot of the node

Signed-off-by: Phil Cameron <pcameron@redhat.com>