### PR TITLE
Bug 1645725: Increase timeout for Docker images and creds

### DIFF
--- a/roles/lib_utils/library/docker_creds.py
+++ b/roles/lib_utils/library/docker_creds.py
@@ -206,7 +206,7 @@ def run_module():
         password=dict(type='str', required=True, no_log=True),
         test_login=dict(type='bool', required=False, default=True),
         proxy_vars=dict(type='str', required=False, default=''),
-        test_timeout=dict(type='int', required=False, default=20),
+        test_timeout=dict(type='int', required=False, default=60),
         test_image=dict(type='str', required=True),
         tls_verify=dict(type='bool', required=False, default=True)
     )

--- a/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_image_availability.py
@@ -20,7 +20,7 @@ class DockerImageAvailability(DockerHostMixin, OpenShiftCheck):
     # to look for images available remotely without actually pulling them.
 
     # command for checking if remote registries have an image, without docker pull
-    skopeo_command = "{proxyvars} timeout 30 skopeo --debug inspect --tls-verify={tls} {creds} docker://{image}"
+    skopeo_command = "{proxyvars} timeout 60 skopeo --debug inspect --tls-verify={tls} {creds} docker://{image}"
     skopeo_example_command = "skopeo inspect [--tls-verify=false] [--creds=<user>:<pass>] docker://<registry>/<image>"
 
     def ensure_list(self, registry_param):

--- a/roles/openshift_health_checker/test/docker_image_availability_test.py
+++ b/roles/openshift_health_checker/test/docker_image_availability_test.py
@@ -17,9 +17,9 @@ def test_is_available_skopeo_image():
     with patch.object(DockerImageAvailability, 'execute_module_with_retries') as m1:
         m1.return_value = result
         assert dia.is_available_skopeo_image('registry.redhat.io/openshift3/ose-pod') is True
-        m1.assert_called_with('command', {'_uses_shell': True, '_raw_params': ' timeout 30 skopeo --debug inspect --tls-verify=true  docker://registry.redhat.io/openshift3/ose-pod'})
+        m1.assert_called_with('command', {'_uses_shell': True, '_raw_params': ' timeout 60 skopeo --debug inspect --tls-verify=true  docker://registry.redhat.io/openshift3/ose-pod'})
         assert dia.is_available_skopeo_image('insecure.redhat.io/openshift3/ose-pod') is True
-        m1.assert_called_with('command', {'_uses_shell': True, '_raw_params': ' timeout 30 skopeo --debug inspect --tls-verify=false  docker://insecure.redhat.io/openshift3/ose-pod'})
+        m1.assert_called_with('command', {'_uses_shell': True, '_raw_params': ' timeout 60 skopeo --debug inspect --tls-verify=false  docker://insecure.redhat.io/openshift3/ose-pod'})
 
     # test auth
     task_vars = {'oreg_auth_user': 'test_user', 'oreg_auth_password': 'test_pass'}
@@ -27,7 +27,7 @@ def test_is_available_skopeo_image():
     with patch.object(DockerImageAvailability, 'execute_module_with_retries') as m1:
         m1.return_value = result
         assert dia.is_available_skopeo_image('registry.redhat.io/openshift3/ose-pod') is True
-        m1.assert_called_with('command', {'_uses_shell': True, '_raw_params': ' timeout 30 skopeo --debug inspect --tls-verify=true --creds=test_user:test_pass docker://registry.redhat.io/openshift3/ose-pod'})
+        m1.assert_called_with('command', {'_uses_shell': True, '_raw_params': ' timeout 60 skopeo --debug inspect --tls-verify=true --creds=test_user:test_pass docker://registry.redhat.io/openshift3/ose-pod'})
 
 
 def test_available_images():


### PR DESCRIPTION
Bumping timeouts from 20 and 30 seconds to a full minute. International users seem to hit this timeout frequently and there does not seem to be any harm to increasing it. Workaround could be to disable docker_image_availability tests.

see https://bugzilla.redhat.com/show_bug.cgi?id=1645725 and #10741 (referenced in bz)