### PR TITLE
Bug 1752532: upgrade from 3.11 failed to upgrade es settings from configmap

### DIFF
--- a/roles/openshift_logging_elasticsearch/defaults/main.yml
+++ b/roles/openshift_logging_elasticsearch/defaults/main.yml
@@ -62,3 +62,16 @@ openshift_logging_es_port: 9200
 openshift_logging_es_ca: /etc/fluent/keys/ca
 openshift_logging_es_client_cert: /etc/fluent/keys/cert
 openshift_logging_es_client_key: /etc/fluent/keys/key
+
+# If this is set to true, the existing logging-elasticsearch
+# configmap will be copied to logging-elasticsearch.old if
+# it does not exist, and logging-elasticsearch will be
+# completely removed and replaced - this assumes you have
+# not customized the logging-elasticsearch configmap, and
+# if you have, you will have to manually retrieve those
+# customizations from logging-elasticsearch.old and
+# reapply them to logging-elasticsearch
+# NOTE: If you need to make custom changes to elasticsearch.yml
+# which are reapplied every time you run ansible, use
+# openshift_logging_es_config for those changes.
+openshift_logging_elasticsearch_replace_configmap: false

--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -230,7 +230,6 @@
     es_unicast_host: "logging-{{ es_component }}-cluster"
   changed_when: no
 
-# create diff between current configmap files and our current files
 - template:
     src: "log4j2.properties.j2"
     dest: "{{ tempdir }}/log4j2.properties"
@@ -238,6 +237,34 @@
     root_logger: "{{ openshift_logging_es_log_appenders | list }}"
   changed_when: no
 
+- when: openshift_logging_elasticsearch_replace_configmap
+  name: Get current configmap logging-elasticsearch
+  oc_configmap:
+    name: logging-elasticsearch
+    state: list
+    namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+  register: __current_es_configmap_output
+
+- when:
+  - openshift_logging_elasticsearch_replace_configmap
+  - __current_es_configmap_output.module_results.stderr is undefined
+  block:
+  - name: Get configmap logging-elasticsearch.old
+    oc_configmap:
+      state: list
+      name: logging-elasticsearch.old
+      namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+    register: __current_es_old_configmap_output
+
+  - when: __current_es_old_configmap_output.module_results.stderr is defined
+    name: Copy current configmap to logging-elasticsearch.old
+    oc_configmap:
+      state: present
+      name: logging-elasticsearch.old
+      namespace: "{{ openshift_logging_elasticsearch_namespace }}"
+      from_literal: "{{ __current_es_configmap_output.module_results.results[0]['data'] | to_json }}"
+
+# create diff between current configmap files and our current files
 - include_role:
     name: openshift_logging
     tasks_from: patch_configmap_files.yaml
@@ -249,7 +276,9 @@
       new_file: "{{ tempdir }}/elasticsearch.yml"
     - current_file: "log4j2.properties"
       new_file: "{{ tempdir }}/log4j2.properties"
-  when: not full_restart_cluster | default(false) | bool
+  when:
+  - not full_restart_cluster | default(false) | bool
+  - not openshift_logging_elasticsearch_replace_configmap
 
 - slurp:
     src: "{{ tempdir }}/elasticsearch.yml"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1752532#c24
The problem is that the code that compares diffs of the configmap does
not know how to handle configmaps that are too old.  In that case,
and if the user has not manually modified the configmap, this introduces
a new option:

`openshift_logging_elasticsearch_replace_configmap`

By default this is `false`. If you set it to true, running ansible
will replace your `logging-elasticsearch` configmap with the current
default values.  It will also copy the current configmap to
`logging-elasticsearch.old` in case there are customizations you would
like to copy from the old one and apply to the new one.

Once you do this, you can remove `openshift_logging_elasticsearch_replace_configmap`
and let ansible use the diff and merge procedure, since the configmap
will now be up-to-date, and the diff and merge code will work.