### PR TITLE
no-jira: Fix travis ci issues with tox

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,11 +4,12 @@
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-#init-hook=
+init-hook="import sys; sys.path.append('roles/openshift_node/library');sys.path.append('roles/openshift_node/callback_plugins')"
 
 # Add files or directories to the ignore list. They should be base names, not
 # paths.
 ignore=CVS,setup.py,ini_file.py,profile_tasks.py,seboolean.py,sysctl.py
+ignore-paths=^.*test/.*$, ^tests/.*$, ^git/.*$, ^.tox/.*$
 
 # Pickle collected data for later comparisons.
 persistent=no
@@ -60,7 +61,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=fixme,locally-disabled,file-ignored,duplicate-code
+disable=fixme,locally-disabled,file-ignored,duplicate-code,consider-using-f-string,use-dict-literal,unnecessary-negation
 
 
 [REPORTS]
@@ -359,6 +360,8 @@ max-public-methods=20
 # Maximum number of boolean expressions in a if statement
 max-bool-expr=5
 
+# Maximum number of arguments for a function (default=5)
+max-positional-arguments=10
 
 [IMPORTS]
 

--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -16,6 +16,7 @@ openshift_node_packages:
   - conmon
   - cri-o-{{ crio_latest }}
   - cri-tools
+  - crun
   - openshift-clients-{{ l_cluster_version }}*
   - openshift-kubelet-{{ l_cluster_version }}*
   - podman

--- a/setup.py
+++ b/setup.py
@@ -380,6 +380,18 @@ class UnsupportedCommand(Command):
         print("Unsupported command for openshift-ansible")
 
 
+test_requirements_file = os.path.abspath(os.path.dirname(__file__)) + "/test-requirements.txt"
+with open(test_requirements_file, "r") as file:
+    test_requirements = [
+        line.rstrip() for line in file if not line.startswith("#")
+    ]
+
+requirements_file = os.path.abspath(os.path.dirname(__file__)) + "/requirements.txt"
+with open(requirements_file, "r") as file:
+    test_requirements.extend([
+        line.rstrip() for line in file if not line.startswith("#")
+    ])
+
 setup(
     name='openshift-ansible',
     license="Apache 2.0",
@@ -396,4 +408,8 @@ setup(
         'ansible_syntax': OpenShiftAnsibleSyntaxCheck,
     },
     packages=[],
+    tests_require=test_requirements,
+    extras_require={
+        "test": test_requirements,
+    }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,43 @@
 [tox]
-envlist =
-    py39-{unit,flake8,pylint,yamllint,ansible_syntax}
+envlist = unit,flake8,pylint,yamllint,ansible_syntax
 skipsdist=True
 skip_missing_interpreters=True
 
 [testenv]
+description = run unit tests
+basepython = python3.9
+deps =
+    -rrequirements.txt
+    -rtest-requirements.txt
+commands = 
+    pytest {posargs}
+
+[testenv:pylint]
+description = run linter on project python files
+basepython = python3.9
+deps = 
+    -rrequirements.txt
+    pylint: pylint>=3.3.1
+commands = 
+    pylint . --recursive=y --rcfile .pylintrc --fail-under=9.0
+
+[testenv:flake8]
+basepython = python3.9
+deps = 
+    -rrequirements.txt
+    -rtest-requirements.txt
+commands = 
+    flake8 {posargs}
+
+[testenv:yamllint]
+basepython = python3.9
+deps = 
+    -rrequirements.txt
+    -rtest-requirements.txt
+commands = 
+    python setup.py yamllint
+
+[testenv:ansible_syntax]
 skip_install=True
 setenv =
     ANSIBLE_CONFIG = ./ansible.cfg
@@ -18,8 +51,4 @@ deps =
     -rtest-requirements.txt
 
 commands =
-    unit: pytest {posargs}
-    flake8: flake8 {posargs}
-    pylint: python setup.py lint
-    yamllint: python setup.py yamllint
-    ansible_syntax: python setup.py ansible_syntax
+    python setup.py ansible_syntax


### PR DESCRIPTION
** There appear to be some issues occurring due to changes in setuptools. The setuptools are used for yamllint and asible-syntax now but not pylinting. The pylint was causing an issue to be hit for an unknown attribute in setuptools_lint. ** Each task was separated out in the travis ci file too in order to run them with different deps - this will allow us to use built in features for pylint.