### PR TITLE
Fix for bug 1755120, when key is undefined ansible sets unicode type

### DIFF
--- a/playbooks/openshift-node/private/join.yml
+++ b/playbooks/openshift-node/private/join.yml
@@ -34,7 +34,7 @@
 
   - name: Find all hostnames for bootstrapping
     set_fact:
-      l_nodes_to_join: "{{ groups['oo_nodes_to_config'] | default([]) | map('extract', hostvars) | map(attribute='l_kubelet_node_name') | list }}"
+      l_nodes_to_join: "{{ groups['oo_nodes_to_config'] | default([]) | map('extract', hostvars) | map(attribute='l_kubelet_node_name') | map('default', None) | list }}"
 
   - name: Dump the bootstrap hostnames
     debug:


### PR DESCRIPTION
Fix for bug 1755120, when key is undefined ansible sets variable to
python type unicode. This fix uses default filter to map undefined
to null. This results in the variable set to python type list as expected.