### PR TITLE
tmpfile.d file clears the cni config on boot

### DIFF
--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -5,6 +5,11 @@
     dest: /usr/local/bin/openshift-node
     mode: 0500
 
+- name: Install cni-cleanup file
+  template:
+    dest: "/usr/lib/tmpfiles.d/cleanup-cni.conf"
+    src: "cleanup-cni.j2"
+
 - name: Install Node service file
   template:
     dest: "/etc/systemd/system/{{ openshift_service_type }}-node.service"

--- a/roles/openshift_node/templates/cleanup-cni.j2
+++ b/roles/openshift_node/templates/cleanup-cni.j2
@@ -1,0 +1,2 @@
+r /etc/cni/net.d/80-openshift-network.conf
+r /etc/origin/openvswitch/conf.db

--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -45,7 +45,7 @@ spec:
           set -euo pipefail
 
           # if another process is listening on the cni-server socket, wait until it exits
-          trap 'kill $(jobs -p); exit 0' TERM
+          trap 'kill $(jobs -p); rm -f /etc/cni/net.d/80-openshift-network.conf ; exit 0' TERM
           retries=0
           while true; do
             if echo 'test' | socat - UNIX-CONNECT:/var/run/openshift-sdn/cni-server.sock >/dev/null; then
@@ -160,9 +160,12 @@ spec:
         #     path: /healthz
         #     port: 10256
         #     scheme: HTTP
+        # force node to be notready when sdn is gone.
         lifecycle:
-      tolerations:
-      - operator: "Exists"
+          preStop:
+            exec:
+              command: ["rm","-f","/etc/cni/net.d/80-openshift-network.conf", "/host/opt/cni/bin/openshift-sdn"]
+
       volumes:
       # In bootstrap mode, the host config contains information not easily available
       # from other locations.


### PR DESCRIPTION
cherry-pick e0bd10ba519a206e726be94674cd01aa8685d774
PR 11409 from release-3.11

Networking is ready when the /etc/cni/net.d/80-openshift-network.conf
exists. When the host is rebooted or power cycled, this file is
still on the disk and the cluster immediately starts creating pods.
This change deletes the file before the cluster node is started.

roles/openshift_node/templates/cleanup-cni.j2 is the tmpfile.d file that does the delete,
tasks/systemd_units.yml is the playbook that references it.

Add a lifecycle: preStop hook to the delete the files.

Also deletes ovs db on boot (contents are invalid after boot)

SDN-329 - Create a systemd unit that clears the cni configuration directory on boot
https://jira.coreos.com/browse/SDN-329

Part of solution to:
Bug 1654044 - OCP 3.11: pods end up in CrashLoopBackOff state after a rolling reboot of the node

Signed-off-by: Phil Cameron <pcameron@redhat.com>