### PR TITLE
Fix #11643 - Allow to not specify ca file for openid

### DIFF
--- a/roles/openshift_control_plane/defaults/main.yml
+++ b/roles/openshift_control_plane/defaults/main.yml
@@ -22,6 +22,7 @@ l_osm_id_providers_dict:
     kind: 'AllowAllPasswordIdentityProvider'
 
 openshift_master_identity_providers: "{{ l_osm_id_providers_dict[openshift_deployment_type] }}"
+openshift_master_openid_ca_file: '/etc/ssl/certs/ca-bundle.crt'
 
 l_osm_disabled_features: "{{ openshift_deployment_subtype == 'registry' | bool }}"
 l_osm_disabled_features_list:


### PR DESCRIPTION
Since ceac075 the identity provider filter enforces a certain ca
file within the OpenID Connect Provider.
If you do not specify `openshift_master_openid_ca_file` the
master-api will fait to start and deployments or reconfiguration
result in a broken non-functioning cluster.

However, there are tons of OpenID Connect IdPs that do not require
a dedicated CA file, as their endpoints are served with SSL
certificates signed by CA that is usually trusted by the system's
CA bundle.

This is also the case for many IdPs of cloud provider, e.g. Azure
AD.
So neither Microsoft's (https://docs.microsoft.com/en-us/azure/virtual-machines/linux/openshift-post-deployment)
nor RedHat's guide (https://access.redhat.com/solutions/2465011)
mention any kind of CA to specify.

Thus many OCP installation getting an OpenID Connect IdP start with
just configuring the IdP, fail on deployment and reconfiguration.
Then digging appears and while crawling through many bugreports
people figure out that the CA file is now mandatory. But they
are still left to what should be the content (except when their
IdP is internally and signed by a private CA).

Additionally, it is currently not possible to disable the enforcment
of the CA file path in the resulting IdP configuration, as the
identity provider filter enforces that path. Thus you must set
the `openshift_master_openid_ca_file` parameter to get a woring
API and thus working OCP.

Based on the following KCS (https://access.redhat.com/solutions/3662731)
and the BZ (https://bugzilla.redhat.com/show_bug.cgi?id=1702853) you
must fill the file with valid content.
And https://bugzilla.redhat.com/show_bug.cgi?id=1632982#c9 has the
proposal to set it to the system's CA bundle.

This commit introduces the system's CA bundle as the default file
to be used as `openshift_master_openid_ca_file` which will make
simple IdP configurations that do not specify a dedicated CA to just
work(TM).