### PR TITLE
Dockerfile: install dnf-command(config-manager)

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -21,8 +21,9 @@ ENV USER_UID=1001 \
 
 # Add image scripts and files for running as a system container
 COPY images/installer/root /
+
 # Install openshift-ansible RPMs
-RUN yum install -y epel-release && \
+RUN yum install -y epel-release 'dnf-command(config-manager)' && \
     yum config-manager --enable built > /dev/null && \
     yum install --setopt=tsflags=nodocs -y \
       'ansible-core < 2.14' \


### PR DESCRIPTION
It seems that the config-manager command is no longer installed by default in the latest centos8 image, which results in this failure:

No such command: config-manager. Please use /usr/bin/yum --help
It could be a YUM plugin command, try: "yum install 'dnf-command(config-manager)'"

We use the config-manager command to inject the openshift-ansible rpm into the ci image. For more details, see:
https://github.com/openshift/openshift-ansible/pull/10960

Testing locally, I can see that the config manager command is not present:
```shell
$ podman run --rm quay.io/centos/centos:stream8 yum --version
4.7.0
  Installed: dnf-0:4.7.0-15.el8.noarch at Wed Mar  8 15:58:07 2023
  Built    : CentOS Buildsys <bugs@centos.org> at Thu Jan 12 09:05:43 2023

  Installed: rpm-0:4.14.3-26.el8.x86_64 at Wed Mar  8 15:58:06 2023
  Built    : CentOS Buildsys <bugs@centos.org> at Wed Dec 21 11:18:39 2022

$ podman run --rm quay.io/centos/centos:stream8 yum config-manager
No such command: config-manager. Please use /usr/bin/yum --help
It could be a YUM plugin command, try: "yum install 'dnf-command(config-manager)'"
```

The changes in this PR resolve, but I do not have a full local setup to test injecting the repos. 

This issue is blocking the problem we are investigating in: https://github.com/openshift/release/pull/38062