### PR TITLE
imageconfig playbook fails with undefined variables

### DIFF
--- a/playbooks/openshift-node/imageconfig.yml
+++ b/playbooks/openshift-node/imageconfig.yml
@@ -1,7 +1,7 @@
 ---
 - import_playbook: ../init/main.yml
   vars:
-    l_init_fact_hosts: "oo_masters_to_config"
+    l_init_fact_hosts: "oo_nodes_to_config"
     l_openshift_version_determine_hosts: "all:!all"
     l_openshift_version_set_hosts: "all:!all"
     skip_sanity_checks: True

--- a/playbooks/openshift-node/private/registry_auth.yml
+++ b/playbooks/openshift-node/private/registry_auth.yml
@@ -10,7 +10,7 @@
       state: present
     register: result
     until: result is succeeded
-    when: not (openshift_is_atomic | bool)
+    when: not (openshift_is_atomic | default(false, true) | bool)
     vars:
       pkg_list:
       - atomic


### PR DESCRIPTION
When running `playbooks/openshift-node/imageconfig.yml`
failures were occur with `openshift_is_atomic` undefined and
`openshift` because facts were not executing on the
nodes.

Bug 1676399 - https://bugzilla.redhat.com/show_bug.cgi?id=1676399