### PR TITLE
OCPBUGS-54955: Add the afterburn package into the openshift_node_packages list

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -13,6 +13,7 @@ openshift_package_directory: '/tmp/openshift-ansible-packages'
 openshift_packages: "{{ (openshift_node_packages + openshift_node_support_packages) | join(',') }}"
 
 openshift_node_packages:
+  - afterburn
   - conmon
   - cri-o-{{ crio_latest }}
   - cri-tools


### PR DESCRIPTION
The latest RHEL scale-up job https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.18-amd64-nightly-gcp-ipi-workers-rhel8-fips-f28-destructive/1911602583869329408  failed for cri-o and kubelet services couldn't be started, the journal log shows the dependency service "gcp-hostname.service" failed as following:

```
[root@gpei-0414g-k5gkm-w-a-l-rhel-0 ~]# journalctl -u gcp-hostname.service --no-pager
-- Logs begin at Mon 2025-04-14 11:19:09 UTC, end at Mon 2025-04-14 12:05:18 UTC. --
Apr 14 11:19:23 localhost.localdomain systemd[1]: Starting Set GCP Transient Hostname...
Apr 14 11:19:23 localhost.localdomain mco-hostname[1042]: /usr/local/bin/mco-hostname: line 26: /usr/bin/afterburn: No such file or directory
Apr 14 11:19:23 localhost.localdomain systemd[1]: gcp-hostname.service: Main process exited, code=exited, status=127/n/a
Apr 14 11:19:23 localhost.localdomain systemd[1]: gcp-hostname.service: Failed with result 'exit-code'.
Apr 14 11:19:23 localhost.localdomain systemd[1]: Failed to start Set GCP Transient Hostname.
Apr 14 11:19:23 localhost.localdomain systemd[1]: gcp-hostname.service: Consumed 4ms CPU time
Apr 14 12:05:11 gpei-0414g-k5gkm-w-a-l-rhel-0 systemd[1]: Starting Set GCP Transient Hostname...
Apr 14 12:05:11 gpei-0414g-k5gkm-w-a-l-rhel-0 mco-hostname[6916]: /usr/local/bin/mco-hostname: line 26: /usr/bin/afterburn: No such file or directory
Apr 14 12:05:11 gpei-0414g-k5gkm-w-a-l-rhel-0 systemd[1]: gcp-hostname.service: Main process exited, code=exited, status=127/n/a
Apr 14 12:05:11 gpei-0414g-k5gkm-w-a-l-rhel-0 systemd[1]: gcp-hostname.service: Failed with result 'exit-code'.
Apr 14 12:05:11 gpei-0414g-k5gkm-w-a-l-rhel-0 systemd[1]: Failed to start Set GCP Transient Hostname.
Apr 14 12:05:11 gpei-0414g-k5gkm-w-a-l-rhel-0 systemd[1]: gcp-hostname.service: Consumed 3ms CPU time
```

The /usr/bin/afterburn command is provided by rpm package "afterburn".
sh-5.1# rpm -qf /usr/bin/afterburn
afterburn-5.5.1-2.el9.x86_64

So install the "afterburn" package on the RHEL node first. 
