### PR TITLE
Introducing boolean variable to bind master's API to default ipv4 address instead of 0.0.0.0

### DIFF
--- a/roles/openshift_master_facts/defaults/main.yml
+++ b/roles/openshift_master_facts/defaults/main.yml
@@ -21,3 +21,5 @@ openshift_master_admission_plugin_config:
         - key: images.openshift.io/deny-execution
           value: "true"
         skipOnResolutionFailure: true
+
+openshift_master_bind_addr_use_default_ipv4_address: false

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -38,7 +38,7 @@
       public_console_url: "{{ openshift_master_public_console_url | default(None) }}"
       logging_public_url: "{{ openshift_master_logging_public_url | default(None) }}"
       logout_url: "{{ openshift_master_logout_url | default(None) }}"
-      bind_addr: "{{ openshift_master_bind_addr | default(None) }}"
+      bind_addr: "{{ openshift_master_bind_addr | default(ansible_default_ipv4.address if openshift_master_bind_addr_use_default_ipv4_address else None) }}"
       session_max_seconds: "{{ openshift_master_session_max_seconds | default(None) }}"
       session_name: "{{ openshift_master_session_name | default(None) }}"
       ldap_ca: "{{ openshift_master_ldap_ca | default(lookup('file', openshift_master_ldap_ca_file) if openshift_master_ldap_ca_file is defined else None) }}"


### PR DESCRIPTION
By default, the installer setups API master process to bind to address: 0.0.0.0:{{ openshift_master_api_port }}. It prevents the administrator to start up another process in the same port but, of course, another IP.

The installer already supports it by declaring the variable in the inventory.

```
[masters]
master01 openshift_master_bind_addr=x.y.z.a
master02 openshift_master_bind_addr=x.y.z.b
master03 openshift_master_bind_addr=x.y.z.c

```
However, this might be redundant and error-prone.

In order to improve it, this PR introduces a variable that instruct the installer to use the host's default ipv4 address: openshift_master_bind_addr_use_default_ipv4_address.

This PR does not change the default and current behavior. Only adds this new option to the administrator.
