### PR TITLE
Adds aarch64 dict to enable the openshift-node role for RHEL ARM Workers

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -98,3 +98,5 @@ openshift_node_support_packages_by_arch:
     # Temporarily only for x86_64 as were not shipping it for other arches atm
     # Tracked in https://bugzilla.redhat.com/show_bug.cgi?id=1715175
     - glusterfs-fuse
+  aarch64:
+    - irqbalance


### PR DESCRIPTION
cc @AnnaZivkovic @jeffdyoung @andymcc 

Refers [ARMOCP-303](https://issues.redhat.com/browse/ARMOCP-303) [ARMOCP-215](https://issues.redhat.com/browse/ARMOCP-215)