### PR TITLE
OCPBUGS-111547: Harden remote inventory fetching in installer container

### DIFF
--- a/README_CONTAINER_IMAGE.md
+++ b/README_CONTAINER_IMAGE.md
@@ -18,6 +18,8 @@ At the very least, when running a container you must specify:
 
 1. An **inventory**. This can be a location inside the container (possibly mounted as a volume) with a path referenced via the `INVENTORY_FILE` environment variable. Alternatively you can serve the inventory file from a web server and use the `INVENTORY_URL` environment variable to fetch it, or `DYNAMIC_SCRIPT_URL` to download a script that provides a dynamic inventory.
 
+   When using remote URLs (`INVENTORY_URL` or `DYNAMIC_SCRIPT_URL`), the URL must use HTTPS. When using `DYNAMIC_SCRIPT_URL`, you must also set `DYNAMIC_SCRIPT_SHA256` to the SHA-256 hex digest of the script (e.g. `sha256sum myscript.sh`). You may optionally set `INVENTORY_SHA256` when using `INVENTORY_URL` for integrity verification.
+
 1. **ssh keys** so that Ansible can reach your hosts. These should be mounted as a volume under `/opt/app-root/src/.ssh` under normal usage (i.e. when running the container as non-root).
 
 1. The **playbook** to run. This is set using the `PLAYBOOK_FILE` environment variable. If you don't specify a playbook the [`openshift_facts`](playbooks/byo/openshift_facts.yml) playbook will be run to collect and show facts about your OpenShift environment.

--- a/images/installer/root/usr/local/bin/run
+++ b/images/installer/root/usr/local/bin/run
@@ -8,6 +8,30 @@
 
 # SOURCE and HOME DIRECTORY: /opt/app-root/src
 
+validate_url_scheme() {
+  local url="$1"
+  local varname="$2"
+  if [[ "${url}" != https://* ]]; then
+    echo "Error: ${varname} must use HTTPS. Refusing to fetch '${url}'." >&2
+    exit 1
+  fi
+}
+
+verify_checksum() {
+  local file="$1"
+  local expected="$2"
+  local varname="$3"
+  local actual
+  actual="$(sha256sum "${file}" | awk '{print $1}')"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "Error: checksum verification failed for ${varname}." >&2
+    echo "  expected: ${expected}" >&2
+    echo "  got:      ${actual}" >&2
+    rm -f "${file}"
+    exit 1
+  fi
+}
+
 if [[ -z "${PLAYBOOK_FILE}" ]]; then
   echo
   echo "PLAYBOOK_FILE must be provided."
@@ -18,18 +42,28 @@ INVENTORY="$(mktemp)"
 if [[ -v INVENTORY_FILE ]]; then
   # Make a copy so that ALLOW_ANSIBLE_CONNECTION_LOCAL below
   # does not attempt to modify the original
-  cp ${INVENTORY_FILE} ${INVENTORY}
+  cp "${INVENTORY_FILE}" "${INVENTORY}"
 elif [[ -v INVENTORY_DIR ]]; then
   INVENTORY="$(mktemp -d)"
-  cp -RL ${INVENTORY_DIR}/* ${INVENTORY}
+  cp -RL "${INVENTORY_DIR}"/* "${INVENTORY}"
 elif [[ -v INVENTORY_URL ]]; then
-  curl -o ${INVENTORY} ${INVENTORY_URL}
+  validate_url_scheme "${INVENTORY_URL}" "INVENTORY_URL"
+  curl --fail --silent --show-error --proto '=https' -o "${INVENTORY}" "${INVENTORY_URL}"
+  if [[ -v INVENTORY_SHA256 ]]; then
+    verify_checksum "${INVENTORY}" "${INVENTORY_SHA256}" "INVENTORY_URL"
+  fi
 elif [[ -v DYNAMIC_SCRIPT_URL ]]; then
-  curl -o ${INVENTORY} ${DYNAMIC_SCRIPT_URL}
-  chmod 755 ${INVENTORY}
+  validate_url_scheme "${DYNAMIC_SCRIPT_URL}" "DYNAMIC_SCRIPT_URL"
+  if [[ ! -v DYNAMIC_SCRIPT_SHA256 ]]; then
+    echo "Error: DYNAMIC_SCRIPT_SHA256 is required when using DYNAMIC_SCRIPT_URL." >&2
+    exit 1
+  fi
+  curl --fail --silent --show-error --proto '=https' -o "${INVENTORY}" "${DYNAMIC_SCRIPT_URL}"
+  verify_checksum "${INVENTORY}" "${DYNAMIC_SCRIPT_SHA256}" "DYNAMIC_SCRIPT_URL"
+  chmod 755 "${INVENTORY}"
 elif [[ -v GENERATE_INVENTORY ]]; then
   # dynamically generate inventory file using bind-mounted info
-  /usr/local/bin/generate ${INVENTORY}
+  /usr/local/bin/generate "${INVENTORY}"
 else
   echo
   echo "One of INVENTORY_FILE, INVENTORY_DIR, INVENTORY_URL, GENERATE_INVENTORY, or DYNAMIC_SCRIPT_URL must be provided."
@@ -38,15 +72,15 @@ fi
 INVENTORY_ARG="-i ${INVENTORY}"
 
 if [[ "$ALLOW_ANSIBLE_CONNECTION_LOCAL" = false ]]; then
-  sed -i s/ansible_connection=local// ${INVENTORY}
+  sed -i s/ansible_connection=local// "${INVENTORY}"
 fi
 
 if [[ -v VAULT_PASS ]]; then
   VAULT_PASS_FILE="$(mktemp)"
-  echo ${VAULT_PASS} > ${VAULT_PASS_FILE}
+  echo "${VAULT_PASS}" > "${VAULT_PASS_FILE}"
   VAULT_PASS_ARG="--vault-password-file ${VAULT_PASS_FILE}"
 fi
 
-cd ${WORK_DIR}
+cd "${WORK_DIR}"
 
 exec ansible-playbook ${INVENTORY_ARG} ${VAULT_PASS_ARG} ${OPTS} ${PLAYBOOK_FILE}

--- a/images/installer/root/usr/local/bin/usage
+++ b/images/installer/root/usr/local/bin/usage
@@ -12,7 +12,10 @@ At a minimum, when running a container using this image you must provide:
   /opt/app-root/src/.ssh
 * An inventory file. This can be mounted inside the container as a volume and specified with the
   INVENTORY_FILE environment variable. Alternatively you can serve the inventory file from a web
-  server and use the INVENTORY_URL environment variable to fetch it.
+  server and use the INVENTORY_URL environment variable to fetch it (HTTPS required), or use
+  DYNAMIC_SCRIPT_URL to download a dynamic inventory script (HTTPS required, and
+  DYNAMIC_SCRIPT_SHA256 must be set to the script's SHA-256 hex digest).
+  You may optionally set INVENTORY_SHA256 when using INVENTORY_URL.
 * The playbook to run. This is set using the PLAYBOOK_FILE environment variable.
 
 Here is an example of how to run a containerized origin-ansible with

--- a/images/installer/root/usr/local/bin/usage.ocp
+++ b/images/installer/root/usr/local/bin/usage.ocp
@@ -12,7 +12,10 @@ At a minimum, when running a container using this image you must provide:
   /opt/app-root/src/.ssh
 * An inventory file. This can be mounted inside the container as a volume and specified with the
   INVENTORY_FILE environment variable. Alternatively you can serve the inventory file from a web
-  server and use the INVENTORY_URL environment variable to fetch it.
+  server and use the INVENTORY_URL environment variable to fetch it (HTTPS required), or use
+  DYNAMIC_SCRIPT_URL to download a dynamic inventory script (HTTPS required, and
+  DYNAMIC_SCRIPT_SHA256 must be set to the script's SHA-256 hex digest).
+  You may optionally set INVENTORY_SHA256 when using INVENTORY_URL.
 * The playbook to run. This is set using the PLAYBOOK_FILE environment variable.
 
 Here is an example of how to run a containerized ose-ansible with


### PR DESCRIPTION
Enforce HTTPS for INVENTORY_URL and DYNAMIC_SCRIPT_URL. Add integrity verification via DYNAMIC_SCRIPT_SHA256 (required) and INVENTORY_SHA256 (optional). Harden curl invocations and fix unquoted variable expansions.

Update documentation to reflect new requirements.

Co-Authored-By: Claude