### PR TITLE
rhel_subscribe: import satellite tasks before attempting to register system

### DIFF
--- a/roles/rhel_subscribe/tasks/main.yml
+++ b/roles/rhel_subscribe/tasks/main.yml
@@ -15,6 +15,11 @@
   register: rh_subscribed
   changed_when: False
 
+- import_tasks: satellite.yml
+  when:
+    - rhsub_server is defined
+    - "'not registered' in rh_subscribed.stdout"
+
 - name: Register host using user/password
   redhat_subscription:
     username: "{{ rhsub_user }}"
@@ -48,8 +53,3 @@
   register: openshift_pool_attached
   changed_when: "'Successfully attached a subscription' in openshift_pool_attached.stdout"
   when: rhsub_pool not in openshift_pool_attached.stdout
-
-- import_tasks: satellite.yml
-  when:
-    - rhsub_server is defined
-    - rhsub_server


### PR DESCRIPTION
Currently the satellite registration which can be used during provisioning on openstack (playbooks/openstack/openshift-cluster/provision.yml) is not working. The reason seems to be a misplaced import of the satellite tasks (satellite.yml). Also the when statement seems not to work as expected.

This pull request aims to fix the position of importing this tasks as well as the when condition.
The satellite tasks will only be imported if a system is not yet registered.
