### PR TITLE
Bug 1968411: do not specify `force` and `grace-period 0` for SDN deleted

### DIFF
--- a/roles/openshift_node/tasks/sdn_delete.yml
+++ b/roles/openshift_node/tasks/sdn_delete.yml
@@ -11,7 +11,5 @@
     -n openshift-sdn |
     {{ openshift_client_binary }} delete
     --config={{ openshift.common.config_base }}/master/admin.kubeconfig
-    --force
-    --grace-period=0
     -f -
   delegate_to: "{{ groups.oo_first_master.0 }}"


### PR DESCRIPTION
As seen in the bug description: https://bugzilla.redhat.com/show_bug.cgi?id=1968411#c21

Specifying `--force` and `--grace-period 0` is dirty and can leave processes
behind on the node that are not terminated when the pod is. This can
have bad secondary effects on whatever pod/process is re-started, as is
the case with this bug.
