### PR TITLE
use openshift3/registry-console instead of cockpit/kubernetes with or…

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -448,13 +448,9 @@ debug_level=2
 #openshift_hosted_routers=[{'name': 'router1', 'certificate': {'certfile': '/path/to/certificate/abc.crt', 'keyfile': '/path/to/certificate/abc.key', 'cafile': '/path/to/certificate/ca.crt'}, 'replicas': 1, 'serviceaccount': 'router', 'namespace': 'default', 'stats_port': 1936, 'edits': [], 'images': 'openshift3/ose-${component}:${version}', 'selector': 'type=router1', 'ports': ['80:80', '443:443']}, {'name': 'router2', 'certificate': {'certfile': '/path/to/certificate/xyz.crt', 'keyfile': '/path/to/certificate/xyz.key', 'cafile': '/path/to/certificate/ca.crt'}, 'replicas': 1, 'serviceaccount': 'router', 'namespace': 'default', 'stats_port': 1936, 'edits': [{'action': 'append', 'key': 'spec.template.spec.containers[0].env', 'value': {'name': 'ROUTE_LABELS', 'value': 'route=external'}}], 'images': 'openshift3/ose-${component}:${version}', 'selector': 'type=router2', 'ports': ['80:80', '443:443']}]
 
 # OpenShift Registry Console Options
-# Override the console image prefix:
-# origin default is "cockpit/", enterprise default is "openshift3/"
-#openshift_cockpit_deployer_prefix=registry.example.com/myrepo/
-# origin default is "kubernetes", enterprise default is "registry-console"
-#openshift_cockpit_deployer_basename=my-console
-# Override image version, defaults to latest for origin, vX.Y product version for enterprise
-#openshift_cockpit_deployer_version=1.4.1
+# Override the console image:
+# origin default is "registry.access.redhat.com/openshift3/registry-console:$OPENSHIFT_RELEASE", enterprise default is "registry.redhat.io/openshift3/registry-console:v$OPENSHIFT_RELEASE" (OPENSHIFT_RELEASE e.g. v3.11)
+# openshift_cockpit_deployer_image='registry.example.com/myrepo/registry-console:v3.11'
 
 # Openshift Registry Options
 #

--- a/roles/cockpit-ui/defaults/main.yml
+++ b/roles/cockpit-ui/defaults/main.yml
@@ -1,11 +1,13 @@
 ---
 openshift_hosted_manage_registry_console: True
 l_os_cockpit_image_version_dict:
-  origin: 'latest'
+  origin: "{{ openshift_image_tag | regex_replace('(v\\d+\\.\\d+).\\d+$', '\\1') }}"
   openshift-enterprise: "{{ openshift_image_tag }}"
 l_os_cockpit_image_version: "{{ l_os_cockpit_image_version_dict[openshift_deployment_type] }}"
 
-l_os_cockpit_image_format: "{{ openshift_facts_registry_url | regex_replace('${version}' | regex_escape, l_os_cockpit_image_version) }}"
+l_os_cockpit_registry_url: "{{ openshift_facts_registry_url | replace('docker.io','registry.access.redhat.com') }}"
+
+l_os_cockpit_image_format: "{{ l_os_cockpit_registry_url | regex_replace('${version}' | regex_escape, l_os_cockpit_image_version) }}"
 
 l_openshift_cockit_search_dict:
   origin: "openshift/origin-${component}"
@@ -13,7 +15,7 @@ l_openshift_cockit_search_dict:
 l_openshift_cockit_search: "{{ l_openshift_cockit_search_dict[openshift_deployment_type] }}"
 
 l_openshift_cockpit_replace_dict:
-  origin: "cockpit/kubernetes"
+  origin: "openshift3/registry-console"
   openshift-enterprise: "registry-console"
 l_openshift_cockpit_replace: "{{ l_openshift_cockpit_replace_dict[openshift_deployment_type] }}"
 


### PR DESCRIPTION
This PR changes the `registry-console` image from `docker.io/cockpit/kubernetes:latest` to `registry.access.redhat.com/openshift3/registry-console:vX.XX` e.g. (3.11) for origin deployments as the old image is deprecated and being replaced with  [an image provided by redhat](https://access.redhat.com/containers/#/registry.access.redhat.com/openshift3/registry-console)

Fixes #12115

Also `inventory/hosts.example` has been updated to document `openshift_cockpit_deployer_image` instead of the old variables.

**Note**:
In order to be able to use this image on CentOS distribution, I had to run the following command
```
openssl s_client -showcerts -servername registry.access.redhat.com -connect registry.access.redhat.com:443 </dev/null 2>/dev/null | openssl x509 -text > /etc/rhsm/ca/redhat-uep.pem
```
Should we add this to the cockpit role? also, note that the packages itself that are responsible for adding the certificates didn't add it in the first place as this path `/etc/rhsm/ca` was empty