### PR TITLE
[release-3.11] Update tox test environment vars

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -392,10 +392,8 @@ class OpenShiftAnsibleSyntaxCheck(Command):
             # --syntax-check each entry point playbook
             try:
                 # Create a host group list to avoid WARNING on unmatched host patterns
-                tox_ansible_inv = os.environ['TOX_ANSIBLE_INV_PATH']
                 subprocess.check_output(
-                    ['ansible-playbook', '-i', tox_ansible_inv,
-                     '--syntax-check', playbook, '-e', '@{}_extras'.format(tox_ansible_inv)]
+                    ['ansible-playbook', '--syntax-check', playbook]
                 )
             except subprocess.CalledProcessError as cpe:
                 print('{}Execution failed: {}{}'.format(

--- a/test/tox-inventory.txt_extras
+++ b/test/tox-inventory.txt_extras
@@ -1,3 +1,0 @@
----
-hostvars:
-  localhost: {}

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,12 @@ skip_missing_interpreters=True
 
 [testenv]
 skip_install=True
-setenv = TOX_ANSIBLE_INV_PATH = {toxinidir}/test/tox-inventory.txt
+setenv =
+    ANSIBLE_INVENTORY = {toxinidir}/test/tox-inventory.txt
+    ANSIBLE_LOG_PATH=/tmp/tox/ansible/ansible.log
+    ANSIBLE_LOCAL_TEMP=/tmp/tox/ansible
+    ANSIBLE_CACHE_PLUGIN_CONNECTION=/tmp/tox/ansible/facts
+
 deps =
     -rrequirements.txt
     -rtest-requirements.txt


### PR DESCRIPTION
Adds Ansible environment vars required to change Ansible to use /tmp
instead of user home.

Backports #11631 