### PR TITLE
Fix container registry block all not blocking all registries

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -78,5 +78,7 @@ docker_no_proxy: "{{ openshift.common.no_proxy | default('') }}"
 l_required_docker_version: '1.13'
 
 l_insecure_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l2_docker_insecure_registries)) }}"
-l_crio_registries: "{{ l2_docker_additional_registries + ['docker.io'] }}"
+
+l_crio_registries: "{% if ('all' in l2_docker_blocked_registries) or ('docker.io' in l2_docker_blocked_registries) %}{{ l2_docker_additional_registries | list }}{% else %}{{ (l2_docker_additional_registries + ['docker.io']) | list }}{% endif %}"
+
 l_additional_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l_crio_registries)) }}"

--- a/roles/container_runtime/tasks/common/pre.yml
+++ b/roles/container_runtime/tasks/common/pre.yml
@@ -8,6 +8,6 @@
   when:
     - openshift_deployment_type == 'openshift-enterprise'
     - openshift_docker_ent_reg != ''
-    - openshift_docker_ent_reg in oreg_url | default('')
     - openshift_docker_ent_reg not in l2_docker_additional_registries
     - not openshift_use_crio_only | bool
+    - ((oreg_url is not defined or oreg_url | default('') == '') or ('all' not in l2_docker_blocked_registries | default([])))

--- a/roles/container_runtime/tasks/package_docker.yml
+++ b/roles/container_runtime/tasks/package_docker.yml
@@ -55,33 +55,10 @@
     get_mime: false
   register: docker_check
 
-- name: Set registry params
-  lineinfile:
-    dest: /etc/sysconfig/docker
-    regexp: '^{{ item.reg_conf_var }}=.*$'
-    line: "{{ item.reg_conf_var }}='{{ item.reg_fact_val | lib_utils_oo_prepend_strings_in_list(item.reg_flag ~ ' ') | join(' ') }}'"
-  when:
-  - item.reg_fact_val != []
-  - docker_check.stat.isreg is defined
-  - docker_check.stat.isreg
-  with_items:
-  - reg_conf_var: ADD_REGISTRY
-    reg_fact_val: "{{ l2_docker_additional_registries }}"
-    reg_flag: --add-registry
-  - reg_conf_var: BLOCK_REGISTRY
-    reg_fact_val: "{{ l2_docker_blocked_registries }}"
-    reg_flag: --block-registry
-  - reg_conf_var: INSECURE_REGISTRY
-    reg_fact_val: "{{ l2_docker_insecure_registries }}"
-    reg_flag: --insecure-registry
-  notify:
-  - restart container runtime
-
 - name: Place additional/blocked/insecure registries in /etc/containers/registries.conf
   template:
     dest: "{{ containers_registries_conf_path }}"
     src: registries.conf.j2
-  when: openshift_docker_use_etc_containers | bool
   notify:
   - restart container runtime
 


### PR DESCRIPTION
The original PR: https://github.com/openshift/openshift-ansible/pull/11390 does not fix the problem.

This PR:
- Adds an additional checks for oreg_url and l2_docker_blocked_registries
- Removes legacy `/etc/sysconfig/docker` configuration
- Modifies default variable `l_crio_registries` if 'all' or 'docker.io' are in l2_docker_blocked_registries
don't include 'docker.io' in the list.

Bug 1689230 - https://bugzilla.redhat.com/show_bug.cgi?id=1689230