### PR TITLE
Bug 1939605: cri-o+kuryr: Switch to proper netns management …

### DIFF
--- a/roles/container_runtime/templates/crio.conf.j2
+++ b/roles/container_runtime/templates/crio.conf.j2
@@ -115,6 +115,12 @@ pids_limit = 1024
 # Negative values indicate that no limit is imposed.
 log_size_max = 52428800
 
+{% if openshift_use_kuryr|default(false)|bool %}
+# manage_network_ns_lifecycle determines whether we pin and remove network namespaces
+# and manage their lifecycle
+manage_network_ns_lifecycle = true
+{% endif %}
+
 # The "crio.image" table contains settings pertaining to the
 # management of OCI images.
 [crio.image]

--- a/roles/kuryr/templates/cni-daemonset.yaml.j2
+++ b/roles/kuryr/templates/cni-daemonset.yaml.j2
@@ -136,6 +136,9 @@ spec:
           mountPath: /host_proc
         - name: openvswitch
           mountPath: /var/run/openvswitch
+        - name: netns
+          mountPath: /run/netns
+          mountPropagation: HostToContainer
 {% if enable_kuryr_cni_probes|default(true)|bool %}
         readinessProbe:
           httpGet:
@@ -181,3 +184,6 @@ spec:
         - name: host-var-run
           hostPath:
             path: /var/run
+        - name: netns
+          hostPath:
+            path: /run/netns


### PR DESCRIPTION
cri-o is not complying with the CNI spec when
manage_network_ns_lifecycle isn't set to "true". This affects Kuryr SDN
so this commit enables that option when Kuryr is enabled.

As in that more reliable mode network namespaces are placed in the
standard /run/netns directory we need to mount it into kuryr-cni
container in order to be able to access the network namespaces there.
This commit does so too.