### PR TITLE
BUG 1753890: Fixing NSX role templates to refer correct variable for clusterip

### DIFF
--- a/roles/nsx/templates/ncp-configmap.yml.j2
+++ b/roles/nsx/templates/ncp-configmap.yml.j2
@@ -80,7 +80,7 @@ data:
     # read and use the Kubernetes Service IP from environment variable
     # KUBERNETES_SERVICE_HOST.
 
-    apiserver_host_ip = "{{ nsx_k8s_api_ip | default(nsx_k8s_svc.results.clusterip) }}"
+    apiserver_host_ip = "{{ nsx_k8s_api_ip | default(nsx_k8s_svc.module_results.clusterip) }}"
 
     # Port of the Kubernetes API Server.
     # Set to 6443 for https. If not set, will try to

--- a/roles/nsx/templates/nsx-node-agent-configmap.yml.j2
+++ b/roles/nsx/templates/nsx-node-agent-configmap.yml.j2
@@ -86,7 +86,7 @@ data:
     # KUBERNETES_SERVICE_HOST.
     #apiserver_host_ip = <ip_address>
 
-    apiserver_host_ip = "{{ nsx_k8s_api_ip | default(nsx_k8s_svc.results.clusterip) }}"
+    apiserver_host_ip = "{{ nsx_k8s_api_ip | default(nsx_k8s_svc.module_results.clusterip) }}"
 
     # Port of the Kubernetes API Server.
     # Set to 6443 for https. If not set, will try to


### PR DESCRIPTION
Changing role/nsx template variables to point to correct variable to resolve clusterip.
