### PR TITLE
restart.yml - check gluster health before and after restart

### DIFF
--- a/playbooks/openshift-node/private/restart.yml
+++ b/playbooks/openshift-node/private/restart.yml
@@ -8,6 +8,11 @@
   - openshift_facts
 
   tasks:
+  - name: Check Gluster Health Before Restart
+    include_role:
+      name: openshift_storage_glusterfs
+      tasks_from: check_cluster_health.yml
+
   - name: Mark node unschedulable
     oc_adm_manage_node:
       node: "{{ l_kubelet_node_name | lower }}"
@@ -98,3 +103,8 @@
     when:
     - node_unschedulable is changed
     - openshift_node_restart_drain | default(false) | bool
+
+  - name: Check Gluster Health After Restart
+    include_role:
+      name: openshift_storage_glusterfs
+      tasks_from: check_cluster_health.yml


### PR DESCRIPTION
When doing restart of openshift services it is really important that the gluster health be checked before a node is taken offline, and wait for health after a node comes back on line. Otherwise, if restarting to quickly, before gluster has time to recover itself you can totally mess up gluster.