### PR TITLE
[release-3.11] Ensure default vars are loaded for sanity checks

### DIFF
--- a/playbooks/init/sanity_checks.yml
+++ b/playbooks/init/sanity_checks.yml
@@ -23,8 +23,11 @@
 - name: Verify Node Prerequisites
   # We only want to run this on new installs and node/master scaleup.
   hosts: "{{ l_prereq_check_hosts | default('all:!all') }}"
-  tasks:
 
+  roles:
+  - role: openshift_facts
+
+  tasks:
   - name: Check for NetworkManager service
     command: 'systemctl show NetworkManager'
     register: nm_show


### PR DESCRIPTION
Ensuring defaults, such as `openshift_use_crio` are loaded during sanity checks.

Bug 1724718
https://bugzilla.redhat.com/show_bug.cgi?id=1724718