### PR TITLE
catch some special situations

### DIFF
--- a/roles/openshift_hosted/tasks/router.yml
+++ b/roles/openshift_hosted/tasks/router.yml
@@ -26,6 +26,7 @@
     backup: True
     dest: "/etc/origin/master/{{ item | basename }}"
     src: "{{ item }}"
+    remote_src: "{{ openshift_hosted_router_certificate_from_remote | default(no) }}"
   with_items: "{{ openshift_hosted_routers | lib_utils_oo_collect(attribute='certificate') |
                   lib_utils_oo_select_keys_from_list(['keyfile', 'certfile', 'cafile']) }}"
   when: ( not openshift_hosted_router_create_certificate | bool ) or openshift_hosted_router_certificate != {} or

--- a/roles/openshift_named_certificates/tasks/main.yml
+++ b/roles/openshift_named_certificates/tasks/main.yml
@@ -29,12 +29,14 @@
   copy:
     src: "{{ item.certfile }}"
     dest: "{{ named_certs_dir }}/{{ item.certfile | basename }}"
+    remote_src: "{{ openshift_named_certificates_from_remote | default(no) }}"
   with_items: "{{ named_certificates }}"
 
 - name: Land named certificate keys
   copy:
     src: "{{ item.keyfile }}"
     dest: "{{ named_certs_dir }}/{{ item.keyfile | basename }}"
+    remote_src: "{{ openshift_named_certificates_from_remote | default(no) }}"
     mode: 0600
   with_items: "{{ named_certificates }}"
 
@@ -42,5 +44,6 @@
   copy:
     src: "{{ item }}"
     dest: "{{ named_certs_dir }}/{{ item | basename }}"
+    remote_src: "{{ openshift_named_certificates_from_remote | default(no) }}"
     mode: 0600
   with_items: "{{ named_certificates | lib_utils_oo_collect('cafile') }}"


### PR DESCRIPTION
In some cases you can't place certificates and keys on the installation host. For that situation you can now place the files somewhere on the master servers and use these paths as `remote_src`.