### PR TITLE
Fix htpasswd for Hawkular when openshift_metrics_hawkular_fips is set.

### DIFF
--- a/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
@@ -32,9 +32,7 @@
   register: htpasswd_output
   when: openshift_metrics_hawkular_fips | default(False) | bool
 
-- copy:
-    content: "{{ htpasswd_output.stdout_lines | join('') }}"
-    dest: "{{ local_tmp.stdout }}/hawkular-metrics.htpasswd"
+- local_action: copy content="{{ htpasswd_output.stdout_lines | join('') }}" dest="{{ local_tmp.stdout }}/hawkular-metrics.htpasswd"
   when: openshift_metrics_hawkular_fips | default(False) | bool
 
 - name: copy local generated passwords to target


### PR DESCRIPTION
When setting openshift_metrics_hawkular_fips to true, the output of the
htwpasswd content would cause a failure due to trying to write to a
local tmp directory that doesn't exist on the remote host.

This fix updates the logic to output the content to the same location as
it would if openshift_metrics_hawkular_fips were set to false.

Signed-off-by: Jared Hocutt <jhocutt@redhat.com>