### PR TITLE
metrics_server: add nodes resource to aggregated-metrics-reader

### DIFF
--- a/roles/metrics_server/files/metrics-server-aggregated-metrics-reader.yaml
+++ b/roles/metrics_server/files/metrics-server-aggregated-metrics-reader.yaml
@@ -4,8 +4,9 @@ metadata:
   name: system:aggregated-metrics-reader
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
 - apiGroups: ["metrics.k8s.io"]
-  resources: ["pods"]
+  resources: ["pods", "nodes"]
   verbs: ["get", "list", "watch"]
 


### PR DESCRIPTION
related with https://github.com/coreos/kube-prometheus/pull/384 and https://github.com/kubernetes-sigs/metrics-server/pull/297
/cc @openshift/openshift-team-monitoring 
