### PR TITLE
OCPBUGS-13165: Fix python2 references

### DIFF
--- a/roles/openshift_node/library/ini_file.py
+++ b/roles/openshift_node/library/ini_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2012, Jan-Piet Mens <jpmens () gmail.com>

--- a/roles/openshift_node/library/oc_csr_approve.py
+++ b/roles/openshift_node/library/oc_csr_approve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 """oc_csr_approve module"""
 # Copyright 2020 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.

--- a/roles/openshift_node/library/seboolean.py
+++ b/roles/openshift_node/library/seboolean.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Copyright: (c) 2012, Stephen Fromm <sfromm@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/roles/openshift_node/library/swapoff.py
+++ b/roles/openshift_node/library/swapoff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # pylint: disable=missing-docstring
 #
 # Copyright 2017 Red Hat, Inc. and/or its affiliates

--- a/roles/openshift_node/library/sysctl.py
+++ b/roles/openshift_node/library/sysctl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 # (c) 2012, David "DaviXX" CHANIAL <david.chanial@gmail.com>


### PR DESCRIPTION
** python2 is no longer installed by default on the nodes so we need to update the references to python3