### PR TITLE
[GlusterFS]: Warn that the health check could take a long time

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/cluster_health.yml
+++ b/roles/openshift_storage_glusterfs/tasks/cluster_health.yml
@@ -1,6 +1,10 @@
 ---
 # glusterfs_check_containerized is a custom module defined at
 # lib_utils/library/glusterfs_check_containerized.py
+- name: GlusterFS cluster health time warning
+  debug:
+    msg: "Depending on the number of volumes in the cluster and their size, this might take few minutes to a couple of hours"
+
 - name: Check for GlusterFS cluster health
   glusterfs_check_containerized:
     oc_bin: "{{ hostvars[groups.oo_first_master.0]['first_master_client_binary'] }}"


### PR DESCRIPTION
Task 'Check for GlusterFS cluster health' can take along time and appear to be stuck. add a warning that lets the user know that it takes along time.

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>