### PR TITLE
fixing vm load balancer deployment if a predefined net was defined.

### DIFF
--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -727,10 +727,12 @@ resources:
 {% if openshift_openstack_provider_network_name %}
           net:         {{ openshift_openstack_provider_network_name }}
           net_name:         {{ openshift_openstack_provider_network_name }}
-{% elif openshift_openstack_node_network_id|default(false) %}
+{% else %}
+{% if openshift_openstack_node_network_id|default(false) %}
           net:         {{ openshift_openstack_node_network_id }}
 {% else %}
           net:         { get_resource: net }
+{% endif %}
 {% if openshift_openstack_node_subnet_name %}
           subnet:      {{ openshift_openstack_node_subnet_name }}
 {% else %}


### PR DESCRIPTION
Deploying the vm load-balancer with a predefined network currently fails because net_name is not defined. This pull request fixes this behavior by fixing an issue with the if statements. If statements in this part are now similar to the other servers deployed (like masters, nodes).

Relevant settings which let the heat stack fail before:
```yaml
openshift_openstack_node_subnet_name: "somenet"
openshift_openstack_use_vm_load_balancer: true
```
