### PR TITLE
Bug 1759835: Ensure openshift_metrics_server_install defaults are set

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
@@ -82,8 +82,7 @@
   hosts: oo_first_master
   roles:
   - role: metrics_server
-    when: openshift_metrics_server_install | default(false) | bool
-
+    when: openshift_metrics_server_install | default(openshift_metrics_install_metrics | default(false)) | bool
 
 - name: Configure components that must be available prior to upgrade
   hosts: oo_first_master

--- a/playbooks/common/private/components.yml
+++ b/playbooks/common/private/components.yml
@@ -35,7 +35,7 @@
   when: openshift_metrics_install_metrics | default(false) | bool
 
 - import_playbook: ../../metrics-server/private/config.yml
-  when: openshift_metrics_server_install | default(false) | bool
+  when: openshift_metrics_server_install | default(openshift_metrics_install_metrics | default(false)) | bool
 
 - import_playbook: ../../openshift-logging/private/config.yml
   when: openshift_logging_install_logging | default(false) | bool

--- a/playbooks/redeploy-certificates.yml
+++ b/playbooks/redeploy-certificates.yml
@@ -41,7 +41,7 @@
   when: openshift_console_install | default(true) | bool
 
 - import_playbook: metrics-server/private/redeploy-certificates.yml
-  when: openshift_metrics_server_install | default(false) | bool
+  when: openshift_metrics_server_install | default(openshift_metrics_install_metrics | default(false)) | bool
 
 - import_playbook: openshift-monitoring/private/redeploy-certificates.yml
   when: openshift_cluster_monitoring_operator_install | default(true) | bool

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -54,9 +54,7 @@ openshift_container_cli: "{{ openshift_use_crio | bool | ternary('crictl', 'dock
 openshift_crio_docker_gc_node_selector:
   runtime: 'cri-o'
 
-# osm_default_subdomain is an old migrated fact, can probably be removed.
-osm_default_subdomain: "router.default.svc.cluster.local"
-openshift_master_default_subdomain: "{{ osm_default_subdomain }}"
+openshift_master_default_subdomain: "router.default.svc.cluster.local"
 
 openshift_portal_net: "{{ openshift_master_portal_net | default(None) }}"
 openshift_cluster_network_cidr: "{{ osm_cluster_network_cidr | default('10.128.0.0/14') }}"
@@ -119,9 +117,6 @@ openshift_loggingops_storage_nfs_options: '*(rw,root_squash)'
 openshift_loggingops_storage_access_modes:
   - 'ReadWriteOnce'
 
-openshift_metrics_deploy: False
-openshift_metrics_duration: 7
-openshift_metrics_resolution: '10s'
 openshift_metrics_storage_volume_name: 'metrics'
 openshift_metrics_storage_volume_size: '10Gi'
 openshift_metrics_storage_create_pv: True

--- a/roles/openshift_master_facts/tasks/main.yml
+++ b/roles/openshift_master_facts/tasks/main.yml
@@ -1,26 +1,4 @@
 ---
-- name: Verify required variables are set
-  fail:
-    msg: openshift_master_default_subdomain must be set to deploy metrics
-  when: openshift_metrics_install_metrics | default(false) | bool and openshift_master_default_subdomain == ""
-
-# NOTE: These metrics variables are unfortunately needed by both the master and the metrics roles
-# to properly configure the master-config.yaml file.
-#
-# NOTE: Today only changing the hostname for the metrics public URL is supported, the
-# path must stay consistent. As such if openshift_metrics_hawkular_hostname is set in
-# inventory, we extract the hostname, and then reset openshift_metrics_hawkular_hostname
-# to the format that we know is valid. (This may change in future)
-- name: Set g_metrics_hostname
-  set_fact:
-    g_metrics_hostname: "{{ openshift_metrics_hawkular_hostname
-                        | default('hawkular-metrics.' ~ openshift_master_default_subdomain)
-                        | lib_utils_oo_hostname_from_url }}"
-
-- set_fact:
-    openshift_hosted_metrics_deploy_url: "https://{{ g_metrics_hostname }}/hawkular/metrics"
-  when: (openshift_metrics_install_metrics | default(false) | bool) or (openshift_metrics_hawkular_hostname is defined)
-
 - name: Set master facts
   openshift_facts:
     role: master


### PR DESCRIPTION
* Update openshift_metrics_server_install defaults
* Remove osm_default_subdomain, unused
* Remove openshift_metrics_deploy, unused
* Removed openshift_metrics_duration from openshift_facts
* Removed openshift_metrics_resolution from openshift_facts
* Removed fail task for openshift_master_default_subdomain, the var has a default value so will never be ""
* Removed set_fact g_metrics_hostname, unused
* Removed openshift_hosted_metrics_deploy_url, unused