### PR TITLE
[GlusterFS]: Update pod name so previously created heketi key can be found

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/heketi_get_key.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_get_key.yml
@@ -4,7 +4,7 @@
     state: list
     kind: deploymentconfig
     namespace: "{{ glusterfs_namespace }}"
-    name: "heketi-{{ glusterfs_name }}"
+    name: "deploy-heketi-{{ glusterfs_name }}"
   register: glusterfs_heketi_deployment_config
 
 - name: Set heketi admin key


### PR DESCRIPTION
Update the playbook that gets heketi keys to use the correct prefix of the heketi pod. That way the pod can be found and then keys can be extracted successfully.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1749904

Signed-off-by: Daniel-Pivonka dpivonka@redhat.com
