### PR TITLE
If managed registry is false modify example ImageStream referencePolicy

### DIFF
--- a/roles/openshift_examples/tasks/modify_imagestreams.yml
+++ b/roles/openshift_examples/tasks/modify_imagestreams.yml
@@ -1,0 +1,22 @@
+---
+- name: Get remote imagestream json file
+  slurp:
+    src: "{{ openshift_example_remote_imagestream }}"
+  register: imagestreams_encoded
+
+- set_fact:
+    openshift_examples_imagestreams: "{{ (imagestreams_encoded['content'] | b64decode | from_json) }}"
+
+- set_fact:
+    openshift_examples_modified_imagestreams: "{% set updatedislist = [] %}{% set updatedspec = {} %}{% set updatedimagestream = {} %}{% for is in openshift_examples_imagestreams['items'] %}{% set updatedtags = [] %}{% for tag in is['spec']['tags'] %}{{ updatedtags.append(tag | combine({'referencePolicy': {'type': 'Source'}})) }}{% endfor %}{% set updatedspec = (is['spec'] | combine({'tags': updatedtags})) %}{% set updatedimagestream = (is | combine({'spec': updatedspec})) %}{% set _ = updatedislist.append(updatedimagestream) %}{% endfor %}{{ updatedislist }}"
+
+- name: Import Modified ImageStreams
+  oc_obj:
+    kubeconfig: "{{ openshift.common.config_base }}/master/admin.kubeconfig"
+    namespace: openshift
+    kind: is
+    content:
+      path: "/tmp/imagestreams"
+      data: "{{ item }}"
+    name: "{{ item['metadata']['name'] }}"
+  with_items: "{{ openshift_examples_modified_imagestreams }}"

--- a/roles/openshift_examples/tasks/x86_64_examples.yml
+++ b/roles/openshift_examples/tasks/x86_64_examples.yml
@@ -1,4 +1,36 @@
 ---
+- include_tasks: modify_imagestreams.yml
+  vars:
+    openshift_example_remote_imagestream: "{{ outer_item.path }}"
+  with_items:
+  - { path: "{{ rhel_image_streams }}", check: "{{ openshift_examples_load_rhel }}" }
+  - { path: "{{ rhel_dotnet_streams }}", check: "{{ openshift_examples_load_rhel }}" }
+  - { path: "{{ centos_image_streams }}", check: "{{ openshift_examples_load_centos }}" }
+  - { path: "{{ centos_dotnet_streams }}", check: "{{ openshift_examples_load_centos }}" }
+  loop_control:
+    loop_var: outer_item
+  when:
+  - outer_item.check | default(true) | bool
+  - not (openshift_hosted_manage_registry | default(true) | bool)
+
+- name: Get xPaaS ImageStream files
+  find:
+    paths: "{{ xpaas_image_streams }}"
+    patterns: "*.json"
+  register: openshift_examples_xpaas_dir_list
+  when:
+  - openshift_examples_load_xpaas | bool
+  - not (openshift_hosted_manage_registry | default(true) | bool)
+
+- include_tasks: modify_imagestreams.yml
+  vars:
+    openshift_example_remote_imagestream: "{{ outer_item.path }}"
+  with_items: "{{ openshift_examples_xpaas_dir_list.files }}"
+  loop_control:
+    loop_var: outer_item
+  when:
+  - openshift_examples_load_xpaas | bool
+  - not (openshift_hosted_manage_registry | default(true) | bool)
 
 # RHEL and Centos image streams are mutually exclusive
 - name: Import RHEL streams


### PR DESCRIPTION
Adds the modification to the example imagestreams if the cluster is not using the hosted managed registry.

Bug 1712496 - https://bugzilla.redhat.com/show_bug.cgi?id=1712496