### PR TITLE
[release-3.7] Fix misspelled openshift_hosted_registry_namespace var.

### DIFF
--- a/roles/openshift_hosted/tasks/storage/glusterfs_endpoints.yml
+++ b/roles/openshift_hosted/tasks/storage/glusterfs_endpoints.yml
@@ -10,7 +10,7 @@
     dest: "{{ mktempHosted.stdout }}/glusterfs-registry-service.yml"
 
 - name: Create GlusterFS registry service and endpoint
-  command: "{{ openshift.common.client_binary }} apply -f {{ item }} -n {{ openshift.hosted.registry.namespace | default('default') }}"
+  command: "{{ openshift.common.client_binary }} apply -f {{ item }} -n {{ openshift_hosted_registry_namespace | default('default') }}"
   with_items:
   - "{{ mktempHosted.stdout }}/glusterfs-registry-service.yml"
   - "{{ mktempHosted.stdout }}/glusterfs-registry-endpoints.yml"

--- a/roles/openshift_storage_glusterfs/defaults/main.yml
+++ b/roles/openshift_storage_glusterfs/defaults/main.yml
@@ -48,7 +48,7 @@ openshift_storage_glusterfs_heketi_fstab: "{{ '/var/lib/heketi/fstab' | quote if
 openshift_storage_glusterfs_namespace: "{{ 'glusterfs' | quote if openshift_storage_glusterfs_is_native or openshift_storage_glusterfs_heketi_is_native else 'default' | quote }}"
 
 openshift_storage_glusterfs_registry_timeout: "{{ openshift_storage_glusterfs_timeout }}"
-openshift_storage_glusterfs_registry_namespace: "{{ openshift.hosted.registry.namespace | default(openshift_storage_glusterfs_namespace) }}"
+openshift_storage_glusterfs_registry_namespace: "{{ openshift_hosted_registry_namespace | default(openshift_storage_glusterfs_namespace) }}"
 openshift_storage_glusterfs_registry_is_native: "{{ openshift_storage_glusterfs_is_native }}"
 openshift_storage_glusterfs_registry_name: 'registry'
 openshift_storage_glusterfs_registry_nodeselector: "glusterfs={{ openshift_storage_glusterfs_registry_name }}-host"


### PR DESCRIPTION
[Bug 1701900](https://bugzilla.redhat.com/show_bug.cgi?id=1701900)
[Original bug for 3.9](https://bugzilla.redhat.com/show_bug.cgi?id=1698627)

In release-3.7 `openshift_hosted_registry_namespace` was misspelled as `openshift.hosted.registry.namespace`. In https://github.com/patrickdillon/openshift-ansible/blob/release-3.7/roles/openshift_storage_glusterfs/defaults/main.yml#L51 this means the var would not be found, causing the namespace to get set to `glusterfs` where it should be `default`.