### PR TITLE
Add redeploy-certificates for service catalog

### DIFF
--- a/playbooks/openshift-service-catalog/private/redeploy-certificates.yml
+++ b/playbooks/openshift-service-catalog/private/redeploy-certificates.yml
@@ -1,0 +1,72 @@
+---
+- name: Update service-catalog certificates
+  hosts: oo_first_master
+  vars:
+  roles:
+  - lib_openshift
+  - openshift_facts
+  tasks:
+  - name: Remove TLS secret
+    oc_obj:
+      name: "{{ item }}"
+      kind: secret
+      state: absent
+      namespace: kube-service-catalog
+    with_items:
+    - apiserver-ssl
+    - controllermanager-ssl
+
+  - include_role:
+      name: openshift_service_catalog
+      tasks_from: generate_certs
+
+  - name: Edit DaemonSet and replace the CA hash
+    oc_edit:
+      state: present
+      kind: daemonset
+      name: apiserver
+      namespace: "kube-service-catalog"
+      content:
+        spec.template.metadata.annotations.ca_hash: "{{ apiserver_ca.content|hash('sha1') }}"
+
+  - name: Remove apiserver pods
+    oc_obj:
+      selector: "app=apiserver"
+      kind: pod
+      state: absent
+      namespace: kube-service-catalog
+
+  - name: Verify that the apiserver is running
+    oc_obj:
+      namespace: kube-service-catalog
+      kind: daemonset
+      state: list
+      name: apiserver
+    register: apiserver_ds
+    until:
+    - apiserver_ds.results.results[0].status.numberReady is defined
+    - apiserver_ds.results.results[0].status.numberReady > 0
+    retries: 60
+    delay: 10
+    changed_when: false
+
+  - name: Remove controller-manager pods
+    oc_obj:
+      selector: "app=controller-manager"
+      kind: pod
+      state: absent
+      namespace: kube-service-catalog
+
+  - name: Verify that the controller-manager is running
+    oc_obj:
+      namespace: kube-service-catalog
+      kind: daemonset
+      state: list
+      name: controller-manager
+    register: cm_ds
+    until:
+    - cm_ds.results.results[0].status.numberReady is defined
+    - cm_ds.results.results[0].status.numberReady > 0
+    retries: 60
+    delay: 10
+    changed_when: false

--- a/playbooks/redeploy-certificates.yml
+++ b/playbooks/redeploy-certificates.yml
@@ -34,7 +34,6 @@
 
 - import_playbook: openshift-master/private/restart.yml
 
-
 - import_playbook: openshift-web-console/private/redeploy-certificates.yml
   when: openshift_web_console_install | default(true) | bool
 
@@ -43,3 +42,6 @@
 
 - import_playbook: openshift-monitoring/private/redeploy-certificates.yml
   when: openshift_cluster_monitoring_operator_install | default(true) | bool
+
+- import_playbook: openshift-service-catalog/private/redeploy-certificates.yml
+  when: openshift_enable_service_catalog | default(false) | bool


### PR DESCRIPTION
Adds a redeploy-certificate playbook for the service-catalog
Adds import to playbooks/redeploy-certificates if service-catalog is installed