### PR TITLE
Fix gluster after restart change

### DIFF
--- a/playbooks/openshift-node/private/restart.yml
+++ b/playbooks/openshift-node/private/restart.yml
@@ -108,3 +108,4 @@
     include_role:
       name: openshift_storage_glusterfs
       tasks_from: check_cluster_health.yml
+    when: groups.oo_glusterfs_to_config | default([]) | count > 0


### PR DESCRIPTION
To resolve the CA trust issue I
added the openshift-node/private/restart playbook.
If gluster is to be installed this causes a failure
Add a check to make sure gluster will be installed.

Ref https://github.com/openshift/openshift-ansible/pull/11968