### PR TITLE
Bug 1685074: workaround bugs in `oc replace`

### DIFF
--- a/roles/lib_openshift/library/oc_adm_ca_server_cert.py
+++ b/roles/lib_openshift/library/oc_adm_ca_server_cert.py
@@ -960,6 +960,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_adm_csr.py
+++ b/roles/lib_openshift/library/oc_adm_csr.py
@@ -940,6 +940,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_adm_manage_node.py
+++ b/roles/lib_openshift/library/oc_adm_manage_node.py
@@ -946,6 +946,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_adm_policy_group.py
+++ b/roles/lib_openshift/library/oc_adm_policy_group.py
@@ -938,6 +938,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_adm_policy_user.py
+++ b/roles/lib_openshift/library/oc_adm_policy_user.py
@@ -952,6 +952,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_adm_registry.py
+++ b/roles/lib_openshift/library/oc_adm_registry.py
@@ -1051,6 +1051,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_adm_router.py
+++ b/roles/lib_openshift/library/oc_adm_router.py
@@ -1064,6 +1064,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_clusterrole.py
+++ b/roles/lib_openshift/library/oc_clusterrole.py
@@ -924,6 +924,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_configmap.py
+++ b/roles/lib_openshift/library/oc_configmap.py
@@ -930,6 +930,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_edit.py
+++ b/roles/lib_openshift/library/oc_edit.py
@@ -980,6 +980,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_env.py
+++ b/roles/lib_openshift/library/oc_env.py
@@ -941,6 +941,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_group.py
+++ b/roles/lib_openshift/library/oc_group.py
@@ -914,6 +914,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_image.py
+++ b/roles/lib_openshift/library/oc_image.py
@@ -933,6 +933,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_label.py
+++ b/roles/lib_openshift/library/oc_label.py
@@ -950,6 +950,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_obj.py
+++ b/roles/lib_openshift/library/oc_obj.py
@@ -960,6 +960,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_objectvalidator.py
+++ b/roles/lib_openshift/library/oc_objectvalidator.py
@@ -885,6 +885,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_process.py
+++ b/roles/lib_openshift/library/oc_process.py
@@ -942,6 +942,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_project.py
+++ b/roles/lib_openshift/library/oc_project.py
@@ -942,6 +942,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_pvc.py
+++ b/roles/lib_openshift/library/oc_pvc.py
@@ -946,6 +946,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_route.py
+++ b/roles/lib_openshift/library/oc_route.py
@@ -993,6 +993,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_scale.py
+++ b/roles/lib_openshift/library/oc_scale.py
@@ -928,6 +928,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_secret.py
+++ b/roles/lib_openshift/library/oc_secret.py
@@ -989,6 +989,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_service.py
+++ b/roles/lib_openshift/library/oc_service.py
@@ -996,6 +996,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_serviceaccount.py
+++ b/roles/lib_openshift/library/oc_serviceaccount.py
@@ -929,6 +929,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_serviceaccount_secret.py
+++ b/roles/lib_openshift/library/oc_serviceaccount_secret.py
@@ -929,6 +929,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_storageclass.py
+++ b/roles/lib_openshift/library/oc_storageclass.py
@@ -959,6 +959,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_user.py
+++ b/roles/lib_openshift/library/oc_user.py
@@ -986,6 +986,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_version.py
+++ b/roles/lib_openshift/library/oc_version.py
@@ -899,6 +899,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/library/oc_volume.py
+++ b/roles/lib_openshift/library/oc_volume.py
@@ -975,6 +975,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):

--- a/roles/lib_openshift/src/lib/base.py
+++ b/roles/lib_openshift/src/lib/base.py
@@ -97,6 +97,8 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade')
+            cmd.append('--grace-period=0')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):


### PR DESCRIPTION
When using --force with `oc replace`, --cascade and --grace-period
should also be set to ensure the object replace completes.