### PR TITLE
Bug 2041983: Pin python-lazy-object version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,7 @@
 flake8==3.3.0
 flake8-mutable==1.1.0
 flake8-print==2.0.2
+lazy-object-proxy==1.5.2
 pylint==1.6.5
 setuptools-lint==0.5.2
 yamllint==1.6.1


### PR DESCRIPTION
It looks like version 1.7.0 of this library discontinued support for Python 2. Pin version to 1.6.0.

https://github.com/ionelmc/python-lazy-object-proxy/blob/v1.7.0/setup.py#L125
https://github.com/ionelmc/python-lazy-object-proxy/blob/v1.6.0/setup.py#L95

We are seeing this error in travis ci builds:

```
Collecting lazy-object-proxy (from astroid<1.5.0,>=1.4.5->pylint==1.6.5->-r test-requirements.txt (line 8))
  Using cached https://files.pythonhosted.org/packages/6f/3e/7c80e8536b9d5eb66e784fff4c359adf9e55b37460fd6928192256ba71f2/lazy-object-proxy-1.7.0.tar.gz
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/lazy_object_proxy.egg-info
    writing pip-egg-info/lazy_object_proxy.egg-info/PKG-INFO
    writing dependency_links to pip-egg-info/lazy_object_proxy.egg-info/dependency_links.txt
    writing top-level names to pip-egg-info/lazy_object_proxy.egg-info/top_level.txt
    writing manifest file 'pip-egg-info/lazy_object_proxy.egg-info/SOURCES.txt'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-UiBks7/lazy-object-proxy/setup.py", line 146, in <module>
        distclass=BinaryDistribution,
      File "/tmp/pip-build-env-stjmHM/lib/python2.7/site-packages/setuptools/__init__.py", line 162, in setup
        return distutils.core.setup(**attrs)
      File "/opt/python/2.7.15/lib/python2.7/distutils/core.py", line 151, in setup
        dist.run_commands()
      File "/opt/python/2.7.15/lib/python2.7/distutils/dist.py", line 953, in run_commands
        self.run_command(cmd)
      File "/opt/python/2.7.15/lib/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "/tmp/pip-build-env-stjmHM/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 296, in run
        self.find_sources()
      File "/tmp/pip-build-env-stjmHM/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 303, in find_sources
        mm.run()
      File "/tmp/pip-build-env-stjmHM/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 534, in run
        self.add_defaults()
      File "/tmp/pip-build-env-stjmHM/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 570, in add_defaults
        sdist.add_defaults(self)
      File "/tmp/pip-build-env-stjmHM/lib/python2.7/site-packages/setuptools/command/py36compat.py", line 36, in add_defaults
        self._add_defaults_ext()
      File "/tmp/pip-build-env-stjmHM/lib/python2.7/site-packages/setuptools/command/py36compat.py", line 118, in _add_defaults_ext
        if self.distribution.has_ext_modules():
      File "/tmp/pip-install-UiBks7/lazy-object-proxy/setup.py", line 70, in has_ext_modules
        return super().has_ext_modules() or 'SETUP_PY_ALLOW_PURE' n
```