### PR TITLE
Remove OVS pod force grace-period 0 on upgrade

### DIFF
--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -11,14 +11,12 @@
 # Delete the SDN/OVS pods to allow any changes to the DaemonSets to be applied.
 - name: Delete OpenShift SDN/OVS pods prior to upgrade
   shell: >
-    {{ openshift_client_binary }} get pods
+    {{ openshift_client_binary }} delete pods
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
     --field-selector=spec.nodeName={{ l_kubelet_node_name | lower }}
-    -o json
-    -n openshift-sdn |
-    {{ openshift_client_binary }} delete
-    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-    -f -
+    -n openshift-sdn
+    --force
+    --grace-period=0
   delegate_to: "{{ groups.oo_first_master.0 }}"
 
 - name: stop services for upgrade


### PR DESCRIPTION
The ovs pods in the namespace openshift-sdn stuck
in state Terminating, causing the playbook stops.
This will force removing the pod from the control
plane, elaving stopping ovs docker pod unmanaged.