### PR TITLE
OCPBUGS-59843: Missing kubeconfig file in the oc apply command

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -96,7 +96,7 @@
 
 - name: Apply use-runc ContainerRuntimeConfig
   command: >
-    oc apply -f {{ local_temp_dir.path }}/openshift-ansible-runc-crc.yaml
+    oc apply -f {{ local_temp_dir.path }}/openshift-ansible-runc-crc.yaml --kubeconfig={{ openshift_node_kubeconfig_path }}
   delegate_to: localhost
   register: oc_apply
   until:


### PR DESCRIPTION
The "oc " command is missing `kubeconfig` option which leads to:

```
TASK [openshift_node : Apply use-runc ContainerRuntimeConfig] *************************************************************************
FAILED - RETRYING: [10.0.128.6 -> localhost]: Apply use-runc ContainerRuntimeConfig (36 retries left).
...
FAILED - RETRYING: [10.0.128.6 -> localhost]: Apply use-runc ContainerRuntimeConfig (1 retries left).
fatal: [10.0.128.6 -> localhost]: FAILED! => {"attempts": 36, "changed": true, "cmd": ["oc", "apply", "-f", "/tmp/ansible.ion9oni5/openshift-ansible-runc-crc.yaml"], "delta": "0:00:00.090951", "end": "2025-08-05 03:19:11.409314", "msg": "non-zero return code", "rc": 1, "start": "2025-08-05 03:19:11.318363", "stderr": "error: Missing or incomplete configuration info.  Please point to an existing, complete config file:\n\n\n  1. Via the command-line flag --kubeconfig\n  2. Via the KUBECONFIG environment variable\n  3. In your home directory as ~/.kube/config\n\nTo view or setup config directly use the 'config' command.", "stderr_lines": ["error: Missing or incomplete configuration info.  Please point to an existing, complete config file:", "", "", "  1. Via the command-line flag --kubeconfig", "  2. Via the KUBECONFIG environment variable", "  3. In your home directory as ~/.kube/config", "", "To view or setup config directly use the 'config' command."], "stdout": "", "stdout_lines": []}
```

Tested locally, with `--kubeconfig` added
```
TASK [openshift_node : Apply use-runc ContainerRuntimeConfig] *************************************************************************
changed: [10.0.128.6 -> localhost] => {"attempts": 1, "changed": true, "cmd": ["oc", "apply", "-f", "/tmp/ansible.8ggs32ny/openshift-ansible-runc-crc.yaml", "--kubeconfig=/root/gpei-test/kubeconfig"], "delta": "0:00:00.366946", "end": "2025-08-05 03:24:34.913768", "msg": "", "rc": 0, "start": "2025-08-05 03:24:34.546822", "stderr": "", "stderr_lines": [], "stdout": "containerruntimeconfig.machineconfiguration.openshift.io/openshift-ansible-use-runc created", "stdout_lines": ["containerruntimeconfig.machineconfiguration.openshift.io/openshift-ansible-use-runc created"]}

```