### PR TITLE
Kube Proxy needed to be deployed for ACI to run as a part of upgrade from OSP 3.10 to 3.11

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
@@ -116,6 +116,14 @@
           ('glusterfs' in groups and inventory_hostname in groups['glusterfs'])
           or ('glusterfs_registry' in groups and inventory_hostname in groups['glusterfs_registry'])
 
+- name: Run kube proxy, needed for ACI
+  hosts: oo_first_master
+  tasks:
+  - import_role:
+      name: kube_proxy_and_dns
+    run_once: True
+    when: openshift_use_aci | default(false) | bool
+
 - import_playbook: ../post_control_plane.yml
 
 - hosts: oo_masters


### PR DESCRIPTION
Kube Proxy needed to be deployed for ACI to run as a part of upgrade from OSP 3.10 to 3.11