### PR TITLE
Bug 1757081: playbooks/openshift-etcd: Ensure etcd CA is present on first etcd host

### DIFF
--- a/playbooks/openshift-etcd/private/redeploy-certificates.yml
+++ b/playbooks/openshift-etcd/private/redeploy-certificates.yml
@@ -1,4 +1,12 @@
 ---
+- name: Ensure etcd CA is present on first etcd host
+  hosts: oo_first_etcd
+  any_errors_fatal: true
+  tasks:
+  - import_role:
+      name: etcd
+      tasks_from: verify_ca_certificates.yml
+
 - import_playbook: certificates-backup.yml
 
 - import_playbook: certificates.yml

--- a/roles/etcd/tasks/verify_ca_certificates.yml
+++ b/roles/etcd/tasks/verify_ca_certificates.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Determine if CA certificate directory exists
+  stat:
+    path: "{{ item }}"
+    get_checksum: false
+    get_attributes: false
+    get_mime: false
+  with_items:
+  - "{{ etcd_ca_dir }}/ca.crt"
+  - "{{ etcd_ca_dir }}/ca.key"
+  register: etcd_ca_dir_stat
+
+- name: Set fact etcd_ca_certs_missing
+  set_fact:
+    etcd_ca_certs_missing: "{{ False in (etcd_ca_dir_stat.results | default({})
+                                         | lib_utils_oo_collect(attribute='stat.exists')
+                                         | list ) }}"
+
+- name: Fail during etcd certificate redeploy if CA certificate directory contents missing
+  fail:
+    msg: >
+      Required files are missing from {{ etcd_ca_dir }} on {{ etcd_ca_host }}.
+      Please run playbooks/openshift-etcd/redeploy-ca.yml to ensure the CA exists before
+      running redeploy-certificates.yml.
+  when: etcd_ca_certs_missing


### PR DESCRIPTION
When redeploying certificates, the etcd CA must be present to allow
certs to be recreated.  This changes adds a task to check for the etcd
CA and fail if it is missing.