### PR TITLE
Bug 1873346: Support upgrades of Kuryr compoments

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_control_plane_part2.yml
@@ -90,6 +90,14 @@
   - role: openshift_sdn
     when: openshift_use_openshift_sdn | default(True) | bool
 
+- name: Configure kuryr components that must be available prior to upgrade
+  hosts: oo_first_master
+  tasks:
+  - import_role:
+      name: kuryr
+      tasks_from: master.yaml
+    when: openshift_use_kuryr | default(False) | bool
+
 - import_playbook: ../upgrade_control_plane.yml
   vars:
     openshift_release: '3.11'

--- a/roles/kuryr/tasks/upgrade.yaml
+++ b/roles/kuryr/tasks/upgrade.yaml
@@ -1,0 +1,14 @@
+---
+- name: Delete OpenShift Kuryr pods prior to upgrade
+  shell: >
+    {{ openshift_client_binary }} get pods
+    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    --field-selector=spec.nodeName={{ l_kubelet_node_name | lower }}
+    -o json
+    -n {{ kuryr_namespace }} |
+    {{ openshift_client_binary }} delete
+    --config={{ openshift.common.config_base }}/master/admin.kubeconfig
+    --force
+    --grace-period=0
+    -f -
+  delegate_to: "{{ groups.oo_first_master.0 }}"

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -9,6 +9,11 @@
 
 - import_tasks: sdn_delete.yml
 
+- import_role:
+    name: kuryr
+    tasks_from: upgrade.yaml
+  when: openshift_use_kuryr | default(False) | bool
+
 - name: stop services for upgrade
   import_tasks: upgrade/stop_services.yml
 


### PR DESCRIPTION
This commit adds support to the upgrade of Kuryr CNI
and controller. It ensures Kuryr manifests are re-applied
with the correct version of the Kuryr controller and CNI
image and delete the CNI pods to enforce the new image.