### PR TITLE
Bug 1792835: Reset selinux context task is failed due to not considering "openshift_node_group_node_data_dir" during upgrade

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -147,7 +147,8 @@ openshift_node_use_kuryr: "{{ openshift_node_use_kuryr_default }}"
 openshift_node_use_aci_default: "{{ openshift_use_aci | default(False) }}"
 openshift_node_use_aci: "{{ openshift_node_use_aci_default }}"
 
-openshift_node_data_dir_default: "{{ openshift_data_dir | default('/var/lib/origin') }}"
+openshift_node_group_node_data_dir: "{{ openshift_data_dir | default('/var/lib/origin') }}"
+openshift_node_data_dir_default: "{{ openshift_node_group_node_data_dir }}"
 openshift_node_data_dir: "{{ openshift_node_data_dir_default }}"
 
 openshift_node_config_dir_default: "/etc/origin/node"


### PR DESCRIPTION
* Version: v3.11

* Reference: [Reset selinux context task is failed due to not considering "openshift_node_group_node_data_dir" during upgrade](https://bugzilla.redhat.com/show_bug.cgi?id=1792835)

* Description:
  As of v3.10, node config is managed by node groups, and volumedirectory config should also be modified using `openshift_node_group_node_data_dir`.

