### PR TITLE
OCPBUGS-44318: Replace the unsupported option "--delete-local-data" to the new one "--delete-emptydir-data"

### DIFF
--- a/roles/openshift_node/tasks/upgrade.yml
+++ b/roles/openshift_node/tasks/upgrade.yml
@@ -15,7 +15,7 @@
   command: >
     oc adm drain {{ ansible_nodename | lower }}
     --kubeconfig={{ openshift_node_kubeconfig_path }}
-    --force --delete-local-data --ignore-daemonsets
+    --force --delete-emptydir-data --ignore-daemonsets
   delegate_to: localhost
 
 # Run the openshift_node_pre_upgrade_hook if defined


### PR DESCRIPTION
In latest 4.17 to 4.18 upgrade [job](https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.18-amd64-nightly-4.18-upgrade-from-stable-4.17-azure-ipi-proxy-workers-rhcos-rhel8-f28/1851377141074104320) with RHEL workers, it's failing for 

```
    "invocation": {
        "module_args": {
            "_raw_params": "oc adm drain ci-op-1s456mng-15dc0-qcg6w-rhel-1 --kubeconfig=/tmp/secret/kubeconfig --force --delete-local-data --ignore-daemonsets\n",
            "_uses_shell": false,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true,
            "warn": false
        }
    },
    "msg": "non-zero return code",
    "rc": 1,
    "start": "2024-10-30 03:08:53.112581",
    "stderr": "error: unknown flag: --delete-local-data\nSee 'oc adm drain --help' for usage.",
    "stderr_lines": [
        "error: unknown flag: --delete-local-data",
        "See 'oc adm drain --help' for usage."

```

It turns out the `--delete-local-data` is already being deprecated for a long time(Since 4.7), and the newly supported one is `--delete-emptydir-data` with the same function.

[1]https://access.redhat.com/solutions/6801291
[2]https://docs.openshift.com/container-platform/4.17/post_installation_configuration/node-tasks.html