### PR TITLE
Console cert redeploy: rerun install

### DIFF
--- a/playbooks/openshift-console/private/redeploy-certificates.yml
+++ b/playbooks/openshift-console/private/redeploy-certificates.yml
@@ -13,23 +13,5 @@
       state: absent
       namespace: openshift-console
 
-  - name: Remove console pods
-    oc_obj:
-      selector: "app=openshift-console"
-      kind: pod
-      state: absent
-      namespace: openshift-console
-
-  - name: Verify that the console is running
-    oc_obj:
-      namespace: openshift-console
-      kind: deployment
-      state: list
-      name: console
-    register: console_deployment
-    until:
-    - console_deployment.results.results[0].status.readyReplicas is defined
-    - console_deployment.results.results[0].status.readyReplicas > 0
-    retries: 60
-    delay: 10
-    changed_when: false
+  - import_role:
+      name: openshift_console


### PR DESCRIPTION
Removing console pods is insufficient: named certificates are not being applied. Console template needs to be reapplied