### PR TITLE
Bug 1746212: [3.11] metrics-server-certs secret does not be removed after metrics-server uninstall due to incorrect label

### DIFF
--- a/roles/metrics_server/templates/serving-certs-secret.j2
+++ b/roles/metrics_server/templates/serving-certs-secret.j2
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: metrics-server-certs
   labels:
-    metrics-infra: metrics-server
+    metrics-server-infra: metrics-server
 data:
   tls.crt: {{ cert }}
   tls.key: {{ key }}


### PR DESCRIPTION
* Fix: [[3.11] metrics-server-certs secret does not be removed after metrics-server uninstall due to incorrect label](https://bugzilla.redhat.com/show_bug.cgi?id=1746212)

* Version: only 3.11

* Description:
  The "metrics-server-certs" is remaining after uninstall metrics-server due to incorrect label "metrics-infra", because uninstall task is selecting using "metrics-server-infra" selector.

