### PR TITLE
Bug 1735751: avoid excessive dentries due to console liveness probe

### DIFF
--- a/roles/openshift_web_console/files/console-template.yaml
+++ b/roles/openshift_web_console/files/console-template.yaml
@@ -81,7 +81,7 @@ objects:
                   elif [[ $(md5sum /var/webconsole-config/webconsole-config.yaml) != $(cat /tmp/webconsole-config.hash) ]]; then \
                     echo 'webconsole-config.yaml has changed.'; \
                     exit 1; \
-                  fi && curl -k -f https://0.0.0.0:8443/console/
+                  fi && NSS_SDB_USE_CACHE=no curl -k -f https://0.0.0.0:8443/console/
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1735751

See also
https://bugzilla.redhat.com/show_bug.cgi?id=1571183
https://github.com/openshift/machine-config-operator/pull/705

/cc @vrutkovs @sdodson 