### PR TITLE
[release-3.11] Fix openshift_logging_elasticsearch handler (Ansible 2.8)

### DIFF
--- a/roles/openshift_logging_elasticsearch/handlers/main.yml
+++ b/roles/openshift_logging_elasticsearch/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Restarting logging-{{ _cluster_component }} cluster"
+- name: "Restarting logging cluster"
   listen: "restart elasticsearch"
   include_tasks: restart_cluster.yml
   with_items: "{{ _restart_logging_components }}"


### PR DESCRIPTION
In Ansible 2.7 the _cluster_component var was not evaluated in the task
name and was allowing the task to complete.  In Ansible 2.8, the var is
attempted to be evaluated but does not exist as it is assigned in the
loop_var of the task itself.  The _cluster_component var has been removed
from the task handler task name.

Ansible 2.7, var is not evaluated in handler name:
`RUNNING HANDLER [Restarting logging-{{ _cluster_component }} cluster]`

Fixes #11715