### PR TITLE
Bug 1729994: Update l_docker_creds_test_image

### DIFF
--- a/roles/container_runtime/tasks/registry_auth.yml
+++ b/roles/container_runtime/tasks/registry_auth.yml
@@ -28,7 +28,7 @@
     # Test that we can actually connect with provided info
     test_login: "{{ item.test_login | default(omit) }}"
     proxy_vars: "{{ l_docker_creds_proxy_vars }}"
-    test_image: "{{ item.test_image | default('openshift3/ose-pod') }}"
+    test_image: "{{ item.test_image | default(l_docker_creds_test_image) }}"
     tls_verify: "{{ item.tls_verify | default(omit) }}"
   when:
   - openshift_additional_registry_credentials != []

--- a/roles/openshift_control_plane/tasks/registry_auth.yml
+++ b/roles/openshift_control_plane/tasks/registry_auth.yml
@@ -28,7 +28,7 @@
     # Test that we can actually connect with provided info
     test_login: "{{ item.test_login | default(omit) }}"
     proxy_vars: "{{ l_docker_creds_proxy_vars }}"
-    test_image: "{{ item.test_image | default('openshift3/ose-pod') }}"
+    test_image: "{{ item.test_image | default(l_docker_creds_test_image) }}"
     tls_verify: "{{ item.tls_verify | default(omit) }}"
   when:
   - openshift_additional_registry_credentials != []

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -23,7 +23,7 @@ openshift_additional_registry_credentials: []
 l_os_non_standard_reg_url: "{{ oreg_url | default(l_osm_registry_url_default) }}"
 
 l_docker_creds_image_dict:
-  openshift-enterprise: 'openshift3/ose'
+  openshift-enterprise: 'openshift3/ose-pod'
   origin: 'openshift/origin'
 l_docker_creds_test_image: "{{ l_docker_creds_image_dict[openshift_deployment_type] }}"
 

--- a/roles/openshift_node/tasks/registry_auth.yml
+++ b/roles/openshift_node/tasks/registry_auth.yml
@@ -39,7 +39,7 @@
     # Test that we can actually connect with provided info
     test_login: "{{ item.test_login | default(omit) }}"
     proxy_vars: "{{ l_docker_creds_proxy_vars }}"
-    test_image: "{{ item.test_image | default('openshift3/ose-pod') }}"
+    test_image: "{{ item.test_image | default(l_docker_creds_test_image) }}"
     tls_verify: "{{ item.tls_verify | default(omit) }}"
   when:
     - openshift_additional_registry_credentials != []


### PR DESCRIPTION
OpenShift 3.11 no longer has an 'ose' image.  Updated to use 'ose-pod'.

https://bugzilla.redhat.com/show_bug.cgi?id=1729994