### PR TITLE
Fixing generate_secret for redeploy-certificates and fixing up checkpoint names

### DIFF
--- a/playbooks/openshift-logging/private/redeploy-certificates.yml
+++ b/playbooks/openshift-logging/private/redeploy-certificates.yml
@@ -1,15 +1,15 @@
 ---
-- name: Logging Install Checkpoint Start
+- name: Logging Cert Redploy Checkpoint Start
   hosts: all
   gather_facts: false
   tasks:
-  - name: Set Logging install 'In Progress'
+  - name: Set Logging cert redeploy 'In Progress'
     run_once: true
     set_stats:
       data:
         installer_phase_logging:
-          title: "Logging Install"
-          playbook: "playbooks/openshift-logging/config.yml"
+          title: "Logging Cert Redeploy"
+          playbook: "playbooks/openshift-logging/redeploy-certificates.yml"
           status: "In Progress"
           start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
@@ -109,11 +109,11 @@
       state: absent
     changed_when: False
 
-- name: Logging Install Checkpoint End
+- name: Logging Cert Redeploy Checkpoint End
   hosts: all
   gather_facts: false
   tasks:
-  - name: Set Logging install 'Complete'
+  - name: Set Logging cert redeploy 'Complete'
     run_once: true
     set_stats:
       data:

--- a/roles/openshift_logging_elasticsearch/tasks/generate_secret.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/generate_secret.yaml
@@ -4,7 +4,7 @@
   oc_secret:
     state: present
     name: "logging-elasticsearch"
-    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    namespace: "{{ openshift_logging_namespace }}"
     files:
     - name: key
       path: "{{ generated_certs_dir }}/logging-es.jks"

--- a/roles/openshift_logging_fluentd/tasks/generate_secret.yaml
+++ b/roles/openshift_logging_fluentd/tasks/generate_secret.yaml
@@ -6,7 +6,7 @@
   oc_secret:
     state: present
     name: logging-fluentd
-    namespace: "{{ openshift_logging_fluentd_namespace }}"
+    namespace: "{{ openshift_logging_namespace }}"
     files:
       - name: ca
         path: "{{ openshift_logging_fluentd_ca_path | default(generated_certs_dir ~ '/ca.crt') }}"

--- a/roles/openshift_logging_mux/tasks/generate_secret.yaml
+++ b/roles/openshift_logging_mux/tasks/generate_secret.yaml
@@ -3,7 +3,7 @@
   oc_secret:
     state: present
     name: logging-mux
-    namespace: "{{ openshift_logging_mux_namespace }}"
+    namespace: "{{ openshift_logging_namespace }}"
     files:
       - name: ca
         path: "{{ generated_certs_dir }}/ca.crt"


### PR DESCRIPTION
Resolves issues encountered while addressing hosted customer issues while performing logging cert rotation where the used namespace was `logging` not `openshift-logging`.