### PR TITLE
release-3.11: Revert code to address issue with missing python-ipaddress module

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -9,11 +9,11 @@ COPY images/installer/origin-extra-root /
 
 # install ansible and deps
 RUN INSTALL_PKGS="ansible-2.9.13 azure-cli-2.0.46 java-1.8.0-openjdk-headless python-lxml python-dns openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch which" \
- && if [ "$(uname -m)" == "x86_64" ]; then INSTALL_PKGS+=" google-cloud-sdk" ; fi \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
  && EPEL_PKGS=" python2-pip.noarch python2-crypto python2-scandir python2-packaging" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
+ && if [ "$(uname -m)" == "x86_64" ]; then yum install -y https://sdodson.fedorapeople.org/google-cloud-sdk-183.0.0-3.el7.x86_64.rpm ; fi \
  && rpm -V $INSTALL_PKGS $EPEL_PKGS \
  && yum clean all
 

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -11,7 +11,7 @@ COPY images/installer/origin-extra-root /
 RUN INSTALL_PKGS="ansible-2.9.13 azure-cli-2.0.46 java-1.8.0-openjdk-headless python-lxml python-dns openssl python2-passlib httpd-tools openssh-clients origin-clients iproute patch which" \
  && if [ "$(uname -m)" == "x86_64" ]; then INSTALL_PKGS+=" google-cloud-sdk" ; fi \
  && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
- && EPEL_PKGS=" python2-pip.noarch python2-scandir python2-packaging" \
+ && EPEL_PKGS=" python2-pip.noarch python2-crypto python2-scandir python2-packaging" \
  && yum install -y epel-release \
  && yum install -y --setopt=tsflags=nodocs $EPEL_PKGS \
  && rpm -V $INSTALL_PKGS $EPEL_PKGS \

--- a/playbooks/common/openshift-cluster/upgrades/init.yml
+++ b/playbooks/common/openshift-cluster/upgrades/init.yml
@@ -7,6 +7,7 @@
 
 - import_playbook: ../../../init/basic_facts.yml
 - import_playbook: ../../../init/base_packages.yml
+- import_playbook: ../../../init/cluster_facts.yml
 
 - name: Inspect cluster certificates
   hosts: "{{ l_upgrade_cert_check_hosts }}"

--- a/playbooks/common/openshift-cluster/upgrades/pre/config.yml
+++ b/playbooks/common/openshift-cluster/upgrades/pre/config.yml
@@ -33,8 +33,6 @@
     # openshift_protect_installed_version is passed n via upgrade_control_plane.yml
     # l_openshift_version_set_hosts is passed via upgrade_control_plane.yml
 
-- import_playbook: ../../../../init/cluster_facts.yml
-
 - name: OpenShift Health Checks
   hosts: "{{ l_upgrade_health_check_hosts }}"
   any_errors_fatal: true

--- a/playbooks/init/basic_facts.yml
+++ b/playbooks/init/basic_facts.yml
@@ -16,17 +16,6 @@
     import_role:
       name: openshift_sanitize_inventory
 
-  - name: Initialize openshift.node.sdn_mtu
-    openshift_facts:
-      role: node
-      system_facts: "{{ vars_openshift_facts_system_facts }}"
-      local_facts:
-        sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
-
-  - name: set_fact l_kubelet_node_name
-    set_fact:
-      l_kubelet_node_name: "{{ openshift_kubelet_name_override | default(openshift.node.nodename) }}"
-
   - name: Detecting Operating System from ostree_booted
     stat:
       path: /run/ostree-booted

--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -24,7 +24,7 @@
     - "groups.oo_first_master | length > 0"
     - "'openshift_portal_net' in hostvars[groups.oo_first_master.0]"
 
-  - name: Gather Common Cluster facts
+  - name: Gather Cluster facts
     openshift_facts:
       role: common
       system_facts: "{{ vars_openshift_facts_system_facts }}"
@@ -38,11 +38,6 @@
         no_proxy: "{{ openshift_no_proxy | default(None) }}"
         generate_no_proxy_hosts: "{{ openshift_generate_no_proxy_hosts | default(True) }}"
         cloudprovider: "{{ openshift_cloudprovider_kind | default(None) }}"
-
-  - name: Gather Master facts
-    include_role:
-      name: openshift_master_facts
-    when: inventory_hostname in groups['oo_masters']
 
   - name: Set fact of no_proxy_internal_hostnames
     openshift_facts:

--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -42,7 +42,7 @@
   - name: Gather Master facts
     include_role:
       name: openshift_master_facts
-    when: inventory_hostname in groups['oo_masters'] | default ([])
+    when: inventory_hostname in groups['oo_masters']
 
   - name: Set fact of no_proxy_internal_hostnames
     openshift_facts:

--- a/playbooks/init/cluster_facts.yml
+++ b/playbooks/init/cluster_facts.yml
@@ -63,6 +63,16 @@
     - openshift_http_proxy is defined or openshift_https_proxy is defined
     - openshift_generate_no_proxy_hosts | default(True) | bool
 
+  - name: Initialize openshift.node.sdn_mtu
+    openshift_facts:
+      role: node
+      system_facts: "{{ vars_openshift_facts_system_facts }}"
+      local_facts:
+        sdn_mtu: "{{ openshift_node_sdn_mtu | default(None) }}"
+  - name: set_fact l_kubelet_node_name
+    set_fact:
+      l_kubelet_node_name: "{{ openshift_kubelet_name_override | default(openshift.node.nodename) }}"
+
 - name: Initialize etcd host variables
   hosts: oo_masters_to_config
   roles:

--- a/playbooks/init/main.yml
+++ b/playbooks/init/main.yml
@@ -30,9 +30,9 @@
 - import_playbook: base_packages.yml
   when: l_install_base_packages | default(False) | bool
 
-- import_playbook: version.yml
-
 - import_playbook: cluster_facts.yml
+
+- import_playbook: version.yml
 
 - import_playbook: sanity_checks.yml
   when: not (skip_sanity_checks | default(False))

--- a/playbooks/openshift-master/private/certificates.yml
+++ b/playbooks/openshift-master/private/certificates.yml
@@ -1,8 +1,12 @@
 ---
+- name: Gather Master Facts
+  hosts: oo_masters
+  roles:
+  - role: openshift_master_facts
+
 - name: Create OpenShift certificates for master hosts
   hosts: oo_masters_to_config
   roles:
-  - role: openshift_master_facts
   - role: openshift_named_certificates
   - role: openshift_ca
   - role: openshift_master_certificates


### PR DESCRIPTION
The rearrangement of tasks in #12268 set off a string of changes required due to the intertwined nature of openshift-ansible playbooks.  Follow-up PRs were required to address issues in CI and upgrades.  In order to address the latest issue of `openshift_facts` being run prior to the `python-ipaddress` package being installed, it was going to require even further rearrangement of playbooks which could lead to additional PRs to fix other issues.  This PR reverts the PRs below to get back to the original code flow.  The final commit ensures master facts are set on all hosts prior to running the certificates playbooks for masters, where during scaleup, only one master would be in scope for the playbook.

Reverts the following:
https://github.com/openshift/openshift-ansible/pull/12268 Bug 1777061: playbooks/init: Refresh master facts during init
https://github.com/openshift/openshift-ansible/pull/12270 playbooks/init: Fix GCP job when oo_masters is not defined
https://github.com/openshift/openshift-ansible/pull/12307 Bug 1921353: [release-3.11] Gather cluster_facts after version.yml during upgrade
https://github.com/openshift/openshift-ansible/pull/12310 Bug 1933090: Move node fact initialization to basic_facts.yml