### PR TITLE
Bug 1692735: Increase wait for aggregated API availability

### DIFF
--- a/roles/openshift_control_plane/tasks/check_master_api_is_ready.yml
+++ b/roles/openshift_control_plane/tasks/check_master_api_is_ready.yml
@@ -30,7 +30,7 @@
     {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig get apiservices/v1beta1.metrics.k8s.io
   register: metrics_service_registration
   failed_when: metrics_service_registration.rc != 0 and 'NotFound' not in metrics_service_registration.stderr
-  retries: 30
+  retries: 60
   delay: 5
   until: metrics_service_registration is succeeded
 
@@ -39,7 +39,7 @@
     {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig get --raw /apis/metrics.k8s.io/v1beta1
   register: metrics_api
   until: metrics_api is succeeded
-  retries: 30
+  retries: 60
   delay: 5
   when: metrics_service_registration.rc == 0
 
@@ -48,7 +48,7 @@
     {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig get apiservices/v1beta1.servicecatalog.k8s.io
   register: servicecatalog_service_registration
   failed_when: servicecatalog_service_registration.rc != 0 and 'NotFound' not in servicecatalog_service_registration.stderr
-  retries: 30
+  retries: 60
   delay: 5
   until: servicecatalog_service_registration is succeeded
 
@@ -58,6 +58,6 @@
     {{ openshift_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig get --raw /apis/servicecatalog.k8s.io/v1beta1
   register: servicecatalog_api
   until: servicecatalog_api is succeeded
-  retries: 30
+  retries: 60
   delay: 5
   when: servicecatalog_service_registration.rc == 0


### PR DESCRIPTION
In some environments, 2.5 minutes may not be enough to wait for API availability.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1692735