### PR TITLE
Bug 1824101: Upgrading the RHEL7 worker nodes from OCP4.2 to OCP4.3 can be failed due to conflict of the podman package dependency

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -13,6 +13,7 @@ openshift_node_packages:
   - cri-o-{{ l_kubernetes_version }}.*
   - openshift-clients-{{ l_cluster_version }}.*
   - openshift-hyperkube-{{ l_cluster_version }}.*
+  - podman
 
 openshift_node_support_packages: "{{ openshift_node_support_packages_base + openshift_node_support_packages_by_arch[ansible_architecture] }}"
 
@@ -36,7 +37,6 @@ openshift_node_support_packages_base:
   #- shim
   - openssh-server
   - openssh-clients
-  - podman
   - skopeo
   - runc
   - containernetworking-plugins


### PR DESCRIPTION
* Version: v4.3
* Descriptions:
  cri-o and podman depend on same conmon package, so if the packages are updates at the individual transaction, then the dependency will conflict each other due to not resolving the dependency automatically.

* References: https://bugzilla.redhat.com/show_bug.cgi?id=1824101