### PR TITLE
Bug 1763046: roles/openshift_cluster_monitoring_operator: remove limits

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-deployment.j2
+++ b/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-deployment.j2
@@ -46,9 +46,6 @@ spec:
         - containerPort: 8080
           name: http
         resources:
-          limits:
-            cpu: 20m
-            memory: 50Mi
           requests:
             cpu: 20m
             memory: 50Mi


### PR DESCRIPTION
Propagate https://github.com/openshift/cluster-monitoring-operator/pull/515

/cc @brancz @s-urbaniak 