### PR TITLE
[release-3.9] Stop gathering Ansible facts in openshift_facts

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/verify_cluster.yml
@@ -72,6 +72,7 @@
 
   - openshift_facts:
       role: master
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
       local_facts:
         ha: "{{ groups.oo_masters_to_config | length > 1 }}"
 

--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -9,6 +9,7 @@
   - name: Gather Cluster facts
     openshift_facts:
       role: common
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
       local_facts:
         deployment_type: "{{ openshift_deployment_type }}"
         deployment_subtype: "{{ openshift_deployment_subtype | default(None) }}"
@@ -26,6 +27,7 @@
   - name: Set fact of no_proxy_internal_hostnames
     openshift_facts:
       role: common
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
       local_facts:
         no_proxy_internal_hostnames: "{{ hostvars | lib_utils_oo_select_keys(groups['oo_nodes_to_config']
                                              | union(groups['oo_masters_to_config'])
@@ -39,6 +41,7 @@
   - name: Initialize openshift.node.sdn_mtu
     openshift_facts:
       role: node
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
       local_facts:
         sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
 

--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -41,6 +41,7 @@
   post_tasks:
   - openshift_facts:
       role: master
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
       local_facts:
         api_port: "{{ openshift_master_api_port | default(None) }}"
         api_url: "{{ openshift_master_api_url | default(None) }}"
@@ -63,6 +64,7 @@
   post_tasks:
   - openshift_facts:
       role: master
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
       local_facts:
         session_auth_secrets: "{{ openshift_master_session_auth_secrets | default(openshift.master.session_auth_secrets | default(None)) }}"
         session_encryption_secrets: "{{ openshift_master_session_encryption_secrets | default(openshift.master.session_encryption_secrets | default(None)) }}"
@@ -144,6 +146,7 @@
   tasks:
   - openshift_facts:
       role: master
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
       local_facts:
         session_auth_secrets: "{{ g_session_auth_secrets }}"
         session_encryption_secrets: "{{ g_session_encryption_secrets }}"

--- a/playbooks/openshift-master/private/scaleup.yml
+++ b/playbooks/openshift-master/private/scaleup.yml
@@ -7,6 +7,7 @@
   post_tasks:
   - openshift_facts:
       role: master
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
       local_facts:
         master_count: "{{ openshift_master_count | default(groups.oo_masters | length) }}"
   - name: Update master count

--- a/playbooks/openshift-master/private/set_network_facts.yml
+++ b/playbooks/openshift-master/private/set_network_facts.yml
@@ -31,6 +31,7 @@
       when: openshift_portal_net is not defined
     - openshift_facts:
         role: common
+        system_facts: "{{ vars_openshift_facts_system_facts }}"
         local_facts:
           portal_net: "{{ openshift_portal_net | default(openshift_master_portal_net) | default(None) }}"
     when:

--- a/playbooks/openshift-master/private/validate_restart.yml
+++ b/playbooks/openshift-master/private/validate_restart.yml
@@ -9,6 +9,7 @@
     when: openshift_rolling_restart_mode is defined and openshift_rolling_restart_mode not in ["services", "system"]
   - openshift_facts:
       role: "{{ item.role }}"
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
       local_facts: "{{ item.local_facts }}"
     with_items:
     - role: common

--- a/roles/etcd/tasks/upgrade/upgrade_image.yml
+++ b/roles/etcd/tasks/upgrade/upgrade_image.yml
@@ -58,5 +58,6 @@
   # DEPENDENCY openshift_facts
   openshift_facts:
     role: etcd
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       etcd_image: "{{ new_etcd_image }}"

--- a/roles/openshift_builddefaults/tasks/main.yml
+++ b/roles/openshift_builddefaults/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Set builddefaults
   openshift_facts:
     role: builddefaults
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     # TODO: add ability to define builddefaults env vars sort of like this
     # may need to move the config generation to a filter however.
     local_facts:
@@ -15,5 +16,6 @@
 - name: Set builddefaults config structure
   openshift_facts:
     role: builddefaults
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       config: "{{ openshift_builddefaults_json | default(builddefaults_yaml) }}"

--- a/roles/openshift_buildoverrides/tasks/main.yml
+++ b/roles/openshift_buildoverrides/tasks/main.yml
@@ -2,5 +2,6 @@
 - name: Set buildoverrides config structure
   openshift_facts:
     role: buildoverrides
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       config: "{{ openshift_buildoverrides_json | default(buildoverrides_yaml) }}"

--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -19,6 +19,7 @@
 
 - name: Reload generated facts
   openshift_facts:
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
   when:
   - hostvars[openshift_ca_host].install_result | default({'changed':false}) is changed
 

--- a/roles/openshift_cli/tasks/main.yml
+++ b/roles/openshift_cli/tasks/main.yml
@@ -41,6 +41,7 @@
 
 - name: Reload facts to pick up installed OpenShift version
   openshift_facts:
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
 
 - name: Install bash completion for oc tools
   package: name=bash-completion state=present

--- a/roles/openshift_cloud_provider/tasks/main.yml
+++ b/roles/openshift_cloud_provider/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Set cloud provider facts
   openshift_facts:
     role: cloudprovider
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       kind: "{{ openshift_cloudprovider_kind | default(None) }}"
 

--- a/roles/openshift_facts/vars/main.yml
+++ b/roles/openshift_facts/vars/main.yml
@@ -1,0 +1,11 @@
+---
+# Private role variables which cannot be overridden
+vars_openshift_facts_system_facts:
+  ansible_default_ipv4: "{{ vars.ansible_default_ipv4 }}"
+  ansible_nodename: "{{ vars.ansible_nodename }}"
+  ansible_fqdn: "{{ vars.ansible_fqdn }}"
+  ansible_product_name: "{{ vars.ansible_product_name }}"
+  ansible_product_version: "{{ vars.ansible_product_version }}"
+  ansible_virtualization_type: "{{ vars.ansible_virtualization_type }}"
+  ansible_virtualization_role: "{{ vars.ansible_virtualization_role }}"
+  ansible_system_vendor: "{{ vars.ansible_system_vendor }}"

--- a/roles/openshift_management/tasks/add_container_provider.yml
+++ b/roles/openshift_management/tasks/add_container_provider.yml
@@ -5,6 +5,7 @@
 
 - name: Ensure OpenShift facts are loaded
   openshift_facts:
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
 
 - name: Ensure we use openshift_master_cluster_public_hostname if it is available
   set_fact:

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -46,6 +46,7 @@
 
 - name: Re-gather package dependent master facts
   openshift_facts:
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
 
 - name: Create config parent directory if it does not exist
   file:
@@ -158,6 +159,7 @@
 - name: Set fact of all etcd host IPs
   openshift_facts:
     role: common
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       no_proxy_etcd_host_ips: "{{ openshift_no_proxy_etcd_host_ips }}"
 

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -24,6 +24,7 @@
 - name: Set master facts
   openshift_facts:
     role: master
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       cluster_hostname: "{{ openshift_master_cluster_hostname | default(None) }}"
       cluster_public_hostname: "{{ openshift_master_cluster_public_hostname | default(None) }}"

--- a/roles/openshift_named_certificates/tasks/main.yml
+++ b/roles/openshift_named_certificates/tasks/main.yml
@@ -7,6 +7,7 @@
 
 - openshift_facts:
     role: master
+    system_facts: "{{ vars_openshift_facts_system_facts }}"
     local_facts:
       named_certificates: "{{ parsed_named_certificates | default([]) }}"
     additive_facts_to_overwrite:


### PR DESCRIPTION
Gathering Ansible facts within modules continues to be problematic and
is unsupported.  Only required facts are now passed in when running the
module reducing the dependency on Ansible internals.

Backports #11525