### PR TITLE
Add boto to Ansible image for CI

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -63,6 +63,7 @@ Summary:       Openshift and Atomic Enterprise Ansible Test Playbooks
 Requires:      %{name} = %{version}-%{release}
 Requires:      ansible >= 2.9.5
 Requires:      openssh-clients
+Requires:      python2-boto
 BuildArch:     noarch
 
 %description test


### PR DESCRIPTION
python2-boto is required for using this image in CI to deploy test
clusters in AWS.