### PR TITLE
kube-proxy, namespace and firewalld corrections

### DIFF
--- a/playbooks/openshift-node/private/contrail_sanitize.yml
+++ b/playbooks/openshift-node/private/contrail_sanitize.yml
@@ -6,7 +6,7 @@
       command: iptables -I INPUT 4 -j ACCEPT -p udp --dport 53
       when:
         - openshift_use_contrail | default(false) | bool
-        - os_firewall_use_firewalld | default(False) | bool
+        - not os_firewall_use_firewalld | default(False) | bool
 
 - name: Contrail wait for come up
   hosts: oo_first_master

--- a/roles/contrail_master/tasks/main.yaml
+++ b/roles/contrail_master/tasks/main.yaml
@@ -6,7 +6,7 @@
 - name: Run kube proxy
   import_role:
     name: kube_proxy_and_dns
-  delegate_to: "{{ groups.oo_first_master.0 }}"
+  when: inventory_hostname == groups.masters.0
 
 - name: Get contrail nodes and ips
   import_role:

--- a/roles/contrail_master/tasks/os_contrail_master.yaml
+++ b/roles/contrail_master/tasks/os_contrail_master.yaml
@@ -41,13 +41,11 @@
     mode: 0644
   run_once: True
 
-- name: Create the contrail-system namespace
-  command: "{{ openshift_client_binary }} create -f /tmp/contrail-namespace.yaml"
-
 - name: Check if the contrail-system namespace is created
   oc_project:
     state: present
     name: "contrail-system"
+    node_selector: ""
   run_once: True
 
 - name: Create the contrail template files


### PR DESCRIPTION
1. kube proxy role should be called for 1 master only
2. namespace can be created/checked with nodeselector
3. firewalld should open port thru iptables if not enabled