### PR TITLE
[release-3.11] - Disable GPG checking for gcloud

### DIFF
--- a/images/installer/origin-extra-root/etc/yum.repos.d/google-cloud-sdk.repo
+++ b/images/installer/origin-extra-root/etc/yum.repos.d/google-cloud-sdk.repo
@@ -3,6 +3,6 @@ name=google-cloud-sdk
 baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg


### PR DESCRIPTION
GPG key checks for the gcloud repo are failing:

https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64/repodata/repomd.xml: [Errno -1] repomd.xml signature could not be verified for google-cloud-sdk

https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
notes that Yum repositories do not usually use GPG keys for repository
validation. Instead, the https endpoint is trusted. The resolution is to
set repo_gpgcheck=0 as in this commit.

Also it does not seem this repository is being used as we are pulling
gcloud directly from a private repo. Another approach could be to remove
this repo.