### PR TITLE
roles/openshift_facts: Set quay.io as default registry

### DIFF
--- a/roles/cockpit-ui/defaults/main.yml
+++ b/roles/cockpit-ui/defaults/main.yml
@@ -5,7 +5,7 @@ l_os_cockpit_image_version_dict:
   openshift-enterprise: "{{ openshift_image_tag }}"
 l_os_cockpit_image_version: "{{ l_os_cockpit_image_version_dict[openshift_deployment_type] }}"
 
-l_os_cockpit_registry_url: "{{ openshift_facts_registry_url | replace('docker.io','registry.access.redhat.com') }}"
+l_os_cockpit_registry_url: "{{ openshift_facts_registry_url | replace('quay.io','registry.access.redhat.com') }}"
 
 l_os_cockpit_image_format: "{{ l_os_cockpit_registry_url | regex_replace('${version}' | regex_escape, l_os_cockpit_image_version) }}"
 

--- a/roles/cockpit-ui/tasks/install.yml
+++ b/roles/cockpit-ui/tasks/install.yml
@@ -47,6 +47,13 @@
     tls_termination: passthrough
   register: registry_console_cockpit_kube
 
+- name: Create /etc/rhsm/ca/redhat-uep.pem
+  file:
+    path: /etc/rhsm/ca/redhat-uep.pem
+    state: touch
+  delegate_to: "{{ item }}"
+  with_items: "{{ groups.oo_masters_to_config | default([]) }}"
+
 - name: Deploy registry-console
   shell: >
     {{ openshift_client_binary }} process openshift//registry-console

--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -3,11 +3,11 @@ openshift_client_binary: "{{ (openshift_is_atomic | bool) | ternary('/usr/local/
 
 system_images_registry_dict:
   openshift-enterprise: "registry.redhat.io"
-  origin: "docker.io"
+  origin: "quay.io"
 system_images_registry: "{{ system_images_registry_dict[openshift_deployment_type | default('origin')] }}"
 
 l_default_registry_url_dict:
-  origin: 'docker.io/openshift/origin-${component}:${version}'
+  origin: 'quay.io/openshift/origin-${component}:${version}'
   openshift-enterprise: 'registry.redhat.io/openshift3/ose-${component}:${version}'
 openshift_facts_default_registry_url: "{{ l_default_registry_url_dict[openshift_deployment_type] }}"
 


### PR DESCRIPTION
quay.io/openshift provides necessary images without pull limits.  Some
images may still be pulled from docker.io.

Added a task to create redhat-uep.pem file for proper pulling the
registry-console image from registry.access.redhat.com.

Non quay.io images after a fresh install:
```
$ oc get pods --all-namespaces -o json | grep -e '\"image\":' | grep -v "quay.io" | sort | uniq         
                        "image": "docker.io/ansibleplaybookbundle/origin-ansible-service-broker:v3.11",
                        "image": "docker.io/grafana/grafana:5.2.1",
                        "image": "docker.io/openshift/oauth-proxy:v1.1.0",
                        "image": "docker.io/openshift/prometheus-alertmanager:v0.15.2",
                        "image": "docker.io/openshift/prometheus-node-exporter:v0.16.0",
                        "image": "docker.io/openshift/prometheus:v2.3.2",
                        "image": "grafana/grafana:5.2.1",
                        "image": "openshift/oauth-proxy:v1.1.0",
                        "image": "openshift/prometheus-alertmanager:v0.15.2",
                        "image": "openshift/prometheus-node-exporter:v0.16.0",
                        "image": "openshift/prometheus:v2.3.2",
                        "image": "registry.access.redhat.com/openshift3/registry-console:v3.11",
```

Fixes #12276
Fixes #12115