### PR TITLE
Enable persistency on journal

### DIFF
--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -66,3 +66,12 @@
   systemd:
     name: "crio"
     enabled: yes
+
+# persistent storage in journal is needed for MachineConfig to work
+- name: Enable persistent storage on journal
+  ini_file:
+    dest: "/etc/systemd/journald.conf"
+    section: Journal
+    option: Storage
+    value: "persistent"
+    no_extra_spaces: yes


### PR DESCRIPTION
In order for MachineConfig to work, logs in
journal need to survive after reboots, otherwise
the system is not capable to detect when
MachineConfig has finished a task. So adding
this configuration on journald.conf file

See: https://github.com/openshift/machine-config-operator/issues/1294

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>