### PR TITLE
Bug 1917013: Evaluate oo_nodes_to_upgrade before pre/config

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/pre/config.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/config.yml
@@ -3,7 +3,6 @@
 # why may affect the tasks here and in imported playbooks.
 
 # Pre-upgrade
-- import_playbook: ../initialize_nodes_to_upgrade.yml
 
 - name: Update repos on upgrade hosts
   hosts: "{{ l_upgrade_repo_hosts }}"

--- a/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_nodes.yml
+++ b/playbooks/common/openshift-cluster/upgrades/v3_11/upgrade_nodes.yml
@@ -16,14 +16,16 @@
       openshift_upgrade_min: '3.10'
       openshift_release: '3.11'
 
+- import_playbook: ../initialize_nodes_to_upgrade.yml
+
 - import_playbook: ../pre/config.yml
   vars:
-    l_upgrade_repo_hosts: "oo_nodes_to_config"
+    l_upgrade_repo_hosts: "oo_nodes_to_upgrade"
     l_upgrade_no_proxy_hosts: "oo_all_hosts"
-    l_upgrade_health_check_hosts: "oo_nodes_to_config"
-    l_upgrade_verify_targets_hosts: "oo_nodes_to_config"
-    l_upgrade_docker_target_hosts: "oo_nodes_to_config"
-    l_upgrade_excluder_hosts: "oo_nodes_to_config:!oo_masters_to_config"
+    l_upgrade_health_check_hosts: "oo_nodes_to_upgrade"
+    l_upgrade_verify_targets_hosts: "oo_nodes_to_upgrade"
+    l_upgrade_docker_target_hosts: "oo_nodes_to_upgrade"
+    l_upgrade_excluder_hosts: "oo_nodes_to_upgrade:!oo_masters_to_config"
     l_upgrade_nodes_only: True
 
 # Need to run sanity checks after version has been run.


### PR DESCRIPTION
The openshift_upgrade_nodes_label inventory variable allows limiting the
node upgrade process to a select set of nodes.  Initializing the
oo_nodes_to_upgrade variable should be performed prior to running
upgrade configuration steps to ensure only the nodes selected are
processed during a node upgrade.