### PR TITLE
Workaround missing network metrics when using cri-o

### DIFF
--- a/playbooks/openshift-metrics/private/config.yml
+++ b/playbooks/openshift-metrics/private/config.yml
@@ -18,6 +18,20 @@
   roles:
   - role: openshift_metrics
 
+# Workaround:
+# When using cri-o networking metrics do
+# not appear unless the -node.service is restarted
+# BZ(s):
+# https://bugzilla.redhat.com/show_bug.cgi?id=1646886
+# https://bugzilla.redhat.com/show_bug.cgi?id=1631300
+# https://bugzilla.redhat.com/show_bug.cgi?id=1649984
+# https://bugzilla.redhat.com/show_bug.cgi?id=1647707
+- import_playbook: ../../openshift-node/private/restart.yml
+  when: openshift_use_crio | default(false) | bool
+  vars:
+    openshift_node_restart_docker_required: False
+    openshift_node_restart_drain: True
+
 - name: Metrics Install Checkpoint End
   hosts: all
   gather_facts: false

--- a/playbooks/openshift-node/private/restart.yml
+++ b/playbooks/openshift-node/private/restart.yml
@@ -8,6 +8,37 @@
   - openshift_facts
 
   tasks:
+  - name: Mark node unschedulable
+    oc_adm_manage_node:
+      node: "{{ l_kubelet_node_name | lower }}"
+      schedulable: False
+    delegate_to: "{{ groups.oo_first_master.0 }}"
+    retries: 10
+    delay: 5
+    register: node_unschedulable
+    until: node_unschedulable is succeeded
+    when:
+    - openshift_node_restart_drain | default(false) | bool
+    - inventory_hostname in groups.oo_nodes_to_config
+
+  - name: Drain Node for Kubelet restart
+    command: >
+      {{ hostvars[groups.oo_first_master.0]['first_master_client_binary'] }} adm drain {{ l_kubelet_node_name | lower }}
+      --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+      --force --delete-local-data --ignore-daemonsets
+      --timeout={{ openshift_upgrade_nodes_drain_timeout | default(0) }}s
+    delegate_to: "{{ groups.oo_first_master.0 }}"
+    when:
+    - openshift_node_restart_drain | default(false) | bool
+    - inventory_hostname in groups.oo_nodes_to_config
+    register: l_docker_upgrade_drain_result
+    until: not (l_docker_upgrade_drain_result is failed)
+    retries: "{{ 1 if ( openshift_upgrade_nodes_drain_timeout | default(0) | int ) == 0 else 0 }}"
+    delay: 5
+    failed_when:
+    - l_docker_upgrade_drain_result is failed
+    - openshift_upgrade_nodes_drain_timeout | default(0) | int == 0
+
   - name: Restart docker
     service:
       name: docker
@@ -54,3 +85,16 @@
     # Give the node three minutes to come back online.
     retries: 36
     delay: 5
+
+  - name: Set node schedulability
+    oc_adm_manage_node:
+      node: "{{ l_kubelet_node_name | lower }}"
+      schedulable: True
+    delegate_to: "{{ groups.oo_first_master.0 }}"
+    retries: 10
+    delay: 5
+    register: node_schedulable
+    until: node_schedulable is succeeded
+    when:
+    - node_unschedulable is changed
+    - openshift_node_restart_drain | default(false) | bool


### PR DESCRIPTION
Adds openshift-node service restart after metrics is installed.

Bug 1646886 - https://bugzilla.redhat.com/show_bug.cgi?id=1646886
Bug 1631300 - https://bugzilla.redhat.com/show_bug.cgi?id=1631300

