### PR TITLE
Bug 1729994: Allow custom mirrored registry paths

### DIFF
--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -10,10 +10,14 @@ l_openshift_images_dict:
   origin: 'docker.io/openshift/origin-${component}:${version}'
   openshift-enterprise: 'registry.redhat.io/openshift3/ose-${component}:${version}'
 
+# oreg_url is defined by user input
+# Example:
+# oreg_url: registry.company.com:443/test/ose3/ose-${component}:${version}
+
 l_osm_registry_url_default: "{{ l_openshift_images_dict[openshift_deployment_type] }}"
 l_oreg_host_temp: "{{ oreg_url | default(l_osm_registry_url_default) }}"
-# oreg_url is defined by user input.
-oreg_host: "{{ l_oreg_host_temp.split('/')[0] }}"
+oreg_host: "{{ l_oreg_host_temp.split('/')[0] }}"  # From example: "registry.company.com:443"
+oreg_image: "{{ l_oreg_host_temp | regex_replace('.*?/(.*)$', '\\1') }}"  # From example: "test/ose3/ose-${component}:${version}"
 
 # Used to define a list of registry credentials
 # ex openshift_additional_registry_credentials=[{'host':'registry.redhat.io','user':'bob','password':'redhat'},{'host':'registry.connect.redhat.com','user':'alice','password':'redhat','test_login':False}]
@@ -23,7 +27,7 @@ openshift_additional_registry_credentials: []
 l_os_non_standard_reg_url: "{{ oreg_url | default(l_osm_registry_url_default) }}"
 
 l_docker_creds_image_dict:
-  openshift-enterprise: "{{ 'openshift3/ose-pod:' ~ openshift_image_tag }}"
+  openshift-enterprise: "{{ oreg_image | regex_replace('ose-${component}:${version}', 'ose-pod:' ~ openshift_image_tag) }}"
   origin: 'openshift/origin'
 l_docker_creds_test_image: "{{ l_docker_creds_image_dict[openshift_deployment_type] }}"
 


### PR DESCRIPTION
An offline registry my not have the standard `openshift3` name.  This
commit changes the creation of the test image string to use the provided
path as it is given in `oreg_url`.

https://bugzilla.redhat.com/show_bug.cgi?id=1729994