### PR TITLE
openshift_node: always check for missing TCMU iSCSI device entry

### DIFF
--- a/roles/openshift_node/tasks/storage_plugin_iscsi.yml
+++ b/roles/openshift_node/tasks/storage_plugin_iscsi.yml
@@ -74,7 +74,6 @@
     mode: 0600
     backup: yes
     state: present
-  when: devices_multipath.rc == 1
 
 #enable multipath
 - name: Enable and start multipath


### PR DESCRIPTION
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1694960

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>