### PR TITLE
[release-3.9] Update tox test environment vars

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -390,10 +390,8 @@ class OpenShiftAnsibleSyntaxCheck(Command):
             # --syntax-check each entry point playbook
             try:
                 # Create a host group list to avoid WARNING on unmatched host patterns
-                tox_ansible_inv = os.environ['TOX_ANSIBLE_INV_PATH']
                 subprocess.check_output(
-                    ['ansible-playbook', '-i', tox_ansible_inv,
-                     '--syntax-check', playbook, '-e', '@{}_extras'.format(tox_ansible_inv)]
+                    ['ansible-playbook', '--syntax-check', playbook]
                 )
             except subprocess.CalledProcessError as cpe:
                 print('{}Execution failed: {}{}'.format(

--- a/test/tox-inventory.txt_extras
+++ b/test/tox-inventory.txt_extras
@@ -1,3 +1,0 @@
----
-hostvars:
-  localhost: {}

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,12 @@ skip_missing_interpreters=True
 
 [testenv]
 skip_install=True
-setenv = TOX_ANSIBLE_INV_PATH = {toxinidir}/test/tox-inventory.txt
+setenv =
+    ANSIBLE_INVENTORY = {toxinidir}/test/tox-inventory.txt
+    ANSIBLE_LOG_PATH=/tmp/tox/ansible/ansible.log
+    ANSIBLE_LOCAL_TEMP=/tmp/tox/ansible
+    ANSIBLE_CACHE_PLUGIN_CONNECTION=/tmp/tox/ansible/facts
+
 deps =
     -rrequirements.txt
     -rtest-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ skip_missing_interpreters=True
 [testenv]
 skip_install=True
 setenv =
+    ANSIBLE_CONFIG = ./ansible.cfg
     ANSIBLE_INVENTORY = {toxinidir}/test/tox-inventory.txt
     ANSIBLE_LOG_PATH=/tmp/tox/ansible/ansible.log
     ANSIBLE_LOCAL_TEMP=/tmp/tox/ansible

--- a/utils/test/cli_installer_tests.py
+++ b/utils/test/cli_installer_tests.py
@@ -514,10 +514,6 @@ class UnattendedCliTests(OOCliFixture):
             os.path.join(self.work_dir, '.ansible/callback_facts.yaml'),
             env_vars['OO_INSTALL_CALLBACK_FACTS_YAML'])
         self.assertEqual('/tmp/ansible.log', env_vars['ANSIBLE_LOG_PATH'])
-        # If user running test has rpm installed, this might be set to default:
-        self.assertTrue(
-            'ANSIBLE_CONFIG' not in env_vars or
-            env_vars['ANSIBLE_CONFIG'] == cli.DEFAULT_ANSIBLE_CONFIG)
 
         # Make sure we ran on the expected masters and nodes:
         hosts = run_playbook_mock.call_args[0][1]


### PR DESCRIPTION
Adds Ansible environment vars required to change Ansible to use /tmp
instead of user home.

Backports #11631