### PR TITLE
Bug 1694014: add more vars to json facts list

### DIFF
--- a/roles/openshift_facts/library/openshift_facts.py
+++ b/roles/openshift_facts/library/openshift_facts.py
@@ -705,8 +705,10 @@ def merge_facts(orig, new, additive_facts_to_overwrite):
     inventory_json_facts = ['admission_plugin_config',
                             'kube_admission_plugin_config',
                             'image_policy_config',
-                            "builddefaults",
-                            "buildoverrides"]
+                            'builddefaults',
+                            'buildoverrides',
+                            'api_server_args',
+                            'audit_config']
 
     facts = dict()
     for key, value in iteritems(orig):


### PR DESCRIPTION
`audit_config` and `api_server_args` should be treated as JSON configs 
so that facts change could be properly updated.

These vars container JSON-like data, so changes to particular keys may be incorrectly cached. This PR ensures key/value changes are invalidating the cache properly.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1694014