### PR TITLE
Bug 1735502: compare solely md5 hash for config change

### DIFF
--- a/roles/openshift_node_group/files/sync.yaml
+++ b/roles/openshift_node_group/files/sync.yaml
@@ -53,6 +53,12 @@ spec:
           #!/bin/bash
           set -euo pipefail
 
+          function md5()
+          {
+               local  md5result=($(md5sum $1))
+               echo "$md5result"
+          }
+
           # set by the node image
           unset KUBECONFIG
 
@@ -60,13 +66,13 @@ spec:
 
           # track the current state of the config
           if [[ -f /etc/origin/node/node-config.yaml ]]; then
-            md5sum /etc/origin/node/node-config.yaml > /tmp/.old
+            md5 /etc/origin/node/node-config.yaml > /tmp/.old
           else
             touch /tmp/.old
           fi
 
           if [[ -f /etc/origin/node/volume-config.yaml ]]; then
-            md5sum /etc/origin/node/volume-config.yaml > /tmp/.old-volume.config
+            md5 /etc/origin/node/volume-config.yaml > /tmp/.old-volume.config
           else
             touch /tmp/.old-volume-config
           fi
@@ -140,12 +146,12 @@ spec:
             if [[ ! -f /etc/origin/node/volume-config.yaml ]]; then
               cat /dev/null > /tmp/.old-volume-config
             fi
-            md5sum /etc/origin/node/tmp/node-config.yaml > /tmp/.new
+            md5 /etc/origin/node/tmp/node-config.yaml > /tmp/.new
 
             if [[ ! -f /etc/origin/node/tmp/volume-config.yaml ]]; then
               cat /dev/null > /tmp/.new-volume-config
             else
-              md5sum /etc/origin/node/tmp/volume-config.yaml > /tmp/.new-volume-config
+              md5 /etc/origin/node/tmp/volume-config.yaml > /tmp/.new-volume-config
             fi
 
             trigger_restart=false
@@ -190,7 +196,7 @@ spec:
             fi
             # annotate node with md5sum of the config
             oc annotate --config=/etc/origin/node/node.kubeconfig "node/${NODE_NAME}" \
-              node.openshift.io/md5sum="$( cat /tmp/.new | cut -d' ' -f1 )" --overwrite
+              node.openshift.io/md5sum="$( cat /tmp/.new )" --overwrite
             cp -f /tmp/.new /tmp/.old
             cp -f /tmp/.new-volume-config /tmp/.old-volume-config
             sleep 180 &


### PR DESCRIPTION
Hi

This is a PR issued for resolving [Bug 1735502](https://bugzilla.redhat.com/show_bug.cgi?id=1735502). It seems the sync pod compares node config using the `md5sum` output, which included file names. This will thus lead to diffs even though the md5 sum is equal. The consequence of this is: killing the kubelet when it should not, which might have several unwanted consequences, but surely in some cases, has this: the network is not properly setup as the kubelet and required CNI plugins are killed unexpectedly during their network setup. 

The fix uses [this answer](https://stackoverflow.com/a/5773761) for only getting the hash of `md5sum`

Please let me know in case this needs to be ported to 4.X version as well. I didn't find this file in release-4.X, but let me know in case I missed something. 

/assign @squeed @danwinship 