### PR TITLE
gluster: configure pod template to enable support for nsenter

### DIFF
--- a/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
+++ b/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
@@ -33,6 +33,7 @@ objects:
       spec:
         nodeSelector: "${{NODE_LABELS}}"
         hostNetwork: true
+        hostPID: true
         containers:
         - name: glusterfs
           image: ${IMAGE_NAME}
@@ -84,6 +85,8 @@ objects:
             readOnly: true
           - name: glusterfs-target
             mountPath: "/etc/target"
+          - name: host-rootfs
+            mountPath: "/rootfs"
           securityContext:
             capabilities: {}
             privileged: true
@@ -152,6 +155,9 @@ objects:
         - name: glusterfs-target
           hostPath:
             path: "/etc/target"
+        - name: host-rootfs
+          hostPath:
+            path: "/"
         restartPolicy: Always
         terminationGracePeriodSeconds: 30
         dnsPolicy: ClusterFirst


### PR DESCRIPTION
The newly added /usr/sbin/exec-on-host wrapper calls 'nsenter' to run
commands (intended for LVM) on the host, instead of in the container.
This will only work correctly in case the /-filesystem of the host is
mounted on $HOST_ROOTFS, which defaults to /rootfs, and the container
can access the PID-namespace of the host (to get to PID 1).

See-also: #12044