### PR TITLE
test: ignore errors when collecting a list of containers

### DIFF
--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -15,5 +15,5 @@
 
 - name: Enable the CRI-O service
   systemd:
-    name: "cri-o"
+    name: "crio"
     enabled: yes

--- a/test/aws/scaleup.yml
+++ b/test/aws/scaleup.yml
@@ -84,7 +84,7 @@
       with_items: "{{ crictl_ps_output.stdout_lines }}"
       ignore_errors: true
     - name: Get crio logs
-      command: journalctl --no-pager -u cri-o
+      command: journalctl --no-pager -u crio
       register: crio_logs
       ignore_errors: true
     - name: Get kubelet logs

--- a/test/aws/scaleup.yml
+++ b/test/aws/scaleup.yml
@@ -76,6 +76,7 @@
     block:
     - name: Collect a list of containers
       command: crictl ps -a -q
+      ignore_errors: true
       register: crictl_ps_output
     - name: Collect container logs
       command: "crictl logs {{ item }}"


### PR DESCRIPTION
This ensures the info collection won't fail when CRIO didn't start.

Current status:
* kubelet errors:
```
    Jun 04 10:17:57 ip-10-0-157-245.ec2.internal hyperkube[13302]: W0604 10:17:57.746401   13302 clientconn.go:1251] grpc: addrConn.createTransport failed to connect to {/var/run/crio/crio.sock 0  <nil>}. Err :connection error: desc = "transport: Error while dialing dial unix /var/run/crio/crio.sock: connect: no such file or directory". Reconnecting...
```
* Crio service didn't start
```
journalctl --no-pager -u cri-o
...
stdout: -- No entries --
```