### PR TITLE
Kuryr controller label

### DIFF
--- a/roles/kuryr/templates/controller-deployment.yaml.j2
+++ b/roles/kuryr/templates/controller-deployment.yaml.j2
@@ -18,6 +18,7 @@ spec:
     metadata:
       labels:
         app: kuryr
+        name: kuryr-controller
         component: network
         type: infra
         openshift.io/component: network


### PR DESCRIPTION
This PR adds name=kuryr-controller label to kuryr-controller pods
to help tempest testing.