### PR TITLE
Bug 1879407: Correctly use ops cluster size if evaluating es-ops component for restart

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml
@@ -1,4 +1,8 @@
 ---
+## determine which cluster size to use
+- set_fact:
+    _component_cluster_size: "{{ openshift_logging_es_ops_cluster_size if _cluster_component == 'es-ops' else openshift_logging_es_cluster_size }}"
+
 ## get all pods for the cluster
 - command: >
     {{ openshift_client_binary }}
@@ -12,7 +16,7 @@
   delay: 5
   until:
   - _cluster_pods.stdout is defined
-  - _cluster_pods.stdout == "" or _cluster_pods.stdout.split(' ') | count == openshift_logging_es_cluster_size
+  - _cluster_pods.stdout == "" or _cluster_pods.stdout.split(' ') | count == _component_cluster_size
 
 # make a temp dir for admin certs
 - command: mktemp -d /tmp/openshift-logging-ansible-XXXXXX


### PR DESCRIPTION
This PR passes the evaluates and uses the ops cluster size if the `_cluster_component` is `'es-ops'` for the case that the ops and non-ops clusters are not the same size.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1879407