### PR TITLE
Change conditional_set_fact templating all facts (#25)

### DIFF
--- a/roles/lib_openshift/action_plugins/conditional_set_fact.py
+++ b/roles/lib_openshift/action_plugins/conditional_set_fact.py
@@ -54,7 +54,7 @@ class ActionModule(ActionBase):
 
             for other_var in other_vars.split('|'):
                 if other_var in facts:
-                    local_facts[param] = facts[other_var]
+                    local_facts[param] = self._templar.template(facts[other_var])
                     break
 
         if local_facts:


### PR DESCRIPTION
The action plugin conditional_set_fact did not
templating the hostvars, causing facts containing
jinja2 templates passed as string.