### PR TITLE
roles/openshift_version: Use only x.y version from first master

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -34,13 +34,7 @@
 
 - name: Ensure firewall is not switched during upgrade
   hosts: "{{ l_upgrade_no_switch_firewall_hosts | default('oo_all_hosts') }}"
-  vars:
-    openshift_master_installed_version: "{{ hostvars[groups.oo_first_master.0].openshift_current_version }}"
   tasks:
-  - name: set currently installed version
-    set_fact:
-      openshift_currently_installed_version: "{{ openshift_master_installed_version }}"
-
   - name: Get iptable service details
     systemd:
       name: "iptables"

--- a/roles/openshift_ca/tasks/main.yml
+++ b/roles/openshift_ca/tasks/main.yml
@@ -3,16 +3,6 @@
     msg: "Both 'certfile' and 'keyfile' keys must be supplied when configuring openshift_master_ca_certificate"
   when: openshift_master_ca_certificate is defined and ('certfile' not in openshift_master_ca_certificate or 'keyfile' not in openshift_master_ca_certificate)
 
-- name: Install the base package for admin tooling
-  package:
-    name: "{{ openshift_service_type }}{{ openshift_pkg_version | default('') | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
-    state: present
-  when: not hostvars[openshift_ca_host].openshift_is_atomic | bool
-  register: install_result
-  until: install_result is succeeded
-  delegate_to: "{{ openshift_ca_host }}"
-  run_once: true
-
 - name: Reload generated facts
   openshift_facts:
     system_facts: "{{ vars_openshift_facts_system_facts }}"

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -7,6 +7,8 @@
   until: result is succeeded
   vars:
     pkg_list:
+    - "{{ openshift_service_type }}{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
+    - "{{ openshift_service_type }}-hyperkube{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
     - "{{ openshift_service_type }}-node{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
     - "{{ openshift_service_type }}-clients{{ (openshift_pkg_version | default('')) | lib_utils_oo_image_tag_to_rpm_version(include_dash=True) }}"
     - conntrack-tools

--- a/roles/openshift_version/tasks/first_master.yml
+++ b/roles/openshift_version/tasks/first_master.yml
@@ -5,7 +5,7 @@
 # openshift_version already.
 - name: Use openshift_current_version fact as version to configure if already installed
   set_fact:
-    openshift_version: "{{ openshift_current_version }}"
+    openshift_version: "{{ openshift_current_version | regex_search('^\\d+\\.\\d+') }}"
   when:
   - openshift_current_version is defined
   - openshift_version is not defined or openshift_version == ""


### PR DESCRIPTION
The base package (atomic-openshift) is installed during upgrades but
should be installed during install as the openshift binary is used for
determining the version of openshift installed on a cluster. Only the
X.Y part of the discovered version should be used to prevent unintended
refspec changes during various playbook execution.  For instance, the
inventory may only specify openshift_release="3.11" without any
openshift_image_tag setting.

- Update openshift_version to X.Y if already installed
- Add atomic-openshift install to openshift_node install task
- Add atomic-openshift-hyperkube to node install to match upgrade
- Remove redundant atomic-openshift install in openshift_ca role
- Remove unused var openshift_currently_installed_version