### PR TITLE
Bug 1921353: [release-3.11] Gather cluster_facts after version.yml during upgrade

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -7,7 +7,6 @@
 
 - import_playbook: ../../../init/basic_facts.yml
 - import_playbook: ../../../init/base_packages.yml
-- import_playbook: ../../../init/cluster_facts.yml
 
 - name: Inspect cluster certificates
   hosts: "{{ l_upgrade_cert_check_hosts }}"

--- a/playbooks/common/openshift-cluster/upgrades/pre/config.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/config.yml
@@ -34,6 +34,8 @@
     # openshift_protect_installed_version is passed n via upgrade_control_plane.yml
     # l_openshift_version_set_hosts is passed via upgrade_control_plane.yml
 
+- import_playbook: ../../../../init/cluster_facts.yml
+
 - name: OpenShift Health Checks
   hosts: "{{ l_upgrade_health_check_hosts }}"
   any_errors_fatal: true


### PR DESCRIPTION
cluster_facts.yml requires openshift_release to be set.  If
openshift_release is not set in the inventory, cluster_facts.yml needs
to be run after openshift_release has been defined by the upgrade
playbook and the openshift_version role has been run.