### PR TITLE
RHEL upgrade: use API to get ignition from machine config

### DIFF
--- a/roles/openshift_node/tasks/apply_machine_config.yml
+++ b/roles/openshift_node/tasks/apply_machine_config.yml
@@ -1,0 +1,90 @@
+---
+- name: Create temp directory
+  tempfile:
+    state: directory
+  register: temp_dir
+
+- name: Get worker machine config name
+  command: >
+    oc get machineconfigpool worker
+    --config={{ openshift_node_kubeconfig_path }}
+    --output=jsonpath='{.status.configuration.name}'
+  delegate_to: localhost
+  register: oc_get
+  until:
+  - oc_get.stdout != ''
+  retries: 36
+  delay: 5
+
+- name: Set l_worker_machine_config_name
+  set_fact:
+    l_worker_machine_config_name: "{{ oc_get.stdout }}"
+
+- name: Get worker ignition config
+  command: >
+    oc get machineconfig {{ l_worker_machine_config_name }}
+    --config={{ openshift_node_kubeconfig_path }}
+    --output=json
+  delegate_to: localhost
+  register: oc_get
+  until:
+  - oc_get.stdout != ''
+  retries: 36
+  delay: 5
+
+- name: Write worker ignition config to file
+  copy:
+    content: "{{ (oc_get.stdout | from_json).spec.config }}"
+    dest: "{{ temp_dir.path }}/worker_ignition_config.json"
+
+- name: Copy pull secret
+  copy:
+    src: "{{ openshift_pull_secret_path }}"
+    dest: "{{ temp_dir.path }}/pull-secret.json"
+
+- name: Get release image
+  command: >
+    oc get clusterversion
+    --config={{ openshift_node_kubeconfig_path }}
+    --output=jsonpath='{.items[0].status.desired.image}'
+  delegate_to: localhost
+  register: oc_get
+  until:
+  - oc_get.stdout != ''
+  retries: 36
+  delay: 5
+
+- name: Set openshift_release_image fact
+  set_fact:
+    openshift_release_image: "{{ oc_get.stdout }}"
+
+- name: Pull release image
+  command: "podman pull --tls-verify={{ openshift_node_tls_verify }} --authfile {{ temp_dir.path }}/pull-secret.json {{ openshift_release_image }}"
+
+- name: Get machine controller daemon image from release image
+  command: "podman run --rm {{ openshift_release_image }} image machine-config-daemon"
+  register: release_image_mcd
+
+- block:
+  - name: Pull MCD image
+    command: "podman pull --tls-verify={{ openshift_node_tls_verify }} --authfile {{ temp_dir.path }}/pull-secret.json {{ release_image_mcd.stdout }}"
+
+  - name: Apply machine config
+    command: "podman run {{ podman_mounts }} {{ podman_flags }} {{ mcd_command }}"
+    vars:
+      podman_flags: "--privileged --rm -ti {{ release_image_mcd.stdout }}"
+      podman_mounts: "-v /:/rootfs -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd"
+      mcd_command: "start --node-name {{ ansible_hostname }} --once-from {{ temp_dir.path }}/worker_ignition_config.json --skip-reboot"
+
+  - name: Remove temp directory
+    file:
+      path: "{{ temp_dir.path }}"
+      state: absent
+
+  - name: Reboot the host and wait for it to come back
+    reboot:
+    #  reboot_timeout: 600  # default, 10 minutes
+
+  rescue:
+  - fail:
+      msg: "Machine config apply failed"

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -27,11 +27,13 @@
   - include_tasks: "{{ openshift_node_pre_upgrade_hook }}"
   when: openshift_node_pre_upgrade_hook is defined
 
-# Upgrade Node
-- import_role:
-    name: openshift_node
+# Upgrade Node Packages
+- import_tasks: install.yml
   vars:
     openshift_node_package_state: latest
+
+# Apply machine config
+- import_tasks: apply_machine_config.yml
 
 # Run the openshift_node_pre_uncordon_hook if defined
 - block:


### PR DESCRIPTION
Switch from using bootstrap ignition config from MCS to using the
ignition config from the worker machine config obtained from the
cluster API.

Bug 1710226
https://bugzilla.redhat.com/show_bug.cgi?id=1710226