### PR TITLE
Bug 1765646: Fluentd single pod logging performance regression 3.x

### DIFF
--- a/roles/openshift_logging/README.md
+++ b/roles/openshift_logging/README.md
@@ -57,6 +57,9 @@ When `openshift_logging_install_logging` is set to `False` the `openshift_loggin
 - `openshift_logging_fluentd_buffer_size_limit`: Buffer chunk limit for Fluentd. Defaults to 1m.
 - `openshift_logging_fluentd_file_buffer_limit`: Fluentd will set the value to the file buffer limit.  Defaults to '1Gi' per destination.
 
+- `openshift_logging_fluentd_refresh_interval`: This allows you to set the Fluentd `in_tail` `refresh_interval` parameter.  The default value is `5` (seconds).
+- `openshift_logging_fluentd_rotate_wait`: This allows you to set the Fluentd `in_tail` `rotate_wait` parameter.  The default value is `5` (seconds).
+
 - `openshift_logging_fluentd_audit_container_engine`: When `openshift_logging_fluentd_audit_container_engine` is set to `True`, the audit log of the container engine will be collected and stored in ES.
 - `openshift_logging_fluentd_audit_file`: Location of audit log file. The default is `/var/log/audit/audit.log`
 - `openshift_logging_fluentd_audit_pos_file`: Location of fluentd in_tail position file for the audit log file. The default is `/var/log/audit/audit.log.pos`

--- a/roles/openshift_logging_fluentd/defaults/main.yml
+++ b/roles/openshift_logging_fluentd/defaults/main.yml
@@ -28,6 +28,9 @@ openshift_logging_fluentd_app_port: 9200
 openshift_logging_fluentd_ops_host: "{{ openshift_logging_fluentd_app_host }}"
 openshift_logging_fluentd_ops_port: "{{ openshift_logging_fluentd_app_port }}"
 
+#openshift_logging_fluentd_refresh_interval: 5
+#openshift_logging_fluentd_rotate_wait: 5
+
 # openshift_logging_fluentd_merge_json_log configures fluentd to parse
 # JSON log messages into the top level payload envelope
 openshift_logging_fluentd_merge_json_log: "true"

--- a/roles/openshift_logging_fluentd/templates/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/fluentd.j2
@@ -265,6 +265,15 @@ spec:
 {% if openshift_logging_fluentd_use_multiline_journal is defined %}
         - name: USE_MULTILINE_JOURNAL
           value: "{{ openshift_logging_fluentd_use_multiline_journal }}"
+
+{% if openshift_logging_fluentd_refresh_interval is defined %}
+        - name: CONTAINER_LOGS_REFRESH_INTERVAL
+          value: "{{ openshift_logging_fluentd_refresh_interval }}"
+{% endif %}
+
+{% if openshift_logging_fluentd_rotate_wait is defined %}
+        - name: CONTAINER_LOGS_ROTATE_WAIT
+          value: "{{ openshift_logging_fluentd_rotate_wait }}"
 {% endif %}
 
       volumes:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1765646
It doesn't really fix the bug.
Allows setting CONTAINER_LOGS_REFRESH_INTERVAL and
CONTAINER_LOGS_ROTATE_WAIT via ansible.