### PR TITLE
Bug 1880784: Fail if cafile is not defined in named certificates

### DIFF
--- a/roles/openshift_named_certificates/tasks/main.yml
+++ b/roles/openshift_named_certificates/tasks/main.yml
@@ -58,6 +58,14 @@
   set_fact:
     named_certificates_ca_file_defined: "{{ named_certificates | lib_utils_oo_collect('cafile')}}"
 
+- name: Show message if the cafile is not configured
+  fail:
+    msg: "The cafile is not configured in the openshift_named_certificates. With cafile the cluster's components will trust the named certificate signer."
+  when:
+  - named_certificates_ca_file_defined | length <= 0
+  - openshift_named_certificate_omit_cafile == false
+  run_once: true
+
 - name: Land named CA certificates
   copy:
     src: "{{ item }}"

--- a/roles/openshift_named_certificates/vars/main.yml
+++ b/roles/openshift_named_certificates/vars/main.yml
@@ -3,3 +3,4 @@ overwrite_named_certs: "{{ openshift_master_overwrite_named_certificates | defau
 named_certs_dir: "{{ openshift.common.config_base }}/master/named_certificates/"
 internal_hostnames: "{{ openshift.common.internal_hostnames }}"
 named_certificates: "{{ openshift_master_named_certificates | default([]) }}"
+openshift_named_certificate_omit_cafile: false


### PR DESCRIPTION
Adding the PR for [BZ#1880784](https://bugzilla.redhat.com/show_bug.cgi?id=1880784) 