### PR TITLE
Bug 1816966: Updating ES restart policy

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/full_cluster_restart.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/full_cluster_restart.yml
@@ -31,7 +31,7 @@
     exec {{ _cluster_pods.stdout.split(' ')[0] }}
     -c elasticsearch
     -n {{ openshift_logging_elasticsearch_namespace }}
-    -- es_util --query=_cluster/settings -XPUT -d '{ "transient": { "cluster.routing.allocation.enable" : "none" } }'
+    -- es_util --query=_cluster/settings -XPUT -d '{ "persistent": { "cluster.routing.allocation.enable" : "primaries" } }'
   register: _disable_output
   changed_when:
   - "_disable_output.stdout != ''"
@@ -170,14 +170,14 @@
     exec {{ _cluster_pods.stdout.split(' ')[0] }}
     -c elasticsearch
     -n {{ openshift_logging_elasticsearch_namespace }}
-    -- es_util --query=_cluster/settings -XPUT -d '{ "transient": { "cluster.routing.allocation.enable" : "all" } }'
+    -- es_util --query=_cluster/settings -XPUT -d '{ "persistent": { "cluster.routing.allocation.enable" : "all" } }'
   register: _enable_output
   changed_when:
   - "_enable_output.stdout != ''"
   - (_enable_output.stdout | from_json)['acknowledged'] | bool
 
 # Skip healthcheck for a full cluster restart always since it could take a long time to recover?
-- name: "Waiting for ES node {{ _es_node }} health to be in ['green']"
+- name: "Waiting for ES node {{ _es_node }} health to be in ['green', 'yellow']"
   command: >
     {{ openshift_client_binary }}
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
@@ -188,7 +188,7 @@
   register: _cluster_status
   until:
   - "_cluster_status.stdout != ''"
-  - (_cluster_status.stdout | from_json)['status'] in ['green']
+  - (_cluster_status.stdout | from_json)['status'] in ['green', 'yellow']
   retries: "{{ __elasticsearch_ready_retries }}"
   delay: 30
   changed_when: false
@@ -201,7 +201,7 @@
   set_stats:
     data:
       installer_phase_logging:
-        message: "Cluster logging-{{ _cluster_component }} was unable to recover to a green state. Please see documentation regarding recovering during a {{ 'full' if full_restart_cluster | bool else 'rolling'}} cluster restart."
+        message: "Cluster logging-{{ _cluster_component }} was unable to recover to at least a yellow state. Please see documentation regarding recovering during a {{ 'full' if full_restart_cluster | bool else 'rolling'}} cluster restart."
 
 # Reenable external communication for {{ _cluster_component }}
 - name: Reenable external communication for logging-{{ _cluster_component }}

--- a/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml
@@ -40,7 +40,7 @@
   until:
   - _pod_status.rc == 0
   - _pod_status.stdout is defined
-  - (_pod_status.stdout | from_json)['status'] == 'green'
+  - (_pod_status.stdout | from_json)['status'] in ['green', 'yellow']
   - (_pod_status.stdout | from_json)['number_of_nodes'] == _cluster_pods.stdout.split(' ') | count
   retries: "{{ __elasticsearch_ready_retries }}"
   delay: 10
@@ -50,7 +50,7 @@
 
 - when:
   - _pod_status.stdout is defined
-  - (_pod_status.stdout | from_json)['status'] in ['yellow', 'red'] or (_pod_status.stdout | from_json)['number_of_nodes'] != _cluster_pods.stdout.split(' ') | count
+  - (_pod_status.stdout | from_json)['status'] in ['red'] or (_pod_status.stdout | from_json)['number_of_nodes'] != _cluster_pods.stdout.split(' ') | count
   block:
   - name: Set Logging message to manually restart
     run_once: true
@@ -61,7 +61,7 @@
 
   - debug: msg="Elasticsearch cluster logging-{{ _cluster_component }} was not in an optimal state and will not be automatically restarted. Please see documentation regarding doing a {{ 'full' if full_restart_cluster | bool else 'rolling'}} restart of cluster logging."
 
-- when: _pod_status.stdout is undefined or ( (_pod_status.stdout | from_json)['status'] in ['green'] and (_pod_status.stdout | from_json)['number_of_nodes'] == _cluster_pods.stdout.split(' ') | count )
+- when: _pod_status.stdout is undefined or ( (_pod_status.stdout | from_json)['status'] in ['green', 'yellow'] and (_pod_status.stdout | from_json)['number_of_nodes'] == _cluster_pods.stdout.split(' ') | count )
   block:
   - command: >
       {{ openshift_client_binary }}

--- a/roles/openshift_logging_elasticsearch/tasks/restart_es_node.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/restart_es_node.yml
@@ -7,7 +7,7 @@
     --cert {{ _logging_handler_tempdir.stdout }}/admin-cert
     --key {{ _logging_handler_tempdir.stdout }}/admin-key
     -XPUT 'https://logging-{{ _cluster_component }}.{{ openshift_logging_elasticsearch_namespace }}.svc:9200/_cluster/settings'
-    -d '{ "transient": { "cluster.routing.allocation.enable" : "none" } }'
+    -d '{ "persistent": { "cluster.routing.allocation.enable" : "primaries" } }'
   register: _disable_output
   changed_when:
     - "_disable_output.stdout != ''"
@@ -66,7 +66,7 @@
     --cert {{ _logging_handler_tempdir.stdout }}/admin-cert
     --key {{ _logging_handler_tempdir.stdout }}/admin-key
     -XPUT 'https://logging-{{ _cluster_component }}.{{ openshift_logging_elasticsearch_namespace }}.svc:9200/_cluster/settings'
-    -d '{ "transient": { "cluster.routing.allocation.enable" : "all" } }'
+    -d '{ "persistent": { "cluster.routing.allocation.enable" : "all" } }'
   register: _enable_output
   changed_when:
     - "_enable_output.stdout != ''"
@@ -79,7 +79,7 @@
     msg: "Node {{ _es_node}} in cluster logging-{{ _cluster_component }} was unable to rollout. Please see documentation regarding recovering during a {{ 'full' if full_restart_cluster | bool else 'rolling'}} cluster restart."
 
 - when: not _skip_healthcheck | bool
-  name: "Waiting for ES node {{ _es_node }} health to be in ['green']"
+  name: "Waiting for ES node {{ _es_node }} health to be in ['green', 'yellow']"
   command: >
     curl -s -k
     --cert {{ _logging_handler_tempdir.stdout }}/admin-cert
@@ -88,7 +88,7 @@
   register: _cluster_status
   until:
     - "_cluster_status.stdout != ''"
-    - (_cluster_status.stdout | from_json)['status'] in ['green']
+    - (_cluster_status.stdout | from_json)['status'] in ['green', 'yellow']
   retries: "{{ __elasticsearch_ready_retries }}"
   delay: 30
   changed_when: false
@@ -102,9 +102,9 @@
   set_stats:
     data:
       installer_phase_logging:
-        message: "Cluster logging-{{ _cluster_component }} was unable to recover to a green state. Please see documentation regarding recovering during a {{ 'full' if full_restart_cluster | bool else 'rolling'}} cluster restart."
+        message: "Cluster logging-{{ _cluster_component }} was unable to recover to at least a yellow state. Please see documentation regarding recovering during a {{ 'full' if full_restart_cluster | bool else 'rolling'}} cluster restart."
 
 - name: Evaluating cluster health
   assert:
     that: _cluster_status.failed is undefined or not _cluster_status.failed
-    msg: "Cluster logging-{{ _cluster_component }} was unable to recover to a green state. Please see documentation regarding recovering during a {{ 'full' if full_restart_cluster | bool else 'rolling'}} cluster restart."
+    msg: "Cluster logging-{{ _cluster_component }} was unable to recover to at least a yellow state. Please see documentation regarding recovering during a {{ 'full' if full_restart_cluster | bool else 'rolling'}} cluster restart."

--- a/roles/openshift_logging_elasticsearch/tasks/rolling_cluster_restart.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/rolling_cluster_restart.yml
@@ -27,7 +27,7 @@
     --cert {{ _logging_handler_tempdir.stdout }}/admin-cert
     --key {{ _logging_handler_tempdir.stdout }}/admin-key
     -XPUT 'https://logging-{{ _cluster_component }}.{{ openshift_logging_elasticsearch_namespace }}.svc:9200/_cluster/settings'
-    -d '{ "transient": { "cluster.routing.allocation.enable" : "none" } }'
+    -d '{ "persistent": { "cluster.routing.allocation.enable" : "primaries" } }'
   register: _cluster_disable_output
   changed_when:
   - "_cluster_disable_output.stdout != ''"
@@ -71,7 +71,7 @@
     --cert {{ _logging_handler_tempdir.stdout }}/admin-cert
     --key {{ _logging_handler_tempdir.stdout }}/admin-key
     -XPUT 'https://logging-{{ _cluster_component }}.{{ openshift_logging_elasticsearch_namespace }}.svc:9200/_cluster/settings'
-    -d '{ "transient": { "cluster.routing.allocation.enable" : "all" } }'
+    -d '{ "persistent": { "cluster.routing.allocation.enable" : "all" } }'
   register: _cluster_enable_output
   until: _cluster_enable_output.rc == 0
   retries: "{{ __elasticsearch_ready_retries }}"


### PR DESCRIPTION
Allowing primaries be placed still and allow `yellow` or `green` status before continuing.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1816966