### PR TITLE
Fix wrong storage_class assignment for Elastic Search when using two GlusterFS clusters

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -404,7 +404,7 @@
       obj_name: "{{ openshift_logging_elasticsearch_pvc_name }}"
       size: "{{ (openshift_logging_elasticsearch_pvc_size | trim | length == 0) | ternary('10Gi', openshift_logging_elasticsearch_pvc_size) }}"
       access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
-      pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"      
+      pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
     when:
     - not openshift_logging_elasticsearch_pvc_dynamic | bool
 

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -404,8 +404,7 @@
       obj_name: "{{ openshift_logging_elasticsearch_pvc_name }}"
       size: "{{ (openshift_logging_elasticsearch_pvc_size | trim | length == 0) | ternary('10Gi', openshift_logging_elasticsearch_pvc_size) }}"
       access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
-      pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
-      storage_class_name: "{{ openshift_logging_elasticsearch_pvc_storage_class_name | default('', true) }}"
+      pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"      
     when:
     - not openshift_logging_elasticsearch_pvc_dynamic | bool
 
@@ -419,6 +418,7 @@
       size: "{{ (openshift_logging_elasticsearch_pvc_size | trim | length == 0) | ternary('10Gi', openshift_logging_elasticsearch_pvc_size) }}"
       access_modes: "{{ openshift_logging_elasticsearch_pvc_access_modes | list }}"
       pv_selector: "{{ openshift_logging_elasticsearch_pvc_pv_selector }}"
+      storage_class_name: "{{ openshift_logging_elasticsearch_pvc_storage_class_name | default('', true) }}"
     when:
     - openshift_logging_elasticsearch_pvc_dynamic | bool
 


### PR DESCRIPTION
Fix #11447, using storage_class_name variable for dynamic pvc instead of static one.