### PR TITLE
openshift_facts: fix MTU detection

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -464,12 +464,10 @@ def set_sdn_facts_if_unset(facts, system_facts):
         facts['node']['sdn_mtu'] = '1450'
 
         for val in itervalues(system_facts):
-            if isinstance(val, dict) and 'mtu' in val:
-                mtu = val['mtu']
 
-                if 'ipv4' in val and val['ipv4'].get('address') == node_ip:
-                    facts['node']['sdn_mtu'] = str(mtu - 50)
-
+            if isinstance(val, dict):
+                if val.get('address') == node_ip:
+                    facts['node']['sdn_mtu'] = str(val.get('mtu') - 50)
     return facts
 
 


### PR DESCRIPTION
This patch fixes incorrect mtu value set in /etc/origin/node/node-config.yaml file.
Since system_facts refactoring, mtu value is always set to default value (1450) as val['ipv4'] doest not exist anymore.