### PR TITLE
Bug 1756255: Fix openshift_health_checker sdn.py key error

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_11/fix_first_master_node.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_11/fix_first_master_node.yml
@@ -23,7 +23,7 @@
     l_openshift_version_set_hosts: "oo_etcd_to_config:oo_masters_to_config:!oo_first_master"
     l_upgrade_repo_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
     l_upgrade_no_proxy_hosts: "oo_masters_to_config"
-    l_upgrade_health_check_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_upgrade_health_check_hosts: "oo_masters_to_config:oo_etcd_to_config"
     l_upgrade_verify_targets_hosts: "oo_masters_to_config"
     l_upgrade_docker_target_hosts: "oo_masters_to_config:oo_etcd_to_config"
     l_upgrade_excluder_hosts: "oo_masters_to_config"

--- a/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
@@ -33,7 +33,7 @@
     l_openshift_version_set_hosts: "oo_etcd_to_config:oo_masters_to_config:!oo_first_master"
     l_upgrade_repo_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
     l_upgrade_no_proxy_hosts: "oo_masters_to_config"
-    l_upgrade_health_check_hosts: "oo_masters_to_config:oo_etcd_to_config:oo_lb_to_config"
+    l_upgrade_health_check_hosts: "oo_masters_to_config:oo_etcd_to_config"
     l_upgrade_verify_targets_hosts: "oo_masters_to_config"
     l_upgrade_docker_target_hosts: "oo_masters_to_config:oo_etcd_to_config"
     l_upgrade_excluder_hosts: "oo_masters_to_config"

--- a/playbooks/openshift-checks/private/adhoc.yml
+++ b/playbooks/openshift-checks/private/adhoc.yml
@@ -1,6 +1,6 @@
 ---
 - name: OpenShift Health Checks
-  hosts: oo_all_hosts
+  hosts: oo_etcd_to_config:oo_nodes_to_config:oo_masters_to_config
 
   roles:
   - lib_openshift

--- a/playbooks/openshift-checks/private/health.yml
+++ b/playbooks/openshift-checks/private/health.yml
@@ -1,6 +1,6 @@
 ---
 - name: OpenShift Health Checks
-  hosts: oo_all_hosts
+  hosts: oo_etcd_to_config:oo_nodes_to_config:oo_masters_to_config
 
   roles:
   - lib_openshift

--- a/playbooks/openshift-checks/private/install.yml
+++ b/playbooks/openshift-checks/private/install.yml
@@ -14,7 +14,7 @@
           start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
 - name: OpenShift Health Checks
-  hosts: oo_all_hosts
+  hosts: oo_etcd_to_config:oo_nodes_to_config:oo_masters_to_config
   any_errors_fatal: true
   roles:
   - openshift_health_checker

--- a/playbooks/openshift-checks/private/pre-install.yml
+++ b/playbooks/openshift-checks/private/pre-install.yml
@@ -1,6 +1,6 @@
 ---
 - name: OpenShift Health Checks
-  hosts: oo_all_hosts
+  hosts: oo_etcd_to_config:oo_nodes_to_config:oo_masters_to_config
 
   roles:
   - openshift_health_checker

--- a/roles/openshift_health_checker/openshift_checks/sdn.py
+++ b/roles/openshift_health_checker/openshift_checks/sdn.py
@@ -218,7 +218,7 @@ class SDNCheck(OpenShiftCheck):
 
     def get_resource(self, kind):
         """Return a list of all resources of the specified kind."""
-        for resource in self.task_vars['resources']['module_results']:
+        for resource in self.task_vars['resources']['results']:
             if resource['item'] == kind:
                 return resource['module_results']['results'][0]['items']
 
@@ -322,7 +322,7 @@ class SDNCheck(OpenShiftCheck):
                 '--label=io.kubernetes.container.name=%s' % container_name,
                 '--label=io.kubernetes.pod.namespace=%s' % namespace
             ])
-            command = ['/bin/crictl', 'exec', container_id]
+            command = ['/bin/crictl', 'exec', container_id.decode("utf-8")]
         else:
             container_id = self.read_command_output([
                 '/bin/docker', 'ps', '-l', '-a', '-q',
@@ -330,7 +330,7 @@ class SDNCheck(OpenShiftCheck):
                 % container_name,
                 '--filter=label=io.kubernetes.pod.namespace=%s' % namespace
             ])
-            command = ['/bin/docker', 'exec', container_id]
+            command = ['/bin/docker', 'exec', container_id.decode("utf-8")]
 
         return command
 

--- a/roles/openshift_health_checker/test/sdn_tests.py
+++ b/roles/openshift_health_checker/test/sdn_tests.py
@@ -58,7 +58,7 @@ def test_check_master():
 
     task_vars = dict(
         group_names=['oo_masters_to_config'],
-        resources=dict(module_results=[
+        resources=dict(results=[
             dict(item='nodes', module_results=dict(results=[dict(items=nodes)])),
             dict(item='pods', module_results=dict(results=[dict(items={})])),
             dict(item='services', module_results=dict(results=[dict(items={})]))
@@ -156,7 +156,7 @@ def test_check_nodes():
 
     task_vars = dict(
         group_names=['oo_nodes_to_config'],
-        resources=dict(module_results=[
+        resources=dict(results=[
             dict(item='nodes', module_results=dict(results=[dict(items=nodes)])),
             dict(item='hostsubnets', module_results=dict(results=[dict(items=hostsubnets)]))
         ]),
@@ -201,7 +201,7 @@ def test_resolve_address():
 def test_no_nodes():
     task_vars = dict(
         group_names=['oo_masters_to_config'],
-        resources=dict(module_results=[
+        resources=dict(results=[
             dict(item='nodes', module_results=dict(results=[dict(items={})])),
             dict(item='pods', module_results=dict(results=[dict(items={})])),
             dict(item='services', module_results=dict(results=[dict(items={})]))


### PR DESCRIPTION
Fixed an incorrect reference to 'module_results'
Fixed var container_id, convert bytes to string
Fixed hosts, health checks should not be run on the load balancer