### PR TITLE
Dockerfile: install python2-psutil and lock azure-cli-core

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -16,7 +16,7 @@ RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl 
  && if [ "$(uname -m)" == "x86_64" ]; then yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm ; fi \
  && yum install -y java-1.8.0-openjdk-headless \
  && rpm -V $INSTALL_PKGS $EPEL_PKGS $EPEL_TESTING_PKGS \
- && pip install 'apache-libcloud~=2.2.1' 'SecretStorage<3' 'ansible[azure]' 'boto3==1.4.6' \
+ && pip install 'apache-libcloud~=2.2.1' 'SecretStorage<3' 'azure-cli-core==2.0.61' 'ansible[azure]==2.4.3' 'boto3==1.4.6' \
  && yum clean all
 
 LABEL name="openshift/origin-ansible" \

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -10,7 +10,7 @@ COPY images/installer/origin-extra-root /
 # install ansible and deps
 RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
- && EPEL_PKGS="ansible-2.4.3.0* python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46" \
+ && EPEL_PKGS="ansible-2.4.3.0* python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46 python2-psutil" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
  && if [ "$(uname -m)" == "x86_64" ]; then yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm ; fi \


### PR DESCRIPTION
Newer azure-cli-core requires psutils via pip, but it can't be installed as base image no longer has gcc