### PR TITLE
Add possibility to add extra target for prometheus

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/defaults/main.yml
+++ b/roles/openshift_cluster_monitoring_operator/defaults/main.yml
@@ -73,3 +73,5 @@ openshift_cluster_monitoring_operator_alertmanager_config: |+
   receivers:
   - name: default
   - name: deadmansswitch
+
+openshift_cluster_monitoring_extra_targets: False

--- a/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-config.j2
+++ b/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-config.j2
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ openshift_cluster_monitoring_operator_namespace }}
 data:
   config.yaml: |+
+{% if openshift_cluster_monitoring_extra_targets -%}
+{{ openshift_cluster_monitoring_extra_targets | to_nice_yaml(indent=2) | indent(4, True) }}
+{%- endif %}
     prometheusOperator:
       baseImage: {{ openshift_cluster_monitoring_operator_prometheus_operator_repo }}
       prometheusConfigReloaderBaseImage: {{ openshift_cluster_monitoring_operator_prometheus_reloader_repo }}


### PR DESCRIPTION
By defining a dictorionary `openshift_cluster_monitoring_extra_targets`
it is possible to inject extra target into prometheus configuration.