### PR TITLE
ASB: use `${version}` in default Origin image

### DIFF
--- a/roles/ansible_service_broker/defaults/main.yml
+++ b/roles/ansible_service_broker/defaults/main.yml
@@ -24,7 +24,7 @@ ansible_service_broker_local_registry_whitelist: []
 ansible_service_broker_local_registry_namespaces: ["openshift"]
 
 l_asb_default_images_dict:
-  origin: 'docker.io/ansibleplaybookbundle/origin-ansible-service-broker:latest'
+  origin: 'docker.io/ansibleplaybookbundle/origin-ansible-service-broker:${version}'
   openshift-enterprise: 'registry.redhat.io/openshift3/ose-ansible-service-broker:${version}'
 
 l_asb_default_images_default: "{{ l_asb_default_images_dict[openshift_deployment_type] }}"


### PR DESCRIPTION
Latest ASB versions are not compatible with 3.11, so default image pullspec should be templated so that it could be used on 3.11 or 3.10

Fixes #11213