### PR TITLE
add php 7.2 into 3.11 cause cuppet says 7.1 will no longer work with sclorg/cakephp-ex (centos as with for CI/e2e testing)

### DIFF
--- a/roles/openshift_examples/files/examples/x86_64/image-streams/image-streams-centos7.json
+++ b/roles/openshift_examples/files/examples/x86_64/image-streams/image-streams-centos7.json
@@ -813,7 +813,7 @@
         "tags": [
           {
             "annotations": {
-              "description": "Build and run PHP applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.1/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of PHP available on OpenShift, including major versions updates.",
+              "description": "Build and run PHP applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.2/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of PHP available on OpenShift, including major versions updates.",
               "iconClass": "icon-php",
               "openshift.io/display-name": "PHP (Latest)",
               "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -823,7 +823,7 @@
             },
             "from": {
               "kind": "ImageStreamTag",
-              "name": "7.1"
+              "name": "7.2"
             },
             "name": "latest",
             "referencePolicy": {
@@ -906,6 +906,26 @@
               "name": "docker.io/centos/php-71-centos7:latest"
             },
             "name": "7.1",
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "annotations": {
+              "description": "Build and run PHP 7.2 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.2/README.md.",
+              "iconClass": "icon-php",
+              "openshift.io/display-name": "PHP 7.2",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/openshift/cakephp-ex.git",
+              "supports": "php:7.2,php",
+              "tags": "builder,php",
+              "version": "7.2"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "docker.io/centos/php-72-centos7:latest"
+            },
+            "name": "7.2",
             "referencePolicy": {
               "type": "Local"
             }


### PR DESCRIPTION
turns out just updating the rhel imagestreams in https://github.com/openshift/openshift-ansible/pull/12258 was insufficient

openshift/origin CI installs via openshift-ansible the centos image streams ..... see https://github.com/openshift/origin/pull/25661#issuecomment-721837899

/assign @bparees 
/assign @mtnbikenc 

@cuppett @adambkaplan fyi