### PR TITLE
OCPBUGS-22366: Restart the openvswitch service on [re]install

### DIFF
--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -107,6 +107,21 @@
         Please ensure repos are configured properly to provide these packages
         and indicated versions.
 
+# Changes are possible to daemons on update. Reload for the most updated state
+- name: reload systemd daemons
+  systemd:
+    daemon_reload: yes
+
+# gather facts to ensure that openvswitch is defined for the next task
+- name: gather service facts
+  ansible.builtin.service_facts:
+
+- name: Restart openvswitch
+  systemd:
+    name: openvswitch
+    state: restarted
+  when: ansible_facts.services['openvswitch.service'] is defined
+
 - name: Enable the CRI-O service
   systemd:
     name: "crio"


### PR DESCRIPTION
Restart the openvswitch service when installed/upgraded if it exists. This should resolve network connectivity issues during upgrades.