### PR TITLE
Pin msgpack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ shade==1.24.0
 passlib==1.6.5
 dogpile.cache==0.9.2
 pyrsistent==0.16.1
+msgpack==1.0.3
 jsonschema<=3.2.0 ; python_version < '3.0'


### PR DESCRIPTION
Tests are failing with:
ERROR: Could not build wheels for msgpack which use PEP 517 and cannot be installed directly
See: 
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_openshift-ansible/12414/pull-ci-openshift-openshift-ansible-release-3.11-unit/1554423865612963840


Pin msgpack to 1.0.3, which is the last version I see in a successful
test:
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_openshift-ansible/12387/pull-ci-openshift-openshift-ansible-release-3.11-unit/1516432849836707840/artifacts/test/

Let's see if this fixes the unit tests...