### PR TITLE
Bug 1832379: Remove cert expiry check during cert redeploy

### DIFF
--- a/playbooks/openshift-etcd/private/redeploy-ca.yml
+++ b/playbooks/openshift-etcd/private/redeploy-ca.yml
@@ -1,16 +1,4 @@
 ---
-- name: Check cert expirys
-  hosts: oo_etcd_to_config:oo_masters_to_config
-  vars:
-    openshift_certificate_expiry_show_all: yes
-  roles:
-  # Sets 'check_results' per host which contains health status for
-  # etcd, master and node certificates.  We will use 'check_results'
-  # to determine if any certificates were expired prior to running
-  # this playbook. Service restarts will be skipped if any
-  # certificates were previously expired.
-  - role: openshift_certificate_expiry
-
 - name: Backup existing etcd CA certificate directories
   hosts: oo_etcd_to_config
   tasks:

--- a/playbooks/openshift-etcd/private/redeploy-certificates.yml
+++ b/playbooks/openshift-etcd/private/redeploy-certificates.yml
@@ -1,16 +1,4 @@
 ---
-- name: Check cert expirys
-  hosts: oo_etcd_to_config
-  vars:
-    openshift_certificate_expiry_show_all: yes
-  roles:
-  # Sets 'check_results' per host which contains health status for
-  # etcd, master and node certificates.  We will use 'check_results'
-  # to determine if any certificates were expired prior to running
-  # this playbook. Service restarts will be skipped if any
-  # certificates were previously expired.
-  - role: openshift_certificate_expiry
-
 - import_playbook: certificates-backup.yml
 
 - import_playbook: certificates.yml

--- a/playbooks/openshift-master/private/redeploy-openshift-ca.yml
+++ b/playbooks/openshift-master/private/redeploy-openshift-ca.yml
@@ -1,16 +1,4 @@
 ---
-- name: Check cert expirys
-  hosts: oo_nodes_to_config:oo_masters_to_config:oo_etcd_to_config
-  vars:
-    openshift_certificate_expiry_show_all: yes
-  roles:
-  # Sets 'check_results' per host which contains health status for
-  # etcd, master and node certificates.  We will use 'check_results'
-  # to determine if any certificates were expired prior to running
-  # this playbook. Service restarts will be skipped if any
-  # certificates were previously expired.
-  - role: openshift_certificate_expiry
-
 # Update master config when ca-bundle not referenced. Services will be
 # restarted below after new CA certificate has been distributed.
 - name: Ensure ca-bundle.crt is referenced in master configuration


### PR DESCRIPTION
When redeploying certificates, the cert expiry check provides little
value because the expectation is that the certificates will be replaced.
Addtionally, there are situations where certificates are in an invalid
state and redploy is blocked by the check.  Removing the checks will
allow certificate redeploy to proceed without requiring additional
inventory vars to override expiry days or invalid/missing certificates.