### PR TITLE
Bug 1759835: Fix redploy-certificates (metrics server)

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
@@ -82,8 +82,7 @@
   hosts: oo_first_master
   roles:
   - role: metrics_server
-    # a default is set on the actual variable in the role, so no fancy logic is needed here
-    when: openshift_metrics_server_install | default(true) | bool
+    when: openshift_metrics_server_install | default(false) | bool
 
 
 - name: Configure components that must be available prior to upgrade

--- a/playbooks/common/private/components.yml
+++ b/playbooks/common/private/components.yml
@@ -35,8 +35,7 @@
   when: openshift_metrics_install_metrics | default(false) | bool
 
 - import_playbook: ../../metrics-server/private/config.yml
-  # a default is set on the actual variable in the role, so no fancy logic is needed here
-  when: openshift_metrics_server_install | default(true) | bool
+  when: openshift_metrics_server_install | default(false) | bool
 
 - import_playbook: ../../openshift-logging/private/config.yml
   when: openshift_logging_install_logging | default(false) | bool

--- a/playbooks/metrics-server/private/redeploy-certificates.yml
+++ b/playbooks/metrics-server/private/redeploy-certificates.yml
@@ -16,7 +16,6 @@
       state: directory
       mode: 0755
     changed_when: False
-    when: openshift_metrics_server_install | bool
 
   - name: Create temp directory local on control node
     local_action: command mktemp -d
@@ -43,7 +42,7 @@
   - name: Generate Certificates
     include_role:
       name: metrics_server
-      tasks_from: generate_certs_and_apiservice
+      tasks_from: generate_certs_and_apiservice.yaml
 
   - name: Create metrics secret certificates
     oc_obj:

--- a/playbooks/redeploy-certificates.yml
+++ b/playbooks/redeploy-certificates.yml
@@ -41,7 +41,7 @@
   when: openshift_console_install | default(true) | bool
 
 - import_playbook: metrics-server/private/redeploy-certificates.yml
-  when: openshift_metrics_server_install | default(true) | bool
+  when: openshift_metrics_server_install | default(false) | bool
 
 - import_playbook: openshift-monitoring/private/redeploy-certificates.yml
   when: openshift_cluster_monitoring_operator_install | default(true) | bool


### PR DESCRIPTION
* Remove unnecessary `when:` conditional in the metrics server certificate redeploy playbook.
* Set correct default (false) for openshift_metrics_server_install.

https://bugzilla.redhat.com/show_bug.cgi?id=1759835

/cc @brancz 