### PR TITLE
Use loop_var with include_tasks

### DIFF
--- a/test/aws/create_machines.yml
+++ b/test/aws/create_machines.yml
@@ -11,9 +11,11 @@
 
   - include_tasks: tasks/create_machineset.yml
     loop: "{{ (machineset.stdout | from_json)['items'] }}"
+    loop_control:
+      loop_var: l_machineset
     when:
-    - item.status.replicas is defined
-    - item.status.replicas != 0
+    - l_machineset.status.replicas is defined
+    - l_machineset.status.replicas != 0
 
 - name: Prepare new nodes
   hosts: new_workers

--- a/test/aws/tasks/create_machineset.yml
+++ b/test/aws/tasks/create_machineset.yml
@@ -1,11 +1,11 @@
 ---
 - name: Create machineset_name
   set_fact:
-    machineset_name: "{{ item.metadata.name ~ '-rhel'}}"
+    machineset_name: "{{ l_machineset.metadata.name ~ '-rhel'}}"
 
 - name: Update machineset definition
   set_fact:
-    machineset: "{{ item | combine(dict_edit, recursive=True) }}"
+    machineset: "{{ l_machineset | combine(dict_edit, recursive=True) }}"
   vars:
     dict_edit:
       metadata:


### PR DESCRIPTION
When looping over included tasks files, the loop_var option should be
used to prevent var collision of the default 'item' loop variable.  The
collision could cause unexpected behavior and failure of included tasks.

[CI Failure](https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/1817/pull-ci-openshift-machine-config-operator-master-e2e-aws-scaleup-rhel7/1272936996519546880#1:build-log.txt%3A8636)