### PR TITLE
Remove variable from logging task name

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml
@@ -30,7 +30,7 @@
     --to={{ _logging_handler_tempdir.stdout }}
 
 ### Check for cluster state before making changes -- if its red, yellow or missing nodes then we don't want to continue
-- name: "Checking current health for {{ _es_node }} cluster"
+- name: "Checking current health for cluster"
   command: >
     curl -s -k
     --cert {{ _logging_handler_tempdir.stdout }}/admin-cert


### PR DESCRIPTION
The `_es_node` variable is undefined when running the included task file
as a handler when using Ansible >=2.8 and causes the handler to fail.

Fixes #12086