### PR TITLE
Fixes NotReady nodes after ca and certificate update

### DIFF
--- a/playbooks/openshift-node/private/certificates-backup.yml
+++ b/playbooks/openshift-node/private/certificates-backup.yml
@@ -1,0 +1,18 @@
+---
+- name: Backup and remove node certificates
+  hosts: oo_nodes_to_config
+  any_errors_fatal: true
+  roles:
+  - openshift_facts
+  tasks:
+  - name: Backup node config directories
+    command: >
+      tar -czvf /etc/origin/node-cert-config-backup-{{ ansible_date_time.epoch }}.tgz
+      {{ openshift.common.config_base }}/node
+  - name: Remove generated certificates
+    file:
+      path: "{{ openshift.common.config_base }}/node/{{ item }}"
+      state: absent
+    with_items:
+    - certificates
+    - bootstrap.kubeconfig

--- a/playbooks/redeploy-certificates.yml
+++ b/playbooks/redeploy-certificates.yml
@@ -15,6 +15,15 @@
   vars:
     openshift_node_restart_docker_required: False
 
+- import_playbook: openshift-master/private/enable_bootstrap.yml
+  when: openshift_redeploy_openshift_ca | default(false) | bool
+
+- import_playbook: openshift-node/private/certificates-backup.yml
+  when: openshift_redeploy_openshift_ca | default(false) | bool
+
+- import_playbook: openshift-node/private/join.yml
+  when: openshift_redeploy_openshift_ca | default(false) | bool
+
 - import_playbook: openshift-hosted/private/redeploy-router-certificates.yml
   when: openshift_hosted_manage_router | default(true) | bool
 
@@ -24,6 +33,7 @@
 - import_playbook: openshift-master/private/revert-client-ca.yml
 
 - import_playbook: openshift-master/private/restart.yml
+
 
 - import_playbook: openshift-web-console/private/redeploy-certificates.yml
   when: openshift_web_console_install | default(true) | bool


### PR DESCRIPTION
Adds existing playbooks to reploy certificates that will bootstrap the node if `openshift_redeploy_openshift_ca` is true.

Removes and replaces the existing node certs and bootstrap.kubeconfig

Bug 1652746 - https://bugzilla.redhat.com/show_bug.cgi?id=1652746

Would require a documentation update.