### PR TITLE
[release-3.11] Bug 1747305: Couldn't regenerate the cert if the /etc/origin/logging…

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/generate_secret.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/generate_secret.yaml
@@ -1,5 +1,22 @@
 ---
 # secret
+- name: Checking for passwd.yml
+  stat:
+    path: "{{ generated_certs_dir }}/passwd.yml"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
+  register: passwd_file
+  check_mode: no
+
+- when: not passwd_file.stat.exists or openshift_logging_elasticsearch_prometheus_sa not in ( _logging_metrics_proxy_passwd['content'] | b64decode | from_yaml )
+  template:
+    src: passwd.j2
+    dest: "{{ generated_certs_dir }}/passwd.yml"
+  vars:
+    logging_user_name: "{{ openshift_logging_elasticsearch_prometheus_sa }}"
+    logging_user_passwd: "{{ 16 | lib_utils_oo_random_word | b64encode }}"
+
 - name: Set ES secret
   oc_secret:
     state: present


### PR DESCRIPTION
… is deleted

If the directory /etc/origin/logging is deleted and ansible is run with
redeploy-certificates.yml, all the files under the directory are
regenerated except passwd.yml.

This patch is adding the code to check if passwd.yml exists or not to
generate the file if it does not.