### PR TITLE
Add nodeName to node-config template for azure

### DIFF
--- a/playbooks/prerequisites.yml
+++ b/playbooks/prerequisites.yml
@@ -6,7 +6,9 @@
   - name: Fail when openshift_kubelet_name_override is defined
     fail:
       msg: "openshift_kubelet_name_override Cannot be defined for new hosts"
-    when: openshift_kubelet_name_override is defined
+    when:
+    - openshift_kubelet_name_override is defined
+    - openshift_cloudprovider_kind | default('', true) != 'azure'
 
 - import_playbook: init/main.yml
   vars:

--- a/roles/openshift_node_group/tasks/create_config.yml
+++ b/roles/openshift_node_group/tasks/create_config.yml
@@ -12,6 +12,8 @@
   template:
     src: node-config.yaml.j2
     dest: "{{ mktempout.stdout }}/node-config.yaml"
+  vars:
+    openshift_node_group_configmap: true
   when:
   - configout.results.results.0 == {}
   run_once: true

--- a/roles/openshift_node_group/templates/node-config.yaml.j2
+++ b/roles/openshift_node_group/templates/node-config.yaml.j2
@@ -70,3 +70,8 @@ volumeConfig:
   localQuota:
     perFSGroup: null
 volumeDirectory: {{ openshift_node_group_node_data_dir }}/openshift.local.volumes
+{% if (openshift_node_group_cloud_provider | default('', true) == 'azure') and
+      (openshift_kubelet_name_override | default('', true) != '') and
+      (not openshift_node_group_configmap | default(false) | bool) %}
+nodeName: {{ l_kubelet_node_name }}
+{% endif %}


### PR DESCRIPTION
In the case of azure with idm apply the `nodeName` or `--hostname-override`
to the node-config during bootstrap.

If using azure allow the use of openshift_kubelet_name_override during install.

Bug 1656983 - https://bugzilla.redhat.com/show_bug.cgi?id=1656983