### PR TITLE
Bug 1880784: playbooks/init: Validate openshift_master_named_certificates

### DIFF
--- a/playbooks/init/main.yml
+++ b/playbooks/init/main.yml
@@ -40,6 +40,8 @@
 - import_playbook: validate_aci_params.yml
   when: openshift_use_aci | default(false) | bool
 
+- import_playbook: validate_cert_params.yml
+
 - name: Initialization Checkpoint End
   hosts: all
   gather_facts: false

--- a/playbooks/init/validate_cert_params.yml
+++ b/playbooks/init/validate_cert_params.yml
@@ -1,0 +1,14 @@
+---
+- name: Validate certificate configuration
+  hosts: oo_first_master
+  tasks:
+  - name: Fail if the cafile is not configured when using openshift_master_named_certificates
+    fail:
+      msg: >
+        The cafile is not configured in openshift_named_certificates. The cafile must be
+        configured for the cluster's components to trust the named certificate signer. Set
+        'openshift_named_certificate_omit_cafile=true' to skip this error.
+    when:
+    - openshift_master_named_certificates | default([]) | length != 0
+    - openshift_master_named_certificates | default([]) | lib_utils_oo_collect('cafile') | length == 0
+    - not openshift_named_certificate_omit_cafile | default(false)


### PR DESCRIPTION
openshift_master_named_certificates must contain the cafile for the
cluster's components to trust the named certificate signer.

Alternative to: #12264