### PR TITLE
Fixed masterIP parameter in the file /etc/origin/master/master-config…

### DIFF
--- a/roles/openshift_control_plane/templates/master.yaml.v1.j2
+++ b/roles/openshift_control_plane/templates/master.yaml.v1.j2
@@ -101,7 +101,7 @@ kubernetesMasterConfig:
     - VolumeScheduling=true
 {% endif %}
   masterCount: {{ openshift_master_count | default(groups.oo_masters | length) }}
-  masterIP: {{ openshift.common.ip }}
+  masterIP: {{ openshift_ip | default(openshift.common.ip) }}
   podEvictionTimeout: {{ openshift_master_pod_eviction_timeout }}
   proxyClientInfo:
     certFile: master.proxy-client.crt


### PR DESCRIPTION
'Openshift_ip' variable in the ansible inventory don't properly determine 'masterIP' parameter. If I understand correctly, SDN uses this address when configuring iptables on node. 

When the network is defined so that the first interface is the main openshift address, the problem does not occur. If the network configuration is different, the address of the first interface (variable openshift.common.ip) is added in the masterIP section. This is not correct in this case.

I described it in this issue:
https://github.com/eliu/openshift-vagrant/issues/14