### PR TITLE
Bug 1787012: gluster - do not enable hostPID for glusterfs-server pods

### DIFF
--- a/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
+++ b/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
@@ -33,7 +33,7 @@ objects:
       spec:
         nodeSelector: "${{NODE_LABELS}}"
         hostNetwork: true
-        hostPID: true
+        hostPID: false
         containers:
         - name: glusterfs
           image: ${IMAGE_NAME}


### PR DESCRIPTION
The glusterfs-server pods need to access the PIDs of the host where the
containers are running, so that 'nsenter' can be used to run LVM
commands in the host environment, and not inside the containers.

Unfortunately this does not work in combination with systemd that is
part of the glusterfs-server container. However, it seems that access to
the /-filesystem of the host (on the /rootfs volume mountpoint) is
sufficient.

The 'exec-on-host' script of the glusterfs-server container uses the
/rootfs volume for getting access to the namespace of the container
host, so commands can be run there.