### PR TITLE
Bump requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pyOpenSSL==17.5.0
 six==1.10.0
 shade==1.24.0
 passlib==1.6.5
+dogpile.cache==0.9.2


### PR DESCRIPTION
Tox tests are failing because of outdated python modules.