### PR TITLE
Expose custom URL configuration for openshift-cluster-monitoring

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/defaults/main.yml
+++ b/roles/openshift_cluster_monitoring_operator/defaults/main.yml
@@ -77,3 +77,7 @@ openshift_cluster_monitoring_operator_alertmanager_config: |+
   receivers:
   - name: default
   - name: deadmansswitch
+
+openshift_cluster_monitoring_prometheus_external_url: ""
+openshift_cluster_monitoring_alertmanager_external_url: ""
+openshift_cluster_monitoring_grafana_external_url: ""

--- a/roles/openshift_cluster_monitoring_operator/files/cluster-monitoring-operator.yaml
+++ b/roles/openshift_cluster_monitoring_operator/files/cluster-monitoring-operator.yaml
@@ -47,7 +47,7 @@ objects:
     resources: [daemonsets, deployments]
     verbs: [create, delete, get, list, update, watch]
   - apiGroups: [route.openshift.io]
-    resources: [routes]
+    resources: [routes, routes/custom-host]
     verbs: [create, delete, get, list, update, watch]
   - apiGroups: [security.openshift.io]
     resources: [securitycontextconstraints]

--- a/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-config.j2
+++ b/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-config.j2
@@ -38,6 +38,9 @@ data:
             requests:
               storage: {{ openshift_cluster_monitoring_operator_prometheus_storage_capacity }}
 {% endif %}
+{% if openshift_cluster_monitoring_prometheus_external_url %}
+      hostport: {{ openshift_cluster_monitoring_prometheus_external_url }}
+{% endif %}
     alertmanagerMain:
       baseImage: {{ openshift_cluster_monitoring_operator_alertmanager_repo }}
 {% if openshift_cluster_monitoring_operator_node_selector is iterable and openshift_cluster_monitoring_operator_node_selector | length > 0 %}
@@ -56,6 +59,9 @@ data:
             requests:
               storage: {{ openshift_cluster_monitoring_operator_alertmanager_storage_capacity }}
 {% endif %}
+{% if openshift_cluster_monitoring_alertmanager_external_url %}
+      hostport: {{ openshift_cluster_monitoring_alertmanager_external_url }}
+{% endif %}
     nodeExporter:
       baseImage: {{ openshift_cluster_monitoring_operator_node_exporter_repo }}
     grafana:
@@ -65,6 +71,9 @@ data:
 {% for key, value in openshift_cluster_monitoring_operator_node_selector.items() %}
         {{ key }}: "{{ value }}"
 {% endfor %}
+{% endif %}
+{% if openshift_cluster_monitoring_grafana_external_url %}
+      hostport: {{ openshift_cluster_monitoring_grafana_external_url }}
 {% endif %}
     kubeStateMetrics:
       baseImage: {{ openshift_cluster_monitoring_operator_kube_state_metrics_image }}


### PR DESCRIPTION
The cluster-monitoring-operator supports configuring custom host names for Prometheus, Alertmanager, and Grafana, but the respective configuration options are not exposed by the openshift-cluster-monitoring role.

This commit introduces variables `openshift_cluster_monitoring_prometheus_external_url`, `openshift_cluster_monitoring_alertmanager_external_url`, and `openshift_cluster_monitoring_grafana_external_url`, which can be used to configure non-standard hostnames for Prometheus, Alertmanager, and Grafana respectively.

The cluster-monitoring-operator provides a field called `hostport` in each service configuration, which is used to set the host on the route objects for the services, and also the `externalUrl` field in the Prometheus and Alertmanager custom resources.

To allow the cluster-monitoring-operator to configure a non-standard host name on the routes, we need to grant it the RBAC permission `routes/custom-host`.

This commit does this by adding the permission in the cluster-monitoring-operator's ClusterRole.