### PR TITLE
Bug 1902067: playbooks/openshift-node: Remove restart from join.yml

### DIFF
--- a/playbooks/openshift-node/private/join.yml
+++ b/playbooks/openshift-node/private/join.yml
@@ -107,11 +107,6 @@
 
 - import_playbook: contrail_sanitize.yml
 
-- import_playbook: restart.yml
-  vars:
-    openshift_node_restart_docker_required: true
-    openshift_node_restart_drain: true
-
 - name: Node Join Checkpoint End
   hosts: all
   gather_facts: false

--- a/playbooks/redeploy-certificates.yml
+++ b/playbooks/redeploy-certificates.yml
@@ -26,6 +26,12 @@
 - import_playbook: openshift-node/private/join.yml
   when: openshift_redeploy_openshift_ca | default(false) | bool
 
+- import_playbook: openshift-node/private/restart.yml
+  when: openshift_redeploy_openshift_ca | default(false) | bool
+  vars:
+    openshift_node_restart_docker_required: true
+    openshift_node_restart_drain: true
+
 - import_playbook: openshift-hosted/private/redeploy-router-certificates.yml
   when: openshift_hosted_manage_router | default(true) | bool
 


### PR DESCRIPTION
Node restart is removed from node join.yml playbook and added to the
redeploy-certificates.yml playbook.  The restart is required for
updating the SDN pods when the openshift CA is redeployed, but was
interfering with fresh installs in some situations.