### PR TITLE
Setup NetworkManager script before starting dnsmasq

### DIFF
--- a/roles/openshift_node/tasks/dnsmasq.yml
+++ b/roles/openshift_node/tasks/dnsmasq.yml
@@ -28,12 +28,12 @@
     - reload systemd units
     - restart dnsmasq
 
+# Dynamic NetworkManager based dispatcher
+- import_tasks: dnsmasq/network-manager.yml
+  when: network_manager_active | bool
+
 - name: Enable dnsmasq
   systemd:
     name: dnsmasq
     enabled: yes
     state: started
-
-# Dynamic NetworkManager based dispatcher
-- import_tasks: dnsmasq/network-manager.yml
-  when: network_manager_active | bool


### PR DESCRIPTION
I've run into a situation trying to install 3.11 on VMWare.  Specifically, the order of dnsmasq operations causes _some_ servers to be inaccessible.  I've redeployed the cluster and it's not always the same nodes.  What I'm seeing is when  the `Enable dnsmasq` task is run it starts dnsmasq.service, but the `Install network manager dispatch script` hasn't happened yet which is what seems to do the magic of creating the `/etcd/dnsmasq.d/origin-upstream-dns.conf` file containing our nameservers.  Immediately after the `Enable dnsmasq` task, I see connection failures and I'm unable to SSH/Sudo (auth goes over AD) until I put the `origin-upstream-dns.conf` file in place and restart dnsmasq.

I tested this successfully on multiple redeploys of a 3.11 cluster running CentOS 7 on VMWare.

Relevant Code: https://github.com/openshift/openshift-ansible/blob/release-3.11/roles/openshift_node/tasks/dnsmasq.yml#L31-L39
Similar issue: https://github.com/openshift/openshift-ansible/issues/11417
Slack Convo: https://openshiftcommons.slack.com/archives/CBGBKBD9S/p1562682212018400