### PR TITLE
playbooks/init: Fix GCP job when oo_masters is not defined

### DIFF
--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -42,7 +42,7 @@
   - name: Gather Master facts
     include_role:
       name: openshift_master_facts
-    when: inventory_hostname in groups['oo_masters']
+    when: inventory_hostname in groups['oo_masters'] | default ([])
 
   - name: Set fact of no_proxy_internal_hostnames
     openshift_facts:


### PR DESCRIPTION
https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-origin-release-3.11-e2e-gcp

In no real world case would oo_masters be undefined.  This only happens because of the way the GCP jobs piecemeal the cluster setup by calling individual playbooks.