### PR TITLE
Bug 1870123: Fix docker_storage health check

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -10,7 +10,7 @@ COPY images/installer/origin-extra-root /
 # install ansible and deps
 RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch" \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
- && EPEL_PKGS="ansible-2.9.4 python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46" \
+ && EPEL_PKGS="ansible-2.9.13 python2-boto python2-crypto which python2-pip.noarch python2-scandir python2-packaging azure-cli-2.0.46" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
  && if [ "$(uname -m)" == "x86_64" ]; then yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm ; fi \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.9.4
+ansible==2.9.13
 boto==2.44.0
 click==6.7
 pyOpenSSL==17.5.0

--- a/roles/openshift_health_checker/openshift_checks/docker_storage.py
+++ b/roles/openshift_health_checker/openshift_checks/docker_storage.py
@@ -44,7 +44,7 @@ class DockerStorage(DockerHostMixin, OpenShiftCheck):
         # attempt to get the docker info hash from the docker cli
         command = ' '.join(['docker', 'info', '--format', '"{{json .}}"'])
         command_args = dict(_raw_params=command)
-        command_result = self._execute_module('command', command_args)
+        command_result = self.execute_module('command', command_args)
         if command_result.get('rc', 0) != 0 or command_result.get('failed'):
             raise OpenShiftCheckException(
                 'RemoteCommandFailure',


### PR DESCRIPTION
Due to internal changes in Ansible v2.9.11, the docker_storage health check was failing.  Using `execute_module` to maintain compatibility.

```
Failure summary:


  1. ec2-18-232-141-57.compute-1.amazonaws.com, ec2-3-87-122-60.compute-1.amazonaws.com, ec2-35-174-16-132.compute-1.amazonaws.com, ec2-54-159-113-128.compute-1.amazonaws.com, ec2-54-204-162-217.compute-1.amazonaws.com, ec2-54-236-15-120.compute-1.amazonaws.com
     OpenShift Health Checks
     Run health checks (install) - EL
     One or more checks failed
     check "docker_storage":
               'ansible_facts'
               Traceback (most recent call last):
                 File "/home/rteague/git/oa-testing/aws-3a/ansible/lib/ansible/plugins/action/__init__.py", line 206, in _configure_module
                   (module_data, module_style, module_shebang) = modify_module(module_name, module_path, module_args, self._templar,
                 File "/home/rteague/git/oa-testing/aws-3a/ansible/lib/ansible/executor/module_common.py", line 1250, in modify_module
                   (b_module_data, module_style, shebang) = _find_module_utils(module_name, b_module_data, module_path, module_args, task_vars, templar, module_compression,
                 File "/home/rteague/git/oa-testing/aws-3a/ansible/lib/ansible/executor/module_common.py", line 1129, in _find_module_utils
                   shebang, interpreter = _get_shebang(u'/usr/bin/python', task_vars, templar)
                 File "/home/rteague/git/oa-testing/aws-3a/ansible/lib/ansible/executor/module_common.py", line 576, in _get_shebang
                   raise InterpreterDiscoveryRequiredError("interpreter discovery needed",
               ansible.executor.interpreter_discovery.InterpreterDiscoveryRequiredError: <unprintable InterpreterDiscoveryRequiredError object>
               
               During handling of the above exception, another exception occurred:
               
               Traceback (most recent call last):
                 File "/home/rteague/git/oa-testing/aws-3a/openshift-ansible/roles/openshift_health_checker/action_plugins/openshift_health_check.py", line 225, in run_check
                   result = check.run()
                 File "/home/rteague/git/oa-testing/aws-3a/openshift-ansible/roles/openshift_health_checker/openshift_checks/docker_storage.py", line 47, in run
                   command_result = self._execute_module('command', command_args)
                 File "/home/rteague/git/oa-testing/aws-3a/ansible/lib/ansible/plugins/action/__init__.py", line 825, in _execute_module
                   (module_style, shebang, module_data, module_path) = self._configure_module(module_name=module_name, module_args=module_args, task_vars=task_vars)
                 File "/home/rteague/git/oa-testing/aws-3a/ansible/lib/ansible/plugins/action/__init__.py", line 225, in _configure_module
                   use_vars['ansible_facts'][discovered_key] = self._discovered_interpreter
               KeyError: 'ansible_facts'
```