### PR TITLE
Remove subPaths when mounting Kuryr pods volumes

### DIFF
--- a/roles/kuryr/templates/cni-daemonset.yaml.j2
+++ b/roles/kuryr/templates/cni-daemonset.yaml.j2
@@ -131,8 +131,7 @@ spec:
         - name: net-conf
           mountPath: /etc/cni/net.d
         - name: config-volume
-          mountPath: /etc/kuryr/kuryr.conf
-          subPath: kuryr-cni.conf
+          mountPath: /etc/kuryr
         - name: proc
           mountPath: /host_proc
         - name: openvswitch
@@ -158,8 +157,13 @@ spec:
           hostPath:
             path: /etc/cni/net.d
         - name: config-volume
-          configMap:
-            name: kuryr-config
+          projected:
+            sources:
+            - configMap:
+              name: kuryr-config
+              items:
+              - key: kuryr-cni.conf
+                path: kuryr.conf
         - name: proc
           hostPath:
             path: /proc

--- a/roles/kuryr/templates/controller-deployment.yaml.j2
+++ b/roles/kuryr/templates/controller-deployment.yaml.j2
@@ -49,8 +49,7 @@ spec:
           runAsUser: 0
         volumeMounts:
         - name: config-volume
-          mountPath: "/etc/kuryr/kuryr.conf"
-          subPath: kuryr.conf
+          mountPath: "/etc/kuryr"
         - name: certificates-volume
           mountPath: "/etc/ssl/certs/kuryr-ca-bundle.crt"
           subPath: kuryr-ca-bundle.crt
@@ -69,9 +68,14 @@ spec:
 {% endif %}
       volumes:
       - name: config-volume
-        configMap:
-          name: kuryr-config
+        projected:
           defaultMode: 0666
+          sources:
+          - configMap:
+            name: kuryr-config
+            items:
+            - key: kuryr.conf
+              path: kuryr.conf
       - name: certificates-volume
         secret:
           secretName: kuryr-certificates


### PR DESCRIPTION
When kuryr-config ConfigMap gets edited and kuryr-daemon pod gets
restarted we seem to suffer from bug [1]. As it's still open, this
commit works it around by removing subPath option used when mounting
kuryr.conf. Instead projected volumes are used for both kuryr-controller
and kuryr-cni pods.

[1] https://github.com/kubernetes/kubernetes/issues/68211