### PR TITLE
Bug 1915760: Increase node ready wait to 10 minutes

### DIFF
--- a/roles/openshift_node/tasks/apply_machine_config.yml
+++ b/roles/openshift_node/tasks/apply_machine_config.yml
@@ -95,8 +95,8 @@
     register: oc_get
     until:
     - oc_get.stdout == "True"
-    retries: 36
-    delay: 5
+    retries: 30
+    delay: 20
     changed_when: false
 
   rescue:

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -202,8 +202,8 @@
     register: oc_get
     until:
     - oc_get.stdout == "True"
-    retries: 36
-    delay: 5
+    retries: 30
+    delay: 20
     changed_when: false
 
   rescue:


### PR DESCRIPTION
On some platforms nodes are taking longer to become ready.