### PR TITLE
Bug 1830158: Add support for global namespaces and removal of remote_group_id

### DIFF
--- a/roles/kuryr/defaults/main.yaml
+++ b/roles/kuryr/defaults/main.yaml
@@ -11,6 +11,9 @@ kuryr_openstack_project_domain_name: default
 # Kuryr OpenShift namespace
 kuryr_namespace: kuryr
 
+# Kuryr global namespaces (e.g.: default)
+kuryr_openstack_global_namespaces: default,openshift-monitoring
+
 # Default pod-in-VM link interface
 kuryr_cni_link_interface: eth0
 

--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -338,6 +338,7 @@ data:
     [namespace_sg]
     sg_allow_from_namespaces = {{ kuryr_openstack_sg_allow_from_namespace_id }}
     sg_allow_from_default = {{ kuryr_openstack_sg_allow_from_default_id }}
+    global_namespaces = {{ kuryr_openstack_global_namespaces }}
 {% endif %}
 
     # Time (in seconds) that Kuryr controller waits for LBaaS to be activated

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -322,15 +322,7 @@ resources:
       description: Give access to the services and pods on the default namespace from the other namespaces
       rules:
       - ethertype: IPv4
-        remote_group_id: { get_resource: sg_allow_from_default }
-        remote_mode: remote_group_id
-
-  sg_allow_from_default_rule:
-    type: OS::Neutron::SecurityGroupRule
-    properties:
-      security_group: { get_resource: sg_allow_from_default }
-      ethertype: IPv4
-      remote_group: { get_resource: sg_allow_from_namespace }
+        remote_ip_prefix: {{ openshift_openstack_kuryr_pod_subnet_cidr }}
 
   common-secgrp_namespace_rule:
     type: OS::Neutron::SecurityGroupRule


### PR DESCRIPTION
Usage of remote_group_id has proven to be error prone as well as
scalability issue. This offers an option to remove its usage