### PR TITLE
CORS-1710: Initial support for RHEL8 worker nodes

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -9,47 +9,36 @@ openshift_node_bootstrap_port: 22623
 openshift_node_bootstrap_server: "{{ openshift_node_kubeconfig.clusters.0.cluster.server.split(':')[0:-1] | join(':') | regex_replace('://api', '://api-int') }}:{{ openshift_node_bootstrap_port }}"
 openshift_node_bootstrap_endpoint: "{{ openshift_node_bootstrap_server }}/config/{{ openshift_node_machineconfigpool }}"
 
-# Packages to be installed from the rhel-7-server-ose repo
+openshift_packages: "{{ (openshift_node_packages + openshift_node_support_packages) | join(',') }}"
+
 openshift_node_packages:
   - conmon
   - cri-o-{{ crio_latest }}
   - cri-tools
   - openshift-clients-{{ l_cluster_version }}*
   - openshift-hyperkube-{{ l_cluster_version }}*
-  - podman  # From of extras, but must be installed concurrently with cri-o
+  - podman
   - runc
 
-openshift_node_support_packages: "{{ openshift_node_support_packages_base + openshift_node_support_packages_by_arch[ansible_architecture] }}"
+openshift_node_support_packages: "{{
+  openshift_node_support_packages_base +
+  openshift_node_support_packages_by_os_major_version[ansible_distribution_major_version] +
+  openshift_node_support_packages_by_arch[ansible_architecture] }}"
 
 openshift_node_support_packages_base:
-  # Packages from redhat-coreos.git manifest-base.yaml
   - kernel
   - systemd
-  #- systemd-journal-gateway
-  #- rpm-ostree
-  #- nss-altfiles
   - selinux-policy-targeted
   - setools-console
-  #- ignition
-  #- ignition-dracut
   - dracut-network
   - passwd
-  #- grub2
-  #- grub2-efi
-  #- ostree-grub2
-  #- efibootmgr
-  #- shim
   - openssh-server
   - openssh-clients
   - skopeo
-  #- runc
   - containernetworking-plugins
-  #- cri-o
-  #- cri-tools
-  #- toolbox
   - nfs-utils
   - NetworkManager
-  - NetworkManager-ovs
+  - NetworkManager-ovs  # https://bugzilla.redhat.com/show_bug.cgi?id=1884095
   - dnsmasq
   - lvm2
   - iscsi-initiator-utils
@@ -60,7 +49,6 @@ openshift_node_support_packages_base:
   - mdadm
   - cryptsetup
   - chrony
-  #- coreos-metadata
   - logrotate
   - sssd
   - shadow-utils
@@ -80,22 +68,20 @@ openshift_node_support_packages_base:
   - bash-completion
   - vim-minimal
   - nano
-  - openvswitch2.13
-  #- openshift-hyperkube
-  #- openshift-clients
-  #- pivot
-  #- subscription-manager-rhsm-certificates
-  #
-  # Packages from redhat-coreos.git maipo/manifest.yaml
-  #- redhat-release-coreos
   - authconfig
-  - policycoreutils-python
   - iptables-services
-  - bridge-utils
-  - container-storage-setup
-  #- cloud-utils-growpart
-  - ceph-common
-  - cifs-utils
+  - cifs-utils  # https://bugzilla.redhat.com/show_bug.cgi?id=1827982
+
+openshift_node_support_packages_by_os_major_version:
+  "7":
+    - openvswitch2.13
+    - policycoreutils-python
+    - bridge-utils
+    - container-storage-setup
+    - ceph-common
+  "8":
+    - openvswitch2.15
+    - policycoreutils-python-utils
 
 openshift_node_support_packages_by_arch:
   ppc64le:

--- a/roles/openshift_node/tasks/apply_machine_config.yml
+++ b/roles/openshift_node/tasks/apply_machine_config.yml
@@ -68,8 +68,8 @@
   - name: Apply machine config
     command: "podman run {{ podman_mounts }} {{ podman_flags }} {{ mcd_command }}"
     vars:
-      podman_flags: "--privileged --rm --entrypoint=/usr/bin/machine-config-daemon -ti {{ l_mcd_image }}"
-      podman_mounts: "-v /:/rootfs -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd"
+      podman_flags: "--pid=host --privileged --rm --entrypoint=/usr/bin/machine-config-daemon -ti {{ l_mcd_image }}"
+      podman_mounts: "-v /:/rootfs"
       mcd_command: "start --node-name {{ ansible_nodename | lower }} --once-from {{ temp_dir.path }}/worker_ignition_config.json --skip-reboot"
   environment:
     http_proxy: "{{ http_proxy | default('')}}"

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -46,6 +46,28 @@
     state: yes
     persistent: yes
 
+# conmon symlink required or crio will fail to start on RHEL8
+# https://bugzilla.redhat.com/show_bug.cgi?id=1965369
+- name: Check for /usr/libexec/crio/conmon
+  stat:
+    path: /usr/libexec/crio/conmon
+  register: conmon_result
+
+- name: Create /usr/libexec/crio directory
+  file:
+    path: /usr/libexec/crio
+    state: directory
+  when:
+  - not conmon_result.stat.exists
+
+- name: Symlink conmon binary
+  file:
+    src: /bin/conmon
+    dest: /usr/libexec/crio/conmon
+    state: link
+  when:
+  - not conmon_result.stat.exists
+
 - name: Create temp directory
   tempfile:
     state: directory
@@ -158,8 +180,8 @@
   - name: Apply ignition manifest
     command: "podman run {{ podman_mounts }} {{ podman_flags }} {{ mcd_command }}"
     vars:
-      podman_flags: "--privileged --rm --entrypoint=/usr/bin/machine-config-daemon -ti {{ release_image_mcd.stdout }}"
-      podman_mounts: "-v /:/rootfs -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd"
+      podman_flags: "--pid=host --privileged --rm --entrypoint=/usr/bin/machine-config-daemon -ti {{ release_image_mcd.stdout }}"
+      podman_mounts: "-v /:/rootfs"
       mcd_command: "start --node-name {{ ansible_nodename | lower }} --once-from {{ temp_dir.path }}/bootstrap.ign --skip-reboot"
 
   - name: Remove temp directory

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -32,16 +32,6 @@
   when:
   - ansible_fips != (cluster_fips.stdout | bool)
 
-- name: Install openshift support packages
-  package:
-    name: "{{ openshift_node_support_packages | join(',') }}"
-    state: latest
-    update_cache: true
-  async: 3600
-  poll: 30
-  register: result
-  until: result is succeeded
-
 - name: Get cluster version
   command: >
     oc get clusterversion
@@ -92,7 +82,7 @@
 - block:
   - name: Install openshift packages
     package:
-      name: "{{ openshift_node_packages | join(',') }}"
+      name: "{{ openshift_packages }}"
       state: latest
     async: 3600
     poll: 30
@@ -103,7 +93,7 @@
   - name: Package install failure message
     fail:
       msg: >
-        Unable to install {{ openshift_node_packages | join(', ') }}.
+        Unable to install {{ openshift_packages }}.
         Please ensure repos are configured properly to provide these packages
         and indicated versions.
 


### PR DESCRIPTION
Added support for scaling up RHEL8 worker nodes, maintaining support for RHEL7.

The OpenShift version of crio expects conmon to be in a different location.  Added tasks to ensure conmon is accessible by crio.

Updated podman mounts when running machine-config-deamon `start` to properly access mounts needed for systemd access.

Package install has been consolidated to a single task to speed install as well as more effectively handle dependency resolution.

Package list kept mostly the same except some packages are separated by OS version availability.

https://issues.redhat.com/browse/CORS-1709
https://issues.redhat.com/browse/CORS-1710