### PR TITLE
glusterfs: add gluster block cli timeout value as a env. variable

### DIFF
--- a/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
+++ b/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
@@ -48,6 +48,8 @@ objects:
             value: "${TCMU_LOGDIR}"
           - name: GB_LOGDIR
             value: "/var/log/glusterfs/gluster-block"
+          - name: GB_CLI_TIMEOUT
+            value: "${GB_CLI_TIMEOUT}"
           resources:
             requests:
               memory: 100Mi
@@ -188,3 +190,8 @@ parameters:
   description: Volume mount point of /dev from the host so that the container can access all devices.
   value: "/mnt/host-dev"
   required: true
+- name: GB_CLI_TIMEOUT
+  displayName: Gluster block cli timeout value
+  description: This value is to set maximum timeout value for gluster block cli.
+  value: "900"
+  required: false


### PR DESCRIPTION
GB_CLI_TIMEOUT is used to set the gluster block cli's timeout value.
This is useful during large gluster block volume creation of size
larger than 2 TB.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>