### PR TITLE
Add crio defaults to openshift_facts

### DIFF
--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -8,6 +8,9 @@ openshift_cli_image_dict:
 repoquery_cmd: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --latest-limit 1 -d 0', 'repoquery --plugins') }}"
 repoquery_installed: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --latest-limit 1 -d 0 --disableexcludes=all --installed', 'repoquery --plugins --installed') }}"
 
+openshift_use_crio: False
+openshift_use_crio_only: False
+
 openshift_cli_image: "{{ osm_image | default(openshift_cli_image_dict[openshift_deployment_type]) }}"
 
 # osm_default_subdomain is an old migrated fact, can probably be removed.


### PR DESCRIPTION
In release-3.10 and 3.11 crio defaults are
defined in `roles/openshift_facts/defaults/main.yml`
and are missing in release-3.9.  Added

`openshift_use_crio: False`
`openshift_use_crio_only: False`

Bug 1678372 - https://bugzilla.redhat.com/show_bug.cgi?id=1678372