### PR TITLE
Inserted a missing "endif"

### DIFF
--- a/roles/openshift_logging_fluentd/templates/fluentd.j2
+++ b/roles/openshift_logging_fluentd/templates/fluentd.j2
@@ -265,6 +265,7 @@ spec:
 {% if openshift_logging_fluentd_use_multiline_journal is defined %}
         - name: USE_MULTILINE_JOURNAL
           value: "{{ openshift_logging_fluentd_use_multiline_journal }}"
+{% endif %}
 
 {% if openshift_logging_fluentd_refresh_interval is defined %}
         - name: CONTAINER_LOGS_REFRESH_INTERVAL


### PR DESCRIPTION
Since the last commit, the jinja-template is no longer valid. The opening if-statement was not closed.