### PR TITLE
Bug 1980127: correct mistake in how the OPENSHIFT_SDN_POD env. var. populates

### DIFF
--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -164,7 +164,9 @@ spec:
             memory: 200Mi
         env:
         - name: OPENSHIFT_SDN_POD
-          value: metadata.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: OPENSHIFT_DNS_DOMAIN
           value: cluster.local
         ports:


### PR DESCRIPTION
the way that it was before the env var OPENSHIFT_SDN_POD was
metadata.name instead of the value it was supposed to be