### PR TITLE
Bug 1884095: Update playbook to install NetworkManager-ovs

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -45,6 +45,7 @@ openshift_node_support_packages_base:
   #- toolbox
   - nfs-utils
   - NetworkManager
+  - NetworkManager-ovs
   - dnsmasq
   - lvm2
   - iscsi-initiator-utils


### PR DESCRIPTION
The ovn-kubernetes OpenShift network plugin requires NetworkManager-ovs
for initial node interface setup.

@trozet @openshift/networking @knobunc 