### PR TITLE
hack: add script to update bundled Ansible modules

### DIFF
--- a/hack/update-ansible-modules.sh
+++ b/hack/update-ansible-modules.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ANSIBLE_POSIX_REPO="https://raw.githubusercontent.com/ansible-collections/ansible.posix"
+ANSIBLE_POSIX_MODULES=(seboolean.py sysctl.py)
+ANSIBLE_POSIX_VERSION=1.4.0
+
+COMMUNITY_GENERAL_REPO="https://raw.githubusercontent.com/ansible-collections/community.general"
+COMMUNITY_GENERAL_MODULES=(files/ini_file.py)
+COMMUNITY_GENERAL_VERSION=4.8.4
+
+srcdir="$(dirname $0)/.."
+
+pushd ${srcdir}/roles/openshift_node/library
+
+for ap in ${ANSIBLE_POSIX_MODULES[*]} ; do
+echo "*** Updating ${ap##*/} from ${ANSIBLE_POSIX_REPO##*/} ${ANSIBLE_POSIX_VERSION}"
+curl -sO ${ANSIBLE_POSIX_REPO}/${ANSIBLE_POSIX_VERSION}/plugins/modules/${ap}
+done
+
+for cg in ${COMMUNITY_GENERAL_MODULES[*]} ; do
+echo "*** Updating ${cg##*/} from ${COMMUNITY_GENERAL_REPO##*/} ${COMMUNITY_GENERAL_VERSION}"
+curl -sO ${COMMUNITY_GENERAL_REPO}/${COMMUNITY_GENERAL_VERSION}/plugins/modules/${cg}
+done
+
+git --no-pager diff --stat .
+
+popd


### PR DESCRIPTION
Per our discussion on the ansible-core update.  This script has the versions baked into it, so that updates are deliberate and recorded, and unreleased code does not get pulled.

You can test this by changing `COMMUNITY_GENERAL_VERSION` to `5.3.0` and running the script; you'll see a documentation spelling fix in one module, but no further changes.  Or, set `ANSIBLE_POSIX_VERSION` back to `1.0.0` and `COMMUNITY_GENERAL_VERSION` back to `4.0.0` to see the effect of such a downgrade.

/cc @barbacbd @jstuever @patrickdillon 

