### PR TITLE
Bug 1882572: playbooks/container-runtime: Combine role import into one task

### DIFF
--- a/playbooks/container-runtime/private/config.yml
+++ b/playbooks/container-runtime/private/config.yml
@@ -3,9 +3,9 @@
 # l_etcd_scale_up_crt_hosts may be passed in via prerequisites.yml during etcd
 # scaleup plays.
 
-- hosts: "{{ l_etcd_scale_up_crt_hosts | default(l_scale_up_hosts) | default('oo_nodes_to_config') }}"
-  roles:
-    - role: container_runtime
+- name: Configure container runtime
+  hosts: "{{ l_etcd_scale_up_crt_hosts | default(l_scale_up_hosts) | default('oo_nodes_to_config') }}"
+
   tasks:
     - import_role:
         name: openshift_excluder
@@ -13,13 +13,7 @@
       vars:
         r_openshift_excluder_action: enable
         r_openshift_excluder_enable_openshift_excluder: false
+
     - import_role:
         name: container_runtime
-        tasks_from: package_docker.yml
-      when:
-        - not openshift_use_crio_only | bool
-    - import_role:
-        name: container_runtime
-        tasks_from: package_crio.yml
-      when:
-        - openshift_use_crio | bool
+        tasks_from: install.yml

--- a/roles/container_runtime/tasks/install.yml
+++ b/roles/container_runtime/tasks/install.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Install docker container runtime
+  include_tasks: package_docker.yml
+  when:
+    - not openshift_use_crio_only | bool
+
+- name: Install crio container runtime
+  include_tasks: package_crio.yml
+  when:
+    - openshift_use_crio | bool


### PR DESCRIPTION
When importing role tasks where handlers are in use, the handler does
not get called correctly.  The two includes have been combined into one
role task file so the role include only needs to be called once.