### PR TITLE
Add rhel-9 attribute in openshift_node_support_packages

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -90,6 +90,9 @@ openshift_node_support_packages_by_os_major_version:
   "8":
     - openvswitch3.1
     - policycoreutils-python-utils
+  "9":
+    - openvswitch3.1
+    - policycoreutils-python-utils
 
 openshift_node_support_packages_by_arch:
   ppc64le:


### PR DESCRIPTION
For the coming RHEL-9 worker support, if no "9" item, the playbook will fail as below when running against RHEL-9 host:
```
TASK [openshift_node : Install openshift packages] *****************************
fatal: [ip-10-0-54-189.us-east-2.compute.internal]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: {{ (openshift_node_packages + openshift_node_support_packages) | join(',') }}: {{ openshift_node_support_packages_base + openshift_node_support_packages_by_os_major_version[ansible_distribution_major_version] + openshift_node_support_packages_by_arch[ansible_architecture] }}: 'dict object' has no attribute '9'\n\nThe error appears to be in '/home/slave2/workspace/ocp4-rhel-scaleup-runner/private-openshift-ansible/roles/openshift_node/tasks/install.yml': line 91, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n- block:\n  - name: Install openshift packages\n    ^ here\n"}

TASK [openshift_node : Package install failure message] ************************
fatal: [ip-10-0-54-189.us-east-2.compute.internal]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: {{ (openshift_node_packages + openshift_node_support_packages) | join(',') }}: {{ openshift_node_support_packages_base + openshift_node_support_packages_by_os_major_version[ansible_distribution_major_version] + openshift_node_support_packages_by_arch[ansible_architecture] }}: 'dict object' has no attribute '9'\n\nThe error appears to be in '/home/slave2/workspace/ocp4-rhel-scaleup-runner/private-openshift-ansible/roles/openshift_node/tasks/install.yml': line 104, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  rescue:\n  - name: Package install failure message\n    ^ here\n"}

```
