### PR TITLE
[release-3.11] Do not require a LDAP CA cert if one is not defined for LDAP IdP

### DIFF
--- a/roles/lib_utils/filter_plugins/openshift_master.py
+++ b/roles/lib_utils/filter_plugins/openshift_master.py
@@ -158,7 +158,7 @@ class LDAPPasswordIdentityProvider(IdentityProviderBase):
             pref_user = self._idp['attributes'].pop('preferred_username')
             self._idp['attributes']['preferredUsername'] = pref_user
 
-        if not self._idp['insecure']:
+        if not self._idp['insecure'] and 'ca' in self._idp:
             self._idp['ca'] = '/etc/origin/master/{}_ldap_ca.crt'.format(self.name)
 
     def validate(self):


### PR DESCRIPTION
It is not required to define a CA certificate for LDAP in order to use
it securely. Thus, in this scenario, one should not be requested.

This is also needed for openshift-ansible in the 3.10 branch to fix it there.