### PR TITLE
Fix machine creation failure message

### DIFF
--- a/test/aws/tasks/create_machineset.yml
+++ b/test/aws/tasks/create_machineset.yml
@@ -86,7 +86,7 @@
   rescue:
   - name: Machine creation failed
     fail:
-      msg: "Machine creation failed, error: {{ new_machine.resources[0].status.errorMessage }}"
+      msg: "Machine creation failed"
 
 - name: Get ssh bastion address
   command: >


### PR DESCRIPTION
In CI we use machine sets to provision RHEL worker instances in AWS.
The rescue clause of the machine creation tasks should summarize the
failure state if one of these tasks fails.  The failure message was
referencing the 'resources' object which was previously used when using
the k8s Ansible modules and therefore was not valid because the creation
tasks have been moved to 'command' which provides 'stdout'.  The
status.errorMessage object is not present during some failures, so the
error detail has been removed.  Previous task output can be used to
determine the cause of the failure.

[CI Failure](https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/pr-logs/pull/openshift_machine-api-operator/602/pull-ci-openshift-machine-api-operator-master-e2e-aws-scaleup-rhel7/1273227196378386432#1:build-log.txt%3A15379)