### PR TITLE
Update Python version for Tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_cache:
 
 language: python
 python:
-  - "3.9"
+  - "3.10"
 
 before_install:
   - python -m pip install --upgrade virtualenv

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py39-{unit,flake8,pylint,yamllint,ansible_syntax}
+    py310-{unit,flake8,pylint,yamllint,ansible_syntax}
 skipsdist=True
 skip_missing_interpreters=True
 


### PR DESCRIPTION
Python3.9 is having issues with TOX. Upgrading to python3.10 appears to solve the linting issues.