### PR TITLE
[release-4.11] node: sync OVS version with RHCOS

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -82,7 +82,7 @@ openshift_node_support_packages_by_os_major_version:
     - container-storage-setup
     - ceph-common
   "8":
-    - openvswitch2.15
+    - openvswitch2.17
     - policycoreutils-python-utils
 
 openshift_node_support_packages_by_arch:


### PR DESCRIPTION
4.10+ should be OVS 2.17

(cherry picked from commit 2157e9b4474ad1b91db6248d344d3e57104a5ee2)