### PR TITLE
Fixes #11697: Dont relay on ansible json auto parse

### DIFF
--- a/roles/openshift_logging/tasks/set_defaults_from_current.yml
+++ b/roles/openshift_logging/tasks/set_defaults_from_current.yml
@@ -185,7 +185,7 @@
 
 # Set the defaults based on collected facts
 - conditional_set_fact:
-    facts: "{{ hostvars[inventory_hostname] }}"
+    facts: hostvars[inventory_hostname]
     vars:
       # Elasticsearch
       openshift_logging_es_number_of_shards: openshift_logging_es_number_of_shards | __openshift_logging_es_number_of_shards


### PR DESCRIPTION
Fixes #11697

conditional_set_facts expects that the parameter `facts` is a dicts.

Ansible tries to parase string parameters as json and if its successfully, the parameter will pass as dict automaticly. If the string can't parse, the argument will pass as string.

By removing the jinja2 template here. The object to string converation is gone. Ansible pass the variable as-is to the module.

This error depends on the hostvars inventory of the first openshift-master1. I didn't found the variable yet which result into this error