### PR TITLE
Bug 1727140: atomic-openshift-node service restarts every 3 minutes after using openshift_node_local_quota_per_fsgroup parameter during installation

### DIFF
--- a/roles/openshift_node_group/files/sync.yaml
+++ b/roles/openshift_node_group/files/sync.yaml
@@ -65,6 +65,12 @@ spec:
             touch /tmp/.old
           fi
 
+          if [[ -f /etc/origin/node/volume-config.yaml ]]; then
+            md5sum /etc/origin/node/volume-config.yaml > /tmp/.old-volume.config
+          else
+            touch /tmp/.old-volume-config
+          fi
+
           # loop until BOOTSTRAP_CONFIG_NAME is set
           while true; do
             file=/etc/sysconfig/origin-node
@@ -137,21 +143,29 @@ spec:
               cat /dev/null > /tmp/.old
             fi
 
-            tmp_path=/etc/origin/node/tmp
-            if [[ -f ${tmp_path}/volume-config.yaml ]]; then
-              tar -Pcf ${tmp_path}/configs.tar ${tmp_path}/volume-config.yaml ${tmp_path}/node-config.yaml
-              md5sum ${tmp_path}/configs.tar > /tmp/.new
-              rm ${tmp_path}/configs.tar
+            if [[ ! -f /etc/origin/node/volume-config.yaml ]]; then
+              cat /dev/null > /tmp/.old-volume-config
+            fi
+            md5sum /etc/origin/node/tmp/node-config.yaml > /tmp/.new
+
+            if [[ ! -f /etc/origin/node/tmp/volume-config.yaml ]]; then
+              cat /dev/null > /tmp/.new-volume-config
             else
-              md5sum ${tmp_path}/node-config.yaml > /tmp/.new
+              md5sum /etc/origin/node/tmp/volume-config.yaml > /tmp/.new-volume-config
             fi
 
-            if [[ "$( cat /tmp/.old )" != "$( cat /tmp/.new )" && -f ${tmp_path}/volume-config.yaml ]]; then
-              mv /etc/origin/node/tmp/volume-config.yaml /etc/origin/node/volume-config.yaml
-            fi
-
+            trigger_restart=false
             if [[ "$( cat /tmp/.old )" != "$( cat /tmp/.new )" ]]; then
               mv /etc/origin/node/tmp/node-config.yaml /etc/origin/node/node-config.yaml
+              trigger_restart=true
+            fi
+
+            if [[ "$( cat /tmp/.old-volume-config )" != "$( cat /tmp/.new-volume-config )" ]]; then
+              mv /etc/origin/node/tmp/volume-config.yaml /etc/origin/node/volume-config.yaml
+              trigger_restart=true
+            fi
+
+            if [[ "$trigger_restart" = true ]]; then
               SYSTEMD_IGNORE_CHROOT=1 systemctl restart tuned || :
               echo "info: Configuration changed, restarting kubelet" 2>&1
               # TODO: kubelet doesn't relabel nodes, best effort for now
@@ -184,6 +198,7 @@ spec:
             oc annotate --config=/etc/origin/node/node.kubeconfig "node/${NODE_NAME}" \
               node.openshift.io/md5sum="$( cat /tmp/.new | cut -d' ' -f1 )" --overwrite
             cp -f /tmp/.new /tmp/.old
+            cp -f /tmp/.new-volume-config /tmp/.old-volume-config
             sleep 180 &
             wait $!
           done


### PR DESCRIPTION
atomic-openshift-node service restarts every 3 minutes after using openshift_node_local_quota_per_fsgroup parameter during installation. This is because of the incorrect comparison of existing node-config.yaml and volume-config.yaml files against a tarball which will never match. 

This is a regression of [Bug 1669555](https://bugzilla.redhat.com/show_bug.cgi?id=1669555)

Fixes [Bug 1728195](https://bugzilla.redhat.com/show_bug.cgi?id=1728195)