### PR TITLE
Bug 1636993: Fix EFS provisioner image name

### DIFF
--- a/roles/openshift_provisioners/defaults/main.yaml
+++ b/roles/openshift_provisioners/defaults/main.yaml
@@ -11,7 +11,7 @@ openshift_provisioners_project: openshift-infra
 
 openshift_provisioners_image_prefix_dict:
   origin: "docker.io/openshift/origin-"
-  openshift-enterprise: "registry.redhat.io/openshift3/"
+  openshift-enterprise: "registry.redhat.io/openshift3/ose-"
 
 openshift_provisioners_image_version_dict:
   origin: "latest"


### PR DESCRIPTION
Use `openshift3/ose-efs-provisioner` image instead of `openshift3/efs-provisioner`. The later one was not rebuilt for 2 years and has some CVEs in it.

`openshift_provisioners_image_prefix_dict` gets used in https://github.com/openshift/openshift-ansible/blob/267344f20d99c645517d51713467cff9bc9b62e6/roles/openshift_provisioners/templates/efs.j2#L31 to compose `registry.redhat.io/openshift3/ose-efs-provisioner`