### PR TITLE
Bug 1995507: Kuryr: Fix lbaas_activation_timeout placement

### DIFF
--- a/roles/kuryr/templates/configmap.yaml.j2
+++ b/roles/kuryr/templates/configmap.yaml.j2
@@ -328,6 +328,8 @@ data:
     external_svc_subnet = {{ kuryr_openstack_public_subnet_id }}
 {% endif %}
     resource_tags = {{ openshift_openstack_clusterid }}
+    # Time (in seconds) that Kuryr controller waits for LBaaS to be activated
+    lbaas_activation_timeout = 1200
 
 {% if openshift_kuryr_subnet_driver|default('default') == 'namespace' %}
     [namespace_subnet]
@@ -341,9 +343,6 @@ data:
     sg_allow_from_default = {{ kuryr_openstack_sg_allow_from_default_id }}
     global_namespaces = {{ kuryr_openstack_global_namespaces }}
 {% endif %}
-
-    # Time (in seconds) that Kuryr controller waits for LBaaS to be activated
-    lbaas_activation_timeout = 1200
 
     [pod_vif_nested]
 


### PR DESCRIPTION
In a certain configuration combination lbaas_activation_timeout option
is placed in a wrong section in kuryr.conf. This fixes it.