### PR TITLE
for debugging docker restart

### DIFF
--- a/playbooks/openshift-node/private/restart.yml
+++ b/playbooks/openshift-node/private/restart.yml
@@ -44,6 +44,12 @@
     - l_docker_upgrade_drain_result is failed
     - openshift_upgrade_nodes_drain_timeout | default(0) | int == 0
 
+  - name: pause before restarting docker - touch /tmp/before-restart-docker to resume
+    wait_for:
+      path: /tmp/before-restart-docker
+      state: present
+      timeout: 86400
+
   - name: Restart docker
     service:
       name: docker
@@ -55,6 +61,12 @@
     when:
     - openshift_node_restart_docker_required | default(True)
     - not openshift_use_crio_only | bool
+
+  - name: pause after restarting docker - touch /tmp/after-restart-docker to resume
+    wait_for:
+      path: /tmp/after-restart-docker
+      state: present
+      timeout: 86400
 
   - name: Wait for master API to come back online
     wait_for:

--- a/roles/openshift_logging/defaults/main.yml
+++ b/roles/openshift_logging/defaults/main.yml
@@ -188,3 +188,4 @@ openshift_logging_mux_namespaces: []
 #fluentd_secureforward_contents:
 #fluentd_mux_config_contents:
 #fluentd_mux_secureforward_contents:
+dummy_logging_setting: true


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1766619
Allows you to pause ansible just before and after the problematic
docker restart that removes the openshift-sdn namespace