### PR TITLE
Bug 1829492: Add six month expiry check back to upgrades

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -13,9 +13,24 @@
   hosts: "{{ l_upgrade_cert_check_hosts }}"
   any_errors_fatal: true
   tasks:
+  # During upgrades we want to check if certificates are expiring within six months.
+  # The upgrade will stop if certificates are expiring, requiring the user to either
+  # deploy new certificates, override openshift_certificate_expiry_warning_days or
+  # openshift_certificate_expiry_fail_on_warn in the inventory.
+  - name: Upgrade - Override default openshift_certificate_expiry_warning_days
+    set_fact:
+      openshift_certificate_expiry_warning_days: 183
+    when:
+    - openshift_certificate_expiry_warning_days is undefined or
+      openshift_certificate_expiry_warning_days == ""
+  - name: Upgrade - Override default openshift_certificate_expiry_fail_on_warn
+    set_fact:
+      openshift_certificate_expiry_fail_on_warn: true
+    when:
+    - openshift_certificate_expiry_fail_on_warn is undefined or
+      openshift_certificate_expiry_fail_on_warn == ""
   - import_role:
       name: openshift_certificate_expiry
-      tasks_from: main.yml
 
 - name: Ensure firewall is not switched during upgrade
   hosts: "{{ l_upgrade_no_switch_firewall_hosts | default('oo_all_hosts') }}"

--- a/roles/openshift_certificate_expiry/defaults/main.yml
+++ b/roles/openshift_certificate_expiry/defaults/main.yml
@@ -6,4 +6,4 @@ openshift_certificate_expiry_generate_html_report: no
 openshift_certificate_expiry_html_report_path: "{{ lookup('env', 'HOME') }}/cert-expiry-report.{{ ansible_date_time.iso8601_basic_short }}.html"
 openshift_certificate_expiry_save_json_results: no
 openshift_certificate_expiry_json_results_path: "{{ lookup('env', 'HOME') }}/cert-expiry-report.{{ ansible_date_time.iso8601_basic_short }}.json"
-openshift_certificate_expiry_fail_on_warn: True
+openshift_certificate_expiry_fail_on_warn: false


### PR DESCRIPTION
During upgrades we want to check if certificates are expiring within six months. The upgrade will stop if certificates are expiring, requiring the user to either deploy new certificates, override openshift_certificate_expiry_warning_days or openshift_certificate_expiry_fail_on_warn in the inventory.

The _expiry_fail_on_warn check was originally `false` and was intended to only by `true` for upgrades.

Follow up to #12154