### PR TITLE
Bug 1828484: Add conditional to fix openshift_master_cluster_hostname check

### DIFF
--- a/playbooks/gcp/openshift-cluster/install.yml
+++ b/playbooks/gcp/openshift-cluster/install.yml
@@ -7,6 +7,8 @@
     include_role:
       name: openshift_gcp
       tasks_from: setup_scale_group_facts.yml
+    vars:
+      all_nodes: true
 
 - name: run the init
   import_playbook: ../../init/main.yml

--- a/roles/openshift_sanitize_inventory/tasks/main.yml
+++ b/roles/openshift_sanitize_inventory/tasks/main.yml
@@ -134,5 +134,6 @@
       openshift_master_cluster_hostname must be set when deploying multiple masters to ensure the loadbalancer name
       is used for accessing the cluster API
   when:
+    - groups.oo_masters_to_config is defined
     - groups.oo_masters_to_config | length > 1
     - openshift_master_cluster_hostname is not defined or openshift_master_cluster_hostname == ''


### PR DESCRIPTION
If hosts are not in [masters] in the inventory file, oo_masters_to_config will not
be set.