### PR TITLE
[release-3.11] Correct usage of openshift_facts

### DIFF
--- a/playbooks/openshift-hosted/private/install_docker_gc.yml
+++ b/playbooks/openshift-hosted/private/install_docker_gc.yml
@@ -1,7 +1,6 @@
 ---
 - name: Install docker gc
   hosts: oo_first_master
-  gather_facts: false
   roles:
   - openshift_facts
   tasks:

--- a/playbooks/openshift-logging/private/config.yml
+++ b/playbooks/openshift-logging/private/config.yml
@@ -17,7 +17,8 @@
 # we want to also collect this for nodes so we can match group entries to nodes
 - name: Get common IP facts when necessary
   hosts: oo_nodes_to_config:!oo_masters
-  gather_facts: false
+  roles:
+  - openshift_facts
   tasks:
   - name: Gather Cluster facts
     openshift_facts:
@@ -28,7 +29,6 @@
 
 - name: Verify and collect ES hosts
   hosts: oo_first_master
-  gather_facts: false
   tasks:
   - when: openshift_logging_install_logging | default(false) | bool
     block:
@@ -95,7 +95,6 @@
 
 - name: Update vm.max_map_count for ES 5.x
   hosts: oo_elasticsearch_nodes
-  gather_facts: false
   tasks:
   - when: openshift_logging_install_logging | default(false) | bool
     block:
@@ -115,7 +114,6 @@
 
 - name: Remove created 99-elasticsearch sysctl
   hosts: all
-  gather_facts: false
   tasks:
   - when: not openshift_logging_install_logging | default(false) | bool
     file:


### PR DESCRIPTION
- The openshift_facts role should be in scope for plays using the custom module.
- gather_facts should not be skipped for tasks using Ansible facts