### PR TITLE
Update deploy-heketi-template.yml.j2

### DIFF
--- a/roles/openshift_storage_glusterfs/templates/deploy-heketi-template.yml.j2
+++ b/roles/openshift_storage_glusterfs/templates/deploy-heketi-template.yml.j2
@@ -135,9 +135,7 @@ parameters:
   displayName: GlusterFS cluster name
   description: A unique name to identify this heketi service, useful for running multiple heketi instances
   value: glusterfs
-{% if glusterfs_is_native | bool %}
 - name: HEKETI_LVMWRAPPER
   displayName: Wrapper for executing LVM commands
   description: Heketi can use a wrapper to execute LVM commands, i.e. run commands in the host namespace instead of in the Gluster container.
   value: "/usr/sbin/exec-on-host"
-{% endif %}


### PR DESCRIPTION
If glusterfs_is_native is enabled, when deploy indipendent glusterfs volumes backend, heketi deploy fail because template doesn't know params HEKETI_LVMWRAPPER