### PR TITLE
test: add timeouts to decrease amount of flakes

### DIFF
--- a/test/aws/create_machineset.yml
+++ b/test/aws/create_machineset.yml
@@ -55,4 +55,4 @@
     name: "{{ new_machine.resources[0].status.addresses | selectattr('type', 'match', '^InternalIP$') | map(attribute='address') | first }}"
     node_name: "{{ new_machine.resources[0].status.addresses | selectattr('type', 'match', '^InternalDNS$') | map(attribute='address') | first }}"
     groups: new_workers
-    ansible_ssh_common_args: "-o ProxyCommand=\"ssh -o IdentityFile='{{ openshift_aws_scaleup_key_path | default('/opt/app-root/src/.ssh/id_rsa') }}' -o StrictHostKeyChecking=no -W %h:%p -q core@{{ ssh_bastion }}\""
+    ansible_ssh_common_args: "-o ProxyCommand=\"ssh -o IdentityFile='{{ openshift_aws_scaleup_key_path | default('/opt/app-root/src/.ssh/id_rsa') }}' -o ConnectTimeout=30 -o ConnectionAttempts=100 -o StrictHostKeyChecking=no -W %h:%p -q core@{{ ssh_bastion }}\""

--- a/test/aws/files/sshd_config
+++ b/test/aws/files/sshd_config
@@ -16,3 +16,5 @@ AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
 AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
 AcceptEnv XMODIFIERS
 Subsystem	sftp	/usr/libexec/openssh/sftp-server
+ClientAliveCountMax 5
+ClientAliveInterval 5


### PR DESCRIPTION
* Set `ClientAliveInterval` to 5 (default: 0) and `ClientAliveCountMax` (default 3) in ssh bastion config to give more time for the clients to respond
* Add `-o ConnectTimeout=30 -o ConnectionAttempts=100` to common ssh args to increase timeout and number of attempts when contacting ssh bastion

/cc @mtnbikenc @patrickdillon @jstuever 