### PR TITLE
Test using Ansible 2.7.10

### DIFF
--- a/images/installer/origin-extra-root/etc/yum.repos.d/ansible-releases.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/ansible-releases.repo
@@ -1,0 +1,5 @@
+[ansible-releases]
+name=Ansible Releases Repo
+baseurl=https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/
+enabled=1
+gpgcheck=0

--- a/images/installer/origin-extra-root/etc/yum.repos.d/centos-ansible27.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/centos-ansible27.repo
@@ -1,6 +1,0 @@
-
-[centos-ansible27-testing]
-name=CentOS Ansible 2.7 testing repo
-baseurl=https://cbs.centos.org/repos/configmanagement7-ansible-27-testing/x86_64/os/
-enabled=1
-gpgcheck=0

--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -66,6 +66,7 @@ cp -rp test %{buildroot}%{_datadir}/ansible/%{name}/
 %package test
 Summary:       Openshift and Atomic Enterprise Ansible Test Playbooks
 Requires:      %{name} = %{version}-%{release}
+Requires:      ansible = 2.7.10
 Requires:      python-boto3
 Requires:      openssh-clients
 BuildArch:     noarch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.7.8
+ansible==2.7.10


### PR DESCRIPTION
Moves tox and CI image to use Ansible 2.7.10 (latest) for testing.

This diverges the testing version of Ansible from the required version of Ansible.  This will improve the ability to test newer versions of Ansible without having to require them.

Required: Ansible >= 2.7.8
Testing: Ansible = 2.7.10