### PR TITLE
Bug 1741432: openshift-node to approve node CSRs

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -132,6 +132,57 @@
   - fail:
       msg: "Ignition apply failed"
 
+- name: Approve node-bootstrapper CSR
+  shell: >
+    count=0;
+    for csr in `oc --config={{ openshift_node_kubeconfig_path }} get csr --no-headers \
+      | grep " system:serviceaccount:openshift-machine-config-operator:node-bootstrapper " \
+      | cut -d " " -f1`;
+    do
+      oc --config={{ openshift_node_kubeconfig_path }} describe csr/$csr \
+        | grep " system:node:{{ hostvars[item].ansible_nodename | lower }}$";
+      if [ $? -eq 0 ];
+      then
+        oc --config={{ openshift_node_kubeconfig_path }} adm certificate approve ${csr};
+        if [ $? -eq 0 ];
+        then
+          count=$((count+1));
+        fi;
+      fi;
+    done;
+    exit $((!count));
+  loop: "{{ ansible_play_batch }}"
+  delegate_to: localhost
+  run_once: true
+  register: oc_get
+  until:
+  - oc_get is success
+  retries: 6
+  delay: 5
+
+- name: Approve node CSR
+  shell: >
+    count=0;
+    for csr in `oc --config={{ openshift_node_kubeconfig_path }} get csr --no-headers \
+      | grep " system:node:{{ hostvars[item].ansible_nodename | lower }} " \
+      | cut -d " " -f1`;
+    do
+      oc --config={{ openshift_node_kubeconfig_path }} adm certificate approve ${csr};
+      if [ $? -eq 0 ];
+      then
+        count=$((count+1));
+      fi;
+    done;
+    exit $((!count));
+  loop: "{{ ansible_play_batch }}"
+  delegate_to: localhost
+  run_once: true
+  register: oc_get
+  until:
+  - oc_get is success
+  retries: 6
+  delay: 5
+
 - name: Wait for nodes to report ready
   command: >
     oc get node {{ hostvars[item].ansible_nodename | lower }}


### PR DESCRIPTION
This change approves the node's bootstrap CSR to enable it to join the cluster. This is required in cases where a node is being added to the cluster which was not deployed by the cluster. Otherwise such nodes will never become ready and the playbook will fail. It also approves the node's other CSR for convenience of the end user.

They are considered approved when at lease one associated CSR exists (based on the nodes name) and `oc adm certificate approve <csr>` has a return code of zero. This could lead to false positives if a CSR for this node already existed such as when a node name has been reused in the cluster. However, the bootstrap CSR was observed have always been pending in the cluster before Ansible recognises the node as having returned from reboot. Because of this, and the fact that all associated CSRs are approved with each attempt, this should have minimal impact.