### PR TITLE
Switch to openshift-kubelet package

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -17,7 +17,7 @@ openshift_node_packages:
   - cri-o-{{ crio_latest }}
   - cri-tools
   - openshift-clients-{{ l_cluster_version }}*
-  - openshift-hyperkube-{{ l_cluster_version }}*
+  - openshift-kubelet-{{ l_cluster_version }}*
   - podman
   - runc
   - ose-aws-ecr-image-credential-provider


### PR DESCRIPTION
See https://github.com/openshift/kubernetes/pull/1882

This will likely require some testing. I would expect clusters upgrading to the new packaging to be fine but still have all of the other packages installed. Maybe at some point we should come back and remove the other packages but it doesn't seem imperative now.