### PR TITLE
Bug 1757725: Temporary DNS failure makes apiserver readiness probe is failed due to not using IP for etcd access check. 

### DIFF
--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -85,7 +85,7 @@
       openshift_master_etcd_hosts: "{{ hostvars
                                        | lib_utils_oo_select_keys(groups['oo_etcd_to_config']
                                                         | default([]))
-                                       | lib_utils_oo_collect('openshift.common.hostname')
+                                       | lib_utils_oo_collect('openshift.common.ip')
                                        | default(none, true) }}"
   # This fact requires the facts set above, so needs to happen in it's own task.
   - set_fact:


### PR DESCRIPTION
* Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1757725
* Version: v3.11
* Description: 
  For suppressing DNS timeout, apiserver communicates with etcd cluster using a IP address instead of a hostname.
