### PR TITLE
Remove early oc client install on upgrade.

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
@@ -43,16 +43,6 @@
     - openshift_release is defined
     - not (openshift_release is version_compare(openshift_upgrade_target ,'='))
 
-  # Need client package to check gluster health when upgrading from containerized.
-  - name: Install openshift clients on first master
-    package:
-      name: "{{ openshift_service_type }}-clients{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
-      state: present
-    register: result
-    until: result is succeeded
-    retries: 3
-    when: not openshift_is_atomic | bool
-
   # Ensure glusterfs clusters are healthy before starting an upgrade.
   - import_role:
       name: openshift_storage_glusterfs

--- a/roles/openshift_storage_glusterfs/tasks/cluster_health.yml
+++ b/roles/openshift_storage_glusterfs/tasks/cluster_health.yml
@@ -1,9 +1,27 @@
 ---
+# according to bz-1649795 the oc client may not be in the path
+# when run as sudo, this task confirms the client is available
+# or tries to set the appropriate value
+- name: Check that oc client binary is available
+  include_tasks: oc_client_check.yml
+  vars:
+    path: "{{ item }}"
+  with_items:
+  - "{{ hostvars[groups.oo_first_master.0]['first_master_client_binary'] }}"
+  - oc
+  - /usr/bin/oc
+  - /usr/local/bin/oc
+
+- name: Ensure oc client binary was found
+  fail:
+    msg: "The oc client binary could not be found. It is required to run GlusterFS health checks."
+  when: oc_bin_path is undefined
+
 # glusterfs_check_containerized is a custom module defined at
 # lib_utils/library/glusterfs_check_containerized.py
 - name: Check for GlusterFS cluster health
   glusterfs_check_containerized:
-    oc_bin: "{{ hostvars[groups.oo_first_master.0]['first_master_client_binary'] }}"
+    oc_bin: "{{ oc_bin_path }}"
     oc_conf: "{{ openshift.common.config_base }}/master/admin.kubeconfig"
     oc_namespace: "{{ glusterfs_namespace }}"
     cluster_name: "{{ glusterfs_name }}"

--- a/roles/openshift_storage_glusterfs/tasks/oc_client_check.yml
+++ b/roles/openshift_storage_glusterfs/tasks/oc_client_check.yml
@@ -1,0 +1,11 @@
+---
+- name: Test oc client path
+  command: "{{ path }} version"
+  register: binary_check
+  failed_when: false
+  when: oc_bin_path is undefined
+
+- name: Set oc_bin_path when client is found
+  set_fact:
+    oc_bin_path: "{{ path }}"
+  when: binary_check is changed


### PR DESCRIPTION
[Bug 1692730](https://bugzilla.redhat.com/show_bug.cgi?id=1692730)
Also, reverts previous fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1649795

This removes the installation of oc client binaries from early in the upgrade process on the first master. Installation was added because the binary can be missing when upgrading from containerized installs, but the installation is problematic because it updates several dependencies early in the upgrade process. Instead of installing the client early on, I added a check to ensure the oc client is available for the gluster health check, otherwise skip it.