### PR TITLE
roles/openshift-metrics: Allow configuring heapster log level

### DIFF
--- a/roles/openshift_metrics/defaults/main.yaml
+++ b/roles/openshift_metrics/defaults/main.yaml
@@ -33,6 +33,7 @@ openshift_metrics_heapster_requests_memory: 0.9375G
 openshift_metrics_heapster_requests_cpu: null
 openshift_metrics_heapster_nodeselector: ""
 openshift_metrics_heapster_concurrency_limit: 5
+openshift_metrics_heapster_log_verbosity: 1
 
 openshift_metrics_install_hawkular_agent: False
 openshift_metrics_hawkular_agent_limits_memory: null

--- a/roles/openshift_metrics/templates/heapster.j2
+++ b/roles/openshift_metrics/templates/heapster.j2
@@ -39,6 +39,7 @@ spec:
         - "--tls_key=/heapster-certs/tls.key"
         - "--tls_client_ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
         - "--allowed_users=%allowed_users%"
+        - "--v={{openshift_metrics_heapster_log_verbosity}}"
         - "--metric_resolution={{openshift_metrics_resolution}}"
 {% if not openshift_metrics_heapster_standalone %}
         - "--wrapper.username_file=/hawkular-account/hawkular-metrics.username"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1593634

@vrutkovs @sdodson 