### PR TITLE
Bug 1798365: gluster: fix how lvm wrapper is passed to heketi templates

### DIFF
--- a/roles/openshift_storage_glusterfs/defaults/main.yml
+++ b/roles/openshift_storage_glusterfs/defaults/main.yml
@@ -64,7 +64,7 @@ openshift_storage_glusterfs_heketi_ssh_user: 'root'
 openshift_storage_glusterfs_heketi_ssh_sudo: False
 openshift_storage_glusterfs_heketi_ssh_keyfile: "{{ omit }}"
 openshift_storage_glusterfs_heketi_fstab: "{{ '/var/lib/heketi/fstab' | quote if openshift_storage_glusterfs_heketi_executor == 'kubernetes' else '/etc/fstab' | quote }}"
-openshift_storage_glusterfs_heketi_lvmwrapper: "/usr/sbin/exec-on-host"
+openshift_storage_glusterfs_heketi_lvm_wrapper: "/usr/sbin/exec-on-host"
 openshift_storage_glusterfs_check_brick_size_health: True
 
 openshift_storage_glusterfs_registry_timeout: "{{ openshift_storage_glusterfs_timeout }}"
@@ -112,7 +112,7 @@ openshift_storage_glusterfs_registry_heketi_ssh_user: "{{ openshift_storage_glus
 openshift_storage_glusterfs_registry_heketi_ssh_sudo: "{{ openshift_storage_glusterfs_heketi_ssh_sudo }}"
 openshift_storage_glusterfs_registry_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_heketi_ssh_keyfile | default(omit) }}"
 openshift_storage_glusterfs_registry_heketi_fstab: "{{ '/var/lib/heketi/fstab' | quote if openshift_storage_glusterfs_registry_heketi_executor == 'kubernetes' else '/etc/fstab' | quote }}"
-openshift_storage_glusterfs_registry_heketi_lvmwrapper: "/usr/sbin/exec-on-host"
+openshift_storage_glusterfs_registry_heketi_lvm_wrapper: "/usr/sbin/exec-on-host"
 openshift_storage_glusterfs_registry_check_brick_size_health: "{{ openshift_storage_glusterfs_check_brick_size_health }}"
 
 r_openshift_storage_glusterfs_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"

--- a/roles/openshift_storage_glusterfs/files/deploy-heketi-template.yml
+++ b/roles/openshift_storage_glusterfs/files/deploy-heketi-template.yml
@@ -81,10 +81,8 @@ objects:
             value: '1'
           - name: HEKETI_IGNORE_STALE_OPERATIONS
             value: "true"
-{% if glusterfs_is_native | bool %}
-          - name: HEKETI_LVMWRAPPER
-            value: ${HEKETI_LVMWRAPPER}
-{% endif %}
+          - name: HEKETI_LVM_WRAPPER
+            value: ${HEKETI_LVM_WRAPPER}
           ports:
           - containerPort: 8080
           volumeMounts:
@@ -135,9 +133,7 @@ parameters:
   displayName: GlusterFS cluster name
   description: A unique name to identify this heketi service, useful for running multiple heketi instances
   value: glusterfs
-{% if glusterfs_is_native | bool %}
-- name: HEKETI_LVMWRAPPER
+- name: HEKETI_LVM_WRAPPER
   displayName: Wrapper for executing LVM commands
   description: Heketi can use a wrapper to execute LVM commands, i.e. run commands in the host namespace instead of in the Gluster container.
   value: "/usr/sbin/exec-on-host"
-{% endif %}

--- a/roles/openshift_storage_glusterfs/files/heketi-template.yml
+++ b/roles/openshift_storage_glusterfs/files/heketi-template.yml
@@ -87,10 +87,8 @@ objects:
             value: "true"
           - name: HEKETI_DEBUG_UMOUNT_FAILURES
             value: "true"
-{% if glusterfs_is_native | bool %}
-          - name: HEKETI_LVMWRAPPER
-            value: ${HEKETI_LVMWRAPPER}
-{% endif %}
+          - name: HEKETI_LVM_WRAPPER
+            value: ${HEKETI_LVM_WRAPPER}
           ports:
           - containerPort: 8080
           volumeMounts:
@@ -147,9 +145,7 @@ parameters:
   displayName: GlusterFS cluster name
   description: A unique name to identify this heketi service, useful for running multiple heketi instances
   value: glusterfs
-{% if glusterfs_is_native | bool %}
-- name: HEKETI_LVMWRAPPER
+- name: HEKETI_LVM_WRAPPER
   displayName: Wrapper for executing LVM commands
   description: Heketi can use a wrapper to execute LVM commands, i.e. run commands in the host namespace instead of in the Gluster container.
   value: "/usr/sbin/exec-on-host"
-{% endif %}

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_config_facts.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_config_facts.yml
@@ -46,6 +46,6 @@
     glusterfs_heketi_ssh_sudo: "{{ openshift_storage_glusterfs_heketi_ssh_sudo | bool }}"
     glusterfs_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_heketi_ssh_keyfile }}"
     glusterfs_heketi_fstab: "{{ openshift_storage_glusterfs_heketi_fstab }}"
-    glusterfs_heketi_lvmwrapper: "{{ openshift_storage_glusterfs_heketi_lvmwrapper }}"
+    glusterfs_heketi_lvm_wrapper: "{{ openshift_storage_glusterfs_heketi_lvm_wrapper }}"
     glusterfs_nodes: "{{ groups.glusterfs | default([]) }}"
     glusterfs_check_brick_size_health: "{{ openshift_storage_glusterfs_check_brick_size_health | bool }}"

--- a/roles/openshift_storage_glusterfs/tasks/glusterfs_registry_facts.yml
+++ b/roles/openshift_storage_glusterfs/tasks/glusterfs_registry_facts.yml
@@ -46,6 +46,6 @@
     glusterfs_heketi_ssh_sudo: "{{ openshift_storage_glusterfs_registry_heketi_ssh_sudo | bool }}"
     glusterfs_heketi_ssh_keyfile: "{{ openshift_storage_glusterfs_registry_heketi_ssh_keyfile }}"
     glusterfs_heketi_fstab: "{{ openshift_storage_glusterfs_registry_heketi_fstab }}"
-    glusterfs_heketi_lvmwrapper: "{{ openshift_storage_glusterfs_registry_heketi_lvmwrapper }}"
+    glusterfs_heketi_lvm_wrapper: "{{ openshift_storage_glusterfs_registry_heketi_lvm_wrapper }}"
     glusterfs_nodes: "{% if groups.glusterfs_registry is defined and groups['glusterfs_registry'] | length > 0 %}{% set nodes = groups.glusterfs_registry %}{% elif 'groups.glusterfs' is defined and groups['glusterfs'] | length > 0 %}{% set nodes = groups.glusterfs %}{% else %}{% set nodes = '[]' %}{% endif %}{{ nodes }}"
     glusterfs_check_brick_size_health: "{{ openshift_storage_glusterfs_registry_check_brick_size_health | bool }}"

--- a/roles/openshift_storage_glusterfs/tasks/heketi_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_deploy.yml
@@ -28,8 +28,8 @@
     - "{{ mktemp.stdout }}/heketi-service.yml"
 
 - name: Generate heketi template
-  template:
-    src: "heketi-template.yml.j2"
+  copy:
+    src: "heketi-template.yml"
     dest: "{{ mktemp.stdout }}/heketi-template.yml"
 
 - name: Create heketi template
@@ -54,6 +54,7 @@
       HEKETI_EXECUTOR: "{{ glusterfs_heketi_executor }}"
       HEKETI_FSTAB: "{{ glusterfs_heketi_fstab }}"
       CLUSTER_NAME: "{{ glusterfs_name }}"
+      HEKETI_LVM_WRAPPER: "{% if glusterfs_is_native | bool %}{{ glusterfs_heketi_lvm_wrapper }}{% endif %}"
 
 - name: Wait for heketi pod
   oc_obj:

--- a/roles/openshift_storage_glusterfs/tasks/heketi_init_deploy.yml
+++ b/roles/openshift_storage_glusterfs/tasks/heketi_init_deploy.yml
@@ -1,7 +1,7 @@
 ---
 - name: Generate initial heketi resource files
-  template:
-    src: "deploy-heketi-template.yml.j2"
+  copy:
+    src: "deploy-heketi-template.yml"
     dest: "{{ mktemp.stdout }}/deploy-heketi-template.yml"
 
 - name: deploy-heketi template
@@ -26,7 +26,7 @@
       HEKETI_EXECUTOR: "{{ glusterfs_heketi_executor }}"
       HEKETI_FSTAB: "{{ glusterfs_heketi_fstab }}"
       CLUSTER_NAME: "{{ glusterfs_name }}"
-      HEKETI_LVMWRAPPER: "{{ glusterfs_heketi_lvmwrapper }}"
+      HEKETI_LVM_WRAPPER: "{% if glusterfs_is_native | bool %}{{ glusterfs_heketi_lvm_wrapper }}{% endif %}"
 
 - name: Wait for deploy-heketi pod
   oc_obj:


### PR DESCRIPTION
This change fixes two issues:
1. The environment variable 'HEKETI_LVMWRAPPER' was incorrect as heketi
   does not make use of a variable by this name. Heketi does make use of
   'HEKETI_LVM_WRAPPER'. So we update the vars in openshift-ansible to
   match and be consistent.
2. Conditionally including the template vars block is incorrect and
   causes 'oc process' to fail when glusterfs_is_native var is false,
   the state known as independent mode. Instead we always set and pass
   the variable, but we pass an empty string to 'oc process' when
   glusterfs_is_native is false.


Signed-off-by: John Mulligan <jmulligan@redhat.com>