### PR TITLE
Fix timeoutSeconds in hawkular-cassandra

### DIFF
--- a/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
@@ -120,7 +120,7 @@ spec:
           exec:
             command:
             - "/opt/apache-cassandra/bin/cassandra-docker-ready.sh"
-          timeoutSeconds: {{openshift_metrics_cassandra_readprobe_timeout | default(10)}}
+          timeoutSeconds: {{openshift_metrics_cassandra_readprobe_timeout | default(10) | int}}
 {%      if openshift_metrics_cassandra_readprobe_initialdelay is not none %}
           initialDelaySeconds: {{openshift_metrics_cassandra_readprobe_initialdelay}}
 {% endif %}

--- a/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
+++ b/roles/openshift_metrics/templates/hawkular_cassandra_rc.j2
@@ -122,7 +122,7 @@ spec:
             - "/opt/apache-cassandra/bin/cassandra-docker-ready.sh"
           timeoutSeconds: {{openshift_metrics_cassandra_readprobe_timeout | default(10) | int}}
 {%      if openshift_metrics_cassandra_readprobe_initialdelay is not none %}
-          initialDelaySeconds: {{openshift_metrics_cassandra_readprobe_initialdelay}}
+          initialDelaySeconds: {{openshift_metrics_cassandra_readprobe_initialdelay | int}}
 {% endif %}
 
         lifecycle:


### PR DESCRIPTION
Fix openshift#11662

timeoutSeconds and initialDelaySeconds are integer values and should be written without quotes in
roles/openshift_metrics/templates/hawkular_cassandra_rc.j2

This fix is removing the quotes so that the playbook won't fail as int32 is the value type for these 2 attributes.