### PR TITLE
Bug 1824828: [release-3.11] Update GCE image disk size (build_image)

### DIFF
--- a/playbooks/gcp/openshift-cluster/build_image.yml
+++ b/playbooks/gcp/openshift-cluster/build_image.yml
@@ -37,7 +37,7 @@
       name: "{{ openshift_gcp_prefix }}build-image-instance"
       disk_type: pd-ssd
       image: "{{ openshift_gcp_base_image }}"
-      size_gb: 10
+      size_gb: 20
       state: present
 
   - name: Launch the image build instance


### PR DESCRIPTION
Underlying image has a base size of 20Gb.

Follow up to #12144