### PR TITLE
Bug 1839965: Enable seboolean for Azure mount support

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -34,6 +34,18 @@
     state: yes
     persistent: yes
 
+- name: Setting sebool virt_use_samba
+  seboolean:
+    name: virt_use_samba
+    state: yes
+    persistent: yes
+
+- name: Setting sebool container_use_cephfs
+  seboolean:
+    name: container_use_cephfs
+    state: yes
+    persistent: yes
+
 - name: Create temp directory
   tempfile:
     state: directory


### PR DESCRIPTION
Required for read/write support to mounted volumes on Azure.
SELinux booleans are updated to match RHCOS 8.x.

https://bugzilla.redhat.com/show_bug.cgi?id=1839965