### PR TITLE
redeploy certificates fails if use_crio_only

### DIFF
--- a/playbooks/openshift-node/private/restart.yml
+++ b/playbooks/openshift-node/private/restart.yml
@@ -16,7 +16,9 @@
     until: not (l_docker_restart_docker_in_node_result is failed)
     retries: 3
     delay: 30
-    when: openshift_node_restart_docker_required | default(True)
+    when:
+    - openshift_node_restart_docker_required | default(True)
+    - not openshift_use_crio_only | bool
 
   - name: Wait for master API to come back online
     wait_for:

--- a/playbooks/redeploy-certificates.yml
+++ b/playbooks/redeploy-certificates.yml
@@ -12,6 +12,8 @@
 - import_playbook: openshift-master/private/restart.yml
 
 - import_playbook: openshift-node/private/restart.yml
+  vars:
+    openshift_node_restart_docker_required: False
 
 - import_playbook: openshift-hosted/private/redeploy-router-certificates.yml
   when: openshift_hosted_manage_router | default(true) | bool


### PR DESCRIPTION
If `openshift_use_crio_only: true` don't try to restart docker since it won't be installed.

Bug 1695856 - https://bugzilla.redhat.com/show_bug.cgi?id=1695856

