### PR TITLE
OCPBUGS-59844: Add SELinux status check in the playbook and hide confidential logs

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -120,6 +120,7 @@
   delay: 10
   retries: 60
   register: bootstrap_ignition
+  no_log: true
   until:
   - bootstrap_ignition.status is defined
   - bootstrap_ignition.status == 200

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -162,6 +162,7 @@
     --output=jsonpath='{.data.\.dockerconfigjson}'
   delegate_to: localhost
   register: oc_get
+  no_log: true
   until:
   - oc_get.stdout != ''
   retries: 36

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -32,6 +32,17 @@
   when:
   - ansible_fips != (cluster_fips.stdout | bool)
 
+# SELinux is required for RHEL package mode worker
+- name: Check if SELinux is enabled on the RHEL machine
+  command: getenforce
+  register: selinux_status
+  changed_when: false
+
+- name: Fail if SELinux is disabled
+  fail:
+    msg: "SELinux is not enabled (current status: {{ selinux_status.stdout }}). This playbook requires SELinux to be enabled."
+  when: selinux_status.stdout != "Enforcing" and selinux_status.stdout != "Permissive"
+
 # Update the yum cache to ensure that the newest available packages can be
 # installed in the tasks below.
 - name: Update Yum Cache


### PR DESCRIPTION
* Add the SELinux check to make sure it's not disabled on the target RHEL nodes
* Add `no_log: true` to prevent the task with confidential information from being logged