### PR TITLE
Bug 1946624: Disable repo_gpgcheck for Google Cloud SDK repo in CI

### DIFF
--- a/images/installer/origin-extra-root/etc/yum.repos.d/google-cloud-sdk.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/google-cloud-sdk.repo
@@ -3,6 +3,6 @@ name=google-cloud-sdk
 baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg


### PR DESCRIPTION
The Google Cloud SDK repo is throwing an error:
```
repomd.xml signature could not be verified when trying to install
google cloud sdk with yum with repo_gpgcheck=1 enabled
```

Disable the GPG check per Google's recommendation:
https://cloud.google.com/compute/docs/troubleshooting/known-issues#known_issues_for_linux_vm_instances

As that doc states:

> Yum repositories do not usually use GPG keys for repository validation. Instead, the https endpoint is trusted.