### PR TITLE
Bug 2052393: Install jq package required by configure-ovs

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -71,6 +71,7 @@ openshift_node_support_packages_base:
   - authconfig
   - iptables-services
   - cifs-utils  # https://bugzilla.redhat.com/show_bug.cgi?id=1827982
+  - jq
 
 openshift_node_support_packages_by_os_major_version:
   "7":


### PR DESCRIPTION
In 4.10, a change introduced in the ovs-configuration service is making use of jq, which is readily available on RHCOS but not on RHEL. Make sure the package is installed.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>