### PR TITLE
Bug 1729994: Add image tag to test image for registry_auth

### DIFF
--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -23,7 +23,7 @@ openshift_additional_registry_credentials: []
 l_os_non_standard_reg_url: "{{ oreg_url | default(l_osm_registry_url_default) }}"
 
 l_docker_creds_image_dict:
-  openshift-enterprise: 'openshift3/ose-pod'
+  openshift-enterprise: "{{ 'openshift3/ose-pod:' ~ openshift_image_tag }}"
   origin: 'openshift/origin'
 l_docker_creds_test_image: "{{ l_docker_creds_image_dict[openshift_deployment_type] }}"
 


### PR DESCRIPTION
By default the registry test command will look for 'latest' which may
not be present when using custom registries, i.e. disconnected installs.
This adds the current image tag reference to ensure an image tag which
should be present exists.

https://bugzilla.redhat.com/show_bug.cgi?id=1729994