### PR TITLE
[release-3.11] Test using Ansible 2.7.10

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -10,7 +10,7 @@ COPY images/installer/origin-extra-root /
 # install ansible and deps
 RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
- && EPEL_PKGS="ansible-2.7.8 python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46" \
+ && EPEL_PKGS="ansible-2.7.10 python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
  && if [ "$(uname -m)" == "x86_64" ]; then yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm ; fi \

--- a/images/installer/origin-extra-root/etc/yum.repos.d/ansible-releases.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/ansible-releases.repo
@@ -1,0 +1,5 @@
+[ansible-releases]
+name=Ansible Releases Repo
+baseurl=https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/
+enabled=1
+gpgcheck=0

--- a/images/installer/origin-extra-root/etc/yum.repos.d/centos-ansible27.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/centos-ansible27.repo
@@ -1,6 +1,0 @@
-
-[centos-ansible27-testing]
-name=CentOS Ansible 2.7 testing repo
-baseurl=https://cbs.centos.org/repos/configmanagement7-ansible-27-testing/x86_64/os/
-enabled=1
-gpgcheck=0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.7.8
+ansible==2.7.10
 boto==2.44.0
 click==6.7
 pyOpenSSL==17.5.0


### PR DESCRIPTION
Moves tox and CI image to use Ansible 2.7.10 (latest) for testing.

This diverges the testing version of Ansible from the required version
of Ansible. This will improve the ability to test newer versions of
Ansible without having to require them.

Required: Ansible >= 2.5.7
Testing: Ansible = 2.7.10