### PR TITLE
OCPBUGS-18595: Update openvswitch package

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -83,7 +83,7 @@ openshift_node_support_packages_by_os_major_version:
     - container-storage-setup
     - ceph-common
   "8":
-    - openvswitch2.17
+    - openvswitch3.1
     - policycoreutils-python-utils
 
 openshift_conflict_packages:


### PR DESCRIPTION
** RHCOS in 4.13 bumped to OVS 3.1, we should do the same for RHEL workers as the client side (SDN pods) may soon depend on 3.1 features and 3.1 is known to perfom better.