### PR TITLE
Bug 1779811: Install pre-release kernel (for scaleup-rhel7 CI)

### DIFF
--- a/test/aws/create_machines.yml
+++ b/test/aws/create_machines.yml
@@ -59,3 +59,32 @@
       owner: core
       group: wheel
       mode: 0700
+
+  # Temporary pre-release kernel install until RHEL 7.9 GA
+  - name: Get current kernel version
+    command: uname -r
+    register: kernel_version
+
+  - name: Test current kernel version
+    debug:
+      msg: "Kernel is old"
+    when: kernel_version.stdout is version('3.10.0-1148', 'lt')
+
+  - when: kernel_version.stdout is version('3.10.0-1148', 'lt')
+    block:
+    - name: Download pre-release kernel
+      get_url:
+        url: https://mirror.openshift.com/enterprise/other/openshift-ansible/rteague/x86_64/kernel-3.10.0-1148.el7.x86_64.rpm
+        dest: /tmp/kernel-3.10.0-1148.el7.x86_64.rpm
+        client_cert: /var/lib/yum/ops-mirror.pem
+      register: result
+      until: result is succeeded
+
+    - name: Install pre-release kernel
+      yum:
+        name: /tmp/kernel-3.10.0-1148.el7.x86_64.rpm
+        state: present
+      async: 3600
+      poll: 30
+      register: result
+      until: result is succeeded


### PR DESCRIPTION
A patched kernel is required to resolve a consistently failing test on RHEL7 worker nodes.

The release periodic jobs still use the scaleup-rhel7 job template and therefore are not getting the updated kernel through the step-registry job.  Once the RHEL 7.9 GA AMI is available this change can be reverted.

Failing test - "[sig-network] Services should be rejected when no endpoints exist"

Patched kernel: https://bugzilla.redhat.com/show_bug.cgi?id=1832332

Tracking this in https://bugzilla.redhat.com/show_bug.cgi?id=1779811