### PR TITLE
Annotating openshift specific namespaces for ACI CNI

### DIFF
--- a/roles/aci/tasks/main.yml
+++ b/roles/aci/tasks/main.yml
@@ -19,10 +19,13 @@
   with_items: "{{ annotate_namespace_list }}"
   delegate_to: "{{ groups.oo_first_master.0 }}"
 - name: Get aci policy tenant name
-  shell: "grep -m1 'aci-policy-tenant' {{ aci_deployment_yaml_file }} | awk -F '\"' '{print $4}'"
+  shell: grep -m1 'aci-policy-tenant' {{ aci_deployment_yaml_file }} | awk -F '\"' '{print $4}'
   register: tenant
   delegate_to: "{{ groups.oo_first_master.0 }}"
-- name: Annotate namespaces created
-  shell: "oc annotate namespace {{ item }} opflex.cisco.com/endpoint-group='{\"policy-space\":\"{{ tenant.stdout }}\", \"name\": \"kubernetes|kube-system\"}' --overwrite=True"
+- name: Annotate namespace created
+  command: >
+    oc annotate namespace {{ item }}
+    opflex.cisco.com/endpoint-group='{"policy-space":"{{ tenant.stdout }}", "name": "kubernetes|kube-system"}'
+    --overwrite=True
   with_items: "{{ annotate_namespace_list }}"
   delegate_to: "{{ groups.oo_first_master.0 }}"


### PR DESCRIPTION
Previous code: https://github.com/openshift/openshift-ansible/blob/release-3.11/roles/aci/tasks/main.yml#L22-L26 . It did not annotate correctly. Putting some extra `\` thought it was introduced as escape char.
New code:
Removing confusing ' and " for better readability. 