### PR TITLE
Bug 1895309: roles/openshift_node: Allow newer cri-o version

### DIFF
--- a/images/installer/root/usr/local/bin/entrypoint-provider
+++ b/images/installer/root/usr/local/bin/entrypoint-provider
@@ -25,8 +25,6 @@ if ! whoami &>/dev/null; then
 fi
 
 mkdir -p "${WORK}/inventory/dynamic/${TYPE}/group_vars/all"
-# Override cluster version check when running in CI
-echo "ci_version_override: true" > "${WORK}/inventory/dynamic/${TYPE}/group_vars/all/ci_version_override.yml"
 # Add any injected variable files into the group vars directory
 find "${FILES}" \( -name '*.yml' -or -name '*.yaml' -or -name vars \) -print0 | xargs -0 -L1 -I {} ln -fs {} "${WORK}/inventory/dynamic/${TYPE}/group_vars/all"
 # Avoid sudo when running locally - nothing in the image requires it.

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -10,7 +10,7 @@ openshift_node_bootstrap_server: "{{ openshift_node_kubeconfig.clusters.0.cluste
 openshift_node_bootstrap_endpoint: "{{ openshift_node_bootstrap_server }}/config/{{ openshift_node_machineconfigpool }}"
 
 openshift_node_packages:
-  - cri-o-{{ l_kubernetes_version }}.*
+  - cri-o-{{ crio_latest }}
   - openshift-clients-{{ l_cluster_version }}*
   - openshift-hyperkube-{{ l_cluster_version }}*
   - podman

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -51,15 +51,11 @@
   register: oc_get
   until:
   - oc_get.stdout != ''
+  changed_when: false
 
 - name: Set fact l_cluster_version
   set_fact:
     l_cluster_version: "{{ oc_get.stdout | regex_search('^\\d+\\.\\d+') }}"
-
-- name: Override cluster version when running CI
-  set_fact:
-    l_cluster_version: "*"
-  when: ci_version_override | default(false) | bool == true
 
 - name: Get kubernetes server version
   command: >
@@ -70,15 +66,28 @@
   register: oc_get
   until:
   - oc_get.stdout != ''
+  changed_when: false
 
-- name: Set fact l_kubernetes_version
+- name: Set fact l_kubernetes_server_version
   set_fact:
-    l_kubernetes_version: "{{ (oc_get.stdout | from_json).serverVersion.major ~ '.' ~  (oc_get.stdout | from_json).serverVersion.minor | regex_search('^\\d+') }}"
+    l_kubernetes_server_version: "{{ (oc_get.stdout | from_json).serverVersion.major ~ '.' ~  (oc_get.stdout | from_json).serverVersion.minor | regex_search('^\\d+') }}"
 
-- name: Override kubernetes version when running CI
+- name: Get available cri-o RPM versions
+  package:
+    list: cri-o
+  register: crio_version
+
+- name: Set fact crio_latest
   set_fact:
-    l_kubernetes_version: "*"
-  when: ci_version_override | default(false) | bool == true
+    crio_latest: "{{ crio_version.results | selectattr('yumstate', 'match', 'available') | map(attribute='version') | list | last }}"
+
+- name: Fail if cri-o is less than current kubernetes server version
+  fail:
+    msg: >
+      Latest available cri-o ({{ crio_latest }}) version is less than current
+      kubernetes server version ({{ l_kubernetes_server_version }}).
+  when:
+  - crio_latest is version(l_kubernetes_server_version, 'lt')
 
 - block:
   - name: Install openshift packages

--- a/roles/openshift_node/tasks/scaleup_checks.yml
+++ b/roles/openshift_node/tasks/scaleup_checks.yml
@@ -18,6 +18,7 @@
   - oc_get.stdout != ''
   retries: 36
   delay: 5
+  changed_when: false
 
 - name: Check for nodes which are already part of the cluster
   set_fact:


### PR DESCRIPTION
Changed the logic to ensure the available cri-o RPM version is not less than the current kubernetes cluster version.

Removed ci_version_override variable as it should no longer be necessary for CI.