### PR TITLE
Remove task to install nfs-utils

### DIFF
--- a/test/aws/create_machines.yml
+++ b/test/aws/create_machines.yml
@@ -18,9 +18,16 @@
 - name: Prepare new nodes
   hosts: new_workers
   gather_facts: false
+  # We want to fail if all expected nodes are not available
+  any_errors_fatal: true
+
   tasks:
-  - wait_for_connection: {}
-  - setup: {}
+  - name: Wait 600 seconds for new nodes to come up
+    wait_for_connection:
+
+  - name: Run setup to gather facts after nodes are up
+    setup:
+
   - name: Copy ops-mirror.pem
     copy:
       src: ../../inventory/dynamic/injected/ops-mirror.pem
@@ -28,6 +35,7 @@
       owner: root
       group: root
       mode: 0644
+
   - name: Initialize openshift repos
     import_tasks: tasks/additional_repos.yml
 
@@ -36,10 +44,12 @@
     selinux:
       policy: targeted
       state: permissive
+
   - name: Create core user for storage tests to pass
     user:
       name: core
       group: wheel
+
   - name: Make sure core user has ssh config directory
     file:
       name: /home/core/.ssh
@@ -47,9 +57,3 @@
       owner: core
       group: wheel
       mode: 0700
-  - name: Install nfs-utils for storage tests
-    package:
-      name: nfs-utils
-      state: present
-    register: result
-    until: result is succeeded


### PR DESCRIPTION
nfs-utils is installed by the openshift-node role and does not need to
be installed separately.  Additionally, any_errors_fatal is added to the
play which prepares new nodes to ensure the scaleup will only continue
if all expected nodes are available in CI.

[CI Failure](https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/pr-logs/pull/openshift_machine-api-operator/600/pull-ci-openshift-machine-api-operator-master-e2e-aws-scaleup-rhel7/1273230346296496128) (nfs-utils failed to install during prep, but the scaleup continued, ultimately reporting a failure.)