### PR TITLE
[GlusterFS]: Install specific  glusterfs-fuse version mentioned

### DIFF
--- a/roles/openshift_node/README.md
+++ b/roles/openshift_node/README.md
@@ -20,12 +20,16 @@ From this role:
 | openshift_node_start_options             | UNDEF (Optional)      | Options to pass to node start cmdline                    |
 | oreg_url                                 | UNDEF (Optional)      | Default docker registry to use                           |
 | openshift_persistentlocalstorage_enabled | false                 | Enable the persistent local storage                      |
+| openshift_storage_glusterfs_fuse_version | UNDEF (Optional)      | To pass the glusterfs-fuse version to install            |
 
 openshift_node_start_options can be used for passing any start node option, e.g.:
 
 --enable=kubelet,plugins
 
 Which would have a node running without kube-proxy and dns.
+
+openshift_storage_glusterfs_fuse_version can be used to pass the glusterfs-fuse version to be installed.
+eg:    openshift_storage_glusterfs_fuse_version=glusterfs-fuse-3.12.2-18.el7
 
 Dependencies
 ------------

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -161,3 +161,5 @@ openshift_node_image_config_latest: "{{ openshift_node_image_config_latest_defau
 openshift_node_use_instance_profiles: False
 
 openshift_node_use_persistentlocalvolumes: "{{ openshift_persistentlocalstorage_enabled | default(False) | bool }}"
+
+glusterfs_fuse_version: "{{ '' if openshift_storage_glusterfs_fuse_version is not defined else ( openshift_storage_glusterfs_fuse_version | regex_replace('glusterfs-fuse','')) }}"

--- a/roles/openshift_node/tasks/glusterfs.yml
+++ b/roles/openshift_node/tasks/glusterfs.yml
@@ -1,8 +1,8 @@
 ---
 - name: Install GlusterFS storage plugin dependencies
   package:
-    name: glusterfs-fuse
-    state: latest
+    name: glusterfs-fuse{{ glusterfs_fuse_version }}
+    state: present
   when: not (openshift_is_atomic | default(False) | bool)
   register: result
   until: result is succeeded


### PR DESCRIPTION
Install the specific glusterfs-fuse mentioned in the inventory file.
If not mentioned, install the system default one.

Variable to be used in the inventory file:

openshift_storage_glusterfs_fuse_version=-3.12.2-18.el7

The above value is only an example and can be adjusted according to
needs.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1694937

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>