### PR TITLE
Fixes 11419 - missing default oreg_url value

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -80,3 +80,6 @@ l_required_docker_version: '1.13'
 l_insecure_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l2_docker_insecure_registries)) }}"
 l_crio_registries: "{{ l2_docker_additional_registries + ['docker.io'] }}"
 l_additional_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l_crio_registries)) }}"
+
+oreg_url: "registry.redhat.io/openshift3/ose-${component}:${version}"
+


### PR DESCRIPTION
Sets a default for `oreg_url` in the `container_runtime` role, as it is needed per https://github.com/openshift/openshift-ansible/commit/6ce0ecc9f44170626a7ed44b06db18f47058db57#diff-90877efe325ca457cac9ff7838e909c8

Fixes #11419

Initial testing looks good