### PR TITLE
[release-3.11] OWNERS File Audit

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
 # approval == this is a good idea /approve
 approvers:
   - mtnbikenc

--- a/playbooks/aws/OWNERS
+++ b/playbooks/aws/OWNERS
@@ -2,15 +2,7 @@
 approvers:
   - kwoodson
   - abutcher
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - kwoodson
   - abutcher
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/playbooks/azure/OWNERS
+++ b/playbooks/azure/OWNERS
@@ -1,8 +1,7 @@
-reviewers:
-- jim-minter
-- kwoodson
-- pweil-
 approvers:
-- jim-minter
-- kwoodson
-- pweil-
+  - jim-minter
+  - kwoodson
+  - pweil-
+reviewers:
+  - jim-minter
+  - kwoodson

--- a/playbooks/gcp/OWNERS
+++ b/playbooks/gcp/OWNERS
@@ -1,14 +1,6 @@
 # approval == this is a good idea /approve
 approvers:
   - smarterclayton
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - smarterclayton
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/playbooks/metrics-server/OWNERS
+++ b/playbooks/metrics-server/OWNERS
@@ -1,20 +1,12 @@
 # approval == this is a good idea /approve
 approvers:
   - ewolinetz
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
   - sross
   - brancz
   - frobware
 # review == this code is good /lgtm
 reviewers:
   - ewolinetz
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
   - sross
   - brancz
   - frobware

--- a/playbooks/openshift-checks/OWNERS
+++ b/playbooks/openshift-checks/OWNERS
@@ -1,14 +1,6 @@
 # approval == this is a good idea /approve
 approvers:
   - sosiouxme
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - sosiouxme
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/playbooks/openshift-console/OWNERS
+++ b/playbooks/openshift-console/OWNERS
@@ -1,14 +1,6 @@
 # approval == this is a good idea /approve
 approvers:
   - spadgett
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - spadgett
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/playbooks/openshift-descheduler/OWNERS
+++ b/playbooks/openshift-descheduler/OWNERS
@@ -1,10 +1,6 @@
 # approval == this is a good idea /approve
 approvers:
-  - aveshagarwal
-  - ingvagabund
   - ravisantoshgudimetla
 # review == this code is good /lgtm
 reviewers:
-  - aveshagarwal
-  - ingvagabund
   - ravisantoshgudimetla

--- a/playbooks/openshift-glusterfs/OWNERS
+++ b/playbooks/openshift-glusterfs/OWNERS
@@ -1,14 +1,6 @@
 # approval == this is a good idea /approve
 approvers:
   - jarrpa
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - jarrpa
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/playbooks/openshift-metrics/OWNERS
+++ b/playbooks/openshift-metrics/OWNERS
@@ -2,15 +2,7 @@
 approvers:
   - ewolinetz
   - jcantrill
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - ewolinetz
   - jcantrill
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/playbooks/openshift-node-problem-detector/OWNERS
+++ b/playbooks/openshift-node-problem-detector/OWNERS
@@ -2,9 +2,7 @@
 approvers:
   - ironcladlou
   - joelsmith
-  - ingvagabund
 # review == this code is good /lgtm
 reviewers:
   - ironcladlou
   - joelsmith
-  - ingvagabund

--- a/playbooks/openshift-service-catalog/OWNERS
+++ b/playbooks/openshift-service-catalog/OWNERS
@@ -1,16 +1,10 @@
 # approval == this is a good idea /approve
 approvers:
-  - jpeeler
   - jboyd01
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
+  - shawn-hurley
+  - jmrodri
 # review == this code is good /lgtm
 reviewers:
-  - jpeeler
   - jboyd01
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
+  - shawn-hurley
+  - jmrodri

--- a/playbooks/openshift-web-console/OWNERS
+++ b/playbooks/openshift-web-console/OWNERS
@@ -1,14 +1,6 @@
 # approval == this is a good idea /approve
 approvers:
   - spadgett
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - spadgett
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/playbooks/ovirt/OWNERS
+++ b/playbooks/ovirt/OWNERS
@@ -1,10 +1,6 @@
 # approval == this is a good idea /approve
 approvers:
-  - jcantrill
-  - ewolinetz
-  - richm
+  - rgolangh
 # review == this code is good /lgtm
 reviewers:
-  - jcantrill
-  - ewolinetz
-  - richm
+  - rgolangh

--- a/roles/ansible_service_broker/OWNERS
+++ b/roles/ansible_service_broker/OWNERS
@@ -3,16 +3,8 @@ approvers:
   - fabianvf
   - dymurray
   - shawn-hurley
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - fabianvf
   - dymurray
   - shawn-hurley
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/roles/openshift_aws/OWNERS
+++ b/roles/openshift_aws/OWNERS
@@ -2,15 +2,7 @@
 approvers:
   - kwoodson
   - abutcher
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - kwoodson
   - abutcher
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/roles/openshift_builddefaults/OWNERS
+++ b/roles/openshift_builddefaults/OWNERS
@@ -1,14 +1,7 @@
 # approval == this is a good idea /approve
 approvers:
   - bparees
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
+  - adambkaplan
 # review == this code is good /lgtm
 reviewers:
-  - bparees
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
+  - adambkaplan

--- a/roles/openshift_buildoverrides/OWNERS
+++ b/roles/openshift_buildoverrides/OWNERS
@@ -1,14 +1,7 @@
 # approval == this is a good idea /approve
 approvers:
   - bparees
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
+  - adambkaplan
 # review == this code is good /lgtm
 reviewers:
-  - bparees
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
+  - adambkaplan

--- a/roles/openshift_ca/OWNERS
+++ b/roles/openshift_ca/OWNERS
@@ -1,14 +1,6 @@
 # approval == this is a good idea /approve
 approvers:
   - abutcher
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - abutcher
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/roles/openshift_certificate_expiry/OWNERS
+++ b/roles/openshift_certificate_expiry/OWNERS
@@ -1,14 +1,6 @@
 # approval == this is a good idea /approve
 approvers:
   - abutcher
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - abutcher
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/roles/openshift_cfme/OWNERS
+++ b/roles/openshift_cfme/OWNERS
@@ -2,11 +2,9 @@
 approvers:
   - jcantrill
   - ewolinetz
-  - sdodson
 # review == this code is good /lgtm
 reviewers:
   - jcantrill
   - ewolinetz
   - richm
-  - wozniakjan
   - zgalor

--- a/roles/openshift_console/OWNERS
+++ b/roles/openshift_console/OWNERS
@@ -2,9 +2,7 @@
 approvers:
   - spadgett
   - jwforres
-  - sdodson
 # review == this code is good /lgtm
 reviewers:
   - spadgett
   - jwforres
-  - sdodson

--- a/roles/openshift_daemonset_config/OWNERS
+++ b/roles/openshift_daemonset_config/OWNERS
@@ -2,15 +2,7 @@
 approvers:
   - kwoodson
   - abutcher
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - kwoodson
   - abutcher
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/roles/openshift_descheduler/OWNERS
+++ b/roles/openshift_descheduler/OWNERS
@@ -1,10 +1,6 @@
 # approval == this is a good idea /approve
 approvers:
-  - aveshagarwal
-  - ingvagabund
   - ravisantoshgudimetla
 # review == this code is good /lgtm
 reviewers:
-  - aveshagarwal
-  - ingvagabund
   - ravisantoshgudimetla

--- a/roles/openshift_docker_gc/OWNERS
+++ b/roles/openshift_docker_gc/OWNERS
@@ -1,10 +1,8 @@
 # approval == this is a good idea /approve
 approvers:
-  - ashcrow
   - kwoodson
   - mrunalp
 # review == this code is good /lgtm
 reviewers:
-  - ashcrow
   - kwoodson
   - mrunalp

--- a/roles/openshift_gcp/OWNERS
+++ b/roles/openshift_gcp/OWNERS
@@ -1,14 +1,6 @@
 # approval == this is a good idea /approve
 approvers:
   - smarterclayton
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - smarterclayton
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/roles/openshift_health_checker/OWNERS
+++ b/roles/openshift_health_checker/OWNERS
@@ -1,14 +1,6 @@
 # approval == this is a good idea /approve
 approvers:
   - sosiouxme
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - sosiouxme
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/roles/openshift_logging/OWNERS
+++ b/roles/openshift_logging/OWNERS
@@ -3,10 +3,8 @@ approvers:
   - jcantrill
   - ewolinetz
   - richm
-  - wozniakjan
 # review == this code is good /lgtm
 reviewers:
   - jcantrill
   - ewolinetz
   - richm
-  - wozniakjan

--- a/roles/openshift_logging_curator/OWNERS
+++ b/roles/openshift_logging_curator/OWNERS
@@ -2,10 +2,8 @@
 approvers:
   - jcantrill
   - ewolinetz
-  - sdodson
 # review == this code is good /lgtm
 reviewers:
   - jcantrill
   - ewolinetz
   - richm
-  - wozniakjan

--- a/roles/openshift_logging_defaults/OWNERS
+++ b/roles/openshift_logging_defaults/OWNERS
@@ -2,7 +2,6 @@
 approvers:
   - jcantrill
   - ewolinetz
-  - sdodson
 # review == this code is good /lgtm
 reviewers:
   - jcantrill

--- a/roles/openshift_logging_elasticsearch/OWNERS
+++ b/roles/openshift_logging_elasticsearch/OWNERS
@@ -2,10 +2,8 @@
 approvers:
   - jcantrill
   - ewolinetz
-  - sdodson
 # review == this code is good /lgtm
 reviewers:
   - jcantrill
   - ewolinetz
   - richm
-  - wozniakjan

--- a/roles/openshift_logging_eventrouter/OWNERS
+++ b/roles/openshift_logging_eventrouter/OWNERS
@@ -2,10 +2,8 @@
 approvers:
   - jcantrill
   - ewolinetz
-  - sdodson
 # review == this code is good /lgtm
 reviewers:
   - jcantrill
   - ewolinetz
   - richm
-  - wozniakjan

--- a/roles/openshift_logging_fluentd/OWNERS
+++ b/roles/openshift_logging_fluentd/OWNERS
@@ -2,10 +2,8 @@
 approvers:
   - jcantrill
   - ewolinetz
-  - sdodson
 # review == this code is good /lgtm
 reviewers:
   - jcantrill
   - ewolinetz
   - richm
-  - wozniakjan

--- a/roles/openshift_logging_kibana/OWNERS
+++ b/roles/openshift_logging_kibana/OWNERS
@@ -2,10 +2,8 @@
 approvers:
   - jcantrill
   - ewolinetz
-  - sdodson
 # review == this code is good /lgtm
 reviewers:
   - jcantrill
   - ewolinetz
   - richm
-  - wozniakjan

--- a/roles/openshift_logging_mux/OWNERS
+++ b/roles/openshift_logging_mux/OWNERS
@@ -3,10 +3,8 @@ approvers:
   - jcantrill
   - ewolinetz
   - richm
-  - wozniakjan
 # review == this code is good /lgtm
 reviewers:
   - jcantrill
   - ewolinetz
   - richm
-  - wozniakjan

--- a/roles/openshift_named_certificates/OWNERS
+++ b/roles/openshift_named_certificates/OWNERS
@@ -1,14 +1,6 @@
 # approval == this is a good idea /approve
 approvers:
   - abutcher
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
 # review == this code is good /lgtm
 reviewers:
   - abutcher
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs

--- a/roles/openshift_node_problem_detector/OWNERS
+++ b/roles/openshift_node_problem_detector/OWNERS
@@ -2,9 +2,7 @@
 approvers:
   - ironcladlou
   - joelsmith
-  - ingvagabund
 # review == this code is good /lgtm
 reviewers:
   - ironcladlou
   - joelsmith
-  - ingvagabund

--- a/roles/openshift_ovirt/OWNERS
+++ b/roles/openshift_ovirt/OWNERS
@@ -1,10 +1,6 @@
 # approval == this is a good idea /approve
 approvers:
-  - jcantrill
-  - ewolinetz
-  - richm
+  - rgolangh
 # review == this code is good /lgtm
 reviewers:
-  - jcantrill
-  - ewolinetz
-  - richm
+  - rgolangh

--- a/roles/openshift_service_catalog/OWNERS
+++ b/roles/openshift_service_catalog/OWNERS
@@ -1,16 +1,10 @@
 # approval == this is a good idea /approve
 approvers:
-  - jpeeler
   - jboyd01
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
+  - shawn-hurley
+  - jmrodri
 # review == this code is good /lgtm
 reviewers:
-  - jpeeler
   - jboyd01
-  - michaelgugino
-  - mtnbikenc
-  - sdodson
-  - vrutkovs
+  - shawn-hurley
+  - jmrodri

--- a/roles/openshift_storage_glusterfs/OWNERS
+++ b/roles/openshift_storage_glusterfs/OWNERS
@@ -2,9 +2,7 @@
 approvers:
   - jarrpa
   - abutcher
-  - sdodson
 # review == this code is good /lgtm
 reviewers:
   - jarrpa
   - abutcher
-  - sdodson

--- a/roles/openshift_web_console/OWNERS
+++ b/roles/openshift_web_console/OWNERS
@@ -2,9 +2,7 @@
 approvers:
   - spadgett
   - jwforres
-  - sdodson
 # review == this code is good /lgtm
 reviewers:
   - spadgett
   - jwforres
-  - sdodson


### PR DESCRIPTION
- Core openshift-ansible team members only listed in root OWNERS file
- Adds roles/openshift_ovirt/OWNERS

Please review the files you are listed in to ensure they are current.  If you are the only person listed, please suggest additional alternates.  If no change is required, a :+1: reaction on the PR description is sufficient.  Thanks!

Summary of all approvers/reviewers for mentioning:
```
grep -r " - " --include "OWNERS" . | awk '{print "@"$(NF)}' | sort | uniq | tr '\n' ' '
```

@abutcher @alecmerdler @ashcrow @aveshagarwal @bparees @brancz @csrwng @dgoodwin @dymurray @ecordell @elad661 @ewolinetz @fabianvf @frobware @ingvagabund @ironcladlou @jarrpa @jboyd01 @jcantrill @jcpowermac @jeremyeder @jim-minter @jmencak @joelsmith @jpeeler @jsanda @jstuever @jwforres @kwoodson @luis5tb @mrunalp @mtnbikenc @mxinden @njhale @patrickdillon @pweil- @ravisantoshgudimetla @rgolangh @richm @sdodson @shawn-hurley @smarterclayton @sosiouxme @spadgett @sross @tomassedovic @tzumainn @vrutkovs @wozniakjan @zgalor

50 approvers/reviewers
