### PR TITLE
Option to add and annotate namespaces for openshift-service-catalog

### DIFF
--- a/roles/aci/defaults/main.yml
+++ b/roles/aci/defaults/main.yml
@@ -11,3 +11,9 @@ r_aci_node_os_firewall_allow:
   port: 53/tcp
 - service: dnsu
   port: 53/udp
+
+annotate_namespace_list:
+- openshift-console
+- openshift-monitoring
+- openshift-web-console
+- kube-service-catalog

--- a/roles/aci/tasks/main.yml
+++ b/roles/aci/tasks/main.yml
@@ -9,3 +9,20 @@
   import_role:
     name: kube_proxy_and_dns
   run_once: True
+- name: include lib_openshift
+  include_role:
+    name: lib_openshift
+- name: Create namespaces
+  oc_project:
+    state: present
+    name: "{{ item }}"
+  with_items: "{{ annotate_namespace_list }}"
+  delegate_to: "{{ groups.oo_first_master.0 }}"
+- name: Get aci policy tenant name
+  shell: "grep -m1 'aci-policy-tenant' {{ aci_deployment_yaml_file }} | awk -F '\"' '{print $4}'"
+  register: tenant
+  delegate_to: "{{ groups.oo_first_master.0 }}"
+- name: Annotate namespaces created
+  shell: "oc annotate namespace {{ item }} opflex.cisco.com/endpoint-group='{\"policy-space\":\"{{ tenant.stdout }}\", \"name\": \"kubernetes|kube-system\"}' --overwrite=True"
+  with_items: "{{ annotate_namespace_list }}"
+  delegate_to: "{{ groups.oo_first_master.0 }}"


### PR DESCRIPTION
Adding tasks in roles/aci to create and annotate the following namespaces:
openshift-console
openshift-monitoring
openshift-web-console
kube-service-catalog