### PR TITLE
Bz 1758552: set arp_announce=2

### DIFF
--- a/roles/tuned/templates/openshift/tuned.conf
+++ b/roles/tuned/templates/openshift/tuned.conf
@@ -16,6 +16,7 @@ nf_conntrack_hashsize=131072
 kernel.pid_max=>131072
 net.netfilter.nf_conntrack_max=1048576
 fs.inotify.max_user_watches=65536
+net.ipv4.conf.all.arp_announce=2
 net.ipv4.neigh.default.gc_thresh1=8192
 net.ipv4.neigh.default.gc_thresh2=32768
 net.ipv4.neigh.default.gc_thresh3=65536


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1758552 for OCP 3.