### PR TITLE
[release-3.11] Remove bash debug flag from 99-origin-dns.sh script

### DIFF
--- a/roles/openshift_node/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node/files/networkmanager/99-origin-dns.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 # -*- mode: sh; sh-indentation: 2 -*-
 
 # This NetworkManager dispatcher script replicates the functionality of


### PR DESCRIPTION
The debug flag was originally added during development is not needed for
ongoing operations.  The debug flag causes the script to generate
unnecessary noise in log files.

Bug 1707799
https://bugzilla.redhat.com/show_bug.cgi?id=1707799