### PR TITLE
[GlusterFS]: Fix registry daemonset deletion as part of upgrade.

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
@@ -68,7 +68,7 @@
   # oc delete --cascade=false seems broken for DaemonSets.
   # Using curl to talk to the API directly.
   - name: Delete glusterfs daemonset w/o cascade
-    shell: "curl -k -X DELETE https://localhost:8443/apis/extensions/v1beta1/namespaces/{{ glusterfs_namespace }}/daemonsets/glusterfs-storage -d '{\"kind\":\"DeleteOptions\",\"apiVersion\":\"v1\",\"propagationPolicy\":\"Orphan\"}' -H \"Accept: application/json\" -H \"Content-Type: application/json\"  --cert {{ openshift.common.config_base }}/master/admin.crt --key {{ openshift.common.config_base }}//master/admin.key"
+    shell: "curl -k -X DELETE https://localhost:8443/apis/extensions/v1beta1/namespaces/{{ glusterfs_namespace }}/daemonsets/glusterfs-{{ glusterfs_name }} -d '{\"kind\":\"DeleteOptions\",\"apiVersion\":\"v1\",\"propagationPolicy\":\"Orphan\"}' -H \"Accept: application/json\" -H \"Content-Type: application/json\"  --cert {{ openshift.common.config_base }}/master/admin.crt --key {{ openshift.common.config_base }}//master/admin.key"
     #shell: "{{ first_master_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig delete ds --namespace={{ glusterfs_namespace }} --cascade=false --selector=glusterfs"
     delegate_to: "{{ groups.oo_first_master.0 }}"
     failed_when: False


### PR DESCRIPTION
Avoid hardcoded daemonset name and use variable to detect both storage
and registry daemonset.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>