### PR TITLE
Consider api-int for openshift_node_bootstrap_server variable

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -6,7 +6,7 @@ openshift_node_tls_verify: false
 openshift_node_kubeconfig_path: "{{ openshift_kubeconfig_path | default('~/.kube/config') | expanduser | realpath }}"
 openshift_node_kubeconfig: "{{ lookup('file', openshift_node_kubeconfig_path) | from_yaml }}"
 openshift_node_bootstrap_port: 22623
-openshift_node_bootstrap_server: "{{ openshift_node_kubeconfig.clusters.0.cluster.server.split(':')[0:-1] | join(':') | regex_replace('://api', '://api-int') }}:{{ openshift_node_bootstrap_port }}"
+openshift_node_bootstrap_server: "{{ openshift_node_kubeconfig.clusters.0.cluster.server.split(':')[0:-1] | join(':') | regex_replace('://api-int|://api', '://api-int') }}:{{ openshift_node_bootstrap_port }}"
 openshift_node_bootstrap_endpoint: "{{ openshift_node_bootstrap_server }}/config/{{ openshift_node_machineconfigpool }}"
 
 openshift_packages: "{{ (openshift_node_packages + openshift_node_support_packages) | join(',') }}"


### PR DESCRIPTION
Since we can authenticate the cluster using `api-int.*` URL, the Ansible task picks the cluster API endpoint in the form of `api-int-int` from the `kubeconfig` file and throws the below error.
```
TASK [openshift_node : Fetch bootstrap ignition file locally] **********************************************************************************************************************************
task path: /usr/share/ansible/openshift-ansible/roles/openshift_node/tasks/config.yml:54
...
fatal: [[node.foo.bar.com]: FAILED! => {"attempts": 60, "changed": false, "content": "", "elapsed": 0, "msg": "Status code was -1 and not [200]: Request failed: <urlopen error [Errno -2] Name or service not known>", "path": "/tmp/ansible.LNwxMs/bootstrap.ign", "redirected": false, "status": -1, "url": "https://api-int-int.foo.bar.com:22623/config/worker"}
...
```