### PR TITLE
OCPCLOUD-2484,OCPCLOUD-2481: Adds azure and gcp image credential providers

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -21,6 +21,8 @@ openshift_node_packages:
   - podman
   - runc
   - ose-aws-ecr-image-credential-provider
+  - ose-azure-acr-image-credential-provider
+  - ose-gcp-gcr-image-credential-provider
 
 openshift_node_support_packages: "{{
   openshift_node_support_packages_base +


### PR DESCRIPTION
Install the azure and gcp image registry credential providers, that are required from 4.16.