### PR TITLE
Added output to master-restart. Avoid searchs and serves as doc

### DIFF
--- a/roles/openshift_control_plane/files/scripts/crio/master-restart
+++ b/roles/openshift_control_plane/files/scripts/crio/master-restart
@@ -10,6 +10,7 @@ fi
 types=( "atomic-openshift" "origin" )
 for type in "${types[@]}"; do
   if systemctl cat "${type}-master-${1}.service" &>/dev/null; then
+    echo "Restarting service ${type}-master-${1}.service"
     systemctl restart "${type}-master-${1}.service"
     exit 0
   fi
@@ -22,4 +23,5 @@ if [[ -z "${pod}" ]]; then
 fi
 # Stop the pod
 # TODO(runcom): expose timeout in the CRI
+echo "Stopping pod ${pod}"
 crictl stopp "${pod}" >/dev/null

--- a/roles/openshift_control_plane/files/scripts/docker/master-restart
+++ b/roles/openshift_control_plane/files/scripts/docker/master-restart
@@ -10,6 +10,7 @@ fi
 types=( "atomic-openshift" "origin" )
 for type in "${types[@]}"; do
   if systemctl cat "${type}-master-${1}.service" &>/dev/null; then
+    echo "Stopping service ${type}-master-${1}.service"
     systemctl restart "${type}-master-${1}.service"
     exit 0
   fi
@@ -27,6 +28,7 @@ if [[ -z "${container}" ]]; then
   exit 0
 fi
 # Stop the pod
+echo "Stopping container ${container}"
 docker stop "${container}" --time 30 >/dev/null
 
 # Wait for child container to change state


### PR DESCRIPTION
I think that it is really useful to have some output in master-restart.

When you are using it, you are never sure about what is happening underneath, unless you open the script with a text-editor.

I had the question once, and I have heard it several times: "Where are the services of the master?".

I think it would be clear if they see that they are restarting containers when they run master-restart :)