### PR TITLE
No longer install etcd package on masters

### DIFF
--- a/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
+++ b/roles/etcd/tasks/certificates/fetch_server_certificates_from_ca.yml
@@ -5,6 +5,7 @@
     state: present
   when:
   - not etcd_is_atomic | bool
+  - not inventory_hostname in groups['oo_masters']
   register: result
   until: result is succeeded
 


### PR DESCRIPTION
Prior to this change, the etcd package was installed on the etcd hosts even if they were masters. It is not necessary on masters because they run etcd as a static pod. This has caused confusion for admins trying to start the etcd services on their clusters. 

This changes removes the installation of the etcd package if the host is a master.

https://bugzilla.redhat.com/show_bug.cgi?id=1690900