### PR TITLE
Bug 1860906: openshift-cluster/upgrades: Allow short nodes names when filtering

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
@@ -31,8 +31,16 @@
       with_items: " {{ groups['oo_nodes_to_config'] }}"
       when:
       - hostvars[item].openshift is defined
-      - hostvars[item].openshift.node.nodename | lower in nodes_to_upgrade.module_results.results[0]['items'] | map(attribute='metadata.name') | list
+      # normalize on short name
+      - (hostvars[item].openshift.node.nodename | lower).split(".")[0] in nodes_to_upgrade.module_results.results[0]['items'] | map(attribute='metadata.name') | map("regex_replace","(^[^\.]+)(\..*$)?","\\1") | list
       changed_when: false
+
+    # Make sure the filtering based on hostname worked
+    # to avoid issues as seen in https://bugzilla.redhat.com/show_bug.cgi?id=1649074
+    - name: Fail if temp_nodes_to_upgrade is empty with openshift_upgrade_nodes_label
+      fail:
+        msg: "openshift_upgrade_nodes_label was specified but no nodes matched after filtering (check the hostnames of the node)"
+      when: ( groups["temp_nodes_to_upgrade"] | default([])) | length == 0
 
   # Build up the oo_nodes_to_upgrade group, use the list filtered by label if
   # present, otherwise hit all nodes:


### PR DESCRIPTION
When filtering the list of nodes to upgrade based on using the
openshift_upgrade_nodes_label variable, the node names may not match if
the kubelet returns the short node name.

 - `hostname` = fqdn          (infra-0.example.com)
 - `hostname -f` = fqdn       (infra-0.example.com)
 - `hostnamectl` = fqdn       (infra-0.example.com)
 - `oc get node` = short name (infra-0)

This changes the filter to test if the short host name is in the node
name returned by the kubelet.  The playbook will also fail if the
filtering results in no hosts to prevent unknowingly upgrading all
nodes.