### PR TITLE
Retry podman pull

### DIFF
--- a/roles/openshift_node/tasks/apply_machine_config.yml
+++ b/roles/openshift_node/tasks/apply_machine_config.yml
@@ -12,7 +12,6 @@
   delegate_to: localhost
   register: oc_get
   until:
-  - oc_get.stdout is defined
   - oc_get.stdout != ''
   retries: 36
   delay: 5
@@ -29,7 +28,6 @@
   delegate_to: localhost
   register: oc_get
   until:
-  - oc_get.stdout is defined
   - oc_get.stdout != ''
   retries: 36
   delay: 5
@@ -48,7 +46,6 @@
   delegate_to: localhost
   register: oc_get
   until:
-  - oc_get.stdout is defined
   - oc_get.stdout != ''
   retries: 36
   delay: 5
@@ -62,6 +59,9 @@
 - block:
   - name: Pull MCD image
     command: "podman pull --tls-verify={{ openshift_node_tls_verify }} --authfile /var/lib/kubelet/config.json {{ l_mcd_image }}"
+    register: podman_pull
+    until:
+      podman_pull.stdout != ''
 
   - name: Apply machine config
     command: "podman run {{ podman_mounts }} {{ podman_flags }} {{ mcd_command }}"

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -112,7 +112,6 @@
   delegate_to: localhost
   register: oc_get
   until:
-  - oc_get.stdout is defined
   - oc_get.stdout != ''
   retries: 36
   delay: 5
@@ -126,6 +125,9 @@
 - block:
   - name: Pull release image
     command: "podman pull --tls-verify={{ openshift_node_tls_verify }} --authfile {{ temp_dir.path }}/pull-secret.json {{ l_release_image }}"
+    register: podman_pull
+    until:
+      podman_pull.stdout != ''
 
   - name: Get machine controller daemon image from release image
     command: "podman run --rm {{ l_release_image }} image machine-config-operator"
@@ -138,6 +140,9 @@
 - block:
   - name: Pull MCD image
     command: "podman pull --tls-verify={{ openshift_node_tls_verify }} --authfile {{ temp_dir.path }}/pull-secret.json {{ release_image_mcd.stdout }}"
+    register: podman_pull
+    until:
+      podman_pull.stdout != ''
 
   - name: Apply ignition manifest
     command: "podman run {{ podman_mounts }} {{ podman_flags }} {{ mcd_command }}"

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -17,7 +17,6 @@
   delegate_to: localhost
   register: oc_get
   until:
-  - oc_get.stdout is defined
   - oc_get.stdout != ''
 
 - name: Set fact l_cluster_version
@@ -37,7 +36,6 @@
   delegate_to: localhost
   register: oc_get
   until:
-  - oc_get.stdout is defined
   - oc_get.stdout != ''
 
 - name: Set fact l_kubernetes_version


### PR DESCRIPTION
Transient network issues could cause the image pull to fail with a 504
Gateway Timout error.  The stdout of the command contains the image hash
when successful.  The command will be retried the default 3 times with
delay of 5.

Occasional failures noticed in CI.

Removed unnecessary '.stdout is defined' for consistency.