### PR TITLE
Bump ansible-core version

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -28,6 +28,7 @@ RUN yum install -y epel-release 'dnf-command(config-manager)' && \
     yum install --setopt=tsflags=nodocs -y \
       'ansible-core < 2.16' \
       python38-dateutil python38-urllib3 \
+      python3-pip \
       openshift-ansible-test && \
     yum clean all
 

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -26,7 +26,7 @@ COPY images/installer/root /
 RUN yum install -y epel-release 'dnf-command(config-manager)' && \
     yum config-manager --enable built > /dev/null && \
     yum install --setopt=tsflags=nodocs -y \
-      'ansible-core < 2.14' \
+      'ansible-core < 2.16' \
       python38-dateutil python38-urllib3 \
       openshift-ansible-test && \
     yum clean all

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -35,7 +35,7 @@ RUN yum install -y epel-release 'dnf-command(config-manager)' && \
 # for ec2_ami_info (in workers-rhel-aws-provision CI step) which requires boto3
 RUN ansible-galaxy collection install -p /usr/share/ansible/collections amazon.aws && \
     find $HOME/.ansible -delete && \
-    pip3 install --no-cache-dir boto3
+    pip3 install --no-cache-dir boto3 botocore
 
 RUN /usr/local/bin/user_setup \
  && rm /usr/local/bin/usage.ocp

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -27,7 +27,6 @@ RUN yum install -y epel-release 'dnf-command(config-manager)' && \
     yum config-manager --enable built > /dev/null && \
     yum install --setopt=tsflags=nodocs -y \
       'ansible-core < 2.16' \
-      python38-dateutil python38-urllib3 \
       python3-pip \
       openshift-ansible-test && \
     yum clean all


### PR DESCRIPTION
Centos stream 8 contains ansible 2.16. 2.14 or older is nowhere to be found, causing CI to fail with:

```
Built RPMs                                      135 kB/s | 1.9 kB     00:00    
Extra Packages for Enterprise Linux 8 - x86_64   31 MB/s |  16 MB     00:00    
Extra Packages for Enterprise Linux Modular 8 - 2.0 MB/s | 733 kB     00:00    
No match for argument: ansible-core < 2.14
Error: Unable to find a match: ansible-core < 2.14
```

Let's try bumping to 2.16.