### PR TITLE
Bug 2100644: Fix FTBFS on RHEL8

### DIFF
--- a/inventory/dynamic/gcp/hosts.py
+++ b/inventory/dynamic/gcp/hosts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible


### PR DESCRIPTION
4.11 builds of openshift-ansible were stopped by https://github.com/openshift/ocp-build-data/commit/8a976dccad2bfeb73c7b63c422e986cf4146dd08 due to a build error:

** ERROR: ambiguous python shebang in /usr/share/ansible/openshift-ansible/inventory/dynamic/gcp/hosts.py: #!/usr/bin/env python. Change it to python3 (or python2) explicitly.

This script in its current state is not compatible with Python 3, so either it needs to use 2 explicitly for now until ported to 3.  (2to3 shows changes are needed wrt `ConfigParser` and `has_key`.)

/cc @patrickdillon 