### PR TITLE
[CI] test/aws/tasks: Properly retry task on command failure

### DIFF
--- a/test/aws/tasks/get_machinesets.yml
+++ b/test/aws/tasks/get_machinesets.yml
@@ -7,7 +7,8 @@
     --output=json
   register: oc_get
   until:
-  - oc_get.stdout != ''
+  - oc_get.rc == 0
+  - (oc_get.stdout | from_json)['items'] | length > 0
   changed_when: false
 
 - name: Set fact pre_scaleup_workers_name
@@ -22,7 +23,8 @@
     --output=json
   register: machineset
   until:
-  - machineset.stdout != ''
+  - machineset.rc == 0
+  - (machineset.stdout | from_json)['items'] | length > 0
   changed_when: false
 
 - name: Set fact pre_scaleup_machineset_names


### PR DESCRIPTION
Retry the task if rc != 0 and if no 'items' are returned.
The task was failing on the first exection and would not retry if
the command module failed.

As seen in [CI](https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/pr-logs/pull/openshift_machine-api-operator/630/pull-ci-openshift-machine-api-operator-master-e2e-aws-scaleup-rhel7/1280081361524232192#1:build-log.txt%3A2146)