### PR TITLE
[release-3.9] Fix ASB ConfigMap

### DIFF
--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -352,16 +352,16 @@
             registry:
               - type: {{ ansible_service_broker_registry_type }}
                 name: {{ ansible_service_broker_registry_name }}
-                url:  {{ ansible_service_broker_registry_url }}
-                org:  {{ ansible_service_broker_registry_organization }}
-                tag:  {{ ansible_service_broker_registry_tag }}
-                white_list: {{  ansible_service_broker_registry_whitelist | to_yaml }}
-                auth_type: "{{ ansible_service_broker_registry_auth_type | default("") }}"
-                auth_name: "{{ ansible_service_broker_registry_auth_name | default("") }}"
+                url: {{ ansible_service_broker_registry_url }}
+                org: {{ ansible_service_broker_registry_organization }}
+                tag: {{ ansible_service_broker_registry_tag }}
+                white_list: {{  ansible_service_broker_registry_whitelist }}
+                auth_type: "{{ ansible_service_broker_registry_auth_type | default('') }}"
+                auth_name: "{{ ansible_service_broker_registry_auth_name | default('') }}"
               - type: local_openshift
                 name: localregistry
                 namespaces: ['openshift']
-                white_list: {{ ansible_service_broker_local_registry_whitelist | to_yaml }}
+                white_list: {{ ansible_service_broker_local_registry_whitelist }}
             dao:
               etcd_host: asb-etcd.openshift-ansible-service-broker.svc
               etcd_port: 2379
@@ -373,9 +373,9 @@
               level: {{ ansible_service_broker_log_level }}
               color: true
             openshift:
-              host: ""
-              ca_file: ""
-              bearer_token_file: ""
+              host: ''
+              ca_file: ''
+              bearer_token_file: ''
               namespace: openshift-ansible-service-broker
               sandbox_role: {{ ansible_service_broker_sandbox_role }}
               image_pull_policy: {{ ansible_service_broker_image_pull_policy }}


### PR DESCRIPTION
The ConfigMap generated is not valid yaml and will cause
an error when upgrading to 3.10.