### PR TITLE
Bug 2001985: Check whether kubelet node name is defined

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
@@ -30,6 +30,7 @@
         ansible_become: "{{ g_sudo | default(omit) }}"
       with_items: " {{ groups['oo_nodes_to_config'] }}"
       when:
+      - hostvars[item].l_kubelet_node_name is defined
       - hostvars[item].l_kubelet_node_name | lower in nodes_to_upgrade.module_results.results[0]['items'] | map(attribute='metadata.name') | list
       changed_when: false
 


### PR DESCRIPTION
We are seeing the failure 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'l_kubelet_node_name'
in upgrades. This simply adds a check to skip if the attribute is not
found.