### PR TITLE
[release-3.11] Control plane pods didn't come up by incorrect data type of "openshift_master_audit_config"

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -955,13 +955,13 @@ debug_level=2
 #openshift_node_env_vars={"ENABLE_HTTP2": "true"}
 
 # Enable API service auditing
-#openshift_master_audit_config={"enabled": "true"}
+#openshift_master_audit_config={"enabled": true}
 #
 # In case you want more advanced setup for the auditlog you can
 # use this line.
 # The directory in "auditFilePath" will be created if it's not
 # exist
-#openshift_master_audit_config={"enabled": "true", "auditFilePath": "/var/lib/origin/openpaas-oscp-audit/openpaas-oscp-audit.log", "maximumFileRetentionDays": "14", "maximumFileSizeMegabytes": "500", "maximumRetainedFiles": "5"}
+#openshift_master_audit_config={"enabled": true, "auditFilePath": "/var/lib/origin/openpaas-oscp-audit/openpaas-oscp-audit.log", "maximumFileRetentionDays": 14, "maximumFileSizeMegabytes": 500, "maximumRetainedFiles": 5}
 
 # Enable origin repos that point at Centos PAAS SIG, defaults to true, only used
 # by openshift_deployment_type=origin


### PR DESCRIPTION
- Version: v3.11, but maybe other version would affect.

- Description:
  `Control plane pods didn't come up` can occur with following error messages, when you are configured incorrect `JSON` data type in `openshift_master_audit_config`.
  The `boolean` and `number` types should not use quotes, it cause not converting correct data type as yaml format. You can see the following error messages when it is configured values with quotes.
  It should match with related documentaion, refer related [docs here](https://docs.openshift.com/container-platform/3.11/install_config/master_node_configuration.html#master-node-config-audit-config).

~~~
start_api.go:68] could not load config file \"/etc/origin/master/master-config.yaml\" due to an error: error reading config: v1.MasterConfig.AuditConfig: v1.AuditConfig.Enabled: ReadBool: expect t or f, but found \", error found in #10 byte of ...|enabled\":\"true\",\"max|..., bigger context ...|ePath\":\"/var/lib/origin/audit-ocp.log\",\"enabled\":\"true\",\"maximumFileRetentionDays\":\"14\",\"maximumFile|...\n","stream":"stderr","time":"2019-06-04T01:31:04.688315106Z"}
~~~