### PR TITLE
catch some special situations

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -76,8 +76,8 @@ l_docker_blocked_registries: "{{ l2_docker_blocked_registries | to_json }}"
 l_docker_insecure_registries: "{{ l2_docker_insecure_registries | to_json }}"
 l_docker_selinux_enabled: "{{ openshift_docker_selinux_enabled | to_json }}"
 
-docker_http_proxy: "{{ openshift_http_proxy | default('') }}"
-docker_https_proxy: "{{ openshift.common.https_proxy | default('') }}"
+docker_http_proxy: "{{ openshift_docker_http_proxy | default(True) | ternary(openshift_http_proxy, '') }}"
+docker_https_proxy: "{{ openshift_docker_https_proxy | default(True) | ternary(openshift_https_proxy, '') }}"
 docker_no_proxy: "{{ openshift.common.no_proxy | default('') }}"
 
 openshift_use_crio: False

--- a/roles/openshift_hosted/tasks/router.yml
+++ b/roles/openshift_hosted/tasks/router.yml
@@ -26,6 +26,7 @@
     backup: True
     dest: "/etc/origin/master/{{ item | basename }}"
     src: "{{ item }}"
+    remote_src: "{{ openshift_hosted_router_certificate_from_remote | default(no) }}"
   with_items: "{{ openshift_hosted_routers | lib_utils_oo_collect(attribute='certificate') |
                   lib_utils_oo_select_keys_from_list(['keyfile', 'certfile', 'cafile']) }}"
   when: ( not openshift_hosted_router_create_certificate | bool ) or openshift_hosted_router_certificate != {} or

--- a/roles/openshift_named_certificates/tasks/main.yml
+++ b/roles/openshift_named_certificates/tasks/main.yml
@@ -28,12 +28,14 @@
   copy:
     src: "{{ item.certfile }}"
     dest: "{{ named_certs_dir }}/{{ item.certfile | basename }}"
+    remote_src: "{{ openshift_named_certificates_from_remote | default(no) }}"
   with_items: "{{ named_certificates }}"
 
 - name: Land named certificate keys
   copy:
     src: "{{ item.keyfile }}"
     dest: "{{ named_certs_dir }}/{{ item.keyfile | basename }}"
+    remote_src: "{{ openshift_named_certificates_from_remote | default(no) }}"
     mode: 0600
   with_items: "{{ named_certificates }}"
 
@@ -41,5 +43,6 @@
   copy:
     src: "{{ item }}"
     dest: "{{ named_certs_dir }}/{{ item | basename }}"
+    remote_src: "{{ openshift_named_certificates_from_remote | default(no) }}"
     mode: 0600
   with_items: "{{ named_certificates | lib_utils_oo_collect('cafile') }}"


### PR DESCRIPTION
Provide possibility to handle some special situations.

1. Now it's possible to provide an extra proxy server for docker daemon. It this variables are not provided they will derive there values from the default one.

2. In some cases you can't place certificates and keys on the installation host. For that situation you can now place the files somewhere on the master servers and use these paths as `remote_src`.