### PR TITLE
#10765 Update installation doc link for release-3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,9 @@ created for you automatically.
 
 ## Complete Production Installation Documentation:
 
-- [OpenShift Enterprise](https://docs.openshift.com/enterprise/latest/install_config/install/advanced_install.html)
-- [OpenShift Origin](https://docs.openshift.org/latest/install_config/install/advanced_install.html)
+- [OpenShift Container Platform](https://docs.openshift.com/container-platform/3.10/install/index.html)
+- [OKD](https://docs.okd.io/3.10/install/index.html) (formerly OpenShift Origin)
+
 
 ## Containerized OpenShift Ansible
 


### PR DESCRIPTION
- Precise link to go directly to the correct version of the installation documentation
- Rename Link OpenShift Origin to OKD
- Rename Link OpenShift Enterprise to OpenShift Container Platform