### PR TITLE
Bug 1814451: Added expiration checks for aggregator-proxy related certs

### DIFF
--- a/roles/lib_utils/library/openshift_cert_expiry.py
+++ b/roles/lib_utils/library/openshift_cert_expiry.py
@@ -559,6 +559,14 @@ an OpenShift Container Platform cluster
             if proxyClient:
                 cert_meta['proxyClient'] = os.path.join(cfg_path, proxyClient)
 
+            frontProxyCA = cfg.get('authConfig', {}).get('requestHeader', {}).get('clientCA')
+            if frontProxyCA:
+                cert_meta['frontProxyCA'] = os.path.join(cfg_path, frontProxyCA)
+
+            aggregatorProxyClient = cfg.get('aggregatorConfig', {}).get('proxyClientInfo', {}).get('certFile')
+            if aggregatorProxyClient:
+                cert_meta['aggregatorProxyClient'] = os.path.join(cfg_path, aggregatorProxyClient)
+
             namedCertificates = cfg.get('servingInfo', {}).get('namedCertificates', [])
             if namedCertificates:
                 for i, v in enumerate(namedCertificates):


### PR DESCRIPTION
Updated the `openshift_cert_expiry` module to check the expiration of the aggregator-proxy client and CA certificates.