### PR TITLE
Bug 1812431: roles/openshift_control_plane: Verify local API health

### DIFF
--- a/roles/openshift_control_plane/handlers/main.yml
+++ b/roles/openshift_control_plane/handlers/main.yml
@@ -26,3 +26,21 @@
   retries: 120
   delay: 1
   changed_when: false
+
+- name: verify Local API server
+  # Using curl here since the uri module requires python-httplib2 and
+  # wait_for port doesn't provide health information.
+  command: >
+    curl --silent --tlsv1.2 --max-time 2
+    --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
+    {{ openshift.master.loopback_api_url }}/healthz/ready
+  args:
+    # Disables the following warning:
+    # Consider using get_url or uri module rather than running curl
+    warn: no
+  register: l_api_available_output
+  until: l_api_available_output.stdout == 'ok'
+  retries: 120
+  delay: 1
+  changed_when: false
+  listen: "verify API server"


### PR DESCRIPTION
When restarting services, verify the health of the local API server before proceeding.