### PR TITLE
Use Python3 for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ before_cache:
 
 language: python
 python:
-  - "2.7"
-  - "3.5"
+  - "3.6"
 
 install:
   - pip install --upgrade pip

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,9 +2,9 @@
 # tests with new APIs/semantics. We want to update versions deliberately.
 
 # flake8 must be listed before pylint to avoid dependency conflicts
-flake8==3.7.7
+flake8==3.7.9
 flake8-mutable==1.2.0
-flake8-print==3.1.0
-pylint==1.9.4
+flake8-print==3.1.4
+pylint==2.4.4
 setuptools-lint==0.6.0
-yamllint==1.15.0
+yamllint==1.20.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
-minversion=2.3.1
 envlist =
-    py{27,35}-{flake8,pylint}
-    py27-{yamllint,ansible_syntax}
+    py3-{flake8,pylint,yamllint,ansible_syntax}
 skipsdist=True
 skip_missing_interpreters=True
 
@@ -18,7 +16,6 @@ setenv =
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
-    py35-flake8: flake8-bugbear==17.3.0
 
 commands =
     flake8: flake8 {posargs}


### PR DESCRIPTION
- Updated tox to only test Python 3
- Updated Travis to use platform default of Python 3.6
- Updated various test-requirements versions