### PR TITLE
Add --debug flag to skopeo inspect in image health check.

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -20,7 +20,7 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
     # to look for images available remotely without actually pulling them.
 
     # command for checking if remote registries have an image, without docker pull
-    skopeo_command = "{proxyvars} timeout 10 skopeo inspect --tls-verify={tls} {creds} docker://{image}"
+    skopeo_command = "{proxyvars} timeout 30 skopeo --debug inspect --tls-verify={tls} {creds} docker://{image}"
     skopeo_example_command = "skopeo inspect [--tls-verify=false] [--creds=<user>:<pass>] docker://<registry>/<image>"
 
     def ensure_list(self, registry_param):

--- a/roles/openshift_health_checker/test/docker_image_availability_test.py
+++ b/roles/openshift_health_checker/test/docker_image_availability_test.py
@@ -17,9 +17,9 @@ def test_is_available_skopeo_image():
     with patch.object(DockerImageAvailability, 'execute_module_with_retries') as m1:
         m1.return_value = result
         assert dia.is_available_skopeo_image('registry.redhat.io/openshift3/ose-pod') is True
-        m1.assert_called_with('command', {'_uses_shell': True, '_raw_params': ' timeout 10 skopeo inspect --tls-verify=true  docker://registry.redhat.io/openshift3/ose-pod'})
+        m1.assert_called_with('command', {'_uses_shell': True, '_raw_params': ' timeout 30 skopeo --debug inspect --tls-verify=true  docker://registry.redhat.io/openshift3/ose-pod'})
         assert dia.is_available_skopeo_image('insecure.redhat.io/openshift3/ose-pod') is True
-        m1.assert_called_with('command', {'_uses_shell': True, '_raw_params': ' timeout 10 skopeo inspect --tls-verify=false  docker://insecure.redhat.io/openshift3/ose-pod'})
+        m1.assert_called_with('command', {'_uses_shell': True, '_raw_params': ' timeout 30 skopeo --debug inspect --tls-verify=false  docker://insecure.redhat.io/openshift3/ose-pod'})
 
     # test auth
     task_vars = {'oreg_auth_user': 'test_user', 'oreg_auth_password': 'test_pass'}
@@ -27,7 +27,7 @@ def test_is_available_skopeo_image():
     with patch.object(DockerImageAvailability, 'execute_module_with_retries') as m1:
         m1.return_value = result
         assert dia.is_available_skopeo_image('registry.redhat.io/openshift3/ose-pod') is True
-        m1.assert_called_with('command', {'_uses_shell': True, '_raw_params': ' timeout 10 skopeo inspect --tls-verify=true --creds=test_user:test_pass docker://registry.redhat.io/openshift3/ose-pod'})
+        m1.assert_called_with('command', {'_uses_shell': True, '_raw_params': ' timeout 30 skopeo --debug inspect --tls-verify=true --creds=test_user:test_pass docker://registry.redhat.io/openshift3/ose-pod'})
 
 
 def test_available_images():


### PR DESCRIPTION
Adding debug output to skopeo inspect in the docker image availability check would make these issues easier to troubleshoot. I have been looking at [bug 1692364](https://bugzilla.redhat.com/show_bug.cgi?id=1692364) and #11369 and it would be very helpful to know whether the nodes are connecting to the registries.