### PR TITLE
Bump ansible in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible==2.9.5
+ansible<2.10


### PR DESCRIPTION
Builds install the latest version of Ansible 2.9.  Updating requirements.txt to match what is used in builds.