### PR TITLE
[GlusterFS]: Add a var to make user acknowledged that upgrade playbook is in tech preview

### DIFF
--- a/playbooks/openshift-glusterfs/upgrade.yml
+++ b/playbooks/openshift-glusterfs/upgrade.yml
@@ -1,4 +1,15 @@
 ---
+- name: Upgrade is in tech preview
+  hosts: all
+  gather_facts: False
+  become: False
+  tasks:
+    - name: Check if user acknowledged that upgrade playbook is in tech preview
+      fail:
+        msg: "Upgrade playbook is in tech preview, please define var openshift_storage_glusterfs_upgrade_in_tech_preview=true to proceed"
+      run_once: True
+      when: openshift_storage_glusterfs_upgrade_in_tech_preview != "true" or openshift_storage_glusterfs_upgrade_in_tech_preview is not defined
+
 - import_playbook: ../init/main.yml
   vars:
     # We need facts on all nodes since we need to check (on RPM installs) that

--- a/playbooks/openshift-glusterfs/upgrade.yml
+++ b/playbooks/openshift-glusterfs/upgrade.yml
@@ -6,9 +6,9 @@
   tasks:
     - name: Check if user acknowledged that upgrade playbook is in tech preview
       fail:
-        msg: "Upgrade playbook is in tech preview, please define var openshift_storage_glusterfs_upgrade_in_tech_preview=true to proceed"
+        msg: "Upgrade playbook is in tech preview, please define var openshift_storage_gluster_update_techpreview=true to proceed"
       run_once: True
-      when: openshift_storage_glusterfs_upgrade_in_tech_preview != "true" or openshift_storage_glusterfs_upgrade_in_tech_preview is not defined
+      when: not openshift_storage_glusterfs_upgrade_in_tech_preview | default('false') | bool
 
 - import_playbook: ../init/main.yml
   vars:

--- a/roles/openshift_storage_glusterfs/README.md
+++ b/roles/openshift_storage_glusterfs/README.md
@@ -121,7 +121,7 @@ GlusterFS cluster into a new or existing OpenShift cluster:
 | openshift_storage_glusterfs_heketi_ssh_keyfile         | Undefined               | Path to a private key file for use with SSH connections to external GlusterFS nodes via native heketi **NOTE:** This must be an absolute path
 | openshift_storage_glusterfs_heketi_fstab               | '/var/lib/heketi/fstab' | When heketi is native, sets the path to the fstab file on the GlusterFS nodes to update on LVM volume mounts, changes to '/etc/fstab/' when the heketi executor is 'ssh' **NOTE:** This should not need to be changed
 | openshift_storage_glusterfs_heketi_wipe                | False                   | Destroy any existing heketi resources, defaults to the value of `openshift_storage_glusterfs_wipe`
-|openshift_storage_glusterfs_upgrade_in_tech_preview     | Undefined               | Acknowledge that upgrade playbook is in tech preview to run it
+| openshift_storage_gluster_update_techpreview           | Undefined               | Acknowledge that upgrade playbook is in tech preview to run it
 
 Each role variable also has a corresponding variable to optionally configure a
 separate GlusterFS cluster for use as storage for an integrated Docker

--- a/roles/openshift_storage_glusterfs/README.md
+++ b/roles/openshift_storage_glusterfs/README.md
@@ -121,6 +121,7 @@ GlusterFS cluster into a new or existing OpenShift cluster:
 | openshift_storage_glusterfs_heketi_ssh_keyfile         | Undefined               | Path to a private key file for use with SSH connections to external GlusterFS nodes via native heketi **NOTE:** This must be an absolute path
 | openshift_storage_glusterfs_heketi_fstab               | '/var/lib/heketi/fstab' | When heketi is native, sets the path to the fstab file on the GlusterFS nodes to update on LVM volume mounts, changes to '/etc/fstab/' when the heketi executor is 'ssh' **NOTE:** This should not need to be changed
 | openshift_storage_glusterfs_heketi_wipe                | False                   | Destroy any existing heketi resources, defaults to the value of `openshift_storage_glusterfs_wipe`
+|openshift_storage_glusterfs_upgrade_in_tech_preview     | Undefined               | Acknowledge that upgrade playbook is in tech preview to run it
 
 Each role variable also has a corresponding variable to optionally configure a
 separate GlusterFS cluster for use as storage for an integrated Docker


### PR DESCRIPTION
User must define var before upgrade playbook can run. This forces them to acknowledged that upgrade playbook is in tech preview.

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1748449

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>