### PR TITLE
Bug 1741713. Omit build api in standalone registry

### DIFF
--- a/roles/openshift_control_plane/tasks/check_master_api_is_ready.yml
+++ b/roles/openshift_control_plane/tasks/check_master_api_is_ready.yml
@@ -7,6 +7,7 @@
   with_items: "{{ l_core_api_list }}"
   retries: 60
   delay: 5
+  when: (item != "build.openshift.io" and openshift_deployment_subtype == 'registry') or openshift_deployment_subtype != 'registry'
 
 - name: "Collect API logs when API didn't become available"
   command: journalctl --no-pager -n 100 -u {{ openshift_service_type }}-master-api


### PR DESCRIPTION
Added a "when" criteria to the "Wait for APIs to become available" task so that if it is a standalone registry that it omits item build.openshift.io