### PR TITLE
Fix openshift_kube_config_path defaults

### DIFF
--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -4,7 +4,8 @@
   connection: local
   gather_facts: no
   tasks:
-  - fail:
+  - name: Ensure [workers] group is populated
+    fail:
       msg: >
         Detected no workers in inventory. Please add hosts to the
         workers host group to upgrade nodes
@@ -14,57 +15,6 @@
   hosts: workers
   serial: 1
   tasks:
-  - block:
-    - debug:
-        msg: "Running openshift_node_pre_cordon_hook {{ openshift_node_pre_cordon_hook }}"
-    - include_tasks: "{{ openshift_node_pre_cordon_hook }}"
-    when: openshift_node_pre_cordon_hook is defined
-
-  - name: Cordon node prior to upgrade
-    command: >
-      oc adm cordon {{ item | lower }}
-      --config={{ openshift_kubeconfig_path }}
-    delegate_to: localhost
-    with_items: "{{ ansible_play_batch }}"
-
-  - name: Drain node prior to upgrade
-    command: >
-      oc adm drain {{ item | lower }}
-      --config={{ openshift_kubeconfig_path }}
-      --force --delete-local-data --ignore-daemonsets
-    delegate_to: localhost
-    with_items: "{{ ansible_play_batch }}"
-
-  # Run the openshift_node_pre_upgrade_hook if defined
-  - block:
-    - debug:
-        msg: "Running node openshift_node_pre_upgrade_hook {{ openshift_node_pre_upgrade_hook }}"
-    - include_tasks: "{{ openshift_node_pre_upgrade_hook }}"
-    when: openshift_node_pre_upgrade_hook is defined
-
-  # Upgrade Node
   - import_role:
       name: openshift_node
-    vars:
-      openshift_node_package_state: latest
-
-  # Run the openshift_node_pre_uncordon_hook if defined
-  - block:
-    - debug:
-        msg: "Running openshift_node_pre_uncordon_hook {{ openshift_node_pre_uncordon_hook }}"
-    - include_tasks: "{{ openshift_node_pre_uncordon_hook }}"
-    when: openshift_node_pre_uncordon_hook is defined
-
-  - name: Uncordon node after upgrade
-    command: >
-      oc adm uncordon {{ item | lower }}
-      --config={{ openshift_kubeconfig_path }}
-    delegate_to: localhost
-    with_items: "{{ ansible_play_batch }}"
-
-  # Run the openshift_node_post_upgrade_hook if defined
-  - block:
-    - debug:
-        msg: "Running node openshift_node_post_upgrade_hook {{ openshift_node_post_upgrade_hook }}"
-    - include_tasks: "{{ openshift_node_post_upgrade_hook }}"
-    when: openshift_node_post_upgrade_hook is defined
+      tasks_from: upgrade.yml

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
-openshift_kubeconfig_path: '~/.kube/config'
 openshift_pull_secret_path: '~/pull-secret.txt'
 
 openshift_node_machineconfigpool: 'worker'
 openshift_node_tls_verify: false
 
-openshift_node_kubeconfig: "{{ lookup('file', openshift_kubeconfig_path) | from_yaml }}"
+openshift_node_kubeconfig_path: "{{ openshift_kubeconfig_path | default('~/.kube/config') | expanduser | realpath }}"
+openshift_node_kubeconfig: "{{ lookup('file', openshift_node_kubeconfig_path) | from_yaml }}"
 openshift_node_bootstrap_port: 22623
 openshift_node_bootstrap_server: "{{ openshift_node_kubeconfig.clusters.0.cluster.server.split(':')[0:-1] | join(':') }}:{{ openshift_node_bootstrap_port }}"
 openshift_node_bootstrap_endpoint: "{{ openshift_node_bootstrap_server }}/config/{{ openshift_node_machineconfigpool }}"

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -51,7 +51,7 @@
 - name: Get release image
   command: >
     oc get clusterversion
-    --config={{ openshift_kubeconfig_path }}
+    --config={{ openshift_node_kubeconfig_path }}
     --output=jsonpath='{.items[0].status.desired.image}'
   delegate_to: localhost
   register: oc_get

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -1,0 +1,55 @@
+---
+- block:
+  - debug:
+      msg: "Running openshift_node_pre_cordon_hook {{ openshift_node_pre_cordon_hook }}"
+  - include_tasks: "{{ openshift_node_pre_cordon_hook }}"
+  when: openshift_node_pre_cordon_hook is defined
+
+- name: Cordon node prior to upgrade
+  command: >
+    oc adm cordon {{ item | lower }}
+    --config={{ openshift_node_kubeconfig_path }}
+  delegate_to: localhost
+  with_items: "{{ ansible_play_batch }}"
+
+- name: Drain node prior to upgrade
+  command: >
+    oc adm drain {{ item | lower }}
+    --config={{ openshift_node_kubeconfig_path }}
+    --force --delete-local-data --ignore-daemonsets
+  delegate_to: localhost
+  with_items: "{{ ansible_play_batch }}"
+
+# Run the openshift_node_pre_upgrade_hook if defined
+- block:
+  - debug:
+      msg: "Running node openshift_node_pre_upgrade_hook {{ openshift_node_pre_upgrade_hook }}"
+  - include_tasks: "{{ openshift_node_pre_upgrade_hook }}"
+  when: openshift_node_pre_upgrade_hook is defined
+
+# Upgrade Node
+- import_role:
+    name: openshift_node
+  vars:
+    openshift_node_package_state: latest
+
+# Run the openshift_node_pre_uncordon_hook if defined
+- block:
+  - debug:
+      msg: "Running openshift_node_pre_uncordon_hook {{ openshift_node_pre_uncordon_hook }}"
+  - include_tasks: "{{ openshift_node_pre_uncordon_hook }}"
+  when: openshift_node_pre_uncordon_hook is defined
+
+- name: Uncordon node after upgrade
+  command: >
+    oc adm uncordon {{ item | lower }}
+    --config={{ openshift_node_kubeconfig_path }}
+  delegate_to: localhost
+  with_items: "{{ ansible_play_batch }}"
+
+# Run the openshift_node_post_upgrade_hook if defined
+- block:
+  - debug:
+      msg: "Running node openshift_node_post_upgrade_hook {{ openshift_node_post_upgrade_hook }}"
+  - include_tasks: "{{ openshift_node_post_upgrade_hook }}"
+  when: openshift_node_post_upgrade_hook is defined


### PR DESCRIPTION
- Expand the path to full path using expanduser and realpath filters
- Move node upgrade tasks inside role to use the same defaults

Bug 1708568
Bug 1708588
