### PR TITLE
Bug 1955012: roles/openshift_facts: Force repoquery option

### DIFF
--- a/roles/openshift_facts/defaults/main.yml
+++ b/roles/openshift_facts/defaults/main.yml
@@ -46,7 +46,7 @@ osn_image: "{{ openshift_facts_versioned_registry_url | regex_replace('${compone
 openshift_facts_pod_image: "{{ openshift_facts_versioned_registry_url | regex_replace('${component}' | regex_escape, 'pod') }}"
 openshift_facts_control_plane_image: "{{ openshift_facts_versioned_registry_url | regex_replace('${component}' | regex_escape, 'control-plane') }}"
 
-repoquery_cmd: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --latest-limit 1 -d 0', 'repoquery --plugins') }}"
+repoquery_cmd: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --latest-limit 1 -d 0', 'repoquery --plugins --setopt=showdupesfromrepos=0') }}"
 repoquery_installed: "{{ (ansible_pkg_mgr == 'dnf') | ternary('dnf repoquery --latest-limit 1 -d 0 --disableexcludes=all --installed', 'repoquery --plugins --installed') }}"
 
 openshift_use_crio: False

--- a/test/ci/template-inventory.j2
+++ b/test/ci/template-inventory.j2
@@ -2,7 +2,7 @@
 ansible_python_interpreter="{{ python }}"
 ansible_user="{{ aws_user }}"
 aws_region="{{ aws_region }}"
-openshift_master_default_subdomain="{{ hostvars[groups[('lb' in groups) | ternary('lb', 'masters')][0]]["aws_ip"] }}.xip.io"
+openshift_master_default_subdomain="{{ hostvars[groups[('lb' in groups) | ternary('lb', 'masters')][0]]["aws_ip"] }}.sslip.io"
 
 [OSEv3:children]
 {% for group in groups %}


### PR DESCRIPTION
In cases where a user sets showdupesfromrepos=1 in /etc/yum.conf, the
logic for parsing the output of `repoquery` will fail.  Adding the
option to the repoquery command directly ensures the expected output.