### PR TITLE
Adding retries for Elastic Search with HA

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml
@@ -8,6 +8,11 @@
     -n {{ openshift_logging_elasticsearch_namespace }}
     -o jsonpath={.items[?(@.status.phase==\"Running\")].metadata.name}
   register: _cluster_pods
+  retries: "{{ __elasticsearch_ready_retries }}"
+  delay: 5
+  until:
+  - _cluster_pods.stdout is defined
+  - _cluster_pods.stdout == "" or _cluster_pods.stdout.split(' ') | count == openshift_logging_es_cluster_size
 
 # make a temp dir for admin certs
 - command: mktemp -d /tmp/openshift-logging-ansible-XXXXXX
@@ -32,49 +37,56 @@
     --key {{ _logging_handler_tempdir.stdout }}/admin-key
     https://logging-{{ _cluster_component }}.{{ openshift_logging_elasticsearch_namespace }}.svc:9200/_cluster/health?pretty
   register: _pod_status
+  until:
+  - _pod_status.rc == 0
+  - _pod_status.stdout is defined
+  - (_pod_status.stdout | from_json)['status'] == 'green'
+  - (_pod_status.stdout | from_json)['number_of_nodes'] == _cluster_pods.stdout.split(' ') | count
+  retries: "{{ __elasticsearch_ready_retries }}"
+  delay: 10
   when:
-    - _cluster_pods.stdout
-    - _cluster_pods.stdout.split(' ') | count > 0
+  - _cluster_pods.stdout
+  - _cluster_pods.stdout.split(' ') | count > 0
 
 - when:
-    - _pod_status.stdout is defined
-    - (_pod_status.stdout | from_json)['status'] in ['yellow', 'red'] or (_pod_status.stdout | from_json)['number_of_nodes'] != _cluster_pods.stdout.split(' ') | count
+  - _pod_status.stdout is defined
+  - (_pod_status.stdout | from_json)['status'] in ['yellow', 'red'] or (_pod_status.stdout | from_json)['number_of_nodes'] != _cluster_pods.stdout.split(' ') | count
   block:
-    - name: Set Logging message to manually restart
-      run_once: true
-      set_stats:
-        data:
-          installer_phase_logging:
-            message: "Elasticsearch cluster logging-{{ _cluster_component }} was not in an optimal state and will not be automatically restarted. Please see documentation regarding doing a {{ 'full' if full_restart_cluster | bool else 'rolling'}} restart of cluster logging."
+  - name: Set Logging message to manually restart
+    run_once: true
+    set_stats:
+      data:
+        installer_phase_logging:
+          message: "Elasticsearch cluster logging-{{ _cluster_component }} was not in an optimal state and will not be automatically restarted. Please see documentation regarding doing a {{ 'full' if full_restart_cluster | bool else 'rolling'}} restart of cluster logging."
 
-    - debug: msg="Elasticsearch cluster logging-{{ _cluster_component }} was not in an optimal state and will not be automatically restarted. Please see documentation regarding doing a {{ 'full' if full_restart_cluster | bool else 'rolling'}} restart of cluster logging."
+  - debug: msg="Elasticsearch cluster logging-{{ _cluster_component }} was not in an optimal state and will not be automatically restarted. Please see documentation regarding doing a {{ 'full' if full_restart_cluster | bool else 'rolling'}} restart of cluster logging."
 
 - when: _pod_status.stdout is undefined or ( (_pod_status.stdout | from_json)['status'] in ['green'] and (_pod_status.stdout | from_json)['number_of_nodes'] == _cluster_pods.stdout.split(' ') | count )
   block:
-    - command: >
-        {{ openshift_client_binary }}
-        --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-        get dc
-        -l component={{ _cluster_component }},provider=openshift
-        -n {{ openshift_logging_elasticsearch_namespace }}
-        -o jsonpath={.items[*].metadata.name}
-      register: _cluster_dcs
+  - command: >
+      {{ openshift_client_binary }}
+      --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      get dc
+      -l component={{ _cluster_component }},provider=openshift
+      -n {{ openshift_logging_elasticsearch_namespace }}
+      -o jsonpath={.items[*].metadata.name}
+    register: _cluster_dcs
 
-    ## restart all dcs for full restart
-    - name: "Performing full cluster restart for {{ _cluster_component }} cluster"
-      include_tasks: full_cluster_restart.yml
-      vars:
-        logging_restart_cluster_dcs: "{{ _cluster_dcs.stdout }}"
-      when:
-        - full_restart_cluster | bool
+  ## restart all dcs for full restart
+  - name: "Performing full cluster restart for {{ _cluster_component }} cluster"
+    include_tasks: full_cluster_restart.yml
+    vars:
+      logging_restart_cluster_dcs: "{{ _cluster_dcs.stdout }}"
+    when:
+    - full_restart_cluster | bool
 
-    ## restart the node if it's dc is in the list of nodes to restart
-    - name: "Performing rolling restart for Elasticsearch cluster {{ _cluster_component }} cluster"
-      include_tasks: rolling_cluster_restart.yml
-      vars:
-        logging_restart_cluster_dcs: "{{ _restart_logging_nodes | intersect(_cluster_dcs.stdout) }}"
-      when:
-        - not full_restart_cluster | bool
+  ## restart the node if it's dc is in the list of nodes to restart
+  - name: "Performing rolling restart for Elasticsearch cluster {{ _cluster_component }} cluster"
+    include_tasks: rolling_cluster_restart.yml
+    vars:
+      logging_restart_cluster_dcs: "{{ _restart_logging_nodes | intersect(_cluster_dcs.stdout) }}"
+    when:
+    - not full_restart_cluster | bool
 
 # remove temp dir
 - name: Cleaning up temp dir

--- a/roles/openshift_logging_elasticsearch/tasks/rolling_cluster_restart.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/rolling_cluster_restart.yml
@@ -73,6 +73,9 @@
     -XPUT 'https://logging-{{ _cluster_component }}.{{ openshift_logging_elasticsearch_namespace }}.svc:9200/_cluster/settings'
     -d '{ "transient": { "cluster.routing.allocation.enable" : "all" } }'
   register: _cluster_enable_output
+  until: _cluster_enable_output.rc == 0
+  retries: "{{ __elasticsearch_ready_retries }}"
+  delay: 5
   changed_when:
   - "_cluster_enable_output.stdout != ''"
   - (_cluster_enable_output.stdout | from_json)['acknowledged'] | bool


### PR DESCRIPTION
When using a HA elastic search setup (`openshift_logging_es_number_of_shards=3` and `openshift_logging_es_number_of_replicas=2`) ansible installer fails in some tasks because do not wait 
long enough for all pods be ready .

```
RUNNING HANDLER [openshift_logging_elasticsearch : command] *************************************************************************************************************************************************
task path: /tmp/openshift/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml:3
(...)
changed: [xxxxxxxxxx] => {
	(...)
    "invocation": {
        "module_args": {
            "_raw_params": "oc --config=/etc/origin/master/admin.kubeconfig get pod -l component=es,provider=openshift -n openshift-logging -o jsonpath={.items[?(@.status.phase==\\\"Running\\\")].metadata.name}",
			(...)
        }
    },
	(...)
    "stdout": "logging-es-data-master-2pe8xnzw-1-m77q9 logging-es-data-master-6kw6otmo-1-gfclh",
    "stdout_lines": [
        "logging-es-data-master-2pe8xnzw-1-m77q9 logging-es-data-master-6kw6otmo-1-gfclh"
    ]
}
```

In this case, it found only 2 of 3 ready pods. After playbook failed the third pod was in "Running" state. It was only matter of time.

Same problem occurred when reenabling sharding balancing:

```
RUNNING HANDLER [openshift_logging_elasticsearch : Enable shard balancing for logging-{{ _cluster_component }} cluster] *************************************************************************************
task path: /tmp/openshift/roles/openshift_logging_elasticsearch/tasks/rolling_cluster_restart.yml:64
(...)
fatal: [xxxxxxxxxx]: FAILED! => {
	(...)
    "invocation": {
        "module_args": {
            "_raw_params": "curl -s -k --cert /tmp/openshift-logging-ansible-owbzo1/admin-cert --key /tmp/openshift-logging-ansible-owbzo1/admin-key -XPUT 'https://logging-es.openshift-logging.svc:9200/_cluster/settings' -d '{ \"transient\": { \"cluster.routing.allocation.enable\" : \"all\" } }'",
            (...)
        }
    },
    "msg": "non-zero return code",
    "rc": 52,
    "start": "2019-05-03 02:02:59.787194",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "",
    "stdout_lines": []
}
```

and while checking es cluster health:

```
RUNNING HANDLER [openshift_logging_elasticsearch : Checking current health for {{ _es_node }} cluster] **************************************************************
task path: /tmp/openshift/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml:28
(...)
FAILED - RETRYING: Checking current health for {{ _es_node }} cluster (60 retries left).Result was: {
    (...)
    "invocation": {
        "module_args": {
            "_raw_params": "curl -s -k --cert /tmp/openshift-logging-ansible-DxK8aW/admin-cert --key /tmp/openshift-logging-ansible-DxK8aW/admin-key https://logging-ealth?pretty",
            (...)
        }
    },
    "msg": "non-zero return code",
    "rc": 7,
    "retries": 61,
    "start": "2019-05-03 00:51:31.484251",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "",
    "stdout_lines": [],
    "warnings": [
        "Consider using the get_url or uri module rather than running 'curl'.  If you need to use command because get_url or uri is insufficient you can add 'warn: fnd_warnings=False' in ansible.cfg to get rid of this message."
    ]
}
```

After playbook failed, the same commands Ansible tried, resulted in success when manually sent.

This PR adds some retries.
