### PR TITLE
Bug 1965827: Add catalog entrypoint playbook

### DIFF
--- a/playbooks/openshift-service-catalog/redeploy-certificates.yml
+++ b/playbooks/openshift-service-catalog/redeploy-certificates.yml
@@ -1,0 +1,9 @@
+---
+- import_playbook: ../init/main.yml
+  vars:
+    l_init_fact_hosts: "oo_masters_to_config"
+    l_openshift_version_set_hosts: "oo_masters_to_config:!oo_first_master"
+    l_openshift_version_check_hosts: "all:!all"
+    l_sanity_check_hosts: "{{ groups['oo_masters_to_config'] }}"
+
+- import_playbook: private/redeploy-certificates.yml


### PR DESCRIPTION
This PR solves [BZ1965827](https://bugzilla.redhat.com/show_bug.cgi?id=1965827) by re-adding the catalog certificates renewal entrypoint playbook as it was present in [3.9](https://github.com/openshift/openshift-ansible/blob/release-3.9/playbooks/openshift-service-catalog/redeploy-certificates.yml).