### PR TITLE
[release 3-11] Bug 1753593: [Reg] openshift_logging_elasticsearch_kibana_index_mode…

### DIFF
--- a/roles/openshift_logging/library/logging_patch.py
+++ b/roles/openshift_logging/library/logging_patch.py
@@ -109,8 +109,8 @@ def run_module():
 
     original_contents = account_for_whitelist(original_contents, new_contents, module.params['whitelist'])
 
-    uni_diff = difflib.unified_diff(new_contents.splitlines(),
-                                    original_contents.splitlines(),
+    uni_diff = difflib.unified_diff(original_contents.splitlines(),
+                                    new_contents.splitlines(),
                                     lineterm='')
 
     return module.exit_json(changed=False,  # noqa: F405

--- a/roles/openshift_logging/tasks/patch_configmap_file.yaml
+++ b/roles/openshift_logging/tasks/patch_configmap_file.yaml
@@ -33,7 +33,7 @@
   - patch_output.raw_patch | length > 0
   block:
   - slurp:
-      src: "{{ configmap_new_file }}"
+      src: "{{ tempdir }}/current.yml"
     register: new_file_slurp
 
   - local_action: copy content="{{ patch_output.raw_patch }}\n" dest={{ local_tmp.stdout }}/patch.patch


### PR DESCRIPTION
… cannot be changed by inventory variable

1) Module logging_patch creates a patch to modify the new file to the original.
2) The configmap to be patched in patch_configmap_file.yaml is the new file.