### PR TITLE
Test using Ansible 2.8.0

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -60,7 +60,7 @@ cp -rp test %{buildroot}%{_datadir}/ansible/%{name}/
 %package test
 Summary:       Openshift and Atomic Enterprise Ansible Test Playbooks
 Requires:      %{name} = %{version}-%{release}
-Requires:      ansible = 2.7.10
+Requires:      ansible = 2.8.0
 Requires:      python2-openshift
 Requires:      openssh-clients
 BuildArch:     noarch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.7.10
+ansible==2.8.0


### PR DESCRIPTION
Moves tox and CI image to use Ansible 2.8.0 (latest) for testing.

Required: Ansible >= 2.7.8
Testing: Ansible = 2.8.0