### PR TITLE
Added mandatory missing argument "system_facts"

### DIFF
--- a/playbooks/byo/openshift_facts.yml
+++ b/playbooks/byo/openshift_facts.yml
@@ -6,7 +6,8 @@
   roles:
   - openshift_facts
   tasks:
-  - openshift_facts: {}
+  - openshift_facts:
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
     register: result
   - debug:
       var: result


### PR DESCRIPTION
The module **openshift_facts** on playbook **playbooks/byo/openshift_facts.yml** is not setting any attribute, but there is a mandatory one called **system_facts**.

This playbook is usefull when you want to see if Openshift will use the values you expect from the variables configured on the inventory.