### PR TITLE
Bug 1852753: Add --force and --grace-period options to SDN pod delete

### DIFF
--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -11,12 +11,16 @@
 # Delete the SDN/OVS pods to allow any changes to the DaemonSets to be applied.
 - name: Delete OpenShift SDN/OVS pods prior to upgrade
   shell: >
-    {{ openshift_client_binary }} delete pods
+    {{ openshift_client_binary }} get pods
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
     --field-selector=spec.nodeName={{ l_kubelet_node_name | lower }}
-    -n openshift-sdn
+    -o json
+    -n openshift-sdn |
+    {{ openshift_client_binary }} delete
+    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
     --force
     --grace-period=0
+    -f -
   delegate_to: "{{ groups.oo_first_master.0 }}"
 
 - name: stop services for upgrade


### PR DESCRIPTION
The underlying problem here is that the 3.10 version of `oc` does not have the --field-selector flag whereas the 3.11 version does.  Since this task is being performed just prior to client upgrade, the task fails because it is using the 3.10 version.

--field-selector is not a valid flag for oc 3.10.

Reverting the original change and adding the additional flags to the delete command.

This reverts commit a69085bff1ac0482d7f1437ec50e2798363d17df.

Reverts #12100