### PR TITLE
1733574: fix check for open file handles on CNI socket

### DIFF
--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -49,7 +49,7 @@ spec:
           trap 'kill $(jobs -p); rm -Rf /etc/cni/net.d/80-openshift-network.conf ; exit 0' TERM
           retries=0
           while true; do
-            if echo 'test' | socat - UNIX-CONNECT:/var/run/openshift-sdn/cni-server.sock >/dev/null; then
+            if lsof /var/run/openshift-sdn/cni-server.sock &>/dev/null; then
               echo "warning: Another process is currently listening on the CNI socket, waiting 15s ..." 2>&1
               sleep 15 & wait
               (( retries += 1 ))


### PR DESCRIPTION
Hi

While looking at [Bug 1733574](https://bugzilla.redhat.com/show_bug.cgi?id=1733574) I realized an error with how we check if the socket is busy. 

`echo 'test' | socat - UNIX-CONNECT:/var/run/openshift-sdn/cni-server.sock >/dev/null` assumes that under normal conditions the socket should not be there and should return `socat[22784] E connect(5, AF=1 "/var/run/openshift-sdn/cni-server.sock", 40): No such file or directory` (i.e return 1 and break the loop). However, that check can return an error such as `socat[13174] E connect(5, AF=1 "/var/run/openshift-sdn/cni-server.sock", 40): Connection refused` which would return 1 and break the loop and assume everything is working fine, even though this indicates other issues that should NOT allow the SDN to start. 

Using `lsof`should be "safer"

/assign @squeed @dcbw 