### PR TITLE
Revert "Bug 2001985: Check whether kubelet node name is defined"

### DIFF
--- a/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
+++ b/playbooks/common/openshift-cluster/upgrades/initialize_nodes_to_upgrade.yml
@@ -30,7 +30,6 @@
         ansible_become: "{{ g_sudo | default(omit) }}"
       with_items: " {{ groups['oo_nodes_to_config'] }}"
       when:
-      - hostvars[item].l_kubelet_node_name is defined
       - hostvars[item].l_kubelet_node_name | lower in nodes_to_upgrade.module_results.results[0]['items'] | map(attribute='metadata.name') | list
       changed_when: false
 


### PR DESCRIPTION
Reverts openshift/openshift-ansible#12349

/cc @e-tienne 
I don't think we need this so let's revert it.