### PR TITLE
[release-3.11]Wait the new scale group nodes to be ready before drain the old nodes during upgrade

### DIFF
--- a/roles/openshift_aws/defaults/main.yml
+++ b/roles/openshift_aws/defaults/main.yml
@@ -9,6 +9,7 @@ openshift_aws_create_scale_group: True
 
 openshift_aws_node_group_upgrade: False
 openshift_aws_wait_for_ssh: True
+openshift_aws_wait_for_node_ready: True
 
 openshift_aws_clusterid: default
 openshift_aws_region: us-east-1

--- a/roles/openshift_aws/tasks/provision_nodes.yml
+++ b/roles/openshift_aws/tasks/provision_nodes.yml
@@ -25,7 +25,7 @@
     loop_var: openshift_aws_node_group
 
 # instances aren't scaling fast enough here, we need to wait for them
-- when: openshift_aws_wait_for_ssh | bool
+- when: (openshift_aws_wait_for_ssh | bool) or (openshift_aws_wait_for_node_ready | bool)
   name: wait for our new nodes to come up
   include_tasks: wait_for_groups.yml
   vars:

--- a/roles/openshift_aws/tasks/wait_for_groups.yml
+++ b/roles/openshift_aws/tasks/wait_for_groups.yml
@@ -34,9 +34,17 @@
     msg: "{{ instancesout.results | sum(attribute='instances', start=[]) }}"
 
 - name: wait for ssh to become available
+  when: openshift_aws_wait_for_ssh | bool
   wait_for:
     port: 22
     host: "{{ item.public_ip_address }}"
     timeout: 300
     search_regex: OpenSSH
+  with_items: "{{ instancesout.results | sum(attribute='instances', start=[]) }}"
+
+- name: wait for new nodes become ready
+  when: openshift_aws_wait_for_node_ready | bool
+  include_tasks: wait_for_node.yml
+  vars:
+    node_name: "{{ item.private_dns_name }}"
   with_items: "{{ instancesout.results | sum(attribute='instances', start=[]) }}"

--- a/roles/openshift_aws/tasks/wait_for_node.yml
+++ b/roles/openshift_aws/tasks/wait_for_node.yml
@@ -1,0 +1,18 @@
+---
+# This will wait for the node to become ready status
+- name: wait for node become ready
+  oc_obj:
+    name: "{{ node_name }}"
+    kind: node
+    state: list
+  delegate_to: "{{ groups.masters.0 }}"
+  register: get_node
+  until:
+    - get_node.module_results.results[0] is defined
+    - get_node.module_results.results[0].status is defined
+    - get_node.module_results.results[0].status.conditions is defined
+    - get_node.module_results.results[0].status.conditions | selectattr('type', 'match', '^Ready$') | map(attribute='status') | join | bool == True
+  retries: 150
+  delay: 10
+- name: dump node info
+  debug: var=get_node


### PR DESCRIPTION
During upgrade, for some reason, the new created node is not in ready status, but we will drain and terminate the old nodes, this will bring cluster outage, we need wait all the new nodes become ready, then procceed.