### PR TITLE
Juniper Contrail SDN patch

### DIFF
--- a/playbooks/openshift-master/private/config.yml
+++ b/playbooks/openshift-master/private/config.yml
@@ -89,6 +89,8 @@
   - role: aci
     when:
     - openshift_use_aci | default(false) | bool
+  - role: contrail_master
+    when: openshift_use_contrail | default(false) | bool
   tasks:
   - import_role:
       name: kuryr

--- a/playbooks/openshift-node/private/contrail_sanitize.yml
+++ b/playbooks/openshift-node/private/contrail_sanitize.yml
@@ -1,0 +1,69 @@
+---
+- name: Opening port 53
+  hosts: "{{ openshift_node_scale_up_group | default('oo_nodes_to_config') }}"
+  tasks:
+    - name: open udp port 53
+      command: iptables -I INPUT 4 -j ACCEPT -p udp --dport 53
+      when:
+        - openshift_use_contrail | default(false) | bool
+        - os_firewall_use_firewalld | default(False) | bool
+
+- name: Contrail wait for come up
+  hosts: oo_first_master
+  tasks:
+    - name: Waiting for pods to come up
+      wait_for: timeout=360
+      delegate_to: localhost
+      when: openshift_use_contrail | default(false) | bool
+
+- name: Contrail wait for pod check script
+  hosts: oo_first_master
+  tasks:
+    - name: Check Pods script to Master Node
+      command: /tmp/wait_for_pod.sh
+      when: openshift_use_contrail | default(false) | bool
+      ignore_errors: True
+
+- name: Contrail Restarting dnsmasq service
+  hosts: "{{ openshift_node_scale_up_group | default('oo_nodes_to_config') }}"
+  tasks:
+    - name: Restart dnsmasq
+      service:
+        name: "dnsmasq"
+        state: restarted
+        enabled: yes
+      when:
+        - openshift_use_contrail | default(false) | bool
+        - not nested_mode_contrail | default(false) | bool
+
+- name: Contrail Sanitize schema transformer
+  hosts: "{{ openshift_node_scale_up_group | default('oo_nodes_to_config') }}"
+  roles:
+    - role: contrail_common
+      when:
+        - openshift_use_contrail | default(false) | bool
+        - not nested_mode_contrail | default(false) | bool
+    - role: contrail_st
+      when:
+        - openshift_use_contrail | default(false) | bool
+        - not nested_mode_contrail | default(false) | bool
+
+- name: Contrail Restarting dnsmasq service
+  hosts: "{{ openshift_node_scale_up_group | default('oo_nodes_to_config') }}"
+  tasks:
+    - name: Restart dnsmasq
+      service: name="dnsmasq" state=restarted enabled=yes
+      when:
+        - openshift_use_contrail | default(false) | bool
+        - not nested_mode_contrail | default(false) | bool
+
+- name: Contrail wait for pod check script
+  hosts: oo_first_master
+  tasks:
+    - name: Check Pods script to Master Node
+      command: /tmp/wait_for_pod.sh
+      register: command_result
+      failed_when: "'ERROR' in command_result.stdout"
+      when:
+        - openshift_use_contrail | default(false) | bool
+        - not nested_mode_contrail | default(false) | bool

--- a/playbooks/openshift-node/private/join.yml
+++ b/playbooks/openshift-node/private/join.yml
@@ -97,6 +97,8 @@
   - role: aci
     when: openshift_use_aci | default(false) | bool
 
+- import_playbook: contrail_sanitize.yml
+
 - name: Node Join Checkpoint End
   hosts: all
   gather_facts: false

--- a/roles/contrail_common/README.md
+++ b/roles/contrail_common/README.md
@@ -1,0 +1,47 @@
+# Contrail SDN
+
+[Contrail Networking](https://www.juniper.net/us/en/products-services/sdn/contrail/contrail-networking/), based on [TungstenFabric](https://tungstenfabric.io/) project, is a truly open, multi-cloud network virtualization and policy management platform. Contrail / TungstenFabric SDN stack is integrated with various orchestration systems such as Kubernetes, OpenShift, OpenStack and Mesos, and provides different isolation modes for virtual machines, containers/pods and bare metal workloads.
+
+## SUPPORTED ARCHITECTURE
+
+* Contrail SDN installed through OpenShift ansible supports both non-HA and  HA configurations.
+
+## CONTRAIL SOFTWARE COMPONENTS
+
+### Contrail Master (DaemonSets)
+
+- **Contrail Image Installer**: Downloads all contrail container images if not present.
+- **Contrail Controller Config**: The config daemonset consists of all config components
+  like contrail service monitor, schema transformer, api server etc which are running as
+  a docker container.
+- **Contrail Controller Control**: The contrail controller is installed by this daemonset.
+- **Contrail Controller WebUI**: WebUI components are deployed here. We use port 8143.
+- **Contrail Analytics**: All Contrail analytics components like the analytics collector,
+  topology, alarm-gen are installed by this daemonset.
+- **Contrail Analytics Database**: Contrail Analytics uses this container as its DB.
+- **Contrail Config DB Node Manager**: Node Manager for Config DB, Node manager containers are run
+  by all Contrail components to provide current status.
+- **Contrail Config DB**: DB used by the Contrail Controller Config component.
+- **Contrail Kubernetes Manager**: The interface between the Openshift API server and
+  Contrail Controller.
+
+Note:  These Contrail components are installed on the infra-node.
+
+### Nodes (DaemonSets)
+- **Contrail Agent**: As part of the agent pod we install the **vrouter kernel module** and the **contrail-cni**.
+
+### Contrail Ansible Roles
+
+* **Contrail common**: This role contains common functions which are required by other contrail roles
+* **Contrail master**: Preps up by creating all daemonsets.
+* **Contrail st**: Preps the contrail schema transformer.
+
+## INSTALLATION
+
+To install Contrail SDN with OpenShift Enterprise, follow this [install guide](https://github.com/Juniper/contrail-kubernetes-docs)
+
+Refer to this example [openshift 3.11 contrail installation](https://github.com/Juniper/contrail-kubernetes-docs/blob/master/install/openshift/3.11/standalone-openshift.md) for non-HA/HA deployments
+
+### CONTACT
+
+Pragash Vijayaragavan <pvijayaragav@juniper.net>

--- a/roles/contrail_common/defaults/main.yml
+++ b/roles/contrail_common/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+contrail_masters: ""
+contrail_masters_ip: ""
+contrail_node_group: "node-config-infra"

--- a/roles/contrail_common/tasks/determine_contrail_masters.yaml
+++ b/roles/contrail_common/tasks/determine_contrail_masters.yaml
@@ -1,0 +1,21 @@
+---
+- name: Set contrail_masters from contrail_control_data_interface
+  set_fact:
+    contrail_masters: "{{ contrail_control_data_interface }}"
+  when:
+    - contrail_control_data_interface is defined
+
+- name: Set contrail_masters from infra nodes
+  set_fact:
+    contrail_masters: "{{ contrail_masters }} {{ item }}"
+  when:
+    - contrail_control_data_interface is not defined
+    - hostvars[item]['openshift_node_group_name'] is defined
+    - hostvars[item]['openshift_node_group_name'] == contrail_node_group
+  with_items: "{{ groups.nodes }}"
+
+- name: Set contrail_masters from masters group if not set before
+  set_fact:
+    contrail_masters: "{{ contrail_masters }} {{ item }}"
+  with_items: "{{ groups.masters }}"
+  when: contrail_masters.split() | length < 1

--- a/roles/contrail_common/tasks/hosts_to_ip.yaml
+++ b/roles/contrail_common/tasks/hosts_to_ip.yaml
@@ -1,0 +1,4 @@
+---
+- set_fact:
+    contrail_masters_ip: "{{ contrail_masters_ip }} {{ hostvars[item]['ansible_default_ipv4']['address'] }}"
+  with_items: "{{ contrail_masters.split() }}"

--- a/roles/contrail_common/tasks/main.yml
+++ b/roles/contrail_common/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Determine contrail masters
+  include_tasks: determine_contrail_masters.yaml
+
+- name: Convert hostnames to ip
+  include_tasks: hosts_to_ip.yaml

--- a/roles/contrail_master/README.md
+++ b/roles/contrail_master/README.md
@@ -1,0 +1,47 @@
+# Contrail SDN
+
+[Contrail Networking](https://www.juniper.net/us/en/products-services/sdn/contrail/contrail-networking/), based on [TungstenFabric](https://tungstenfabric.io/) project, is a truly open, multi-cloud network virtualization and policy management platform. Contrail / TungstenFabric SDN stack is integrated with various orchestration systems such as Kubernetes, OpenShift, OpenStack and Mesos, and provides different isolation modes for virtual machines, containers/pods and bare metal workloads.
+
+## SUPPORTED ARCHITECTURE
+
+* Contrail SDN installed through OpenShift ansible supports both non-HA and  HA configurations.
+
+## CONTRAIL SOFTWARE COMPONENTS
+
+### Contrail Master (DaemonSets)
+
+- **Contrail Image Installer**: Downloads all contrail container images if not present.
+- **Contrail Controller Config**: The config daemonset consists of all config components
+  like contrail service monitor, schema transformer, api server etc which are running as
+  a docker container.
+- **Contrail Controller Control**: The contrail controller is installed by this daemonset.
+- **Contrail Controller WebUI**: WebUI components are deployed here. We use port 8143.
+- **Contrail Analytics**: All Contrail analytics components like the analytics collector,
+  topology, alarm-gen are installed by this daemonset.
+- **Contrail Analytics Database**: Contrail Analytics uses this container as its DB.
+- **Contrail Config DB Node Manager**: Node Manager for Config DB, Node manager containers are run
+  by all Contrail components to provide current status.
+- **Contrail Config DB**: DB used by the Contrail Controller Config component.
+- **Contrail Kubernetes Manager**: The interface between the Openshift API server and
+  Contrail Controller.
+
+Note:  These Contrail components are installed on the infra-node.
+
+### Nodes (DaemonSets)
+- **Contrail Agent**: As part of the agent pod we install the **vrouter kernel module** and the **contrail-cni**.
+
+### Contrail Ansible Roles
+
+* **Contrail common**: This role contains common functions which are required by other contrail roles
+* **Contrail master**: Preps up by creating all daemonsets.
+* **Contrail st**: Preps the contrail schema transformer.
+
+## INSTALLATION
+
+To install Contrail SDN with OpenShift Enterprise, follow this [install guide](https://github.com/Juniper/contrail-kubernetes-docs)
+
+Refer to this example [openshift 3.11 contrail installation](https://github.com/Juniper/contrail-kubernetes-docs/blob/master/install/openshift/3.11/standalone-openshift.md) for non-HA/HA deployments
+
+### CONTACT
+
+Pragash Vijayaragavan <pvijayaragav@juniper.net>

--- a/roles/contrail_master/defaults/main.yml
+++ b/roles/contrail_master/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+contrail_os_release: redhat7
+analyticsdb_min_diskgb: 50
+configdb_min_diskgb: 25
+aaa_mode: no-auth
+auth_mode: noauth
+LOG_LEVEL: SYS_NOTICE
+METADATA_PROXY_SECRET: contrail
+cloud_orchestrator: kubernetes
+metadata_proxy_secret: contrail
+log_level: SYS_NOTICE
+rabbitmq_node_port: 5672
+zookeeper_analytics_port: 2182
+zookeeper_port: 2181
+zookeeper_ports: 2888:3888
+zookeeper_analytics_ports: 4888:5888
+vrouter_gateway:
+kubernetes_api_secure_port: 8443
+nested_mode_contrail: false
+contrail_registry: opencontrailnightly
+contrail_container_tag: latest

--- a/roles/contrail_master/meta/main.yml
+++ b/roles/contrail_master/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  author: Contrail
+  description: Contrail Networking
+  company: Juniper Networks, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 2.5
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+  - system

--- a/roles/contrail_master/tasks/main.yaml
+++ b/roles/contrail_master/tasks/main.yaml
@@ -1,0 +1,26 @@
+---
+- fail:
+    msg: Contrail doesn't support CRI-O
+  when: openshift_use_crio_only
+
+- name: Run kube proxy
+  import_role:
+    name: kube_proxy_and_dns
+  delegate_to: "{{ groups.oo_first_master.0 }}"
+
+- name: Get contrail nodes and ips
+  import_role:
+    name: contrail_common
+
+- name: Create contrail controller components and Daemonsets
+  include_tasks: os_contrail_master.yaml
+  when: not nested_mode_contrail | default(false) | bool
+
+- name: Create contrail nested components
+  include_tasks: os_contrail_nested.yaml
+  when: nested_mode_contrail | default(false) | bool
+
+- name: Enable Fabric SNAT on default project
+  command: >
+    {{ openshift_client_binary }} annotate namespace default "opencontrail.org/ip_fabric_snat=true" --overwrite
+  delegate_to: "{{ groups.oo_first_master.0 }}"

--- a/roles/contrail_master/tasks/os_contrail_master.yaml
+++ b/roles/contrail_master/tasks/os_contrail_master.yaml
@@ -1,0 +1,109 @@
+---
+- name: Create the get IP file to convert hostname to ip
+  template:
+    src: getIp.j2
+    dest: /tmp/getIp.py
+    owner: root
+    mode: 0644
+  run_once: True
+
+- set_fact:
+    api_vip: "{{ groups.lb.0 | ipaddr }}"
+  when: groups.lb is defined
+  run_once: True
+
+- set_fact:
+    api_vip: "{{ openshift_master_cluster_public_hostname }}"
+  when: openshift_master_cluster_public_hostname is defined
+  run_once: True
+
+- set_fact:
+    api_vip: "{{ groups.masters.0 }}"
+  when: api_vip is not defined
+  run_once: True
+
+- name: validate api_vip hostname or ip
+  command: python /tmp/getIp.py {{ api_vip }}
+  register: api_vip_result
+  run_once: True
+
+- name: set api_vip
+  set_fact:
+    api_vip: "{{ api_vip_result.stdout }}"
+  when: api_vip_result is success
+  run_once: True
+
+- name: Create the contrail namespace template file
+  template:
+    src: contrail-namespace.j2
+    dest: /tmp/contrail-namespace.yaml
+    owner: root
+    mode: 0644
+  run_once: True
+
+- name: Create the contrail-system namespace
+  oc_project:
+    state: present
+    name: "contrail-system"
+  run_once: True
+
+- name: Create the contrail template files
+  template:
+    src: "{{ item }}-5.j2"
+    dest: "/tmp/{{ item }}.yaml"
+    owner: root
+    mode: 0644
+  run_once: True
+  with_items:
+    - "contrail-image-downloader"
+    - "contrail-infra-vars"
+    - "contrail-agent"
+    - "contrail-analytics"
+    - "contrail-analytics-alarm"
+    - "contrail-analytics-db"
+    - "contrail-analytics-snmp"
+    - "contrail-config-db"
+    - "contrail-control-config"
+    - "contrail-ext-redis"
+    - "contrail-kube-manager"
+    - "contrail-webui"
+
+- name: Copy the wait for POD script to master node
+  template:
+    src: wait_for_pod.j2
+    dest: /tmp/wait_for_pod.sh
+    owner: root
+    mode: 0777
+  run_once: true
+
+- name: Give privileged access to default service account of contrail-system namespace
+  oc_adm_policy_user:
+    user: system:serviceaccount:contrail-system:default
+    resource_kind: scc
+    resource_name: privileged
+    state: present
+  run_once: True
+
+- name: Create Contrail registry secret
+  command: "{{ openshift_client_binary }} create secret docker-registry contrail-registry-secret --docker-server={{ contrail_registry }} --docker-username={{ contrail_registry_username }} --docker-password={{ contrail_registry_password }} --docker-email=contrail@helloworld.com -n contrail-system"
+  run_once: True
+  when: contrail_registry_username is defined
+  ignore_errors: True
+
+- name: Starting the contrail components on required nodes
+  command: "{{ openshift_client_binary }} create -f /tmp/{{ item }}.yaml"
+  run_once: True
+  ignore_errors: True
+  with_items:
+    - "contrail-image-downloader"
+    - "contrail-infra-vars"
+    - "contrail-agent"
+    - "contrail-analytics"
+    - "contrail-analytics-alarm"
+    - "contrail-analytics-db"
+    - "contrail-analytics-snmp"
+    - "contrail-config-db"
+    - "contrail-control-config"
+    - "contrail-ext-redis"
+    - "contrail-kube-manager"
+    - "contrail-webui"

--- a/roles/contrail_master/tasks/os_contrail_nested.yaml
+++ b/roles/contrail_master/tasks/os_contrail_nested.yaml
@@ -1,0 +1,58 @@
+---
+- name: Create the get IP file to convert hostname to ip
+  template:
+    src: getIp.j2
+    dest: /tmp/getIp.py
+    owner: root
+    mode: 0644
+  run_once: True
+
+- name: Copy the wait for POD script to master node
+  template:
+    src: wait_for_pod.j2
+    dest: /tmp/wait_for_pod.sh
+    owner: root
+    mode: 0777
+  run_once: true
+
+- name: Create the contrail nested template file
+  template:
+    src: contrail-nested.j2
+    dest: /tmp/contrail-nested.yaml
+    owner: root
+    mode: 0644
+  run_once: True
+
+- name: Create the contrail namespace template file
+  template:
+    src: contrail-namespace.j2
+    dest: /tmp/contrail-namespace.yaml
+    owner: root
+    mode: 0644
+  run_once: True
+
+- name: Create the contrail namespace
+  command: "{{ openshift_client_binary }} create -f /tmp/contrail-namespace.yaml"
+  run_once: True
+  ignore_errors: True
+
+- name: Give privileged access to default service account of contrail-system namespace
+  oc_adm_policy_user:
+    user: system:serviceaccount:contrail-system:default
+    resource_kind: scc
+    resource_name: privileged
+    state: present
+  run_once: True
+
+- name: Create Contrail registry secret
+  command: "{{ openshift_client_binary }} create secret docker-registry contrail-registry-secret --docker-server={{ contrail_registry }} --docker-username={{ contrail_registry_username }} --docker-password={{ contrail_registry_password }} --docker-email=contrail@helloworld.com -n contrail-system"
+  run_once: True
+  when: contrail_registry_username is defined
+  ignore_errors: True
+
+- name: Create the contrail nested components
+  command: "{{ openshift_client_binary }} create -f /tmp/contrail-nested.yaml"
+  run_once: True
+  ignore_errors: True
+  when:
+    - contrail_version is version('5.0', '>=')

--- a/roles/contrail_master/templates/contrail-agent-5.j2
+++ b/roles/contrail_master/templates/contrail-agent-5.j2
@@ -1,0 +1,277 @@
+# This file contains the contrail agent components.
+# This component will be installed as DaemonSet on all nodes
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-env
+  namespace: contrail-system
+data:
+  AAA_MODE: {{ aaa_mode }}
+  ANALYTICS_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ANALYTICSDB_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  AUTH_MODE: {{ auth_mode }}
+  CLOUD_ORCHESTRATOR: {{ cloud_orchestrator }}
+  CONFIG_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONFIGDB_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONTROL_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONTROLLER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  KAFKA_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  LOG_LEVEL: {{ log_level }}
+  METADATA_PROXY_SECRET: {{ metadata_proxy_secret }}
+  PHYSICAL_INTERFACE: {{ vrouter_physical_interface | default('') }}
+  RABBITMQ_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  RABBITMQ_NODE_PORT: "{{ rabbitmq_node_port }}"
+  DNS_SERVER_PORT: "{{ dns_server_port | default('9053') }}"
+  REDIS_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  VROUTER_GATEWAY: {{ vrouter_gateway }}
+  WEBUI_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ZOOKEEPER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ANALYTICS_SNMP_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ANALYTICS_ALARM_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ANALYTICSDB_PORT: "9163"
+  ANALYTICSDB_CQL_PORT: "9045"
+  CONFIGDB_PORT: "9164"
+  CONFIGDB_CQL_PORT: "9044"
+  ANALYTICSDB_ENABLE: "true"
+  ANALYTICS_ALARM_ENABLE: "true"
+  ANALYTICS_SNMP_ENABLE: "true"
+  ANALYTICS_SNMP_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ANALYTICS_ALARM_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-nodemgr-config
+  namespace: contrail-system
+data:
+  DOCKER_HOST: "unix://mnt/docker.sock"
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-agent
+  namespace: contrail-system
+  labels:
+    app: contrail-agent
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-agent
+    spec:
+      automountServiceAccountToken: false
+      hostNetwork: true
+      initContainers:
+      - name: kubernetes-entrypoint-init
+        image: quay.io/stackanetes/kubernetes-entrypoint:v0.2.1
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        command:
+        - kubernetes-entrypoint
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        #- name: INTERFACE_NAME
+        #  value: eth0
+        - name: DEPENDENCY_SERVICE
+        - name: DEPENDENCY_JOBS
+        - name: DEPENDENCY_DAEMONSET
+          value: contrail-controller-config
+        - name: DEPENDENCY_CONTAINER
+        - name: COMMAND
+          value: echo done
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: pod-secret
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONFIGURE_IPTABLES
+          value: "true"
+        - name: IPTABLES_CHAIN
+          value: "OS_FIREWALL_ALLOW"
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        - name: NODE_TYPE
+          value: "vrouter"
+        envFrom:
+        - configMapRef:
+            name: agent-env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      - name: contrail-download-contrail-status-image
+        image: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-contrail-kubernetes-cni-init-image
+        image: "{{ contrail_registry }}/contrail-kubernetes-cni-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-contrail-vrouter-agent-image
+        image: "{{ contrail_registry }}/contrail-vrouter-agent:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-contrail-nodemgr-image
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-vrouter-kernel-init
+        image: "{{ contrail_registry }}/contrail-vrouter-kernel-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: agent-env
+        volumeMounts:
+        - mountPath: /usr/src
+          name: usr-src
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /etc/sysconfig/network-scripts
+          name: network-scripts
+        - mountPath: /host/bin
+          name: host-bin
+      - name: contrail-kubernetes-cni-init
+        image: "{{ contrail_registry }}/contrail-kubernetes-cni-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: agent-env
+        volumeMounts:
+        - mountPath: /var/lib/contrail
+          name: var-lib-contrail
+        - mountPath: /host/etc_cni
+          name: etc-cni
+        - mountPath: /host/opt_cni_bin
+          name: opt-cni-bin
+        - mountPath: /host/log_cni
+          name: var-log-contrail-cni
+        - mountPath: /var/log/contrail
+          name: agent-logs
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-vrouter-agent
+        image: "{{ contrail_registry }}/contrail-vrouter-agent:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        # TODO: Priveleged mode is requied because w/o it the device /dev/net/tun
+        # is not present in the container. The mounting it into container
+        # doesnt help because of permissions are not enough syscalls,
+        # e.g. https://github.com/Juniper/contrail-controller/blob/master/src/vnsw/agent/contrail/linux/pkt0_interface.cc: 48.
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: agent-env
+        volumeMounts:
+        - mountPath: /dev
+          name: dev
+        - mountPath: /etc/sysconfig/network-scripts
+          name: network-scripts
+        - mountPath: /host/bin
+          name: host-bin
+        - mountPath: /var/log/contrail
+          name: agent-logs
+        - mountPath: /usr/src
+          name: usr-src
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /var/lib/contrail
+          name: var-lib-contrail
+        - mountPath: /var/crashes
+          name: var-crashes
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-agent-nodemgr
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: agent-env
+        - configMapRef:
+            name: agent-nodemgr-config
+        env:
+        - name: NODE_TYPE
+          value: vrouter
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: agent-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: network-scripts
+        hostPath:
+          path: /etc/sysconfig/network-scripts
+      - name: host-bin
+        hostPath:
+          path: /bin
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: var-lib-contrail
+        hostPath:
+          path: /var/lib/contrail
+      - name: var-crashes
+        hostPath:
+          path: /var/contrail/crashes
+      - name: etc-cni
+        hostPath:
+          path: /etc/cni
+      - name: opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: var-log-contrail-cni
+        hostPath:
+          path: /var/log/contrail/cni
+      - name: agent-logs
+        hostPath:
+          path: /var/log/contrail/agent
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: pod-secret
+        secret:
+          secretName: contrail-kubernetes-token
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---

--- a/roles/contrail_master/templates/contrail-analytics-5.j2
+++ b/roles/contrail_master/templates/contrail-analytics-5.j2
@@ -1,0 +1,124 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-analytics
+  namespace: contrail-system
+  labels:
+    app: contrail-analytics
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-analytics
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/infra"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONFIGURE_IPTABLES
+          value: "true"
+        - name: IPTABLES_CHAIN
+          value: "OS_FIREWALL_ALLOW"
+        - name: NODE_TYPE
+          value: "analytics"
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-analytics-api
+        image: "{{ contrail_registry }}/contrail-analytics-api:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-analytics-collector
+        image: "{{ contrail_registry }}/contrail-analytics-collector:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: analytics
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-analytics-nodemgr
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        env:
+        - name: NODE_TYPE
+          value: analytics
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /etc/localtime
+          name: localtime
+          containers:
+      volumes:
+      - name: analytics-logs
+        hostPath:
+          path: /var/log/contrail/analytics
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+      - name: analytics-zookeeper-data
+        hostPath:
+          path: /var/lib/analytics_zookeeper_data
+      - name: analytics-zookeeper-datalog
+        hostPath:
+          path: /var/lib/analytics_zookeeper_datalog
+      - name: zookeeper-logs
+        hostPath:
+          path: /var/log/contrail/analytics
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---

--- a/roles/contrail_master/templates/contrail-analytics-alarm-5.j2
+++ b/roles/contrail_master/templates/contrail-analytics-alarm-5.j2
@@ -1,0 +1,144 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-analytics-alarm
+  namespace: contrail-system
+  labels:
+    app: contrail-analytics-alarm
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-analytics-alarm
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/infra"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        env:
+        - name: CONFIGURE_IPTABLES
+          value: "true"
+        - name: IPTABLES_CHAIN
+          value: "OS_FIREWALL_ALLOW"
+        - name: NODE_TYPE
+          value: "analytics-alarm"
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: contrail-analyticsdb-config
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+        - mountPath: /host/var/lib
+          name: host-var-lib
+      - name: contrail-kafka-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        command: ["mkdir","-pm","777","/host/var/lib/contrail/kafka-logs"]
+        imagePullPolicy: "IfNotPresent"
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: contrail-analyticsdb-config
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+        - mountPath: /host/var/lib
+          name: host-var-lib
+      containers:
+      - name: kafka
+        image: "{{ contrail_registry }}/contrail-external-kafka:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: analytics-alarm
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /tmp/kafka-logs
+          name: kafka-logs
+      - name: contrail-analytics-alarm-gen
+        image: "{{ contrail_registry }}/contrail-analytics-alarm-gen:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-alarm-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-analytics-alarm-nodemgr
+        image: "{{contrail_registry}}/contrail-nodemgr:{{contrail_container_tag}}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        - configMapRef:
+            name: contrail-analyticsdb-config
+        env:
+        - name: NODE_TYPE
+          value: analytics-alarm
+        - name: DATABASE_NODEMGR__DEFAULTS__minimum_diskGB
+          value: "2"
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-alarm-nodemgr-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: host-var-lib
+        hostPath:
+          path: /var/lib
+      - name: kafka-logs
+        hostPath:
+          path: /var/lib/contrail/kafka-logs
+      - name: analytics-alarm-logs
+        hostPath:
+          path: /var/log/contrail/analytics-alarm
+      - name: analytics-alarm-nodemgr-logs
+        hostPath:
+          path: /var/log/contrail/analytics-alarm
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---

--- a/roles/contrail_master/templates/contrail-analytics-db-5.j2
+++ b/roles/contrail_master/templates/contrail-analytics-db-5.j2
@@ -1,0 +1,127 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-analyticsdb
+  namespace: contrail-system
+  labels:
+    app: contrail-analyticsdb
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-analyticsdb
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/infra"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        env:
+        - name: CONFIGURE_IPTABLES
+          value: "true"
+        - name: IPTABLES_CHAIN
+          value: "OS_FIREWALL_ALLOW"
+        - name: NODE_TYPE
+          value: "database"
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: contrail-analyticsdb-config
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+        - mountPath: /host/var/lib
+          name: host-var-lib
+      containers:
+      - name: contrail-analyticsdb-nodemgr
+        image: "{{contrail_registry}}/contrail-nodemgr:{{contrail_container_tag}}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        - configMapRef:
+            name: contrail-analyticsdb-config
+        env:
+        - name: NODE_TYPE
+          value: database
+        - name: DATABASE_NODEMGR__DEFAULTS__minimum_diskGB
+          value: "2"
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analyticsdb-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-analyticsdb
+        image: "{{ contrail_registry }}/contrail-external-cassandra:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: database
+        envFrom:
+        - configMapRef:
+            name: contrail-analyticsdb-config
+        volumeMounts:
+        - mountPath: /var/lib/cassandra
+          name: analyticsdb-data
+        - mountPath: /var/log/cassandra
+          name: analyticsdb-logs
+      - name: contrail-analytics-query-engine
+        image: "{{ contrail_registry }}/contrail-analytics-query-engine:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: database
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analyticsdb-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: analyticsdb-data
+        hostPath:
+          path: /var/lib/contrail/analyticsdb
+      - name: analyticsdb-logs
+        hostPath:
+          path: /var/log/contrail/analyticsdb
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: host-var-lib
+        hostPath:
+          path: /var/lib
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---

--- a/roles/contrail_master/templates/contrail-analytics-snmp-5.j2
+++ b/roles/contrail_master/templates/contrail-analytics-snmp-5.j2
@@ -1,0 +1,132 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-analytics-snmp
+  namespace: contrail-system
+  labels:
+    app: contrail-analytics-snmp
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-analytics-snmp
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/infra"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        env:
+        - name: CONFIGURE_IPTABLES
+          value: "true"
+        - name: IPTABLES_CHAIN
+          value: "OS_FIREWALL_ALLOW"
+        - name: NODE_TYPE
+          value: "analytics-snmp"
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: contrail-analyticsdb-config
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+        - mountPath: /host/var/lib
+          name: host-var-lib
+      containers:
+      - name: contrail-analytics-snmp-collector
+        image: "{{ contrail_registry }}/contrail-analytics-snmp-collector:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: analytics-snmp
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-snmp-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-analytics-snmp-nodemgr
+        image: "{{contrail_registry}}/contrail-nodemgr:{{contrail_container_tag}}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        - configMapRef:
+            name: contrail-analyticsdb-config
+        env:
+        - name: NODE_TYPE
+          value: analytics-snmp
+        - name: DATABASE_NODEMGR__DEFAULTS__minimum_diskGB
+          value: "2"
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-snmp-nodemgr-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-analytics-topology
+        image: "{{ contrail_registry }}/contrail-analytics-snmp-topology:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: analytics-snmp
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: analyticszookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: analytics-snmp-topology-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: host-var-lib
+        hostPath:
+          path: /var/lib
+      - name: analytics-snmp-topology-logs
+        hostPath:
+          path: /var/lib/contrail/analytics-snmp
+      - name: analytics-snmp-logs
+        hostPath:
+          path: /var/lib/contrail/analytics-snmp
+      - name: analytics-snmp-nodemgr-logs
+        hostPath:
+          path: /var/log/contrail/analytics-snmp
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---

--- a/roles/contrail_master/templates/contrail-config-db-5.j2
+++ b/roles/contrail_master/templates/contrail-config-db-5.j2
@@ -1,0 +1,157 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-configdb
+  namespace: contrail-system
+  labels:
+    app: contrail-configdb
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-configdb
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/infra"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONFIGURE_IPTABLES
+          value: "true"
+        - name: IPTABLES_CHAIN
+          value: "OS_FIREWALL_ALLOW"
+        - name: NODE_TYPE
+          value: "config-database"
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: contrail-configdb-config
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-config-database-nodemgr
+        image: "{{contrail_registry}}/contrail-nodemgr:{{contrail_container_tag}}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        - configMapRef:
+            name: contrail-configdb-config
+        env:
+        - name: NODE_TYPE
+          value: config-database
+        - name: CONFIG_DATABASE_NODEMGR__DEFAULTS__minimum_diskGB
+          value: "2"
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: configdb-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: config-zookeeper
+        image: "{{ contrail_registry }}/contrail-external-zookeeper:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: config-database
+        envFrom:
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/lib/zookeeper
+          name: zookeeper-data
+        - mountPath: /var/log/zookeeper
+          name: zookeeper-logs
+      - name: rabbitmq
+        image: "{{ contrail_registry }}/contrail-external-rabbitmq:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: config-database
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: rabbitmq-config
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/lib/rabbitmq
+          name: rabbitmq-data
+        - mountPath: /var/log/rabbitmq
+          name: rabbitmq-logs
+      - name: contrail-configdb
+        image: "{{ contrail_registry }}/contrail-external-cassandra:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_TYPE
+          value: config-database
+        envFrom:
+        - configMapRef:
+            name: contrail-configdb-config
+        volumeMounts:
+        - mountPath: /var/lib/cassandra
+          name: configdb-data
+        - mountPath: /var/log/cassandra
+          name: configdb-log
+      volumes:
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: configdb-data
+        hostPath:
+          path: /var/lib/contrail/configdb
+      - name: configdb-log
+        hostPath:
+          path: /var/log/contrail/configdb
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: configdb-logs
+        hostPath:
+          path: /var/log/contrail/configdb
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+      - name: zookeeper-data
+        hostPath:
+          path: /var/lib/contrail/config-zookeeper
+      - name: zookeeper-logs
+        hostPath:
+          path: /var/log/contrail/config-zookeeper
+      - name: rabbitmq-data
+        hostPath:
+          path: /var/lib/contrail/rabbitmq
+      - name: rabbitmq-logs
+        hostPath:
+          path: /var/log/contrail/rabbitmq
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---

--- a/roles/contrail_master/templates/contrail-control-config-5.j2
+++ b/roles/contrail_master/templates/contrail-control-config-5.j2
@@ -1,0 +1,360 @@
+# This file contains the contrail controller and config components.
+# These 2 components will be installed as DaemonSets on the infra node
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-controller-control
+  namespace: contrail-system
+  labels:
+    app: contrail-controller-control
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-controller-control
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/infra"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: kubernetes-entrypoint-init
+        image: quay.io/stackanetes/kubernetes-entrypoint:v0.2.1
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        command:
+        - kubernetes-entrypoint
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        #- name: INTERFACE_NAME
+        #  value: eth0
+        - name: DEPENDENCY_SERVICE
+        - name: DEPENDENCY_JOBS
+        - name: DEPENDENCY_DAEMONSET
+          value: contrail-image-installer,contrail-configdb
+        - name: DEPENDENCY_CONTAINER
+        - name: COMMAND
+          value: echo done
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: pod-secret
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONFIGURE_IPTABLES
+          value: "true"
+        - name: IPTABLES_CHAIN
+          value: "OS_FIREWALL_ALLOW"
+        - name: NODE_TYPE
+          value: "control"
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-controller-control
+        image: "{{ contrail_registry }}/contrail-controller-control-control:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: control-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-control-dns
+        image: "{{ contrail_registry }}/contrail-controller-control-dns:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /etc/contrail
+          name: dns-config
+        - mountPath: /var/log/contrail
+          name: control-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-control-named
+        image: "{{ contrail_registry }}/contrail-controller-control-named:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/contrail
+          name: dns-config
+        - mountPath: /var/log/contrail
+          name: control-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-control-nodemgr
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        - configMapRef:
+            name: nodemgr-config
+        env:
+        - name: NODE_TYPE
+          value: control
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: control-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: control-logs
+        hostPath:
+          path: /var/log/contrail/control
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: dns-config
+        emptyDir: {}
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: pod-secret
+        secret:
+          secretName: contrail-kubernetes-token
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-controller-config
+  namespace: contrail-system
+  labels:
+    app: contrail-controller-config
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-controller-config
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/infra"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: kubernetes-entrypoint-init
+        image: quay.io/stackanetes/kubernetes-entrypoint:v0.2.1
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        command:
+        - kubernetes-entrypoint
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        #- name: INTERFACE_NAME
+        #  value: eth0
+        - name: DEPENDENCY_SERVICE
+        - name: DEPENDENCY_JOBS
+        - name: DEPENDENCY_DAEMONSET
+          value: contrail-image-installer,contrail-configdb
+        - name: DEPENDENCY_CONTAINER
+        - name: COMMAND
+          value: echo done
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: pod-secret
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONFIGURE_IPTABLES
+          value: "true"
+        - name: IPTABLES_CHAIN
+          value: "OS_FIREWALL_ALLOW"
+        - name: NODE_TYPE
+          value: "config"
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-controller-config-api
+        image: "{{ contrail_registry }}/contrail-controller-config-api:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-config-devicemgr
+        image: "{{ contrail_registry }}/contrail-controller-config-devicemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-config-schema
+        image: "{{ contrail_registry }}/contrail-controller-config-schema:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-config-svcmonitor
+        image: "{{ contrail_registry }}/contrail-controller-config-svcmonitor:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-config-nodemgr
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: nodemgr-config
+        env:
+        - name: NODE_TYPE
+          value: config
+        - name: CASSANDRA_CQL_PORT
+          value: "9041"
+        - name: CASSANDRA_JMX_LOCAL_PORT
+          value: "7201"
+        - name: CONFIG_NODEMGR__DEFAULTS__minimum_diskG
+          value: "2"
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: config-logs
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: config-logs
+        hostPath:
+          path: /var/log/contrail/config
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: pod-secret
+        secret:
+          secretName: contrail-kubernetes-token
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---

--- a/roles/contrail_master/templates/contrail-ext-redis-5.j2
+++ b/roles/contrail_master/templates/contrail-ext-redis-5.j2
@@ -1,0 +1,65 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: redis
+  namespace: contrail-system
+  labels:
+    app: redis
+spec:
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/infra"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: redis
+        image: "docker.io/redis:4.0.2"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /var/lib/redis
+          name: redis-data
+        - mountPath: /var/log/redis
+          name: redis-logs
+      volumes:
+      - name: redis-data
+        hostPath:
+          path: /var/lib/contrail/redis
+      - name: redis-logs
+        hostPath:
+          path: /var/log/contrail/redis
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---

--- a/roles/contrail_master/templates/contrail-image-downloader-5.j2
+++ b/roles/contrail_master/templates/contrail-image-downloader-5.j2
@@ -1,0 +1,130 @@
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-image-installer
+  namespace: contrail-system
+  labels:
+    app: contrail-image-download
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-image-download
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/infra"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-download-contrail-status-image
+        image: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-redis-image
+        image: "redis:4.0.2"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-node-init-image
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-node-manager-image
+        image: "{{ contrail_registry }}/contrail-nodemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-external-cassandra-image
+        image: "{{ contrail_registry }}/contrail-external-cassandra:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-external-zookeeper-image
+        image: "{{ contrail_registry }}/contrail-external-zookeeper:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-external-rabbitmq-image
+        image: "{{ contrail_registry }}/contrail-external-rabbitmq:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-external-kafka-image
+        image: "{{ contrail_registry }}/contrail-external-kafka:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-analytics-api-image
+        image: "{{ contrail_registry }}/contrail-analytics-api:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-analytics-collector-image
+        image: "{{ contrail_registry }}/contrail-analytics-collector:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-analytics-alarm-gen-image
+        image: "{{ contrail_registry }}/contrail-analytics-alarm-gen:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-analytics-query-engine-image
+        image: "{{ contrail_registry }}/contrail-analytics-query-engine:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-analytics-snmp-collector-image
+        image: "{{ contrail_registry }}/contrail-analytics-snmp-collector:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-analytics-topology-image
+        image: "{{ contrail_registry }}/contrail-analytics-snmp-topology:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-control-image
+        image: "{{ contrail_registry }}/contrail-controller-control-control:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-control-dns-image
+        image: "{{ contrail_registry }}/contrail-controller-control-dns:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-control-named-image
+        image: "{{ contrail_registry }}/contrail-controller-control-named:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-config-image
+        image: "{{ contrail_registry }}/contrail-controller-config-api:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-config-devicemgr-image
+        image: "{{ contrail_registry }}/contrail-controller-config-devicemgr:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-config-schema-image
+        image: "{{ contrail_registry }}/contrail-controller-config-schema:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-config-svc-monitor-image
+        image: "{{ contrail_registry }}/contrail-controller-config-svcmonitor:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-webui-job-image
+        image: "{{ contrail_registry }}/contrail-controller-webui-job:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-webui-web-image
+        image: "{{ contrail_registry }}/contrail-controller-webui-web:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      - name: contrail-download-controller-kube-manager-image
+        image: "{{ contrail_registry }}/contrail-kubernetes-kube-manager:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/true"]
+      containers:
+      - name: contrail-download-image
+        image: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        command: ["tailf","/dev/null"]
+        securityContext:
+          privileged: true
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}

--- a/roles/contrail_master/templates/contrail-infra-vars-5.j2
+++ b/roles/contrail_master/templates/contrail-infra-vars-5.j2
@@ -1,0 +1,183 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: env
+  namespace: contrail-system
+data:
+  AAA_MODE: {{ aaa_mode }}
+  ANALYTICS_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ANALYTICSDB_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  AUTH_MODE: {{ auth_mode }}
+  CLOUD_ORCHESTRATOR: {{ cloud_orchestrator }}
+  CONFIG_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONFIGDB_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONTROL_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CONTROLLER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  KAFKA_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  LOG_LEVEL: {{ log_level }}
+  METADATA_PROXY_SECRET: {{ metadata_proxy_secret }}
+  PHYSICAL_INTERFACE: {{ vrouter_physical_interface | default('') }}
+  RABBITMQ_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  RABBITMQ_NODE_PORT: "{{ rabbitmq_node_port }}"
+  DNS_SERVER_PORT: "{{ dns_server_port | default('9053') }}"
+  REDIS_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  VROUTER_GATEWAY: {{ vrouter_gateway }}
+  WEBUI_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ZOOKEEPER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ANALYTICSDB_PORT: "9163"
+  ANALYTICSDB_CQL_PORT: "9045"
+  CONFIGDB_PORT: "9164"
+  CONFIGDB_CQL_PORT: "9044"
+  ANALYTICSDB_ENABLE: "true"
+  ANALYTICS_ALARM_ENABLE: "true"
+  ANALYTICS_SNMP_ENABLE: "true"
+  ANALYTICS_SNMP_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  ANALYTICS_ALARM_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contrail
+  namespace: contrail-system
+---
+kind: ClusterRole
+apiVersion: v1
+metadata:
+  name: contrail
+  namespace: contrail-system
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: v1
+kind: ClusterRoleBinding
+metadata:
+  name: contrail
+roleRef:
+  name: contrail
+subjects:
+- kind: SystemUser
+  name: contrail-system:contrail
+- kind: ServiceAccount
+  name: contrail
+  namespace: contrail-system
+userNames:
+  - system:serviceaccount:contrail-system:contrail
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: contrail-kubernetes-token
+  namespace: contrail-system
+  annotations:
+    kubernetes.io/service-account.name: contrail
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-manager-config
+  namespace: contrail-system
+data:
+  KUBERNETES_API_SERVER: {{ kubernetes_api_server | default(api_vip | ipaddr) }}
+  KUBERNETES_API_SECURE_PORT: "{{ openshift_master_api_port | default(kubernetes_api_secure_port) }}"
+  K8S_TOKEN_FILE: "/tmp/serviceaccount/token"
+  KUBERNETES_CLUSTER_NAME: "{{ cluster_name | default('k8s') }}"
+  KUBERNETES_CLUSTER_PROJECT: "{{ cluster_project | default('{}') }}"
+  KUBERNETES_CLUSTER_NETWORK: "{{ cluster_network | default('{}') }}"
+  KUBERNETES_POD_SUBNETS: "{{ pod_subnets | default('10.32.0.0/12') }}"
+  KUBERNETES_IP_FABRIC_SUBNETS: "{{ ip_fabric_subnets | default('10.64.0.0/12') }}"
+  KUBERNETES_SERVICE_SUBNETS: "{{ service_subnets | default('10.96.0.0/12') }}"
+  KUBERNETES_IP_FABRIC_FORWARDING: "{{ ip_fabric_forwarding | default('false') }}"
+  KUBERNETES_IP_FABRIC_SNAT: "{{ ip_fabric_snat | default('false') }}"
+  KUBERNETES_PUBLIC_FIP_POOL: "{{ public_fip_pool | default('{}') }}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-config
+  namespace: contrail-system
+data:
+  KUBERNETES_API_SERVER: {{ kubernetes_api_server | default(api_vip | ipaddr) }}
+  KUBERNETES_API_PORT: "{{ openshift_master_api_port | default(kubernetes_api_secure_port) }}"
+  K8S_TOKEN_FILE: "/tmp/serviceaccount/token"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configzookeeperenv
+  namespace: contrail-system
+data:
+  ZOOKEEPER_PORT: "{{ zookeeper_port }}"
+  ZOOKEEPER_PORTS: "{{ zookeeper_ports }}"
+  ZOOKEEPER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: analyticszookeeperenv
+  namespace: contrail-system
+data:
+  ZOOKEEPER_PORT: "{{ zookeeper_port }}"
+  ZOOKEEPER_PORTS: "{{ zookeeper_ports }}"
+  ZOOKEEPER_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contrail-analyticsdb-config
+  namespace: contrail-system
+data:
+  CASSANDRA_SEEDS: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CASSANDRA_CLUSTER_NAME: Contrail
+  CASSANDRA_START_RPC: "true"
+  CASSANDRA_LISTEN_ADDRESS: auto
+  CASSANDRA_PORT: "9163"
+  CASSANDRA_CQL_PORT: "9045"
+  CASSANDRA_SSL_STORAGE_PORT: "7004"
+  CASSANDRA_STORAGE_PORT: "7003"
+  CASSANDRA_JMX_LOCAL_PORT: "7203"
+  ANALYTICSDB_PORT: "9163"
+  ANALYTICSDB_CQL_PORT: "9045"
+  CONFIGDB_PORT: "9164"
+  CONFIGDB_CQL_PORT: "9044"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contrail-configdb-config
+  namespace: contrail-system
+data:
+  CASSANDRA_SEEDS: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  CASSANDRA_CLUSTER_NAME: ContrailConfigDB
+  CASSANDRA_START_RPC: "true"
+  CASSANDRA_LISTEN_ADDRESS: auto
+  CASSANDRA_PORT: "9164"
+  CASSANDRA_CQL_PORT: "9044"
+  CASSANDRA_SSL_STORAGE_PORT: "7014"
+  CASSANDRA_STORAGE_PORT: "7013"
+  CASSANDRA_JMX_LOCAL_PORT: "7204"
+  ANALYTICSDB_PORT: "9163"
+  ANALYTICSDB_CQL_PORT: "9045"
+  CONFIGDB_PORT: "9164"
+  CONFIGDB_CQL_PORT: "9044"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rabbitmq-config
+  namespace: contrail-system
+data:
+  RABBITMQ_NODES: {{ contrail_masters_ip.split() | ipaddr | join(',') }}
+  RABBITMQ_NODE_PORT: "{{ rabbitmq_node_port }}"
+  RABBITMQ_ERLANG_COOKIE: "47EFF3BB-4786-46E0-A5BB-58455B3C2CB4"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nodemgr-config
+  namespace: contrail-system
+data:
+  DOCKER_HOST: "unix://mnt/docker.sock"
+---

--- a/roles/contrail_master/templates/contrail-installer-4.j2
+++ b/roles/contrail_master/templates/contrail-installer-4.j2
@@ -1,0 +1,340 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contrail-config
+  namespace: contrail-system
+data:
+  global-config: |-
+    [GLOBAL]
+    cloud_orchestrator = openshift
+    sandesh_ssl_enable = False
+    enable_config_service = True
+    enable_control_service = True
+    enable_webui_service = True
+    introspect_ssl_enable = False
+    config_nodes = {{ groups.contrail_masters | ipaddr | join(',') }}
+    controller_nodes = {{ groups.contrail_masters | ipaddr | join(',') }}
+    analytics_nodes = {{ groups.contrail_masters | ipaddr | join(',') }}
+    analyticsdb_nodes = {{ groups.contrail_masters | ipaddr | join(',') }}
+    analyticsdb_minimum_diskgb = {{ analyticsdb_min_diskgb }}
+    configdb_minimum_diskgb = {{ configdb_min_diskgb }}
+    opscenter_ip = 1.1.1.1
+  agent-config: |-
+    [AGENT]
+    compile_vrouter_module = False
+    vrouter_physical_interface = {{ vrouter_physical_interface }}
+  kubemanager-config: |-
+    [KUBERNETES]
+    cluster_name = k8s-default
+    cluster_project = {}
+    cluster_network = {}
+    service_subnets = 10.96.0.0/12
+    pod_subnets = 10.32.0.0/12
+    api_server = {{ api_vip | ipaddr }}
+  kubernetes-agent-config: |-
+    [AGENT]
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-analyticsdb
+  namespace: contrail-system
+  labels:
+    app: contrail-analyticsdb
+spec:
+  selector:
+    matchLabels:
+      app: contrail-analyticsdb
+  template:
+    metadata:
+      labels:
+        app: contrail-analyticsdb
+    spec:
+      nodeSelector: 
+        "node-role.kubernetes.io/infra": "true"
+      hostNetwork: true
+      containers:
+      - name: contrail-analyticsdb
+        image: "contrail-analyticsdb-{{ contrail_os_release }}:{{ contrail_version }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/contrailctl
+          name: contrail-config
+        - mountPath: /var/lib/cassandra
+          name: analyticsdb-data
+        - mountPath: /var/lib/zookeeper
+          name: zookeeper-analyticsdb-data
+      volumes:
+      - name: contrail-config
+        configMap:
+          name: contrail-config
+          items:
+          - key: global-config
+            path: analyticsdb.conf
+      - name: analyticsdb-data
+        hostPath:
+          path: /var/lib/analyticsdb 
+      - name: zookeeper-analyticsdb-data
+        hostPath:
+          path: /var/lib/analyticsdb_zookeeper_data
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-analytics
+  namespace: contrail-system
+  labels:
+    app: contrail-analytics
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-analytics
+    spec:
+      nodeSelector:
+        "node-role.kubernetes.io/infra": "true"
+      hostNetwork: true
+      containers:
+      - name: contrail-analytics
+        image: "contrail-analytics-{{ contrail_os_release }}:{{ contrail_version }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/contrailctl
+          name: contrail-config
+      volumes:
+      - name: contrail-config
+        configMap:
+          name: contrail-config
+          items:
+          - key: global-config
+            path: analytics.conf
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-controller
+  namespace: contrail-system
+  labels:
+    app: contrail-controller
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-controller
+    spec:
+      nodeSelector:
+        "node-role.kubernetes.io/infra": "true"
+      hostNetwork: true
+      containers:
+      - name: contrail-controller
+        image: "contrail-controller-{{ contrail_os_release }}:{{ contrail_version }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/contrailctl
+          name: contrail-config
+        - mountPath: /var/lib/cassandra
+          name: configdb-data
+        - mountPath: /var/lib/zookeeper
+          name: zookeeper-data
+      volumes:
+      - name: contrail-config
+        configMap:
+          name: contrail-config
+          items:
+          - key: global-config
+            path: controller.conf
+      - name: configdb-data
+        hostPath: 
+          path: /var/lib/configdb
+      - name: zookeeper-data
+        hostPath: 
+          path: /var/lib/config_zookeeper_data
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-kube-manager
+  namespace: contrail-system
+  labels:
+    app: contrail-kube-manager
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-kube-manager
+    spec:
+      nodeSelector:
+        "node-role.kubernetes.io/infra": "true"
+      automountServiceAccountToken: false
+      hostNetwork: true
+      containers:
+      - name: contrail-kube-manager
+        image: "contrail-kube-manager-{{ contrail_os_release }}:{{ contrail_version }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /tmp/contrailctl
+          name: tmp-contrail-config
+        - mountPath: /tmp/serviceaccount
+          name: pod-secret
+      volumes:
+      - name: tmp-contrail-config
+        configMap:
+          name: contrail-config
+          items:
+          - key: global-config
+            path: global.conf
+          - key: kubemanager-config
+            path: kubemanager.conf
+      - name: pod-secret
+        secret:
+          secretName: contrail-kube-manager-token
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-agent
+  namespace: contrail-system
+  labels:
+    app: contrail-agent
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-agent
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/infra"
+                operator: DoesNotExist
+      automountServiceAccountToken: false
+      hostNetwork: true
+      initContainers:
+      - name: contrail-kubernetes-agent
+        image: "contrail-kubernetes-agent-{{ contrail_os_release }}:{{ contrail_version }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /tmp/contrailctl
+          name: tmp-contrail-config
+        - mountPath: /var/lib/contrail/
+          name: var-lib-contrail
+        - mountPath: /host/etc_cni
+          name: etc-cni
+        - mountPath: /host/opt_cni_bin
+          name: opt-cni-bin
+        - mountPath: /var/log/contrail/cni
+          name: var-log-contrail-cni
+      containers:
+      - name: contrail-agent
+        image: "contrail-agent-{{ contrail_os_release }}:{{ contrail_version }}"
+        imagePullPolicy: ""
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /usr/src
+          name: usr-src
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /tmp/contrailctl
+          name: tmp-contrail-config
+        - mountPath: /var/lib/contrail/
+          name: var-lib-contrail
+        - mountPath: /host/etc_cni
+          name: etc-cni
+        - mountPath: /host/opt_cni_bin
+          name: opt-cni-bin
+        # This is a workaround just to make sure the directory is created on host
+        - mountPath: /var/log/contrail/cni
+          name: var-log-contrail-cni
+        - mountPath: /tmp/serviceaccount
+          name: pod-secret
+      volumes:
+      - name: tmp-contrail-config
+        configMap:
+          name: contrail-config
+          items:
+          - key: global-config
+            path: global.conf
+          - key: agent-config
+            path: agent.conf
+          - key: kubemanager-config
+            path: kubemanager.conf
+          - key: kubernetes-agent-config
+            path: kubernetesagent.conf
+      - name: pod-secret
+        secret:
+          secretName: contrail-kube-manager-token
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: usr-src-kernels
+        hostPath:
+          path: /usr/src/kernels
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: var-lib-contrail
+        hostPath:
+          path: /var/lib/contrail/
+      - name: etc-cni
+        hostPath:
+          path: /etc/cni
+      - name: opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: var-log-contrail-cni
+        hostPath:
+          path: /var/log/contrail/cni/
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contrail
+  namespace: contrail-system
+---
+kind: ClusterRole
+apiVersion: v1
+metadata:
+  name: contrail
+  namespace: contrail-system
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: v1
+kind: ClusterRoleBinding
+metadata:
+  name: contrail
+roleRef:
+  name: contrail
+subjects:
+- kind: SystemUser
+  name: contrail-system:contrail
+- kind: ServiceAccount
+  name: contrail
+  namespace: contrail-system
+userNames:
+  - system:serviceaccount:contrail-system:contrail
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: contrail-kube-manager-token
+  namespace: contrail-system
+  annotations:
+    kubernetes.io/service-account.name: contrail
+type: kubernetes.io/service-account-token

--- a/roles/contrail_master/templates/contrail-kube-manager-5.j2
+++ b/roles/contrail_master/templates/contrail-kube-manager-5.j2
@@ -1,0 +1,114 @@
+# This file contains the contrail kube manager components.
+# This component will be installed as DaemonSet on the infra nodes.
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-kube-manager
+  namespace: contrail-system
+  labels:
+    app: contrail-kube-manager
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-kube-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/infra"
+                operator: Exists
+      automountServiceAccountToken: false
+      hostNetwork: true
+      initContainers:
+      - name: kubernetes-entrypoint-init
+        image: quay.io/stackanetes/kubernetes-entrypoint:v0.2.1
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        command:
+        - kubernetes-entrypoint
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        #- name: INTERFACE_NAME
+        #  value: eth0
+        - name: DEPENDENCY_SERVICE
+        - name: DEPENDENCY_JOBS
+        - name: DEPENDENCY_DAEMONSET
+          value: contrail-agent
+        - name: DEPENDENCY_CONTAINER
+        - name: COMMAND
+          value: echo done
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: pod-secret
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONFIGURE_IPTABLES
+          value: "true"
+        - name: IPTABLES_CHAIN
+          value: "OS_FIREWALL_ALLOW"
+        - name: NODE_TYPE
+          value: "kubernetes"
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-kube-manager
+        image: "{{ contrail_registry }}/contrail-kubernetes-kube-manager:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: kube-manager-config
+        - configMapRef:
+            name: configzookeeperenv
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: kube-manager-logs
+        - mountPath: /tmp/serviceaccount
+          name: pod-secret
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: kube-manager-logs
+        hostPath:
+          path: /var/log/contrail/kube-manager
+      - name: pod-secret
+        secret:
+          secretName: contrail-kubernetes-token
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---

--- a/roles/contrail_master/templates/contrail-namespace.j2
+++ b/roles/contrail_master/templates/contrail-namespace.j2
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: contrail-system
+  labels:
+    name: contrail-system
+  annotations:
+    openshift.io/node-selector:

--- a/roles/contrail_master/templates/contrail-nested.j2
+++ b/roles/contrail_master/templates/contrail-nested.j2
@@ -1,0 +1,196 @@
+# Configs section
+# Note: using ".." for ports, because in v1 there is a bug
+# which leads to an error
+# "..error unmarshaling JSON: json: cannot unmarshal number into Go value of type string.."
+# (https://github.com/kubernetes/kubernetes/issues/2763)
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contrail
+  namespace: contrail-system
+---
+kind: ClusterRole
+apiVersion: v1
+metadata:
+  name: contrail
+  namespace: contrail-system
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: v1
+kind: ClusterRoleBinding
+metadata:
+  name: contrail
+roleRef:
+  name: contrail
+subjects:
+- kind: SystemUser
+  name: contrail-system:contrail
+- kind: ServiceAccount
+  name: contrail
+  namespace: contrail-system
+userNames:
+  - system:serviceaccount:contrail-system:contrail
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: contrail-kubernetes-token
+  namespace: contrail-system
+  annotations:
+    kubernetes.io/service-account.name: contrail
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: env
+  namespace: contrail-system
+data:
+  AUTH_MODE: {{ auth_mode }}
+  KEYSTONE_AUTH_HOST: {{ keystone_auth_host }}
+  KEYSTONE_AUTH_ADMIN_TENANT: "{{ keystone_auth_admin_tenant }}"
+  KEYSTONE_AUTH_ADMIN_USER: "{{ keystone_auth_admin_user }}"
+  KEYSTONE_AUTH_ADMIN_PASSWORD: "{{ keystone_auth_admin_password }}"
+  KEYSTONE_AUTH_ADMIN_PORT: "{{ keystone_auth_admin_port }}"
+  KEYSTONE_AUTH_URL_VERSION: "{{ keystone_auth_url_version }}"
+  CLOUD_ORCHESTRATOR: {{ cloud_orchestrator }}
+  CONTROLLER_NODES: {{ contrail_nested_masters_ip.split() | ipaddr | join(',') }}
+{% if config_nodes is defined %}
+  CONFIG_NODES: {{ config_nodes.split() | ipaddr | join(',') }}
+{% else %}
+  CONFIG_NODES: {{ contrail_nested_masters_ip.split() | ipaddr | join(',') }}
+{% endif %}
+{% if analytics_nodes is defined %}
+  ANALYTICS_NODES: {{ analytics_nodes.split() | ipaddr | join(',') }}
+{% else %}
+  ANALYTICS_NODES: {{ contrail_nested_masters_ip.split() | ipaddr | join(',') }}
+{% endif %}
+  LOG_LEVEL: {{ log_level }}
+  RABBITMQ_NODES: {{ contrail_nested_masters_ip.split() | ipaddr | join(',') }}
+  RABBITMQ_NODE_PORT: "{{ rabbitmq_node_port | default('5672') }}"
+  ZOOKEEPER_SERVERS: {{ contrail_nested_masters_ip.split() | ipaddr | join(',') }}
+  KUBEMANAGER_NESTED_MODE: "1"
+  K8S_TOKEN_FILE: "/tmp/serviceaccount/token"
+  KUBERNETES_CLUSTER_NAME: "{{ cluster_name | default('k8s') }}"
+  KUBERNETES_CLUSTER_PROJECT: "{{ cluster_project | default('{}') }}"
+  KUBERNETES_CLUSTER_NETWORK: "{{ cluster_network }}"
+  KUBERNETES_POD_SUBNETS: "{{ pod_subnets | default('10.32.0.0/12') }}"
+  KUBERNETES_IP_FABRIC_SUBNETS: "{{ ip_fabric_subnets | default('10.64.0.0/12') }}"
+  KUBERNETES_SERVICE_SUBNETS: "{{ service_subnets | default('10.96.0.0/12') }}"
+  KUBERNETES_IP_FABRIC_FORWARDING: "{{ ip_fabric_forwarding | default('false') }}"
+  KUBERNETES_IP_FABRIC_SNAT: "{{ ip_fabric_snat | default('false') }}"
+  KUBERNETES_PUBLIC_FIP_POOL: "{{ public_fip_pool | default('{}') }}"
+  KUBERNESTES_NESTED_VROUTER_VIP: {{ k8s_nested_vrouter_vip }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-manager-config
+  namespace: contrail-system
+data:
+  KUBERNETES_API_SERVER: {{ k8s_vip }}
+  KUBERNETES_API_SECURE_PORT: "{{ openshift_master_api_port | default(kubernetes_api_secure_port) }}"
+  K8S_TOKEN_FILE: "/tmp/serviceaccount/token"
+# Containers section
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-kube-manager
+  namespace: contrail-system
+  labels:
+    app: contrail-kube-manager
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-kube-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/infra"
+                operator: Exists
+      automountServiceAccountToken: false
+      hostNetwork: true
+      containers:
+      - name: contrail-kube-manager
+        image: "{{contrail_registry}}/contrail-kubernetes-kube-manager:{{contrail_container_tag}}"
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: kube-manager-config
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: kube-manager-logs
+        - mountPath: /tmp/serviceaccount
+          name: pod-secret
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+      volumes:
+      - name: kube-manager-logs
+        hostPath:
+          path: /var/log/contrail/kube-manager
+      - name: pod-secret
+        secret:
+          secretName: contrail-kubernetes-token
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-kubernetes-cni-agent
+  namespace: contrail-system
+  labels:
+    app: contrail-kubernetes-cni-agent
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-agent
+    spec:
+      #Disable affinity for single node setup
+      automountServiceAccountToken: false
+      hostNetwork: true
+      containers:
+      - name: contrail-kubernetes-cni-init
+        image: "{{contrail_registry}}/contrail-kubernetes-cni-init:{{contrail_container_tag}}"
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/etc_cni
+          name: etc-cni
+        - mountPath: /host/opt_cni_bin
+          name: opt-cni-bin
+        - mountPath: /var/lib/contrail
+          name: var-lib-contrail
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+      volumes:
+      - name: etc-cni
+        hostPath:
+          path: /etc/cni
+      - name: opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: var-lib-contrail
+        hostPath:
+          path: /var/lib/contrail
+---

--- a/roles/contrail_master/templates/contrail-webui-5.j2
+++ b/roles/contrail_master/templates/contrail-webui-5.j2
@@ -1,0 +1,102 @@
+# This file contains the contrail webui components.
+# Thiscomponent will be installed as DaemonSet on the infra node
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-controller-webui
+  namespace: contrail-system
+  labels:
+    app: contrail-controller-webui
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-controller-webui
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io/infra"
+                operator: Exists
+      hostNetwork: true
+      initContainers:
+      - name: contrail-node-init
+        image: "{{ contrail_registry }}/contrail-node-init:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        env:
+        - name: CONFIGURE_IPTABLES
+          value: "true"
+        - name: IPTABLES_CHAIN
+          value: "OS_FIREWALL_ALLOW"
+        - name: NODE_TYPE
+          value: "webui"
+        - name: CONTRAIL_STATUS_IMAGE
+          value: "{{ contrail_registry }}/contrail-status:{{ contrail_container_tag }}"
+        envFrom:
+        - configMapRef:
+            name: env
+        volumeMounts:
+        - mountPath: /host/usr/bin
+          name: host-usr-bin
+      containers:
+      - name: contrail-controller-webui-job
+        image: "{{ contrail_registry }}/contrail-controller-webui-job:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        - configMapRef:
+            name: kubernetes-config
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: webui-logs
+        - mountPath: /tmp/serviceaccount
+          name: ssl-secret-gen-token
+        - mountPath: /etc/localtime
+          name: localtime
+      - name: contrail-controller-webui-web
+        image: "{{ contrail_registry }}/contrail-controller-webui-web:{{ contrail_container_tag }}"
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: env
+        - configMapRef:
+            name: configzookeeperenv
+        - configMapRef:
+            name: kubernetes-config
+        volumeMounts:
+        - mountPath: /var/log/contrail
+          name: webui-logs
+        - mountPath: /tmp/serviceaccount
+          name: ssl-secret-gen-token
+        - mountPath: /etc/localtime
+          name: localtime
+      volumes:
+      - name: webui-logs
+        hostPath:
+          path: /var/log/contrail/webui
+      - name: host-usr-bin
+        hostPath:
+          path: /usr/bin
+      - name: ssl-secret-gen-token
+        secret:
+          secretName: contrail-kubernetes-token
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+{% if contrail_registry_username is defined and contrail_registry_password %}
+      imagePullSecrets:
+      - name: contrail-registry-secret
+{% endif %}
+---

--- a/roles/contrail_master/templates/getIp.j2
+++ b/roles/contrail_master/templates/getIp.j2
@@ -1,0 +1,13 @@
+import sys
+import socket
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print >> sys.stderr, "Invalid Usage: No hostname provided as argument."
+        sys.exit(1)
+    try:
+       sys.stdout.write(socket.gethostbyname(sys.argv[1]))
+       sys.exit(0)
+    except Exception as e:
+        print >> sys.stderr, e
+        sys.exit(1)

--- a/roles/contrail_master/templates/wait_for_pod.j2
+++ b/roles/contrail_master/templates/wait_for_pod.j2
@@ -1,0 +1,55 @@
+#!/bin/bash 
+###
+### Borrowed from https://github.com/kubernetes/charts/blob/master/test/verify-release.sh
+### 
+
+NAMESPACE=contrail-system
+
+# Ensure all pods in the namespace entered a Running state
+SUCCESS=0
+PODS_FOUND=0
+POD_RETRY_COUNT=0
+RETRY=100
+RETRY_DELAY=5
+while [ "$POD_RETRY_COUNT" -lt "$RETRY" ]; do
+  POD_RETRY_COUNT=$((POD_RETRY_COUNT+1))
+  POD_STATUS=`{{ openshift_client_binary }} get pods --no-headers --namespace $NAMESPACE`
+  if [ -z "$POD_STATUS" ];then
+    echo "INFO: No pods found for this release, retrying after sleep"
+    POD_RETRY_COUNT=$((POD_RETRY_COUNT+1))
+    sleep $RETRY_DELAY
+    continue
+  else
+    PODS_FOUND=1
+    sleep $RETRY_DELAY
+  fi
+
+  if ! echo "$POD_STATUS" | grep -v Running;then
+    echo "INFO: All pods entered the Running state"
+
+    CONTAINER_RETRY_COUNT=0
+    while [ "$CONTAINER_RETRY_COUNT" -lt "$RETRY" ]; do
+      UNREADY_CONTAINERS=`{{ openshift_client_binary }} get pods --namespace $NAMESPACE \
+        -o jsonpath="{.items[*].status.containerStatuses[?(@.ready!=true)].name}"`
+      if [ -n "$UNREADY_CONTAINERS" ];then
+        echo "INFO: Some containers are not yet ready; retrying after sleep"
+        CONTAINER_RETRY_COUNT=$((CONTAINER_RETRY_COUNT+1))
+  	sleep $RETRY_DELAY
+        continue
+      else
+        echo "INFO: All containers are ready"
+        exit 0
+      fi
+    done
+  fi
+done
+
+if [ "$PODS_FOUND" -eq 0 ];then
+  echo "WARN: No pods launched by this chart's default settings"
+  exit 0
+else
+  POD_FAILED=`{{ openshift_client_binary }} get pods --no-headers --namespace contrail-system | grep -v Running | cut -d " " -f1`
+  echo "ERROR: Some containers failed to reach the ready state"
+  echo ERROR  POD $POD_FAILED is not ready
+  exit 1
+fi

--- a/roles/contrail_st/README.md
+++ b/roles/contrail_st/README.md
@@ -1,0 +1,47 @@
+# Contrail SDN
+
+[Contrail Networking](https://www.juniper.net/us/en/products-services/sdn/contrail/contrail-networking/), based on [TungstenFabric](https://tungstenfabric.io/) project, is a truly open, multi-cloud network virtualization and policy management platform. Contrail / TungstenFabric SDN stack is integrated with various orchestration systems such as Kubernetes, OpenShift, OpenStack and Mesos, and provides different isolation modes for virtual machines, containers/pods and bare metal workloads.
+
+## SUPPORTED ARCHITECTURE
+
+* Contrail SDN installed through OpenShift ansible supports both non-HA and  HA configurations.
+
+## CONTRAIL SOFTWARE COMPONENTS
+
+### Contrail Master (DaemonSets)
+
+- **Contrail Image Installer**: Downloads all contrail container images if not present.
+- **Contrail Controller Config**: The config daemonset consists of all config components
+  like contrail service monitor, schema transformer, api server etc which are running as
+  a docker container.
+- **Contrail Controller Control**: The contrail controller is installed by this daemonset.
+- **Contrail Controller WebUI**: WebUI components are deployed here. We use port 8143.
+- **Contrail Analytics**: All Contrail analytics components like the analytics collector,
+  topology, alarm-gen are installed by this daemonset.
+- **Contrail Analytics Database**: Contrail Analytics uses this container as its DB.
+- **Contrail Config DB Node Manager**: Node Manager for Config DB, Node manager containers are run
+  by all Contrail components to provide current status.
+- **Contrail Config DB**: DB used by the Contrail Controller Config component.
+- **Contrail Kubernetes Manager**: The interface between the Openshift API server and
+  Contrail Controller.
+
+Note:  These Contrail components are installed on the infra-node.
+
+### Nodes (DaemonSets)
+- **Contrail Agent**: As part of the agent pod we install the **vrouter kernel module** and the **contrail-cni**.
+
+### Contrail Ansible Roles
+
+* **Contrail common**: This role contains common functions which are required by other contrail roles
+* **Contrail master**: Preps up by creating all daemonsets.
+* **Contrail st**: Preps the contrail schema transformer.
+
+## INSTALLATION
+
+To install Contrail SDN with OpenShift Enterprise, follow this [install guide](https://github.com/Juniper/contrail-kubernetes-docs)
+
+Refer to this example [openshift 3.11 contrail installation](https://github.com/Juniper/contrail-kubernetes-docs/blob/master/install/openshift/3.11/standalone-openshift.md) for non-HA/HA deployments
+
+### CONTACT
+
+Pragash Vijayaragavan <pvijayaragav@juniper.net>

--- a/roles/contrail_st/tasks/main.yaml
+++ b/roles/contrail_st/tasks/main.yaml
@@ -1,0 +1,3 @@
+---
+- name: Sanitize Schema Transformer process.
+  include_tasks: schema_transformer_sanity.yaml

--- a/roles/contrail_st/tasks/schema_transformer_sanity.yaml
+++ b/roles/contrail_st/tasks/schema_transformer_sanity.yaml
@@ -1,0 +1,41 @@
+---
+- name: Run contrail-status command to get status of contrail services.
+  command: /usr/bin/contrail-status
+  register: contrail_status_output
+  when:
+    - inventory_hostname in contrail_masters
+
+- set_fact:
+    schema_valid: true
+  when:
+    - inventory_hostname in contrail_masters
+
+- name: If Schema Transformer is not in active or backup state, mark it as being in invalid state.
+  set_fact:
+    schema_valid: false
+  when:
+    - inventory_hostname in contrail_masters
+    - '"schema: active" not in contrail_status_output.stdout'
+    - '"schema: backup" not in contrail_status_output.stdout'
+
+- when:
+    - inventory_hostname in contrail_masters
+    - not schema_valid
+
+    # Schema Transformer is invalid.
+    # We will attempt to resuscitate it by restarting its container.
+
+  block:
+    - name: Get docker container details of Schema Transformer
+      command: docker ps --filter "name=schema" -q
+      register: schema_docker_output
+      ignore_errors: yes
+
+    - name: Restart Schema Transformer container "{{ schema_docker_output.stdout }}"
+      command: docker restart "{{ schema_docker_output.stdout }}"
+      when: schema_docker_output.stdout != ""
+      ignore_errors: yes
+
+    - name: Wait for Schema Transformer to restart.
+      wait_for: timeout=10
+      when: schema_docker_output.stdout != ""


### PR DESCRIPTION
** Contrail SDN **

[Contrail Networking](https://www.juniper.net/us/en/products-services/sdn/contrail/contrail-networking/),
based on [TungstenFabric](https://tungstenfabric.io/) project, is a truly open,
multi-cloud network virtualization and policy management platform.
Contrail / TungstenFabric SDN stack is integrated with various orchestration systems
such as Kubernetes, OpenShift, OpenStack and Mesos, and provides different isolation
modes for virtual machines, containers/pods and bare metal workloads.

** SUPPORTED ARCHITECTURE **

- Contrail SDN installed through OpenShift ansible supports both non-HA and
  HA configurations.

** CONTRAIL SOFTWARE COMPONENTS **

* Contrail components are installed on the infra-node.

* Contrail Master (DaemonSets)

- Contrail Image Installer: Downloads all contrail container images if not present.
- Contrail Controller Config: The config daemonset consists of all config components
  like contrail service monitor, schema transformer, api server etc which are running as
  a docker container.
- Contrail Controller Control: The contrail controller is installed by this daemonset.
- Contrail Controller WebUI: WebUI components are deployed here. We use port 8143.
- Contrail Analytics: All Contrail analytics components like the analytics collector,
  topology, alarm-gen are installed by this daemonset.
- Contrail Analytics Database: Contrail Analytics uses this container as its DB.
- Contrail Config DB Node Manager: Node Manager for Config DB, Node manager containers are run
  by all Contrail components to provide current status.
- Contrail Config DB: DB used by the Contrail Controller Config component.
- Contrail Kubernetes Manager: The interface between the Openshift API server and
  Contrail Controller.

Note:  These Contrail components are installed on the infra-node.

* Nodes (DaemonSets)

- Contrail Agent: As part of out contrail-agent daemonset we install the **vrouter kernel module** and the
  **contrail-cni** on all nodes.

** INSTALLATION **

To install Contrail SDN with OpenShift Enterprise, follow this
Refer to this example [openshift 3.x contrail installation]
(https://github.com/Juniper/contrail-kubernetes-docs/blob/master/install/openshift/3.9/standalone-openshift.md)
for non-HA/HA deployments

** Openshift ansible code changes **

1. Added contrail roles to openshift roles.
2. Added openshift hooks to call contrail when contrail is chosen as sdn provider.
        - playbooks/openshift-master/private/config.yml
3. After installing Contrail vrouter kernel module, a flap in the interface
  causes the dnsmasq service to stop working, hence a restart of the service is
  required. Issue may be seen only on RHEL systems.
        - playbooks/openshift-node/private/join.yml is modified to do this

* Contrail Ansible Roles

- Contrail common: This role contains common functions which are required by other contrail roles
- Contrail master: Preps up the openshift master node
- Contrail st: Preps the contrail schema transformer

** CONTACT **

Pragash Vijayaragavan <pvijayaragav@juniper.net>