### PR TITLE
Bug 1993647 - request to change the openshift_certificate_expiry_warning_days value to 90 days

### DIFF
--- a/roles/openshift_certificate_expiry/defaults/main.yml
+++ b/roles/openshift_certificate_expiry/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 openshift_certificate_expiry_config_base: "/etc/origin"
-openshift_certificate_expiry_warning_days: 365
+openshift_certificate_expiry_warning_days: 90
 openshift_certificate_expiry_show_all: no
 openshift_certificate_expiry_generate_html_report: no
 openshift_certificate_expiry_html_report_path: "{{ lookup('env', 'HOME') }}/cert-expiry-report.{{ ansible_date_time.iso8601_basic_short }}.html"


### PR DESCRIPTION
Bug 1993647

Request to change the value to 90 days.
