### PR TITLE
Bug 1989547: Drop liveness probe on OVS pods

### DIFF
--- a/roles/openshift_sdn/files/sdn-ovs.yaml
+++ b/roles/openshift_sdn/files/sdn-ovs.yaml
@@ -106,14 +106,6 @@ spec:
           requests:
             cpu: 100m
             memory: 300Mi
-        livenessProbe:
-          exec:
-            command:
-            - /usr/share/openvswitch/scripts/ovs-ctl
-            - status
-          initialDelaySeconds: 15
-          periodSeconds: 5
-
       volumes:
       - name: host-modules
         hostPath:

--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -166,17 +166,9 @@ spec:
         ports:
         - name: healthz
           containerPort: 10256
-        # TODO: Temporarily disabled until we determine how to wait for clean default
-        # config
-        # livenessProbe:
-        #   initialDelaySeconds: 10
-        #   httpGet:
-        #     path: /healthz
-        #     port: 10256
-        #     scheme: HTTP
-        # force node to be notready when sdn is gone.
         tolerations:
         - operator: "Exists"
+        # force node to be notready when sdn is gone.
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
It turns out to basically never be helpful; inevitably whenever it
fails, it's because the node is just overloaded and slow, in which
case restarting OVS will just make things worse.

Also remove the commented-out SDN liveness probe, since it won't be
brought back, for the same reason. And fix a nearby comment that got
misplaced at some point...