### PR TITLE
Bug 1836157: roles/openshift_peristent_volumes: Correct persistent-volume.yml template

### DIFF
--- a/roles/openshift_persistent_volumes/templates/persistent-volume.yml.j2
+++ b/roles/openshift_persistent_volumes/templates/persistent-volume.yml.j2
@@ -23,7 +23,11 @@ items:
     capacity:
       storage: "{{ volume.capacity }}"
     accessModes: {{ volume.access_modes | lib_utils_to_padded_yaml(2, 2) }}
-    {{ (volume.storage.keys() | list)[0] }}: {{ volume.storage[(volume.storage.keys() | list)[0]] | lib_utils_to_padded_yaml(3, 2) }}
+{% for key in (volume.storage.keys() | list) %}
+{% if key != 'claimName' %}
+    {{ key }}: {{ volume.storage[key] | lib_utils_to_padded_yaml(3, 2) }}
+{% endif %}
+{% endfor %}
 {% if 'claimName' in volume.storage %}
     claimRef:
       name: {{ volume.storage.claimName }}


### PR DESCRIPTION
Due to changes between Ansible 2.7 and 2.9 the order of keys when
templating is now an alphabatized list.  Updating the template to not
rely on the first item being the correct item to template.