### PR TITLE
Bug 1756457: Ensure openshift_master_cluster_hostname is set when deploying multiple masters

### DIFF
--- a/roles/openshift_sanitize_inventory/tasks/main.yml
+++ b/roles/openshift_sanitize_inventory/tasks/main.yml
@@ -127,3 +127,12 @@
     l_masters: "{{ groups['oo_masters_to_config'] | default([]) }}"
     l_openshift_schedulable: "{{ l_masters | map('extract', hostvars, 'openshift_schedulable') | select('defined') | list }}"
     l_master_schedulable: "{{ l_openshift_schedulable | map('bool') | list }}"
+
+- name: Ensure openshift_master_cluster_hostname is set when deploying multiple masters
+  fail:
+    msg: >
+      openshift_master_cluster_hostname must be set when deploying multiple masters to ensure the loadbalancer name
+      is used for accessing the cluster API
+  when:
+    - groups.oo_masters_to_config | length > 1
+    - openshift_master_cluster_hostname is not defined or openshift_master_cluster_hostname == ''


### PR DESCRIPTION
If openshift_master_cluster_hostname is not set, it will default to the
first master hostname.  In the event the first master is down, other
hosts are not able to access the cluster API.