### PR TITLE
gluster: add env variable to run Heketis LVM commands through a wrapper

### DIFF
--- a/roles/openshift_storage_glusterfs/tasks/heketi_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_deploy.yml
@@ -27,9 +27,9 @@
     files:
     - "{{ mktemp.stdout }}/heketi-service.yml"
 
-- name: Copy heketi template
-  copy:
-    src: "heketi-template.yml"
+- name: Generate heketi template
+  template:
+    src: "heketi-template.yml.j2"
     dest: "{{ mktemp.stdout }}/heketi-template.yml"
 
 - name: Create heketi template

--- a/roles/openshift_storage_glusterfs/templates/heketi-template.yml.j2
+++ b/roles/openshift_storage_glusterfs/templates/heketi-template.yml.j2
@@ -87,6 +87,10 @@ objects:
             value: "true"
           - name: HEKETI_DEBUG_UMOUNT_FAILURES
             value: "true"
+{% if not glusterfs_is_native | bool %}
+          - name: HEKETI_LVMWRAPPER
+            value: ${HEKETI_LVMWRAPPER}
+{% endif %}
           ports:
           - containerPort: 8080
           volumeMounts:
@@ -143,3 +147,9 @@ parameters:
   displayName: GlusterFS cluster name
   description: A unique name to identify this heketi service, useful for running multiple heketi instances
   value: glusterfs
+{% if not glusterfs_is_native | bool %}
+- name: HEKETI_LVMWRAPPER
+  displayName: Wrapper for executing LVM commands
+  description: Heketi can use a wrapper to execute LVM commands, i.e. run commands in the host namespace instead of in the Gluster container.
+  value: "/usr/sbin/exec-on-host"
+{% endif %}


### PR DESCRIPTION
New Gluster containers contain a wrapper scripts that calls LVM commands
on the host instead of in the container namespace.

See-also: heketi/heketi#1650
Signed-off-by: Niels de Vos <ndevos@redhat.com>