### PR TITLE
Bug 1791160: roles/openshift_master_certificates: Update node.kubeconfig

### DIFF
--- a/roles/openshift_master_certificates/tasks/main.yml
+++ b/roles/openshift_master_certificates/tasks/main.yml
@@ -262,3 +262,4 @@
     mode: 0600
   with_items:
   - /etc/origin/node/bootstrap.kubeconfig
+  - /etc/origin/node/node.kubeconfig


### PR DESCRIPTION
When redeploying master certificates, the master/admin.kubeconfig is
updated. The master node needs the updated node.kubeconfig to
prevent issues with pods using the node.kubeconfig (such as the sync
pod) from failing to authenticate to the API.