### PR TITLE
lib_utils to parse *_storage_host variables with get_templated

### DIFF
--- a/roles/lib_utils/action_plugins/generate_pv_pvcs_list.py
+++ b/roles/lib_utils/action_plugins/generate_pv_pvcs_list.py
@@ -32,7 +32,7 @@ class ActionModule(ActionBase):
 
     def build_pv_nfs(self, varname=None):
         """Build pv dictionary for nfs storage type"""
-        host = self.task_vars.get(str(varname) + '_host')
+        host = self.get_templated(str(varname) + '_host')
         if host:
             self._templar.template(host)
         elif host is None:


### PR DESCRIPTION
Prior to this change, lib_utils did not parse the *_storage_host variables using ansible templating mechanics prior to using their values when configuring nfs persistent volumes. As a result, if these variables included other variables (ie openshift_metrics_storage_host="{{ netapp }}"), then their literal string values (ie "{{ netapp }}") would be used instead of the parsed value of the variable.

This change parses the *_storage_host variables via ansible templating before using them to configure nfs persistent volumes.

https://bugzilla.redhat.com/show_bug.cgi?id=1670418