### PR TITLE
Bug 2052901: sdn: use pod enviroment for preStop hook

### DIFF
--- a/roles/openshift_sdn/files/sdn.yaml
+++ b/roles/openshift_sdn/files/sdn.yaml
@@ -178,7 +178,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["rm","-Rf","/etc/cni/net.d/80-openshift-network.conf", "/host/opt/cni/bin/openshift-sdn", "/host/opt/cni/bin/openshift-sdn-${OPENSHIFT_SDN_POD}"]
+              command: ["sh","-c","rm -Rf /etc/cni/net.d/80-openshift-network.conf /host/opt/cni/bin/openshift-sdn /host/opt/cni/bin/openshift-sdn-${OPENSHIFT_SDN_POD}"]
 
       volumes:
       # In bootstrap mode, the host config contains information not easily available


### PR DESCRIPTION
No parameters are passed to preStop hook handlers and OPENSHIFT_SDN_POD
environment variable is never expanded. Use the existing pod environment
through a shell instead.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>