### PR TITLE
Providing default oreg_url for validation

### DIFF
--- a/roles/container_runtime/tasks/common/pre.yml
+++ b/roles/container_runtime/tasks/common/pre.yml
@@ -8,6 +8,6 @@
   when:
     - openshift_deployment_type == 'openshift-enterprise'
     - openshift_docker_ent_reg != ''
-    - openshift_docker_ent_reg in oreg_url
+    - openshift_docker_ent_reg in oreg_url | default('')
     - openshift_docker_ent_reg not in l2_docker_additional_registries
     - not openshift_use_crio_only | bool


### PR DESCRIPTION
Sets a default for oreg_url in the container_runtime pre check, as it is needed per 6ce0ecc#diff-90877efe325ca457cac9ff7838e909c8

Fixes #11419

Initial testing looks good