### PR TITLE
Switch to the new default storage class annotation

### DIFF
--- a/roles/lib_openshift/library/oc_storageclass.py
+++ b/roles/lib_openshift/library/oc_storageclass.py
@@ -1531,7 +1531,7 @@ class StorageClassConfig(object):
         if self.annotations is not None:
             self.data['metadata']['annotations'] = self.annotations
 
-        self.data['metadata']['annotations']['storageclass.beta.kubernetes.io/is-default-class'] = \
+        self.data['metadata']['annotations']['storageclass.kubernetes.io/is-default-class'] = \
                 self.default_storage_class
 
         self.data['provisioner'] = self.provisioner

--- a/roles/lib_openshift/src/lib/storageclass.py
+++ b/roles/lib_openshift/src/lib/storageclass.py
@@ -41,7 +41,7 @@ class StorageClassConfig(object):
         if self.annotations is not None:
             self.data['metadata']['annotations'] = self.annotations
 
-        self.data['metadata']['annotations']['storageclass.beta.kubernetes.io/is-default-class'] = \
+        self.data['metadata']['annotations']['storageclass.kubernetes.io/is-default-class'] = \
                 self.default_storage_class
 
         self.data['provisioner'] = self.provisioner

--- a/roles/lib_openshift/src/test/unit/test_oc_storageclass.py
+++ b/roles/lib_openshift/src/test/unit/test_oc_storageclass.py
@@ -42,7 +42,7 @@ class OCStorageClassTest(unittest.TestCase):
             'debug': False,
             'name': 'testsc',
             'provisioner': 'aws-ebs',
-            'annotations': {'storageclass.beta.kubernetes.io/is-default-class': "true"},
+            'annotations': {'storageclass.kubernetes.io/is-default-class': "true"},
             'parameters': {'type': 'gp2'},
             'api_version': 'v1',
             'default_storage_class': 'true',
@@ -59,7 +59,7 @@ class OCStorageClassTest(unittest.TestCase):
                 "uid": "4d8320c9-e66f-11e6-8edc-0eece8f2ce22",
                 "resourceVersion": "2828",
                 "creationTimestamp": "2017-01-29T22:07:19Z",
-                "annotations": {"storageclass.beta.kubernetes.io/is-default-class": "true"}
+                "annotations": {"storageclass.kubernetes.io/is-default-class": "true"}
             },
             "provisioner": "kubernetes.io/aws-ebs",
             "parameters": {"type": "gp2"},
@@ -129,7 +129,7 @@ class OCStorageClassTest(unittest.TestCase):
             'debug': False,
             'name': 'testsc',
             'provisioner': 'kubernetes.io/aws-ebs',
-            'annotations': {'storageclass.beta.kubernetes.io/is-default-class': "true"},
+            'annotations': {'storageclass.kubernetes.io/is-default-class': "true"},
             'parameters': {'type': 'gp2'},
             'api_version': 'v1',
             'default_storage_class': 'true',
@@ -146,7 +146,7 @@ class OCStorageClassTest(unittest.TestCase):
                 "uid": "4d8320c9-e66f-11e6-8edc-0eece8f2ce22",
                 "resourceVersion": "2828",
                 "creationTimestamp": "2017-01-29T22:07:19Z",
-                "annotations": {"storageclass.beta.kubernetes.io/is-default-class": "true"}
+                "annotations": {"storageclass.kubernetes.io/is-default-class": "true"}
             },
             "provisioner": "kubernetes.io/aws-ebs",
             "parameters": {"type": "gp2"},


### PR DESCRIPTION
Since OCP 3.6 the new annotation is without .beta - While the
beta annotation still works, it is for example not picked up by
the cluster-console and thus not showing the specific storage-class
as the default one.

https://docs.openshift.com/container-platform/3.11/install_config/persistent_storage/dynamically_provisioning_pvs.html#storage-class-annotations