### PR TITLE
[GlusterFS]: Limited sanity checks in upgrade playbook

### DIFF
--- a/playbooks/openshift-glusterfs/upgrade.yml
+++ b/playbooks/openshift-glusterfs/upgrade.yml
@@ -16,7 +16,8 @@
     # glusterfs-fuse is up to date across the cluster.
     l_init_fact_hosts: "oo_masters_to_config:oo_nodes_to_config"
     l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
-    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] | union(groups['oo_glusterfs_to_config']) }}"
+    l_glusterfs_nodes: "{{ groups['oo_nodes_to_config'] | intersect(groups['oo_glusterfs_to_config']) }}"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] | union(l_glusterfs_nodes) }}"
     l_install_base_packages: False
     l_base_packages_hosts: "all:!all"
 


### PR DESCRIPTION
Change init/main vars in upgrade playbook to limit nodes sanity checks run on.

Sanity checks should not run on gluster nodes outside the cluster i.e. independent mode.

Related to bz: https://bugzilla.redhat.com/show_bug.cgi?id=1732140

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>