### PR TITLE
Replay um changes from um-release-3.9

### DIFF
--- a/roles/container_runtime/defaults/main.yml
+++ b/roles/container_runtime/defaults/main.yml
@@ -79,8 +79,8 @@ l_docker_blocked_registries: "{{ l2_docker_blocked_registries | to_json }}"
 l_docker_insecure_registries: "{{ l2_docker_insecure_registries | to_json }}"
 l_docker_selinux_enabled: "{{ openshift_docker_selinux_enabled | to_json }}"
 
-docker_http_proxy: "{{ openshift_http_proxy | default('') }}"
-docker_https_proxy: "{{ openshift.common.https_proxy | default('') }}"
+docker_http_proxy: "{{ openshift_docker_http_proxy | default(True) | ternary(openshift_http_proxy, '') }}"
+docker_https_proxy: "{{ openshift_docker_https_proxy | default(True) | ternary(openshift_https_proxy, '') }}"
 docker_no_proxy: "{{ openshift.common.no_proxy | default('') }}"
 
 l_required_docker_version: '1.13'

--- a/roles/openshift_hosted/tasks/router.yml
+++ b/roles/openshift_hosted/tasks/router.yml
@@ -26,6 +26,7 @@
     backup: True
     dest: "/etc/origin/master/{{ item | basename }}"
     src: "{{ item }}"
+    remote_src: "{{ openshift_hosted_router_certificate_from_remote | default(no) }}"
   with_items: "{{ openshift_hosted_routers | lib_utils_oo_collect(attribute='certificate') |
                   lib_utils_oo_select_keys_from_list(['keyfile', 'certfile', 'cafile']) }}"
   when: ( not openshift_hosted_router_create_certificate | bool ) or openshift_hosted_router_certificate != {} or

--- a/roles/openshift_loadbalancer/defaults/main.yml
+++ b/roles/openshift_loadbalancer/defaults/main.yml
@@ -14,7 +14,7 @@ openshift_loadbalancer_backends: "{{ (openshift_master_api_port
                                       + openshift_loadbalancer_additional_backends | default([]) }}"
 
 r_openshift_loadbalancer_os_firewall_deny: []
-r_openshift_loadbalancer_os_firewall_allow:
+default_r_openshift_loadbalancer_os_firewall_allow:
 - service: haproxy stats
   port: "9000/tcp"
 - service: haproxy balance
@@ -22,6 +22,7 @@ r_openshift_loadbalancer_os_firewall_allow:
 - service: nuage mon
   port: "{{ nuage_mon_rest_server_port | default(9443) }}/tcp"
   cond: "{{ r_openshift_lb_use_nuage | bool }}"
+r_openshift_loadbalancer_os_firewall_allow: "{{ default_r_openshift_loadbalancer_os_firewall_allow | union(openshift_loadbalancer_open_ports) }}"
 
 openshift_docker_service_name: "docker"
 

--- a/roles/openshift_named_certificates/tasks/main.yml
+++ b/roles/openshift_named_certificates/tasks/main.yml
@@ -29,12 +29,14 @@
   copy:
     src: "{{ item.certfile }}"
     dest: "{{ named_certs_dir }}/{{ item.certfile | basename }}"
+    remote_src: "{{ openshift_named_certificates_from_remote | default(no) }}"
   with_items: "{{ named_certificates }}"
 
 - name: Land named certificate keys
   copy:
     src: "{{ item.keyfile }}"
     dest: "{{ named_certs_dir }}/{{ item.keyfile | basename }}"
+    remote_src: "{{ openshift_named_certificates_from_remote | default(no) }}"
     mode: 0600
   with_items: "{{ named_certificates }}"
 
@@ -42,5 +44,6 @@
   copy:
     src: "{{ item }}"
     dest: "{{ named_certs_dir }}/{{ item | basename }}"
+    remote_src: "{{ openshift_named_certificates_from_remote | default(no) }}"
     mode: 0600
   with_items: "{{ named_certificates | lib_utils_oo_collect('cafile') }}"

--- a/roles/openshift_nfs/defaults/main.yml
+++ b/roles/openshift_nfs/defaults/main.yml
@@ -3,6 +3,7 @@ r_openshift_nfs_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
 r_openshift_nfs_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
 r_openshift_nfs_os_firewall_deny: []
-r_openshift_nfs_firewall_allow:
+default_r_openshift_nfs_firewall_allow:
 - service: nfs
   port: "2049/tcp"
+r_openshift_nfs_firewall_allow: "{{ default_r_openshift_nfs_firewall_allow | union(openshift_nfs_open_ports) }}"

--- a/roles/openshift_storage_nfs/defaults/main.yml
+++ b/roles/openshift_storage_nfs/defaults/main.yml
@@ -3,9 +3,10 @@ r_openshift_storage_nfs_firewall_enabled: "{{ os_firewall_enabled | default(True
 r_openshift_storage_nfs_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
 
 r_openshift_storage_nfs_os_firewall_deny: []
-r_openshift_storage_nfs_os_firewall_allow:
+default_r_openshift_nfs_firewall_allow:
 - service: nfs
   port: "2049/tcp"
+r_openshift_nfs_firewall_allow: "{{ default_r_openshift_nfs_firewall_allow | union(openshift_nfs_open_ports) }}"
 
 openshift:
   hosted:


### PR DESCRIPTION
Provide possibility to handle some special situations.

1. Now it's possible to provide an extra proxy server for docker daemon. It this variables are not provided they will derive there values from the default one.

2. In some cases you can't place certificates and keys on the installation host. For that situation you can now place the files somewhere on the master servers and use these paths as remote_src.

3. Now it is more easier to define extra firewall rules besides the existing defaults for loadbalancer and nfs server