### PR TITLE
add php 7.2 into 3.11 cause cuppet says 7.1 will no longer work with sclorg/cakephp-ex

### DIFF
--- a/roles/openshift_examples/files/examples/x86_64/image-streams/image-streams-rhel7.json
+++ b/roles/openshift_examples/files/examples/x86_64/image-streams/image-streams-rhel7.json
@@ -764,7 +764,7 @@
         "tags": [
           {
             "annotations": {
-              "description": "Build and run PHP applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.1/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of PHP available on OpenShift, including major versions updates.",
+              "description": "Build and run PHP applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.2/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of PHP available on OpenShift, including major versions updates.",
               "iconClass": "icon-php",
               "openshift.io/display-name": "PHP (Latest)",
               "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -774,7 +774,7 @@
             },
             "from": {
               "kind": "ImageStreamTag",
-              "name": "7.1"
+              "name": "7.2"
             },
             "name": "latest",
             "referencePolicy": {
@@ -857,6 +857,26 @@
               "name": "registry.redhat.io/rhscl/php-71-rhel7:latest"
             },
             "name": "7.1",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run PHP 7.2 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.2/README.md.",
+              "iconClass": "icon-php",
+              "openshift.io/display-name": "PHP 7.2",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/openshift/cakephp-ex.git",
+              "supports": "php:7.2,php",
+              "tags": "builder,php",
+              "version": "7.2"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.redhat.io/rhscl/php-72-rhel7:latest"
+            },
+            "name": "7.2",
             "referencePolicy": {
               "type": "Local"
             }

--- a/roles/openshift_examples/files/examples/x86_64/quickstart-templates/cakephp-mysql-persistent.json
+++ b/roles/openshift_examples/files/examples/x86_64/quickstart-templates/cakephp-mysql-persistent.json
@@ -466,11 +466,11 @@
             "value": "openshift"
         },
         {
-            "description": "Version of PHP image to be used (5.6, 7.0, 7.1 or latest).",
+            "description": "Version of PHP image to be used (7.2 or latest).",
             "displayName": "PHP Version",
             "name": "PHP_VERSION",
             "required": true,
-            "value": "7.1"
+            "value": "7.2"
         },
         {
             "description": "Maximum amount of memory the CakePHP container can use.",

--- a/roles/openshift_examples/files/examples/x86_64/quickstart-templates/cakephp-mysql.json
+++ b/roles/openshift_examples/files/examples/x86_64/quickstart-templates/cakephp-mysql.json
@@ -447,11 +447,11 @@
             "value": "openshift"
         },
         {
-            "description": "Version of PHP image to be used (5.6, 7.0, 7.1 or latest).",
+            "description": "Version of PHP image to be used (7.2 or latest).",
             "displayName": "PHP Version",
             "name": "PHP_VERSION",
             "required": true,
-            "value": "7.1"
+            "value": "7.2"
         },
         {
             "description": "Maximum amount of memory the CakePHP container can use.",


### PR DESCRIPTION
@bparees @cuppett per Steve's recent findings in working https://github.com/sclorg/cakephp-ex this is an update so that php / cakephp is functional, minimally in 3.11 PR e2e's 

WDYT?

@adambkaplan FYI