### PR TITLE
OCPBUGS-13165: Fix systemctl status for crio

### DIFF
--- a/roles/openshift_node/tasks/gather_debug.yml
+++ b/roles/openshift_node/tasks/gather_debug.yml
@@ -7,7 +7,7 @@
   ignore_errors: true
   register: systemctl_status
   loop:
-  - cri-o
+  - crio
   - kubelet
 
 - name: Gather Debug - Get complete node objects


### PR DESCRIPTION
** crio was misspelled in the gather_debug playbook