### PR TITLE
Use oc binary instead of k8s_facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ tracks our current work **in development**.
 Requirements:
 
 - Ansible >= 2.7.8
-- pyOpenSSL
-- python2-openshift
 
 # Quickstart
 

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -49,24 +49,20 @@
     dest: "{{ tempfile.path }}/pull-secret.json"
 
 - name: Get release image
-  k8s_facts:
-    kubeconfig: "{{ openshift_kubeconfig_path }}"
-    kind: ClusterVersion
-    name: version
+  command: >
+    oc get clusterversion
+    --config={{ openshift_kubeconfig_path }}
+    --output=jsonpath='{.items[0].status.desired.image}'
   delegate_to: localhost
-  register: clusterversion
+  register: oc_get
   until:
-  - clusterversion.resources is defined
-  - clusterversion.resources | length > 0
-  - clusterversion.resources[0].status is defined
-  - clusterversion.resources[0].status.desired is defined
-  - clusterversion.resources[0].status.desired.image is defined
+  - oc_get.stdout != ''
   retries: 36
   delay: 5
 
 - name: Set openshift_release_image fact
   set_fact:
-    openshift_release_image: "{{ clusterversion.resources[0].status.desired.image }}"
+    openshift_release_image: "{{ oc_get.stdout }}"
 
 - name: Pull release image
   command: "podman pull --tls-verify={{ openshift_node_tls_verify }} --authfile {{ tempfile.path }}/pull-secret.json {{ openshift_release_image }}"


### PR DESCRIPTION
Removes dependency on python2-openshift for public playbooks.

'test' playbooks still use k8s modules and require python2-openshift