### PR TITLE
Bug 1744900: Bump up etcd release to 3.2.26

### DIFF
--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -7,7 +7,7 @@ l_etcd_static_pod: "{{ (inventory_hostname in groups['oo_masters']) | bool }}"
 # runc, docker, static pod, host
 r_etcd_common_etcd_runtime: "{{ 'static_pod' if l_etcd_static_pod  else 'host' }}"
 
-r_etcd_default_version: "3.2.22"
+r_etcd_default_version: "3.2.26"
 # lib_utils_oo_oreg_image is a custom filter defined in roles/lib_utils/filter_plugins/oo_filters.py
 # This filter attempts to combine oreg_url host with project/component from etcd_image_dict.
 # "oreg.example.com/openshift3/ose-${component}:${version}"


### PR DESCRIPTION
ETCD in 3.9/3.10 is higher than in 3.11, because in the past we used to take the latest version of etcd. Manually bumping the 3.11 version to be on par with the version 3.9/3.10.