### PR TITLE
Bug 1874324: Update playbook to install and activate openvswitch2.13

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -75,6 +75,7 @@ openshift_node_support_packages_base:
   - bash-completion
   - vim-minimal
   - nano
+  - openvswitch2.13
   #- openshift-hyperkube
   #- openshift-clients
   #- pivot


### PR DESCRIPTION
Replaces https://github.com/openshift/openshift-ansible/pull/12216

Mike is on PTO so I'll take this bit over.

@trozet @mccv1r0 