### PR TITLE
Fix: generate hawkular-cassandra pvc (dynamic)

### DIFF
--- a/roles/openshift_metrics/tasks/generate_cassandra_pvcs.yaml
+++ b/roles/openshift_metrics/tasks/generate_cassandra_pvcs.yaml
@@ -41,6 +41,5 @@
         access_modes: "{{ openshift_metrics_cassandra_pvc_access | list }}"
         size: "{{ openshift_metrics_cassandra_pvc_size }}"
         pv_selector: "{{ openshift_metrics_cassandra_pv_selector }}"
-        storage_class_name: "{{ openshift_metrics_cassandra_pvc_storage_class_name | default('', true) }}"
       when: openshift_metrics_cassandra_storage_type == 'dynamic'
       changed_when: false


### PR DESCRIPTION
storage_class_name should not be defined when the storage type is dynamic