### PR TITLE
add quay.io/coreos to images list

### DIFF
--- a/playbooks/adhoc/uninstall_openshift.yml
+++ b/playbooks/adhoc/uninstall_openshift.yml
@@ -230,6 +230,7 @@
         - registry\.qe\.openshift\.com/.*
         - registry\.access\..*redhat\.com/rhel7/etcd
         - docker.io/openshift
+        - quay.io/coreos
 
       - shell: "docker rmi -f {{ item.stdout_lines | join(' ') }}"
         changed_when: False

--- a/playbooks/adhoc/uninstall_openshift.yml
+++ b/playbooks/adhoc/uninstall_openshift.yml
@@ -231,6 +231,7 @@
         - registry\.access\..*redhat\.com/rhel7/etcd
         - docker.io/openshift
         - quay.io/coreos
+        - docker.io/ansibleplaybookbundle/origin-ansible-service-broker
 
       - shell: "docker rmi -f {{ item.stdout_lines | join(' ') }}"
         changed_when: False


### PR DESCRIPTION
While uninstalling OpenShift, Multiple images from `quay.io/coreos` and `docker.io/ansibleplaybookbundle/origin-ansible-service-broker` were not removed unless we add the related urls to the task which is responsible for removing the installed docker images.