### PR TITLE
OCPBUGS-44589: Add crun to the openshift_node_packages list

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -16,6 +16,7 @@ openshift_node_packages:
   - conmon
   - cri-o-{{ crio_latest }}
   - cri-tools
+  - crun
   - openshift-clients-{{ l_cluster_version }}*
   - openshift-kubelet-{{ l_cluster_version }}*
   - podman


### PR DESCRIPTION
As what we found in https://issues.redhat.com/browse/OCPBUGS-43493, the `crun` package is newly required for a 4.18 node to be running. 

During the RHEL worker upgrade from 4.17 to 4.18, if there's no existing `crun` package available, the OCP cluster upgrade will be failed, due to MCO can't finish the rolling update on the RHEL nodes, once MCO applied the new 4.18 mc to one of the RHEL worker, it will get stuck for crio service never come back. 

So install the `crun` package in advance for 4.17 RHEL worker to avoid the 4.18 upgrading error, although it's not mandatory for OCP 4.17 scaling up. 

```
[root@preserve-gpei-worker k_files]# oc get node
NAME                                        STATUS                        ROLES                  AGE    VERSION
ip-10-0-51-47.us-east-2.compute.internal    Ready                         control-plane,master   3h3m   v1.31.2
ip-10-0-53-53.us-east-2.compute.internal    NotReady,SchedulingDisabled   worker                 100m   v1.30.5
ip-10-0-57-65.us-east-2.compute.internal    Ready                         control-plane,master   3h3m   v1.31.2
ip-10-0-57-84.us-east-2.compute.internal    Ready                         worker                 176m   v1.31.2
ip-10-0-59-240.us-east-2.compute.internal   Ready                         worker                 100m   v1.30.5
ip-10-0-63-36.us-east-2.compute.internal    Ready                         worker                 176m   v1.31.2
ip-10-0-69-221.us-east-2.compute.internal   Ready                         worker                 176m   v1.30.5
ip-10-0-72-170.us-east-2.compute.internal   Ready                         control-plane,master   3h3m   v1.31.2

[root@preserve-gpei-worker k_files]# oc get clusterversion
NAME      VERSION                              AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.17.0-0.nightly-2024-11-13-161445   True        True          83m     Working towards 4.18.0-0.nightly-2024-11-14-090045: 763 of 892 done (85% complete), waiting up to 40 minutes on machine-config
```



```
Nov 15 06:18:38 ip-10-0-53-53.us-east-2.compute.internal crio[8360]: time="2024-11-15 06:18:38.147720956Z" level=fatal msg="validating runtime config: runtime validation: \"crun\" not found in $PATH: exec: \"crun\": executable file not found in $PATH"
Nov 15 06:18:38 ip-10-0-53-53.us-east-2.compute.internal systemd[1]: crio.service: Main process exited, code=exited, status=1/FAILURE
Nov 15 06:18:38 ip-10-0-53-53.us-east-2.compute.internal systemd[1]: crio.service: Failed with result 'exit-code'.
Nov 15 06:18:38 ip-10-0-53-53.us-east-2.compute.internal systemd[1]: Failed to start Container Runtime Interface for OCI (CRI-O).
Nov 15 06:18:38 ip-10-0-53-53.us-east-2.compute.internal systemd[1]: crio.service: Consumed 55ms CPU time
```