### PR TITLE
[release-4.1] Refactor openshift_node

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ An example inventory can be found in [inventory/hosts.example](inventory/hosts.e
 Required variables include:
 
 - `openshift_kubeconfig_path` - Path to the kubeconfig for the cluster
-- `openshift_pull_secret_path` - Path to the pull secret to the image registry
 
 ## Run the RHEL node scaleup playbook
 

--- a/images/installer/root/usr/local/bin/entrypoint-provider
+++ b/images/installer/root/usr/local/bin/entrypoint-provider
@@ -24,9 +24,6 @@ if ! whoami &>/dev/null; then
   echo "${USER:-default}:x:$(id -u):$(id -g):Default User:$HOME:/sbin/nologin" >> /etc/passwd
 fi
 
-# Provide a path to the pull secret
-mkdir -p "${WORK}/inventory/dynamic/${TYPE}/group_vars/all"
-echo "openshift_pull_secret_path: \"${FILES}/pull-secret\"" > "${WORK}/inventory/dynamic/${TYPE}/group_vars/all/00_pull_secret_path.yml"
 # Add any injected variable files into the group vars directory
 find "${FILES}" \( -name '*.yml' -or -name '*.yaml' -or -name vars \) -print0 | xargs -0 -L1 -I {} ln -fs {} "${WORK}/inventory/dynamic/${TYPE}/group_vars/all"
 # Avoid sudo when running locally - nothing in the image requires it.

--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -12,7 +12,6 @@ ansible_user=root
 # Required configuration variables                                            #
 ###############################################################################
 openshift_kubeconfig_path="~/.kube/config"
-openshift_pull_secret_path="~/pull-secret.txt"
 
 # For running RHEL worker upgrades
 [workers]

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-openshift_pull_secret_path: '~/pull-secret.txt'
-
 openshift_node_machineconfigpool: 'worker'
 openshift_node_tls_verify: false
 

--- a/roles/openshift_node/tasks/apply_machine_config.yml
+++ b/roles/openshift_node/tasks/apply_machine_config.yml
@@ -37,16 +37,12 @@
     content: "{{ (oc_get.stdout | from_json).spec.config }}"
     dest: "{{ temp_dir.path }}/worker_ignition_config.json"
 
-- name: Copy pull secret
-  copy:
-    src: "{{ openshift_pull_secret_path }}"
-    dest: "{{ temp_dir.path }}/pull-secret.json"
-
-- name: Get release image
+- name: Get machine-config-daemon image
   command: >
-    oc get clusterversion
+    oc get daemonset machine-config-daemon
     --config={{ openshift_node_kubeconfig_path }}
-    --output=jsonpath='{.items[0].status.desired.image}'
+    --namespace=openshift-machine-config-operator
+    --output=jsonpath='{.spec.template.spec.containers[?(@.name=="machine-config-daemon")].image}'
   delegate_to: localhost
   register: oc_get
   until:
@@ -54,37 +50,22 @@
   retries: 36
   delay: 5
 
-- name: Set openshift_release_image fact
+- name: Set l_mcd_image fact
   set_fact:
-    openshift_release_image: "{{ oc_get.stdout }}"
+    l_mcd_image: "{{ oc_get.stdout }}"
 
-- name: Pull release image
-  command: "podman pull --tls-verify={{ openshift_node_tls_verify }} --authfile {{ temp_dir.path }}/pull-secret.json {{ openshift_release_image }}"
+- name: Apply machine config
+  command: "podman run {{ podman_mounts }} {{ podman_flags }} {{ mcd_command }}"
+  vars:
+    podman_flags: "--privileged --rm -ti {{ l_mcd_image }}"
+    podman_mounts: "-v /:/rootfs -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd"
+    mcd_command: "start --node-name {{ ansible_hostname }} --once-from {{ temp_dir.path }}/worker_ignition_config.json --skip-reboot"
 
-- name: Get machine controller daemon image from release image
-  command: "podman run --rm {{ openshift_release_image }} image machine-config-daemon"
-  register: release_image_mcd
+- name: Remove temp directory
+  file:
+    path: "{{ temp_dir.path }}"
+    state: absent
 
-- block:
-  - name: Pull MCD image
-    command: "podman pull --tls-verify={{ openshift_node_tls_verify }} --authfile {{ temp_dir.path }}/pull-secret.json {{ release_image_mcd.stdout }}"
-
-  - name: Apply machine config
-    command: "podman run {{ podman_mounts }} {{ podman_flags }} {{ mcd_command }}"
-    vars:
-      podman_flags: "--privileged --rm -ti {{ release_image_mcd.stdout }}"
-      podman_mounts: "-v /:/rootfs -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd"
-      mcd_command: "start --node-name {{ ansible_hostname }} --once-from {{ temp_dir.path }}/worker_ignition_config.json --skip-reboot"
-
-  - name: Remove temp directory
-    file:
-      path: "{{ temp_dir.path }}"
-      state: absent
-
-  - name: Reboot the host and wait for it to come back
-    reboot:
-    #  reboot_timeout: 600  # default, 10 minutes
-
-  rescue:
-  - fail:
-      msg: "Machine config apply failed"
+- name: Reboot the host and wait for it to come back
+  reboot:
+  #  reboot_timeout: 600  # default, 10 minutes

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -9,7 +9,8 @@
 # The atomic-openshift-node service will set this parameter on
 # startup, but if the network service is restarted this setting is
 # lost. Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1372388
-- sysctl:
+- name: Enable IP Forwarding
+  sysctl:
     name: net.ipv4.ip_forward
     value: 1
     sysctl_file: "/etc/sysctl.d/99-openshift.conf"
@@ -21,10 +22,10 @@
     state: yes
     persistent: yes
 
-- name: create temp directory
+- name: Create temp directory
   tempfile:
     state: directory
-  register: tempfile
+  register: temp_dir
 
 - name: Wait for bootstrap endpoint to show up
   uri:
@@ -40,15 +41,28 @@
 - name: Fetch bootstrap ignition file locally
   uri:
     url: "{{ openshift_node_bootstrap_endpoint }}"
-    dest: "{{ tempfile.path }}/bootstrap.ign"
+    dest: "{{ temp_dir.path }}/bootstrap.ign"
     validate_certs: false
 
-- name: Copy pull secret in the directory
-  copy:
-    src: "{{ openshift_pull_secret_path }}"
-    dest: "{{ tempfile.path }}/pull-secret.json"
+- name: Get cluster pull-secret
+  command: >
+    oc get secret pull-secret
+    --config={{ openshift_node_kubeconfig_path }}
+    --namespace=openshift-config
+    --output=jsonpath='{.data.\.dockerconfigjson}'
+  delegate_to: localhost
+  register: oc_get
+  until:
+  - oc_get.stdout != ''
+  retries: 36
+  delay: 5
 
-- name: Get release image
+- name: Write pull-secret to file
+  copy:
+    content: "{{ oc_get.stdout | b64decode }}"
+    dest: "{{ temp_dir.path }}/pull-secret.json"
+
+- name: Get cluster release image
   command: >
     oc get clusterversion
     --config={{ openshift_node_kubeconfig_path }}
@@ -60,27 +74,32 @@
   retries: 36
   delay: 5
 
-- name: Set openshift_release_image fact
+- name: Set l_release_image fact
   set_fact:
-    openshift_release_image: "{{ oc_get.stdout }}"
+    l_release_image: "{{ oc_get.stdout }}"
 
 - name: Pull release image
-  command: "podman pull --tls-verify={{ openshift_node_tls_verify }} --authfile {{ tempfile.path }}/pull-secret.json {{ openshift_release_image }}"
+  command: "podman pull --tls-verify={{ openshift_node_tls_verify }} --authfile {{ temp_dir.path }}/pull-secret.json {{ l_release_image }}"
 
 - name: Get machine controller daemon image from release image
-  command: "podman run --rm {{ openshift_release_image }} image machine-config-daemon"
+  command: "podman run --rm {{ l_release_image }} image machine-config-daemon"
   register: release_image_mcd
 
 - block:
   - name: Pull MCD image
-    command: "podman pull --tls-verify={{ openshift_node_tls_verify }} --authfile {{ tempfile.path }}/pull-secret.json {{ release_image_mcd.stdout }}"
+    command: "podman pull --tls-verify={{ openshift_node_tls_verify }} --authfile {{ temp_dir.path }}/pull-secret.json {{ release_image_mcd.stdout }}"
 
   - name: Apply ignition manifest
     command: "podman run {{ podman_mounts }} {{ podman_flags }} {{ mcd_command }}"
     vars:
       podman_flags: "--privileged --rm -ti {{ release_image_mcd.stdout }}"
       podman_mounts: "-v /:/rootfs -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd"
-      mcd_command: "start --node-name {{ ansible_hostname }} --once-from {{ tempfile.path }}/bootstrap.ign --skip-reboot"
+      mcd_command: "start --node-name {{ ansible_hostname }} --once-from {{ temp_dir.path }}/bootstrap.ign --skip-reboot"
+
+  - name: Remove temp directory
+    file:
+      path: "{{ temp_dir.path }}"
+      state: absent
 
   - name: Reboot the host and wait for it to come back
     reboot:


### PR DESCRIPTION
- Get pull secret from cluster instead of file
- Use temp_dir var for temp directory
- Remove temp directory
- Upgrade: use (updated) local MCD image

Backports https://github.com/openshift/openshift-ansible/pull/11623