### PR TITLE
Fix #12209 - regenerate logging certs

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/generate_secret.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/generate_secret.yaml
@@ -9,7 +9,8 @@
   register: passwd_file
   check_mode: no
 
-- slurp:
+- when: passwd_file.stat.exists
+  slurp:
     src: "{{ generated_certs_dir }}/passwd.yml"
   register: _logging_metrics_proxy_passwd
 


### PR DESCRIPTION
Add conditional to slurping passwd.yml file only when it exists.

If /etc/origin/logging/passwd.yml is deleted and a user runs
redeploy-certificates.yml playbook, it will fail because of a missing
condition.