### PR TITLE
CORS-3957 - Drop the support for RHEL node when cluster version is 4.19 and above

### DIFF
--- a/roles/openshift_node/tasks/version_checks.yml
+++ b/roles/openshift_node/tasks/version_checks.yml
@@ -26,5 +26,5 @@
 
 - name: Fail if cluster version is greater than or equal to 4.19
   fail:
-    msg: "Cluster version {{ l_cluster_version }} is >= 4.19 and is not supported anymore"
+    msg: "RHEL nodes in version 4.19 and above are no longer supported"
   when: l_cluster_version is version('4.19', '>=')

--- a/roles/openshift_node/tasks/version_checks.yml
+++ b/roles/openshift_node/tasks/version_checks.yml
@@ -23,3 +23,8 @@
   - l_cluster_version is version('4.10', '>=')
   - ansible_facts['distribution'] == "RedHat"
   - ansible_facts['distribution_version'] is version('8.4', '<')
+
+- name: Fail if cluster version is greater than or equal to 4.19
+  fail:
+    msg: "Cluster version {{ l_cluster_version }} is >= 4.19 and is not supported anymore"
+  when: l_cluster_version is version('4.19', '>=')


### PR DESCRIPTION
Add a new check to prevent customers from adding RHEL worker nodes on version 4.19 and above.