### PR TITLE
possibility to patch configmaps on remote

### DIFF
--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -13,6 +13,8 @@ openshift_logging_image_pull_secret: ""
 
 openshift_logging_image: "{{ openshift_facts_versioned_registry_url | regex_replace(l_openshift_logging_search | regex_escape, 'logging-deployer') }}"
 
+openshift_logging_patch_configmaps_on_remote: False
+
 openshift_logging_curator_default_days: 30
 openshift_logging_curator_run_hour: 3
 openshift_logging_curator_run_minute: 30

--- a/roles/openshift_logging/tasks/patch_configmap_file.yaml
+++ b/roles/openshift_logging/tasks/patch_configmap_file.yaml
@@ -39,15 +39,38 @@
   - local_action: copy content="{{ patch_output.raw_patch }}\n" dest={{ local_tmp.stdout }}/patch.patch
     vars:
       ansible_become: false
+    when: not openshift_logging_patch_configmaps_on_remote | default(False)
+
+  - copy:
+      content: "{{ patch_output.raw_patch }}\n"
+      dest: "{{ tempdir }}/patch.patch"
+    when: openshift_logging_patch_configmaps_on_remote | default(False)
 
   - local_action: copy content={{ new_file_slurp['content'] | b64decode }} dest={{ local_tmp.stdout }}/configmap_new_file
     vars:
       ansible_become: false
+    when: not openshift_logging_patch_configmaps_on_remote | default(False)
+
+  - copy:
+      content: "{{ new_file_slurp['content'] | b64decode }}"
+      dest: "{{ tempdir }}/configmap_new_file"
+    when: openshift_logging_patch_configmaps_on_remote | default(False)
 
   - local_action: command patch --force --quiet -u {{ local_tmp.stdout }}/configmap_new_file {{ local_tmp.stdout }}/patch.patch
     vars:
       ansible_become: false
+    when: not openshift_logging_patch_configmaps_on_remote | default(False)
+
+  - command: patch --force --quiet -u {{ tempdir }}/configmap_new_file {{ tempdir }}/patch.patch
+    when: openshift_logging_patch_configmaps_on_remote | default(False)
 
   - copy:
       src: "{{ local_tmp.stdout }}/configmap_new_file"
       dest: "{{ configmap_new_file }}"
+    when: not openshift_logging_patch_configmaps_on_remote | default(False)
+
+  - copy:
+      src: "{{ tempdir }}/configmap_new_file"
+      remote_src: True
+      dest: "{{ configmap_new_file }}"
+    when: openshift_logging_patch_configmaps_on_remote | default(False)

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -68,6 +68,7 @@ default_r_openshift_node_image_prep_packages:
 - cifs-utils    # requested by Azure
 - samba-common  # requested by Azure
 - samba-client  # requested by Azure
+- patch
 r_openshift_node_image_prep_packages: "{{ default_r_openshift_node_image_prep_packages | union(openshift_node_image_prep_packages | default([])) }}"
 
 r_openshift_node_os_firewall_deny: []


### PR DESCRIPTION
Cause of a missing patch command on my ansible controller wich is
running in a container, I needed the possibility to patch the configmaps
on the remote host which got the patch package. So I've added this
ability with an additional variable called
"openshift_logging_patch_configmaps_on_remote" (Default is FALSE).