### PR TITLE
Specify version when installing oc on first master.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
@@ -45,12 +45,18 @@
 
   # Need client package to check gluster health when upgrading from containerized.
   - name: Install openshift clients on first master
-    package:
-      name: "{{ openshift_service_type }}-clients{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
-      state: present
+    command: "{{ ansible_pkg_mgr }} install -y {{ openshift_node_upgrade_rpm_list | join(' ')}}"
     register: result
     until: result is succeeded
-    retries: 3
+    failed_when:
+    - result.stdout is search(".*No package .* available.*") or result is failed
+    vars:
+      openshift_node_upgrade_rpm_list:
+      - "{{ openshift_service_type }}{{ openshift_pkg_version }}"
+      - "{{ openshift_service_type }}-clients{{ openshift_pkg_version }}"
+      - "{{ openshift_service_type }}-master{{ openshift_pkg_version }}"
+      - "{{ openshift_service_type }}-node{{ openshift_pkg_version }}"
+      - "{{ openshift_service_type }}-sdn-ovs{{ openshift_pkg_version }}"
     when: not openshift_is_atomic | bool
 
   # Ensure glusterfs clusters are healthy before starting an upgrade.


### PR DESCRIPTION
[Bug 1692730](https://bugzilla.redhat.com/show_bug.cgi?id=1692730)

When installing the oc client on the first master, we should do it the same way we do on the nodes, where we specify the package version for every dependency:
https://github.com/openshift/openshift-ansible/blob/release-3.11/roles/openshift_node/tasks/upgrade/rpm_upgrade_install.yml

This will ensure that the installed package is the version specified in the inventory. Without this fix, a circular dependency could cause a later version to be installed.