### PR TITLE
playbooks/openshift-hosted: Use 'command' and tidy conditionals

### DIFF
--- a/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-registry-certificates.yml
@@ -38,14 +38,18 @@
 
   # Replace dc/docker-registry environment variable certificate data if set.
   - name: Update docker-registry environment variables
-    shell: >
+    command: >
       {{ openshift_client_binary }} set env dc/docker-registry
       OPENSHIFT_CA_DATA="$(cat /etc/origin/master/ca.crt)"
       OPENSHIFT_CERT_DATA="$(cat /etc/origin/master/openshift-registry.crt)"
       OPENSHIFT_KEY_DATA="$(cat /etc/origin/master/openshift-registry.key)"
       --config={{ mktemp.stdout }}/admin.kubeconfig
       -n default
-    when: l_docker_registry_dc.rc == 0 and 'OPENSHIFT_CA_DATA' in docker_registry_env_vars and 'OPENSHIFT_CERT_DATA' in docker_registry_env_vars and 'OPENSHIFT_KEY_DATA' in docker_registry_env_vars
+    when:
+    - l_docker_registry_dc.rc == 0
+    - ('OPENSHIFT_CA_DATA' in docker_registry_env_vars)
+    - ('OPENSHIFT_CERT_DATA' in docker_registry_env_vars)
+    - ('OPENSHIFT_KEY_DATA' in docker_registry_env_vars)
 
   # Replace dc/docker-registry certificate secret contents if set.
   - block:

--- a/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
+++ b/playbooks/openshift-hosted/private/redeploy-router-certificates.yml
@@ -51,7 +51,7 @@
     when: l_router_svc.rc == 0
 
   - name: Update router environment variables
-    shell: >
+    command: >
       {{ openshift_client_binary }} set env dc/router
       OPENSHIFT_CA_DATA="$(cat /etc/origin/master/ca.crt)"
       OPENSHIFT_CERT_DATA="$(cat /etc/origin/master/openshift-router.crt)"


### PR DESCRIPTION
The 'command' module is more secure than 'shell' which is unecessary in
these tasks.  Convert conditionals to list for consistency.