### PR TITLE
Bug 1848723: Correct GCP group mapping for infra and compute

### DIFF
--- a/inventory/dynamic/gcp/group_vars/all/00_defaults.yml
+++ b/inventory/dynamic/gcp/group_vars/all/00_defaults.yml
@@ -36,8 +36,8 @@ osm_cluster_network_cidr: 172.16.0.0/16
 osm_host_subnet_length: 9
 openshift_portal_net: 172.30.0.0/16
 
-# masters and infra are the same in CI
+# compute and infra are the same in CI
 openshift_gcp_node_group_mapping:
   masters: 'node-config-master'
-  infra: 'node-config-master'
-  compute: 'node-config-compute'
+  infra: 'node-config-node'
+  compute: 'node-config-node'


### PR DESCRIPTION
Based on openshift_node_groups defined in CI for GCP, infra and compute
are the same nodes.

https://github.com/openshift/release/blob/master/cluster/test-deploy/gcp/vars.yaml#L32
