### PR TITLE
Use variable for EPEL RPM URL for CentOS

### DIFF
--- a/roles/openshift_repos/defaults/main.yaml
+++ b/roles/openshift_repos/defaults/main.yaml
@@ -1,3 +1,4 @@
 ---
 openshift_additional_repos: {}
 openshift_repos_enable_testing: false
+openshift_epel_rpm_url: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm

--- a/roles/openshift_repos/tasks/centos_repos.yml
+++ b/roles/openshift_repos/tasks/centos_repos.yml
@@ -23,6 +23,6 @@
 
 - name: Enable the EPEL repo for installing Ansible
   yum:
-    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    name: "{{ openshift_epel_rpm_url }}"
     state: present
   notify: refresh cache


### PR DESCRIPTION
Allows the RPM source to be overridden.