### PR TITLE
[3.11]: allow cluster autoscaler to evict pods

### DIFF
--- a/roles/openshift_cluster_autoscaler/files/clusterrole.yml
+++ b/roles/openshift_cluster_autoscaler/files/clusterrole.yml
@@ -60,3 +60,11 @@ rules:
   - list
   - watch
   attributeRestrictions: null
+- apiGroups:
+  - ""
+  resources:
+  - "pods/eviction"
+  verbs:
+  - "create"
+  attributeRestrictions: null
+


### PR DESCRIPTION
Otherwise, cluster autoscaler complains about:

User "system:serviceaccount:cluster-autoscaler:cluster-autoscaler" cannot create pods/eviction in the namespace "xxxx": no RBAC policy matched

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1718458