### PR TITLE
GlusterFS: make pods cluster-critical

### DIFF
--- a/roles/openshift_storage_glusterfs/files/deploy-heketi-template.yml
+++ b/roles/openshift_storage_glusterfs/files/deploy-heketi-template.yml
@@ -100,6 +100,7 @@ objects:
             httpGet:
               path: /hello
               port: 8080
+        priorityClassName: system-cluster-critical
         volumes:
         - name: db
         - name: config

--- a/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
+++ b/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
@@ -110,6 +110,7 @@ objects:
             successThreshold: 1
             failureThreshold: 50
           terminationMessagePath: "/var/log/termination.log"
+        priorityClassName: system-cluster-critical
         volumes:
         - name: glusterfs-heketi
           hostPath:


### PR DESCRIPTION
Even though we add tolerations, on situations with low resources the evict_manager.go will rank for eviction the gluster pods before any system-node-critical.