### PR TITLE
Bug 2037620: Require RHEL v8.4 or newer beginning with OpenShift v4.10

### DIFF
--- a/playbooks/scaleup.yml
+++ b/playbooks/scaleup.yml
@@ -1,5 +1,5 @@
 ---
-- name: Pre-scaleup checks
+- name: Pre-scaleup hostfile checks
   hosts: localhost
   connection: local
   gather_facts: no
@@ -7,6 +7,13 @@
   - import_role:
       name: openshift_node
       tasks_from: scaleup_checks.yml
+
+- name: Pre-scaleup checks
+  hosts: new_workers
+  tasks:
+  - import_role:
+      name: openshift_node
+      tasks_from: version_checks.yml
 
 - name: install nodes
   hosts: new_workers

--- a/playbooks/scaleup.yml
+++ b/playbooks/scaleup.yml
@@ -4,18 +4,18 @@
   connection: local
   gather_facts: no
   tasks:
-  - import_role:
-      name: openshift_node
-      tasks_from: scaleup_checks.yml
+    - import_role:
+        name: openshift_node
+        tasks_from: scaleup_checks.yml
 
 - name: Pre-scaleup checks
   hosts: new_workers
   tasks:
-  - import_role:
-      name: openshift_node
-      tasks_from: version_checks.yml
+    - import_role:
+        name: openshift_node
+        tasks_from: version_checks.yml
 
 - name: install nodes
   hosts: new_workers
   roles:
-  - openshift_node
+    - openshift_node

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -4,24 +4,24 @@
   connection: local
   gather_facts: no
   tasks:
-  - name: Ensure [workers] group is populated
-    fail:
-      msg: >
-        Detected no workers in inventory. Please add hosts to the
-        workers host group to upgrade nodes
-    when: groups.workers | default([]) | length == 0
+    - name: Ensure [workers] group is populated
+      fail:
+        msg: >
+          Detected no workers in inventory. Please add hosts to the
+          workers host group to upgrade nodes
+      when: groups.workers | default([]) | length == 0
 
 - name: Pre-upgrade checks
   hosts: workers
   tasks:
-  - import_role:
-      name: openshift_node
-      tasks_from: version_checks.yml
+    - import_role:
+        name: openshift_node
+        tasks_from: version_checks.yml
 
 - name: upgrade nodes
   hosts: workers
   serial: 1
   tasks:
-  - import_role:
-      name: openshift_node
-      tasks_from: upgrade.yml
+    - import_role:
+        name: openshift_node
+        tasks_from: upgrade.yml

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -1,5 +1,5 @@
 ---
-- name: Pre-upgrade checks
+- name: Pre-upgrade hostfile checks
   hosts: localhost
   connection: local
   gather_facts: no
@@ -10,6 +10,13 @@
         Detected no workers in inventory. Please add hosts to the
         workers host group to upgrade nodes
     when: groups.workers | default([]) | length == 0
+
+- name: Pre-upgrade checks
+  hosts: workers
+  tasks:
+  - import_role:
+      name: openshift_node
+      tasks_from: version_checks.yml
 
 - name: upgrade nodes
   hosts: workers

--- a/roles/openshift_node/tasks/version_checks.yml
+++ b/roles/openshift_node/tasks/version_checks.yml
@@ -1,0 +1,25 @@
+---
+# This task file is run with import_role for localhost from scaleup.yml and upgrade.yml
+
+- name: Get cluster version
+  command: >
+    oc get clusterversion
+    --kubeconfig={{ openshift_node_kubeconfig_path }}
+    --output=jsonpath='{.items[0].status.desired.version}'
+  delegate_to: localhost
+  register: oc_get
+  until:
+  - oc_get.stdout != ''
+  changed_when: false
+
+- name: Set fact l_cluster_version
+  set_fact:
+    l_cluster_version: "{{ oc_get.stdout | regex_search('^\\d+\\.\\d+') }}"
+
+- name: Fail if not using RHEL8 beginning with version 4.10
+  fail:
+    msg: "As of v4.10, RHEL nodes must be at least version 8.4"
+  when:
+    - l_cluster_version is version('4.10', '>=')
+    - ansible_facts['distribution'] == "RedHat"
+    - ansible_facts['distribution_version'] is version('8.4', '<')

--- a/roles/openshift_node/tasks/version_checks.yml
+++ b/roles/openshift_node/tasks/version_checks.yml
@@ -20,6 +20,6 @@
   fail:
     msg: "As of v4.10, RHEL nodes must be at least version 8.4"
   when:
-    - l_cluster_version is version('4.10', '>=')
-    - ansible_facts['distribution'] == "RedHat"
-    - ansible_facts['distribution_version'] is version('8.4', '<')
+  - l_cluster_version is version('4.10', '>=')
+  - ansible_facts['distribution'] == "RedHat"
+  - ansible_facts['distribution_version'] is version('8.4', '<')


### PR DESCRIPTION
This change forces the scaleup and upgrade playbooks to fail quickly on clusters
running OpenShift v4.10 or later when the BYOH nodes are running a version of
RHEL that is less than v8.4.