### PR TITLE
[GlusterFS]: Use openshift_master_api_port var in delete daemonset task

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
@@ -90,7 +90,7 @@
   # oc delete --cascade=false seems broken for DaemonSets.
   # Using curl to talk to the API directly.
   - name: Delete glusterfs daemonset w/o cascade
-    shell: "curl -k -X DELETE https://localhost:8443/apis/extensions/v1beta1/namespaces/{{ glusterfs_namespace }}/daemonsets/glusterfs-{{ glusterfs_name }} -d '{\"kind\":\"DeleteOptions\",\"apiVersion\":\"v1\",\"propagationPolicy\":\"Orphan\"}' -H \"Accept: application/json\" -H \"Content-Type: application/json\"  --cert {{ openshift.common.config_base }}/master/admin.crt --key {{ openshift.common.config_base }}//master/admin.key"
+    shell: "curl -k -X DELETE https://localhost:{{ openshift_master_api_port | default('8443') }}/apis/extensions/v1beta1/namespaces/{{ glusterfs_namespace }}/daemonsets/glusterfs-{{ glusterfs_name }} -d '{\"kind\":\"DeleteOptions\",\"apiVersion\":\"v1\",\"propagationPolicy\":\"Orphan\"}' -H \"Accept: application/json\" -H \"Content-Type: application/json\"  --cert {{ openshift.common.config_base }}/master/admin.crt --key {{ openshift.common.config_base }}//master/admin.key"
     #shell: "{{ first_master_client_binary }} --config={{ openshift.common.config_base }}/master/admin.kubeconfig delete ds --namespace={{ glusterfs_namespace }} --cascade=false --selector=glusterfs"
     delegate_to: "{{ groups.oo_first_master.0 }}"
     failed_when: False


### PR DESCRIPTION
During an upgrade the gluster daemonset is deleted through the openshift rest api during the 'Delete glusterfs daemonset w/o cascade' task. This will allow deletes to succeed if the default port is not used.

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>