### PR TITLE
[release-3.11] To provide a way to specify audit policyFile add "openshift_master_audit_policyfile"

### DIFF
--- a/roles/openshift_control_plane/tasks/main.yml
+++ b/roles/openshift_control_plane/tasks/main.yml
@@ -62,6 +62,17 @@
   - openshift.master.audit_config.auditFilePath is defined
   - '"/var/log/origin" in openshift.master.audit_config.auditFilePath'
 
+- name: Copy openshift audit policy file
+  copy:
+    src: "{{ openshift.master.audit_policyfile }}"
+    dest: "{{ openshift.master.audit_config.policyFile }}"
+    mode: 0644
+  when:
+  - openshift.master.audit_config is defined
+  - openshift.master.audit_policyfile is defined
+  - openshift.master.audit_config.policyFile is defined
+  - '"/etc/origin/master" in openshift.master.audit_config.policyFile'
+
 - name: Create the policy file if it does not already exist
   command: >
     {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -55,6 +55,7 @@
       image_policy_config: "{{ openshift_master_image_policy_config | default(None) }}"
       image_policy_allowed_registries_for_import: "{{ openshift_master_image_policy_allowed_registries_for_import | default(None) }}"
       audit_config: "{{ openshift_master_audit_config | default(None) }}"
+      audit_policyfile: "{{ openshift_master_audit_policyfile | default(None) }}"
 
 - name: Determine if scheduler config present
   stat:


### PR DESCRIPTION
- Fix: [If Advanced Audit is configured during initial installation, Control plane pods didn't come up](https://bugzilla.redhat.com/show_bug.cgi?id=1710723)

- Version: only `v3.11`

- Description:
  To add `openshift_master_audit_policyfile` to specify user-defined `audit policy` file which would copy to `/etc/origin/master` for initial installation. 

- Related issues:
  - [enterprise-3.11] Edit suggested in file install_config/master_node_configuration.adoc : https://github.com/openshift/openshift-docs/issues/14688
  - [release-3.11] Need to provide a way to configure "policyFile" during initial installation : https://github.com/openshift/openshift-ansible/issues/11591

