### PR TITLE
Avoid gathering facts on set_fact-only play

### DIFF
--- a/playbooks/openshift-etcd/private/upgrade_backup.yml
+++ b/playbooks/openshift-etcd/private/upgrade_backup.yml
@@ -12,6 +12,7 @@
 - name: Gate on etcd backup
   hosts: localhost
   connection: local
+  gather_facts: false
   tasks:
   - set_fact:
       etcd_backup_completed: "{{ hostvars

--- a/playbooks/openshift-master/private/upgrade.yml
+++ b/playbooks/openshift-master/private/upgrade.yml
@@ -154,6 +154,7 @@
 - name: Gate on master update
   hosts: localhost
   connection: local
+  gather_facts: false
   tasks:
   - set_fact:
       master_update_completed: "{{ hostvars
@@ -213,6 +214,7 @@
 - name: Gate on reconcile
   hosts: localhost
   connection: local
+  gather_facts: false
   tasks:
   - set_fact:
       reconcile_completed: "{{ hostvars


### PR DESCRIPTION
This fails running from inside a container with:

```
....
PLAY [Gate on etcd backup] **********************************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TimeoutError: Timer expired after 10 seconds
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/sbin/udevadm info --query property --name /dev/xvdg1", "msg": "Timer expired after 10 seconds", "rc": 257}
```