### PR TITLE
Bug 1934136: [release-3.11] Do not use connection local with localhost

### DIFF
--- a/playbooks/openshift-node/private/clean_image.yml
+++ b/playbooks/openshift-node/private/clean_image.yml
@@ -1,7 +1,6 @@
 ---
 - name: Reboot instance
   hosts: localhost
-  connection: local
   gather_facts: no
   tasks:
   # After installing certain packages rebooting the instance is a must before all


### PR DESCRIPTION
A bugfix in Ansible 2.9.10 changed the behavior of delegate_to for plays
using `connection: local` with `hosts: localhost`.  The new bahavior is
expected and `connection: local` should not be used.

https://github.com/ansible/ansible/issues/70495