### PR TITLE
Bug 1762932: Back up certificates on all masters

### DIFF
--- a/playbooks/openshift-master/private/certificates-backup.yml
+++ b/playbooks/openshift-master/private/certificates-backup.yml
@@ -2,30 +2,44 @@
 - name: Backup and remove master cerftificates
   hosts: oo_masters_to_config
   any_errors_fatal: true
+
   roles:
   - openshift_facts
-  pre_tasks:
-  - stat:
+
+  tasks:
+  - name: Check for generated-configs directory
+    stat:
       path: "{{ openshift.common.config_base }}/generated-configs"
       get_checksum: false
       get_attributes: false
       get_mime: false
     register: openshift_generated_configs_dir_stat
-  - name: Backup generated certificate and config directories
+    delegate_to: "{{ openshift_ca_host }}"
+    run_once: true
+
+  - name: Backup generated-configs directory
     command: >
-      tar -czvf /etc/origin/master-node-cert-config-backup-{{ ansible_date_time.epoch }}.tgz
+      tar -czvf /etc/origin/generated-configs-backup-{{ ansible_date_time.epoch }}.tgz
       {{ openshift.common.config_base }}/generated-configs
-      {{ openshift.common.config_base }}/master
     when: openshift_generated_configs_dir_stat.stat.exists
     delegate_to: "{{ openshift_ca_host }}"
     run_once: true
-  - name: Remove generated certificate directories
+
+  - name: Remove generated-configs directory
     file:
       path: "{{ item }}"
       state: absent
     with_items:
     - "{{ openshift.common.config_base }}/generated-configs"
-  - name: Remove generated certificates
+    delegate_to: "{{ openshift_ca_host }}"
+    run_once: true
+
+  - name: Backup master certificates and config
+    command: >
+      tar -czvf /etc/origin/master-cert-config-backup-{{ ansible_date_time.epoch }}.tgz
+      {{ openshift.common.config_base }}/master
+
+  - name: Remove master certificates and config
     file:
       path: "{{ openshift.common.config_base }}/master/{{ item }}"
       state: absent


### PR DESCRIPTION
When redeploying certificates on masters, the generated-configs/ and
master/ directories in /etc/origin would be backed up only on the first
master.  Then the certs and configs in /etc/origin/master on all masters
would be removed.  This caused issues if the certificate redeploy
playbook failed and was later run again because certificates would be
missing.  To recover from this it required restoring the master
certificates which were located in the generated-configs backup on the
first master but it did not also include all the configs.

https://bugzilla.redhat.com/show_bug.cgi?id=1762932

This change separates the generated-configs/ backup from the master/
backup and runs the master/ backup on all masters to make the recovery
of removed certificates and configs easier. The backup filename has been
changed as follows:

Original name (first master only):
/etc/origin/master-node-cert-config-backup-{{ ansible_date_time.epoch }}.tgz

New generated-config backup name (first master only):
/etc/origin/generated-configs-backup-{{ ansible_date_time.epoch }}.tgz

New master certificate and config backup name:
/etc/origin/master-cert-config-backup-{{ ansible_date_time.epoch }}.tgz

(This name conforms to the same backup file created for the node cert and config.)