### PR TITLE
Fix API version for 1.17 rebase

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -10,7 +10,7 @@ openshift_node_bootstrap_server: "{{ openshift_node_kubeconfig.clusters.0.cluste
 openshift_node_bootstrap_endpoint: "{{ openshift_node_bootstrap_server }}/config/{{ openshift_node_machineconfigpool }}"
 
 openshift_node_packages:
-  - cri-o-{{ kubernetes_major_version }}.{{ kubernetes_minor_version }}.*
+  - cri-o-{{ l_kubernetes_version }}.*
   - openshift-clients-{{ l_cluster_version }}.*
   - openshift-hyperkube-{{ l_cluster_version }}.*
 

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -40,13 +40,14 @@
   - oc_get.stdout is defined
   - oc_get.stdout != ''
 
-- name: Set fact kubernetes_major_version
+- name: Set fact l_kubernetes_version
   set_fact:
-    kubernetes_major_version: "{{ (oc_get.stdout | from_json).serverVersion.major }}"
+    l_kubernetes_version: "{{ (oc_get.stdout | from_json).serverVersion.major ~ '.' ~  (oc_get.stdout | from_json).serverVersion.minor | regex_search('^\\d+') }}"
 
-- name: Set fact kubernetes_minor_version
+- name: Override kubernetes version when running CI
   set_fact:
-    kubernetes_minor_version: "{{ (oc_get.stdout | from_json).serverVersion.minor | regex_search('^\\d+') }}"
+    l_kubernetes_version: "*"
+  when: ci_version_override | default(false) | bool == true
 
 - block:
   - name: Install openshift packages

--- a/test/aws/files/07_deployment.yml
+++ b/test/aws/files/07_deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
Fixes apiVersion for ssh-bastion deployment
Allows cri-o version override since cri-o 1.17 is not yet ready