### PR TITLE
Bug 1732154: Explicitly pass storage class var to logging role

### DIFF
--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -126,6 +126,7 @@
     openshift_logging_elasticsearch_storage_type: "{{ elasticsearch_storage_type | default(default_elasticsearch_storage_type) }}"
     openshift_logging_elasticsearch_pvc_pv_selector: "{{ openshift_logging_es_pv_selector }}"
     openshift_logging_elasticsearch_pvc_storage_class_name: "{{ openshift_logging_es_pvc_storage_class_name | default() }}"
+    openshift_logging_elasticsearch_pvc_dynamic: "{{ openshift_logging_es_pvc_dynamic }}"
 
     es_dc_index: "{{ outer_item | int + openshift_logging_facts.elasticsearch.deploymentconfigs | count - 1 }}"
 


### PR DESCRIPTION
This PR fixes https://bugzilla.redhat.com/show_bug.cgi?id=1732154 by:

Explicity passing the storage class var to the role when generating non-ops pvcs
```
# oc get pvc
NAME           STATUS    VOLUME    CAPACITY   ACCESS MODES   STORAGECLASS         AGE
logging-es-0   Pending                                       glusterfs-registry   46s
```