### PR TITLE
ignore failure on master

### DIFF
--- a/playbooks/adhoc/uninstall_openshift.yml
+++ b/playbooks/adhoc/uninstall_openshift.yml
@@ -393,6 +393,8 @@
     with_subelements:
     - "{{ directories.results | default([]) }}"
     - files
+    # Ignore failure when openshift.local.volumes is mounted.
+    failed_when: false
 
   - set_fact:
       client_users: "{{ [ansible_ssh_user, 'root'] | unique }}"


### PR DESCRIPTION
making the uninstall playbook more tolerant against mounted volumes inside the folder `/var/lib/origin`.

this is just a copy of the existing two lines (276-277) for the nodes hosts over to the master hosts (the same task but just for the master).