### PR TITLE
BUG 2090151: Scaleup: Increase scaleup attempts in the workbook

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -220,7 +220,7 @@
     register: oc_get
     until:
     - oc_get.stdout == "True"
-    retries: 30
+    retries: 60
     delay: 20
     changed_when: false
 


### PR DESCRIPTION
** Increased scaleup time by increasing the number of attempts from 30 to 60. This will double the time spent. Decided not to increase wait time because it would require a wait of 40+ seconds between attempts which may look like a frozen process. Instead alert the user every 20 seconds but attempt max of 60 times.