### PR TITLE
Test kubelet restart

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -199,6 +199,12 @@
   - fail:
       msg: "Ignition apply failed"
 
+- name: Restart service kubelet, in all cases, also issue daemon-reload to pick up config changes
+  ansible.builtin.systemd_service:
+    state: restarted
+    daemon_reload: true
+    name: kubelet
+
 - block:
   - name: Approve node CSRs
     oc_csr_approve:


### PR DESCRIPTION
Periodics are failing with

```
    "stderr": "Warning: The unit file, source configuration file or drop-ins of kubelet.service changed on disk. Run 'systemctl daemon-reload' to reload units.",
    "stderr_lines": [
        "Warning: The unit file, source configuration file or drop-ins of kubelet.service changed on disk. Run 'systemctl daemon-reload' to reload units."
```

This happens right after a reboot, so I'm skeptical that the restart in this PR will fix anything but let's test!