### PR TITLE
Fix to rename ovirt_vms to ovirt_vm

### DIFF
--- a/playbooks/ovirt/openshift-cluster/ovirt-vm-uninstall.yml
+++ b/playbooks/ovirt/openshift-cluster/ovirt-vm-uninstall.yml
@@ -21,7 +21,7 @@
 
   tasks:
     - name: Erase vms
-      ovirt_vms:
+      ovirt_vm:
         auth: "{{ ovirt_auth }}"
         state: absent
         name: "{{ item.name }}"


### PR DESCRIPTION
Ansible 2.8 and above require the name change. 

https://docs.ansible.com/ansible/latest/modules/ovirt_vm_module.html (no alias)
https://docs.ansible.com/ansible/2.8/modules/ovirt_vm_module.html (no alias)
https://docs.ansible.com/ansible/2.7/modules/ovirt_vm_module.html (alias)
https://docs.ansible.com/ansible/2.6/modules/ovirt_vms_module.html (last release as ovirt_vms)

If we are still supporting Ansible 2.6, we need to go further and make the task dependent on version.