### PR TITLE
Adds current registry route hostname when generating the new certs

### DIFF
--- a/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml
@@ -57,9 +57,24 @@
       register: docker_registry_service_ip
       changed_when: false
 
+    # Assume default hostname for docker-registry route
     - set_fact:
         docker_registry_route_hostname: "{{ 'docker-registry-default.' ~ openshift_master_default_subdomain }}"
       changed_when: false
+
+    - name: Retrieve current registry route
+      oc_route:
+        namespace: default
+        name: docker-registry
+        state: list
+      register: docker_registry_current_route
+      changed_when: false
+
+    # Appends current registry route hostname, if its not the default one.
+    - set_fact:
+        docker_registry_route_hostname: "{{ docker_registry_route_hostname }},{{ docker_registry_current_route.module_results[0].spec.host }}"
+      changed_when: false
+      when: docker_registry_route_hostname != docker_registry_current_route.module_results[0].spec.host
 
     - name: Generate registry certificate
       command: >


### PR DESCRIPTION
There are situations when docker-registry hostname is not "docker-registry-default." + {{ openshift_master_default_subdomain }}.

For example when a customer wants to give the Registry a prettier name, or when using Router sharding, labelling the default NS, and using a different subdomain than the default one.

The redeploy registry certs playbooks does not take that into account, so It will never add the current docker-registry route hostname to the certificates..

This PR fix that,