### PR TITLE
Use Ansible 2.9.5 for OCP 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ tracks our current work **in development**.
 
 Requirements: (localhost)
 
-- Ansible >= 2.9.1
+- Ansible >= 2.9.5
 - OpenShift Client (oc)
 
 # Quickstart

--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -17,7 +17,7 @@ URL:            https://github.com/openshift/openshift-ansible
 Source0:        https://github.com/openshift/openshift-ansible/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-Requires:      ansible >= 2.9.1
+Requires:      ansible >= 2.9.5
 Requires:      openshift-clients
 
 %description
@@ -60,7 +60,7 @@ cp -rp test %{buildroot}%{_datadir}/ansible/%{name}/
 %package test
 Summary:       Openshift and Atomic Enterprise Ansible Test Playbooks
 Requires:      %{name} = %{version}-%{release}
-Requires:      ansible = 2.9.1
+Requires:      ansible = 2.9.5
 Requires:      python2-openshift
 Requires:      openssh-clients
 BuildArch:     noarch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.9.1
+ansible==2.9.5

--- a/roles/openshift_node/callback_plugins/aa_version_requirement.py
+++ b/roles/openshift_node/callback_plugins/aa_version_requirement.py
@@ -21,7 +21,7 @@ def display(*args, **kwargs):
 
 
 # Set to minimum required Ansible version
-REQUIRED_VERSION = '2.9.1'
+REQUIRED_VERSION = '2.9.5'
 DESCRIPTION = "Supported versions: %s or newer" % REQUIRED_VERSION
 
 


### PR DESCRIPTION
Provides supported Ansible version for OCP 4.5 support cycle