### PR TITLE
Bug 1800467: gluster: use memory (tmpfs) emptydir for glusterfs-run volume

### DIFF
--- a/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
+++ b/roles/openshift_storage_glusterfs/files/glusterfs-template.yml
@@ -118,7 +118,8 @@ objects:
           hostPath:
             path: "/var/lib/heketi"
         - name: glusterfs-run
-          emptyDir: {}
+          emptyDir:
+            medium: Memory
         - name: glusterfs-lvm
           hostPath:
             path: "/run/lvm"


### PR DESCRIPTION
Because gluster(d) needs a whole-system-alike environment it expects to
manage pid files in /run like a typical linux system. Ensure that this
directory doesn't persist across node reboots by making it a temporary
file system, much like a typical linux system.

Signed-off-by: John Mulligan <jmulligan@redhat.com>