### PR TITLE
don't fail if no proxies are configured

### DIFF
--- a/roles/openshift_node/tasks/proxy.yml
+++ b/roles/openshift_node/tasks/proxy.yml
@@ -6,6 +6,7 @@
     --output=jsonpath='{.status.httpProxy}'
   register: oc_get_http_proxy
   delegate_to: localhost
+  failed_when: false
 
 - name: Set http proxy
   set_fact:
@@ -19,6 +20,7 @@
     --output=jsonpath='{.status.httpsProxy}'
   register: oc_get_https_proxy
   delegate_to: localhost
+  failed_when: false
 
 - name: Set https proxy
   set_fact:
@@ -32,6 +34,7 @@
     --output=jsonpath='{.status.noProxy}'
   register: oc_get_no_proxy
   delegate_to: localhost
+  failed_when: false
 
 - name: Set no proxy
   set_fact:


### PR DESCRIPTION
In my 4.1 cluster, the command `oc get proxies.config.openshift.io cluster` fails:
```
$ oc get proxies.config.openshift.io cluster
error: the server doesn't have a resource type "proxies"
```

So the scaleup playbook fails. This change ignores those errors. It fixes issue#11861