### PR TITLE
Add retries to package command

### DIFF
--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -5,6 +5,8 @@
     update_cache: true
   async: 3600
   poll: 30
+  register: result
+  until: result is succeeded
 
 # FIXME: Creation of these directories should not be required for crio 1.14.5
 - name: Create CNI dirs for crio
@@ -48,6 +50,8 @@
       state: present
     async: 3600
     poll: 30
+    register: result
+    until: result is succeeded
 
   rescue:
   - name: Package install failure message

--- a/test/aws/scaleup.yml
+++ b/test/aws/scaleup.yml
@@ -55,6 +55,8 @@
     package:
       name: nfs-utils
       state: present
+    register: result
+    until: result is succeeded
   - name: Wait for new nodes to be ready
     k8s_facts:
       kubeconfig: "{{ kubeconfig_path }}"


### PR DESCRIPTION
The package command could fail due to intermittent network issues. The
command will be retried 3 times (Ansible default) and will fail if there
is a package or repo issue.

Package failures (flakes) have been observed in CI testing.