### PR TITLE
Contrail namespace edited

### DIFF
--- a/roles/contrail_master/tasks/os_contrail_master.yaml
+++ b/roles/contrail_master/tasks/os_contrail_master.yaml
@@ -42,6 +42,9 @@
   run_once: True
 
 - name: Create the contrail-system namespace
+  command: "{{ openshift_client_binary }} create -f /tmp/contrail-namespace.yaml"
+
+- name: Check if the contrail-system namespace is created
   oc_project:
     state: present
     name: "contrail-system"


### PR DESCRIPTION
1. contrail-system namespace is created with annotation so
   that openshift will schedule contrail pods on master/infra