### PR TITLE
OCPBUGS-5255: exclude kubelet from fixfiles on upgrade

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -62,12 +62,8 @@
     state: yes
     persistent: yes
 
-# Exclude kubelet from fixfiles to prevent cluster components from
-# changing the selinux context: https://issues.redhat.com/browse/OCPBUGS-5255
-- name: Exclude kubelet dir from fixfiles
-  copy:
-    dest: /etc/selinux/fixfiles_exclude_dirs
-    content: /var/lib/kubelet
+# Preserve SE Linux data
+- import_tasks: selinux.yml
 
 - name: Create temp directory
   tempfile:

--- a/roles/openshift_node/tasks/selinux.yml
+++ b/roles/openshift_node/tasks/selinux.yml
@@ -1,0 +1,7 @@
+---
+# Exclude kubelet from fixfiles to prevent cluster components from
+# changing the selinux context: https://issues.redhat.com/browse/OCPBUGS-5255
+- name: Exclude kubelet dir from fixfiles
+  copy:
+    dest: /etc/selinux/fixfiles_exclude_dirs
+    content: /var/lib/kubelet

--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -50,3 +50,6 @@
       msg: "Running node openshift_node_post_upgrade_hook {{ openshift_node_post_upgrade_hook }}"
   - include_tasks: "{{ openshift_node_post_upgrade_hook }}"
   when: openshift_node_post_upgrade_hook is defined
+
+# Preserve SE Linux data
+- import_tasks: selinux.yml


### PR DESCRIPTION
** Original PR merged (https://github.com/openshift/openshift-ansible/pull/12445) but the upgrade was not correctly applying selinux configuration details. The selinux config is broken out into another task and imported in install and upgrade tasks.