### PR TITLE
[GlusterFS]: Add check to see if daemon set was deleted successfully during upgrade

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
@@ -95,6 +95,18 @@
     delegate_to: "{{ groups.oo_first_master.0 }}"
     failed_when: False
 
+  - name: Check GlusterFS DaemonSet status
+    oc_obj:
+      namespace: "{{ glusterfs_namespace }}"
+      kind: daemonset
+      name: glusterfs-{{ glusterfs_name }}
+      state: list
+    register: glusterfs_ds
+
+  - fail:
+      msg: Unable to delete glusterfs daemonset
+    when: glusterfs_ds.module_results.results[0].status is defined
+
   - name: Get old-style GlusterFS pods
     oc_obj:
       namespace: "{{ glusterfs_namespace }}"


### PR DESCRIPTION
During an upgrade the task to delete the old gluster daemon set could fail.
as seen in this bug: https://bugzilla.redhat.com/show_bug.cgi?id=1754760
The play book continues on and fails the upgrade the cluster. This check will stop the playbook if the delete fails. 

Signed-off-by: Daniel-Pivonka dpivonka@redhat.com