### PR TITLE
Bug 1791667: gluster: Heketi template does not contain LVM-wrapper on containerized deployment

### DIFF
--- a/roles/openshift_storage_glusterfs/defaults/main.yml
+++ b/roles/openshift_storage_glusterfs/defaults/main.yml
@@ -64,6 +64,7 @@ openshift_storage_glusterfs_heketi_ssh_user: 'root'
 openshift_storage_glusterfs_heketi_ssh_sudo: False
 openshift_storage_glusterfs_heketi_ssh_keyfile: "{{ omit }}"
 openshift_storage_glusterfs_heketi_fstab: "{{ '/var/lib/heketi/fstab' | quote if openshift_storage_glusterfs_heketi_executor == 'kubernetes' else '/etc/fstab' | quote }}"
+openshift_storage_glusterfs_heketi_lvmwrapper: "/usr/sbin/exec-on-host"
 openshift_storage_glusterfs_check_brick_size_health: True
 
 openshift_storage_glusterfs_registry_timeout: "{{ openshift_storage_glusterfs_timeout }}"
@@ -111,6 +112,7 @@ openshift_storage_glusterfs_registry_heketi_ssh_user: "{{ openshift_storage_glus
 openshift_storage_glusterfs_registry_heketi_ssh_sudo: "{{ openshift_storage_glusterfs_heketi_ssh_sudo }}"
 openshift_storage_glusterfs_registry_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_heketi_ssh_keyfile | default(omit) }}"
 openshift_storage_glusterfs_registry_heketi_fstab: "{{ '/var/lib/heketi/fstab' | quote if openshift_storage_glusterfs_registry_heketi_executor == 'kubernetes' else '/etc/fstab' | quote }}"
+openshift_storage_glusterfs_registry_heketi_lvmwrapper: "/usr/sbin/exec-on-host"
 openshift_storage_glusterfs_registry_check_brick_size_health: "{{ openshift_storage_glusterfs_check_brick_size_health }}"
 
 r_openshift_storage_glusterfs_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_config_facts.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_config_facts.yml
@@ -46,5 +46,6 @@
     glusterfs_heketi_ssh_sudo: "{{ openshift_storage_glusterfs_heketi_ssh_sudo | bool }}"
     glusterfs_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_heketi_ssh_keyfile }}"
     glusterfs_heketi_fstab: "{{ openshift_storage_glusterfs_heketi_fstab }}"
+    glusterfs_heketi_lvmwrapper: "{{ openshift_storage_glusterfs_heketi_lvmwrapper }}"
     glusterfs_nodes: "{{ groups.glusterfs | default([]) }}"
     glusterfs_check_brick_size_health: "{{ openshift_storage_glusterfs_check_brick_size_health | bool }}"

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_registry_facts.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_registry_facts.yml
@@ -46,5 +46,6 @@
     glusterfs_heketi_ssh_sudo: "{{ openshift_storage_glusterfs_registry_heketi_ssh_sudo | bool }}"
     glusterfs_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_registry_heketi_ssh_keyfile }}"
     glusterfs_heketi_fstab: "{{ openshift_storage_glusterfs_registry_heketi_fstab }}"
+    glusterfs_heketi_lvmwrapper: "{{ openshift_storage_glusterfs_registry_heketi_lvmwrapper }}"
     glusterfs_nodes: "{% if groups.glusterfs_registry is defined and groups['glusterfs_registry'] | length > 0 %}{% set nodes = groups.glusterfs_registry %}{% elif 'groups.glusterfs' is defined and groups['glusterfs'] | length > 0 %}{% set nodes = groups.glusterfs %}{% else %}{% set nodes = '[]' %}{% endif %}{{ nodes }}"
     glusterfs_check_brick_size_health: "{{ openshift_storage_glusterfs_registry_check_brick_size_health | bool }}"

--- a/roles/openshift_storage_glusterfs/tasks/heketi_init_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_init_deploy.yml
@@ -1,12 +1,10 @@
 ---
-- name: Copy initial heketi resource files
-  copy:
-    src: "{{ item }}"
-    dest: "{{ mktemp.stdout }}/{{ item }}"
-  with_items:
-  - "deploy-heketi-template.yml"
+- name: Generate initial heketi resource files
+  template:
+    src: "deploy-heketi-template.yml.j2"
+    dest: "{{ mktemp.stdout }}/deploy-heketi-template.yml"
 
-- name: Create deploy-heketi template
+- name: deploy-heketi template
   oc_obj:
     namespace: "{{ glusterfs_namespace }}"
     kind: template
@@ -28,6 +26,7 @@
       HEKETI_EXECUTOR: "{{ glusterfs_heketi_executor }}"
       HEKETI_FSTAB: "{{ glusterfs_heketi_fstab }}"
       CLUSTER_NAME: "{{ glusterfs_name }}"
+      HEKETI_LVMWRAPPER: "{{ glusterfs_heketi_lvmwrapper }}"
 
 - name: Wait for deploy-heketi pod
   oc_obj:

--- a/roles/openshift_storage_glusterfs/templates/deploy-heketi-template.yml.j2
+++ b/roles/openshift_storage_glusterfs/templates/deploy-heketi-template.yml.j2
@@ -81,6 +81,10 @@ objects:
             value: '1'
           - name: HEKETI_IGNORE_STALE_OPERATIONS
             value: "true"
+{% if glusterfs_is_native | bool %}
+          - name: HEKETI_LVMWRAPPER
+            value: ${HEKETI_LVMWRAPPER}
+{% endif %}
           ports:
           - containerPort: 8080
           volumeMounts:
@@ -131,3 +135,9 @@ parameters:
   displayName: GlusterFS cluster name
   description: A unique name to identify this heketi service, useful for running multiple heketi instances
   value: glusterfs
+{% if glusterfs_is_native | bool %}
+- name: HEKETI_LVMWRAPPER
+  displayName: Wrapper for executing LVM commands
+  description: Heketi can use a wrapper to execute LVM commands, i.e. run commands in the host namespace instead of in the Gluster container.
+  value: "/usr/sbin/exec-on-host"
+{% endif %}

--- a/roles/openshift_storage_glusterfs/templates/heketi-template.yml.j2
+++ b/roles/openshift_storage_glusterfs/templates/heketi-template.yml.j2
@@ -87,7 +87,7 @@ objects:
             value: "true"
           - name: HEKETI_DEBUG_UMOUNT_FAILURES
             value: "true"
-{% if not glusterfs_is_native | bool %}
+{% if glusterfs_is_native | bool %}
           - name: HEKETI_LVMWRAPPER
             value: ${HEKETI_LVMWRAPPER}
 {% endif %}
@@ -147,7 +147,7 @@ parameters:
   displayName: GlusterFS cluster name
   description: A unique name to identify this heketi service, useful for running multiple heketi instances
   value: glusterfs
-{% if not glusterfs_is_native | bool %}
+{% if glusterfs_is_native | bool %}
 - name: HEKETI_LVMWRAPPER
   displayName: Wrapper for executing LVM commands
   description: Heketi can use a wrapper to execute LVM commands, i.e. run commands in the host namespace instead of in the Gluster container.


### PR DESCRIPTION
Due to an incorrect statement in the heketi-template.yml.j2 template,
the HEKETI_LVMWRAPPER environment variable is only incluseded in
deployments where Gluster runs on an external cluster, and not in the
case where Gluster is deployed on OpenStack in containers.

The environment variable is needed to specify a wrapper for LVM commands
so that the commands can be run on the container node, outside the
container. This improved the stability of the LVM configuration.

The first time Heketi is deployed, there is a Gluster volume created for
the Heketi database. During this phase, the HEKETI_LVMWRAPPER
environment variable was not set, and there was a chance on problems
while running LVM commands.