### PR TITLE
[GlusterFS]: Fix version check avoiding minor version comparison

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/version_check.yml
+++ b/roles/openshift_storage_glusterfs/tasks/version_check.yml
@@ -17,9 +17,10 @@
 
       {% if glusterfs_block_deploy | bool %}glusterblock-provisioner: {{ glusterblock_version }}{% endif %}
   vars:
-    glusterfs_version: "{{ (openshift_storage_glusterfs_image | regex_replace('^.*rhgs-server-rhel7(v?)(?P<version>.*$)', '\\g<version>')) }}"
-    heketi_version: "{{ (openshift_storage_glusterfs_heketi_image | regex_replace('^.*rhgs-volmanager-rhel7(v?)(?P<version>.*$)', '\\g<version>')) }}"
-    glusterblock_version: "{{ (openshift_storage_glusterfs_block_image | regex_replace('^.*rhgs-gluster-block-prov-rhel7(v?)(?P<version>.*$)', '\\g<version>')) }}"
+    glusterfs_version: '{{ (openshift_storage_glusterfs_image | regex_replace("^.*rhgs-server-rhel7(v?)(?P<version>:[^-]*)(?:-.*)?$",  "\g<version>")) }}'
+    heketi_version: '{{ (openshift_storage_glusterfs_heketi_image | regex_replace("^.*rhgs-volmanager-rhel7(v?)(?P<version>:[^-]*)(?:-.*)?$",  "\g<version>")) }}'
+    glusterblock_version: '{{ (openshift_storage_glusterfs_block_image | regex_replace("^.*rhgs-gluster-block-prov-rhel7(v?)(?P<version>:[^-]*)(?:-.*)?$",  "\g<version>")) }}'
+
     glusterfs_fail: "{{ glusterfs_is_native | bool and glusterfs_version in [ ':latest', '' ] }}"
     heketi_fail: "{{ glusterfs_heketi_is_native | bool and heketi_version in [ ':latest', '' ] }}"
     glusterblock_fail: "{{ glusterfs_block_deploy | bool and glusterblock_version in [ ':latest', '' ] }}"


### PR DESCRIPTION
container versions can be mentioned like:
:v3.XX.YY-ZZ
:v3.XX.YY

All the major version needs be same (v3.XX.YY) above and the minor
versions among the containers may differ.
So, during comparison, avoid comparing with minor version (and check only
major version).

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1740598

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>