### PR TITLE
[release-3.10] Test using Ansible 2.7.10

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -10,7 +10,7 @@ COPY images/installer/origin-extra-root /
 # install ansible and deps
 RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
- && EPEL_PKGS="ansible-2.4.3.0* python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46 python2-psutil" \
+ && EPEL_PKGS="ansible-2.7.10 python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46 python2-psutil" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
  && if [ "$(uname -m)" == "x86_64" ]; then yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm ; fi \

--- a/images/installer/origin-extra-root/etc/yum.repos.d/ansible-releases.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/ansible-releases.repo
@@ -1,0 +1,5 @@
+[ansible-releases]
+name=Ansible Releases Repo
+baseurl=https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/
+enabled=1
+gpgcheck=0

--- a/images/installer/origin-extra-root/etc/yum.repos.d/centos-ansible24.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/centos-ansible24.repo
@@ -1,6 +1,0 @@
-
-[centos-ansible24-release]
-name=CentOS Ansible 2.4 release repo
-baseurl=https://cbs.centos.org/repos/configmanagement7-ansible-24-release/x86_64/os/
-enabled=1
-gpgcheck=0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.4.3.0
+ansible==2.7.10
 boto==2.44.0
 click==6.7
 pyOpenSSL==17.5.0

--- a/roles/openshift_health_checker/test/action_plugin_test.py
+++ b/roles/openshift_health_checker/test/action_plugin_test.py
@@ -50,8 +50,18 @@ def fake_check(name='fake_check', tags=None, is_active=True, run_return=None, ru
 @pytest.fixture
 def plugin():
     task = FakeTask('openshift_health_check', {'checks': ['fake_check']})
-    plugin = ActionModule(task, None, PlayContext(), None, None, None)
+    plugin = ActionModule(task, FakeConnection(), PlayContext(), None, None, None)
     return plugin
+
+
+class FakeShell(object):
+    def __init__(self):
+        self.tmpdir = None
+
+
+class FakeConnection(object):
+    def __init__(self):
+        self._shell = FakeShell()
 
 
 class FakeTask(object):
@@ -59,6 +69,8 @@ class FakeTask(object):
         self.action = action
         self.args = args
         self.async = 0
+        self.async_val = 0
+        self._supports_async = True
 
 
 @pytest.fixture
@@ -149,7 +161,7 @@ def test_action_plugin_skip_disabled_checks(to_disable, plugin, task_vars, monke
 
 def test_action_plugin_run_list_checks(monkeypatch):
     task = FakeTask('openshift_health_check', {'checks': []})
-    plugin = ActionModule(task, None, PlayContext(), None, None, None)
+    plugin = ActionModule(task, FakeConnection(), PlayContext(), None, None, None)
     monkeypatch.setattr(plugin, 'load_known_checks', lambda *_: {})
     result = plugin.run()
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ def find_playbooks():
     all_playbooks = set()
     included_playbooks = set()
 
-    exclude_dirs = ('adhoc', 'tasks')
+    # Skip cluster-operator playbooks, does not conform to user run playbooks
+    exclude_dirs = ('adhoc', 'tasks', 'cluster-operator')
     for yaml_file in find_files(
             os.path.join(os.getcwd(), 'playbooks'),
             exclude_dirs, None, r'^[^\.].*\.ya?ml$'):


### PR DESCRIPTION
Moves tox and CI image to use Ansible 2.7.10 (latest) for testing.

This diverges the testing version of Ansible from the required version
of Ansible. This will improve the ability to test newer versions of
Ansible without having to require them.

Required: Ansible >= 2.4.3.0
Testing: Ansible = 2.7.10

Backports #11517