### PR TITLE
Ensure master facts are set executing node config

### DIFF
--- a/playbooks/openshift-node/config.yml
+++ b/playbooks/openshift-node/config.yml
@@ -1,4 +1,9 @@
 ---
 - import_playbook: ../init/main.yml
 
+- name: Ensure master facts are set
+  hosts: oo_masters_to_config
+  roles:
+  - role: openshift_master_facts
+
 - import_playbook: private/config.yml


### PR DESCRIPTION
Running the openshift-node playbook can fail, when the facts
have peen purged. The variable openshift_node_master_api_url
is required by the openshift-node config roles, but not set
in this case.

To ensure the variable is going to be available, enforce
gathering the master facts as already done in the
openshift-node scalup playbook.