### PR TITLE
Set default remote_tmp

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -16,6 +16,7 @@ retry_files_enabled = False
 retry_files_save_path = ~/ansible-installer-retries
 nocows = True
 remote_user = root
+remote_tmp = /tmp/.ansible-tmp
 roles_path = roles/
 gathering = smart
 fact_caching = jsonfile


### PR DESCRIPTION
Ansible will try to create the temp directory if it doesn't already exist, but will be unable to if that user does not have a home directory or if their home directory permissions do not allow them write access.