### PR TITLE
OCPBUGS-29561: Install ose-aws-ecr-image-credential-provider

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -20,6 +20,7 @@ openshift_node_packages:
   - openshift-hyperkube-{{ l_cluster_version }}*
   - podman
   - runc
+  - ose-aws-ecr-image-credential-provider
 
 openshift_node_support_packages: "{{
   openshift_node_support_packages_base +


### PR DESCRIPTION
This is a new package required since 4.14.11

/jira cherry-pick OCPBUGS-29527