### PR TITLE
GlusterFS: Remove the default values used for keys

### DIFF
--- a/roles/openshift_storage_glusterfs/templates/heketi.json.j2
+++ b/roles/openshift_storage_glusterfs/templates/heketi.json.j2
@@ -9,11 +9,9 @@
 	"jwt" : {
 		"_admin" : "Admin has access to all APIs",
 		"admin" : {
-			"key" : "My Secret"
 		},
 		"_user" : "User only has access to /volumes endpoint",
 		"user" : {
-			"key" : "My Secret"
 		}
 	},
 


### PR DESCRIPTION
Remove the default values used for the keys to access heketi.

This should ensure proper authentication parameters to be provided, and
not making use of dummy default values.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1724935

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>