### PR TITLE
apiVersion moved to stable and to apps/v1

### DIFF
--- a/roles/openshift_logging_fluentd/templates/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/fluentd.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: "DaemonSet"
 metadata:
   name: "{{ daemonset_name }}"


### PR DESCRIPTION
The core workloads API, which is composed of the DaemonSet, Deployment, ReplicaSet, and StatefulSet kinds, has been promoted to GA stability in the apps/v1 group version in OpenShift Container Platform 3.9.