### PR TITLE
[release-3.11] WIP Ensure master vars are passed to openshift_facts on upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
@@ -73,4 +73,10 @@
   - openshift_facts:
       role: master
       local_facts:
+        api_use_ssl: "{{ openshift_master_api_use_ssl | default(None) }}"
+        api_port: "{{ openshift_master_api_port }}"
+        controllers_port: "{{ openshift_master_controllers_port | default(None) }}"
+        console_use_ssl: "{{ openshift_master_console_use_ssl | default(None) }}"
+        console_path: "{{ openshift_master_console_path | default(None) }}"
+        console_port: "{{ openshift_master_console_port | default(None) }}"
         ha: "{{ groups.oo_masters_to_config | length > 1 }}"


### PR DESCRIPTION
This ensures a custom api_port/controllers_port/console_port and other vital connection params are passed to openshift_facts. Without these set it may use default values

Cherrypick of #11487 to release-3.11

/cc @jstuever @sdodson @mtnbikenc 