### PR TITLE
OCPBUGS-44452: no-jira: Update Test Requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,3 +9,4 @@ pylint==2.4.4
 pytest==5.4.1
 setuptools-lint==0.6.0
 yamllint==1.20.0
+setuptools==45.0.0


### PR DESCRIPTION
**  Most people consider the deprecation of setuptools `tests_require` in 40.0.0 (this still causes errors). Previous versions also give errors but for different missing features. Setuptools 45.0.0 appears new enough to get rid of said errors while still including the `tests_require` feature. Considering 45.0.0 the sweetspot. This simplifies the travis config changes and setup.py changes. This also ensures we stick to specific versions.