### PR TITLE
[GlusterFS]: variable to skip brick size check

### DIFF
--- a/roles/openshift_storage_glusterfs/defaults/main.yml
+++ b/roles/openshift_storage_glusterfs/defaults/main.yml
@@ -64,6 +64,7 @@ openshift_storage_glusterfs_heketi_ssh_user: 'root'
 openshift_storage_glusterfs_heketi_ssh_sudo: False
 openshift_storage_glusterfs_heketi_ssh_keyfile: "{{ omit }}"
 openshift_storage_glusterfs_heketi_fstab: "{{ '/var/lib/heketi/fstab' | quote if openshift_storage_glusterfs_heketi_executor == 'kubernetes' else '/etc/fstab' | quote }}"
+openshift_storage_glusterfs_check_brick_size_health: True
 
 openshift_storage_glusterfs_registry_timeout: "{{ openshift_storage_glusterfs_timeout }}"
 openshift_storage_glusterfs_registry_health_timeout: "{{ openshift_storage_glusterfs_health_timeout }}"
@@ -110,6 +111,7 @@ openshift_storage_glusterfs_registry_heketi_ssh_user: "{{ openshift_storage_glus
 openshift_storage_glusterfs_registry_heketi_ssh_sudo: "{{ openshift_storage_glusterfs_heketi_ssh_sudo }}"
 openshift_storage_glusterfs_registry_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_heketi_ssh_keyfile | default(omit) }}"
 openshift_storage_glusterfs_registry_heketi_fstab: "{{ '/var/lib/heketi/fstab' | quote if openshift_storage_glusterfs_registry_heketi_executor == 'kubernetes' else '/etc/fstab' | quote }}"
+openshift_storage_glusterfs_registry_check_brick_size_health: "{{ openshift_storage_glusterfs_check_brick_size_health }}"
 
 r_openshift_storage_glusterfs_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
 r_openshift_storage_glusterfs_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_config_facts.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_config_facts.yml
@@ -47,3 +47,4 @@
     glusterfs_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_heketi_ssh_keyfile }}"
     glusterfs_heketi_fstab: "{{ openshift_storage_glusterfs_heketi_fstab }}"
     glusterfs_nodes: "{{ groups.glusterfs | default([]) }}"
+    glusterfs_check_brick_size_health: "{{ openshift_storage_glusterfs_check_brick_size_health | bool }}"

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_registry_facts.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_registry_facts.yml
@@ -47,3 +47,4 @@
     glusterfs_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_registry_heketi_ssh_keyfile }}"
     glusterfs_heketi_fstab: "{{ openshift_storage_glusterfs_registry_heketi_fstab }}"
     glusterfs_nodes: "{% if groups.glusterfs_registry is defined and groups['glusterfs_registry'] | length > 0 %}{% set nodes = groups.glusterfs_registry %}{% elif 'groups.glusterfs' is defined and groups['glusterfs'] | length > 0 %}{% set nodes = groups.glusterfs %}{% else %}{% set nodes = '[]' %}{% endif %}{{ nodes }}"
+    glusterfs_check_brick_size_health: "{{ openshift_storage_glusterfs_registry_check_brick_size_health | bool }}"

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
@@ -1,7 +1,7 @@
 ---
 - import_tasks: cluster_health.yml
   vars:
-    l_check_bricks: true
+    l_check_bricks: "{{ glusterfs_check_brick_size_health }}"
     glusterfs_health_timeout: 30
   when: glusterfs_is_native
 


### PR DESCRIPTION
As part cluster health check, there is brick size check.

Volumes may be full(especially block hosting volume) and hence
this check needs to be avoided to carry out upgrade playbook operation.

User needs to explicitly set this variable to False to avoid the brick
size check. By default, the value is True.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1726620

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>