### PR TITLE
Bug 1962884: Bump up etcd to version 3.2.32

### DIFF
--- a/roles/etcd/defaults/main.yaml
+++ b/roles/etcd/defaults/main.yaml
@@ -7,7 +7,7 @@ l_etcd_static_pod: "{{ (inventory_hostname in groups['oo_masters']) | bool }}"
 # runc, docker, static pod, host
 r_etcd_common_etcd_runtime: "{{ 'static_pod' if l_etcd_static_pod  else 'host' }}"
 
-r_etcd_default_version: "3.2.28"
+r_etcd_default_version: "3.2.32"
 # lib_utils_oo_oreg_image is a custom filter defined in roles/lib_utils/filter_plugins/oo_filters.py
 # This filter attempts to combine oreg_url host with project/component from etcd_image_dict.
 # "oreg.example.com/openshift3/ose-${component}:${version}"


### PR DESCRIPTION
A couple important security fixes were added to the latest etcd, and hence the need to bump up etcd version in 3.11

Security Fix(es):
etcd: Large slice causes panic in decodeRecord method (CVE-2020-15106)
etcd: DoS in wal/wal.go (CVE-2020-15112)

For more information, see errata: https://access.redhat.com/errata/RHSA-2021:1407