### PR TITLE
Bug 1772580: roles/openshift_master_certificates: Update bootstrap.kubeconfig

### DIFF
--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -253,3 +253,12 @@
     state: link
     force: yes
   when: ca_crt_stat.stat.isreg and not ca_bundle_stat.stat.exists
+
+- name: Update the default bootstrap kubeconfig for masters
+  copy:
+    remote_src: true
+    src: "/etc/origin/master/admin.kubeconfig"
+    dest: "{{ item }}"
+    mode: 0600
+  with_items:
+  - /etc/origin/node/bootstrap.kubeconfig


### PR DESCRIPTION
When redeploying master certificates, the master/admin.kubeconfig is
updated.  The master node needs the updated bootstrap.kubeconfig to
handle cases where the masters are rebootstrapped after a CA redeploy.