### PR TITLE
[release-3.10] Add openshift ca to trust via node sync

### DIFF
--- a/roles/openshift_node_group/files/sync.yaml
+++ b/roles/openshift_node_group/files/sync.yaml
@@ -117,6 +117,20 @@ spec:
               continue
             fi
 
+            # does the openshift-ca.crt exist
+            if [[ -f /etc/pki/ca-trust/source/anchors/openshift-ca.crt ]]; then
+              md5sum /etc/pki/ca-trust/source/anchors/openshift-ca.crt > /tmp/.old-openshift-ca
+            else
+              cat /dev/null > /tmp/.old-openshift-ca
+            fi
+
+            md5sum  /run/secrets/kubernetes.io/serviceaccount/ca.crt > /tmp/.new-openshift-ca
+
+            if [[ "$( cat /tmp/.old-openshift-ca )" != "$( cat /tmp/.new-openshift-ca )" ]]; then
+              cp /run/secrets/kubernetes.io/serviceaccount/ca.crt /etc/pki/ca-trust/source/anchors/openshift-ca.crt
+              update-ca-trust
+            fi
+
             KUBELET_HOSTNAME_OVERRIDE=$(cat /etc/sysconfig/KUBELET_HOSTNAME_OVERRIDE 2>/dev/null) || :
             if ! [[ -z "$KUBELET_HOSTNAME_OVERRIDE" ]]; then
                   #Patching node-config for hostname override
@@ -210,6 +224,8 @@ spec:
         - mountPath: /run/systemd/system
           name: run-systemd-system
           readOnly: true
+        - mountPath: /etc/pki
+          name: host-pki
       tolerations:
       - operator: "Exists"
       volumes:
@@ -227,3 +243,7 @@ spec:
       - name: run-systemd-system
         hostPath:
           path: /run/systemd/system
+      - hostPath:
+          path: /etc/pki
+          type: ""
+        name: host-pki


### PR DESCRIPTION
Manual CP: https://github.com/openshift/openshift-ansible/pull/11721

Updated DaemonSet with:
- Additional host volume of /etc/pki
- Check if ca has changed if so copy it