### PR TITLE
JKS renewal bug

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/generate_secret.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/generate_secret.yaml
@@ -9,6 +9,11 @@
   register: passwd_file
   check_mode: no
 
+- when: passwd_file.stat.exists
+  slurp:
+    src: "{{ generated_certs_dir }}/passwd.yml"
+  register: _logging_metrics_proxy_passwd
+
 - when: not passwd_file.stat.exists or openshift_logging_elasticsearch_prometheus_sa not in ( _logging_metrics_proxy_passwd['content'] | b64decode | from_yaml )
   template:
     src: passwd.j2
@@ -16,6 +21,10 @@
   vars:
     logging_user_name: "{{ openshift_logging_elasticsearch_prometheus_sa }}"
     logging_user_passwd: "{{ 16 | lib_utils_oo_random_word | b64encode }}"
+
+- slurp:
+    src: "{{ generated_certs_dir }}/passwd.yml"
+  register: _logging_metrics_proxy_passwd
 
 - name: Set ES secret
   oc_secret:

--- a/roles/openshift_logging_elasticsearch/tasks/generate_secret.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/generate_secret.yaml
@@ -9,11 +9,6 @@
   register: passwd_file
   check_mode: no
 
-- when: passwd_file.stat.exists
-  slurp:
-    src: "{{ generated_certs_dir }}/passwd.yml"
-  register: _logging_metrics_proxy_passwd
-
 - when: not passwd_file.stat.exists or openshift_logging_elasticsearch_prometheus_sa not in ( _logging_metrics_proxy_passwd['content'] | b64decode | from_yaml )
   template:
     src: passwd.j2

--- a/roles/openshift_logging_elasticsearch/tasks/generate_secret.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/generate_secret.yaml
@@ -9,6 +9,10 @@
   register: passwd_file
   check_mode: no
 
+- slurp:
+    src: "{{ generated_certs_dir }}/passwd.yml"
+  register: _logging_metrics_proxy_passwd
+
 - when: not passwd_file.stat.exists or openshift_logging_elasticsearch_prometheus_sa not in ( _logging_metrics_proxy_passwd['content'] | b64decode | from_yaml )
   template:
     src: passwd.j2


### PR DESCRIPTION
The additions to generate_secret now are the same as lines 163-187 of
the openshift_logging_elasticsearch /task/main.yml

Without these entries, the following bug was encountered during JKS cert
renewal.

```
FAILED! => {"msg": "The conditional check 'not passwd_file.stat.exists or openshift_logging_elasticsearch_prometheus_sa not in ( _logging_metrics_proxy_passwd['content'] | b64decode | from_yaml )' failed. The error was: error while evaluating conditional (not passwd_file.stat.exists or openshift_logging_elasticsearch_prometheus_sa not in ( _logging_metrics_proxy_passwd['content'] | b64decode | from_yaml )): '_logging_metrics_proxy_passwd' is undefined\n\nThe error appears to have been in '/tmp/tmp.pRclMax4pr/openshift-ansible/roles/openshift_logging_elasticsearch/tasks/generate_secret.yaml': line 12, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- when: not passwd_file.stat.exists or openshift_logging_elasticsearch_prometheus_sa not in ( _logging_metrics_proxy_passwd['content'] | b64decode | from_yaml )\n  ^ here\n"}
```