### PR TITLE
Pin zipp=3.4.0, Fixes image build issue

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -17,7 +17,7 @@ RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl 
  && yum install -y java-1.8.0-openjdk-headless \
  && rpm -V $INSTALL_PKGS $EPEL_PKGS $EPEL_TESTING_PKGS \
  && pip install -U 'setuptools==44.0.0' 'wheel' \
- && pip install 'apache-libcloud~=2.2.1' 'SecretStorage<3' 'ansible[azure]' 'PyJWT==1.7.1' 'boto3==1.4.6' \
+ && pip install 'apache-libcloud~=2.2.1' 'SecretStorage<3' 'ansible[azure]' 'PyJWT==1.7.1' 'zipp==3.4.0' 'boto3==1.4.6' \
  && yum clean all
 
 LABEL name="openshift/origin-ansible" \


### PR DESCRIPTION
zipp >= 3.4.1 dropped support for python2