### PR TITLE
distribute ca to etcd hosts

### DIFF
--- a/playbooks/openshift-etcd/private/config.yml
+++ b/playbooks/openshift-etcd/private/config.yml
@@ -15,6 +15,8 @@
 
 - import_playbook: ca.yml
 
+- import_playbook: distribute_ca.yml
+
 - import_playbook: certificates.yml
 
 - name: Configure etcd

--- a/playbooks/openshift-etcd/private/distribute_ca.yml
+++ b/playbooks/openshift-etcd/private/distribute_ca.yml
@@ -1,0 +1,33 @@
+---
+- name: Create temp directory for syncing certs
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - name: Create local temp directory for syncing certs
+    local_action: command mktemp -d /tmp/openshift-ansible-XXXXXXX
+    register: g_etcd_mktemp
+    changed_when: false
+
+  - name: Chmod local temp directory for syncing certs
+    local_action: file path="{{ g_etcd_mktemp.stdout }}" mode=0777
+    changed_when: false
+
+- name: Distribute etcd CA to etcd hosts
+  hosts: oo_etcd_to_config
+  tasks:
+  - import_role:
+      name: etcd
+      tasks_from: distribute_ca.yml
+    vars:
+      etcd_sync_cert_dir: "{{ hostvars['localhost'].g_etcd_mktemp.stdout }}"
+
+- name: Delete temporary directory on localhost
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - file:
+      name: "{{ g_etcd_mktemp.stdout }}"
+      state: absent
+    changed_when: false


### PR DESCRIPTION
Resolves an issue when doing a master scaleup, using a dynamic inventory, in this case, master[0] can be any one of the master group, 
the issue is 
TASK [etcd : fail] **********************************************************************************************************************************************************************************************************************************************************************
fatal: [xxxx-bxfs]: FAILED! => {"changed": false, "msg": "CA certificate /etc/etcd/ca/ca.crt doesn't exist on CA host xxxx. Apply 'etcd_ca' action from `etcd` role to xxxx-1bfn.\n"}

the issue is also reported here https://bugzilla.redhat.com/show_bug.cgi?id=1674421
