### PR TITLE
Bug 1751975: Modify mounts when using atomic during imageconfig if oreg username i…

### DIFF
--- a/playbooks/openshift-node/imageconfig.yml
+++ b/playbooks/openshift-node/imageconfig.yml
@@ -7,3 +7,8 @@
     skip_sanity_checks: True
 
 - import_playbook: private/imageconfig.yml
+
+- import_playbook: private/configure_system_container.yml
+  when:
+  - openshift_is_atomic | default(false) | bool
+  - oreg_auth_user is defined or openshift_additional_registry_credentials != []

--- a/playbooks/openshift-node/private/configure_system_container.yml
+++ b/playbooks/openshift-node/private/configure_system_container.yml
@@ -1,0 +1,17 @@
+---
+- name: Update Atomic container mounts
+  hosts: oo_nodes_to_config
+  tasks:
+  - name: Get a list of the containers with ostree backend
+    command: "atomic containers list --json -f backend=ostree"
+    register: l_atomic_containers_list_json
+
+  - set_fact:
+      l_atomic_containers_list: "{{ l_atomic_containers_list_json.stdout | from_json }}"
+
+  - import_role:
+      name: openshift_node
+      tasks_from: node_system_container_install
+    vars:
+      l_bind_docker_reg_auth: True
+      system_osn_image: "{{ l_atomic_containers_list[0]['image_name'] }}"


### PR DESCRIPTION
…s defined

When upgrading from 3.10 to 3.11 on if the registry is changed
to one that requires authentication the upgrade will fail
unable to pull images.  The cause is
there is no mount to `/root/.docker/` to the atomic-openshift-node
container.  This PR adds to the `playbooks/openshift-node/imageconfig.yml`
playbook an conditional to run a new playbook
`openshift-node/private/configure_system_container.yml`
if using atomic and oreg_auth_user is used.
The new playbook:
- grabs the current registry image url
- uses the existing openshift-node role task to update
the mount with the existing image.