### PR TITLE
Bug 1726717 : Add missing es_dc_index for ops install

### DIFF
--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -187,6 +187,8 @@
     _es_containers: "{{ outer_item.0.containers}}"
     _es_configmap: "{{ openshift_logging_facts | walk('elasticsearch_ops#configmaps#logging-elasticsearch-ops#elasticsearch.yml', '{}', delimiter='#') | from_yaml }}"
 
+    es_dc_index: "{{ outer_item.2 }}"
+
   with_together:
   - "{{ openshift_logging_facts.elasticsearch_ops.deploymentconfigs.values() | list }}"
   - "{{ openshift_logging_facts.elasticsearch_ops.pvcs }}"
@@ -223,6 +225,8 @@
     openshift_logging_es_hostname: "{{ openshift_logging_es_ops_hostname }}"
     openshift_logging_es_edge_term_policy: "{{ openshift_logging_es_ops_edge_term_policy | default('') }}"
     openshift_logging_es_allow_external: "{{ openshift_logging_es_ops_allow_external }}"
+
+    es_dc_index: "{{ outer_item | int + openshift_logging_facts.elasticsearch_ops.deploymentconfigs | count - 1 }}"
 
   with_sequence: count={{ openshift_logging_es_ops_cluster_size | int - openshift_logging_facts.elasticsearch_ops.deploymentconfigs.keys() | count }}
   loop_control:

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -19,6 +19,16 @@
     msg: Invalid deployment type, one of ['data-master', 'data-client', 'master', 'client'] allowed
   when: not openshift_logging_elasticsearch_deployment_type in __allowed_es_types
 
+- when:
+  - openshift_logging_elasticsearch_storage_type == "hostmount"
+  name: "Ensure openshift_logging_elasticsearch_hostmount_path is set"
+  assert:
+    that:
+    - openshift_logging_elasticsearch_hostmount_path is defined
+    - "openshift_logging_elasticsearch_hostmount_path != ''"
+    msg: |-
+      openshift_logging_elasticsearch_hostmount_path has not been set and is required for openshift_logging_elasticsearch_storage_type = "hostmount"
+
 - set_fact:
     elasticsearch_name: "{{ 'logging-elasticsearch' ~ ( (openshift_logging_elasticsearch_ops_deployment | default(false) | bool) | ternary('-ops', '')) }}"
     es_component: "{{ 'es' ~ ( (openshift_logging_elasticsearch_ops_deployment | default(false) | bool) | ternary('-ops', '') ) }}"
@@ -465,7 +475,7 @@
       assert:
         that: "{{ es_available_nodes['module_results']['results'][0]['items'] | default([]) | length != 0 }}"
         msg: |-
-          No schedulable nodes found matching node selector for elastic search.'
+          No schedulable nodes found matching node selector for elasticsearch.
 
     - name: label node where dc will be stick
       oc_label:


### PR DESCRIPTION
Also adding assert for hostmount_path when hostmount storage is used

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1726717