### PR TITLE
Bug 1848454: OpenShift logging upgrade from 3.11.161 to 3.11.219 fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 ---
 sudo: false
 
-cache:
-  - pip
-
-before_cache:
-  - rm ~/.cache/pip/log/debug.log
-
 language: python
 python:
   - "2.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ six==1.10.0
 shade==1.24.0
 passlib==1.6.5
 dogpile.cache==0.9.2
+pyrsistent==0.16.1

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -65,7 +65,8 @@
   with_sequence: count={{ openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count }}
   when: openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count > 0
 
-- set_fact: es_indices=[]
+- set_fact:
+    es_indices: []
   when: openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count == 0
 
 - set_fact: openshift_logging_es_pvc_prefix="logging-es"

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -82,6 +82,13 @@
 - set_fact:
     default_elasticsearch_storage_type: "{{ 'pvc' if ( openshift_logging_es_pvc_dynamic | bool or openshift_logging_storage_kind | default('') == 'nfs' or openshift_logging_es_pvc_size | length > 0)  else 'emptydir' }}"
 
+# Pre-condition check for the following include_role, to make sure the lists in with_together are
+# the same length and do not get padded with Nones
+#
+- fail:
+    msg: There must be the same number of ES DeploymentConfigs, ES PVCs and ES indices. Found ES DeploymentConfigs - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs.keys() }}", ES PVCs - "{{ openshift_logging_facts.elasticsearch.pvcs }}" and ES indices - "{{ es_indices }}"
+  when: (openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count != openshift_logging_facts.elasticsearch.pvcs | length) or (openshift_logging_facts.elasticsearch.pvcs | length != es_indices | length) or (openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count != es_indices | length)
+
 - include_role:
     name: openshift_logging_elasticsearch
   vars:
@@ -154,6 +161,15 @@
 - set_fact:
     default_elasticsearch_storage_type: "{{ 'pvc' if ( openshift_logging_es_ops_pvc_dynamic | bool or openshift_logging_storage_kind | default('') == 'nfs' or openshift_logging_es_ops_pvc_size | length > 0)  else 'emptydir' }}"
   when:
+  - openshift_logging_use_ops | bool
+
+# Pre-condition check for the following include_role, to make sure the lists in with_together are
+# the same length and do not get padded with Nones
+#
+- fail:
+    msg: There must be the same number of ES DeploymentConfigs, ES PVCs and ES Ops indices. Found ES DeploymentConfigs - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs.keys() }}", ES PVCs - "{{ openshift_logging_facts.elasticsearch.pvcs }}" and ES Ops indices - "{{ es_ops_indices }}"
+  when:
+  - (openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count != openshift_logging_facts.elasticsearch.pvcs | length) or (openshift_logging_facts.elasticsearch.pvcs | length != es_ops_indices | length) or (openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count != es_ops_indices | length)
   - openshift_logging_use_ops | bool
 
 - include_role:

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -153,7 +153,8 @@
   - openshift_logging_use_ops | bool
   - openshift_logging_facts.elasticsearch_ops.deploymentconfigs.keys() | count > 0
 
-- set_fact: es_ops_indices=[]
+- set_fact:
+    es_ops_indices: []
   when: openshift_logging_facts.elasticsearch_ops.deploymentconfigs.keys() | count == 0
 
 - set_fact: openshift_logging_es_ops_pvc_prefix="logging-es-ops"

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -86,7 +86,7 @@
 # the same length and do not get padded with Nones
 #
 - fail:
-    msg: There must be the same number of ES DeploymentConfigs, ES PVCs and ES indices. Found ES DeploymentConfigs - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs.keys() }}", ES PVCs - "{{ openshift_logging_facts.elasticsearch.pvcs }}" and ES indices - "{{ es_indices }}"
+    msg: There must be the same number of ES DeploymentConfigs, ES PVCs and ES indices. Found ES DeploymentConfigs - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs.keys() }}", ES DC count - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count }}", ES PVCs - "{{ openshift_logging_facts.elasticsearch.pvcs }}", ES PVC length - "{{ openshift_logging_facts.elasticsearch.pvcs | length  }}" and ES indices - "{{ es_indices }}", ES indices length - "{{ es_indices | length  }}"
   when: (openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count != openshift_logging_facts.elasticsearch.pvcs | length) or (openshift_logging_facts.elasticsearch.pvcs | length != es_indices | length) or (openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | count != es_indices | length)
 
 - include_role:


### PR DESCRIPTION
This PR adds pre-condition checks for two with_together loops in order to avoid cryptic error messages when with_together pads missing list members with Nones.

Before:

```
TASK [openshift_logging_elasticsearch : set_fact] ********************************************************************
fatal: [svvtocp1mastr01.vegvesen.no]: FAILED! => {"msg": "The conditional check 'openshift_logging_elasticsearch_deployment_name == \"\"' failed. The error was: error while evaluating conditional (openshift_logging_elasticsearch_deployment_name == \"\"): 'None' has no attribute 'name'\n\nThe error appears to be in '/usr/share/ansible/openshift-ansible/roles/openshift_logging_elasticsearch/tasks/main.yaml': line 470, column 3, but may\nbe elsewhere in the file depending
on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- set_fact:\n  ^ here\n"}
********************************************************************
```

After:

```
TASK [openshift_logging : fail] **********************************************************************************************
fatal: [master]: FAILED! => {"changed": false, "msg": "There should be the same number of ES DeploymentConfigs, ES PVCs and ES indices. Found ES DeploymentConfigs - \"[u'logging-es-data-master-cya0nlrl']\", ES PVCs - \"{u'logging-es-1': {}, u'logging-es-0': {}}\" and ES indices - \"[0]\""}

PLAY RECAP *******************************************************************************************************************
localhost                  : ok=11   changed=0    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
master                     : ok=127  changed=6    unreachable=0    failed=1    skipped=116  rescued=0    ignored=0   


INSTALLER STATUS *************************************************************************************************************
Initialization   : Complete (0:00:15)
Logging Install  : In Progress (0:00:27)
	This phase can be restarted by running: playbooks/openshift-logging/config.yml
[root@ansible ~]#
```