### PR TITLE
Add proxy support to scaleup.

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -79,12 +79,19 @@
   set_fact:
     l_release_image: "{{ oc_get.stdout }}"
 
-- name: Pull release image
-  command: "podman pull --tls-verify={{ openshift_node_tls_verify }} --authfile {{ temp_dir.path }}/pull-secret.json {{ l_release_image }}"
+- import_tasks: proxy.yml
 
-- name: Get machine controller daemon image from release image
-  command: "podman run --rm {{ l_release_image }} image machine-config-operator"
-  register: release_image_mcd
+- block:
+  - name: Pull release image
+    command: "podman pull --tls-verify={{ openshift_node_tls_verify }} --authfile {{ temp_dir.path }}/pull-secret.json {{ l_release_image }}"
+
+  - name: Get machine controller daemon image from release image
+    command: "podman run --rm {{ l_release_image }} image machine-config-operator"
+    register: release_image_mcd
+  environment:
+    http_proxy: "{{ http_proxy | default('')}}"
+    https_proxy: "{{https_proxy | default('')}}"
+    no_proxy: "{{ no_proxy | default('')}}"
 
 - block:
   - name: Pull MCD image
@@ -105,7 +112,10 @@
   - name: Reboot the host and wait for it to come back
     reboot:
     #  reboot_timeout: 600  # default, 10 minutes
-
+  environment:
+    http_proxy: "{{ http_proxy | default('')}}"
+    https_proxy: "{{ https_proxy | default('')}}"
+    no_proxy: "{{ no_proxy | default('')}}"
   rescue:
   - fail:
       msg: "Ignition apply failed"

--- a/roles/openshift_node/tasks/proxy.yml
+++ b/roles/openshift_node/tasks/proxy.yml
@@ -1,0 +1,62 @@
+---
+- name: Check for cluster http proxy
+  command: >
+    oc get proxies.config.openshift.io cluster
+    --config={{ openshift_node_kubeconfig_path }}
+    --output=jsonpath='{.status.httpProxy}'
+  register: oc_get_http_proxy
+  delegate_to: localhost
+
+- name: Set http proxy
+  set_fact:
+    http_proxy: "{{ oc_get_http_proxy.stdout }}"
+  when: oc_get_http_proxy.stdout | length > 0
+
+- name: Check for cluster https proxy
+  command: >
+    oc get proxies.config.openshift.io cluster
+    --config={{ openshift_node_kubeconfig_path }}
+    --output=jsonpath='{.status.httpsProxy}'
+  register: oc_get_https_proxy
+  delegate_to: localhost
+
+- name: Set https proxy
+  set_fact:
+    https_proxy: "{{ oc_get_https_proxy.stdout }}"
+  when: oc_get_https_proxy.stdout | length > 0
+
+- name: Check for cluster no proxy
+  command: >
+    oc get proxies.config.openshift.io cluster
+    --config={{ openshift_node_kubeconfig_path }}
+    --output=jsonpath='{.status.noProxy}'
+  register: oc_get_no_proxy
+  delegate_to: localhost
+
+- name: Set no proxy
+  set_fact:
+    no_proxy: "{{ oc_get_no_proxy.stdout }}"
+  when: oc_get_no_proxy.stdout | length > 0
+
+- name: Check for additional trust bundle
+  command: >
+    oc get configmap user-ca-bundle -n openshift-config
+    --config={{ openshift_node_kubeconfig_path }}
+    --output=jsonpath='{.data.ca-bundle\.crt}'
+  register: oc_get_additional_trust_bundle
+  delegate_to: localhost
+  failed_when: false
+
+- when: oc_get_additional_trust_bundle.stdout | length > 0
+  block:
+  - name: Set additional trust bundle
+    set_fact:
+      l_additional_trust_bundle: "{{ oc_get_additional_trust_bundle.stdout }}"
+
+  - name: Copy additional trust bundle to system CA trust
+    copy:
+      content: "{{ l_additional_trust_bundle }}"
+      dest: "/etc/pki/ca-trust/source/anchors/ca-bundle.crt"
+
+  - name: Update CA trust
+    command: update-ca-trust extract


### PR DESCRIPTION
Checks whether there is a proxy object, and if so applies proxy environment variables when running podman commands.

I marked this as a work in progress because I need to do some more testing, but I have settled on an approach so I am ready for feedback. 

I can not complete an install using a proxy (apiserver does not come up) so I have had to test in two parts. I confirmed that the k8s_facts module can read the proxy object. I subsequently installed a cluster without a proxy and hard coded in a proxy value in the playbook. I need to do further testing with this setup. 
