### PR TITLE
#10765 Update installation doc link for release-3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ sudo ansible-playbook -i inventory/hosts.localhost playbooks/deploy_cluster.yml
 
 ## Complete Production Installation Documentation:
 
-- [OpenShift Enterprise](https://docs.openshift.com/enterprise/latest/install_config/install/advanced_install.html)
-- [OpenShift Origin](https://docs.openshift.org/latest/install_config/install/advanced_install.html)
+- [OpenShift Container Platform](https://docs.openshift.com/container-platform/3.9/install_config/install/planning.html)
+- [OpenShift Origin](https://docs.okd.io/3.9/install_config/install/planning.html)
 
 ## Containerized OpenShift Ansible
 


### PR DESCRIPTION
- Fix link to go directly correct version of the installation documentation
- Rename Link from OpenShift Enterprise to OpenShift Container Platform