### PR TITLE
Bug 1746143: Add CA to system trust

### DIFF
--- a/playbooks/openshift-node/private/join.yml
+++ b/playbooks/openshift-node/private/join.yml
@@ -99,6 +99,11 @@
 
 - import_playbook: contrail_sanitize.yml
 
+- import_playbook: restart.yml
+  vars:
+    openshift_node_restart_docker_required: True
+    openshift_node_restart_drain: True
+
 - name: Node Join Checkpoint End
   hosts: all
   gather_facts: false

--- a/roles/openshift_node/tasks/bootstrap.yml
+++ b/roles/openshift_node/tasks/bootstrap.yml
@@ -57,7 +57,10 @@
 - name: Create a symlink to the node client CA for the docker registry
   file:
     src: "{{ openshift_node_config_dir }}/client-ca.crt"
-    dest: "/etc/docker/certs.d/docker-registry.default.svc:5000/node-client-ca.crt"
+    dest: "{{ item }}"
     state: link
     force: yes
     follow: no
+  with_items:
+  - "/etc/docker/certs.d/docker-registry.default.svc:5000/node-client-ca.crt"
+  - "/etc/pki/ca-trust/source/anchors/node-client-ca.crt"

--- a/roles/openshift_node/tasks/distribute_bootstrap.yml
+++ b/roles/openshift_node/tasks/distribute_bootstrap.yml
@@ -36,3 +36,6 @@
       msg: "{{ logs_node.stdout_lines }}"
   - fail:
       msg: Node start failed.
+
+- name: Update CA trust
+  command: update-ca-trust extract

--- a/roles/openshift_node/tasks/upgrade/config_changes.yml
+++ b/roles/openshift_node/tasks/upgrade/config_changes.yml
@@ -10,13 +10,16 @@
     state: directory
     path: "/etc/docker/certs.d/docker-registry.default.svc:5000"
 
-- name: Update the docker-registry CA symlink
+- name: Update symlink to the node client CA for the docker registry
   file:
     src: "{{ openshift_node_config_dir }}/client-ca.crt"
-    dest: "/etc/docker/certs.d/docker-registry.default.svc:5000/node-client-ca.crt"
+    dest: "{{ item }}"
     state: link
     force: yes
     follow: no
+  with_items:
+  - "/etc/docker/certs.d/docker-registry.default.svc:5000/node-client-ca.crt"
+  - "/etc/pki/ca-trust/source/anchors/node-client-ca.crt"
 
 - name: Reset selinux context
   command: restorecon -RF {{ openshift_node_data_dir }}/openshift.local.volumes


### PR DESCRIPTION
This originally existed in 3.9 but was removed.
Caused various BZs the last few months.
Tried to replace with node sync pod but
unable to restart the container runtime after
update-ca-trust extract is a problem.