### PR TITLE
Fix issue with metrics undefined l_kubelet_node_name

### DIFF
--- a/playbooks/openshift-metrics/config.yml
+++ b/playbooks/openshift-metrics/config.yml
@@ -1,7 +1,7 @@
 ---
 - import_playbook: ../init/main.yml
   vars:
-    l_init_fact_hosts: "oo_masters_to_config"
+    l_init_fact_hosts: "oo_nodes_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
     l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
 


### PR DESCRIPTION
Switch `l_init_fact_hosts` from `oo_masters_to_config` to `oo_nodes_to_config`

Bug 1720466 - https://bugzilla.redhat.com/show_bug.cgi?id=1720466