### PR TITLE
Change the cni-cleanup file path to /etc

### DIFF
--- a/roles/openshift_node/tasks/systemd_units.yml
+++ b/roles/openshift_node/tasks/systemd_units.yml
@@ -7,7 +7,7 @@
 
 - name: Install cni-cleanup file
   template:
-    dest: "/usr/lib/tmpfiles.d/cleanup-cni.conf"
+    dest: "/etc/tmpfiles.d/cleanup-cni.conf"
     src: "cleanup-cni.j2"
 
 - name: Install Node service file


### PR DESCRIPTION
The path /usr/lib/tmpfiles.d is not writeable on Atomic Hosts.