### PR TITLE
[GlusterFS]: revert heketi block secret type

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/glusterblock_storageclass.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterblock_storageclass.yml
@@ -4,7 +4,7 @@
     namespace: "{{ glusterfs_namespace }}"
     state: present
     name: "heketi-{{ glusterfs_name }}-admin-secret-block"
-    type: "gluster.org/glusterblock-{{ glusterfs_namespace }}"
+    type: "gluster.org/glusterblock"
     force: True
     contents:
     - path: key


### PR DESCRIPTION
In a previous PR, we had changed the name of the provisioner and also the type of the secret. The type of the secret should not have been changed. A validation in glusterblock external provisioner fails if the type is changed thereby failing volume creates.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1759837

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>