### PR TITLE
Bug 2040488: Unit tests to use python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_cache:
 
 language: python
 python:
-  - "3.6"
+  - "3.7"
 
 before_install:
   - python -m pip install --upgrade virtualenv

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py36-{unit,flake8,pylint,yamllint,ansible_syntax}
+    py37-{unit,flake8,pylint,yamllint,ansible_syntax}
 skipsdist=True
 skip_missing_interpreters=True
 


### PR DESCRIPTION
This change updates the unit tests to use python 3.7