### PR TITLE
Upgrade virtualenv in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ language: python
 python:
   - "3.6"
 
+before_install:
+  - python -m pip install --upgrade virtualenv
+
 install:
   - pip install --upgrade pip
   - pip install tox-travis


### PR DESCRIPTION
Older pip in the Travis created virtualenv is not pulling the
cryptography wheel and instead requiring building cryptography.  The
build fails because a Rust compiler does not exist.  Upgrading
virtualenv allows the cryptography wheel to be used.

pyca/cryptography#5771