### PR TITLE
Bug 1766792: Restrict new scaleup machinesets to 1 replica

### DIFF
--- a/test/aws/create_machineset.yml
+++ b/test/aws/create_machineset.yml
@@ -12,6 +12,7 @@
         name: "{{ machineset_name }}"
         resourceVersion: ""
       spec:
+        replicas: 1
         selector:
           matchLabels:
             machine.openshift.io/cluster-api-machineset: "{{ machineset_name }}"


### PR DESCRIPTION
Scaleup playbooks assume only one replica per machineset

Attempting to resolve Prometheus alert in CI, alertname="MachineWithNoRunningPhase".

https://bugzilla.redhat.com/show_bug.cgi?id=1766792