### PR TITLE
Add possibility to use certs on master as source

### DIFF
--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -65,6 +65,8 @@ openshift_hosted_routers:
 openshift_hosted_router_certificate: {}
 openshift_hosted_router_create_certificate: True
 
+openshift_hosted_router_certificate_from_remote: False
+
 r_openshift_hosted_router_os_firewall_deny: []
 r_openshift_hosted_router_os_firewall_allow: []
 

--- a/roles/openshift_hosted/tasks/router.yml
+++ b/roles/openshift_hosted/tasks/router.yml
@@ -26,6 +26,7 @@
     backup: True
     dest: "/etc/origin/master/{{ item | basename }}"
     src: "{{ item }}"
+    remote_src: "{{ openshift_hosted_router_certificate_from_remote | default(False) }}"
   with_items: "{{ openshift_hosted_routers | lib_utils_oo_collect(attribute='certificate') |
                   lib_utils_oo_select_keys_from_list(['keyfile', 'certfile', 'cafile']) }}"
   when: ( not openshift_hosted_router_create_certificate | bool ) or openshift_hosted_router_certificate != {} or

--- a/roles/openshift_named_certificates/defaults/main.yml
+++ b/roles/openshift_named_certificates/defaults/main.yml
@@ -3,3 +3,4 @@ openshift_ca_config_dir: "{{ openshift.common.config_base }}/master"
 openshift_ca_cert: "{{ openshift_ca_config_dir }}/ca.crt"
 openshift_ca_key: "{{ openshift_ca_config_dir }}/ca.key"
 openshift_ca_serial: "{{ openshift_ca_config_dir }}/ca.serial.txt"
+openshift_named_certificates_from_remote: False

--- a/roles/openshift_named_certificates/tasks/main.yml
+++ b/roles/openshift_named_certificates/tasks/main.yml
@@ -29,12 +29,14 @@
   copy:
     src: "{{ item.certfile }}"
     dest: "{{ named_certs_dir }}/{{ item.certfile | basename }}"
+    remote_src: "{{ openshift_named_certificates_from_remote | default(False) }}"
   with_items: "{{ named_certificates }}"
 
 - name: Land named certificate keys
   copy:
     src: "{{ item.keyfile }}"
     dest: "{{ named_certs_dir }}/{{ item.keyfile | basename }}"
+    remote_src: "{{ openshift_named_certificates_from_remote | default(False) }}"
     mode: 0600
   with_items: "{{ named_certificates }}"
 
@@ -42,5 +44,6 @@
   copy:
     src: "{{ item }}"
     dest: "{{ named_certs_dir }}/{{ item | basename }}"
+    remote_src: "{{ openshift_named_certificates_from_remote | default(False) }}"
     mode: 0600
   with_items: "{{ named_certificates | lib_utils_oo_collect('cafile') }}"


### PR DESCRIPTION
If you use an `AWX` or `Tower` as install host you don't have an easy
option to place source certificates on this. In this cases you can copy
certificates on master hosts and provide
`roles/container_runtime/defaults/main.yml` or.
`roles/container_runtime/defaults/main.yml` to use these files as
source.