### PR TITLE
Gather node objects when node Ready check fails

### DIFF
--- a/roles/openshift_node/tasks/apply_machine_config.yml
+++ b/roles/openshift_node/tasks/apply_machine_config.yml
@@ -73,15 +73,29 @@
   reboot:
   #  reboot_timeout: 600  # default, 10 minutes
 
-- name: Wait for nodes to report ready
-  command: >
-    oc get node {{ ansible_nodename | lower }}
-    --config={{ openshift_node_kubeconfig_path }}
-    --output=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
-  delegate_to: localhost
-  run_once: true
-  register: oc_get
-  until:
-  - oc_get.stdout == "True"
-  retries: 36
-  delay: 5
+- block:
+  - name: Wait for nodes to report ready
+    command: >
+      oc get node {{ ansible_nodename | lower }}
+      --config={{ openshift_node_kubeconfig_path }}
+      --output=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+    delegate_to: localhost
+    register: oc_get
+    until:
+    - oc_get.stdout == "True"
+    retries: 36
+    delay: 5
+    changed_when: false
+
+  rescue:
+  - name: DEBUG - Get complete node object
+    command: >
+      oc get node {{ ansible_nodename | lower }}
+      --config={{ openshift_kubeconfig_path }}
+      --output=json
+    delegate_to: localhost
+    changed_when: false
+
+  - name: DEBUG - failed to report ready
+    fail:
+      msg: "Node failed to report ready"

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -122,16 +122,33 @@
   - fail:
       msg: "Ignition apply failed"
 
-- name: Wait for nodes to report ready
-  command: >
-    oc get node {{ hostvars[item].ansible_nodename | lower }}
-    --config={{ openshift_node_kubeconfig_path }}
-    --output=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
-  loop: "{{ ansible_play_batch }}"
-  delegate_to: localhost
-  run_once: true
-  register: oc_get
-  until:
-  - oc_get.stdout == "True"
-  retries: 36
-  delay: 5
+- block:
+  - name: Wait for nodes to report ready
+    command: >
+      oc get node {{ hostvars[item].ansible_nodename | lower }}
+      --config={{ openshift_node_kubeconfig_path }}
+      --output=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+    loop: "{{ ansible_play_batch }}"
+    delegate_to: localhost
+    run_once: true
+    register: oc_get
+    until:
+    - oc_get.stdout == "True"
+    retries: 36
+    delay: 5
+    changed_when: false
+
+  rescue:
+  - name: DEBUG - Get complete node objects
+    command: >
+      oc get node {{ hostvars[item].ansible_nodename | lower }}
+      --config={{ openshift_kubeconfig_path }}
+      --output=json
+    loop: "{{ ansible_play_batch }}"
+    delegate_to: localhost
+    run_once: true
+    changed_when: false
+
+  - name: DEBUG - Node failed to report ready
+    fail:
+      msg: "Node failed to report ready"


### PR DESCRIPTION
Gather the complete node object when the node Ready check fails for
debugging purposes.

This issue has been observed in CI flakes.