### PR TITLE
Correctly evaluate openshift_metrics_heapster_standalone variable if …

### DIFF
--- a/roles/openshift_metrics/templates/heapster.j2
+++ b/roles/openshift_metrics/templates/heapster.j2
@@ -40,7 +40,7 @@ spec:
         - "--tls_client_ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
         - "--allowed_users=%allowed_users%"
         - "--metric_resolution={{openshift_metrics_resolution}}"
-{% if not openshift_metrics_heapster_standalone %}
+{% if not openshift_metrics_heapster_standalone | bool %}
         - "--wrapper.username_file=/hawkular-account/hawkular-metrics.username"
         - "--wrapper.password_file=/hawkular-account/hawkular-metrics.password"
         - "--wrapper.endpoint_check=https://hawkular-metrics:443/hawkular/metrics/status"
@@ -83,7 +83,7 @@ spec:
           mountPath: "/secrets"
         - name: heapster-certs
           mountPath: "/heapster-certs"
-{% if not openshift_metrics_heapster_standalone %}
+{% if not openshift_metrics_heapster_standalone | bool %}
         - name: hawkular-metrics-certs
           mountPath: "/hawkular-metrics-certs"
         - name: hawkular-metrics-account
@@ -100,7 +100,7 @@ spec:
         - name: heapster-certs
           secret:
             secretName: heapster-certs
-{% if not openshift_metrics_heapster_standalone %}
+{% if not openshift_metrics_heapster_standalone | bool %}
         - name: hawkular-metrics-certs
           secret:
             secretName: hawkular-metrics-certs


### PR DESCRIPTION
…it is 'false' with small f

This ensures that if `openshift_metrics_heapster_standalone` is defined as false **with small f**, then it will be treated as false (as one would reasonably expect) in all places, and the needed parts about hawkular-metrics-certs and Heapster configuration will not be skipped.

https://bugzilla.redhat.com/show_bug.cgi?id=1696249