### PR TITLE
Bug 1827982: Install cifs-utils, required for azure-file mounts

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -89,6 +89,7 @@ openshift_node_support_packages_base:
   - container-storage-setup
   #- cloud-utils-growpart
   - ceph-common
+  - cifs-utils
 
 openshift_node_support_packages_by_arch:
   ppc64le:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1827982