### PR TITLE
[release-3.10] Fix openshift sdn taint toleration

### DIFF
--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -161,8 +161,6 @@ spec:
         #     port: 10256
         #     scheme: HTTP
         # force node to be notready when sdn is gone.
-        tolerations:
-        - operator: "Exists"
         lifecycle:
           preStop:
             exec:
@@ -207,3 +205,5 @@ spec:
       - name: host-var-lib-cni-networks-openshift-sdn
         hostPath:
           path: /var/lib/cni/networks/openshift-sdn
+      tolerations:
+      - operator: "Exists"


### PR DESCRIPTION
Tolerations should be set in PodSpec not Container. See:
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#pod-v1-core
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#container-v1-core

Bug 1709422 - https://bugzilla.redhat.com/show_bug.cgi?id=1709422