### PR TITLE
Bug 1721336: Only delete and regenerate service signer cert when updating CA

### DIFF
--- a/playbooks/openshift-master/private/certificates-backup.yml
+++ b/playbooks/openshift-master/private/certificates-backup.yml
@@ -42,8 +42,6 @@
     - master.kubelet-client.key
     - master.proxy-client.crt
     - master.proxy-client.key
-    - service-signer.crt
-    - service-signer.key
     - etcd.server.crt
     - etcd.server.key
     - master.server.crt
@@ -51,3 +49,12 @@
     - openshift-master.crt
     - openshift-master.key
     - openshift-master.kubeconfig
+
+  - name: Remove service signer certificates
+    file:
+      path: "{{ openshift.common.config_base }}/master/{{ item }}"
+      state: absent
+    with_items:
+    - service-signer.crt
+    - service-signer.key
+    when: openshift_redeploy_openshift_ca | default(false) | bool


### PR DESCRIPTION
The certificate backup playbook backups then deletes
the certificates.  If the certificate is not available
a another playbook will recreate the certificate.
Adding additional file absent with openshift_redeploy_openshift_ca conditional.