### PR TITLE
[release-3.10] Fail on Ansible 2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install base dependencies:
 
 Requirements:
 
-- Ansible >= 2.4.3.0, 2.5.x is not currently supported for OCP installations
+- Ansible >= 2.4.3.0, 2.8.x and above is not currently supported for OCP installations
 - Jinja >= 2.7
 - pyOpenSSL
 - python-lxml

--- a/roles/lib_utils/callback_plugins/aa_version_requirement.py
+++ b/roles/lib_utils/callback_plugins/aa_version_requirement.py
@@ -22,7 +22,7 @@ def display(*args, **kwargs):
 
 # Set to minimum required Ansible version
 REQUIRED_VERSION = '2.4.3.0'
-DESCRIPTION = "Supported versions: %s or newer" % REQUIRED_VERSION
+DESCRIPTION = "Supported versions: %s or newer but less than 2.8.0" % REQUIRED_VERSION
 
 
 class CallbackModule(CallbackBase):
@@ -40,7 +40,7 @@ class CallbackModule(CallbackBase):
         """
         super(CallbackModule, self).__init__()
 
-        if not parse_version(__version__) >= parse_version(REQUIRED_VERSION):
+        if not parse_version(REQUIRED_VERSION) <= parse_version(__version__) < parse_version('2.8.0'):
             display(
                 'FATAL: Current Ansible version (%s) is not supported. %s'
                 % (__version__, DESCRIPTION), color='red')


### PR DESCRIPTION
Ansible 2.8 breaks compatibility in multiple areas of the code. Fail
early to prevent non-specific error messages.

Backports #11650