### PR TITLE
[GlusterFS]: fix cluster health check retry variable

### DIFF
--- a/roles/openshift_storage_glusterfs/defaults/main.yml
+++ b/roles/openshift_storage_glusterfs/defaults/main.yml
@@ -24,7 +24,7 @@ l_gluster_heketi_image_dict:
 openshift_storage_glusterfs_heketi_image: "{{ l_gluster_heketi_image_dict[openshift_deployment_type] | lib_utils_oo_oreg_image((oreg_url | default('None'))) }}"
 
 openshift_storage_glusterfs_timeout: 300
-openshift_storage_glusterfs_health_timeout: 1200
+openshift_storage_glusterfs_health_timeout: 30
 openshift_storage_glusterfs_restart: False
 openshift_storage_glusterfs_namespace: "{{ 'glusterfs' | quote if openshift_storage_glusterfs_is_native or openshift_storage_glusterfs_heketi_is_native else 'default' | quote }}"
 openshift_storage_glusterfs_is_native: True

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
@@ -9,7 +9,6 @@
 - include_tasks: cluster_health.yml
   vars:
     l_check_bricks: "{{ glusterfs_check_brick_size_health }}"
-    glusterfs_health_timeout: 30
   when: glusterfs_is_native
 
 - block:


### PR DESCRIPTION
GlusterFS cluster health timeout was hard coded. Remove hard coded value and change default value to allow for timeouts to be defined in inventory file.

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>