### PR TITLE
Bug 1894032: Force kuryr pods to be prioritized

### DIFF
--- a/roles/kuryr/templates/cni-daemonset.yaml.j2
+++ b/roles/kuryr/templates/cni-daemonset.yaml.j2
@@ -23,10 +23,9 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
+      priorityClassName: system-node-critical
       tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
+      - operator: Exists
       serviceAccountName: kuryr-controller
       initContainers:
       - name: install-cni-plugins

--- a/roles/kuryr/templates/controller-deployment.yaml.j2
+++ b/roles/kuryr/templates/controller-deployment.yaml.j2
@@ -28,6 +28,9 @@ spec:
     spec:
       serviceAccountName: kuryr-controller
       hostNetwork: true
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: Exists
       containers:
       - image: {{ openshift_openstack_kuryr_controller_image }}
         name: controller


### PR DESCRIPTION
This commit copies all the prioritization options that openshift-sdn
pods use to kuryr-kubernetes pods in order to make sure they will be
scheduled first and evicted last.