### PR TITLE
Bug 1933090: Move node fact initialization to basic_facts.yml

### DIFF
--- a/playbooks/init/basic_facts.yml
+++ b/playbooks/init/basic_facts.yml
@@ -16,6 +16,17 @@
     import_role:
       name: openshift_sanitize_inventory
 
+  - name: Initialize openshift.node.sdn_mtu
+    openshift_facts:
+      role: node
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
+      local_facts:
+        sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
+
+  - name: set_fact l_kubelet_node_name
+    set_fact:
+      l_kubelet_node_name: "{{ openshift_kubelet_name_override | default(openshift.node.nodename) }}"
+
   - name: Detecting Operating System from ostree_booted
     stat:
       path: /run/ostree-booted

--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -63,16 +63,6 @@
     - openshift_http_proxy is defined or openshift_https_proxy is defined
     - openshift_generate_no_proxy_hosts | default(True) | bool
 
-  - name: Initialize openshift.node.sdn_mtu
-    openshift_facts:
-      role: node
-      system_facts: "{{ vars_openshift_facts_system_facts }}"
-      local_facts:
-        sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
-  - name: set_fact l_kubelet_node_name
-    set_fact:
-      l_kubelet_node_name: "{{ openshift_kubelet_name_override | default(openshift.node.nodename) }}"
-
 - name: Initialize etcd host variables
   hosts: oo_masters_to_config
   roles:


### PR DESCRIPTION
Facts such as l_kubelet_node_name need to be set earlier during upgrades
for proper node upgrade playbook execution.