### PR TITLE
Adjust Kuryr probes

### DIFF
--- a/roles/kuryr/templates/cni-daemonset.yaml.j2
+++ b/roles/kuryr/templates/cni-daemonset.yaml.j2
@@ -143,11 +143,13 @@ spec:
             port: {{ kuryr_cni_healthcheck_port }}
           initialDelaySeconds: 15
           timeoutSeconds: 5
+          failureThreshold: 10
         livenessProbe:
           httpGet:
             path: /alive
             port: {{ kuryr_cni_healthcheck_port }}
           initialDelaySeconds: 15
+          failureThreshold: 10
 {% endif %}
       volumes:
         - name: bin

--- a/roles/kuryr/templates/controller-deployment.yaml.j2
+++ b/roles/kuryr/templates/controller-deployment.yaml.j2
@@ -36,12 +36,15 @@ spec:
           httpGet:
             path: /ready
             port: {{ kuryr_controller_healthcheck_port }}
-          timeoutSeconds: 5
+          timeoutSeconds: 20
+          periodSeconds: 30
+          failureThreshold: 10
         livenessProbe:
           httpGet:
             path: /alive
             port: {{ kuryr_controller_healthcheck_port }}
           initialDelaySeconds: 15
+          failureThreshold: 10
 {% endif %}
         # FIXME(dulek): This shouldn't be required, but without it selinux is
         #               complaining about access to kuryr.conf.

--- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
@@ -323,20 +323,6 @@ resources:
       rules:
       - ethertype: IPv4
         remote_ip_prefix: {{ openshift_openstack_kuryr_pod_subnet_cidr }}
-
-  common-secgrp_namespace_rule:
-    type: OS::Neutron::SecurityGroupRule
-    properties:
-      security_group: { get_resource: common-secgrp }
-      ethertype: IPv4
-      remote_group: { get_resource: sg_allow_from_namespace }
-
-  common-secgrp_default_rule:
-    type: OS::Neutron::SecurityGroupRule
-    properties:
-      security_group: { get_resource: common-secgrp }
-      ethertype: IPv4
-      remote_group: { get_resource: sg_allow_from_default }
 {% endif %}
 
 


### PR DESCRIPTION
Adjust kuryr probes to avoid false positives (unifies them with
the 4.X settings).

It also removes one extra appearance of remote_group_id which is
not needed