### PR TITLE
[release-3.9] Don't use hostvars fact for openshift_master_etcd_urls

### DIFF
--- a/playbooks/openshift-node/private/additional_config.yml
+++ b/playbooks/openshift-node/private/additional_config.yml
@@ -36,7 +36,7 @@
   hosts: oo_nodes_use_flannel
   roles:
   - role: flannel
-    etcd_urls: "{{ hostvars[groups.oo_first_master.0].openshift_master_etcd_urls }}"
+    etcd_urls: "{{ openshift_master_etcd_urls }}"
     when: openshift_use_flannel | default(false) | bool
 
 - name: Additional node config

--- a/roles/calico_master/tasks/certs.yml
+++ b/roles/calico_master/tasks/certs.yml
@@ -16,7 +16,7 @@
     calico_etcd_ca_cert_file: "/etc/origin/master/master.etcd-ca.crt"
     calico_etcd_cert_file: "/etc/origin/master/master.etcd-client.crt"
     calico_etcd_key_file: "/etc/origin/master/master.etcd-client.key"
-    calico_etcd_endpoints: "{{ hostvars[groups.oo_first_master.0].openshift_master_etcd_urls | join(',') }}"
+    calico_etcd_endpoints: "{{ openshift_master_etcd_urls | join(',') }}"
 
 - name: Calico Node | Error if no certs set.
   fail:


### PR DESCRIPTION
The Pull-Request https://github.com/openshift/openshift-ansible/pull/7542 removes `etcd_hosts` and `etcd_urls` from `openshift_facts`. But the Ansible role `calico_master` use one of the undefined `hostvars` facts...

We have become aware of this problem when we scaleup a new master in one of our clusters:

```
TASK [calico_master : Calico Node | Set etcd cert location facts] ***************************************************************************************************************************************************************************
Thursday 23 May 2019  13:35:59 +0200 (0:00:00.088)       0:04:37.523 *********** 
fatal: [openshift-master-0***]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'openshift_master_etcd_urls'\n\nThe error appears to have been in 'openshift-ansible/roles/calico_master/tasks/certs.yml': line 13, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Calico Node | Set etcd cert location facts\n  ^ here\n"}
```

Additionally, the Ansible task `Additional node config` for `flannel` in `playbooks/openshift-node/private/additional_config.yml` also uses one of the undefined `hostvars` facts.