### PR TITLE
OCPBUGS-5255: exclude kubelet from fixfiles

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -62,6 +62,13 @@
     state: yes
     persistent: yes
 
+# Exclude kubelet from fixfiles to prevent cluster components from
+# changing the selinux context: https://issues.redhat.com/browse/OCPBUGS-5255
+- name: Exclude kubelet dir from fixfiles
+  copy:
+    dest: /etc/selinux/fixfiles_exclude_dirs
+    content: /var/lib/kubelet
+
 - name: Create temp directory
   tempfile:
     state: directory


### PR DESCRIPTION
The node tuning operator and potentially other cluster components can change the selinux context of the kubelet dir. By adding the kubelet dir to the fixfiles_exclude_dirs we can prevent that.

Fixes: https://issues.redhat.com/browse/OCPBUGS-5255