### PR TITLE
[release-3.9] Test using Ansible 2.7.10

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -10,14 +10,12 @@ COPY images/installer/origin-extra-root /
 # install ansible and deps
 RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
- && EPEL_PKGS="python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli" \
- && EPEL_TESTING_PKGS="ansible" \
+ && EPEL_PKGS="ansible-2.7.10 python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
- && yum install -y --setopt=tsflags=nodocs --enablerepo=epel-testing $EPEL_TESTING_PKGS \
  && yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm \
  && yum install -y java-1.8.0-openjdk-headless \
- && rpm -V $INSTALL_PKGS $EPEL_PKGS $EPEL_TESTING_PKGS \
+ && rpm -V $INSTALL_PKGS $EPEL_PKGS \
  && pip install 'apache-libcloud~=2.2.1' 'SecretStorage<3' 'ansible[azure]' 'boto3==1.4.6' \
  && yum clean all
 

--- a/images/installer/origin-extra-root/etc/yum.repos.d/ansible-releases.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/ansible-releases.repo
@@ -1,0 +1,5 @@
+[ansible-releases]
+name=Ansible Releases Repo
+baseurl=https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/
+enabled=1
+gpgcheck=0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.4.3.0
+ansible==2.7.10
 boto==2.34.0
 click==6.7
 pyOpenSSL==17.5.0

--- a/roles/openshift_health_checker/test/action_plugin_test.py
+++ b/roles/openshift_health_checker/test/action_plugin_test.py
@@ -50,8 +50,18 @@ def fake_check(name='fake_check', tags=None, is_active=True, run_return=None, ru
 @pytest.fixture
 def plugin():
     task = FakeTask('openshift_health_check', {'checks': ['fake_check']})
-    plugin = ActionModule(task, None, PlayContext(), None, None, None)
+    plugin = ActionModule(task, FakeConnection(), PlayContext(), None, None, None)
     return plugin
+
+
+class FakeShell(object):
+    def __init__(self):
+        self.tmpdir = None
+
+
+class FakeConnection(object):
+    def __init__(self):
+        self._shell = FakeShell()
 
 
 class FakeTask(object):
@@ -59,6 +69,8 @@ class FakeTask(object):
         self.action = action
         self.args = args
         self.async = 0
+        self.async_val = 0
+        self._supports_async = True
 
 
 @pytest.fixture
@@ -149,7 +161,7 @@ def test_action_plugin_skip_disabled_checks(to_disable, plugin, task_vars, monke
 
 def test_action_plugin_run_list_checks(monkeypatch):
     task = FakeTask('openshift_health_check', {'checks': []})
-    plugin = ActionModule(task, None, PlayContext(), None, None, None)
+    plugin = ActionModule(task, FakeConnection(), PlayContext(), None, None, None)
     monkeypatch.setattr(plugin, 'load_known_checks', lambda *_: {})
     result = plugin.run()
 


### PR DESCRIPTION
Moves tox and CI image to use Ansible 2.7.10 (latest) for testing.

This diverges the testing version of Ansible from the required version
of Ansible. This will improve the ability to test newer versions of
Ansible without having to require them.

Required: Ansible >= 2.4.3.0
Testing: Ansible = 2.7.10

Backports #11517