### PR TITLE
OCPBUGS-39178: Update the network backend of podman to Netavark if installing Podman 5.0 and higher

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -19,6 +19,7 @@ openshift_node_packages:
   - openshift-clients-{{ l_cluster_version }}*
   - openshift-kubelet-{{ l_cluster_version }}*
   - podman
+  - netavark
   - runc
   - ose-aws-ecr-image-credential-provider
   - ose-azure-acr-image-credential-provider

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -139,3 +139,15 @@
     option: Storage
     value: "persistent"
     no_extra_spaces: yes
+
+- name: set package facts
+  ansible.builtin.package_facts:
+
+# since podman-5.0, cni is not supported anymore, update the network backend to netavark
+- name: Update the network backend to Netavark
+  lineinfile:
+    path: /usr/share/containers/containers.conf
+    regexp: '^network_backend.*'
+    line: 'network_backend = "netavark"'
+    backrefs: yes
+  when: ansible_facts.packages.podman[0].version.split(".")[0] | int >= 5


### PR DESCRIPTION
CNI network backend is not supported anymore since Podman version 5.0[1], now we've got podman-5.2.0-3.rhaos4.17.el8.x86_64 installed from the OCP-4.17 RHEL-8 repo, but the network backend is still configured as "cni" by default in /usr/share/containers/containers.conf, so update the `network_backend` option to "netavark" when installing podman-5.0.x and higher, which also requiring the "netavark" related packages. 



[1]https://docs.podman.io/en/latest/markdown/podman-network.1.html