### PR TITLE
[release-3.10] While upgrading to 3.10 add node-config file check

### DIFF
--- a/roles/openshift_node/handlers/main.yml
+++ b/roles/openshift_node/handlers/main.yml
@@ -18,3 +18,22 @@
     state: restarted
   when:
   - (not skip_node_svc_handlers | default(False) | bool)
+
+- name: restart node service
+  service:
+    name: "{{ openshift_service_type }}-node"
+    state: restarted
+  async: 300
+  poll: 0
+  register: restart_node_service
+  failed_when: false
+  notify:
+  - check status of node service
+
+- name: check status of node service
+  async_status:
+    jid: "{{ restart_node_service.ansible_job_id }}"
+  register: restart_job_result
+  until: restart_job_result.finished
+  retries: 30
+  delay: 10

--- a/roles/openshift_node/tasks/upgrade/restart.yml
+++ b/roles/openshift_node/tasks/upgrade/restart.yml
@@ -57,6 +57,17 @@
   retries: 30
   until: node_upgrade_oc_csr_approve is succeeded
 
+- name: Check if node-config exists
+  stat:
+    path: "{{ openshift.common.config_base}}/node/node-config.yaml"
+  register: node_config
+  until: node_config.stat.exists
+  changed_when: node_config.stat.exists
+  retries: 30
+  delay: 10
+  notify:
+    - restart node service
+
 - name: Check status of node service
   async_status:
     jid: "{{ node_service.ansible_job_id }}"


### PR DESCRIPTION
- Adds loop to check if `/etc/origin/node/node-config.yaml` exists
- Adds handler to restart service once node-config exists.

Bug 1705642 - https://bugzilla.redhat.com/show_bug.cgi?id=1705642

Related: https://github.com/openshift/openshift-ansible/pull/11576