### PR TITLE
Bug 1757501: Fixup kibana-proxy proxy variable sources

### DIFF
--- a/roles/openshift_logging_kibana/templates/kibana.j2
+++ b/roles/openshift_logging_kibana/templates/kibana.j2
@@ -143,29 +143,29 @@ spec:
                resourceFieldRef:
                  containerName: kibana-proxy
                  resource: limits.memory
-{% if (openshift_http_proxy is defined and openshift_http_proxy is not none and openshift_http_proxy != "") %}
+{% if 'http_proxy' in openshift.common %}
             -
              name: "http_proxy"
-             value: "{{ openshift_http_proxy }}"
+             value: "{{ openshift.common.http_proxy | default('') }}"
             -
              name: "HTTP_PROXY"
-             value: "{{ openshift_http_proxy }}"
+             value: "{{ openshift.common.http_proxy | default('') }}"
 {% endif %}
-{% if (openshift_https_proxy is defined and openshift_https_proxy is not none and openshift_https_proxy != "") %}
+{% if 'https_proxy' in openshift.common %}
             -
              name: "https_proxy"
-             value: "{{ openshift_https_proxy }}"
+             value: "{{ openshift.common.https_proxy | default('') }}"
             -
              name: "HTTPS_PROXY"
-             value: "{{ openshift_https_proxy }}"
+             value: "{{ openshift.common.https_proxy | default('') }}"
 {% endif %}
-{% if (openshift_no_proxy is defined and openshift_no_proxy is not none and openshift_no_proxy != "") %}
+{% if 'no_proxy' in openshift.common %}
             -
              name: "no_proxy"
-             value: "{{ openshift_no_proxy }}"
+             value: "{{ openshift.common.no_proxy | default('') }}"
             -
              name: "NO_PROXY"
-             value: "{{ openshift_no_proxy }}"
+             value: "{{ openshift.common.no_proxy | default('') }}"
 {% endif %}
           volumeMounts:
             - name: kibana-proxy


### PR DESCRIPTION
Updating to use the `openshift.common.{http,https,no}_proxy` facts instead.

Should address https://bugzilla.redhat.com/show_bug.cgi?id=1757501

Similar to https://github.com/openshift/openshift-ansible/blob/release-3.11/roles/openshift_control_plane/templates/master.env.j2#L11-L19