### PR TITLE
Increase podman pull timeout

### DIFF
--- a/roles/openshift_node/tasks/apply_machine_config.yml
+++ b/roles/openshift_node/tasks/apply_machine_config.yml
@@ -62,6 +62,8 @@
     register: podman_pull
     until:
       podman_pull.stdout != ''
+    retries: 12
+    delay: 10
 
   - name: Apply machine config
     command: "podman run {{ podman_mounts }} {{ podman_flags }} {{ mcd_command }}"

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -128,6 +128,8 @@
     register: podman_pull
     until:
       podman_pull.stdout != ''
+    retries: 12
+    delay: 10
 
   - name: Get machine controller daemon image from release image
     command: "podman run --rm {{ l_release_image }} image machine-config-operator"
@@ -143,6 +145,8 @@
     register: podman_pull
     until:
       podman_pull.stdout != ''
+    retries: 12
+    delay: 10
 
   - name: Apply ignition manifest
     command: "podman run {{ podman_mounts }} {{ podman_flags }} {{ mcd_command }}"


### PR DESCRIPTION
Observing error pulling image in CI
"received unexpected HTTP status: 504 Gateway Time-out"

Example:
https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/1516/pull-ci-openshift-machine-config-operator-master-e2e-aws-scaleup-rhel7/1268