### PR TITLE
test: Remove task to delete CoreOS nodes

### DIFF
--- a/test/aws/scaleup.yml
+++ b/test/aws/scaleup.yml
@@ -128,13 +128,5 @@
       state: absent
     with_items: "{{ pre_scaleup_machineset_names }}"
 
-  - name: Delete CoreOS nodes
-    k8s:
-      kubeconfig: "{{ kubeconfig_path }}"
-      kind: Node
-      name: "{{ item }}"
-      state: absent
-    with_items: "{{ pre_scaleup_workers_name }}"
-
   - name: Wait for worker configs to roll out
     command: oc wait machineconfigpool/worker --for=condition=Updated --timeout=5m


### PR DESCRIPTION
Removal of the CoreOS machinesets will automatically trigger a delete of
the associated machine.  The task to delete the nodes is redundant and
potentially flakes due to the node already being removed.