### PR TITLE
Modify the default kuryr images

### DIFF
--- a/roles/kuryr/defaults/main.yaml
+++ b/roles/kuryr/defaults/main.yaml
@@ -15,8 +15,17 @@ kuryr_namespace: kuryr
 kuryr_cni_link_interface: eth0
 
 # Default controller and CNI images
-openshift_openstack_kuryr_controller_image: kuryr/controller:latest
-openshift_openstack_kuryr_cni_image: kuryr/cni:latest
+kuryr_version: "v3.11"
+
+kuryr_controller_dict:
+  origin: "quay.io/openshift/origin-kuryr-controller:{{ kuryr_version }}"
+  openshift-enterprise: "{{ l_osm_registry_url | regex_replace('${component}' | regex_escape, 'kuryr-controller') }}"
+kuryr_cni_dict:
+  origin: "quay.io/openshift/origin-kuryr-cni:{{ kuryr_version }}"
+  openshift-enterprise: "{{ l_osm_registry_url | regex_replace('${component}' | regex_escape, 'kuryr-cni') }}"
+
+openshift_openstack_kuryr_controller_image: "{{ kuryr_controller_dict[openshift_deployment_type] }}"
+openshift_openstack_kuryr_cni_image: "{{ kuryr_cni_dict[openshift_deployment_type] }}"
 
 # Number of kuryr-controller replicas, more than 1 only supported since
 # OpenStack Rocky release.


### PR DESCRIPTION
This PR modifies the default Kuryr images to point to OpenShift
generated images at quay repository (upstream) or automatically
selecting the proper downstream repo and image.