### PR TITLE
Require matching cri-o in CI

### DIFF
--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -44,11 +44,6 @@
   set_fact:
     l_kubernetes_version: "{{ (oc_get.stdout | from_json).serverVersion.major ~ '.' ~  (oc_get.stdout | from_json).serverVersion.minor | regex_search('^\\d+') }}"
 
-- name: Override kubernetes version when running CI
-  set_fact:
-    l_kubernetes_version: "*"
-  when: ci_version_override | default(false) | bool == true
-
 - block:
   - name: Install openshift packages
     package:


### PR DESCRIPTION
This override was added for 4.4 (1.17 API) before cri-o 1.17 was
available.