### PR TITLE
Bug 1773446: Remove cloud-utils-growpart from node package list

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -87,7 +87,7 @@ openshift_node_support_packages_base:
   - iptables-services
   - bridge-utils
   - container-storage-setup
-  - cloud-utils-growpart
+  #- cloud-utils-growpart
   - ceph-common
 
 openshift_node_support_packages_by_arch:


### PR DESCRIPTION
This package is already installed on AWS base images and conflicts with
gce-disk-expand which is pre-installed on GCP images.  growpart is not
implemented for RHEL hosts and is not required.