### PR TITLE
Replace remote_group_id by remote_ip_prefix

### DIFF
--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -488,7 +488,7 @@ resources:
         remote_ip_prefix: {{ openshift_openstack_subnet_cidr }}
 {% if openshift_kuryr_sg_driver|default('default') != 'namespace' %}
       - ethertype: IPv4
-        remote_mode: remote_group_id
+        remote_ip_prefix: {{ openshift_openstack_kuryr_pod_subnet_cidr }}
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
Remote_group_id has scalability issues when many ports are associated
to the security group pointed by it. To avoid that it is replaced
by remote_ip_prefix, allowing traffic from the complete CIDR where
pods can be created.