### PR TITLE
[release-3.10] Stop gathering Ansible facts in openshift_facts

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
@@ -84,6 +84,7 @@
 
   - openshift_facts:
       role: master
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
       local_facts:
         api_use_ssl: "{{ openshift_master_api_use_ssl | default(None) }}"
         api_port: "{{ openshift_master_api_port }}"

--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -28,6 +28,7 @@
   - name: Gather Cluster facts
     openshift_facts:
       role: common
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
       local_facts:
         hostname: "{{ openshift_kubelet_name_override | default(None) }}"
         ip: "{{ openshift_ip | default(None) }}"
@@ -43,6 +44,7 @@
   - name: Set fact of no_proxy_internal_hostnames
     openshift_facts:
       role: common
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
       local_facts:
         no_proxy_internal_hostnames: "{{ hostvars | lib_utils_oo_select_keys(groups['oo_nodes_to_config']
                                              | union(groups['oo_masters_to_config'])
@@ -61,6 +63,7 @@
   - name: Initialize openshift.node.sdn_mtu
     openshift_facts:
       role: node
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
       local_facts:
         sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
         bootstrapped: "{{ openshift_is_bootstrapped }}"

--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -48,6 +48,7 @@
 
   - openshift_facts:
       role: master
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
       local_facts:
         api_port: "{{ openshift_master_api_port }}"
         api_url: "{{ openshift_master_api_url | default(None) }}"

--- a/roles/openshift_builddefaults/tasks/main.yml
+++ b/roles/openshift_builddefaults/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Set builddefaults
   openshift_facts:
     role: builddefaults
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     # TODO: add ability to define builddefaults env vars sort of like this
     # may need to move the config generation to a filter however.
     local_facts:
@@ -15,5 +16,6 @@
 - name: Set builddefaults config structure
   openshift_facts:
     role: builddefaults
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       config: "{{ openshift_builddefaults_json | default(builddefaults_yaml) }}"

--- a/roles/openshift_buildoverrides/tasks/main.yml
+++ b/roles/openshift_buildoverrides/tasks/main.yml
@@ -2,5 +2,6 @@
 - name: Set buildoverrides config structure
   openshift_facts:
     role: buildoverrides
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       config: "{{ openshift_buildoverrides_json | default(buildoverrides_yaml) }}"

--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -15,6 +15,7 @@
 
 - name: Reload generated facts
   openshift_facts:
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
   when:
   - hostvars[openshift_ca_host].install_result | default({'changed':false}) is changed
 

--- a/roles/openshift_cloud_provider/tasks/main.yml
+++ b/roles/openshift_cloud_provider/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Set cloud provider facts
   openshift_facts:
     role: cloudprovider
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       kind: "{{ openshift_cloudprovider_kind | default(None) }}"
 

--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -81,6 +81,7 @@
 - name: Set fact of all etcd host IPs
   openshift_facts:
     role: common
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       no_proxy_etcd_host_ips: "{{ openshift_no_proxy_etcd_host_ips }}"
 

--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -24,7 +24,6 @@ from ansible.module_utils.six import string_types
 # pylint: disable=redefined-builtin, unused-wildcard-import, wildcard-import
 # import module snippets
 from ansible.module_utils.basic import *  # noqa: F403
-from ansible.module_utils.facts import *  # noqa: F403
 from ansible.module_utils.urls import *  # noqa: F403
 from ansible.module_utils.six import iteritems, itervalues
 from ansible.module_utils.six.moves.urllib.parse import urlparse, urlunparse
@@ -988,7 +987,7 @@ class OpenShiftFacts(object):
 
     # Disabling too-many-arguments, this should be cleaned up as a TODO item.
     # pylint: disable=too-many-arguments,no-value-for-parameter
-    def __init__(self, role, filename, local_facts,
+    def __init__(self, role, filename, system_facts, local_facts,
                  additive_facts_to_overwrite=None):
         self.changed = False
         self.filename = filename
@@ -997,18 +996,7 @@ class OpenShiftFacts(object):
                 "Role %s is not supported by this module" % role
             )
         self.role = role
-
-        # Collect system facts and preface each fact with 'ansible_'.
-        try:
-            # pylint: disable=too-many-function-args,invalid-name
-            self.system_facts = ansible_facts(module, ['hardware', 'network', 'virtual', 'facter'])  # noqa: F405
-            additional_facts = {}
-            for (k, v) in self.system_facts.items():
-                additional_facts["ansible_%s" % k.replace('-', '_')] = v
-            self.system_facts.update(additional_facts)
-        except UnboundLocalError:
-            # ansible-2.2,2.3
-            self.system_facts = get_all_facts(module)['ansible_facts']  # noqa: F405
+        self.system_facts = system_facts
 
         self.facts = self.generate_facts(local_facts,
                                          additive_facts_to_overwrite)
@@ -1238,6 +1226,7 @@ def main():
         argument_spec=dict(
             role=dict(default='common', required=False,
                       choices=OpenShiftFacts.known_roles),
+            system_facts=dict(type='dict', required=True),
             local_facts=dict(default=None, type='dict', required=False),
             additive_facts_to_overwrite=dict(default=[], type='list', required=False),
         ),
@@ -1245,11 +1234,8 @@ def main():
         add_file_common_args=True,
     )
 
-    module.params['gather_subset'] = ['hardware', 'network', 'virtual', 'facter']  # noqa: F405
-    module.params['gather_timeout'] = 10  # noqa: F405
-    module.params['filter'] = '*'  # noqa: F405
-
     role = module.params['role']  # noqa: F405
+    system_facts = module.params['system_facts']
     local_facts = module.params['local_facts']  # noqa: F405
     additive_facts_to_overwrite = module.params['additive_facts_to_overwrite']  # noqa: F405
 
@@ -1257,6 +1243,7 @@ def main():
 
     openshift_facts = OpenShiftFacts(role,
                                      fact_file,
+                                     system_facts,
                                      local_facts,
                                      additive_facts_to_overwrite)
 

--- a/roles/openshift_facts/vars/main.yml
+++ b/roles/openshift_facts/vars/main.yml
@@ -1,0 +1,11 @@
+---
+# Private role variables which cannot be overridden
+vars_openshift_facts_system_facts:
+  ansible_default_ipv4: "{{ vars.ansible_default_ipv4 }}"
+  ansible_nodename: "{{ vars.ansible_nodename }}"
+  ansible_fqdn: "{{ vars.ansible_fqdn }}"
+  ansible_product_name: "{{ vars.ansible_product_name }}"
+  ansible_product_version: "{{ vars.ansible_product_version }}"
+  ansible_virtualization_type: "{{ vars.ansible_virtualization_type }}"
+  ansible_virtualization_role: "{{ vars.ansible_virtualization_role }}"
+  ansible_system_vendor: "{{ vars.ansible_system_vendor }}"

--- a/roles/openshift_management/tasks/add_container_provider.yml
+++ b/roles/openshift_management/tasks/add_container_provider.yml
@@ -5,6 +5,7 @@
 
 - name: Ensure OpenShift facts are loaded
   openshift_facts:
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
 
 - name: Ensure we use openshift_master_cluster_public_hostname if it is available
   set_fact:

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -24,6 +24,7 @@
 - name: Set master facts
   openshift_facts:
     role: master
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       cluster_hostname: "{{ openshift_master_cluster_hostname | default(None) }}"
       cluster_public_hostname: "{{ openshift_master_cluster_public_hostname | default(None) }}"

--- a/roles/openshift_named_certificates/tasks/main.yml
+++ b/roles/openshift_named_certificates/tasks/main.yml
@@ -7,6 +7,7 @@
 
 - openshift_facts:
     role: master
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       named_certificates: "{{ parsed_named_certificates | default([]) }}"
     additive_facts_to_overwrite:

--- a/roles/openshift_node/tasks/configure-proxy-settings.yml
+++ b/roles/openshift_node/tasks/configure-proxy-settings.yml
@@ -1,6 +1,7 @@
 ---
 - openshift_facts:
     role: master
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       cluster_hostname: "{{ openshift_master_cluster_hostname | default(None) }}"
 

--- a/roles/openshift_node/tasks/distribute_bootstrap.yml
+++ b/roles/openshift_node/tasks/distribute_bootstrap.yml
@@ -2,6 +2,7 @@
 - name: Gather node information
   openshift_facts:
     role: node
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       bootstrapped: true
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ def find_playbooks():
     all_playbooks = set()
     included_playbooks = set()
 
-    exclude_dirs = ('adhoc', 'tasks')
+    # Skip cluster-operator playbooks, does not conform to user run playbooks
+    exclude_dirs = ('adhoc', 'tasks', 'cluster-operator')
     for yaml_file in find_files(
             os.path.join(os.getcwd(), 'playbooks'),
             exclude_dirs, None, r'^[^\.].*\.ya?ml$'):


### PR DESCRIPTION
Gathering Ansible facts within modules continues to be problematic and
is unsupported.  Only required facts are now passed in when running the
module reducing the dependency on Ansible internals.

Backports: https://github.com/openshift/openshift-ansible/pull/11525