### PR TITLE
[GlusterFS]: Upgrade playbook is supported for converged mode only.

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
@@ -1,4 +1,11 @@
 ---
+- name: Upgrade playbook support for converged mode
+  fail:
+    msg: |
+      Upgrade playbook is supported for converged mode only.
+      Use manual method for independent mode.
+  when: not glusterfs_is_native | bool
+
 - import_tasks: cluster_health.yml
   vars:
     l_check_bricks: true


### PR DESCRIPTION
If upgrade playbook is run for independent mode, fail with a message.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1732140

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>