### PR TITLE
Bug 1807201: logging_elasticsearch: disable system_call_filter check on non-amd64 architectures

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/main.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/main.yaml
@@ -227,6 +227,7 @@
   vars:
     allow_cluster_reader: "{{ openshift_logging_elasticsearch_ops_allow_cluster_reader | lower | default('false') }}"
     es_kibana_index_mode: "{{ openshift_logging_elasticsearch_kibana_index_mode | default('unique') }}"
+    es_system_call_filter: "{{ ansible_architecture == 'x86_64' }}"
     es_unicast_host: "logging-{{ es_component }}-cluster"
   changed_when: no
 

--- a/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/openshift_logging_elasticsearch/templates/elasticsearch.yml.j2
@@ -1,6 +1,9 @@
 cluster:
   name: ${CLUSTER_NAME}
 
+bootstrap:
+  system_call_filter: {{ es_system_call_filter }}
+
 script:
   inline: true
   stored: true


### PR DESCRIPTION
This bootstrap check requires architecture-specific supporting code in
ElasticSearch, which upstream has outright refused to accept.