### PR TITLE
Bug 1777061: playbooks/init: Refresh master facts during init

### DIFF
--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -24,7 +24,7 @@
     - "groups.oo_first_master | length > 0"
     - "'openshift_portal_net' in hostvars[groups.oo_first_master.0]"
 
-  - name: Gather Cluster facts
+  - name: Gather Common Cluster facts
     openshift_facts:
       role: common
       system_facts: "{{ vars_openshift_facts_system_facts }}"
@@ -38,6 +38,11 @@
         no_proxy: "{{ openshift_no_proxy | default(None) }}"
         generate_no_proxy_hosts: "{{ openshift_generate_no_proxy_hosts | default(True) }}"
         cloudprovider: "{{ openshift_cloudprovider_kind | default(None) }}"
+
+  - name: Gather Master facts
+    include_role:
+      name: openshift_master_facts
+    when: inventory_hostname in groups['oo_masters']
 
   - name: Set fact of no_proxy_internal_hostnames
     openshift_facts:

--- a/playbooks/init/main.yml
+++ b/playbooks/init/main.yml
@@ -30,9 +30,9 @@
 - import_playbook: base_packages.yml
   when: l_install_base_packages | default(False) | bool
 
-- import_playbook: cluster_facts.yml
-
 - import_playbook: version.yml
+
+- import_playbook: cluster_facts.yml
 
 - import_playbook: sanity_checks.yml
   when: not (skip_sanity_checks | default(False))


### PR DESCRIPTION
In some cases the /etc/ansible/facts.d/openshift.fact file might be
missing on masters, which can cause failures due to undefined master
facts.  Refreshing the master facts during initialization will ensure
master facts are properly set even if the openshift.fact file is
missing.