### PR TITLE
Enable ports population for new namespaces

### DIFF
--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -237,9 +237,9 @@ data:
     # in the pipeline. (list value)
 {% if openshift_kuryr_subnet_driver|default('default') == 'namespace' %}
 {% if openshift_kuryr_sg_driver|default('default') == 'policy' %}
-    enabled_handlers = vif,lb,lbaasspec,namespace,policy,pod_label,kuryrnetpolicy
+    enabled_handlers = vif,lb,lbaasspec,namespace,policy,pod_label,kuryrnetpolicy,kuryrnet
 {% else %}
-    enabled_handlers = vif,lb,lbaasspec,namespace
+    enabled_handlers = vif,lb,lbaasspec,namespace,kuryrnet
 {% endif %}
 {% else %}
     enabled_handlers = vif,lb,lbaasspec


### PR DESCRIPTION
When using the namespace subnet driver, kuryr creates a new Neutron
subnet for each new namespace. This will require a new pool for the
pods allocated in that subnet, and therefore the pre-population of
ports done during the deployment is not useful. By enabling the new
kuryr kuryrnet handler, for each newly created namespace the handler
will create a new pool in each node so that pods deployment on that
new namespace are later speeded up.