### PR TITLE
ignore failed msg when running task Verify if the ca-bundle contains …

### DIFF
--- a/roles/openshift_named_certificates/tasks/main.yml
+++ b/roles/openshift_named_certificates/tasks/main.yml
@@ -70,9 +70,10 @@
   command: >
     openssl verify -CAfile /etc/origin/master/ca-bundle.crt "{{ named_certs_dir }}{{ item.certfile | basename }}"
   with_items: "{{ named_certificates }}"
-  ignore_errors: True
   register: ca_bundle_result
   when: named_certificates_ca_file_defined | length > 0
+  changed_when: false
+  failed_when: false
 
 - name: Append the custom ca to the bundle
   block:
@@ -98,5 +99,6 @@
       owner: root
       group: root
   when:
-  - not ca_bundle_result
+  - ca_bundle_result.results[0].rc is defined
+  - ca_bundle_result.results[0].rc != 0
   - named_certificates_ca_file_defined | length > 0


### PR DESCRIPTION
…the CA to trust the named certificate

Signed-off-by: Vladislav Walek <22072258+vwalek@users.noreply.github.com>

Adding additional fix for BZ#1882203 to ignore the message from task "Verify if the ca-bundle contains …".
The task shows the message as failed if the verification is not ok, causing failed task in the log. 
It could be interpreted as an issue by administrator, where it is only a check.