### PR TITLE
[wip] Add redeploy certificates playbook for asb and tsb

### DIFF
--- a/playbooks/openshift-service-catalog/private/redeploy-certificates-asb.yml
+++ b/playbooks/openshift-service-catalog/private/redeploy-certificates-asb.yml
@@ -1,0 +1,36 @@
+---
+- name: Update ansible service broker certificates
+  hosts: oo_first_master
+  vars:
+    openshift_service_catalog_namespace: openshift-ansible-service-broker
+  roles:
+  - lib_openshift
+  - openshift_facts
+  tasks:
+  - name: Remove certificates secret
+    oc_obj:
+      name: asb-tls
+      kind: secret
+      state: absent
+      namespace: "{{ openshift_service_catalog_namespace }}"
+
+  - name: Remove pods
+    oc_obj:
+      selector: "app=openshift-ansible-service-broker"
+      kind: pod
+      state: absent
+      namespace: "{{ openshift_service_catalog_namespace }}"
+
+  - name: Verify that running
+    oc_obj:
+      namespace: "{{ openshift_service_catalog_namespace }}"
+      kind: dc
+      state: list
+      name: asb
+    register: asb_dc
+    until:
+    - asb_dc.results.results[0].status.readyReplicas is defined
+    - asb_dc.results.results[0].status.readyReplicas > 0
+    retries: 60
+    delay: 10
+    changed_when: false

--- a/playbooks/openshift-service-catalog/private/redeploy-certificates-tsb.yml
+++ b/playbooks/openshift-service-catalog/private/redeploy-certificates-tsb.yml
@@ -1,0 +1,36 @@
+---
+- name: Update template service broker certificates
+  hosts: oo_first_master
+  vars:
+    openshift_service_catalog_namespace: openshift-template-service-broker
+  roles:
+  - lib_openshift
+  - openshift_facts
+  tasks:
+  - name: Remove certificates secret
+    oc_obj:
+      name: apiserver-serving-cert
+      kind: secret
+      state: absent
+      namespace: "{{ openshift_service_catalog_namespace }}"
+
+  - name: Remove apiserver pods
+    oc_obj:
+      selector: "apiserver"
+      kind: pod
+      state: absent
+      namespace: "{{ openshift_service_catalog_namespace }}"
+
+  - name: Verify that the apiserver is running
+    oc_obj:
+      namespace: "{{ openshift_service_catalog_namespace }}"
+      kind: daemonset
+      state: list
+      name: apiserver
+    register: apiserver_ds
+    until:
+    - apiserver_ds.results.results[0].status.numberReady is defined
+    - apiserver_ds.results.results[0].status.numberReady > 0
+    retries: 60
+    delay: 10
+    changed_when: false

--- a/playbooks/redeploy-certificates.yml
+++ b/playbooks/redeploy-certificates.yml
@@ -34,7 +34,6 @@
 
 - import_playbook: openshift-master/private/restart.yml
 
-
 - import_playbook: openshift-web-console/private/redeploy-certificates.yml
   when: openshift_web_console_install | default(true) | bool
 
@@ -43,3 +42,9 @@
 
 - import_playbook: openshift-monitoring/private/redeploy-certificates.yml
   when: openshift_cluster_monitoring_operator_install | default(true) | bool
+
+- import_playbook: openshift-service-catalog/private/redeploy-certificates-asb.yml
+  when: ansible_service_broker_install | default(false) | bool
+
+- import_playbook: openshift-service-catalog/private/redeploy-certificates-tsb.yml
+  when: template_service_broker_install | default(false) | bool


### PR DESCRIPTION
- Modifies redeploy-certificates.yml importing playbooks
if asb or tsb installed
- Adds playbook for asb and tsb certificate recreate.

Bug 1715322 - https://bugzilla.redhat.com/show_bug.cgi?id=1715322