### PR TITLE
Remove block storageclass when uninstalling

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_uninstall.yml
@@ -42,6 +42,8 @@
     name: "glusterfs-{{ glusterfs_name }}"
   - kind: storageclass
     name: "glusterfs-{{ glusterfs_name }}"
+  - kind: storageclass
+    name: "glusterfs-{{ glusterfs_name }}-block"
 
 - name: Unlabel GlusterFS nodes
   oc_label:


### PR DESCRIPTION
Removes block storageclass when uninstalling gluster. This resource was left behind prior this patch.