### PR TITLE
Bug 2037626: Openshift_nodes: Added version for ignition to use

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -72,6 +72,8 @@
     url: "{{ openshift_node_bootstrap_endpoint }}"
     dest: "{{ temp_dir.path }}/bootstrap.ign"
     validate_certs: false
+    headers:
+      Accept: application/vnd.coreos.ignition+json; version=3.2.0
     http_agent: "Ignition/0.35.0"
   delay: 10
   retries: 60


### PR DESCRIPTION
** Forced version 3.2 for ignition. Default was 2.2 and causing issues
when tang encryption is selected (available in 4.9+).