### PR TITLE
Use user/pass auth when the user_pass_auth var is present

### DIFF
--- a/roles/openshift_gcp/templates/yum_repo.j2
+++ b/roles/openshift_gcp/templates/yum_repo.j2
@@ -17,4 +17,8 @@ sslclientkey={{ "/var/lib/yum/custom_secret_" + (loop.index-1)|string + "_key" i
 {{ key }}={{ value }}
 {% endif %}
 {% endfor %}
+{% if 'user_pass_auth' in repo %}
+username={{ lookup('env', 'MIRROR_USERNAME') }}
+password={{ lookup('env', 'MIRROR_PASSWORD') }}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
[release PR26007](https://github.com/openshift/release/pull/26007/files) needs to merge first for this to work.

If this PR is merged, nothing different will happen until [openshift/release PR25761](https://github.com/openshift/release/pull/25761) is merged.  Testing in this PR, found that [release PR26012](https://github.com/openshift/release/pull/26012/files) also needed to merge.
