### PR TITLE
When upgrading rerun package_docker

### DIFF
--- a/roles/container_runtime/tasks/package_docker.yml
+++ b/roles/container_runtime/tasks/package_docker.yml
@@ -26,6 +26,7 @@
     state: present
   when:
   - not (openshift_is_atomic | bool)
+  - not (l_docker_upgrade | default(false) | bool)
   register: result
   until: result is succeeded
   vars:

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -33,6 +33,10 @@
   - l_docker_upgrade is defined
   - l_docker_upgrade | bool
 
+- import_role:
+    name: container_runtime
+    tasks_from: package_docker
+
 - name: Ensure cri-o is updated
   package:
     name: "{{ pkg_list | join (',') }}"


### PR DESCRIPTION
When performing an upgrade if the inventory was changed
for example to add proxy configuration it would not be applied.

This PR adds the tasks from  `package_docker` the role `container_runtime`
to `roles/openshift_node/tasks/upgrade.yml` to perform the file configuration for the docker service.

Bug 1700764 - https://bugzilla.redhat.com/show_bug.cgi?id=1700764