### PR TITLE
[release-3.10] Fix container registry block all not blocking all registries

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -88,5 +88,7 @@ l_required_docker_version: '1.13'
 l_crio_var_sock: "/var/run/crio/crio.sock"
 
 l_insecure_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l2_docker_insecure_registries)) }}"
-l_crio_registries: "{{ l2_docker_additional_registries + ['docker.io'] }}"
+
+l_crio_registries: "{% if ('all' in l2_docker_blocked_registries) or ('docker.io' in l2_docker_blocked_registries) %}{{ l2_docker_additional_registries | list }}{% else %}{{ (l2_docker_additional_registries + ['docker.io']) | list }}{% endif %}"
+
 l_additional_crio_registries: "{{ '\"{}\"'.format('\", \"'.join(l_crio_registries)) }}"

--- a/roles/container_runtime/tasks/common/pre.yml
+++ b/roles/container_runtime/tasks/common/pre.yml
@@ -10,3 +10,4 @@
     - openshift_docker_ent_reg != ''
     - openshift_docker_ent_reg not in l2_docker_additional_registries
     - not openshift_use_crio_only | bool
+    - ((oreg_url is not defined or oreg_url | default('') == '') or ('all' not in l2_docker_blocked_registries | default([])))


### PR DESCRIPTION
This PR:
- Adds an additional checks for oreg_url and l2_docker_blocked_registries
- Modifies default variable `l_crio_registries` if 'all' or 'docker.io' are in l2_docker_blocked_registries
don't include 'docker.io' in list.

CP: https://github.com/openshift/openshift-ansible/pull/11565