### PR TITLE
Add support to configure subnetpool prefixlen at Kuryr

### DIFF
--- a/roles/openshift_openstack/defaults/main.yml
+++ b/roles/openshift_openstack/defaults/main.yml
@@ -56,6 +56,7 @@ openshift_openstack_kuryr_service_subnet_cidr: "172.30.0.0/16"
 openshift_openstack_kuryr_service_pool_start: "172.30.128.1"
 openshift_openstack_kuryr_service_pool_end: "172.30.255.253"
 openshift_openstack_kuryr_pod_subnet_cidr: "10.11.0.0/16"
+openshift_openstack_kuryr_pod_subnet_prefixlen: "24"
 openshift_openstack_master_hostname: master
 openshift_openstack_infra_hostname: infra-node
 openshift_openstack_cns_hostname: cns

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -292,7 +292,7 @@ resources:
     type: OS::Neutron::SubnetPool
     properties:
       prefixes: [ {{ openshift_openstack_kuryr_pod_subnet_cidr }} ]
-      default_prefixlen: 24
+      default_prefixlen: {{ openshift_openstack_kuryr_pod_subnet_prefixlen }}
       name:
         str_replace:
           template: openshift-ansible-cluster_id-pod-subnet-pool


### PR DESCRIPTION
A new config option is added to enable the modification of the
default subnets size that Kuryr later creates:
- openshift_openstack_kuryr_pod_subnet_prefixlen