### PR TITLE
Update OKD and OCP installing references in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ ansible-playbook -i inventory/hosts playbooks/upgrade.yml
 # Further reading
 
 ## Complete Production Installation Documentation:
-- [OpenShift Container Platform](https://docs.openshift.com/container-platform/4.13/installing/index.html)
+- [OpenShift Container Platform](https://docs.openshift.com/container-platform/latest/installing/index.html)
 - [OKD](https://docs.okd.io/latest/installing/index.html) (formerly OpenShift Origin)
 
 ## Containerized OpenShift Ansible

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ ansible-playbook -i inventory/hosts playbooks/upgrade.yml
 # Further reading
 
 ## Complete Production Installation Documentation:
-- [OpenShift Container Platform](https://docs.openshift.com/container-platform/latest/install/index.html)
+- [OpenShift Container Platform](https://docs.openshift.com/container-platform/4.13/installing/index.html)
 - [OKD](https://docs.okd.io/latest/installing/index.html) (formerly OpenShift Origin)
 
 ## Containerized OpenShift Ansible

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ ansible-playbook -i inventory/hosts playbooks/upgrade.yml
 
 ## Complete Production Installation Documentation:
 - [OpenShift Container Platform](https://docs.openshift.com/container-platform/latest/install/index.html)
-- [OKD](https://docs.okd.io/latest/install/index.html) (formerly OpenShift Origin)
+- [OKD](https://docs.okd.io/latest/installing/index.html) (formerly OpenShift Origin)
 
 ## Containerized OpenShift Ansible
 


### PR DESCRIPTION
Update OKD installing reference. The current URL returns not found.

![Screenshot from 2023-06-07 12-07-48](https://github.com/openshift/openshift-ansible/assets/3216894/9f1419da-978e-4731-8c47-c12715b5f3c3)
