### PR TITLE
Bug 1848606: Fix repeating logging restarts

### DIFF
--- a/roles/openshift_logging_elasticsearch/handlers/main.yml
+++ b/roles/openshift_logging_elasticsearch/handlers/main.yml
@@ -2,7 +2,7 @@
 - name: "Restarting logging cluster"
   listen: "restart elasticsearch"
   include_tasks: restart_cluster.yml
-  with_items: "{{ _restart_logging_components }}"
+  with_items: "{{ _restart_logging_components | unique }}"
   loop_control:
     loop_var: _cluster_component
   when: not logging_elasticsearch_rollout_override | default(false) | bool

--- a/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml
@@ -84,7 +84,7 @@
   - name: "Performing rolling restart for Elasticsearch cluster {{ _cluster_component }} cluster"
     include_tasks: rolling_cluster_restart.yml
     vars:
-      logging_restart_cluster_dcs: "{{ _restart_logging_nodes | intersect(_cluster_dcs.stdout) }}"
+      logging_restart_cluster_dcs: "{{ _restart_logging_nodes | unique | intersect(_cluster_dcs.stdout) }}"
     when:
     - not full_restart_cluster | bool
 


### PR DESCRIPTION
Addresses: https://bugzilla.redhat.com/show_bug.cgi?id=1848606

Currently, running with multiple ES nodes can result in the variables provided to the handler to be like:
```
"_restart_logging_components": ["es", "es", "es", "es"]
```