### PR TITLE
[release-3.10] Correct usage of openshift_facts

### DIFF
--- a/playbooks/openshift-hosted/private/install_docker_gc.yml
+++ b/playbooks/openshift-hosted/private/install_docker_gc.yml
@@ -1,7 +1,6 @@
 ---
 - name: Install docker gc
   hosts: oo_first_master
-  gather_facts: false
   roles:
   - openshift_facts
   tasks:


### PR DESCRIPTION
- The openshift_facts role should be in scope for plays using the custom
module.
- gather_facts should not be skipped for tasks using Ansible facts

Backports #11548