### PR TITLE
Modify "Updating vm.max_map_count value" task to create 99-elasticsearch.conf file when vm.max_map_count is set to <= 262144

### DIFF
--- a/playbooks/openshift-logging/private/config.yml
+++ b/playbooks/openshift-logging/private/config.yml
@@ -100,7 +100,7 @@
       command:
         cat /proc/sys/vm/max_map_count
       register: _vm_max_map_count
-      
+
     - name: Check if /etc/sysctl.d/99-elasticsearch.conf file exists
       stat:
         path: /etc/sysctl.d/99-elasticsearch.conf

--- a/playbooks/openshift-logging/private/config.yml
+++ b/playbooks/openshift-logging/private/config.yml
@@ -100,6 +100,11 @@
       command:
         cat /proc/sys/vm/max_map_count
       register: _vm_max_map_count
+      
+    - name: Check if /etc/sysctl.d/99-elasticsearch.conf file exists
+      stat:
+        path: /etc/sysctl.d/99-elasticsearch.conf
+      register: stat_result
 
     - name: Updating vm.max_map_count value
       sysctl:
@@ -108,7 +113,7 @@
         sysctl_file: "/etc/sysctl.d/99-elasticsearch.conf"
         reload: yes
       when:
-      - _vm_max_map_count.stdout | default(0) | int <= 262144 | int
+      - _vm_max_map_count.stdout | default(0) | int <= 262144 | int or stat_result.stat.exists == False
 
 - name: Remove created 99-elasticsearch sysctl
   hosts: all

--- a/playbooks/openshift-logging/private/config.yml
+++ b/playbooks/openshift-logging/private/config.yml
@@ -108,7 +108,7 @@
         sysctl_file: "/etc/sysctl.d/99-elasticsearch.conf"
         reload: yes
       when:
-      - _vm_max_map_count.stdout | default(0) | int < 262144 | int
+      - _vm_max_map_count.stdout | default(0) | int <= 262144 | int
 
 - name: Remove created 99-elasticsearch sysctl
   hosts: all


### PR DESCRIPTION
Modify Updating vm.max_map_count value task to create 99-elasticsearch.conf file when vm.max_map_count is set to <= 262144

If the logging is installed and removed later, it will remove the generated /etc/sysctl.d/99-elasticsearch.conf file. However, it will not reload the sysctl value.

So, if we reinstall logging again, it will still install fine, however, it will not create the above file. Once we reboot the node, the ES pod will fail to come up stating the vm.max_map_count  value is set to the default one which is less than 262144.

There are two ways to resolve this:

1. We can modify the condition to create this value if vm.max_map_count is set to <= 262144
2. Reload the sysctl parameter when removing the above file which will set it to the default again. 

However, with the second method, we will have to create a new file and hardcode this value again which doesn't seem to be a good idea.

