### PR TITLE
Update podman default runtime to runc if necessary

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -21,7 +21,6 @@ openshift_node_packages:
   - openshift-clients-{{ l_cluster_version }}*
   - openshift-kubelet-{{ l_cluster_version }}*
   - podman
-  - netavark
   - runc
   - ose-aws-ecr-image-credential-provider
   - ose-azure-acr-image-credential-provider

--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -114,6 +114,23 @@
     state: restarted
   when: update_registries is changed
 
+#Update the Default OCI runtime to runc of Podman
+- name: Check if crun is currently the default runtime
+  command: podman info --format '{{"{{"}}.Host.OCIRuntime.Name{{"}}"}}'
+  register: current_runtime
+  changed_when: false
+  ignore_errors: true
+
+- name: Modify Podman configuration to use runc
+  ini_file:
+    path: /usr/share/containers/containers.conf
+    section: engine
+    option: runtime
+    value: '"runc"'
+    create: yes
+    mode: 0644
+  when: "'crun' in current_runtime.stdout"
+
 - name: Get cluster pull-secret
   command: >
     oc get secret pull-secret

--- a/roles/openshift_node/tasks/install.yml
+++ b/roles/openshift_node/tasks/install.yml
@@ -87,6 +87,19 @@
   when:
   - crio_latest is version(l_kubernetes_server_version, 'lt')
 
+- name: Enable container-tools module for netavark
+  command: dnf module enable container-tools:rhel{{ ansible_distribution_major_version }} -y
+  ignore_errors: true
+
+- name: Install netavark for podman dependency with container-tools modules enabled
+  dnf:
+    name: netavark
+    state: latest
+    allowerasing: true
+    disable_gpg_check: true
+  async: 3600
+  poll: 30
+
 - name: Disable container-tools:rhel{{ ansible_distribution_major_version }} modularity appstream
   command: dnf module disable container-tools:rhel{{ ansible_distribution_major_version }} -y
   ignore_errors: true


### PR DESCRIPTION
The default runtime of Podman was configured from
```
[root@gpei-07301-r4xvm-w-a-l-rhel-0 ~]# grep ^runtime /usr/share/containers/containers.conf
runtime = "crun"
[root@gpei-07301-r4xvm-w-a-l-rhel-0 ~]# rpm -qf /usr/share/containers/containers.conf
containers-common-1-87.rhaos4.18.el8.x86_64
```
Updated it to "runc" to avoid "crun" incompatibility issue in 4.18. 