### PR TITLE
[Glusterfs]: Check image tag versions earlier in the upgrade

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_upgrade.yml
@@ -6,6 +6,8 @@
       Use manual method for independent mode.
   when: not glusterfs_is_native | bool
 
+- import_tasks: version_check.yml
+
 - include_tasks: cluster_health.yml
   vars:
     l_check_bricks: "{{ glusterfs_check_brick_size_health }}"


### PR DESCRIPTION
Move task to verify container image versions prior to deleting resources in upgrade playbook. 

related to bz: https://bugzilla.redhat.com/show_bug.cgi?id=1729929

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>