### PR TITLE
Bug 1879407: Adding int typecasting for _component_cluster_size

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/restart_cluster.yml
@@ -16,7 +16,7 @@
   delay: 5
   until:
   - _cluster_pods.stdout is defined
-  - _cluster_pods.stdout == "" or _cluster_pods.stdout.split(' ') | count == _component_cluster_size
+  - _cluster_pods.stdout == "" or _cluster_pods.stdout.split(' ') | count == _component_cluster_size | int
 
 # make a temp dir for admin certs
 - command: mktemp -d /tmp/openshift-logging-ansible-XXXXXX


### PR DESCRIPTION
In openshift_logging_elasticsearch handler task for restarting cluster, we had updated to switch between the different cluster size based on the component we were restarting. However, it was now doing a comparison between an `int` and a `string` rather than an `int` and an `int` like previously.

This adds a typecasting to evaluate it as `int == int`.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1879407

/cc @blockloop @anpingli 