### PR TITLE
Fix namespace for rh-operators.configmap.yaml

### DIFF
--- a/roles/olm/files/rh-operators.configmap.yaml
+++ b/roles/olm/files/rh-operators.configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: rh-operators
-  namespace: openshift-operator-lifecycle-manager
+  namespace: operator-lifecycle-manager
 
 data:
   customResourceDefinitions: |-


### PR DESCRIPTION
In https://github.com/openshift/openshift-ansible/commit/2d16237c6c5595be61b17ce1702590c9b8180b3d the namespace was changed from `operator-lifecycle-manager` to `openshift-operator-lifecycle-manager`.  This doesn't match the namespace defined in https://github.com/openshift/openshift-ansible/blob/release-3.11/roles/olm/tasks/install.yaml#L98 so fails to apply it.

This PR reverts the namespace name to to the original value.

# Tests

Tested during an install from commit 557da0687a27c2ad7ce254642adcdc223bc3266f.
Changing the namespace name as above resolved the issue and allowed the deployment to continue.