### PR TITLE
test: wait for machineconfigpool to rollout

### DIFF
--- a/test/aws/scaleup.yml
+++ b/test/aws/scaleup.yml
@@ -134,3 +134,6 @@
       name: "{{ item }}"
       state: absent
     with_items: "{{ pre_scaleup_workers_name }}"
+
+  - name: Wait for worker configs to roll out
+    command: oc wait machineconfigpool/worker --for=condition=Updated --timeout=5m


### PR DESCRIPTION
This ensures all necessary configs were placed on the scaled up nodes 
before tests are started