### PR TITLE
Bug 1760665: Ensure cri-o is upgraded

### DIFF
--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -2,6 +2,7 @@
 - name: Install openshift support packages
   package:
     name: "{{ openshift_node_support_packages | join(',') }}"
+    state: latest
     update_cache: true
   async: 3600
   poll: 30
@@ -47,7 +48,7 @@
   - name: Install openshift packages
     package:
       name: "{{ openshift_node_packages | join(',') }}"
-      state: present
+      state: latest
     async: 3600
     poll: 30
     register: result


### PR DESCRIPTION
Update package command to use 'latest' which will ensure packages are
upgraded to the latest version, even if they are already installed.

https://bugzilla.redhat.com/show_bug.cgi?id=1760665