### PR TITLE
Bug 2012587: Pin jsonschema version for Python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ shade==1.24.0
 passlib==1.6.5
 dogpile.cache==0.9.2
 pyrsistent==0.16.1
+jsonschema<=3.2.0 ; python_version < '3.0'


### PR DESCRIPTION
An indirect dependency, jsonschema, is causing the Travis job to fail
when run with Python 2.7. The dependency is pulling in jsonschema at
a version that no longer supports 2.7, so this pins the version of
jsonschema when using 2.7.

From https://app.travis-ci.com/github/openshift/openshift-ansible/jobs/541736192
```
Collecting jsonschema>=2.6.0 (from python-ironicclient>=1.14.0->shade==1.24.0->-r requirements.txt (line 10))
  Using cached https://files.pythonhosted.org/packages/9c/99/9789c7fd0bb8876a7d624d903195ce11e5618b421bdb1bf7c975d17a9bc3/jsonschema-4.0.0.tar.gz
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    IOError: [Errno 2] No such file or directory: '/tmp/pip-install-fKOSbe/jsonschema/setup.py'
```