### PR TITLE
Port to ansible-core

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,7 @@
 [flake8]
 # TODO: cleanup flake8 issues with utils/test/*
-exclude=.tox,inventory
+# bundled ansible modules are copied as-is, have their own standards
+exclude=.tox,inventory,ini_file.py,seboolean.py,sysctl.py
 max_line_length = 120
 ignore = E501,T003
 per-file-ignores =

--- a/.pylintrc
+++ b/.pylintrc
@@ -8,7 +8,7 @@
 
 # Add files or directories to the ignore list. They should be base names, not
 # paths.
-ignore=CVS,setup.py
+ignore=CVS,setup.py,ini_file.py,seboolean.py,sysctl.py
 
 # Pickle collected data for later comparisons.
 persistent=no

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -24,12 +24,18 @@ COPY images/installer/root /
 # Add origin repo for including the oc client
 COPY images/installer/origin-extra-root /
 # Install openshift-ansible RPMs
-RUN yum install -y centos-release-ansible-29 epel-release && \
+RUN yum install -y epel-release && \
     yum config-manager --enable built > /dev/null && \
     yum install --setopt=tsflags=nodocs -y \
-      'ansible < 2.10' \
+      'ansible-core < 2.14' \
+      python38-dateutil python38-urllib3 \
       openshift-ansible-test && \
     yum clean all
+
+# for ec2_ami_info (in workers-rhel-aws-provision CI step) which requires boto3
+RUN ansible-galaxy collection install -p /usr/share/ansible/collections amazon.aws && \
+    find $HOME/.ansible -delete && \
+    pip3 install boto3
 
 RUN /usr/local/bin/user_setup \
  && rm /usr/local/bin/usage.ocp

--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -17,7 +17,7 @@ URL:            https://github.com/openshift/openshift-ansible
 Source0:        https://github.com/openshift/openshift-ansible/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-Requires:      ansible >= 2.9.5
+Requires:      ansible-core
 Requires:      openshift-clients
 Requires:      openssl
 
@@ -61,10 +61,8 @@ cp -rp test %{buildroot}%{_datadir}/ansible/%{name}/
 %package test
 Summary:       Openshift and Atomic Enterprise Ansible Test Playbooks
 Requires:      %{name} = %{version}-%{release}
-Requires:      ansible >= 2.9.5
+Requires:      ansible-core
 Requires:      openssh-clients
-#Requires:      python3-boto
-Requires:      python3-boto3
 BuildArch:     noarch
 
 %description test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
-ansible<2.10
+ansible-core<2.14

--- a/roles/openshift_node/library/ini_file.py
+++ b/roles/openshift_node/library/ini_file.py
@@ -1,0 +1,483 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2012, Jan-Piet Mens <jpmens () gmail.com>
+# Copyright: (c) 2015, Ales Nosek <anosek.nosek () gmail.com>
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: ini_file
+short_description: Tweak settings in INI files
+extends_documentation_fragment: files
+description:
+     - Manage (add, remove, change) individual settings in an INI-style file without having
+       to manage the file as a whole with, say, M(ansible.builtin.template) or M(ansible.builtin.assemble).
+     - Adds missing sections if they don't exist.
+     - Before Ansible 2.0, comments are discarded when the source file is read, and therefore will not show up in the destination file.
+     - Since Ansible 2.3, this module adds missing ending newlines to files to keep in line with the POSIX standard, even when
+       no other modifications need to be applied.
+options:
+  path:
+    description:
+      - Path to the INI-style file; this file is created if required.
+      - Before Ansible 2.3 this option was only usable as I(dest).
+    type: path
+    required: true
+    aliases: [ dest ]
+  section:
+    description:
+      - Section name in INI file. This is added if C(state=present) automatically when
+        a single value is being set.
+      - If left empty or set to C(null), the I(option) will be placed before the first I(section).
+      - Using C(null) is also required if the config format does not support sections.
+    type: str
+    required: true
+  option:
+    description:
+      - If set (required for changing a I(value)), this is the name of the option.
+      - May be omitted if adding/removing a whole I(section).
+    type: str
+  value:
+    description:
+      - The string value to be associated with an I(option).
+      - May be omitted when removing an I(option).
+      - Mutually exclusive with I(values).
+      - I(value=v) is equivalent to I(values=[v]).
+    type: str
+  values:
+    description:
+      - The string value to be associated with an I(option).
+      - May be omitted when removing an I(option).
+      - Mutually exclusive with I(value).
+      - I(value=v) is equivalent to I(values=[v]).
+    type: list
+    elements: str
+    version_added: 3.6.0
+  backup:
+    description:
+      - Create a backup file including the timestamp information so you can get
+        the original file back if you somehow clobbered it incorrectly.
+    type: bool
+    default: no
+  state:
+    description:
+      - If set to C(absent) and I(exclusive) set to C(yes) all matching I(option) lines are removed.
+      - If set to C(absent) and I(exclusive) set to C(no) the specified C(option=value) lines are removed,
+        but the other I(option)s with the same name are not touched.
+      - If set to C(present) and I(exclusive) set to C(no) the specified C(option=values) lines are added,
+        but the other I(option)s with the same name are not touched.
+      - If set to C(present) and I(exclusive) set to C(yes) all given C(option=values) lines will be
+        added and the other I(option)s with the same name are removed.
+    type: str
+    choices: [ absent, present ]
+    default: present
+  exclusive:
+    description:
+      - If set to C(yes) (default), all matching I(option) lines are removed when I(state=absent),
+        or replaced when I(state=present).
+      - If set to C(no), only the specified I(value(s)) are added when I(state=present),
+        or removed when I(state=absent), and existing ones are not modified.
+    type: bool
+    default: yes
+    version_added: 3.6.0
+  no_extra_spaces:
+    description:
+      - Do not insert spaces before and after '=' symbol.
+    type: bool
+    default: no
+  create:
+    description:
+      - If set to C(no), the module will fail if the file does not already exist.
+      - By default it will create the file if it is missing.
+    type: bool
+    default: yes
+  allow_no_value:
+    description:
+      - Allow option without value and without '=' symbol.
+    type: bool
+    default: no
+notes:
+   - While it is possible to add an I(option) without specifying a I(value), this makes no sense.
+   - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
+   - As of community.general 3.2.0, UTF-8 BOM markers are discarded when reading files.
+author:
+    - Jan-Piet Mens (@jpmens)
+    - Ales Nosek (@noseka1)
+'''
+
+EXAMPLES = r'''
+# Before Ansible 2.3, option 'dest' was used instead of 'path'
+- name: Ensure "fav=lemonade is in section "[drinks]" in specified file
+  community.general.ini_file:
+    path: /etc/conf
+    section: drinks
+    option: fav
+    value: lemonade
+    mode: '0600'
+    backup: yes
+
+- name: Ensure "temperature=cold is in section "[drinks]" in specified file
+  community.general.ini_file:
+    path: /etc/anotherconf
+    section: drinks
+    option: temperature
+    value: cold
+    backup: yes
+
+- name: Add "beverage=lemon juice" is in section "[drinks]" in specified file
+  community.general.ini_file:
+    path: /etc/conf
+    section: drinks
+    option: beverage
+    value: lemon juice
+    mode: '0600'
+    state: present
+    exclusive: no
+
+- name: Ensure multiple values "beverage=coke" and "beverage=pepsi" are in section "[drinks]" in specified file
+  community.general.ini_file:
+    path: /etc/conf
+    section: drinks
+    option: beverage
+    values:
+      - coke
+      - pepsi
+    mode: '0600'
+    state: present
+'''
+
+import io
+import os
+import re
+import tempfile
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_bytes, to_text
+
+
+def match_opt(option, line):
+    option = re.escape(option)
+    return re.match('[#;]?( |\t)*(%s)( |\t)*(=|$)( |\t)*(.*)' % option, line)
+
+
+def match_active_opt(option, line):
+    option = re.escape(option)
+    return re.match('( |\t)*(%s)( |\t)*(=|$)( |\t)*(.*)' % option, line)
+
+
+def update_section_line(changed, section_lines, index, changed_lines, newline, msg):
+    option_changed = section_lines[index] != newline
+    changed = changed or option_changed
+    if option_changed:
+        msg = 'option changed'
+    section_lines[index] = newline
+    changed_lines[index] = 1
+    return (changed, msg)
+
+
+def do_ini(module, filename, section=None, option=None, values=None,
+           state='present', exclusive=True, backup=False, no_extra_spaces=False,
+           create=True, allow_no_value=False):
+
+    if section is not None:
+        section = to_text(section)
+    if option is not None:
+        option = to_text(option)
+
+    # deduplicate entries in values
+    values_unique = []
+    [values_unique.append(to_text(value)) for value in values if value not in values_unique and value is not None]
+    values = values_unique
+
+    diff = dict(
+        before='',
+        after='',
+        before_header='%s (content)' % filename,
+        after_header='%s (content)' % filename,
+    )
+
+    if not os.path.exists(filename):
+        if not create:
+            module.fail_json(rc=257, msg='Destination %s does not exist!' % filename)
+        destpath = os.path.dirname(filename)
+        if not os.path.exists(destpath) and not module.check_mode:
+            os.makedirs(destpath)
+        ini_lines = []
+    else:
+        with io.open(filename, 'r', encoding="utf-8-sig") as ini_file:
+            ini_lines = [to_text(line) for line in ini_file.readlines()]
+
+    if module._diff:
+        diff['before'] = u''.join(ini_lines)
+
+    changed = False
+
+    # ini file could be empty
+    if not ini_lines:
+        ini_lines.append(u'\n')
+
+    # last line of file may not contain a trailing newline
+    if ini_lines[-1] == u"" or ini_lines[-1][-1] != u'\n':
+        ini_lines[-1] += u'\n'
+        changed = True
+
+    # append fake section lines to simplify the logic
+    # At top:
+    # Fake random section to do not match any other in the file
+    # Using commit hash as fake section name
+    fake_section_name = u"ad01e11446efb704fcdbdb21f2c43757423d91c5"
+
+    # Insert it at the beginning
+    ini_lines.insert(0, u'[%s]' % fake_section_name)
+
+    # At bottom:
+    ini_lines.append(u'[')
+
+    # If no section is defined, fake section is used
+    if not section:
+        section = fake_section_name
+
+    within_section = not section
+    section_start = section_end = 0
+    msg = 'OK'
+    if no_extra_spaces:
+        assignment_format = u'%s=%s\n'
+    else:
+        assignment_format = u'%s = %s\n'
+
+    option_no_value_present = False
+
+    non_blank_non_comment_pattern = re.compile(to_text(r'^[ \t]*([#;].*)?$'))
+
+    before = after = []
+    section_lines = []
+
+    for index, line in enumerate(ini_lines):
+        # find start and end of section
+        if line.startswith(u'[%s]' % section):
+            within_section = True
+            section_start = index
+        elif line.startswith(u'['):
+            if within_section:
+                section_end = index
+                break
+
+    before = ini_lines[0:section_start]
+    section_lines = ini_lines[section_start:section_end]
+    after = ini_lines[section_end:len(ini_lines)]
+
+    # Keep track of changed section_lines
+    changed_lines = [0] * len(section_lines)
+
+    # handling multiple instances of option=value when state is 'present' with/without exclusive is a bit complex
+    #
+    # 1. edit all lines where we have a option=value pair with a matching value in values[]
+    # 2. edit all the remaing lines where we have a matching option
+    # 3. delete remaining lines where we have a matching option
+    # 4. insert missing option line(s) at the end of the section
+
+    if state == 'present' and option:
+        for index, line in enumerate(section_lines):
+            if match_opt(option, line):
+                match = match_opt(option, line)
+                if values and match.group(6) in values:
+                    matched_value = match.group(6)
+                    if not matched_value and allow_no_value:
+                        # replace existing option with no value line(s)
+                        newline = u'%s\n' % option
+                        option_no_value_present = True
+                    else:
+                        # replace existing option=value line(s)
+                        newline = assignment_format % (option, matched_value)
+                    (changed, msg) = update_section_line(changed, section_lines, index, changed_lines, newline, msg)
+                    values.remove(matched_value)
+                elif not values and allow_no_value:
+                    # replace existing option with no value line(s)
+                    newline = u'%s\n' % option
+                    (changed, msg) = update_section_line(changed, section_lines, index, changed_lines, newline, msg)
+                    option_no_value_present = True
+                    break
+
+    if state == 'present' and exclusive and not allow_no_value:
+        # override option with no value to option with value if not allow_no_value
+        if len(values) > 0:
+            for index, line in enumerate(section_lines):
+                if not changed_lines[index] and match_active_opt(option, section_lines[index]):
+                    newline = assignment_format % (option, values.pop(0))
+                    (changed, msg) = update_section_line(changed, section_lines, index, changed_lines, newline, msg)
+                    if len(values) == 0:
+                        break
+        # remove all remaining option occurrences from the rest of the section
+        for index in range(len(section_lines) - 1, 0, -1):
+            if not changed_lines[index] and match_active_opt(option, section_lines[index]):
+                del section_lines[index]
+                del changed_lines[index]
+                changed = True
+                msg = 'option changed'
+
+    if state == 'present':
+        # insert missing option line(s) at the end of the section
+        for index in range(len(section_lines), 0, -1):
+            # search backwards for previous non-blank or non-comment line
+            if not non_blank_non_comment_pattern.match(section_lines[index - 1]):
+                if option and values:
+                    # insert option line(s)
+                    for element in values[::-1]:
+                        # items are added backwards, so traverse the list backwards to not confuse the user
+                        # otherwise some of their options might appear in reverse order for whatever fancy reason ¯\_(ツ)_/¯
+                        if element is not None:
+                            # insert option=value line
+                            section_lines.insert(index, assignment_format % (option, element))
+                            msg = 'option added'
+                            changed = True
+                        elif element is None and allow_no_value:
+                            # insert option with no value line
+                            section_lines.insert(index, u'%s\n' % option)
+                            msg = 'option added'
+                            changed = True
+                elif option and not values and allow_no_value and not option_no_value_present:
+                    # insert option with no value line(s)
+                    section_lines.insert(index, u'%s\n' % option)
+                    msg = 'option added'
+                    changed = True
+                break
+
+    if state == 'absent':
+        if option:
+            if exclusive:
+                # delete all option line(s) with given option and ignore value
+                new_section_lines = [line for line in section_lines if not (match_active_opt(option, line))]
+                if section_lines != new_section_lines:
+                    changed = True
+                    msg = 'option changed'
+                    section_lines = new_section_lines
+            elif not exclusive and len(values) > 0:
+                # delete specified option=value line(s)
+                new_section_lines = [i for i in section_lines if not (match_active_opt(option, i) and match_active_opt(option, i).group(6) in values)]
+                if section_lines != new_section_lines:
+                    changed = True
+                    msg = 'option changed'
+                    section_lines = new_section_lines
+        else:
+            # drop the entire section
+            if section_lines:
+                section_lines = []
+                msg = 'section removed'
+                changed = True
+
+    # reassemble the ini_lines after manipulation
+    ini_lines = before + section_lines + after
+
+    # remove the fake section line
+    del ini_lines[0]
+    del ini_lines[-1:]
+
+    if not within_section and state == 'present':
+        ini_lines.append(u'[%s]\n' % section)
+        msg = 'section and option added'
+        if option and values:
+            for value in values:
+                ini_lines.append(assignment_format % (option, value))
+        elif option and not values and allow_no_value:
+            ini_lines.append(u'%s\n' % option)
+        else:
+            msg = 'only section added'
+        changed = True
+
+    if module._diff:
+        diff['after'] = u''.join(ini_lines)
+
+    backup_file = None
+    if changed and not module.check_mode:
+        if backup:
+            backup_file = module.backup_local(filename)
+
+        encoded_ini_lines = [to_bytes(line) for line in ini_lines]
+        try:
+            tmpfd, tmpfile = tempfile.mkstemp(dir=module.tmpdir)
+            f = os.fdopen(tmpfd, 'wb')
+            f.writelines(encoded_ini_lines)
+            f.close()
+        except IOError:
+            module.fail_json(msg="Unable to create temporary file %s", traceback=traceback.format_exc())
+
+        try:
+            module.atomic_move(tmpfile, filename)
+        except IOError:
+            module.ansible.fail_json(msg='Unable to move temporary \
+                                   file %s to %s, IOError' % (tmpfile, filename), traceback=traceback.format_exc())
+
+    return (changed, backup_file, diff, msg)
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            path=dict(type='path', required=True, aliases=['dest']),
+            section=dict(type='str', required=True),
+            option=dict(type='str'),
+            value=dict(type='str'),
+            values=dict(type='list', elements='str'),
+            backup=dict(type='bool', default=False),
+            state=dict(type='str', default='present', choices=['absent', 'present']),
+            exclusive=dict(type='bool', default=True),
+            no_extra_spaces=dict(type='bool', default=False),
+            allow_no_value=dict(type='bool', default=False),
+            create=dict(type='bool', default=True)
+        ),
+        mutually_exclusive=[
+            ['value', 'values']
+        ],
+        add_file_common_args=True,
+        supports_check_mode=True,
+    )
+
+    path = module.params['path']
+    section = module.params['section']
+    option = module.params['option']
+    value = module.params['value']
+    values = module.params['values']
+    state = module.params['state']
+    exclusive = module.params['exclusive']
+    backup = module.params['backup']
+    no_extra_spaces = module.params['no_extra_spaces']
+    allow_no_value = module.params['allow_no_value']
+    create = module.params['create']
+
+    if state == 'present' and not allow_no_value and value is None and not values:
+        module.fail_json(msg="Parameter 'value(s)' must be defined if state=present and allow_no_value=False.")
+
+    if value is not None:
+        values = [value]
+    elif values is None:
+        values = []
+
+    (changed, backup_file, diff, msg) = do_ini(module, path, section, option, values, state, exclusive, backup, no_extra_spaces, create, allow_no_value)
+
+    if not module.check_mode and os.path.exists(path):
+        file_args = module.load_file_common_arguments(module.params)
+        changed = module.set_fs_attributes_if_different(file_args, changed)
+
+    results = dict(
+        changed=changed,
+        diff=diff,
+        msg=msg,
+        path=path,
+    )
+    if backup_file is not None:
+        results['backup_file'] = backup_file
+
+    # Mission complete
+    module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/openshift_node/library/seboolean.py
+++ b/roles/openshift_node/library/seboolean.py
@@ -1,0 +1,335 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2012, Stephen Fromm <sfromm@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: seboolean
+short_description: Toggles SELinux booleans
+description:
+     - Toggles SELinux booleans.
+version_added: "1.0.0"
+options:
+  name:
+    description:
+      - Name of the boolean to configure.
+    required: true
+    type: str
+  persistent:
+    description:
+      - Set to C(yes) if the boolean setting should survive a reboot.
+    type: bool
+    default: 'no'
+  state:
+    description:
+      - Desired boolean value
+    type: bool
+    required: true
+  ignore_selinux_state:
+    description:
+    - Useful for scenarios (chrooted environment) that you can't get the real SELinux state.
+    type: bool
+    default: false
+notes:
+   - Not tested on any Debian based system.
+requirements:
+- libselinux-python
+- libsemanage-python
+- python3-libsemanage
+author:
+- Stephen Fromm (@sfromm)
+'''
+
+EXAMPLES = r'''
+- name: Set httpd_can_network_connect flag on and keep it persistent across reboots
+  ansible.posix.seboolean:
+    name: httpd_can_network_connect
+    state: yes
+    persistent: yes
+'''
+
+import os
+import traceback
+
+SELINUX_IMP_ERR = None
+try:
+    import selinux
+    HAVE_SELINUX = True
+except ImportError:
+    SELINUX_IMP_ERR = traceback.format_exc()
+    HAVE_SELINUX = False
+
+SEMANAGE_IMP_ERR = None
+try:
+    import semanage
+    HAVE_SEMANAGE = True
+except ImportError:
+    SEMANAGE_IMP_ERR = traceback.format_exc()
+    HAVE_SEMANAGE = False
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.six import binary_type
+from ansible.module_utils._text import to_bytes, to_text
+
+
+def get_runtime_status(ignore_selinux_state=False):
+    return True if ignore_selinux_state is True else selinux.is_selinux_enabled()
+
+
+def has_boolean_value(module, name):
+    bools = []
+    try:
+        rc, bools = selinux.security_get_boolean_names()
+    except OSError:
+        module.fail_json(msg="Failed to get list of boolean names")
+    # work around for selinux who changed its API, see
+    # https://github.com/ansible/ansible/issues/25651
+    if len(bools) > 0:
+        if isinstance(bools[0], binary_type):
+            name = to_bytes(name)
+    if name in bools:
+        return True
+    else:
+        return False
+
+
+def get_boolean_value(module, name):
+    state = 0
+    try:
+        state = selinux.security_get_boolean_active(name)
+    except OSError:
+        module.fail_json(msg="Failed to determine current state for boolean %s" % name)
+    if state == 1:
+        return True
+    else:
+        return False
+
+
+def semanage_get_handle(module):
+    handle = semanage.semanage_handle_create()
+    if not handle:
+        module.fail_json(msg="Failed to create semanage library handle")
+
+    managed = semanage.semanage_is_managed(handle)
+    if managed <= 0:
+        semanage.semanage_handle_destroy(handle)
+    if managed < 0:
+        module.fail_json(msg="Failed to determine whether policy is manage")
+    if managed == 0:
+        if os.getuid() == 0:
+            module.fail_json(msg="Cannot set persistent booleans without managed policy")
+        else:
+            module.fail_json(msg="Cannot set persistent booleans; please try as root")
+
+    if semanage.semanage_connect(handle) < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to connect to semanage")
+
+    return handle
+
+
+def semanage_begin_transaction(module, handle):
+    if semanage.semanage_begin_transaction(handle) < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to begin semanage transaction")
+
+
+def semanage_set_boolean_value(module, handle, name, value):
+    rc, t_b = semanage.semanage_bool_create(handle)
+    if rc < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to create seboolean with semanage")
+
+    if semanage.semanage_bool_set_name(handle, t_b, name) < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to set seboolean name with semanage")
+
+    rc, boolkey = semanage.semanage_bool_key_extract(handle, t_b)
+    if rc < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to extract boolean key with semanage")
+
+    rc, exists = semanage.semanage_bool_exists(handle, boolkey)
+    if rc < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to check if boolean is defined")
+    if not exists:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="SELinux boolean %s is not defined in persistent policy" % name)
+
+    rc, sebool = semanage.semanage_bool_query(handle, boolkey)
+    if rc < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to query boolean in persistent policy")
+
+    semanage.semanage_bool_set_value(sebool, value)
+
+    if semanage.semanage_bool_modify_local(handle, boolkey, sebool) < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to modify boolean key with semanage")
+
+    if semanage.semanage_bool_set_active(handle, boolkey, sebool) < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to set boolean key active with semanage")
+
+    semanage.semanage_bool_key_free(boolkey)
+    semanage.semanage_bool_free(t_b)
+    semanage.semanage_bool_free(sebool)
+
+
+def semanage_get_boolean_value(module, handle, name):
+    rc, t_b = semanage.semanage_bool_create(handle)
+    if rc < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to create seboolean with semanage")
+
+    if semanage.semanage_bool_set_name(handle, t_b, name) < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to set seboolean name with semanage")
+
+    rc, boolkey = semanage.semanage_bool_key_extract(handle, t_b)
+    if rc < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to extract boolean key with semanage")
+
+    rc, exists = semanage.semanage_bool_exists(handle, boolkey)
+    if rc < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to check if boolean is defined")
+    if not exists:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="SELinux boolean %s is not defined in persistent policy" % name)
+
+    rc, sebool = semanage.semanage_bool_query(handle, boolkey)
+    if rc < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to query boolean in persistent policy")
+
+    value = semanage.semanage_bool_get_value(sebool)
+
+    semanage.semanage_bool_key_free(boolkey)
+    semanage.semanage_bool_free(t_b)
+    semanage.semanage_bool_free(sebool)
+
+    return value
+
+
+def semanage_commit(module, handle, load=0):
+    semanage.semanage_set_reload(handle, load)
+    if semanage.semanage_commit(handle) < 0:
+        semanage.semanage_handle_destroy(handle)
+        module.fail_json(msg="Failed to commit changes to semanage")
+
+
+def semanage_destroy_handle(module, handle):
+    rc = semanage.semanage_disconnect(handle)
+    semanage.semanage_handle_destroy(handle)
+    if rc < 0:
+        module.fail_json(msg="Failed to disconnect from semanage")
+
+
+# The following method implements what setsebool.c does to change
+# a boolean and make it persist after reboot..
+def semanage_boolean_value(module, name, state):
+    value = 0
+    changed = False
+    if state:
+        value = 1
+    try:
+        handle = semanage_get_handle(module)
+        semanage_begin_transaction(module, handle)
+        cur_value = semanage_get_boolean_value(module, handle, name)
+        if cur_value != value:
+            changed = True
+            if not module.check_mode:
+                semanage_set_boolean_value(module, handle, name, value)
+                semanage_commit(module, handle)
+        semanage_destroy_handle(module, handle)
+    except Exception as e:
+        module.fail_json(msg=u"Failed to manage policy for boolean %s: %s" % (name, to_text(e)))
+    return changed
+
+
+def set_boolean_value(module, name, state):
+    rc = 0
+    value = 0
+    if state:
+        value = 1
+    try:
+        rc = selinux.security_set_boolean(name, value)
+    except OSError:
+        module.fail_json(msg="Failed to set boolean %s to %s" % (name, value))
+    if rc == 0:
+        return True
+    else:
+        return False
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            ignore_selinux_state=dict(type='bool', default=False),
+            name=dict(type='str', required=True),
+            persistent=dict(type='bool', default=False),
+            state=dict(type='bool', required=True),
+        ),
+        supports_check_mode=True,
+    )
+
+    if not HAVE_SELINUX:
+        module.fail_json(msg=missing_required_lib('libselinux-python'), exception=SELINUX_IMP_ERR)
+
+    if not HAVE_SEMANAGE:
+        module.fail_json(msg=missing_required_lib('libsemanage-python or python3-libsemanage'), exception=SEMANAGE_IMP_ERR)
+
+    ignore_selinux_state = module.params['ignore_selinux_state']
+
+    if not get_runtime_status(ignore_selinux_state):
+        module.fail_json(msg="SELinux is disabled on this host.")
+
+    name = module.params['name']
+    persistent = module.params['persistent']
+    state = module.params['state']
+
+    result = dict(
+        name=name,
+        persistent=persistent,
+        state=state
+    )
+    changed = False
+
+    if hasattr(selinux, 'selinux_boolean_sub'):
+        # selinux_boolean_sub allows sites to rename a boolean and alias the old name
+        # Feature only available in selinux library since 2012.
+        name = selinux.selinux_boolean_sub(name)
+
+    if not has_boolean_value(module, name):
+        module.fail_json(msg="SELinux boolean %s does not exist." % name)
+
+    if persistent:
+        changed = semanage_boolean_value(module, name, state)
+    else:
+        cur_value = get_boolean_value(module, name)
+        if cur_value != state:
+            changed = True
+            if not module.check_mode:
+                changed = set_boolean_value(module, name, state)
+                if not changed:
+                    module.fail_json(msg="Failed to set boolean %s to %s" % (name, state))
+                try:
+                    selinux.security_commit_booleans()
+                except Exception:
+                    module.fail_json(msg="Failed to commit pending boolean %s value" % name)
+
+    result['changed'] = changed
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/openshift_node/library/sysctl.py
+++ b/roles/openshift_node/library/sysctl.py
@@ -1,0 +1,420 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012, David "DaviXX" CHANIAL <david.chanial@gmail.com>
+# (c) 2014, James Tanner <tanner.jc@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: sysctl
+short_description: Manage entries in sysctl.conf.
+description:
+    - This module manipulates sysctl entries and optionally performs a C(/sbin/sysctl -p) after changing them.
+version_added: "1.0.0"
+options:
+    name:
+        description:
+            - The dot-separated path (also known as I(key)) specifying the sysctl variable.
+        required: true
+        aliases: [ 'key' ]
+        type: str
+    value:
+        description:
+            - Desired value of the sysctl key.
+        aliases: [ 'val' ]
+        type: str
+    state:
+        description:
+            - Whether the entry should be present or absent in the sysctl file.
+        choices: [ "present", "absent" ]
+        default: present
+        type: str
+    ignoreerrors:
+        description:
+            - Use this option to ignore errors about unknown keys.
+        type: bool
+        default: 'no'
+    reload:
+        description:
+            - If C(yes), performs a I(/sbin/sysctl -p) if the C(sysctl_file) is
+              updated. If C(no), does not reload I(sysctl) even if the
+              C(sysctl_file) is updated.
+        type: bool
+        default: 'yes'
+    sysctl_file:
+        description:
+            - Specifies the absolute path to C(sysctl.conf), if not C(/etc/sysctl.conf).
+        default: /etc/sysctl.conf
+        type: path
+    sysctl_set:
+        description:
+            - Verify token value with the sysctl command and set with -w if necessary
+        type: bool
+        default: 'no'
+author:
+- David CHANIAL (@davixx)
+'''
+
+EXAMPLES = r'''
+# Set vm.swappiness to 5 in /etc/sysctl.conf
+- ansible.posix.sysctl:
+    name: vm.swappiness
+    value: '5'
+    state: present
+
+# Remove kernel.panic entry from /etc/sysctl.conf
+- ansible.posix.sysctl:
+    name: kernel.panic
+    state: absent
+    sysctl_file: /etc/sysctl.conf
+
+# Set kernel.panic to 3 in /tmp/test_sysctl.conf
+- ansible.posix.sysctl:
+    name: kernel.panic
+    value: '3'
+    sysctl_file: /tmp/test_sysctl.conf
+    reload: no
+
+# Set ip forwarding on in /proc and verify token value with the sysctl command
+- ansible.posix.sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    sysctl_set: yes
+
+# Set ip forwarding on in /proc and in the sysctl file and reload if necessary
+- ansible.posix.sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    sysctl_set: yes
+    state: present
+    reload: yes
+'''
+
+# ==============================================================
+
+import os
+import platform
+import re
+import tempfile
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import string_types
+from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE, BOOLEANS_TRUE
+from ansible.module_utils._text import to_native
+
+
+class SysctlModule(object):
+
+    # We have to use LANG=C because we are capturing STDERR of sysctl to detect
+    # success or failure.
+    LANG_ENV = {'LANG': 'C', 'LC_ALL': 'C', 'LC_MESSAGES': 'C'}
+
+    def __init__(self, module):
+        self.module = module
+        self.args = self.module.params
+
+        self.sysctl_cmd = self.module.get_bin_path('sysctl', required=True)
+        self.sysctl_file = self.args['sysctl_file']
+
+        self.proc_value = None  # current token value in proc fs
+        self.file_value = None  # current token value in file
+        self.file_lines = []    # all lines in the file
+        self.file_values = {}   # dict of token values
+
+        self.changed = False    # will change occur
+        self.set_proc = False   # does sysctl need to set value
+        self.write_file = False  # does the sysctl file need to be reloaded
+
+        self.process()
+
+    # ==============================================================
+    #   LOGIC
+    # ==============================================================
+
+    def process(self):
+
+        self.platform = platform.system().lower()
+
+        # Whitespace is bad
+        self.args['name'] = self.args['name'].strip()
+        self.args['value'] = self._parse_value(self.args['value'])
+
+        thisname = self.args['name']
+
+        # get the current proc fs value
+        self.proc_value = self.get_token_curr_value(thisname)
+
+        # get the current sysctl file value
+        self.read_sysctl_file()
+        if thisname not in self.file_values:
+            self.file_values[thisname] = None
+
+        # update file contents with desired token/value
+        self.fix_lines()
+
+        # what do we need to do now?
+        if self.file_values[thisname] is None and self.args['state'] == "present":
+            self.changed = True
+            self.write_file = True
+        elif self.file_values[thisname] is None and self.args['state'] == "absent":
+            self.changed = False
+        elif self.file_values[thisname] and self.args['state'] == "absent":
+            self.changed = True
+            self.write_file = True
+        elif self.file_values[thisname] != self.args['value']:
+            self.changed = True
+            self.write_file = True
+        # with reload=yes we should check if the current system values are
+        # correct, so that we know if we should reload
+        elif self.args['reload']:
+            if self.proc_value is None:
+                self.changed = True
+            elif not self._values_is_equal(self.proc_value, self.args['value']):
+                self.changed = True
+
+        # use the sysctl command or not?
+        if self.args['sysctl_set'] and self.args['state'] == "present":
+            if self.proc_value is None:
+                self.changed = True
+            elif not self._values_is_equal(self.proc_value, self.args['value']):
+                self.changed = True
+                self.set_proc = True
+
+        # Do the work
+        if not self.module.check_mode:
+            if self.set_proc:
+                self.set_token_value(self.args['name'], self.args['value'])
+            if self.write_file:
+                self.write_sysctl()
+            if self.changed and self.args['reload']:
+                self.reload_sysctl()
+
+    def _values_is_equal(self, a, b):
+        """Expects two string values. It will split the string by whitespace
+        and compare each value. It will return True if both lists are the same,
+        contain the same elements and the same order."""
+        if a is None or b is None:
+            return False
+
+        a = a.split()
+        b = b.split()
+
+        if len(a) != len(b):
+            return False
+
+        return len([i for i, j in zip(a, b) if i == j]) == len(a)
+
+    def _parse_value(self, value):
+        if value is None:
+            return ''
+        elif isinstance(value, bool):
+            if value:
+                return '1'
+            else:
+                return '0'
+        elif isinstance(value, string_types):
+            if value.lower() in BOOLEANS_TRUE:
+                return '1'
+            elif value.lower() in BOOLEANS_FALSE:
+                return '0'
+            else:
+                return value.strip()
+        else:
+            return value
+
+    def _stderr_failed(self, err):
+        # sysctl can fail to set a value even if it returns an exit status 0
+        # (https://bugzilla.redhat.com/show_bug.cgi?id=1264080). That's why we
+        # also have to check stderr for errors. For now we will only fail on
+        # specific errors defined by the regex below.
+        errors_regex = r'^sysctl: setting key "[^"]+": (Invalid argument|Read-only file system)$'
+        return re.search(errors_regex, err, re.MULTILINE) is not None
+
+    # ==============================================================
+    #   SYSCTL COMMAND MANAGEMENT
+    # ==============================================================
+
+    # Use the sysctl command to find the current value
+    def get_token_curr_value(self, token):
+        if self.platform == 'openbsd':
+            # openbsd doesn't support -e, just drop it
+            thiscmd = "%s -n %s" % (self.sysctl_cmd, token)
+        else:
+            thiscmd = "%s -e -n %s" % (self.sysctl_cmd, token)
+        rc, out, err = self.module.run_command(thiscmd, environ_update=self.LANG_ENV)
+        if rc != 0:
+            return None
+        else:
+            return out
+
+    # Use the sysctl command to set the current value
+    def set_token_value(self, token, value):
+        if len(value.split()) > 0:
+            value = '"' + value + '"'
+        if self.platform == 'openbsd':
+            # openbsd doesn't accept -w, but since it's not needed, just drop it
+            thiscmd = "%s %s=%s" % (self.sysctl_cmd, token, value)
+        elif self.platform == 'freebsd':
+            ignore_missing = ''
+            if self.args['ignoreerrors']:
+                ignore_missing = '-i'
+            # freebsd doesn't accept -w, but since it's not needed, just drop it
+            thiscmd = "%s %s %s=%s" % (self.sysctl_cmd, ignore_missing, token, value)
+        else:
+            ignore_missing = ''
+            if self.args['ignoreerrors']:
+                ignore_missing = '-e'
+            thiscmd = "%s %s -w %s=%s" % (self.sysctl_cmd, ignore_missing, token, value)
+        rc, out, err = self.module.run_command(thiscmd, environ_update=self.LANG_ENV)
+        if rc != 0 or self._stderr_failed(err):
+            self.module.fail_json(msg='setting %s failed: %s' % (token, out + err))
+        else:
+            return rc
+
+    # Run sysctl -p
+    def reload_sysctl(self):
+        if self.platform == 'freebsd':
+            # freebsd doesn't support -p, so reload the sysctl service
+            rc, out, err = self.module.run_command('/etc/rc.d/sysctl reload', environ_update=self.LANG_ENV)
+        elif self.platform == 'openbsd':
+            # openbsd doesn't support -p and doesn't have a sysctl service,
+            # so we have to set every value with its own sysctl call
+            for k, v in self.file_values.items():
+                rc = 0
+                if k != self.args['name']:
+                    rc = self.set_token_value(k, v)
+                    # FIXME this check is probably not needed as set_token_value would fail_json if rc != 0
+                    if rc != 0:
+                        break
+            if rc == 0 and self.args['state'] == "present":
+                rc = self.set_token_value(self.args['name'], self.args['value'])
+
+            # set_token_value would have called fail_json in case of failure
+            # so return here and do not continue to the error processing below
+            # https://github.com/ansible/ansible/issues/58158
+            return
+        else:
+            # system supports reloading via the -p flag to sysctl, so we'll use that
+            sysctl_args = [self.sysctl_cmd, '-p', self.sysctl_file]
+            if self.args['ignoreerrors']:
+                sysctl_args.insert(1, '-e')
+
+            rc, out, err = self.module.run_command(sysctl_args, environ_update=self.LANG_ENV)
+
+        if rc != 0 or self._stderr_failed(err):
+            self.module.fail_json(msg="Failed to reload sysctl: %s" % to_native(out) + to_native(err))
+
+    # ==============================================================
+    #   SYSCTL FILE MANAGEMENT
+    # ==============================================================
+
+    # Get the token value from the sysctl file
+    def read_sysctl_file(self):
+
+        lines = []
+        if os.path.isfile(self.sysctl_file):
+            try:
+                with open(self.sysctl_file, "r") as read_file:
+                    lines = read_file.readlines()
+            except IOError as e:
+                self.module.fail_json(msg="Failed to open %s: %s" % (to_native(self.sysctl_file), to_native(e)))
+
+        for line in lines:
+            line = line.strip()
+            self.file_lines.append(line)
+
+            # don't split empty lines or comments or line without equal sign
+            if not line or line.startswith(("#", ";")) or "=" not in line:
+                continue
+
+            k, v = line.split('=', 1)
+            k = k.strip()
+            v = v.strip()
+            self.file_values[k] = v.strip()
+
+    # Fix the value in the sysctl file content
+    def fix_lines(self):
+        checked = []
+        self.fixed_lines = []
+        for line in self.file_lines:
+            if not line.strip() or line.strip().startswith(("#", ";")) or "=" not in line:
+                self.fixed_lines.append(line)
+                continue
+            tmpline = line.strip()
+            k, v = tmpline.split('=', 1)
+            k = k.strip()
+            v = v.strip()
+            if k not in checked:
+                checked.append(k)
+                if k == self.args['name']:
+                    if self.args['state'] == "present":
+                        new_line = "%s=%s\n" % (k, self.args['value'])
+                        self.fixed_lines.append(new_line)
+                else:
+                    new_line = "%s=%s\n" % (k, v)
+                    self.fixed_lines.append(new_line)
+
+        if self.args['name'] not in checked and self.args['state'] == "present":
+            new_line = "%s=%s\n" % (self.args['name'], self.args['value'])
+            self.fixed_lines.append(new_line)
+
+    # Completely rewrite the sysctl file
+    def write_sysctl(self):
+        # open a tmp file
+        fd, tmp_path = tempfile.mkstemp('.conf', '.ansible_m_sysctl_', os.path.dirname(self.sysctl_file))
+        f = open(tmp_path, "w")
+        try:
+            for l in self.fixed_lines:
+                f.write(l.strip() + "\n")
+        except IOError as e:
+            self.module.fail_json(msg="Failed to write to file %s: %s" % (tmp_path, to_native(e)))
+        f.flush()
+        f.close()
+
+        # replace the real one
+        self.module.atomic_move(tmp_path, self.sysctl_file)
+
+
+# ==============================================================
+# main
+
+def main():
+
+    # defining module
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(aliases=['key'], required=True),
+            value=dict(aliases=['val'], required=False, type='str'),
+            state=dict(default='present', choices=['present', 'absent']),
+            reload=dict(default=True, type='bool'),
+            sysctl_set=dict(default=False, type='bool'),
+            ignoreerrors=dict(default=False, type='bool'),
+            sysctl_file=dict(default='/etc/sysctl.conf', type='path')
+        ),
+        supports_check_mode=True,
+        required_if=[('state', 'present', ['value'])],
+    )
+
+    if module.params['name'] is None:
+        module.fail_json(msg="name cannot be None")
+    if module.params['state'] == 'present' and module.params['value'] is None:
+        module.fail_json(msg="value cannot be None")
+
+    # In case of in-line params
+    if module.params['name'] == '':
+        module.fail_json(msg="name cannot be blank")
+    if module.params['state'] == 'present' and module.params['value'] == '':
+        module.fail_json(msg="value cannot be blank")
+
+    result = SysctlModule(module)
+
+    module.exit_json(changed=result.changed)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Ansible Engine 2.9 is [going out of support,](https://access.redhat.com/support/policy/updates/ansible-automation-platform) and being replaced by ansible-core in RHEL AppStream.  Therefore, openshift-ansible needs to migrate.  Since this requires modules which are no longer builtin the core but provided through collections -- `seboolean` and `sysctl` from ansible.posix, and `ini_file` from community.general -- those need to be either bundled or their collections packaged as RPMs.

/cc @patrickdillon @barbacbd 