### PR TITLE
Bug 1829492: Remove hard coded openshift_certificate_expiry_warning_days

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -16,8 +16,6 @@
   - import_role:
       name: openshift_certificate_expiry
       tasks_from: main.yml
-    vars:
-      openshift_certificate_expiry_warning_days: 183
 
 - name: Ensure firewall is not switched during upgrade
   hosts: "{{ l_upgrade_no_switch_firewall_hosts | default('oo_all_hosts') }}"


### PR DESCRIPTION
Using this var in 'vars:' prevents the value from being overridden in
the inventory.