### PR TITLE
Don't create dirs for crio

### DIFF
--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -6,19 +6,6 @@
   async: 3600
   poll: 30
 
-# FIXME: Creation of these directories should not be required for crio 1.14.5
-- name: Create CNI dirs for crio
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-  loop:
-  - /var/lib/cni/bin
-  - /etc/kubernetes/cni/net.d/
-  - /opt/cni/bin/
-
 - name: Get cluster version
   command: >
     oc get clusterversion


### PR DESCRIPTION
crio 1.14.6 and above should not need these dirs created in order for
nodes to come online

Tracking crio fixes here: https://bugzilla.redhat.com/show_bug.cgi?id=1723295

Reverts: https://github.com/openshift/openshift-ansible/pull/11698