### PR TITLE
Bug 1824056: fix task name for removal of openshift-monitoring project

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/tasks/remove.yaml
+++ b/roles/openshift_cluster_monitoring_operator/tasks/remove.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Remove openshift-prometheus-operator project
+- name: Remove openshift-monitoring project
   oc_project:
     name: openshift-monitoring
     state: absent


### PR DESCRIPTION
As in title.

cc: @openshift/openshift-team-monitoring 