### PR TITLE
Bug 2060147: Include libseccomp in the list of packages that we ensure are up to date

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -72,6 +72,7 @@ openshift_node_support_packages_base:
   - iptables-services
   - cifs-utils  # https://bugzilla.redhat.com/show_bug.cgi?id=1827982
   - jq
+  - libseccomp
 
 openshift_node_support_packages_by_os_major_version:
   "7":


### PR DESCRIPTION
It looks like runc depends on >= 2.5 even though it just requires
libseccomp.so.2. This will ensure that it's up to date when we install.