### PR TITLE
OCPBUGS-11677: Fix package conflicts on upgrade.

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -8,6 +8,7 @@ openshift_node_kubeconfig: "{{ lookup('file', openshift_node_kubeconfig_path) | 
 openshift_node_bootstrap_port: 22623
 openshift_node_bootstrap_server: "{{ openshift_node_kubeconfig.clusters.0.cluster.server.split(':')[0:-1] | join(':') | regex_replace('://api-int|://api', '://api-int') }}:{{ openshift_node_bootstrap_port }}"
 openshift_node_bootstrap_endpoint: "{{ openshift_node_bootstrap_server }}/config/{{ openshift_node_machineconfigpool }}"
+openshift_package_directory: '/tmp/openshift-ansible-packages'
 
 openshift_packages: "{{ (openshift_node_packages + openshift_node_support_packages) | join(',') }}"
 
@@ -84,6 +85,9 @@ openshift_node_support_packages_by_os_major_version:
   "8":
     - openvswitch2.17
     - policycoreutils-python-utils
+
+openshift_conflict_packages:
+  - openvswitch
 
 openshift_node_support_packages_by_arch:
   ppc64le:

--- a/roles/openshift_node/tasks/package_conflicts.yml
+++ b/roles/openshift_node/tasks/package_conflicts.yml
@@ -1,0 +1,49 @@
+---
+- name: Install manager to download packages
+  yum:
+    name: "yum-utils"
+    state: latest
+
+- name: Create a temporary directory for packages
+  file:
+    path: "{{ openshift_package_directory }}"
+    state: directory
+
+# not all packages can be safely or easily upgraded due to conflicts
+# Download the rpms and then remove conflicting packages and install the new ones.
+# A particular issue is openvswitch which conflicts with itself, but removing
+# older versions of the package causes network issues.
+- name: Download rpms for conflicting packages
+  command: "yumdownloader --destdir {{ openshift_package_directory }} {{ item }}"
+  with_items: "{{ openshift_node_support_packages_by_os_major_version[ansible_distribution_major_version] }}"
+
+- name: Find all downloaded rpms
+  find:
+    paths: "{{ openshift_package_directory }}"
+    patterns: "*.rpm"
+  register: rpms
+
+- name: Setting list of rpms
+  set_fact:
+    rpm_list: "{{ rpms.files | map(attribute='path') | list}}"
+
+- name: Remove known conflicts
+  yum:
+    name: "{{ item }}*"
+    state: absent
+  with_items: "{{ openshift_conflict_packages }}"
+
+- name: Install downloaded packages
+  yum:
+    name: "{{ rpm_list }}"
+    state: present
+
+- name: Remove temporary directory
+  file:
+    path: "{{ openshift_package_directory }}"
+    state: absent
+
+- name: Remove temporary manager for downloaded packages
+  yum:
+    name: "yum-utils"
+    state: absent

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -25,6 +25,9 @@
   - include_tasks: "{{ openshift_node_pre_upgrade_hook }}"
   when: openshift_node_pre_upgrade_hook is defined
 
+# Manually upgrade challenging packages that may have conflicts during normal upgrade
+- import_tasks: package_conflicts.yml
+
 # Upgrade Node Packages
 - import_tasks: install.yml
 


### PR DESCRIPTION
**Openvswitch 2.1 to 2.17 cause upgrade issues. The package conflicts with itself. Further it causes issues when the original is removed and the next is attempted to be installed because openvswitch causes network issues when it is removed.