### PR TITLE
Increase ssh retries for CI scaleup

### DIFF
--- a/inventory/dynamic/aws/ansible.cfg
+++ b/inventory/dynamic/aws/ansible.cfg
@@ -39,7 +39,7 @@ unparsed_is_failed=true
 
 # Additional ssh options for OpenShift Ansible
 [ssh_connection]
-retries = 10
+retries = 15
 pipelining = True
 ssh_args = -o ControlMaster=auto -o ControlPersist=600s
 timeout = 10


### PR DESCRIPTION
Seeing success at 9 retries and failures at 10.  Bumping this up to prevent being on the edge of success.