### PR TITLE
WIP: [release-3.11] Use updated pip version in test container.

### DIFF
--- a/hack/ci-build-unittests.sh
+++ b/hack/ci-build-unittests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 # This script installs tox dependencies in the test container
-yum install -y gcc libffi-devel python-devel openssl-devel python-pip
+yum install -y gcc libffi-devel python-devel openssl-devel
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python get-pip.py
 pip install tox
 chmod uga+w /etc/passwd


### PR DESCRIPTION
According to https://github.com/chainer/chainer/issues/7937 the pip in CentOS is out of date, which causes an error we are seeing in unit tests: 
```
Traceback (most recent call last):
  File "/usr/bin/tox", line 7, in <module>
    from tox import cmdline
  File "/usr/lib/python2.7/site-packages/tox/__init__.py", line 9, in <module>
    import pluggy
  File "/usr/lib/python2.7/site-packages/pluggy/__init__.py", line 16, in <module>
    from .manager import PluginManager, PluginValidationError
  File "/usr/lib/python2.7/site-packages/pluggy/manager.py", line 6, in <module>
    import importlib_metadata
  File "/usr/lib/python2.7/site-packages/importlib_metadata/__init__.py", line 9, in <module>
    import zipp
  File "/usr/lib/python2.7/site-packages/zipp.py", line 12, in <module>
    import more_itertools
  File "/usr/lib/python2.7/site-packages/more_itertools/__init__.py", line 1, in <module>
    from more_itertools.more import *  # noqa
  File "/usr/lib/python2.7/site-packages/more_itertools/more.py", line 340
    def _collate(*iterables, key=lambda a: a, reverse=False):
                               ^
SyntaxError: invalid syntax
````

We can get the new version by skipping the package manager and downloading directly.

This is seen on #11834 & #11857 and probably any PR running these tests. Will need to cherrypick and also port to master.

I have not tested this PR at all. I figured running the test in CI would be the best way.