### PR TITLE
[release-3.9] Add a condition not to add "compute" label badly when master scaleup.yml

### DIFF
--- a/roles/openshift_manage_node/tasks/set_default_node_role.yml
+++ b/roles/openshift_manage_node/tasks/set_default_node_role.yml
@@ -28,4 +28,6 @@
         labels:
           - key: node-role.kubernetes.io/compute
             value: 'true'
-      when: groups['oo_nodes_to_config'] | default([]) | union(groups['oo_nodes_to_bootstrap'] | default([])) | union(groups['oo_masters_to_config']) | length == 1
+      when:
+        - groups['oo_nodes_to_config'] | default([]) | union(groups['oo_nodes_to_bootstrap'] | default([])) | union(groups['oo_masters_to_config']) | length == 1
+        - groups['new_masters'] | default([]) | length == 0


### PR DESCRIPTION
- Fix: [Labeled "compute" role badly to new master added after scaleup.yml](https://bugzilla.redhat.com/show_bug.cgi?id=1709004)

- Version: only `v3.9`

- Description:
  Both `all-in-one` cluster and `new_masters` host group has just one node member during running playbooks, it results in unexpected role labeling when new master scales up using `openshift-master/scaleup.yml`. So add a condition not to label `compute` `node-role` if `[new_masters]` host group is existing in `invnetory` file.
