### PR TITLE
[release-3.10] ASB: use `${version}` in default image

### DIFF
--- a/roles/ansible_service_broker/defaults/main.yml
+++ b/roles/ansible_service_broker/defaults/main.yml
@@ -23,7 +23,7 @@ ansible_service_broker_auto_escalate: false
 ansible_service_broker_local_registry_whitelist: []
 
 l_asb_default_images_dict:
-  origin: 'docker.io/ansibleplaybookbundle/origin-ansible-service-broker:latest'
+  origin: 'docker.io/ansibleplaybookbundle/origin-ansible-service-broker:${version}'
   openshift-enterprise: 'registry.access.redhat.com/openshift3/ose-ansible-service-broker:${version}'
 
 l_asb_default_images_default: "{{ l_asb_default_images_dict[openshift_deployment_type] }}"


### PR DESCRIPTION
Latest ASB versions are not compatible with 3.11, so default image pullspec should be templated so that it could be used on 3.11 or 3.10

Cherrypick of #11411 on 3.10