### PR TITLE
Bug 1754081: Certificate expiration misses node certificates

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -15,6 +15,8 @@
   - import_role:
       name: openshift_certificate_expiry
       tasks_from: main.yml
+    vars:
+      openshift_certificate_expiry_warning_days: 183
 
 - name: Ensure firewall is not switched during upgrade
   hosts: "{{ l_upgrade_no_switch_firewall_hosts | default('oo_all_hosts') }}"

--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -11,6 +11,7 @@
 
 - name: Inspect cluster certificates
   hosts: "{{ l_upgrade_cert_check_hosts }}"
+  any_errors_fatal: true
   tasks:
   - import_role:
       name: openshift_certificate_expiry

--- a/roles/lib_utils/library/openshift_cert_expiry.py
+++ b/roles/lib_utils/library/openshift_cert_expiry.py
@@ -623,7 +623,16 @@ an OpenShift Container Platform cluster
                 # Read in the nodes kubeconfig file and grab the good stuff
                 cfg = yaml.load(fp)
 
-            c = cfg['users'][0]['user'].get('client-certificate-data')
+            # A worker node node.kubeconfig is different than a masters
+            client_certificate_path = cfg['users'][0]['user'].get('client-certificate')
+            if client_certificate_path is not None:
+                base64decode = False
+                with io.open(client_certificate_path, 'rb') as fp:
+                    c = fp.read()
+            else:
+                base64decode = True
+                c = cfg['users'][0]['user'].get('client-certificate-data')
+
             if not c:
                 # This is not a node
                 raise IOError
@@ -631,7 +640,7 @@ an OpenShift Container Platform cluster
              cert_expiry_date,
              time_remaining,
              cert_serial,
-             issuer) = load_and_handle_cert(c, now, base64decode=True, ans_module=module)
+             issuer) = load_and_handle_cert(c, now, base64decode=base64decode, ans_module=module)
 
             expire_check_result = {
                 'cert_cn': cert_subject,


### PR DESCRIPTION
The `node.kubeconfig` is different between masters
and worker nodes. The `openshift_cert_expiry` module
was not updated to support the kubelet rotating the
certificates. The problem is that the customer
does not know the date of expiration and to
approve the csr.