### PR TITLE
Bug 1888962: roles/openshift_node: Update NetworkManager conf.d default

### DIFF
--- a/roles/openshift_node/tasks/dnsmasq/network-manager.yml
+++ b/roles/openshift_node/tasks/dnsmasq/network-manager.yml
@@ -20,6 +20,6 @@
   with_items:
     - key: dns
       value: none
-      present: "{{ openshift_node_dnsmasq_disable_network_manager_dns | default(false) | bool }}"
+      present: "{{ openshift_node_dnsmasq_disable_network_manager_dns | default(true) | bool }}"
 
 - meta: flush_handlers


### PR DESCRIPTION
Setting conf.d default to dns=none to prevent NetworkManager from
updating resolv.conf due to race conditions discovered on RHEL7.9.