### PR TITLE
[GlusterFS]: include varaible at runtime for cluster health

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
@@ -6,7 +6,7 @@
       Use manual method for independent mode.
   when: not glusterfs_is_native | bool
 
-- import_tasks: cluster_health.yml
+- include_tasks: cluster_health.yml
   vars:
     l_check_bricks: "{{ glusterfs_check_brick_size_health }}"
     glusterfs_health_timeout: 30


### PR DESCRIPTION
include_task rather than import task as variables values needs
to be picked up at run time.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>