### PR TITLE
Reenable container tools, exclude container common

### DIFF
--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -91,8 +91,8 @@
   - name: Install openshift packages
     dnf:
       name: "{{ openshift_packages }}"
-      disablerepo: "container-tools"
       state: latest
+      exclude: "containers-common" 
       allowerasing: true
       disable_gpg_check: true
     async: 3600

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -87,10 +87,6 @@
   when:
   - crio_latest is version(l_kubernetes_server_version, 'lt')
 
-- name: Disable container-tools:rhel{{ ansible_distribution_major_version }} modularity appstream
-  command: dnf module disable container-tools:rhel{{ ansible_distribution_major_version }} -y
-  ignore_errors: true
-
 - block:
   - name: Install openshift packages
     dnf:


### PR DESCRIPTION
Builds on #12533 and adds an exclude for containers-common so that we don't reintroduce https://issues.redhat.com/browse/OCPBUGS-34844 (untested)