### PR TITLE
Add repository Glusterfs7 for CentOS OKD. 

### DIFF
--- a/roles/openshift_repos/tasks/centos_repos.yml
+++ b/roles/openshift_repos/tasks/centos_repos.yml
@@ -17,3 +17,9 @@
     src: "CentOS-OpenShift-Origin39.repo.j2"
     dest: "/etc/yum.repos.d/CentOS-OpenShift-Origin39.repo"
   notify: refresh cache
+
+- name: Configure correct origin release repository for GlusterFS
+  template:
+    src: "CentOS-OpenShift-Origin40.repo.j2"
+    dest: "/etc/yum.repos.d/CentOS-OpenShift-Origin40.repo"
+  notify: refresh cache

--- a/roles/openshift_repos/templates/CentOS-OpenShift-Origin40.repo.j2
+++ b/roles/openshift_repos/templates/CentOS-OpenShift-Origin40.repo.j2
@@ -1,0 +1,5 @@
+[centos-openshift-origin40]
+name=CentOS OpenShift Origin GLusterfs
+baseurl=http://mirror.centos.org/centos-7/7.7.1908/storage/x86_64/gluster-7
+enabled=1
+gpgcheck=0


### PR DESCRIPTION
Add repository Glusterfs7 for CentOS. It will aline the version of Glusterfs between Images Heketi and GLusterfs  and the OS Glusterfs-Client. As the last Heketi and Glusterfs Images use glusterfs 
 7.1, the OS client must be compatibile, adding this repository will install  glusterfs 7.3 perfectly compatible with the version of the Images.

Tested with OKD 3.9 + CentOS + CNS on Vagrant installation.

Fix error:
The following error information was pulled from the glusterfs log to help diagnose this issue:
[graph.y:321:volume_end] 0-parser: "type" not specified for volume heketidbstorage-utime
Documented in: https://github.com/openshift/openshift-ansible/issues/12083