### PR TITLE
Reorder the when checks to take into account the case that the named …

### DIFF
--- a/roles/openshift_named_certificates/tasks/main.yml
+++ b/roles/openshift_named_certificates/tasks/main.yml
@@ -99,6 +99,6 @@
       owner: root
       group: root
   when:
+  - named_certificates_ca_file_defined | length > 0
   - ca_bundle_result.results[0].rc is defined
   - ca_bundle_result.results[0].rc != 0
-  - named_certificates_ca_file_defined | length > 0


### PR DESCRIPTION
…certificates are not used to avoid the failure.

It is necessary to put `named_certificates_ca_file_defined | length > 0` as first check to first check if the named certificates are being used, otherwise the `ca_bundle_result.results[0].rc is defined` check will fail due the ` ca_bundle_result.results` list will be empty in this case.