### PR TITLE
no-jira:  Update Test Requirements

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,12 +4,11 @@
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-init-hook="import sys; sys.path.append('roles/openshift_node/library');sys.path.append('roles/openshift_node/callback_plugins')"
+#init-hook=
 
 # Add files or directories to the ignore list. They should be base names, not
 # paths.
 ignore=CVS,setup.py,ini_file.py,profile_tasks.py,seboolean.py,sysctl.py
-ignore-paths=^.*test/.*$, ^tests/.*$, ^git/.*$, ^.tox/.*$
 
 # Pickle collected data for later comparisons.
 persistent=no
@@ -61,7 +60,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=fixme,locally-disabled,file-ignored,duplicate-code,consider-using-f-string,use-dict-literal,unnecessary-negation
+disable=fixme,locally-disabled,file-ignored,duplicate-code
 
 
 [REPORTS]
@@ -360,8 +359,6 @@ max-public-methods=20
 # Maximum number of boolean expressions in a if statement
 max-bool-expr=5
 
-# Maximum number of arguments for a function (default=5)
-max-positional-arguments=10
 
 [IMPORTS]
 

--- a/setup.py
+++ b/setup.py
@@ -380,18 +380,6 @@ class UnsupportedCommand(Command):
         print("Unsupported command for openshift-ansible")
 
 
-test_requirements_file = os.path.abspath(os.path.dirname(__file__)) + "/test-requirements.txt"
-with open(test_requirements_file, "r") as file:
-    test_requirements = [
-        line.rstrip() for line in file if not line.startswith("#")
-    ]
-
-requirements_file = os.path.abspath(os.path.dirname(__file__)) + "/requirements.txt"
-with open(requirements_file, "r") as file:
-    test_requirements.extend([
-        line.rstrip() for line in file if not line.startswith("#")
-    ])
-
 setup(
     name='openshift-ansible',
     license="Apache 2.0",
@@ -408,8 +396,4 @@ setup(
         'ansible_syntax': OpenShiftAnsibleSyntaxCheck,
     },
     packages=[],
-    tests_require=test_requirements,
-    extras_require={
-        "test": test_requirements,
-    }
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,3 +9,4 @@ pylint==2.4.4
 pytest==5.4.1
 setuptools-lint==0.6.0
 yamllint==1.20.0
+setuptools==45.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,43 +1,10 @@
 [tox]
-envlist = unit,flake8,pylint,yamllint,ansible_syntax
+envlist =
+    py39-{unit,flake8,pylint,yamllint,ansible_syntax}
 skipsdist=True
 skip_missing_interpreters=True
 
 [testenv]
-description = run unit tests
-basepython = python3.9
-deps =
-    -rrequirements.txt
-    -rtest-requirements.txt
-commands = 
-    pytest {posargs}
-
-[testenv:pylint]
-description = run linter on project python files
-basepython = python3.9
-deps = 
-    -rrequirements.txt
-    pylint: pylint>=3.3.1
-commands = 
-    pylint . --recursive=y --rcfile .pylintrc --fail-under=9.0
-
-[testenv:flake8]
-basepython = python3.9
-deps = 
-    -rrequirements.txt
-    -rtest-requirements.txt
-commands = 
-    flake8 {posargs}
-
-[testenv:yamllint]
-basepython = python3.9
-deps = 
-    -rrequirements.txt
-    -rtest-requirements.txt
-commands = 
-    python setup.py yamllint
-
-[testenv:ansible_syntax]
 skip_install=True
 setenv =
     ANSIBLE_CONFIG = ./ansible.cfg
@@ -51,4 +18,8 @@ deps =
     -rtest-requirements.txt
 
 commands =
-    python setup.py ansible_syntax
+    unit: pytest {posargs}
+    flake8: flake8 {posargs}
+    pylint: python setup.py lint
+    yamllint: python setup.py yamllint
+    ansible_syntax: python setup.py ansible_syntax


### PR DESCRIPTION
** This reverts 879fe0ec0ed1643a3ee13643b0252fc2376c69d9 in favor of using a specific version of setuptools. 
**  Most people consider the deprecation of setuptools `tests_require` in 40.0.0 (this still causes errors). Previous versions also give errors but for different missing features. Setuptools 45.0.0 appears new enough to get rid of said errors while still including the `tests_require` feature. Considering 45.0.0 the sweetspot. This simplifies the travis config changes and setup.py changes. This also ensures we stick to specific versions.