### PR TITLE
Kube Proxy needed to be deployed for ACI to run as a part of upgrade from 3.9 to 3.10

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_10/upgrade_control_plane.yml
@@ -136,6 +136,14 @@
   vars:
     openshift_release: '3.10'
 
+- name: Run kube proxy, needed for ACI
+  hosts: oo_first_master
+  tasks:
+  - import_role:
+      name: kube_proxy_and_dns
+    run_once: True
+    when: openshift_use_aci | default(false) | bool
+
 - import_playbook: ../post_control_plane.yml
 
 - hosts: oo_masters


### PR DESCRIPTION
Kube Proxy needed to be deployed for ACI to run as a part of upgrade from OSP 3.9 to 3.10