### PR TITLE
Configure Ansible service broker secrets

### DIFF
--- a/roles/ansible_service_broker/defaults/main.yml
+++ b/roles/ansible_service_broker/defaults/main.yml
@@ -30,3 +30,9 @@ l_asb_default_images_default: "{{ l_asb_default_images_dict[openshift_deployment
 l_asb_image_url: "{{ oreg_url | default(l_asb_default_images_default) | regex_replace('${version}' | regex_escape, openshift_image_tag) }}"
 
 ansible_service_broker_image: "{{ l_asb_image_url | regex_replace('${component}' | regex_escape, 'ansible-service-broker') }}"
+# Secrets to be mounted for APBs. Format:
+# - title: Database credentials
+#   secret: db_creds
+#   apb_name: dh-rhscl-postgresql-apb
+# https://github.com/openshift/ansible-service-broker/blob/master/docs/config.md#secrets-configuration
+ansible_service_broker_secrets: []

--- a/roles/ansible_service_broker/templates/configmap.yaml.j2
+++ b/roles/ansible_service_broker/templates/configmap.yaml.j2
@@ -52,4 +52,4 @@ data:
       auth:
         - type: basic
           enabled: false
-
+    secrets: {{ ansible_service_broker_secrets | to_yaml }}

--- a/roles/ansible_service_broker/templates/configmap.yaml.j2
+++ b/roles/ansible_service_broker/templates/configmap.yaml.j2
@@ -52,4 +52,4 @@ data:
       auth:
         - type: basic
           enabled: false
-    secrets: {{ ansible_service_broker_secrets | to_yaml }}
+    secrets: {{ ansible_service_broker_secrets | to_json }}


### PR DESCRIPTION
Make the secrets to be mounted by Ansible playbook bundles configurable.
The ASB can be configured to mount secrets for running APBs [1].

[1] https://github.com/openshift/ansible-service-broker/blob/master/docs/config.md#secrets-configuration
