### PR TITLE
container_runtime: Check last docker version number from repoquery

### DIFF
--- a/roles/container_runtime/tasks/docker_upgrade_check.yml
+++ b/roles/container_runtime/tasks/docker_upgrade_check.yml
@@ -45,7 +45,7 @@
     - docker_version is not defined
     - docker_upgrade | bool
     - pkg_check.rc == 0
-    - avail_docker_version.stdout == "" or avail_docker_version.stdout is version(l_required_docker_version,'<')
+    - avail_docker_version.stdout == "" or avail_docker_version.stdout_lines[-1] is version(l_required_docker_version,'<')
 
 # Default l_docker_upgrade to False, we'll set to True if an upgrade is required:
 - set_fact:


### PR DESCRIPTION
Currently the the `upgrade_control_plane.yml` fails with:

```
1. Hosts:    cpn1, cpn2, cpn3
   Play:     Verify docker upgrade targets
   Task:     Required docker version not available (non-atomic)
   Message:  This playbook requires access to Docker 1.13 or later
```

if a user configures  `showdupesfromrepos=1` in the `/etc/yum.conf` config file on the cluster nodes.

If a user configures `showdupesfromrepos=1`  the `repoquery` output will contain all available versions. Debug output of the var from one node:

```
ok: [cpn1] => {
    "avail_docker_version.stdout": "0.11.1\n0.11.1\n1.1.2\n1.2.0\n1.3.2\n1.4.1\n1.5.0\n1.5.0\n1.6.0\n1.6.2\n1.7.1\n1.7.1\n1.8.2\n1.8.2\n1.8.2\n1.9.1\n1.9.1\n
1.10.3\n1.10.3\n1.10.3\n1.10.3\n1.10.3\n1.12.5\n1.12.6\n1.12.6\n1.12.6\n1.12.6\n1.12.6\n1.12.6\n1.12.6\n1.12.6\n1.12.6\n1.13.1\n1.13.1\n1.13.1\n1.13.1\n1.13.
1\n1.13.1\n1.13.1\n1.13.1\n1.13.1\n1.13.1\n1.13.1\n1.13.1\n1.13.1\n1.13.1\n1.13.1\n1.13.1\n1.13.1\n1.13.1\n1.13.1\n1.13.1\n1.13.1"
}
```

The `version()` test only looks at the first line and returns true.

Accessing the last element of `avail_docker_version.stdout_lines` makes
the test pass with false and the playbook succeeds.


## Test playbook for version()  

```
---
- name: Test version() with multiline
  gather_facts: false
  hosts: localhost

  tasks:
  - name: Test
    debug:
      msg: "{{ my_version }} is less than 1.2: {{ my_version is version('1.2','<') }}"
    vars:
      my_version: "1.3"

  - name: Test multiline (sorted in ascending order)
    debug:
      msg: "{{ my_version }} is less than 1.2: {{ my_version is version('1.2','<') }}"
    vars:
      my_version: |
        1.1
        1.2
        1.3

  - name: Test multiline (sorted in descending order)
    debug:
      msg: "{{ my_version }} is less than 1.2: {{ my_version is version('1.2','<') }}"
    vars:
      my_version: |
        1.3
        1.2
        1.1
```

Output:

```
PLAY [Test version() with multiline] *******************************************

TASK [Test] ********************************************************************
Friday 09 April 2021  11:52:34 +0200 (0:00:00.022)       0:00:00.022 ********** 
ok: [localhost] => {
    "msg": "1.3 is less than 1.2: False"
}

TASK [Test multiline (sorted in ascending order)] ******************************
Friday 09 April 2021  11:52:34 +0200 (0:00:00.030)       0:00:00.052 ********** 
ok: [localhost] => {
    "msg": "1.1\n1.2\n1.3\n is less than 1.2: True"
}

TASK [Test multiline (sorted in descending order)] *****************************
Friday 09 April 2021  11:52:34 +0200 (0:00:00.031)       0:00:00.083 ********** 
ok: [localhost] => {
    "msg": "1.3\n1.2\n1.1\n is less than 1.2: False"
}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

Friday 09 April 2021  11:52:34 +0200 (0:00:00.029)       0:00:00.113 ********** 
=============================================================================== 
Test multiline (sorted in ascending order) ------------------------------ 0.03s
Test -------------------------------------------------------------------- 0.03s
Test multiline (sorted in descending order) ----------------------------- 0.03s
```