### PR TITLE
Bug 1946624: Fix CI

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -17,7 +17,7 @@ RUN INSTALL_PKGS="python-lxml python-dns pyOpenSSL python2-cryptography openssl 
  && yum install -y java-1.8.0-openjdk-headless \
  && rpm -V $INSTALL_PKGS $EPEL_PKGS $EPEL_TESTING_PKGS \
  && pip install -U 'setuptools==44.0.0' 'wheel' \
- && pip install 'apache-libcloud~=2.2.1' 'SecretStorage<3' 'ansible[azure]' 'PyJWT==1.7.1' 'zipp==3.4.0' 'boto3==1.4.6' \
+ && pip install 'apache-libcloud~=2.2.1' 'SecretStorage<3' 'ansible[azure]' 'PyJWT==1.7.1' 'more-itertools==5.0.0' 'zipp==1.2.0' 'boto3==1.4.6' 'importlib-metadata==2.1.1' 'configparser==4.0.2' \
  && yum clean all
 
 LABEL name="openshift/origin-ansible" \

--- a/images/installer/origin-extra-root/etc/yum.repos.d/google-cloud-sdk.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/google-cloud-sdk.repo
@@ -3,6 +3,6 @@ name=google-cloud-sdk
 baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg


### PR DESCRIPTION
This commit disables repo_gpgcheck for Google Cloud SDK repo in CI and
makes sure the Dockerfile uses 2.x versions of Python libraries instead
of using the Python-3-only ones.