### PR TITLE
[release-3.7] Test using Ansible 2.7.10

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -214,7 +214,8 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+# Ignoring ansible.constants to suppress `no-member` warnings
+ignored-modules=ansible.constants
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -11,7 +11,7 @@ COPY images/installer/origin-extra-root /
 RUN INSTALL_PKGS="python-lxml pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
  && yum install -y java-1.8.0-openjdk-headless \
- && EPEL_PKGS="ansible python2-boto" \
+ && EPEL_PKGS="ansible-2.7.10 python2-boto" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
  && rpm -V $INSTALL_PKGS $EPEL_PKGS \

--- a/images/installer/origin-extra-root/etc/yum.repos.d/ansible-releases.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/ansible-releases.repo
@@ -1,0 +1,5 @@
+[ansible-releases]
+name=Ansible Releases Repo
+baseurl=https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/
+enabled=1
+gpgcheck=0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.3.2.0
+ansible==2.7.10
 boto==2.34.0
 click==6.7
 pyOpenSSL==17.5.0

--- a/roles/openshift_health_checker/test/action_plugin_test.py
+++ b/roles/openshift_health_checker/test/action_plugin_test.py
@@ -50,8 +50,18 @@ def fake_check(name='fake_check', tags=None, is_active=True, run_return=None, ru
 @pytest.fixture
 def plugin():
     task = FakeTask('openshift_health_check', {'checks': ['fake_check']})
-    plugin = ActionModule(task, None, PlayContext(), None, None, None)
+    plugin = ActionModule(task, FakeConnection(), PlayContext(), None, None, None)
     return plugin
+
+
+class FakeShell(object):
+    def __init__(self):
+        self.tmpdir = None
+
+
+class FakeConnection(object):
+    def __init__(self):
+        self._shell = FakeShell()
 
 
 class FakeTask(object):
@@ -59,6 +69,8 @@ class FakeTask(object):
         self.action = action
         self.args = args
         self.async = 0
+        self.async_val = 0
+        self._supports_async = True
 
 
 @pytest.fixture
@@ -149,7 +161,7 @@ def test_action_plugin_skip_disabled_checks(to_disable, plugin, task_vars, monke
 
 def test_action_plugin_run_list_checks(monkeypatch):
     task = FakeTask('openshift_health_check', {'checks': []})
-    plugin = ActionModule(task, None, PlayContext(), None, None, None)
+    plugin = ActionModule(task, FakeConnection(), PlayContext(), None, None, None)
     monkeypatch.setattr(plugin, 'load_known_checks', lambda *_: {})
     result = plugin.run()
 


### PR DESCRIPTION
Moves tox and CI image to use Ansible 2.7.10 (latest) for testing.

This diverges the testing version of Ansible from the required version
of Ansible. This will improve the ability to test newer versions of
Ansible without having to require them.

Required: Ansible >= 2.3.2.0
Testing: Ansible = 2.7.10