### PR TITLE
Bug 1968041: Remove the masterPublicURL verification

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -17,7 +17,7 @@ RUN INSTALL_PKGS="ansible-2.9.13 azure-cli-2.0.46 java-1.8.0-openjdk-headless py
  && rpm -V $INSTALL_PKGS $EPEL_PKGS \
  && yum clean all
 
-RUN pip install --upgrade 'pip<21' 'setuptools<45' 'wheel' \
+RUN pip install --upgrade 'pip<21' 'setuptools<45' 'wheel<0.38' \
  && pip install 'boto' 'pyOpenSSL' 'apache-libcloud' 'SecretStorage<3' 'ansible[azure]' 'boto3'
 
 LABEL name="openshift/origin-ansible" \

--- a/roles/openshift_control_plane/handlers/main.yml
+++ b/roles/openshift_control_plane/handlers/main.yml
@@ -10,23 +10,6 @@
   until: result.rc == 0
   notify: verify API server
 
-- name: verify API server
-  # Using curl here since the uri module requires python-httplib2 and
-  # wait_for port doesn't provide health information.
-  command: >
-    curl --silent --tlsv1.2 --max-time 2
-    --cacert {{ openshift.common.config_base }}/master/ca-bundle.crt
-    {{ openshift.master.api_url }}/healthz/ready
-  args:
-    # Disables the following warning:
-    # Consider using get_url or uri module rather than running curl
-    warn: no
-  register: l_api_available_output
-  until: l_api_available_output.stdout == 'ok'
-  retries: 120
-  delay: 1
-  changed_when: false
-
 - name: verify Local API server
   # Using curl here since the uri module requires python-httplib2 and
   # wait_for port doesn't provide health information.


### PR DESCRIPTION
** Verification fails when certificates are invalid. Removing the checks against the
    masterPublicURL and leaving the checks against the local server. Based on the comment here:
    https://bugzilla.redhat.com/show_bug.cgi?id=1968041#c9