### PR TITLE
Remove kuryrnet handler from default kuryr configuration

### DIFF
--- a/playbooks/openstack/configuration.md
+++ b/playbooks/openstack/configuration.md
@@ -760,6 +760,23 @@ openshift_kuryr_subnet_driver: namespace
 openshift_kuryr_sg_driver: namespace
 ```
 
+When namespace isolation is enabled there is a new subnet per namespace being
+created. If port pooling is enabled, in order to pre-populate the newly created
+namespaces, i.e., to have pools ready for the pods on that namespace, the
+kuryrnet handler needs to be enabled on the kuryr-config configmap after the
+installation is completed:
+
+```
+$ oc -n KURYR_NAMESPACE edit cm kuryr-config
+
+...
+[kubernetes]
+enabled_handlers = vif,lb,lbaasspec,namespace,*kuryrnet*
+...
+```
+
+Note depending on the Kuryr controller image version, this feature (handler)
+may not be available.
 
 ### Network Policies
 

--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -239,7 +239,7 @@ data:
 {% if openshift_kuryr_sg_driver|default('default') == 'policy' %}
     enabled_handlers = vif,lb,lbaasspec,namespace,policy,pod_label,kuryrnetpolicy,kuryrnet
 {% else %}
-    enabled_handlers = vif,lb,lbaasspec,namespace,kuryrnet
+    enabled_handlers = vif,lb,lbaasspec,namespace
 {% endif %}
 {% else %}
     enabled_handlers = vif,lb,lbaasspec


### PR DESCRIPTION
Kuryrnet handler has been added recently. In order to avoid installation
problems when using older kuryr container images, that is removed from
the default configuration at installation time for namespace isolation
feature. It is documented how to enable it at kuryr config map after
the deployment.

Note for network policy option it is still left as the default since
in order to have network policy support a recent kuryr container image
is needed, which should include the mentioned new handler.