### PR TITLE
Bug 1585070: remove cpu_manager_state file

### DIFF
--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -38,3 +38,9 @@
     line: pause_image = "{{ openshift_crio_pause_image }}"
     regexp: '^pause_image ='
   when: crio_conf.stat.exists == True
+
+# BZ1585070
+- name: Clean cpu_manager_state module
+  file:
+    state: absent
+    path: "{{ openshift_node_data_dir }}/openshift.local.volumes/cpu_manager_state"


### PR DESCRIPTION
Prevents an issue where the kubelet will not start with an incompatible
cpu_manager_state file.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1585070