### PR TITLE
bug 2044713: swapoff: resolve issue where fstab and systemd conflict

### DIFF
--- a/roles/openshift_node/library/swapoff.py
+++ b/roles/openshift_node/library/swapoff.py
@@ -149,16 +149,18 @@ def run_module():
     changed = False
 
     swap_fstab_res = check_swap_in_fstab(module)
-    swap_is_inuse_res = check_swapon_status(module)
-    swap_systemd_units = check_swap_in_systemd(module)
 
     if swap_fstab_res:
         comment_swap_fstab(module)
         changed = True
 
+    swap_is_inuse_res = check_swapon_status(module)
+
     if swap_is_inuse_res:
         run_swapoff(module, changed)
         changed = True
+
+    swap_systemd_units = check_swap_in_systemd(module)
 
     if swap_systemd_units:
         disable_systemd_units(module, swap_systemd_units)


### PR DESCRIPTION
Prior to this change, there was an error when a swap mount existed in
the fstab and was propagated to a systemd swap unit. This change
modifies the behavior so that the list of systemd swap units to remove
is not obtained until after the fstab changes are made.