### PR TITLE
Remove systemd-journal-gateway from package list

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -22,7 +22,7 @@ openshift_node_support_packages:
   - irqbalance
   - microcode_ctl
   - systemd
-  - systemd-journal-gateway
+  #- systemd-journal-gateway
   #- rpm-ostree
   #- nss-altfiles
   - selinux-policy-targeted


### PR DESCRIPTION
Removes unnecessary package for RHEL nodes.

Bug 1699808

https://bugzilla.redhat.com/show_bug.cgi?id=1699808