### PR TITLE
Bug 1745202: Correct dockergc service account namespace

### DIFF
--- a/roles/openshift_docker_gc/tasks/main.yml
+++ b/roles/openshift_docker_gc/tasks/main.yml
@@ -3,14 +3,10 @@
   command: mktemp -d
   register: templates_tmpdir
 
-# NOTE: oc_adm_policy_user does not support -z (yet)
 - name: Add dockergc as privileged
-  command: "{{ openshift_client_binary }}  adm policy add-scc-to-user -z dockergc privileged"
-#  oc_adm_policy_user:
-#    user: dockergc
-#    resource_kind: scc
-#    resource_name: privileged
-#    state: present
+  command: >
+    {{ openshift_client_binary }} adm policy add-scc-to-user privileged system:serviceaccount:default:dockergc
+    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
 
 - name: Create dockergc DaemonSet
   become: yes


### PR DESCRIPTION
Ensure the privileged scc is added to dockergc in the default namespace

https://bugzilla.redhat.com/show_bug.cgi?id=1745202