### PR TITLE
[BZ 1710311] Make readinessProbe timeout configurable and add initialDelaySeconds

### DIFF
--- a/roles/openshift_metrics/defaults/main.yaml
+++ b/roles/openshift_metrics/defaults/main.yaml
@@ -31,6 +31,8 @@ openshift_metrics_cassandra_requests_cpu: null
 openshift_metrics_cassandra_nodeselector: ""
 openshift_metrics_cassandra_storage_group: 65534
 openshift_metrics_cassandra_take_snapshot: False
+openshift_metrics_cassandra_readprobe_initialdelay: null
+openshift_metrics_cassandra_readprobe_timeout: 10
 
 openshift_metrics_heapster_standalone: False
 openshift_metrics_heapster_limits_memory: 3.75G

--- a/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
@@ -120,7 +120,11 @@ spec:
           exec:
             command:
             - "/opt/apache-cassandra/bin/cassandra-docker-ready.sh"
-          timeoutSeconds: 10
+          timeoutSeconds: "{{openshift_metrics_cassandra_readprobe_timeout | default(10)}}"
+{%      if openshift_metrics_cassandra_readprobe_initialdelay is not none %}
+          initialDelaySeconds: "{{openshift_metrics_cassandra_readprobe_initialdelay}}"
+{% endif %}
+
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
This is to address an issue described in https://bugzilla.redhat.com/show_bug.cgi?id=1710311

I also want to back-port this to 3.10 which is the version used by the reporter of that issue.