### PR TITLE
BUG 1819597: Install rh-operators in the correct namespace

### DIFF
--- a/roles/olm/files/rh-operators.configmap.yaml
+++ b/roles/olm/files/rh-operators.configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: rh-operators
-  namespace: openshift-operator-lifecycle-manager
+  namespace: operator-lifecycle-manager
 
 data:
   customResourceDefinitions: |-


### PR DESCRIPTION
This commit updates the  rh-operators configmap to be created in the
operator-lifecycle-manager namespace rather than incorrectly creating
the configmap in the openshift-operator-lifecycle-manager namespace.