### PR TITLE
[release-3.11] Bug 1747307: The redeploy-certificates.yml failed when ops is enabled

### DIFF
--- a/roles/openshift_logging_kibana/defaults/main.yml
+++ b/roles/openshift_logging_kibana/defaults/main.yml
@@ -11,6 +11,7 @@ openshift_logging_kibana_cpu_request: 100m
 openshift_logging_kibana_memory_limit: 736Mi
 
 openshift_logging_kibana_hostname: "{{ 'kibana.' ~ openshift_master_default_subdomain }}"
+openshift_logging_kibana_ops_hostname: "{{ 'kibana-ops.' ~ openshift_master_default_subdomain }}"
 
 openshift_logging_kibana_es_host: "logging-es"
 openshift_logging_kibana_es_port: 9200


### PR DESCRIPTION
Running ansible-playbook playbooks/openshift-logging/redeploy-certificates.yml
fails when ops is enabled due to undefined openshift_logging_kibana_ops_hostname.
Adding it to openshift_logging_kibana/defaults/main.yml.