### PR TITLE
Refine Python version for tox in travis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3-{flake8,pylint,yamllint,ansible_syntax}
+    py36-{flake8,pylint,yamllint,ansible_syntax}
 skipsdist=True
 skip_missing_interpreters=True
 


### PR DESCRIPTION
Python version needs to be more specific to support tox-travis.

Travis tests have been silently passing since recent tox updates.  CI `unit` test was properly testing with installed python3.