### PR TITLE
container needs privileged mode if hostmount used

### DIFF
--- a/roles/openshift_logging_mux/templates/2.x/mux.j2
+++ b/roles/openshift_logging_mux/templates/2.x/mux.j2
@@ -37,6 +37,10 @@ spec:
       - name: "mux"
         image: {{image}}
         imagePullPolicy: IfNotPresent
+{% if openshift_logging_mux_file_buffer_storage_type is defined and openshift_logging_mux_file_buffer_storage_type == 'hostmount' %}
+        securityContext:
+          privileged: true
+{% endif %}
 {% if (mux_memory_limit is defined and mux_memory_limit is not none) or (mux_cpu_limit is defined and mux_cpu_limit is not none) or (mux_cpu_request is defined and mux_cpu_request is not none) %}
         resources:
 {%   if (mux_memory_limit is defined and mux_memory_limit is not none) or (mux_cpu_limit is defined and mux_cpu_limit is not none) %}

--- a/roles/openshift_logging_mux/templates/5.x/mux.j2
+++ b/roles/openshift_logging_mux/templates/5.x/mux.j2
@@ -37,6 +37,10 @@ spec:
       - name: "mux"
         image: {{image}}
         imagePullPolicy: IfNotPresent
+{% if openshift_logging_mux_file_buffer_storage_type is defined and openshift_logging_mux_file_buffer_storage_type == 'hostmount' %}
+        securityContext:
+          privileged: true
+{% endif %}
 {% if (mux_memory_limit is defined and mux_memory_limit is not none) or (mux_cpu_limit is defined and mux_cpu_limit is not none) or (mux_cpu_request is defined and mux_cpu_request is not none) %}
         resources:
 {%   if (mux_memory_limit is defined and mux_memory_limit is not none) or (mux_cpu_limit is defined and mux_cpu_limit is not none) %}


### PR DESCRIPTION
If one uses a `hostmount` for `openshift_logging_mux_file_buffer_storage_type`, the container needs to run in privileged mode. 
The scc for the `aggregated-logging-mux` service account is already set to allow the hostmount, but without the correct context a mount will fail.