### PR TITLE
Bug 1827982: Add cifs-utils package for Azure-file usage

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -89,6 +89,7 @@ openshift_node_support_packages_base:
   - container-storage-setup
   #- cloud-utils-growpart
   - ceph-common
+  - cifs-utils
 
 openshift_node_support_packages_by_arch:
   ppc64le:


### PR DESCRIPTION
Fix https://bugzilla.redhat.com/show_bug.cgi?id=1827982, Aure-file mount fail on RHEL worker due to missing `cifs-utils` package.
After installed `cifs-utils`, can mount azure file manually. Add `cifs-utils` in the default openshift_node_support_packages_base list.