### PR TITLE
fixing rh-operator configmap namespace

### DIFF
--- a/roles/olm/files/rh-operators.configmap.yaml
+++ b/roles/olm/files/rh-operators.configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: rh-operators
-  namespace: openshift-operator-lifecycle-manager
+  namespace: operator-lifecycle-manager
 
 data:
   customResourceDefinitions: |-


### PR DESCRIPTION
rh-operator namespace should have been operator-lifecycle-manager.