### PR TITLE
Increase worker config rollout timeout

### DIFF
--- a/test/aws/scaleup.yml
+++ b/test/aws/scaleup.yml
@@ -117,7 +117,7 @@
         oc wait machineconfigpool/worker
         --kubeconfig={{ kubeconfig_path }}
         --for=condition=Updated
-        --timeout=5m
+        --timeout=10m
 
     rescue:
     - name: DEBUG - Get worker machine config pool


### PR DESCRIPTION
Observed in CI this timeout expired before all node configs were
updated however, after reviewing node status, the nodes were all
properly updated.  Increasing the timeout to avoid flakes.