### PR TITLE
Bug 1816422: Fix CRDs names on Kuryr tasks

### DIFF
--- a/roles/kuryr/tasks/master.yaml
+++ b/roles/kuryr/tasks/master.yaml
@@ -118,7 +118,7 @@
   oc_obj:
     state: present
     kind: CustomResourceDefinition
-    name: "kuryrnets"
+    name: "kuryrnets.openstack.org"
     files:
     - "{{ manifests_tmpdir.stdout }}/kuryrnet.yaml"
   run_once: true
@@ -128,7 +128,7 @@
   oc_obj:
     state: present
     kind: CustomResourceDefinition
-    name: "kuryrnetpolicies"
+    name: "kuryrnetpolicies.openstack.org"
     files:
     - "{{ manifests_tmpdir.stdout }}/kuryrnetpolicy.yaml"
   run_once: true


### PR DESCRIPTION
In case an attempt to recreate any of Kuryr CRDs happens
the installatian is unable to progress. This is due to the
wrong CRD name being defined on the Ansible task resulting
in not finding the previous applied CRD and attempting to
recreate it.