### PR TITLE
Fix until conditionals to handle failed tasks

### DIFF
--- a/roles/openshift_node/tasks/apply_machine_config.yml
+++ b/roles/openshift_node/tasks/apply_machine_config.yml
@@ -12,6 +12,7 @@
   delegate_to: localhost
   register: oc_get
   until:
+  - oc_get.stdout is defined
   - oc_get.stdout != ''
   retries: 36
   delay: 5
@@ -28,6 +29,7 @@
   delegate_to: localhost
   register: oc_get
   until:
+  - oc_get.stdout is defined
   - oc_get.stdout != ''
   retries: 36
   delay: 5
@@ -50,6 +52,7 @@
   delegate_to: localhost
   register: oc_get
   until:
+  - oc_get.stdout is defined
   - oc_get.stdout != ''
   retries: 36
   delay: 5

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -34,7 +34,7 @@
   retries: 60
   register: result
   until:
-  - "'status' in result"
+  - result.status is defined
   - result.status == 200
 
 - name: Fetch bootstrap ignition file locally
@@ -56,6 +56,7 @@
   delegate_to: localhost
   register: oc_get
   until:
+  - oc_get.stdout is defined
   - oc_get.stdout != ''
   retries: 36
   delay: 5


### PR DESCRIPTION
If the task fails and does not create the expected result, such as
oc_get.stdout, the task will fail because 'stdout' is not defined.  This
obscures the actual reason the task is failing making it more difficult
to troubleshoot.

This commit ensures consistency for all until: conditionals.